### PR TITLE
fix: recognize complete swarm jobs as terminal

### DIFF
--- a/webapp/src/__tests__/swarmAwaitChrome.test.ts
+++ b/webapp/src/__tests__/swarmAwaitChrome.test.ts
@@ -431,11 +431,12 @@ describe("swarm await chrome", () => {
     expect(
       terminalJobIdsFromSwarmLive([
         { job_id: "job_done", status: "completed" },
+        { job_id: "job_complete", status: "complete" },
         { job_id: "job_alive", status: "running" },
         { id: "local-x", status: "failed" },
         { job_id: "job_cancel", status: "cancelled" },
       ]),
-    ).toEqual(["job_done", "local-x", "job_cancel"]);
+    ).toEqual(["job_done", "job_complete", "local-x", "job_cancel"]);
     expect(
       pruneTerminalJobIds(
         ["job_done", "job_alive", "local-x"],

--- a/webapp/src/components/conversation/swarmPoll.ts
+++ b/webapp/src/components/conversation/swarmPoll.ts
@@ -129,7 +129,8 @@ export function terminalJobIdsFromSwarmLive(
   for (const job of jobs) {
     const status = String(job?.status || "").toLowerCase();
     if (
-      status !== "completed"
+      status !== "complete"
+      && status !== "completed"
       && status !== "failed"
       && status !== "cancelled"
       && status !== "canceled"


### PR DESCRIPTION
## Problem
Puppetmaster reports a successfully finished durable job with status `complete`, while Marionette’s swarm/live terminal filter recognizes `completed` but not `complete`. After transcript rehydration, that finished job can remain in the local pending set and leave the UI displaying `Still working…` even though the backend has no active work.

## Summary
- treat Puppetmaster status `complete` as terminal during swarm/live pruning
- preserve existing `completed`, failed, cancelled, and done handling
- prevent completed jobs from rehydrating into persistent `Still working…` chrome

## Verification
- `npm test -- --run src/__tests__/swarmAwaitChrome.test.ts` — 19 passed
- `npm run build` passed
- independent Sol review passed with no findings or risks