### PR TITLE
Release v0.9.212: OpenAI GPT-5 Chat Completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Internal-first research rig and daily-driver app. stdlib-only backend (urllib +
 sqlite); Puppetmaster is the one real dependency, installed editable from a local
 checkout.
 
-> Status: v0.9.211, deliberately pre-1.0. Tracker timeout/truncated/interrupted jobs finish instead of pinning above the fold, reload no longer ghosts Still working, stacked right-pane cards split vertically, and Investigating clears after an idle runner; rides puppetmaster-ai==1.22.2.
+> Status: v0.9.212, deliberately pre-1.0. Direct OpenAI GPT-5 Chat Completions uses `max_completion_tokens`, omits custom temperature, and keeps tool calls free of competing reasoning fields; rides puppetmaster-ai==1.22.2.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.211"
+__version__ = "0.9.212"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pmharness/drivers/openai_compat.py
+++ b/pmharness/drivers/openai_compat.py
@@ -80,6 +80,24 @@ class OpenAICompatDriver:
             raise RuntimeError(f"missing API key in env var {self.api_key_env}")
         return key
 
+    def _uses_openai_gpt5_chat_parameters(self) -> bool:
+        return (
+            self.base_url == "https://api.openai.com/v1"
+            and self.model.lower().startswith("gpt-5")
+        )
+
+    def _output_token_limit_field(self) -> str:
+        """Return the Chat Completions output-limit field for this endpoint/model."""
+        return (
+            "max_completion_tokens"
+            if self._uses_openai_gpt5_chat_parameters()
+            else "max_tokens"
+        )
+
+    def _apply_temperature(self, body: dict) -> None:
+        if not self._uses_openai_gpt5_chat_parameters():
+            body["temperature"] = self.temperature
+
     def _pool_rotate_backoff(
         self,
         code: int,
@@ -317,9 +335,9 @@ class OpenAICompatDriver:
                 {"role": "system", "content": system},
                 {"role": "user", "content": task_prompt},
             ],
-            "temperature": self.temperature,
-            "max_tokens": self.max_tokens,
+            self._output_token_limit_field(): self.max_tokens,
         }
+        self._apply_temperature(body)
         self._prepare_body(
             body,
             messages=body["messages"],
@@ -418,14 +436,18 @@ class OpenAICompatDriver:
         body = {
             "model": self.model,
             "messages": full_messages,
-            "temperature": self.temperature,
-            "max_tokens": self.max_tokens,
+            self._output_token_limit_field(): self.max_tokens,
         }
-        if self.enable_reasoning:
+        self._apply_temperature(body)
+        if self.enable_reasoning and not (
+            tools and self._uses_openai_gpt5_chat_parameters()
+        ):
             body["reasoning"] = {"max_tokens": 1024}
         if tools:
             body["tools"] = tools
             body["tool_choice"] = "auto"
+            if self._uses_openai_gpt5_chat_parameters():
+                body["reasoning_effort"] = "none"
         self._prepare_body(
             body,
             messages=full_messages,
@@ -585,16 +607,20 @@ class OpenAICompatDriver:
         body = {
             "model": self.model,
             "messages": full_messages,
-            "temperature": self.temperature,
-            "max_tokens": self.max_tokens,
+            self._output_token_limit_field(): self.max_tokens,
             "stream": True,
             "stream_options": {"include_usage": True},
         }
-        if self.enable_reasoning:
+        self._apply_temperature(body)
+        if self.enable_reasoning and not (
+            tools and self._uses_openai_gpt5_chat_parameters()
+        ):
             body["reasoning"] = {"max_tokens": 1024}
         if tools:
             body["tools"] = tools
             body["tool_choice"] = "auto"
+            if self._uses_openai_gpt5_chat_parameters():
+                body["reasoning_effort"] = "none"
         self._prepare_body(
             body,
             messages=full_messages,

--- a/pmharness/drivers/openai_compat.py
+++ b/pmharness/drivers/openai_compat.py
@@ -98,6 +98,23 @@ class OpenAICompatDriver:
         if not self._uses_openai_gpt5_chat_parameters():
             body["temperature"] = self.temperature
 
+    def _apply_openai_gpt5_chat_constraints(self, body: dict) -> None:
+        """Keep direct OpenAI GPT-5 Chat Completions on fields the API accepts.
+
+        extra_body is applied first and can reintroduce legacy OpenAI /
+        OpenRouter knobs (temperature, max_tokens, reasoning). Strip those
+        after the merge so a GPT-5 request cannot 400 on rejected fields.
+        """
+        if not self._uses_openai_gpt5_chat_parameters() or not isinstance(body, dict):
+            return
+        body.pop("temperature", None)
+        limit = body.pop("max_tokens", None)
+        if limit is not None:
+            body.setdefault("max_completion_tokens", limit)
+        body.pop("reasoning", None)
+        if body.get("tools"):
+            body["reasoning_effort"] = "none"
+
     def _pool_rotate_backoff(
         self,
         code: int,
@@ -198,6 +215,7 @@ class OpenAICompatDriver:
             )
         except Exception:
             pass
+        self._apply_openai_gpt5_chat_constraints(body)
         return body
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.211"
+version = "0.9.212"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_provider_cache_usage_normalization.py
+++ b/tests/test_provider_cache_usage_normalization.py
@@ -155,6 +155,130 @@ def _fake_json_response(payload: dict):
     return FakeResponse()
 
 
+def _capturing_openai_response(monkeypatch, captured):
+    def mock_urlopen(req, timeout=None):
+        captured.update(json.loads(req.data.decode("utf-8")))
+        return _fake_json_response({
+            "choices": [{
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        })
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+
+def _capturing_openai_stream(monkeypatch, captured):
+    sse = (
+        'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}\n\n'
+        'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1}}\n\n'
+        "data: [DONE]\n\n"
+    )
+
+    class FakeStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def __iter__(self):
+            for line in sse.splitlines(keepends=True):
+                yield line.encode("utf-8")
+
+    def mock_urlopen(req, timeout=None):
+        captured.update(json.loads(req.data.decode("utf-8")))
+        return FakeStream()
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+
+def test_openai_compat_gpt_5_uses_max_completion_tokens(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="openai:gpt-5.6-luna",
+        model="gpt-5.6-luna",
+        base_url="https://api.openai.com/v1",
+        api_key_env="OPENAI_API_KEY",
+        max_tokens=8000,
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_response(monkeypatch, captured)
+
+    response = driver.complete("hi", system="sys")
+
+    assert response.error is None
+    assert captured["max_completion_tokens"] == 8000
+    assert "max_tokens" not in captured
+    assert "temperature" not in captured
+
+
+def test_openai_compat_gpt_5_tools_disable_reasoning_effort(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="openai:gpt-5.6-luna",
+        model="gpt-5.6-luna",
+        base_url="https://api.openai.com/v1",
+        api_key_env="OPENAI_API_KEY",
+        enable_reasoning=True,
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_response(monkeypatch, captured)
+
+    response = driver.chat(
+        [{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "noop", "parameters": {}}}],
+    )
+
+    assert response.error is None
+    assert captured["reasoning_effort"] == "none"
+    assert "reasoning" not in captured
+
+
+def test_openai_compat_gpt_5_streaming_tools_disable_reasoning_effort(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="openai:gpt-5.6-luna",
+        model="gpt-5.6-luna",
+        base_url="https://api.openai.com/v1",
+        api_key_env="OPENAI_API_KEY",
+        enable_reasoning=True,
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_stream(monkeypatch, captured)
+
+    response = driver.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "noop", "parameters": {}}}],
+        on_delta=lambda _text: None,
+    )
+
+    assert response.error is None
+    assert captured["reasoning_effort"] == "none"
+    assert "reasoning" not in captured
+
+
+def test_openai_compat_legacy_provider_keeps_max_tokens(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="legacy:model",
+        model="legacy-model",
+        base_url="https://api.example.com/v1",
+        api_key_env="LEGACY_API_KEY",
+        max_tokens=1500,
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_response(monkeypatch, captured)
+
+    response = driver.complete("hi", system="sys")
+
+    assert response.error is None
+    assert captured["max_tokens"] == 1500
+    assert "max_completion_tokens" not in captured
+    assert captured["temperature"] == 0.0
+
+
 def test_openai_compat_usage_meta_reads_alias_shapes(monkeypatch):
     driver = OpenAICompatDriver(
         name="openai-test",

--- a/tests/test_provider_cache_usage_normalization.py
+++ b/tests/test_provider_cache_usage_normalization.py
@@ -259,6 +259,74 @@ def test_openai_compat_gpt_5_streaming_tools_disable_reasoning_effort(monkeypatc
     assert "reasoning" not in captured
 
 
+def test_openai_compat_gpt_5_extra_body_cannot_reintroduce_rejected_fields(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="openai:gpt-5.6-luna",
+        model="gpt-5.6-luna",
+        base_url="https://api.openai.com/v1",
+        api_key_env="OPENAI_API_KEY",
+        max_tokens=8000,
+        extra_body={
+            "temperature": 0.2,
+            "max_tokens": 99,
+            "reasoning": {"max_tokens": 1024},
+        },
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_response(monkeypatch, captured)
+
+    response = driver.complete("hi", system="sys")
+
+    assert response.error is None
+    assert captured["max_completion_tokens"] == 8000
+    assert "max_tokens" not in captured
+    assert "temperature" not in captured
+    assert "reasoning" not in captured
+
+
+def test_openai_compat_gpt_5_omits_openrouter_reasoning_without_tools(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="openai:gpt-5.6-luna",
+        model="gpt-5.6-luna",
+        base_url="https://api.openai.com/v1",
+        api_key_env="OPENAI_API_KEY",
+        enable_reasoning=True,
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_response(monkeypatch, captured)
+
+    response = driver.chat([{"role": "user", "content": "hi"}])
+
+    assert response.error is None
+    assert "reasoning" not in captured
+    assert "reasoning_effort" not in captured
+
+
+def test_openai_compat_gpt_5_tools_keep_reasoning_effort_none_after_extra_body(monkeypatch):
+    driver = OpenAICompatDriver(
+        name="openai:gpt-5.6-luna",
+        model="gpt-5.6-luna",
+        base_url="https://api.openai.com/v1",
+        api_key_env="OPENAI_API_KEY",
+        extra_body={"reasoning_effort": "high", "temperature": 0.2},
+    )
+    driver._key = lambda: "fake-key"
+    captured = {}
+    _capturing_openai_response(monkeypatch, captured)
+
+    response = driver.chat(
+        [{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "noop", "parameters": {}}}],
+    )
+
+    assert response.error is None
+    assert captured["reasoning_effort"] == "none"
+    assert "temperature" not in captured
+    assert "reasoning" not in captured
+
+
 def test_openai_compat_legacy_provider_keeps_max_tokens(monkeypatch):
     driver = OpenAICompatDriver(
         name="legacy:model",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.211",
+  "version": "0.9.212",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.211",
+      "version": "0.9.212",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.211",
+  "version": "0.9.212",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/swarmAwaitChrome.test.ts
+++ b/webapp/src/__tests__/swarmAwaitChrome.test.ts
@@ -260,6 +260,7 @@ describe("swarm await chrome", () => {
       pendingJobIdsFromSwarmLive([
         { job_id: "job_alive", status: "running" },
         { job_id: "job_done", status: "completed" },
+        { job_id: "job_complete", status: "complete" },
         { id: "local-swarm-skip", status: "pending" },
         { job_id: "job_queued", status: "queued" },
       ]),
@@ -474,12 +475,13 @@ describe("swarm await chrome", () => {
     expect(
       terminalJobIdsFromSwarmLive([
         { job_id: "job_done", status: "completed" },
+        { job_id: "job_complete", status: "complete" },
         { job_id: "job_alive", status: "running" },
         { id: "local-x", status: "failed" },
         { job_id: "job_cancel", status: "cancelled" },
         { job_id: "job_interrupted", status: "interrupted" },
       ]),
-    ).toEqual(["job_done", "local-x", "job_cancel", "job_interrupted"]);
+    ).toEqual(["job_done", "job_complete", "local-x", "job_cancel", "job_interrupted"]);
     expect(
       pruneTerminalJobIds(
         ["job_done", "job_alive", "local-x"],


### PR DESCRIPTION
## Summary
- Direct OpenAI GPT-5 Chat Completions uses `max_completion_tokens`, omits custom temperature, and keeps tool calls on `reasoning_effort: none` (contributor PR #1).
- Re-apply those constraints after `extra_body` so OpenRouter-style knobs cannot 400 the request; drop the OpenRouter `reasoning` object on tool-less GPT-5 chats.
- Lock Puppetmaster status `complete` as a terminal swarm-await alias (PR #2 was already superseded in tree).

## Test plan
- [x] Local pytest: 4150 passed, 79 skipped
- [x] `tests/test_version_consistency.py` green at 0.9.212
- [x] vitest `swarmAwaitChrome.test.ts` 21 passed
- [ ] CI `tests` workflow green on this PR (3.9 + 3.11 + frontend-build)