### PR TITLE
fix: support OpenAI GPT-5 Chat Completions parameters

### DIFF
--- a/pmharness/drivers/openai_compat.py
+++ b/pmharness/drivers/openai_compat.py
@@ -80,6 +80,24 @@ class OpenAICompatDriver:
             raise RuntimeError(f"missing API key in env var {self.api_key_env}")
         return key
 
+    def _uses_openai_gpt5_chat_parameters(self) -> bool:
+        return (
+            self.base_url == "https://api.openai.com/v1"
+            and self.model.lower().startswith("gpt-5")
+        )
+
+    def _output_token_limit_field(self) -> str:
+        """Return the Chat Completions output-limit field for this endpoint/model."""
+        return (
+            "max_completion_tokens"
+            if self._uses_openai_gpt5_chat_parameters()
+            else "max_tokens"
+        )
+
+    def _apply_temperature(self, body: dict) -> None:
+        if not self._uses_openai_gpt5_chat_parameters():
+            body["temperature"] = self.temperature
+
     def _pool_rotate_backoff(
         self,
         code: int,
@@ -317,9 +335,9 @@ class OpenAICompatDriver:
                 {"role": "system", "content": system},
                 {"role": "user", "content": task_prompt},
             ],
-            "temperature": self.temperature,
-            "max_tokens": self.max_tokens,
+            self._output_token_limit_field(): self.max_tokens,
         }
+        self._apply_temperature(body)
         self._prepare_body(
             body,
             messages=body["messages"],
@@ -418,14 +436,18 @@ class OpenAICompatDriver:
         body = {
             "model": self.model,
             "messages": full_messages,
-            "temperature": self.temperature,
-            "max_tokens": self.max_tokens,
+            self._output_token_limit_field(): self.max_tokens,
         }
-        if self.enable_reasoning:
+        self._apply_temperature(body)
+        if self.enable_reasoning and not (
+            tools and self._uses_openai_gpt5_chat_parameters()
+        ):
             body["reasoning"] = {"max_tokens": 1024}
         if tools:
             body["tools"] = tools
             body["tool_choice"] = "auto"
+            if self._uses_openai_gpt5_chat_parameters():
+                body["reasoning_effort"] = "none"
         self._prepare_body(
             body,
             messages=full_messages,
@@ -585,16 +607,20 @@ class OpenAICompatDriver:
         body = {
             "model": self.model,
             "messages": full_messages,
-            "temperature": self.temperature,
-            "max_tokens": self.max_tokens,
+            self._output_token_limit_field(): self.max_tokens,
             "stream": True,
             "stream_options": {"include_usage": True},
         }
-        if self.enable_reasoning:
+        self._apply_temperature(body)
+        if self.enable_reasoning and not (
+            tools and self._uses_openai_gpt5_chat_parameters()
+        ):
             body["reasoning"] = {"max_tokens": 1024}
         if tools:
             body["tools"] = tools
             body["tool_choice"] = "auto"
+            if self._uses_openai_gpt5_chat_parameters():
+                body["reasoning_effort"] = "none"
         self._prepare_body(
             body,
             messages=full_messages,

--- a/tests/test_provider_cache_usage_normalization.py
+++ b/tests/test_provider_cache_usage_normalization.py
@@ -155,6 +155,130 @@ def _fake_json_response(payload: dict):
     return FakeResponse()
 
 
+def _capturing_openai_response(monkeypatch, captured):
+    def mock_urlopen(req, timeout=None):
+        captured.update(json.loads(req.data.decode("utf-8")))
+        return _fake_json_response({
+            "choices": [{
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        })
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+
+def _capturing_openai_stream(monkeypatch, captured):
+    sse = (
+        'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}\n\n'
+        'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1}}\n\n'
+        "data: [DONE]\n\n"
+    )
+
+    class FakeStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def __iter__(self):
+            for line in sse.splitlines(keepends=True):
+                yield line.encode("utf-8")
+
+    def mock_urlopen(req, timeout=None):
+        captured.update(json.loads(req.data.decode("utf-8")))
+        return FakeStream()
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+
+def test_openai_compat_gpt_5_uses_max_completion_tokens(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="openai:gpt-5.6-luna",
+        model="gpt-5.6-luna",
+        base_url="https://api.openai.com/v1",
+        api_key_env="OPENAI_API_KEY",
+        max_tokens=8000,
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_response(monkeypatch, captured)
+
+    response = driver.complete("hi", system="sys")
+
+    assert response.error is None
+    assert captured["max_completion_tokens"] == 8000
+    assert "max_tokens" not in captured
+    assert "temperature" not in captured
+
+
+def test_openai_compat_gpt_5_tools_disable_reasoning_effort(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="openai:gpt-5.6-luna",
+        model="gpt-5.6-luna",
+        base_url="https://api.openai.com/v1",
+        api_key_env="OPENAI_API_KEY",
+        enable_reasoning=True,
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_response(monkeypatch, captured)
+
+    response = driver.chat(
+        [{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "noop", "parameters": {}}}],
+    )
+
+    assert response.error is None
+    assert captured["reasoning_effort"] == "none"
+    assert "reasoning" not in captured
+
+
+def test_openai_compat_gpt_5_streaming_tools_disable_reasoning_effort(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="openai:gpt-5.6-luna",
+        model="gpt-5.6-luna",
+        base_url="https://api.openai.com/v1",
+        api_key_env="OPENAI_API_KEY",
+        enable_reasoning=True,
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_stream(monkeypatch, captured)
+
+    response = driver.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "noop", "parameters": {}}}],
+        on_delta=lambda _text: None,
+    )
+
+    assert response.error is None
+    assert captured["reasoning_effort"] == "none"
+    assert "reasoning" not in captured
+
+
+def test_openai_compat_legacy_provider_keeps_max_tokens(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="legacy:model",
+        model="legacy-model",
+        base_url="https://api.example.com/v1",
+        api_key_env="LEGACY_API_KEY",
+        max_tokens=1500,
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_response(monkeypatch, captured)
+
+    response = driver.complete("hi", system="sys")
+
+    assert response.error is None
+    assert captured["max_tokens"] == 1500
+    assert "max_completion_tokens" not in captured
+    assert captured["temperature"] == 0.0
+
+
 def test_openai_compat_usage_meta_reads_alias_shapes(monkeypatch):
     driver = OpenAICompatDriver(
         name="openai-test",


### PR DESCRIPTION
## Problem
Direct OpenAI GPT-5 chat cannot complete a normal Marionette turn because the Chat Completions driver sends request fields that the current OpenAI API rejects: legacy `max_tokens`, `temperature: 0`, and competing reasoning controls when function tools are present. This makes API-backed GPT-5 models unusable for both ordinary and tool-enabled chat despite valid credentials and model access.

## Summary
- use `max_completion_tokens` for direct OpenAI GPT-5 models
- omit unsupported custom temperature for that API/model family
- keep tool-enabled Chat Completions coherent with `reasoning_effort: none` and no competing reasoning object
- preserve legacy OpenAI-compatible provider request fields

## Verification
- `PYTHONPATH=. uvx --from pytest pytest -q tests/test_provider_cache_usage_normalization.py` — 20 passed
- `py_compile` and `git diff --check` passed
- live `openai:gpt-5.6-luna` driver and Marionette chat returned expected responses
- independent Sol review passed after one blocking reasoning/tools finding was fixed