### PR TITLE
Fix duplicate swarm tracker cards with dispatch identity

### DIFF
--- a/harness/api/jobs.py
+++ b/harness/api/jobs.py
@@ -195,6 +195,7 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
         apply_job_economics_policy,
         annotate_job_accounting,
         filter_local_jobs,
+        parse_job_dispatch_id,
         parse_job_session_id,
         resolve_job_model,
     )
@@ -525,6 +526,7 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
                 "tasks": tasks_list,
                 "source": j.get("source", "harness"),
                 "label": j.get("label"),
+                "dispatch_id": parse_job_dispatch_id(j.get("label")),
                 "session_id": j.get("session_id") or parse_job_session_id(j.get("label"), []),
                 "accounting_scope": j.get("accounting_scope", "visibility_only"),
                 "accounting_owned": bool(j.get("accounting_owned")),

--- a/harness/job_scoping.py
+++ b/harness/job_scoping.py
@@ -51,12 +51,15 @@ def job_label_for_session(
     *,
     app_run_id: str = "",
     origin: str = "marionette",
+    dispatch_id: str = "",
 ) -> Optional[str]:
     """JSON job label carrying session + Marionette provenance for dispatch."""
     sid = (session_id or "").strip()
     if not sid:
         return None
     data: dict[str, str] = {"session_id": sid}
+    if dispatch_id:
+        data["dispatch_id"] = str(dispatch_id).strip()
     if origin:
         data["origin"] = str(origin)
     run_id = (app_run_id or current_app_run_id()).strip()
@@ -152,6 +155,11 @@ def parse_job_session_id(label: Any, tasks: list) -> str:
         if sid:
             return str(sid)
     return ""
+
+
+def parse_job_dispatch_id(label: Any) -> str:
+    """Extract the host dispatch identity stamped before PM starts workers."""
+    return str(_parse_label_dict(label).get("dispatch_id") or "").strip()
 
 
 def _norm_path(path: str) -> str:

--- a/harness/local_job_swarm_view.py
+++ b/harness/local_job_swarm_view.py
@@ -236,12 +236,19 @@ def merge_local_jobs_into_swarm_live(
     store_jobs: Iterable[dict],
     local_jobs: Iterable[dict],
 ) -> list[dict]:
-    """Append projected local rows without duplicating store job ids."""
+    """Merge local rows while durable store identities remain authoritative."""
     out = list(store_jobs or [])
     existing_ids = {j.get("id") for j in out if j.get("id")}
+    replaced_local_ids = {
+        f"local-swarm-{str(job.get('dispatch_id') or '').strip()}"
+        for job in out
+        if isinstance(job, dict)
+        and str(job.get("id") or "").startswith("job_")
+        and str(job.get("dispatch_id") or "").strip()
+    }
     for job in local_jobs or []:
         jid = job.get("id") if isinstance(job, dict) else None
-        if not jid or jid in existing_ids:
+        if not jid or jid in existing_ids or jid in replaced_local_ids:
             continue
         out.append(project_local_job_for_swarm_live(job))
         existing_ids.add(jid)

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -506,7 +506,11 @@ Yields the same ConvEvent stream. Generator return value is ``None``
     import queue as _queue
     import threading as _threading
     _delta_q: '_queue.Queue' = _queue.Queue()
-    _swarm_thread = _threading.Thread(target=stream_swarm, args=(session, intent, _delta_q), daemon=True)
+    _swarm_thread = _threading.Thread(
+        target=stream_swarm,
+        args=(session, intent, _delta_q, aid),
+        daemon=True,
+    )
     _swarm_thread.start()
     result = None
     swarm_error = None
@@ -718,24 +722,6 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         if _store_jid != _sync_local_id:
             if _store_jid not in session._session_job_ids:
                 session._session_job_ids.append(_store_jid)
-            session._register_local_job(
-                _store_jid, act.goal, role=_sync_register_role,
-                cwd=_swarm_repo, engine=_job_engine,
-                model=_job_model,
-            )
-            session._finish_local_job(
-                _store_jid, ok=_swarm_ok, summary=_badge_summary,
-                status='done' if _swarm_ok else 'failed', engine=_job_engine,
-                model=_job_model,
-                findings=_job_findings,
-                reuse_status=_finish_reuse_status if _swarm_ok else '',
-                source_job_id=_finish_source_job,
-                invalidated_paths=_finish_invalidated,
-                reuse_reason=_finish_reuse_reason,
-                validation_fingerprint=_finish_fingerprint,
-                environment_fingerprint=_finish_env_fingerprint,
-                acceptance_criteria=list(_finish_criteria),
-            )
     except Exception:
         pass
     session._display_transcript.append({'type': 'swarm_result', **_badge})

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -273,6 +273,7 @@ def stream_swarm(
     session: Any,
     intent: Any,
     delta_q: Any,
+    dispatch_id: str = "",
 ) -> None:
     """Background target: execute_intent with on_delta → delta_q (delta/done/error).
 
@@ -291,6 +292,7 @@ def stream_swarm(
             intent,
             state_dir=session.state_dir,
             session_id=session.harness_session_id or "",
+            dispatch_id=dispatch_id,
             cwd=_cwd,
             repo=_cwd,
             on_delta=lambda wid, kind, text: delta_q.put(

--- a/pmharness/bridge.py
+++ b/pmharness/bridge.py
@@ -1394,6 +1394,7 @@ def execute_intent(
     worker_mode: Optional[str] = None,
     on_delta: Optional[Callable[[str, str, str], None]] = None,
     session_id: Optional[str] = None,
+    dispatch_id: Optional[str] = None,
     cwd: Optional[str] = None,
     repo: Optional[str] = None,
 ) -> Optional[BridgeResult]:
@@ -1432,7 +1433,9 @@ def execute_intent(
     _clear_delta_sink = _install_delta_sink(on_delta)
     tmp = state_dir or tempfile.mkdtemp(prefix="pmh-exec-")
     store = create_store("sqlite", tmp)
-    job_label = job_label_for_session(session_id or "")
+    job_label = job_label_for_session(
+        session_id or "", dispatch_id=dispatch_id or "",
+    )
 
     # Explicit per-runner cwd wins over the process-wide HARNESS_REPO view pointer.
     # Resolve at this seam so callers that forget resolve_effective_repo still

--- a/tests/test_local_job_swarm_view.py
+++ b/tests/test_local_job_swarm_view.py
@@ -184,6 +184,64 @@ def test_merge_skips_duplicate_store_ids():
     assert merged[0]["goal"] == "store wins"
 
 
+def test_merge_replaces_placeholder_by_exact_dispatch_identity():
+    store = [{
+        "id": "job_durable",
+        "goal": "Durable PM goal may be normalized",
+        "status": "running",
+        "dispatch_id": "call_abc",
+        "created_at": "2030-01-01T00:00:00+00:00",
+    }]
+    local = [_sample_local_job(
+        id="local-swarm-call_abc",
+        goal="Original pilot goal",
+        created_at=1_700_000_000.0,
+    )]
+
+    merged = merge_local_jobs_into_swarm_live(store, local)
+
+    assert [job["id"] for job in merged] == ["job_durable"]
+
+
+def test_merge_keeps_identical_goal_with_different_dispatch_identity():
+    store = [{
+        "id": "job_first",
+        "goal": "Run one PM smoke test",
+        "status": "running",
+        "dispatch_id": "call_first",
+    }]
+    local = [_sample_local_job(
+        id="local-swarm-call_second",
+        goal="Run one PM smoke test",
+    )]
+
+    merged = merge_local_jobs_into_swarm_live(store, local)
+
+    assert [job["id"] for job in merged] == [
+        "job_first",
+        "local-swarm-call_second",
+    ]
+
+
+def test_merge_keeps_placeholder_when_durable_dispatch_identity_is_missing():
+    store = [{
+        "id": "job_legacy",
+        "goal": "Run one PM smoke test",
+        "status": "running",
+    }]
+    local = [_sample_local_job(
+        id="local-swarm-call_legacy",
+        goal="Run one PM smoke test",
+    )]
+
+    merged = merge_local_jobs_into_swarm_live(store, local)
+
+    assert [job["id"] for job in merged] == [
+        "job_legacy",
+        "local-swarm-call_legacy",
+    ]
+
+
 def test_merge_appends_unique_local_rows():
     store = [{"id": "job-store", "goal": "store", "status": "complete"}]
     local = [

--- a/tests/test_send_loop_dispatch.py
+++ b/tests/test_send_loop_dispatch.py
@@ -239,7 +239,7 @@ def test_dispatch_swarm_registers_and_surfaces_error(monkeypatch):
 
     monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda *_a, **_k: None)
 
-    def boom(session, intent, q):
+    def boom(session, intent, q, _dispatch_id):
         q.put(("error", RuntimeError("stream failed")))
 
     original = dispatch.stream_swarm
@@ -302,7 +302,7 @@ def test_dispatch_swarm_registers_resolved_git_child(tmp_path):
     )
     import harness.send_loop_dispatch as dispatch
 
-    def boom(session, intent, q):
+    def boom(session, intent, q, _dispatch_id):
         q.put(("error", RuntimeError("stream failed")))
 
     original = dispatch.stream_swarm
@@ -532,7 +532,7 @@ def test_dispatch_swarm_demo_never_shown(monkeypatch):
         summary="demo",
     )
 
-    def fake_stream(session, intent, q):
+    def fake_stream(session, intent, q, _dispatch_id):
         q.put(("done", demo_result))
 
     monkeypatch.setattr(dispatch, "stream_swarm", fake_stream)
@@ -557,6 +557,7 @@ def test_dispatch_swarm_demo_never_shown(monkeypatch):
     assert badge["applied"] is False
     assert badge.get("adapter") == "refused-demo"
     assert "demo substrate" in (badge.get("error") or "")
+    assert session._register_local_job.call_count == 1
     session._finish_local_job.assert_called()
     finish_kwargs = session._finish_local_job.call_args.kwargs
     assert finish_kwargs.get("ok") is False or finish_kwargs.get("status") == "failed"

--- a/tests/test_send_loop_phases.py
+++ b/tests/test_send_loop_phases.py
@@ -250,8 +250,10 @@ def test_run_prefetch_handler_exception_surfaces_as_tuple():
 def test_stream_swarm_puts_done_and_forwards_deltas(monkeypatch):
     q: queue.Queue = queue.Queue()
     result = SimpleNamespace(job_id="job_abc123def456")
+    seen: dict = {}
 
     def fake_execute(intent, **kwargs):
+        seen.update(kwargs)
         kwargs["on_delta"]("w1", "text", "hi")
         return result
 
@@ -263,9 +265,12 @@ def test_stream_swarm_puts_done_and_forwards_deltas(monkeypatch):
         harness_session_id="sess",
         config=SimpleNamespace(repo="/repo"),
     )
-    stream_swarm(session, intent=SimpleNamespace(), delta_q=q)
+    stream_swarm(
+        session, intent=SimpleNamespace(), delta_q=q, dispatch_id="call_abc",
+    )
     assert q.get_nowait() == ("delta", ("w1", "text", "hi"))
     assert q.get_nowait() == ("done", result)
+    assert seen["dispatch_id"] == "call_abc"
 
 
 def test_stream_swarm_passes_resolved_git_child_cwd(monkeypatch, tmp_path):

--- a/tests/test_session_job_scoping.py
+++ b/tests/test_session_job_scoping.py
@@ -75,6 +75,15 @@ def test_job_label_roundtrip():
     assert parse_job_session_id(label, []) == "sess-a"
 
 
+def test_job_label_roundtrips_dispatch_identity():
+    from harness.job_scoping import parse_job_dispatch_id
+
+    label = job_label_for_session("sess-a", dispatch_id="call_abc")
+
+    assert json.loads(label)["dispatch_id"] == "call_abc"
+    assert parse_job_dispatch_id(label) == "call_abc"
+
+
 def test_legacy_job_visible_only_in_matching_repo():
     tasks = [SimpleNamespace(payload={"cwd": "/work/a/project"})]
     assert job_visible_for_view(


### PR DESCRIPTION
## Problem
A single `run_swarm` dispatch can appear as two Swarm Tracker cards while it is running:

- a provisional `local-swarm-<action-id>` card registered by Marionette;
- the authoritative durable Puppetmaster `job_*` card.

The completion path also registered the durable job a second time in Marionette’s local sidecar. Because the tracker previously reconciled only identical row IDs, both lifecycle identities remained visible and could show conflicting worker counts or statuses.

## Changes
- reuse the existing action ID as an explicit `dispatch_id`;
- stamp `dispatch_id` into the existing JSON PM job label before workers start;
- project it through `/api/swarm/live`;
- replace only the exact `local-swarm-<dispatch_id>` placeholder when its durable job appears;
- delete the duplicate durable-job registration from Marionette’s local sidecar;
- fail safe for legacy jobs without dispatch identity;
- keep simultaneous identical goals separate when their dispatch IDs differ.

No timestamp window or goal-text heuristic is used.

## Verification
- 8 focused dispatch/label/merge tests passed in 0.20s;
- pinned `puppetmaster-ai==1.22.2` running-state simulation returned `RUNNING_DEDUP_OK`;
- `py_compile` passed for changed Python files;
- `git diff --check` passed;
- focused security scan found no hardcoded secrets, shell injection, dangerous eval/exec, or unsafe pickle use.

The branch is based on current `dev` (`v0.9.212`).