### PR TITLE
Release v0.9.213: one Swarm Tracker card per run_swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Internal-first research rig and daily-driver app. stdlib-only backend (urllib +
 sqlite); Puppetmaster is the one real dependency, installed editable from a local
 checkout.
 
-> Status: v0.9.212, deliberately pre-1.0. Direct OpenAI GPT-5 Chat Completions uses `max_completion_tokens`, omits custom temperature, and keeps tool calls free of competing reasoning fields; rides puppetmaster-ai==1.22.2.
+> Status: v0.9.213, deliberately pre-1.0. A single `run_swarm` dispatch is one Swarm Tracker card: the durable Puppetmaster `job_*` replaces the provisional `local-swarm-<action-id>` placeholder by explicit `dispatch_id`; rides puppetmaster-ai==1.22.2.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.212"
+__version__ = "0.9.213"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/jobs.py
+++ b/harness/api/jobs.py
@@ -195,6 +195,7 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
         apply_job_economics_policy,
         annotate_job_accounting,
         filter_local_jobs,
+        parse_job_dispatch_id,
         parse_job_session_id,
         resolve_job_model,
     )
@@ -525,6 +526,7 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
                 "tasks": tasks_list,
                 "source": j.get("source", "harness"),
                 "label": j.get("label"),
+                "dispatch_id": parse_job_dispatch_id(j.get("label")),
                 "session_id": j.get("session_id") or parse_job_session_id(j.get("label"), []),
                 "accounting_scope": j.get("accounting_scope", "visibility_only"),
                 "accounting_owned": bool(j.get("accounting_owned")),

--- a/harness/job_scoping.py
+++ b/harness/job_scoping.py
@@ -51,12 +51,15 @@ def job_label_for_session(
     *,
     app_run_id: str = "",
     origin: str = "marionette",
+    dispatch_id: str = "",
 ) -> Optional[str]:
     """JSON job label carrying session + Marionette provenance for dispatch."""
     sid = (session_id or "").strip()
     if not sid:
         return None
     data: dict[str, str] = {"session_id": sid}
+    if dispatch_id:
+        data["dispatch_id"] = str(dispatch_id).strip()
     if origin:
         data["origin"] = str(origin)
     run_id = (app_run_id or current_app_run_id()).strip()
@@ -152,6 +155,11 @@ def parse_job_session_id(label: Any, tasks: list) -> str:
         if sid:
             return str(sid)
     return ""
+
+
+def parse_job_dispatch_id(label: Any) -> str:
+    """Extract the host dispatch identity stamped before PM starts workers."""
+    return str(_parse_label_dict(label).get("dispatch_id") or "").strip()
 
 
 def _norm_path(path: str) -> str:

--- a/harness/local_job_swarm_view.py
+++ b/harness/local_job_swarm_view.py
@@ -236,12 +236,19 @@ def merge_local_jobs_into_swarm_live(
     store_jobs: Iterable[dict],
     local_jobs: Iterable[dict],
 ) -> list[dict]:
-    """Append projected local rows without duplicating store job ids."""
+    """Merge local rows while durable store identities remain authoritative."""
     out = list(store_jobs or [])
     existing_ids = {j.get("id") for j in out if j.get("id")}
+    replaced_local_ids = {
+        f"local-swarm-{str(job.get('dispatch_id') or '').strip()}"
+        for job in out
+        if isinstance(job, dict)
+        and str(job.get("id") or "").startswith("job_")
+        and str(job.get("dispatch_id") or "").strip()
+    }
     for job in local_jobs or []:
         jid = job.get("id") if isinstance(job, dict) else None
-        if not jid or jid in existing_ids:
+        if not jid or jid in existing_ids or jid in replaced_local_ids:
             continue
         out.append(project_local_job_for_swarm_live(job))
         existing_ids.add(jid)

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -506,7 +506,11 @@ Yields the same ConvEvent stream. Generator return value is ``None``
     import queue as _queue
     import threading as _threading
     _delta_q: '_queue.Queue' = _queue.Queue()
-    _swarm_thread = _threading.Thread(target=stream_swarm, args=(session, intent, _delta_q), daemon=True)
+    _swarm_thread = _threading.Thread(
+        target=stream_swarm,
+        args=(session, intent, _delta_q, aid),
+        daemon=True,
+    )
     _swarm_thread.start()
     result = None
     swarm_error = None
@@ -718,24 +722,6 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         if _store_jid != _sync_local_id:
             if _store_jid not in session._session_job_ids:
                 session._session_job_ids.append(_store_jid)
-            session._register_local_job(
-                _store_jid, act.goal, role=_sync_register_role,
-                cwd=_swarm_repo, engine=_job_engine,
-                model=_job_model,
-            )
-            session._finish_local_job(
-                _store_jid, ok=_swarm_ok, summary=_badge_summary,
-                status='done' if _swarm_ok else 'failed', engine=_job_engine,
-                model=_job_model,
-                findings=_job_findings,
-                reuse_status=_finish_reuse_status if _swarm_ok else '',
-                source_job_id=_finish_source_job,
-                invalidated_paths=_finish_invalidated,
-                reuse_reason=_finish_reuse_reason,
-                validation_fingerprint=_finish_fingerprint,
-                environment_fingerprint=_finish_env_fingerprint,
-                acceptance_criteria=list(_finish_criteria),
-            )
     except Exception:
         pass
     session._display_transcript.append({'type': 'swarm_result', **_badge})

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -273,6 +273,7 @@ def stream_swarm(
     session: Any,
     intent: Any,
     delta_q: Any,
+    dispatch_id: str = "",
 ) -> None:
     """Background target: execute_intent with on_delta → delta_q (delta/done/error).
 
@@ -291,6 +292,7 @@ def stream_swarm(
             intent,
             state_dir=session.state_dir,
             session_id=session.harness_session_id or "",
+            dispatch_id=dispatch_id,
             cwd=_cwd,
             repo=_cwd,
             on_delta=lambda wid, kind, text: delta_q.put(

--- a/pmharness/bridge.py
+++ b/pmharness/bridge.py
@@ -1394,6 +1394,7 @@ def execute_intent(
     worker_mode: Optional[str] = None,
     on_delta: Optional[Callable[[str, str, str], None]] = None,
     session_id: Optional[str] = None,
+    dispatch_id: Optional[str] = None,
     cwd: Optional[str] = None,
     repo: Optional[str] = None,
 ) -> Optional[BridgeResult]:
@@ -1432,7 +1433,9 @@ def execute_intent(
     _clear_delta_sink = _install_delta_sink(on_delta)
     tmp = state_dir or tempfile.mkdtemp(prefix="pmh-exec-")
     store = create_store("sqlite", tmp)
-    job_label = job_label_for_session(session_id or "")
+    job_label = job_label_for_session(
+        session_id or "", dispatch_id=dispatch_id or "",
+    )
 
     # Explicit per-runner cwd wins over the process-wide HARNESS_REPO view pointer.
     # Resolve at this seam so callers that forget resolve_effective_repo still

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.212"
+version = "0.9.213"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_local_job_swarm_view.py
+++ b/tests/test_local_job_swarm_view.py
@@ -184,6 +184,64 @@ def test_merge_skips_duplicate_store_ids():
     assert merged[0]["goal"] == "store wins"
 
 
+def test_merge_replaces_placeholder_by_exact_dispatch_identity():
+    store = [{
+        "id": "job_durable",
+        "goal": "Durable PM goal may be normalized",
+        "status": "running",
+        "dispatch_id": "call_abc",
+        "created_at": "2030-01-01T00:00:00+00:00",
+    }]
+    local = [_sample_local_job(
+        id="local-swarm-call_abc",
+        goal="Original pilot goal",
+        created_at=1_700_000_000.0,
+    )]
+
+    merged = merge_local_jobs_into_swarm_live(store, local)
+
+    assert [job["id"] for job in merged] == ["job_durable"]
+
+
+def test_merge_keeps_identical_goal_with_different_dispatch_identity():
+    store = [{
+        "id": "job_first",
+        "goal": "Run one PM smoke test",
+        "status": "running",
+        "dispatch_id": "call_first",
+    }]
+    local = [_sample_local_job(
+        id="local-swarm-call_second",
+        goal="Run one PM smoke test",
+    )]
+
+    merged = merge_local_jobs_into_swarm_live(store, local)
+
+    assert [job["id"] for job in merged] == [
+        "job_first",
+        "local-swarm-call_second",
+    ]
+
+
+def test_merge_keeps_placeholder_when_durable_dispatch_identity_is_missing():
+    store = [{
+        "id": "job_legacy",
+        "goal": "Run one PM smoke test",
+        "status": "running",
+    }]
+    local = [_sample_local_job(
+        id="local-swarm-call_legacy",
+        goal="Run one PM smoke test",
+    )]
+
+    merged = merge_local_jobs_into_swarm_live(store, local)
+
+    assert [job["id"] for job in merged] == [
+        "job_legacy",
+        "local-swarm-call_legacy",
+    ]
+
+
 def test_merge_appends_unique_local_rows():
     store = [{"id": "job-store", "goal": "store", "status": "complete"}]
     local = [

--- a/tests/test_send_loop_dispatch.py
+++ b/tests/test_send_loop_dispatch.py
@@ -239,7 +239,7 @@ def test_dispatch_swarm_registers_and_surfaces_error(monkeypatch):
 
     monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda *_a, **_k: None)
 
-    def boom(session, intent, q):
+    def boom(session, intent, q, _dispatch_id):
         q.put(("error", RuntimeError("stream failed")))
 
     original = dispatch.stream_swarm
@@ -302,7 +302,7 @@ def test_dispatch_swarm_registers_resolved_git_child(tmp_path):
     )
     import harness.send_loop_dispatch as dispatch
 
-    def boom(session, intent, q):
+    def boom(session, intent, q, _dispatch_id):
         q.put(("error", RuntimeError("stream failed")))
 
     original = dispatch.stream_swarm
@@ -532,7 +532,7 @@ def test_dispatch_swarm_demo_never_shown(monkeypatch):
         summary="demo",
     )
 
-    def fake_stream(session, intent, q):
+    def fake_stream(session, intent, q, _dispatch_id):
         q.put(("done", demo_result))
 
     monkeypatch.setattr(dispatch, "stream_swarm", fake_stream)
@@ -557,6 +557,7 @@ def test_dispatch_swarm_demo_never_shown(monkeypatch):
     assert badge["applied"] is False
     assert badge.get("adapter") == "refused-demo"
     assert "demo substrate" in (badge.get("error") or "")
+    assert session._register_local_job.call_count == 1
     session._finish_local_job.assert_called()
     finish_kwargs = session._finish_local_job.call_args.kwargs
     assert finish_kwargs.get("ok") is False or finish_kwargs.get("status") == "failed"

--- a/tests/test_send_loop_dispatch.py
+++ b/tests/test_send_loop_dispatch.py
@@ -563,6 +563,63 @@ def test_dispatch_swarm_demo_never_shown(monkeypatch):
     assert finish_kwargs.get("ok") is False or finish_kwargs.get("status") == "failed"
 
 
+def test_dispatch_swarm_does_not_register_durable_job_in_sidecar(monkeypatch):
+    """Placeholder local-swarm-<aid> is the only sidecar row; job_* lives in PM."""
+    act = PilotAction(kind="run_swarm", goal="audit routing", roles=["explore"])
+    session = SimpleNamespace(
+        config=SimpleNamespace(repo="/repo"),
+        _session_job_ids=[],
+        _register_local_job=MagicMock(),
+        _finish_local_job=MagicMock(),
+        _append_action_result=MagicMock(),
+        _display_transcript=[],
+    )
+    import harness.send_loop_dispatch as dispatch
+
+    monkeypatch.delenv("HARNESS_ALLOW_DEMO_SWARM", raising=False)
+    monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda *_a, **_k: None)
+
+    result = SimpleNamespace(
+        job_id="job_durable1",
+        adapter="agentic",
+        mode="swarm",
+        artifacts=[{
+            "type": "finding",
+            "headline": "CSRF missing in harness/auth.py:42",
+            "body": "Auth middleware does not check CSRF on POST /api/session.",
+        }],
+        artifact_types=["finding"],
+        num_artifacts=1,
+        auth_failure="",
+        summary="one finding",
+        applied=True,
+        files=[],
+        error=None,
+    )
+
+    def fake_stream(session, intent, q, dispatch_id):
+        assert dispatch_id == "call_abc"
+        q.put(("done", result))
+
+    monkeypatch.setattr(dispatch, "stream_swarm", fake_stream)
+    events = list(
+        dispatch_swarm_action(
+            session,
+            act,
+            "call_abc",
+            True,
+            counters={"swarms": 0, "demo_swarms": 0},
+            turn_findings=[],
+        )
+    )
+    assert any(e.kind == "swarm_result" for e in events)
+    registered = [c.args[0] for c in session._register_local_job.call_args_list]
+    assert registered == ["local-swarm-call_abc"]
+    assert "job_durable1" in session._session_job_ids
+    finished = [c.args[0] for c in session._finish_local_job.call_args_list]
+    assert finished == ["local-swarm-call_abc"]
+
+
 def test_is_untracked_pm_start_tool():
     assert is_untracked_pm_start_tool("puppetmaster_start_cursor_swarm")
     assert is_untracked_pm_start_tool("user-puppetmaster/start_implement")

--- a/tests/test_send_loop_phases.py
+++ b/tests/test_send_loop_phases.py
@@ -250,8 +250,10 @@ def test_run_prefetch_handler_exception_surfaces_as_tuple():
 def test_stream_swarm_puts_done_and_forwards_deltas(monkeypatch):
     q: queue.Queue = queue.Queue()
     result = SimpleNamespace(job_id="job_abc123def456")
+    seen: dict = {}
 
     def fake_execute(intent, **kwargs):
+        seen.update(kwargs)
         kwargs["on_delta"]("w1", "text", "hi")
         return result
 
@@ -263,9 +265,12 @@ def test_stream_swarm_puts_done_and_forwards_deltas(monkeypatch):
         harness_session_id="sess",
         config=SimpleNamespace(repo="/repo"),
     )
-    stream_swarm(session, intent=SimpleNamespace(), delta_q=q)
+    stream_swarm(
+        session, intent=SimpleNamespace(), delta_q=q, dispatch_id="call_abc",
+    )
     assert q.get_nowait() == ("delta", ("w1", "text", "hi"))
     assert q.get_nowait() == ("done", result)
+    assert seen["dispatch_id"] == "call_abc"
 
 
 def test_stream_swarm_passes_resolved_git_child_cwd(monkeypatch, tmp_path):

--- a/tests/test_session_job_scoping.py
+++ b/tests/test_session_job_scoping.py
@@ -75,6 +75,15 @@ def test_job_label_roundtrip():
     assert parse_job_session_id(label, []) == "sess-a"
 
 
+def test_job_label_roundtrips_dispatch_identity():
+    from harness.job_scoping import parse_job_dispatch_id
+
+    label = job_label_for_session("sess-a", dispatch_id="call_abc")
+
+    assert json.loads(label)["dispatch_id"] == "call_abc"
+    assert parse_job_dispatch_id(label) == "call_abc"
+
+
 def test_legacy_job_visible_only_in_matching_repo():
     tasks = [SimpleNamespace(payload={"cwd": "/work/a/project"})]
     assert job_visible_for_view(

--- a/tests/test_swarm_run_facts.py
+++ b/tests/test_swarm_run_facts.py
@@ -727,7 +727,7 @@ class TestSynchronousBoundary:
         monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda *_a, **_k: None)
         monkeypatch.setattr(
             dispatch, "stream_swarm",
-            lambda session, intent, q: q.put(("done", result)),
+            lambda session, intent, q, *_a: q.put(("done", result)),
         )
         session = SimpleNamespace(
             config=SimpleNamespace(repo=_EXPLICIT_SUBJECT_REPO),

--- a/tests/test_swarm_subject_repo.py
+++ b/tests/test_swarm_subject_repo.py
@@ -95,7 +95,7 @@ def _run(monkeypatch, session, act, *, result=None, capture=None):
         summary="one finding",
     )
 
-    def fake_stream(session_arg, intent, queue):
+    def fake_stream(session_arg, intent, queue, _dispatch_id=""):
         if capture is not None:
             capture.append(intent)
         queue.put(("done", bridge_result))

--- a/tests/test_swarm_surfaced_honesty.py
+++ b/tests/test_swarm_surfaced_honesty.py
@@ -195,7 +195,7 @@ def _run_dispatch(monkeypatch, result, *, turn_findings=None):
     monkeypatch.delenv("HARNESS_ALLOW_DEMO_SWARM", raising=False)
     monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda *_a, **_k: None)
     monkeypatch.setattr(
-        dispatch, "stream_swarm", lambda session, intent, q: q.put(("done", result)),
+        dispatch, "stream_swarm", lambda session, intent, q, *_a: q.put(("done", result)),
     )
     session = _session()
     events = list(dispatch_swarm_action(

--- a/tests/test_validation_reuse.py
+++ b/tests/test_validation_reuse.py
@@ -1772,7 +1772,7 @@ def test_dispatch_swarm_narrow_verify_registers_verifier_and_fingerprint(monkeyp
     )
     captured = {}
 
-    def fake_stream(_session, intent, q):
+    def fake_stream(_session, intent, q, _dispatch_id=""):
         captured["roles"] = list(intent.roles or [])
         captured["goal"] = intent.goal or ""
         result = SimpleNamespace(
@@ -2632,7 +2632,7 @@ def test_full_swarm_reason_persists_on_sync_badge(monkeypatch):
         ),
     )
 
-    def fake_stream(_session, intent, q):
+    def fake_stream(_session, intent, q, _dispatch_id=""):
         # Criteria must reach the full-swarm worker intent.
         assert getattr(intent, "acceptance_criteria", None) == ["keep criteria"]
         result = SimpleNamespace(

--- a/tests/test_worker_handles.py
+++ b/tests/test_worker_handles.py
@@ -60,7 +60,7 @@ def test_sync_swarm_default_is_handle_first(monkeypatch):
         summary="fat summary " + ("x" * 4000),
     )
     monkeypatch.setattr(
-        dispatch, "stream_swarm", lambda session, intent, q: q.put(("done", result)),
+        dispatch, "stream_swarm", lambda session, intent, q, *_a: q.put(("done", result)),
     )
     session = SimpleNamespace(
         config=SimpleNamespace(repo="/repo"),

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.212",
+  "version": "0.9.213",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.212",
+      "version": "0.9.213",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.212",
+  "version": "0.9.213",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Contributor PR #9: stamp an explicit `dispatch_id` (the existing action ID) on the PM job label before workers start, project it through `/api/swarm/live`, and replace only the matching `local-swarm-<dispatch_id>` placeholder. No timestamp or goal-text heuristic.
- Stop re-registering the durable `job_*` in Marionette’s local sidecar on completion.
- Follow-up: remaining `stream_swarm` test doubles accept `dispatch_id`; success-path test asserts the sidecar keeps a single placeholder row.

## Test plan
- [x] Local pytest: 4155 passed, 79 skipped
- [x] `tests/test_version_consistency.py` green at 0.9.213
- [ ] CI `tests` workflow green on this PR (3.9 + 3.11 + frontend-build)