### PR TITLE
Document the dev-then-main git flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ Ownership rule: new pilot tools -> `pilot.py` schema + `tool_dispatch` /
   installers, but do not rely on it -- check first, tag second. Local tests
   pass on the dev interpreter only; CI is what proves the 3.9 floor.
 - Never commit keys or `results/*.sqlite`.
+- Git flow: day-to-day work is on `dev`. Feature PRs target `dev`. Ship by
+  merging `dev` into `main`, waiting for `tests` CI green on that SHA, then
+  tagging `main`. Never push product work or `pmedit-*` worker branches to
+  `main` / origin scratch.
 
 <!-- puppetmaster:rules:begin -->
 <!-- managed by `puppetmaster install-rules`; delete this whole block to disable -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ runs from source.
 
 ## Workflow
 
-1. Branch off `main`: `git checkout -b fix/<short-name>`.
+1. Branch off `dev`: `git checkout -b fix/<short-name>`.
 2. Make the change. Add/adjust tests -- behavioral changes need a test.
 3. Run `.venv/bin/python -m pytest -q` and `cd webapp && npm run build` locally.
    When touching full-auto / command policy / SSE reattach / tool-pair repair,
@@ -55,8 +55,7 @@ runs from source.
    `.venv/bin/python -m pytest -q -m full_auto_safety`
    (AutoBudget, command policy/approvals, tool-pair sanitizer, SSE ring-miss,
    stub deterministic eval — no live keys).
-4. Open a PR against `main`. CI runs the same pytest matrix + frontend build +
-   the `full-auto-safety` marker job and must pass before merge.
+4. Open a PR against `dev`. Day-to-day work does not land on `main`.
 5. Keep commits scoped: don't fold unrelated work into one commit. A release
    commit is its own commit.
 
@@ -64,14 +63,15 @@ runs from source.
 
 Marionette self-updates from git, Hermes-style: every source checkout tracks
 `main` and shows an `update (N)` pill when it's behind, then pulls + rebuilds +
-relaunches in place. So **merging a green PR to `main` ships your change to every
-source install** on their next relaunch. Tagged releases also rebuild the thin
-Electron installers (macOS, Windows, Linux) via CI; those users pick up changes
-after bootstrap + update or by installing a newer Release.
+relaunches in place. So **merging `dev` into `main` (green `tests` CI on that
+SHA) ships your change to every source install** on their next relaunch. Tagged
+releases also rebuild the thin Electron installers (macOS, Windows, Linux) via
+CI; those users pick up changes after bootstrap + update or by installing a
+newer Release.
 
 Keep `main` releasable: it must build (`npm run build`) and pass CI, because a
 red `main` is what everyone's checkout tries to pull. The updater fast-forwards
-only, so never force-push `main`.
+only, so never force-push `main`. Never push `pmedit-*` worker branches to origin.
 
 ## Releases
 


### PR DESCRIPTION
## What
Document day-to-day work on `dev` and shipping via PR into `main`, so contributors and agents stop landing product commits (and `pmedit-*` scratch) on `main`.

`AGENTS.md` is the public agent contract in the repo (not local). `.cursor/` stays gitignored. This is docs-only; v0.9.211 already shipped from `main` at `01c9f61`.

## How verified
- [x] N/A pytest (markdown only)
- [x] N/A webapp build
- [x] Behavioral change has a test (or N/A with reason): N/A, documentation

## Notes
Branch rulesets on `main`/`dev`/`pmedit-*`/`v*` are already Active. This is the first PR under that protection.