### PR TITLE
fix: treat timed-out swarm jobs as terminal

### DIFF
--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -559,6 +559,35 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
     expect(screen.queryByText("cancelled")).not.toBeInTheDocument();
   });
 
+  it("moves timed-out jobs into Finished with failed worker chrome", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-timeout",
+        goal: "Timed-out command",
+        status: "timeout",
+        adapter: "command",
+        tasks: [
+          {
+            id: "job-timeout-w0",
+            status: "timeout",
+            role: "command",
+            instruction: "pytest",
+            adapter: "command",
+          },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    expect(screen.getByText(/1 failed/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Timed-out command"));
+    expect(screen.getByText("1/1 · 1 failed")).toBeInTheDocument();
+    expect(screen.getByTitle("Dismiss from tracker (stays in Puppetmaster history)")).toBeInTheDocument();
+  });
+
   it("keeps dead_run_failure authoritative as failed chrome", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -102,6 +102,10 @@ function looksLikePromptEcho(headline: string): boolean {
   return /^(Role\s*:|Goal\s*:|Return\s+only\b)/i.test(text);
 }
 
+function isTimeoutStatus(status: string): boolean {
+  return /time(?:d)?[-_ ]?out/.test(status);
+}
+
 function jobStatus(j: Job): Status {
   const s = (j.status || "").toLowerCase();
   if (s.includes("complete") || s.includes("done")) return "completed";
@@ -118,6 +122,7 @@ function jobStatus(j: Job): Status {
     || s.includes("error")
     || s.includes("stall")
     || s.includes("dead")
+    || isTimeoutStatus(s)
   ) {
     return "failed";
   }
@@ -137,7 +142,12 @@ function taskState(t: Task): "running" | "done" | "fail" | "idle" {
   const s = (t.status || "").toLowerCase();
   if (s.includes("run") || s.includes("progress") || s.includes("active")) return "running";
   if (s.includes("complete") || s.includes("done")) return "done";
-  if (s.includes("fail") || s.includes("cancel") || s.includes("error")) return "fail";
+  if (
+    s.includes("fail")
+    || s.includes("cancel")
+    || s.includes("error")
+    || isTimeoutStatus(s)
+  ) return "fail";
   return "idle";
 }
 


### PR DESCRIPTION
## Problem
The Swarm Tracker does not recognize raw job/task status `timeout` as terminal. Timed-out local command jobs fall through to pending/idle, remain pinned above Finished despite no running process, and expose neither Cancel nor Dismiss/Clear controls.

Live reproduction showed two timeout rows while the backend was idle:

```text
local-cmd-0765e00e: timeout
local-cmd-707e0d99: timeout
pending_swarms: false
worker processes: none
```

## Summary
- classify `timeout`, `timed-out`, `timed_out`, and `timed out` as failed terminal statuses
- apply the same classification to worker task progress
- move timed-out rows into Finished so Dismiss and bulk Clear work while preserving PM history

## Verification
- RED rendered a timeout job as pending with no Finished section
- `npm test -- --run src/__tests__/SwarmPane.test.tsx` — 43 passed
- `npm run build` passed
- live tracker recomputation: 27 terminal jobs, 0 non-terminal
- independent Sol review passed with no findings or risks

Closes #3