### PR TITLE
Release v0.9.215: compact receipts, lazy MCP boot, and unverified-edit remind

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,9 +72,10 @@ jobs:
           cache: npm
           cache-dependency-path: webapp/package-lock.json
 
-      - name: Install + typecheck + Electron unit tests + build
+      - name: Install + vitest + Electron unit tests + build
         working-directory: webapp
         run: |
           npm ci
+          npm test
           npm run test:electron
           npm run build

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Internal-first research rig and daily-driver app. stdlib-only backend (urllib +
 sqlite); Puppetmaster is the one real dependency, installed editable from a local
 checkout.
 
-> Status: v0.9.214, deliberately pre-1.0. Turns classify MICRO / STANDARD / DEEP so small edits skip wiki, CodeGraph, and swarm-gate orchestration without bypassing the safety kernel; frontend CI now runs vitest. Rides puppetmaster-ai==1.22.2.
+> Status: v0.9.215, deliberately pre-1.0. MICRO/STANDARD/DEEP depth now records compact JSONL receipts, defers MCP connect until first use, tightens STANDARD wiki inject, and reminds unverified file edits. Rides puppetmaster-ai==1.22.2.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Internal-first research rig and daily-driver app. stdlib-only backend (urllib +
 sqlite); Puppetmaster is the one real dependency, installed editable from a local
 checkout.
 
-> Status: v0.9.213, deliberately pre-1.0. A single `run_swarm` dispatch is one Swarm Tracker card: the durable Puppetmaster `job_*` replaces the provisional `local-swarm-<action-id>` placeholder by explicit `dispatch_id`; rides puppetmaster-ai==1.22.2.
+> Status: v0.9.214, deliberately pre-1.0. Turns classify MICRO / STANDARD / DEEP so small edits skip wiki, CodeGraph, and swarm-gate orchestration without bypassing the safety kernel; frontend CI now runs vitest. Rides puppetmaster-ai==1.22.2.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.213"
+__version__ = "0.9.214"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.214"
+__version__ = "0.9.215"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/agent_plugins.py
+++ b/harness/agent_plugins.py
@@ -260,6 +260,23 @@ def _validate_manifest(root: Path) -> Tuple[dict, List[AgentPluginDiagnostic]]:
             manifest.pop("extensions")
         elif any(not isinstance(value, dict) for value in extensions.values()):
             raise AgentPluginError("plugin.json extension namespace values must be objects")
+        else:
+            # Optional Marionette extension: capabilities / task_types lists.
+            # Unknown top-level fields are still stripped above; this object is
+            # namespaced under extensions and must survive load when present.
+            marionette = extensions.get("marionette")
+            if isinstance(marionette, dict):
+                for list_key in ("capabilities", "task_types"):
+                    if list_key not in marionette:
+                        continue
+                    value = marionette[list_key]
+                    if not isinstance(value, list) or any(
+                        not isinstance(item, str) for item in value
+                    ):
+                        raise AgentPluginError(
+                            f"plugin.json extensions.marionette.{list_key} "
+                            "must be an array of strings"
+                        )
 
     return manifest, diagnostics
 

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -170,6 +170,29 @@ def main(argv=None) -> int:
     ap.add_argument("--swarm-adapter", default=None, choices=["demo", "openai"],
                     help="demo (free/safe substrate) | openai (real read-only code analysis)")
     ap.add_argument("--json", action="store_true", help="emit raw JSON events")
+    depth = ap.add_mutually_exclusive_group()
+    depth.add_argument(
+        "--micro",
+        action="store_const",
+        const="micro",
+        dest="task_profile",
+        help="force MICRO task depth (skip wiki/codegraph/swarm-gate orchestration)",
+    )
+    depth.add_argument(
+        "--standard",
+        action="store_const",
+        const="standard",
+        dest="task_profile",
+        help="force STANDARD task depth",
+    )
+    depth.add_argument(
+        "--deep",
+        action="store_const",
+        const="deep",
+        dest="task_profile",
+        help="force DEEP task depth",
+    )
+    ap.set_defaults(task_profile=None)
     args = ap.parse_args(raw)
 
     cfg = HarnessConfig.from_env()
@@ -179,6 +202,8 @@ def main(argv=None) -> int:
     if args.state_dir: cfg.state_dir = args.state_dir
     if args.repo: cfg.repo = args.repo
     if args.swarm_adapter: cfg.swarm_adapter = args.swarm_adapter
+    if args.task_profile:
+        cfg.task_profile = args.task_profile
 
     try:
         session = Session(cfg)

--- a/harness/config.py
+++ b/harness/config.py
@@ -54,6 +54,9 @@ class HarnessConfig:
     resource_pressure_load_reject: float | None = None
     resource_pressure_wait_timeout_sec: float = 5.0
     resource_pressure_poll_interval_sec: float = 0.25
+    # Adaptive task depth: auto | micro | standard | deep (see harness.task_profile).
+    # Separate from repo-scale is_tiny_workspace; MICRO skips orchestration only.
+    task_profile: str = "auto"
 
     @classmethod
     def from_env(cls) -> "HarnessConfig":
@@ -217,4 +220,8 @@ class HarnessConfig:
                     "resource_pressure_poll_interval_sec",
                 ) or 0.25
             ),
+            task_profile=str(
+                pick("HARNESS_TASK_PROFILE", "task_profile", "auto") or "auto"
+            ).strip().lower()
+            or "auto",
         )

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -462,6 +462,7 @@ ConvEventKind = Literal[
     "swarm_auth_failure",
     "swarm_pending",
     "swarm_result",
+    "task_profile",
     "thinking",
     "tool_prep",
     "verification",
@@ -851,6 +852,10 @@ class ConversationalSession(
         self._stagnation_last_actions = None
         self._stagnation_streak = 0
         self._failed_objective_resume_counts: dict[str, int] = {}
+        # Adaptive task depth for the current originating user turn.
+        self._task_profile: str = ""
+        self._task_profile_source: str = ""
+        self._task_profile_escalated_from: Optional[str] = None
         # Per-message CodeGraph slice cache. The codegraph_context() call is a
         # blocking Node subprocess (~270-500ms) -- recomputing it on every step
         # of a multi-step turn (same query) is pure dead time stacked in front of
@@ -1731,6 +1736,7 @@ class ConversationalSession(
             mcp_tools=mcp_tools,
             no_delegation=getattr(self.config, "no_delegation", False),
             browser_enabled=getattr(self.config, "browser_enabled", True),
+            profile=getattr(self, "_task_profile", None) or None,
         )
 
     def _context_usage_prefix_tokens(self) -> dict:
@@ -1947,7 +1953,98 @@ class ConversationalSession(
             **self._spill_usage_fields(),
             **self._turn_budget_usage_fields(),
             **self._append_only_usage_fields(),
+            **self._task_profile_usage_fields(),
         }
+
+    def _task_profile_usage_fields(self) -> dict:
+        """Compact task-depth receipt fields for usage / context APIs."""
+        try:
+            from harness.turn_economy import TurnEconomy
+
+            return TurnEconomy.task_profile_fields(
+                getattr(self, "_task_profile", "") or "",
+                source=getattr(self, "_task_profile_source", "") or "",
+                escalated_from=getattr(self, "_task_profile_escalated_from", None),
+            )
+        except Exception:
+            return {}
+
+    def _resolve_task_profile_for_turn(self, user_message: str) -> str:
+        """Classify adaptive depth for a fresh user turn; store on session."""
+        from harness.task_profile import classify_task_profile, normalize_profile
+
+        override = getattr(self.config, "task_profile", "auto") or "auto"
+        profile = classify_task_profile(user_message, override=override)
+        self._task_profile = profile
+        norm_override = normalize_profile(override)
+        if norm_override in ("MICRO", "STANDARD", "DEEP"):
+            self._task_profile_source = "override"
+        else:
+            self._task_profile_source = "heuristic"
+        self._task_profile_escalated_from = None
+        try:
+            self._tool_catalog.refresh(
+                mcp_tools=self._mcp.discovered_tools() if self._mcp else None,
+                no_delegation=getattr(self.config, "no_delegation", False),
+                browser_enabled=getattr(self.config, "browser_enabled", True),
+                profile=profile,
+            )
+        except Exception:
+            pass
+        return profile
+
+    def _maybe_escalate_task_profile(
+        self,
+        *,
+        files_touched: int = 0,
+        tests_failed: bool = False,
+        broad_search: bool = False,
+        user_wants_deep: bool = False,
+    ) -> Optional[dict]:
+        """Promote MICRO/STANDARD when the turn outgrows its lane. Best-effort.
+
+        Returns event payload when escalated (caller yields ConvEvent), else None.
+        Never raises.
+        """
+        try:
+            from harness.task_profile import maybe_escalate
+
+            current = getattr(self, "_task_profile", "") or "STANDARD"
+            nxt = maybe_escalate(
+                current,
+                files_touched=int(files_touched or 0),
+                tests_failed=bool(tests_failed),
+                broad_search=bool(broad_search),
+                user_wants_deep=bool(user_wants_deep),
+            )
+            if nxt == current:
+                return None
+            escalated_from = current
+            self._task_profile = nxt
+            self._task_profile_source = "escalate"
+            self._task_profile_escalated_from = escalated_from
+            gs = getattr(self, "_turn_guard_state", None)
+            if gs is not None:
+                try:
+                    gs.task_profile = nxt
+                except Exception:
+                    pass
+            try:
+                self._tool_catalog.refresh(
+                    mcp_tools=self._mcp.discovered_tools() if self._mcp else None,
+                    no_delegation=getattr(self.config, "no_delegation", False),
+                    browser_enabled=getattr(self.config, "browser_enabled", True),
+                    profile=nxt,
+                )
+            except Exception:
+                pass
+            return {
+                "profile": nxt,
+                "source": "escalate",
+                "escalated_from": escalated_from,
+            }
+        except Exception:
+            return None
 
     def _append_only_usage_fields(self) -> dict:
         try:
@@ -2059,6 +2156,13 @@ class ConversationalSession(
         if not self.config.repo or _no_deleg:
             return cg_section
         try:
+            from .task_profile import profile_skips_codegraph
+
+            if profile_skips_codegraph(getattr(self, "_task_profile", "") or ""):
+                return cg_section
+        except Exception:
+            pass
+        try:
             from puppetmaster.codegraph import codegraph_context, codegraph_prompt_section
 
             cg_slice = codegraph_context(task=user_message, cwd=self.config.repo)
@@ -2083,12 +2187,23 @@ class ConversationalSession(
     def _append_turn_context_trailer(self, message: str, user_message: str) -> str:
         try:
             parts = []
-            cg_section = self._build_turn_cg_section(user_message)
-            if cg_section:
-                parts.append(cg_section)
-            wiki_section = self._build_turn_wiki_section(user_message)
-            if wiki_section:
-                parts.append(wiki_section)
+            try:
+                from .task_profile import profile_skips_codegraph, profile_skips_wiki
+
+                profile = getattr(self, "_task_profile", "") or ""
+                skip_cg = profile_skips_codegraph(profile)
+                skip_wiki = profile_skips_wiki(profile)
+            except Exception:
+                skip_cg = False
+                skip_wiki = False
+            if not skip_cg:
+                cg_section = self._build_turn_cg_section(user_message)
+                if cg_section:
+                    parts.append(cg_section)
+            if not skip_wiki:
+                wiki_section = self._build_turn_wiki_section(user_message)
+                if wiki_section:
+                    parts.append(wiki_section)
             turn_note = self._turn_budget_system_note()
             if turn_note:
                 parts.append(turn_note)

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -856,6 +856,11 @@ class ConversationalSession(
         self._task_profile: str = ""
         self._task_profile_source: str = ""
         self._task_profile_escalated_from: Optional[str] = None
+        self._task_tx = None
+        self._turn_ran_command = False
+        self._verify_remind_count = 0
+        self._turn_user_message = ""
+        self._turn_verification = ""
         # Per-message CodeGraph slice cache. The codegraph_context() call is a
         # blocking Node subprocess (~270-500ms) -- recomputing it on every step
         # of a multi-step turn (same query) is pure dead time stacked in front of

--- a/harness/delivery_mode.py
+++ b/harness/delivery_mode.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 """DeliveryMode enum — shared vocabulary for composer inject and schedule→busy.
 
-Modes: auto | steer | follow_up
-Actions: run_auto | enqueue_steer | enqueue_prompt
+Modes: auto | steer | follow_up | interrupt
+Actions: run_auto | enqueue_steer | enqueue_prompt | interrupt_then_queue
 """
 
 from enum import Enum
@@ -14,12 +14,14 @@ class DeliveryMode(str, Enum):
     AUTO = "auto"
     STEER = "steer"
     FOLLOW_UP = "follow_up"
+    INTERRUPT = "interrupt"
 
 
 class DeliveryAction(str, Enum):
     RUN_AUTO = "run_auto"
     ENQUEUE_STEER = "enqueue_steer"
     ENQUEUE_PROMPT = "enqueue_prompt"
+    INTERRUPT_THEN_QUEUE = "interrupt_then_queue"
 
 
 def normalize_delivery_mode(requested: Optional[str]) -> Optional[str]:
@@ -33,23 +35,40 @@ def normalize_delivery_mode(requested: Optional[str]) -> Optional[str]:
         DeliveryMode.AUTO.value,
         DeliveryMode.STEER.value,
         DeliveryMode.FOLLOW_UP.value,
+        DeliveryMode.INTERRUPT.value,
     ):
         return mode
     return None
 
 
+def _try_interrupt_session(session: Any) -> bool:
+    """Call the first available stop/interrupt hook. Never raises."""
+    for name in ("interrupt", "request_interrupt", "stop"):
+        fn = getattr(session, name, None)
+        if callable(fn):
+            try:
+                fn()
+            except Exception:
+                pass
+            return True
+    return False
+
+
 def resolve_delivery(session_busy: bool, requested: Optional[str]) -> str:
-    """Map (busy, mode) → action for run_auto / enqueue_steer / enqueue_prompt.
+    """Map (busy, mode) → action for run_auto / enqueue_steer / enqueue_prompt / interrupt_then_queue.
 
     ``session_busy`` influences steer (mid-turn inject when busy; when idle,
     steer still maps to enqueue_steer so the host can stage a redirect). Auto
-    always maps to run_auto; follow_up always queues a next-turn prompt.
+    always maps to run_auto; follow_up always queues a next-turn prompt;
+    interrupt stops the current turn when busy, then queues the text.
     """
     mode = normalize_delivery_mode(requested) or DeliveryMode.AUTO.value
     if mode == DeliveryMode.STEER.value:
         return DeliveryAction.ENQUEUE_STEER.value
     if mode == DeliveryMode.FOLLOW_UP.value:
         return DeliveryAction.ENQUEUE_PROMPT.value
+    if mode == DeliveryMode.INTERRUPT.value:
+        return DeliveryAction.INTERRUPT_THEN_QUEUE.value
     # auto
     _ = session_busy  # reserved for future busy-auto policy; action stays run_auto
     return DeliveryAction.RUN_AUTO.value
@@ -84,6 +103,19 @@ def apply_delivery(
             return {"ok": False, "error": "session lacks enqueue_prompt", "action": action}
         item = session.enqueue_prompt(cleaned, images=imgs)
         return {"ok": True, "action": action, "item": item}
+    if action == DeliveryAction.INTERRUPT_THEN_QUEUE.value:
+        if not cleaned:
+            return {"ok": False, "error": "missing text", "action": action}
+        interrupted = False
+        if session_busy:
+            interrupted = _try_interrupt_session(session)
+        if not hasattr(session, "enqueue_prompt"):
+            return {"ok": False, "error": "session lacks enqueue_prompt", "action": action}
+        item = session.enqueue_prompt(cleaned, images=imgs)
+        result: dict = {"ok": True, "action": action, "item": item}
+        if interrupted:
+            result["interrupted"] = True
+        return result
     # run_auto
     if not cleaned:
         return {"ok": False, "error": "missing text", "action": action}

--- a/harness/mcp_manager.py
+++ b/harness/mcp_manager.py
@@ -411,7 +411,11 @@ class McpManager:
         return self.start_server(name, expect_gen=refresh_gen)
 
     def start_all(self) -> Dict[str, object]:
-        """Start every configured server; return {name: tool_count | error_str}."""
+        """Start every configured server; return {name: tool_count | error_str}.
+
+        Explicit operator path (manage_mcp / Settings). Boot uses lazy connect
+        instead — see ``ensure_server`` and ``boot_mcp_servers``.
+        """
         report: Dict[str, object] = {}
         for name in self.effective_config():
             try:
@@ -420,6 +424,17 @@ class McpManager:
             except McpError as e:
                 report[name] = f"error: {_sanitize_lifecycle_error(str(e))}"
         return report
+
+    def ensure_server(self, name: str) -> List[McpTool]:
+        """Start ``name`` only if it is not already alive; return its tools."""
+        name = (name or "").strip()
+        if not name:
+            raise McpError("ensure_server requires a server name")
+        with self._lock:
+            existing = self._clients.get(name)
+            if existing is not None and existing.alive:
+                return [t for t in self._tools.values() if t.server == name]
+        return self.start_server(name)
 
     def manage(
         self,
@@ -593,17 +608,21 @@ class McpManager:
                 self._reject_if_disallowed(cached.server, cached.name)
                 client = self._clients.get(cached.server)
                 if not client or not client.alive:
-                    self.start_server(cached.server)
+                    # Dead/missing client: reconnect on demand (unchanged).
+                    self.ensure_server(cached.server)
                     client = self._clients.get(cached.server)
                 out = client.call_tool(cached.name, arguments)
                 self._record_invocation(cached.server, cached.name, ok=True)
                 return out
 
-            # Allow "server.tool" when the server is running but the tool is not
-            # in the local cache (e.g. freshly advertised tools).
+            # Allow "server.tool" for configured servers that are idle or whose
+            # tools are not yet in the local cache (lazy boot / fresh ads).
             if server and tool_name:
                 self._reject_if_disallowed(server, tool_name)
                 client = self._clients.get(server)
+                if (not client or not client.alive) and server in self.effective_config():
+                    self.ensure_server(server)
+                    client = self._clients.get(server)
                 if client and client.alive:
                     out = client.call_tool(tool_name, arguments)
                     self._record_invocation(server, tool_name, ok=True)

--- a/harness/pilot_guards.py
+++ b/harness/pilot_guards.py
@@ -511,6 +511,9 @@ class TurnGuardState:
     # (objective_key, model_key) pairs for plumbing-only / no-FINDING swarms.
     # Identical redispatch soft-refuses; changing model pin or goal is allowed.
     plumbing_degraded_swarms: set[tuple[str, str]] = field(default_factory=set)
+    # Adaptive task depth for this turn (MICRO / STANDARD / DEEP). Separate from
+    # tiny_workspace (repo scale). MICRO disables swarm-gate suppress only.
+    task_profile: str = ""
 
 
 @dataclass(frozen=True)
@@ -1266,6 +1269,17 @@ def check_swarm_gate(state: TurnGuardState, kind: str, act: Any) -> GuardVerdict
     if not swarm_gate_enabled():
         return GuardVerdict(False)
 
+    # MICRO disables swarm-gate suppress (orchestration skip only). INVARIANT:
+    # never hide run_swarm while swarm_gate is on — MICRO leaves the gate off.
+    try:
+        from .task_profile import profile_disables_swarm_gate
+
+        profile = getattr(state, "task_profile", "") or ""
+        if profile_disables_swarm_gate(profile):
+            return GuardVerdict(False)
+    except Exception:
+        pass
+
     if not is_swarm_gate_blocked_exploration(state, kind, act):
         return GuardVerdict(False)
 
@@ -1447,6 +1461,7 @@ def new_turn_guard_state(
     *,
     repo_path: Optional[str] = None,
     nested_implement: bool = False,
+    task_profile: str = "",
 ) -> TurnGuardState:
     tiny = bool(repo_path) and is_tiny_workspace(repo_path or "")
     # Foreground tiny pilots tighten to 12; nested implement workers keep the
@@ -1463,6 +1478,7 @@ def new_turn_guard_state(
         iteration_budget=IterationBudget(cap) if cap > 0 else None,
         tiny_workspace=tiny,
         nested_implement=bool(nested_implement),
+        task_profile=(task_profile or "").strip().upper(),
     )
 
 
@@ -1472,6 +1488,7 @@ def reuse_or_new_turn_guard_state(
     *,
     repo_path: Optional[str] = None,
     nested_implement: bool = False,
+    task_profile: str = "",
 ) -> TurnGuardState:
     """Reuse prior guard state across model steps / keep-alive resume.
 
@@ -1481,11 +1498,14 @@ def reuse_or_new_turn_guard_state(
     swarm-gate progress safely without preview/unrelated state leaks.
     """
     if prior is not None:
+        if task_profile and not getattr(prior, "task_profile", ""):
+            prior.task_profile = (task_profile or "").strip().upper()
         return prior
     return new_turn_guard_state(
         user_message,
         repo_path=repo_path,
         nested_implement=nested_implement,
+        task_profile=task_profile,
     )
 
 

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -103,6 +103,34 @@ def _build_step_tools(synthesis_nudge_active: bool, build_tools: Any) -> list:
     return [] if synthesis_nudge_active else build_tools()
 
 
+def emit_turn_task_profile(session: Any, user_message: str) -> Iterator[Any]:
+    """Classify adaptive depth for a fresh user turn and emit a ConvEvent."""
+    from .conversation import ConvEvent
+
+    try:
+        profile = session._resolve_task_profile_for_turn(user_message)
+        yield ConvEvent("task_profile", {
+            "profile": profile,
+            "source": getattr(session, "_task_profile_source", "") or "",
+            "escalated_from": getattr(session, "_task_profile_escalated_from", None),
+        })
+    except Exception:
+        session._task_profile = "STANDARD"
+        session._task_profile_source = "heuristic"
+        session._task_profile_escalated_from = None
+
+
+def profile_skips_auto_inject(session: Any) -> tuple[bool, bool]:
+    """MICRO skips wiki/CodeGraph auto-inject. Best-effort; never raises."""
+    try:
+        from .task_profile import profile_skips_codegraph, profile_skips_wiki
+
+        profile = getattr(session, "_task_profile", "") or ""
+        return profile_skips_codegraph(profile), profile_skips_wiki(profile)
+    except Exception:
+        return False, False
+
+
 class SendLoopMixin:
     """Mixin holding send-loop orchestration for ConversationalSession.
 
@@ -830,6 +858,7 @@ class SendLoopMixin:
             self._stagnation_last_actions = None
             self._stagnation_streak = 0
             self._failed_objective_resume_counts = {}
+            yield from emit_turn_task_profile(self, user_message)
             try:
                 from .turn_budget import turn_budget_enabled
 
@@ -883,9 +912,11 @@ class SendLoopMixin:
             # so the driver sees the most relevant code BEFORE it starts calling tools.
             # Skip for no_delegation worker sessions (they run in a fresh worktree with
             # no CodeGraph index). Degrades to a no-op when codegraph is unavailable.
+            _skip_cg, _ = profile_skips_auto_inject(self)
             if (
                 not getattr(self.config, "no_delegation", False)
                 and not self._resolve_append_only()
+                and not _skip_cg
             ):
                 cg_context = self._get_codegraph_context(user_message)
                 if cg_context:
@@ -965,7 +996,8 @@ class SendLoopMixin:
             _no_deleg = getattr(self.config, "no_delegation", False)
             cg_symbol_count = 0
             append_only = self._resolve_append_only()
-            if self.config.repo and not _no_deleg and not append_only:
+            _skip_cg, _skip_wiki = profile_skips_auto_inject(self)
+            if self.config.repo and not _no_deleg and not append_only and not _skip_cg:
                 # Cache the CodeGraph slice per user message: the underlying
                 # codegraph_context() is a blocking Node subprocess (~270-500ms).
                 # Recomputing it on every step of a multi-step turn (identical
@@ -1011,7 +1043,7 @@ class SendLoopMixin:
                         pass
 
             wiki_section = ""
-            if self._wiki.configured and not append_only:
+            if self._wiki.configured and not append_only and not _skip_wiki:
                 if self._wiki_cache_key == user_message:
                     wiki_section = self._wiki_cache_section
                 else:

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -50,6 +50,7 @@ from .send_loop_actions import execute_turn_actions
 from .send_loop_phases import (
     drain_idle_turn,
     drain_stream_queue,
+    finalize_assistant_turn,
     maybe_attach_pilot_session_id,
     promote_trailing_reasoning_to_say,
     meter_pilot_step,
@@ -106,7 +107,9 @@ def _build_step_tools(synthesis_nudge_active: bool, build_tools: Any) -> list:
 def emit_turn_task_profile(session: Any, user_message: str) -> Iterator[Any]:
     """Classify adaptive depth for a fresh user turn and emit a ConvEvent."""
     from .conversation import ConvEvent
+    from .send_loop_phases import begin_turn_task_kernel
 
+    begin_turn_task_kernel(session, user_message)
     try:
         profile = session._resolve_task_profile_for_turn(user_message)
         yield ConvEvent("task_profile", {
@@ -1330,14 +1333,10 @@ class SendLoopMixin:
                 and not turn.has_actions
             ):
                 # Close the turn for the UI before wiki ingest (network I/O).
-                yield ConvEvent("assistant_done", {
-                    "turns": step + 1,
-                    "swarms": swarms,
-                    "turn_budget_exhausted": True,
-                })
-                self._submit_housekeeping(
-                    self._maybe_ingest,
-                    user_message, list(turn_prose), list(turn_findings),
+                yield from finalize_assistant_turn(
+                    self, user_message=user_message, step=step, swarms=swarms,
+                    turn_prose=turn_prose, turn_findings=turn_findings,
+                    extra={"turn_budget_exhausted": True},
                 )
                 return
 
@@ -1406,14 +1405,11 @@ class SendLoopMixin:
                             "role": "assistant",
                             "text": halt_msg,
                         })
-                        yield ConvEvent("assistant_done", {
-                            "turns": step + 1,
-                            "swarms": swarms,
-                            "stagnation_halt": True,
-                        })
-                        self._submit_housekeeping(
-                            self._maybe_ingest,
-                            user_message, list(turn_prose), list(turn_findings),
+                        yield from finalize_assistant_turn(
+                            self, user_message=user_message, step=step,
+                            swarms=swarms, turn_prose=turn_prose,
+                            turn_findings=turn_findings,
+                            extra={"stagnation_halt": True},
                         )
                         return
             except Exception:
@@ -1522,9 +1518,8 @@ class SendLoopMixin:
         limit_msg = "(Reached the investigation step limit for this message.)"
         yield ConvEvent("message", {"role": "assistant", "text": limit_msg})
         self._display_transcript.append({"type": "message", "role": "assistant", "text": limit_msg})
-        yield ConvEvent("assistant_done", {"turns": step + 1, "swarms": swarms})
-        self._submit_housekeeping(
-            self._maybe_ingest,
-            user_message, list(turn_prose), list(turn_findings),
+        yield from finalize_assistant_turn(
+            self, user_message=user_message, step=step, swarms=swarms,
+            turn_prose=turn_prose, turn_findings=turn_findings,
         )
 

--- a/harness/send_loop_actions.py
+++ b/harness/send_loop_actions.py
@@ -90,6 +90,7 @@ def execute_turn_actions(
         user_message,
         repo_path=action_cwd,
         nested_implement=nested_implement,
+        task_profile=getattr(session, "_task_profile", "") or "",
     )
     session._turn_guard_state = guard_state
     guard_suppressed: dict[int, Any] = {}

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -79,6 +79,19 @@ PLAN_SKIP_KINDS: frozenset[str] = frozenset({
 _RUN_COMMAND_UI_OUTPUT_CAP = 4 * 1024
 
 
+def _yield_task_profile_escalation(session: Any, turn_changed_files: list) -> Iterator[Any]:
+    """Best-effort MICRO/STANDARD escalate after a successful write/edit."""
+    from .conversation import ConvEvent
+
+    try:
+        uniq = len(dict.fromkeys(turn_changed_files))
+        payload = session._maybe_escalate_task_profile(files_touched=uniq)
+        if payload:
+            yield ConvEvent("task_profile", payload)
+    except Exception:
+        pass
+
+
 def _truncate_run_command_ui_output(
     output: str, cap: int = _RUN_COMMAND_UI_OUTPUT_CAP,
 ) -> str:
@@ -1682,6 +1695,7 @@ def dispatch_local_action(
             })
             session._append_action_result(act, aid, f"(write_file {act.path} successfully wrote {bytes_written} bytes)", is_native)
             turn_changed_files.append(target_path)
+            yield from _yield_task_profile_escalation(session, turn_changed_files)
         except Exception as e:
             yield ConvEvent("action_result", {"id": aid, "error": str(e)})
             session._append_action_result(act, aid, f"(write_file {act.path} failed: {e})", is_native)
@@ -1739,6 +1753,7 @@ def dispatch_local_action(
             })
             session._append_action_result(act, aid, f"(edit_file {act.path} successfully edited: {headline})", is_native)
             turn_changed_files.append(target_path)
+            yield from _yield_task_profile_escalation(session, turn_changed_files)
         except Exception as e:
             yield ConvEvent("action_result", {"id": aid, "error": str(e)})
             session._append_action_result(act, aid, f"(edit_file {act.path} failed: {e})", is_native)
@@ -1803,6 +1818,7 @@ def dispatch_local_action(
             yield ConvEvent("action_result", hash_edit_result)
             session._append_action_result(act, aid, f"(hash_edit {act.path} successfully applied: {headline})", is_native)
             turn_changed_files.append(target_path)
+            yield from _yield_task_profile_escalation(session, turn_changed_files)
         except Exception as e:
             yield ConvEvent("action_result", {"id": aid, "error": str(e)})
             session._append_action_result(act, aid, f"(hash_edit {act.path} failed: {e})", is_native)

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -84,12 +84,175 @@ def _yield_task_profile_escalation(session: Any, turn_changed_files: list) -> It
     from .conversation import ConvEvent
 
     try:
+        from .task_transaction import note_files
+
+        session._task_tx = note_files(
+            getattr(session, "_task_tx", None), turn_changed_files,
+        )
+    except Exception:
+        pass
+    try:
         uniq = len(dict.fromkeys(turn_changed_files))
         payload = session._maybe_escalate_task_profile(files_touched=uniq)
         if payload:
             yield ConvEvent("task_profile", payload)
     except Exception:
         pass
+
+
+def begin_turn_task_kernel(session: Any, user_message: str) -> None:
+    """Start a compact task transaction and reset per-turn verify flags."""
+    try:
+        from .task_transaction import new_transaction
+
+        session._task_tx = new_transaction(user_message)
+    except Exception:
+        session._task_tx = None
+    session._turn_ran_command = False
+    session._verify_remind_count = 0
+    session._turn_user_message = user_message or ""
+    session._turn_verification = ""
+
+
+def _note_turn_command(session: Any, verification: str = "") -> None:
+    """Mark that this turn ran a command (or auto-verify). Never raises."""
+    try:
+        session._turn_ran_command = True
+        text = (verification or "").strip()
+        if not text:
+            return
+        session._turn_verification = text
+        from .task_transaction import note_verification
+
+        session._task_tx = note_verification(
+            getattr(session, "_task_tx", None), text,
+        )
+    except Exception:
+        pass
+
+
+def persist_turn_receipt(session: Any, user_message: str = "") -> None:
+    """Append a compact JSONL receipt. Best-effort; never raises."""
+    try:
+        from .task_receipt import (
+            append_receipt,
+            build_receipt,
+            compute_patch_hash,
+            git_branch,
+            prompt_hash,
+        )
+        from .task_transaction import as_dict
+
+        cfg = getattr(session, "config", None)
+        state_dir = str(
+            getattr(cfg, "state_dir", "")
+            or getattr(session, "state_dir", "")
+            or ""
+        )
+        if not state_dir:
+            return
+        txd = as_dict(getattr(session, "_task_tx", None))
+        files = list(txd.get("files") or [])
+        msg = user_message or getattr(session, "_turn_user_message", "") or ""
+        repo = str(getattr(cfg, "repo", "") or "")
+        verification = (
+            getattr(session, "_turn_verification", "")
+            or txd.get("verification")
+            or ""
+        )
+        if getattr(session, "_turn_ran_command", False) and not verification:
+            verification = "pass"
+        elif files and not getattr(session, "_turn_ran_command", False) and not verification:
+            verification = "skipped"
+        model = ""
+        adapter = ""
+        try:
+            model = str(getattr(getattr(session, "pilot", None), "model", "") or "")
+        except Exception:
+            pass
+        try:
+            adapter = str(getattr(cfg, "driver", "") or "")
+        except Exception:
+            pass
+        rec = build_receipt(
+            task_id=str(getattr(session, "harness_session_id", "") or "") or "turn",
+            profile=getattr(session, "_task_profile", "") or "",
+            profile_source=getattr(session, "_task_profile_source", "") or "",
+            escalated_from=getattr(session, "_task_profile_escalated_from", None),
+            model=model,
+            adapter=adapter,
+            prompt_hash=prompt_hash(msg),
+            repo=repo,
+            branch=git_branch(repo) if repo else "",
+            changed_files=files,
+            patch_hash=compute_patch_hash(files),
+            verification=verification,
+        )
+        append_receipt(state_dir, rec)
+    except Exception:
+        return
+
+
+def finalize_assistant_turn(
+    session: Any,
+    *,
+    user_message: str,
+    step: int,
+    swarms: Any,
+    turn_prose: list,
+    turn_findings: list,
+    extra: Optional[dict] = None,
+) -> Iterator[Any]:
+    """Persist a compact receipt, emit assistant_done, then housekeeping."""
+    from .conversation import ConvEvent
+
+    persist_turn_receipt(session, user_message)
+    payload: Dict[str, Any] = {"turns": step + 1, "swarms": swarms}
+    if extra:
+        payload.update(extra)
+    yield ConvEvent("assistant_done", payload)
+    session._submit_housekeeping(
+        session._maybe_ingest,
+        user_message, list(turn_prose), list(turn_findings),
+    )
+
+
+def maybe_soft_verify_nudge(session: Any) -> Iterator[Any]:
+    """Remind-then-escalate unverified MICRO/STANDARD edits. True = continue."""
+    from .conversation import ConvEvent
+
+    try:
+        from .task_transaction import as_dict
+        from .tool_requirement import SoftToolRequirement
+
+        txd = as_dict(getattr(session, "_task_tx", None))
+        files = list(txd.get("files") or [])
+        profile = getattr(session, "_task_profile", "") or ""
+        ran = bool(getattr(session, "_turn_ran_command", False))
+        count = int(getattr(session, "_verify_remind_count", 0) or 0)
+        nfiles = len(files)
+        if SoftToolRequirement.should_remind_verify(profile, nfiles, ran, count):
+            session._history.append({
+                "role": "user",
+                "content": SoftToolRequirement.remind_message(),
+            })
+            session._verify_remind_count = count + 1
+            return True
+        if SoftToolRequirement.should_escalate_unverified(
+            profile, nfiles, ran, count,
+        ):
+            try:
+                payload = session._maybe_escalate_task_profile(
+                    files_touched=nfiles,
+                )
+            except Exception:
+                payload = None
+            if payload:
+                yield ConvEvent("task_profile", payload)
+            session._turn_verification = "unverified"
+        return False
+    except Exception:
+        return False
 
 
 def _truncate_run_command_ui_output(
@@ -1029,14 +1192,20 @@ def drain_idle_turn(
         # to the newly-running queued prompt instead of the previous
         # completed one.
         return ("continue", q_text)
+    # Soft verify: remind MICRO/STANDARD file edits that skipped a command.
+    if (yield from maybe_soft_verify_nudge(session)):
+        return ("continue", user_message)
     # assistant_done first; ingest in housekeeping so the busy lock
     # releases immediately. Sync wiki I/O here used to leave the
     # final answer painted while Stop/Still working stayed up
     # (content sat in the Investigating fold until Stop flushed it).
-    yield ConvEvent("assistant_done", {"turns": step + 1, "swarms": swarms})
-    session._submit_housekeeping(
-        session._maybe_ingest,
-        user_message, list(turn_prose), list(turn_findings),
+    yield from finalize_assistant_turn(
+        session,
+        user_message=user_message,
+        step=step,
+        swarms=swarms,
+        turn_prose=turn_prose,
+        turn_findings=turn_findings,
     )
     return ("return", user_message)
 
@@ -1395,6 +1564,7 @@ def run_auto_verify(
         })
         if not passed and not session._cancel.is_set():
             auto_verify_iters += 1
+            _note_turn_command(session, "fail")
             feedback = (
                 "[auto-verify] The project check failed after your edits:\n"
                 f"$ {_verify_display}\n{output}\n"
@@ -1402,6 +1572,7 @@ def run_auto_verify(
             )
             session._history.append({"role": "user", "content": feedback})
             return (auto_verify_iters, True)
+        _note_turn_command(session, "pass")
     return (auto_verify_iters, False)
 
 
@@ -1894,6 +2065,7 @@ def dispatch_local_action(
                 ),
                 is_native,
             )
+            _note_turn_command(session)
             return
         # FULL-AUTO safety + cancellable execution live in
         # ToolDispatchMixin._do_run_command; yield/append stay here.
@@ -1982,6 +2154,7 @@ def dispatch_local_action(
                     is_native,
                     ok=False,
                 )
+                _note_turn_command(session)
                 return
             yield ConvEvent("action_result", {
                 "id": aid, "error": val, "kind": "run_command", "command": command,
@@ -2030,6 +2203,7 @@ def dispatch_local_action(
         session._append_action_result(
             act, aid, _with_command_footer(hist, val), is_native,
         )
+        _note_turn_command(session, "pass" if run_status == "ok" else run_status)
         return
     # ---- run_command_batch branch (Wave 3) -------------------------
     if act.kind == "run_command_batch":
@@ -2114,6 +2288,7 @@ def dispatch_local_action(
             ),
             is_native,
         )
+        _note_turn_command(session)
         return
     # ---- run_ipython branch (persistent session kernel) ------------
     if act.kind == "run_ipython":
@@ -2142,6 +2317,7 @@ def dispatch_local_action(
                 f"(run_ipython [{backend}] ok)\n{output}",
                 is_native,
             )
+            _note_turn_command(session)
         else:
             err = val
             if isinstance(val, dict):

--- a/harness/server.py
+++ b/harness/server.py
@@ -2975,18 +2975,26 @@ _sys.modules[__name__].__class__ = _HarnessServerModule
 
 
 def boot_mcp_servers(mcp: Any = None, diag: Any = None) -> None:
-    """Start configured MCP servers and record failures via ``diag``.
+    """Load MCP config at boot without connecting (Hermes-style lazy start).
 
     Extracted from the serve() boot thread so tests exercise the real
     production path (msg=/exc= kwargs) instead of reimplementing the body.
+    Servers stay idle until first use (``call`` / ``ensure_server`` /
+    explicit ``start_all`` / manage_mcp), so boot does not call ``start_all``.
     """
     mcp_client = _mcp if mcp is None else mcp
     note = _diag if diag is None else diag
     try:
-        report = mcp_client.start_all()
-        for name, result in report.items():
-            if isinstance(result, str):
-                note("mcp.boot_error", msg=f"{name}: {result}")
+        # Register/read config only — do not connect every server at boot.
+        if hasattr(mcp_client, "effective_config"):
+            cfg = mcp_client.effective_config() or {}
+        elif hasattr(mcp_client, "load_config"):
+            cfg = mcp_client.load_config() or {}
+        else:
+            cfg = {}
+        names = [n for n in cfg.keys() if isinstance(n, str) and n.strip()]
+        if names:
+            note("mcp.boot_deferred", msg=", ".join(names))
     except Exception as exc:
         note("mcp.boot_fail", exc=exc)
 

--- a/harness/steer_mixin.py
+++ b/harness/steer_mixin.py
@@ -265,6 +265,14 @@ class SteerMixin:
             return
         for steer in steers:
             marker_text = self._steer_marker(steer)
+            try:
+                from .task_transaction import context_block
+
+                extra = context_block(getattr(self, "_task_tx", None))
+                if extra:
+                    marker_text = marker_text + "\n\n" + extra
+            except Exception:
+                pass
             yield ConvEvent("steer", {"text": steer})
             # Inject into the last result-bearing message (tool role for native
             # tool-calling, or the user-role result the JSON-envelope path appends).

--- a/harness/task_profile.py
+++ b/harness/task_profile.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+"""Adaptive task-depth profiles: MICRO / STANDARD / DEEP.
+
+Task depth is a separate classifier from repo-scale ``is_tiny_workspace``.
+MICRO skips expensive orchestration (wiki auto-inject, CodeGraph auto-inject,
+swarm-gate suppress) only — the safety kernel (path confinement, hash_edit,
+sandbox, receipts) is never bypassed.
+"""
+
+import re
+from typing import FrozenSet, Optional
+
+MICRO = "MICRO"
+STANDARD = "STANDARD"
+DEEP = "DEEP"
+
+_PROFILES = (MICRO, STANDARD, DEEP)
+_OVERRIDE_ALIASES = {
+    "micro": MICRO,
+    "standard": STANDARD,
+    "deep": DEEP,
+    "auto": "auto",
+}
+
+# Broad / deep-intent language (audit, architecture, codebase-wide).
+_DEEP_RE = re.compile(
+    r"(?:"
+    r"\baudit\b|"
+    r"\bthroughout\b|"
+    r"\brefactor\b|"
+    r"\barchitecture\b|"
+    r"\bfind\s+all\b|"
+    r"\bacross\s+the\b|"
+    r"\bcodebase[- ]wide\b|"
+    r"\bacross\s+this\s+(?:codebase|repo|repository|project)\b"
+    r")",
+    re.IGNORECASE,
+)
+
+# MICRO cues: typo / rename-comment / one explicit filename with extension.
+_TYPO_RE = re.compile(r"\btypo(?:s)?\b", re.IGNORECASE)
+_RENAME_COMMENT_RE = re.compile(
+    r"\brename\b.*\bcomment\b|\bcomment\b.*\brename\b",
+    re.IGNORECASE,
+)
+_FILENAME_RE = re.compile(
+    r"(?<![\w./\\-])"
+    r"([A-Za-z0-9_.-]+\.[A-Za-z0-9]{1,12})"
+    r"(?![\w./\\-])"
+)
+
+# Keep MICRO for short, local asks only.
+_SHORT_MAX_CHARS = 120
+_SHORT_MAX_WORDS = 16
+
+_MICRO_VISIBLE: FrozenSet[str] = frozenset(
+    {
+        "read_file",
+        "write_file",
+        "edit_file",
+        "hash_edit",
+        "run_command",
+        "run_ipython",
+        "list_dir",
+        "search_tools",
+        "search_files",
+    }
+)
+
+_RANK = {MICRO: 0, STANDARD: 1, DEEP: 2}
+
+
+def normalize_profile(value: Optional[str]) -> Optional[str]:
+    """Map lowercase/alias input to MICRO/STANDARD/DEEP, or 'auto', or None."""
+    if value is None:
+        return None
+    key = str(value).strip().lower()
+    if not key:
+        return None
+    if key in _OVERRIDE_ALIASES:
+        return _OVERRIDE_ALIASES[key]
+    upper = key.upper()
+    if upper in _PROFILES:
+        return upper
+    return None
+
+
+def classify_task_profile(message: str, override: Optional[str] = None) -> str:
+    """Resolve MICRO / STANDARD / DEEP for a user turn.
+
+    Explicit override wins when in {micro, standard, deep, auto}.
+    ``auto`` / None falls through to deterministic heuristics.
+    """
+    normalized = normalize_profile(override)
+    if normalized in _PROFILES:
+        return normalized
+
+    text = (message or "").strip()
+    if _looks_deep(text):
+        return DEEP
+    if _looks_micro(text):
+        return MICRO
+    return STANDARD
+
+
+def _looks_deep(text: str) -> bool:
+    if not text:
+        return False
+    return bool(_DEEP_RE.search(text))
+
+
+def _looks_micro(text: str) -> bool:
+    if not text:
+        return False
+    if len(text) > _SHORT_MAX_CHARS:
+        return False
+    words = text.split()
+    if len(words) > _SHORT_MAX_WORDS:
+        return False
+    if _TYPO_RE.search(text):
+        return True
+    if _RENAME_COMMENT_RE.search(text):
+        return True
+    filenames = _FILENAME_RE.findall(text)
+    if len(filenames) == 1:
+        return True
+    return False
+
+
+def maybe_escalate(
+    profile: str,
+    *,
+    files_touched: int = 0,
+    tests_failed: bool = False,
+    broad_search: bool = False,
+    user_wants_deep: bool = False,
+) -> str:
+    """Promote profile when the turn outgrows its lane. Never demotes."""
+    current = normalize_profile(profile) or STANDARD
+    if current not in _PROFILES:
+        current = STANDARD
+
+    nxt = current
+    if nxt == MICRO:
+        if files_touched >= 3 or broad_search or tests_failed:
+            nxt = STANDARD
+    if nxt == STANDARD:
+        if user_wants_deep or files_touched >= 8:
+            nxt = DEEP
+    # Never demote: only move up the rank ladder.
+    if _RANK.get(nxt, 0) < _RANK.get(current, 0):
+        return current
+    return nxt
+
+
+def profile_skips_wiki(profile: Optional[str]) -> bool:
+    return (normalize_profile(profile) or "") == MICRO
+
+
+def profile_skips_codegraph(profile: Optional[str]) -> bool:
+    return (normalize_profile(profile) or "") == MICRO
+
+
+def profile_disables_swarm_gate(profile: Optional[str]) -> bool:
+    return (normalize_profile(profile) or "") == MICRO
+
+
+def micro_visible_tool_names() -> FrozenSet[str]:
+    """Always-visible MICRO tool set (search_tools kept for lazy activation)."""
+    return _MICRO_VISIBLE
+
+
+def task_profile_usage_fields(
+    profile: str = "",
+    source: str = "",
+    escalated_from: Optional[str] = None,
+) -> dict:
+    """Compact receipt fields for usage / context APIs (no parallel schema)."""
+    resolved = normalize_profile(profile)
+    if not resolved or resolved == "auto":
+        raw = (profile or "").strip().upper()
+        if raw not in _PROFILES:
+            return {}
+        resolved = raw
+    out: dict = {
+        "task_profile": resolved,
+        "task_profile_source": (source or "").strip(),
+    }
+    if escalated_from:
+        from_norm = normalize_profile(escalated_from) or str(escalated_from).strip().upper()
+        if from_norm:
+            out["escalated_from"] = from_norm
+    return out

--- a/harness/task_receipt.py
+++ b/harness/task_receipt.py
@@ -1,0 +1,168 @@
+"""Compact MICRO/STANDARD task receipts (not a swarm artifact tree).
+
+Append-only JSONL under ``{state_dir}/task_receipts.jsonl``. Hot-path helpers
+never raise — a failed write must not block chat turns.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+
+JSONL_FILENAME = "task_receipts.jsonl"
+PROMPT_HASH_LEN = 16
+GIT_TIMEOUT_S = 5
+
+
+@dataclass
+class TaskReceipt:
+    """One compact task receipt row.
+
+    ``task_id`` is required; every other field is optional and omitted from
+    serialized dicts when empty.
+    """
+
+    task_id: str
+    profile: Optional[str] = None
+    profile_source: Optional[str] = None
+    escalated_from: Optional[str] = None
+    model: Optional[str] = None
+    adapter: Optional[str] = None
+    prompt_hash: Optional[str] = None
+    repo: Optional[str] = None
+    branch: Optional[str] = None
+    changed_files: Optional[List[str]] = field(default=None)
+    patch_hash: Optional[str] = None
+    verification: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+def prompt_hash(message: str) -> str:
+    """Return a short sha256 hex digest of the user message (16 hex chars)."""
+    raw = message if isinstance(message, str) else ""
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:PROMPT_HASH_LEN]
+
+
+def git_branch(repo: str) -> str:
+    """Best-effort current branch name; empty string on any failure."""
+    if not repo or not isinstance(repo, str):
+        return ""
+    try:
+        path = os.path.abspath(repo)
+        if not os.path.isdir(path):
+            return ""
+        proc = subprocess.run(
+            ["git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GIT_TIMEOUT_S,
+        )
+        if proc.returncode != 0:
+            return ""
+        return (proc.stdout or "").strip()
+    except Exception:
+        return ""
+
+
+def _is_empty(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str) and value == "":
+        return True
+    if isinstance(value, (list, tuple, dict)) and len(value) == 0:
+        return True
+    return False
+
+
+def build_receipt(**kwargs: Any) -> dict:
+    """Build a receipt dict, omitting empty / missing values.
+
+    Accepts TaskReceipt field names as kwargs. ``task_id`` should be provided
+    by the caller; if absent the dict simply omits it. When ``created_at`` is
+    not supplied, stamps UTC ISO-8601 now.
+    """
+    data = dict(kwargs)
+    if "created_at" not in data or _is_empty(data.get("created_at")):
+        data["created_at"] = (
+            datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        )
+    out: dict = {}
+    for key, value in data.items():
+        if _is_empty(value):
+            continue
+        out[key] = value
+    return out
+
+
+def compute_patch_hash(changed_files: Optional[List[str]]) -> str:
+    """Sha256 of concatenated ``path\\0mtime`` for each existing path, else ``\"\"``."""
+    if not changed_files:
+        return ""
+    parts: List[str] = []
+    for raw in changed_files:
+        if not isinstance(raw, str) or not raw:
+            continue
+        try:
+            mtime = os.path.getmtime(raw)
+        except OSError:
+            continue
+        parts.append("{0}\0{1}".format(raw, mtime))
+    if not parts:
+        return ""
+    blob = "\n".join(parts).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def append_receipt(state_dir: str, receipt: Any) -> None:
+    """Append one receipt as a JSONL line under ``state_dir``. Never raises."""
+    try:
+        if isinstance(receipt, TaskReceipt):
+            payload = build_receipt(**asdict(receipt))
+        elif isinstance(receipt, dict):
+            payload = build_receipt(**receipt)
+        else:
+            return
+        if not payload:
+            return
+        root = os.path.abspath(str(state_dir))
+        os.makedirs(root, exist_ok=True)
+        path = os.path.join(root, JSONL_FILENAME)
+        line = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        with open(path, "a", encoding="utf-8", newline="\n") as fh:
+            fh.write(line + "\n")
+    except Exception:
+        return
+
+
+def load_receipts(state_dir: str, limit: int = 20) -> list:
+    """Load up to ``limit`` most recent receipts (chronological order)."""
+    try:
+        if limit is None or int(limit) <= 0:
+            return []
+        limit = int(limit)
+        path = os.path.join(os.path.abspath(str(state_dir)), JSONL_FILENAME)
+        if not os.path.isfile(path):
+            return []
+        rows: List[dict] = []
+        with open(path, encoding="utf-8") as fh:
+            for raw_line in fh:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except (ValueError, TypeError):
+                    continue
+                if isinstance(rec, dict):
+                    rows.append(rec)
+        if len(rows) <= limit:
+            return rows
+        return rows[-limit:]
+    except Exception:
+        return []

--- a/harness/task_transaction.py
+++ b/harness/task_transaction.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+"""Lightweight per-turn task transaction (not a swarm).
+
+Immutable-style helpers for tracking goal, touched files, and verification
+across a single user ask. Intended for steer-merge context — never raises.
+"""
+
+from dataclasses import dataclass, field, replace
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+PHASES = ("intake", "acting", "verifying", "done")
+_PHASE_RANK = {name: idx for idx, name in enumerate(PHASES)}
+_PASS_RESULTS = frozenset({"pass", "ok", "skipped"})
+
+
+@dataclass(frozen=True)
+class TaskTransaction:
+    goal: str = ""
+    constraints: List[str] = field(default_factory=list)
+    plan: str = ""
+    files: List[str] = field(default_factory=list)
+    invariants: List[str] = field(default_factory=list)
+    verification: str = ""
+    phase: str = "intake"
+
+
+def _safe_str(value: Any) -> str:
+    try:
+        if value is None:
+            return ""
+        return str(value)
+    except Exception:
+        return ""
+
+
+def _normalize_phase(value: Any) -> str:
+    phase = _safe_str(value).strip().lower()
+    if phase in _PHASE_RANK:
+        return phase
+    return "intake"
+
+
+def _at_least_phase(current: str, minimum: str) -> str:
+    cur = _normalize_phase(current)
+    floor = _normalize_phase(minimum)
+    if _PHASE_RANK[cur] >= _PHASE_RANK[floor]:
+        return cur
+    return floor
+
+
+def _unique_ordered(existing: Sequence[str], incoming: Iterable[Any]) -> List[str]:
+    out: List[str] = []
+    seen = set()
+    for item in list(existing or []) + list(incoming or []):
+        path = _safe_str(item).strip()
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        out.append(path)
+    return out
+
+
+def new_transaction(user_message: str) -> TaskTransaction:
+    """Start a transaction from a user message (goal truncated to 500 chars)."""
+    goal = _safe_str(user_message).strip()[:500]
+    return TaskTransaction(goal=goal, phase="intake")
+
+
+def note_files(
+    tx: Optional[TaskTransaction],
+    paths: Optional[Iterable[Any]],
+) -> TaskTransaction:
+    """Append unique file paths; bump phase to at least acting."""
+    base = tx if isinstance(tx, TaskTransaction) else TaskTransaction()
+    files = _unique_ordered(base.files, paths or [])
+    phase = _at_least_phase(base.phase, "acting")
+    return replace(base, files=files, phase=phase)
+
+
+def note_verification(
+    tx: Optional[TaskTransaction],
+    result: str,
+) -> TaskTransaction:
+    """Record a verification result; done on pass/ok/skipped, else verifying."""
+    base = tx if isinstance(tx, TaskTransaction) else TaskTransaction()
+    text = _safe_str(result).strip()
+    key = text.lower()
+    phase = "done" if key in _PASS_RESULTS else "verifying"
+    return replace(base, verification=text, phase=phase)
+
+
+def as_dict(tx: Optional[TaskTransaction]) -> Dict[str, Any]:
+    """Serialize, omitting empty lists and empty strings."""
+    if not isinstance(tx, TaskTransaction):
+        return {}
+    out: Dict[str, Any] = {}
+    if tx.goal:
+        out["goal"] = tx.goal
+    if tx.constraints:
+        out["constraints"] = list(tx.constraints)
+    if tx.plan:
+        out["plan"] = tx.plan
+    if tx.files:
+        out["files"] = list(tx.files)
+    if tx.invariants:
+        out["invariants"] = list(tx.invariants)
+    if tx.verification:
+        out["verification"] = tx.verification
+    if tx.phase:
+        out["phase"] = tx.phase
+    return out
+
+
+def context_block(tx: Optional[TaskTransaction]) -> str:
+    """Compact markdown for steer merge; empty when only a goal is set."""
+    if not isinstance(tx, TaskTransaction):
+        return ""
+    has_extra = bool(
+        tx.constraints
+        or tx.plan
+        or tx.files
+        or tx.invariants
+        or tx.verification
+    )
+    if not has_extra:
+        return ""
+    lines: List[str] = ["## Task transaction"]
+    if tx.goal:
+        lines.append("goal: %s" % tx.goal)
+    if tx.phase:
+        lines.append("phase: %s" % tx.phase)
+    if tx.plan:
+        lines.append("plan: %s" % tx.plan)
+    if tx.constraints:
+        lines.append("constraints:")
+        lines.extend("- %s" % item for item in tx.constraints)
+    if tx.files:
+        lines.append("files:")
+        lines.extend("- %s" % path for path in tx.files)
+    if tx.invariants:
+        lines.append("invariants:")
+        lines.extend("- %s" % item for item in tx.invariants)
+    if tx.verification:
+        lines.append("verification: %s" % tx.verification)
+    return "\n".join(lines)

--- a/harness/tool_discovery.py
+++ b/harness/tool_discovery.py
@@ -81,7 +81,35 @@ _PILOT_EXTRAS: Set[str] = {
 _WORKER_EXTRAS: Set[str] = {"route_task"}
 
 
-def core_visible_names(no_delegation: bool = False) -> Set[str]:
+def core_visible_names(
+    no_delegation: bool = False,
+    profile: Optional[str] = None,
+) -> Set[str]:
+    """Core always-visible tool names for the current pilot mode / task profile.
+
+    MICRO returns the compact micro set (plus hash_edit when enabled) so prompts
+    stay small; STANDARD/DEEP keep CORE_PILOT / CORE_WORKER behavior.
+    """
+    try:
+        from .task_profile import MICRO, micro_visible_tool_names, normalize_profile
+
+        resolved = normalize_profile(profile)
+        if resolved == MICRO and not no_delegation:
+            names = set(micro_visible_tool_names())
+            try:
+                from .hash_edit import hash_edit_enabled
+
+                if hash_edit_enabled():
+                    names.add("hash_edit")
+                else:
+                    names.discard("hash_edit")
+            except Exception as exc:
+                _diag_note("tool_discovery.core_visible_hash_edit", exc)
+                names.discard("hash_edit")
+            return names
+    except Exception as exc:
+        _diag_note("tool_discovery.core_visible_profile", exc)
+
     base = _core_always()
     return base | (_WORKER_EXTRAS if no_delegation else _PILOT_EXTRAS)
 
@@ -176,6 +204,7 @@ class ToolCatalog:
         self._last_mcp_tools: Optional[Sequence] = None
         self._last_no_delegation = False
         self._last_browser_enabled = True
+        self._last_profile: Optional[str] = None
 
     @property
     def activated(self) -> Set[str]:
@@ -187,6 +216,7 @@ class ToolCatalog:
         mcp_tools: Optional[Sequence] = None,
         no_delegation: bool = False,
         browser_enabled: bool = True,
+        profile: Optional[str] = None,
     ) -> None:
         """Rebuild the search index from the current built-in + MCP tool set."""
         if mcp_tools is not None:
@@ -194,7 +224,9 @@ class ToolCatalog:
         mcp_tools = self._last_mcp_tools
         self._last_no_delegation = no_delegation
         self._last_browser_enabled = browser_enabled
-        core = core_visible_names(no_delegation)
+        if profile is not None:
+            self._last_profile = profile
+        core = core_visible_names(no_delegation, profile=self._last_profile)
         schema = build_tools_schema(
             mcp_tools,
             no_delegation=no_delegation,
@@ -336,12 +368,14 @@ class ToolCatalog:
         mcp_tools: Optional[Sequence] = None,
         no_delegation: Optional[bool] = None,
         browser_enabled: Optional[bool] = None,
+        profile: Optional[str] = None,
     ) -> List[dict]:
         """Build the tool schema exposed to the pilot for this turn."""
         self.refresh(
             mcp_tools=mcp_tools,
             no_delegation=self._last_no_delegation if no_delegation is None else no_delegation,
             browser_enabled=self._last_browser_enabled if browser_enabled is None else browser_enabled,
+            profile=self._last_profile if profile is None else profile,
         )
         if not discovery_enabled():
             return [e.schema_entry for e in sorted(self._entries.values(), key=lambda x: x.name)]

--- a/harness/tool_discovery.py
+++ b/harness/tool_discovery.py
@@ -164,6 +164,27 @@ def _truncate(text: str, limit: int = _MAX_DESC_CHARS) -> str:
     return text[: limit - 3].rstrip() + "..."
 
 
+def _profile_compacts_descriptions(profile: Optional[str]) -> bool:
+    """MICRO/STANDARD shrink tool descriptions; DEEP/None keep full text."""
+    try:
+        from .task_profile import MICRO, STANDARD, normalize_profile
+
+        return normalize_profile(profile) in (MICRO, STANDARD)
+    except Exception as exc:
+        _diag_note("tool_discovery.profile_compacts", exc)
+        return False
+
+
+def _compact_description(text: str, limit: int = _MAX_DESC_CHARS) -> str:
+    """First sentence (split on ``. ``), then hard-cap at ``limit`` chars."""
+    text = (text or "").strip()
+    if not text:
+        return ""
+    if ". " in text:
+        text = text.split(". ", 1)[0]
+    return _truncate(text, limit)
+
+
 @dataclass
 class CatalogEntry:
     tool_id: str
@@ -234,12 +255,20 @@ class ToolCatalog:
             include_search_tools=discovery_enabled(),
         )
         entries: Dict[str, CatalogEntry] = {}
+        compact = _profile_compacts_descriptions(self._last_profile)
         for item in schema:
             fn = item.get("function") or {}
             name = fn.get("name") or ""
             if not name:
                 continue
-            desc = _normalize_path_text(fn.get("description") or "")
+            raw_desc = _normalize_path_text(fn.get("description") or "")
+            desc = _compact_description(raw_desc) if compact else raw_desc
+            schema_entry = item
+            if desc != raw_desc:
+                schema_entry = {
+                    **item,
+                    "function": {**fn, "description": desc},
+                }
             if name.startswith("mcp_"):
                 qualified = _parse_mcp_wire_name(name)
                 tool_id = f"mcp:{qualified}"
@@ -259,7 +288,7 @@ class ToolCatalog:
                 description=desc,
                 source=source,
                 hidden=hidden,
-                schema_entry=item,
+                schema_entry=schema_entry,
                 search_text=search_text,
             )
 

--- a/harness/tool_requirement.py
+++ b/harness/tool_requirement.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Soft tool-use requirements (oh-my-pi remind-then-escalate).
+
+On MICRO/STANDARD turns that touch files, nudge the pilot to run tests/verify
+before settling. After a fixed remind budget with still no ``run_command``,
+callers may escalate rather than silently accept unverified edits.
+"""
+
+from typing import Optional, Union
+
+from .task_profile import MICRO, STANDARD, normalize_profile
+
+_REMIND_PROFILES = frozenset({MICRO, STANDARD})
+_MAX_REMINDS = 3
+
+
+def _as_int(value: Union[int, float, None]) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _profile_uses_soft_verify(profile: Optional[str]) -> bool:
+    resolved = normalize_profile(profile)
+    return resolved in _REMIND_PROFILES
+
+
+class SoftToolRequirement:
+    """Remind-then-escalate verify gate for MICRO/STANDARD file edits."""
+
+    MAX_REMINDS = _MAX_REMINDS
+
+    @staticmethod
+    def should_remind_verify(
+        profile: Optional[str],
+        files_touched: int,
+        ran_command: bool,
+        remind_count: int,
+    ) -> bool:
+        """True when MICRO/STANDARD edits lack a command and reminds remain."""
+        if not _profile_uses_soft_verify(profile):
+            return False
+        if _as_int(files_touched) < 1:
+            return False
+        if ran_command:
+            return False
+        return _as_int(remind_count) < SoftToolRequirement.MAX_REMINDS
+
+    @staticmethod
+    def remind_message() -> str:
+        """Short nudge to run tests/verify before finishing."""
+        return (
+            "You changed files but have not run tests or a verify command yet. "
+            "Run tests/verify before finishing."
+        )
+
+    @staticmethod
+    def should_escalate_unverified(
+        profile: Optional[str],
+        files_touched: int,
+        ran_command: bool,
+        remind_count: int,
+    ) -> bool:
+        """True after the remind budget with edits still unverified by a command.
+
+        Profile is accepted for API symmetry with ``should_remind_verify``;
+        escalation itself keys off remind budget, missing command, and edits.
+        """
+        if _as_int(files_touched) < 1:
+            return False
+        if ran_command:
+            return False
+        return _as_int(remind_count) >= SoftToolRequirement.MAX_REMINDS

--- a/harness/turn_economy.py
+++ b/harness/turn_economy.py
@@ -150,3 +150,19 @@ class TurnEconomy:
     def wiki_grounding_fields(self, price_in: float) -> dict[str, Any]:
         """Delegate to ``session_grounding_payload`` for this session."""
         return session_grounding_payload(self.state_dir, self.session_id, price_in)
+
+    @staticmethod
+    def task_profile_fields(
+        profile: str = "",
+        *,
+        source: str = "",
+        escalated_from: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Compact adaptive-depth receipt fields for usage merge."""
+        from .task_profile import task_profile_usage_fields
+
+        return task_profile_usage_fields(
+            profile,
+            source=source,
+            escalated_from=escalated_from,
+        )

--- a/harness/wiki_distill.py
+++ b/harness/wiki_distill.py
@@ -37,6 +37,19 @@ class WikiDistillMixin:
     """
 
     _WIKI_GROUNDING_MAX_CHARS = 8000  # ~2k tokens at chars//4
+    _WIKI_GROUNDING_STANDARD_MAX_CHARS = 2500
+
+    def _wiki_grounding_budget(self) -> tuple[int, int]:
+        """Return (search_limit, max_chars) for profile-aware wiki auto-inject."""
+        try:
+            from .task_profile import STANDARD, normalize_profile
+
+            profile = normalize_profile(getattr(self, "_task_profile", "") or "")
+            if profile == STANDARD:
+                return 3, self._WIKI_GROUNDING_STANDARD_MAX_CHARS
+        except Exception:
+            pass
+        return 5, self._WIKI_GROUNDING_MAX_CHARS
 
     def _wiki_grounding_query(self, user_message: str) -> str:
         """Build a compact wiki search query from the user turn and repo."""
@@ -68,7 +81,8 @@ class WikiDistillMixin:
             query = self._wiki_grounding_query(user_message)
             if not query:
                 return wiki_section
-            hits = self._wiki.search_pages(query, limit=5)
+            search_limit, max_chars = self._wiki_grounding_budget()
+            hits = self._wiki.search_pages(query, limit=search_limit)
             if not hits:
                 self._wiki_cache_key = user_message
                 self._wiki_cache_section = ""
@@ -83,7 +97,7 @@ class WikiDistillMixin:
                 "question is outside this injected slice.\n"
             )
             lines = [authoritative, "### Wiki grounding (auto-injected)"]
-            budget = self._WIKI_GROUNDING_MAX_CHARS - len(authoritative) - 40
+            budget = max_chars - len(authoritative) - 40
             per_hit = max(120, budget // max(1, len(hits)))
             for hit in hits:
                 title = str(hit.get("title") or hit.get("slug") or "").strip()
@@ -97,8 +111,8 @@ class WikiDistillMixin:
                 lines.append(f"- {label}: {snippet}" if snippet else f"- {label}")
 
             wiki_section = "\n".join(lines)
-            if len(wiki_section) > self._WIKI_GROUNDING_MAX_CHARS:
-                wiki_section = wiki_section[: self._WIKI_GROUNDING_MAX_CHARS].rstrip() + "…"
+            if len(wiki_section) > max_chars:
+                wiki_section = wiki_section[:max_chars].rstrip() + "…"
 
             try:
                 from pmharness.registry import resolve_price

--- a/harness/wiki_distill.py
+++ b/harness/wiki_distill.py
@@ -52,6 +52,15 @@ class WikiDistillMixin:
         return " ".join(parts).strip()
 
     def _build_turn_wiki_section(self, user_message: str) -> str:
+        # MICRO skips wiki auto-inject (orchestration only; never raises).
+        try:
+            from .task_profile import profile_skips_wiki
+
+            profile = getattr(self, "_task_profile", "") or ""
+            if profile_skips_wiki(profile):
+                return ""
+        except Exception:
+            pass
         wiki_section = ""
         if not self._wiki.configured:
             return wiki_section

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.214"
+version = "0.9.215"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.213"
+version = "0.9.214"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -243,3 +243,30 @@ def test_remote_only_plugin_enable_contributes_no_mcp(
         Path(record.path), plugins_home / "plugin-data" / record.namespace
     )
     assert any("not supported" in d.message for d in package.diagnostics)
+
+
+def test_extensions_marionette_capabilities_survives_load(tmp_path: Path) -> None:
+    root = tmp_path / "plugin"
+    root.mkdir()
+    _write_json(
+        root / "plugin.json",
+        _manifest(
+            name="portable.depth",
+            version="0.1.0",
+            description="depth plugin",
+            extensions={
+                "marionette": {
+                    "capabilities": ["adaptive-depth"],
+                    "task_types": ["micro", "standard"],
+                }
+            },
+            # Unknown top-level field must still be stripped.
+            capabilities=["should-be-stripped"],
+        ),
+    )
+    _write_skill(root)
+    package = load_agent_plugin(root, tmp_path / "data")
+    assert "capabilities" not in package.manifest
+    marionette = package.manifest["extensions"]["marionette"]
+    assert marionette["capabilities"] == ["adaptive-depth"]
+    assert marionette["task_types"] == ["micro", "standard"]

--- a/tests/test_boot_mcp_diag.py
+++ b/tests/test_boot_mcp_diag.py
@@ -1,23 +1,30 @@
-"""Regression: MCP boot thread must record errors via diag.note, not TypeError."""
+"""Regression: MCP boot is lazy (config only) and records via diag.note."""
 from __future__ import annotations
 
 import harness.server as srv
 
 
-def test_boot_mcp_records_string_errors_with_msg_kw(monkeypatch):
+def test_boot_mcp_defers_start_and_records_names(monkeypatch):
     notes: list[tuple] = []
+    started = {"n": 0}
 
     def fake_note(where, exc=None, msg=""):
         notes.append((where, exc, msg))
 
     class FakeMcp:
+        def effective_config(self):
+            return {"docker": {}, "wiki": {}}
+
         def start_all(self):
+            started["n"] += 1
             return {"docker": "connection refused", "wiki": "ok"}
 
     # Exercise the production helper — do not reimplement the nested body.
     srv.boot_mcp_servers(mcp=FakeMcp(), diag=fake_note)
 
-    assert ("mcp.boot_error", None, "docker: connection refused") in notes
+    assert started["n"] == 0, "boot must not call start_all"
+    assert ("mcp.boot_deferred", None, "docker, wiki") in notes
+    assert all(n[0] != "mcp.boot_error" for n in notes)
     assert all(isinstance(n[1], (type(None), BaseException)) for n in notes)
 
 
@@ -28,8 +35,11 @@ def test_boot_mcp_records_boot_fail_with_exc_kw(monkeypatch):
         notes.append((where, exc, msg))
 
     class FakeMcp:
-        def start_all(self):
+        def effective_config(self):
             raise RuntimeError("boom")
+
+        def start_all(self):
+            raise AssertionError("start_all must not be called on boot")
 
     srv.boot_mcp_servers(mcp=FakeMcp(), diag=fake_note)
 
@@ -48,12 +58,15 @@ def test_boot_mcp_servers_uses_module_defaults(monkeypatch):
         notes.append((where, exc, msg))
 
     class FakeMcp:
+        def effective_config(self):
+            return {"local": {}}
+
         def start_all(self):
-            return {"local": "timeout"}
+            raise AssertionError("start_all must not be called on boot")
 
     monkeypatch.setattr(srv, "_diag", fake_note)
     monkeypatch.setattr(srv, "_mcp", FakeMcp())
 
     srv.boot_mcp_servers()
 
-    assert ("mcp.boot_error", None, "local: timeout") in notes
+    assert ("mcp.boot_deferred", None, "local") in notes

--- a/tests/test_delivery_mode.py
+++ b/tests/test_delivery_mode.py
@@ -1,4 +1,4 @@
-"""DeliveryMode — auto | steer | follow_up shared vocabulary."""
+"""DeliveryMode — auto | steer | follow_up | interrupt shared vocabulary."""
 from __future__ import annotations
 
 from harness.delivery_mode import (
@@ -34,6 +34,15 @@ class _FakeSession:
     def run_auto(self, objective, budget=None):
         self.auto_calls.append(objective)
         return iter(())
+
+
+class _FakeSessionWithInterrupt(_FakeSession):
+    def __init__(self):
+        super().__init__()
+        self.interrupts = []
+
+    def interrupt(self):
+        self.interrupts.append(True)
 
 
 def test_delivery_mode_steer_when_busy():
@@ -108,3 +117,31 @@ def test_delivery_mode_follow_up_on_schedule_busy():
     delivered = deliver_schedule_to_session(schedule, session, session_busy=True)
     assert delivered["action"] == "enqueue_prompt"
     assert session.prompts[0]["text"] == "queue this"
+
+
+def test_delivery_mode_interrupt_when_busy():
+    assert resolve_delivery(True, "interrupt") == DeliveryAction.INTERRUPT_THEN_QUEUE.value
+    session = _FakeSessionWithInterrupt()
+    session._busy = True
+    result = apply_delivery(
+        session, "stop and do this", session_busy=True, requested="interrupt",
+    )
+    assert result["ok"] is True
+    assert result["action"] == "interrupt_then_queue"
+    assert result.get("interrupted") is True
+    assert session.interrupts == [True]
+    assert session.prompts[0]["text"] == "stop and do this"
+
+
+def test_delivery_mode_interrupt_when_idle():
+    assert resolve_delivery(False, "interrupt") == DeliveryAction.INTERRUPT_THEN_QUEUE.value
+    session = _FakeSession()
+    session._busy = False
+    result = apply_delivery(
+        session, "just queue", session_busy=False, requested="interrupt",
+    )
+    assert result["ok"] is True
+    assert result["action"] == "interrupt_then_queue"
+    assert "interrupted" not in result
+    assert session.prompts[0]["text"] == "just queue"
+    assert normalize_delivery_mode("interrupt") == DeliveryMode.INTERRUPT.value

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -103,6 +103,51 @@ def test_manager_start_all_reports_errors(tmp_path):
         m.stop_all()
 
 
+def test_lazy_boot_status_idle_and_discovered_empty(tmp_path):
+    """Configured-but-never-started servers are idle, not errors; tools empty."""
+    cfgp = tmp_path / "mcp.json"
+    m = McpManager(config_path=str(cfgp))
+    m.save_server("fake", {"command": sys.executable, "args": [FAKE]})
+    st = m.status()
+    assert len(st) == 1
+    assert st[0]["name"] == "fake"
+    assert st[0]["running"] is False
+    assert st[0]["tools"] == 0
+    assert not st[0].get("error")
+    assert m.discovered_tools() == []
+
+
+def test_ensure_server_starts_only_when_not_alive(tmp_path):
+    cfgp = tmp_path / "mcp.json"
+    m = McpManager(config_path=str(cfgp))
+    m.save_server("fake", {"command": sys.executable, "args": [FAKE]})
+    try:
+        tools = m.ensure_server("fake")
+        assert {t.name for t in tools} == {"echo", "add"}
+        assert m.status()[0]["running"]
+        # Second call must not restart (same tool set, still alive).
+        again = m.ensure_server("fake")
+        assert {t.name for t in again} == {"echo", "add"}
+        assert m.status()[0]["running"]
+    finally:
+        m.stop_all()
+
+
+def test_call_starts_missing_client_without_prior_start(tmp_path):
+    """Lazy connect: call() starts a configured idle server on first use."""
+    cfgp = tmp_path / "mcp.json"
+    m = McpManager(config_path=str(cfgp))
+    m.save_server("fake", {"command": sys.executable, "args": [FAKE]})
+    try:
+        assert m.discovered_tools() == []
+        out = m.call("fake.echo", {"text": "hi"})
+        assert out["content"][0]["text"] == "hi"
+        assert m.status()[0]["running"]
+        assert any(t.qualified == "fake.echo" for t in m.discovered_tools())
+    finally:
+        m.stop_all()
+
+
 def test_manager_refresh_reconnects(tmp_path):
     """Refresh must stop then start so a previously-failed server can recover."""
     cfgp = tmp_path / "mcp.json"

--- a/tests/test_parallel_reads.py
+++ b/tests/test_parallel_reads.py
@@ -137,8 +137,17 @@ def test_parallel_reads_mixed_with_write():
     with open(file3_actual_path, "r") as f:
         assert f.read() == "file3 written content"
         
-    # Verify order and values
-    user_inputs_and_tools = [h for h in s._history if h["role"] in ("user", "tool") and h != s._history[1]]
+    # Verify order and values. MICRO/STANDARD file edits may append a
+    # verify-remind user message after the action results; ignore it here.
+    from harness.tool_requirement import SoftToolRequirement
+
+    remind = SoftToolRequirement.remind_message()
+    user_inputs_and_tools = [
+        h for h in s._history
+        if h["role"] in ("user", "tool")
+        and h != s._history[1]
+        and remind not in (h.get("content") or "")
+    ]
     assert len(user_inputs_and_tools) == 3
     
     assert "file1 init" in user_inputs_and_tools[0]["content"]

--- a/tests/test_task_kernel_wire.py
+++ b/tests/test_task_kernel_wire.py
@@ -1,0 +1,182 @@
+"""Last-mile wiring: receipts, task transaction, and soft verify in the send loop."""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from harness.send_loop_phases import (
+    _yield_task_profile_escalation,
+    begin_turn_task_kernel,
+    drain_idle_turn,
+    finalize_assistant_turn,
+    maybe_soft_verify_nudge,
+    persist_turn_receipt,
+)
+from harness.task_profile import MICRO, STANDARD
+from harness.task_receipt import JSONL_FILENAME, load_receipts, prompt_hash
+from harness.task_transaction import as_dict, new_transaction, note_files
+from harness.tool_requirement import SoftToolRequirement
+
+
+def test_begin_turn_task_kernel_starts_transaction():
+    session = SimpleNamespace()
+    begin_turn_task_kernel(session, "  fix the typo in README  ")
+    assert session._turn_ran_command is False
+    assert session._verify_remind_count == 0
+    assert session._turn_user_message == "  fix the typo in README  "
+    assert session._turn_verification == ""
+    assert as_dict(session._task_tx)["goal"] == "fix the typo in README"
+    assert as_dict(session._task_tx)["phase"] == "intake"
+
+
+def test_yield_task_profile_escalation_notes_files():
+    session = SimpleNamespace(
+        _task_tx=new_transaction("edit helpers"),
+        _maybe_escalate_task_profile=lambda **_k: None,
+    )
+    events = list(_yield_task_profile_escalation(session, ["a.py", "a.py", "b.py"]))
+    assert events == []
+    assert as_dict(session._task_tx)["files"] == ["a.py", "b.py"]
+    assert as_dict(session._task_tx)["phase"] == "acting"
+
+
+def test_persist_turn_receipt_writes_jsonl(tmp_path: Path):
+    changed = tmp_path / "edited.py"
+    changed.write_text("x = 1\n", encoding="utf-8")
+    session = SimpleNamespace(
+        config=SimpleNamespace(
+            state_dir=str(tmp_path),
+            repo=str(tmp_path),
+            driver="stub-oracle-v2",
+        ),
+        harness_session_id="sess-1",
+        _task_profile=MICRO,
+        _task_profile_source="heuristic",
+        _task_profile_escalated_from=None,
+        _task_tx=note_files(new_transaction("typo in README"), [str(changed)]),
+        _turn_ran_command=True,
+        _turn_verification="pass",
+        _turn_user_message="typo in README",
+        pilot=SimpleNamespace(model="stub"),
+    )
+    persist_turn_receipt(session, "typo in README")
+    rows = load_receipts(str(tmp_path), limit=5)
+    assert len(rows) == 1
+    rec = rows[0]
+    assert rec["task_id"] == "sess-1"
+    assert rec["profile"] == MICRO
+    assert rec["prompt_hash"] == prompt_hash("typo in README")
+    assert rec["verification"] == "pass"
+    assert rec["changed_files"] == [str(changed)]
+    assert rec["adapter"] == "stub-oracle-v2"
+    assert (tmp_path / JSONL_FILENAME).is_file()
+
+
+def test_persist_turn_receipt_never_raises_without_state_dir():
+    persist_turn_receipt(SimpleNamespace(), "hi")
+
+
+def test_maybe_soft_verify_nudge_reminds_then_continues():
+    session = SimpleNamespace(
+        _history=[],
+        _task_profile=MICRO,
+        _task_tx=note_files(new_transaction("edit"), ["a.py"]),
+        _turn_ran_command=False,
+        _verify_remind_count=0,
+    )
+    gen = maybe_soft_verify_nudge(session)
+    try:
+        while True:
+            next(gen)
+    except StopIteration as stop:
+        nudged = stop.value
+    assert nudged is True
+    assert session._verify_remind_count == 1
+    assert session._history[-1]["role"] == "user"
+    assert session._history[-1]["content"] == SoftToolRequirement.remind_message()
+
+
+def test_maybe_soft_verify_nudge_skips_when_command_ran():
+    session = SimpleNamespace(
+        _history=[],
+        _task_profile=STANDARD,
+        _task_tx=note_files(new_transaction("edit"), ["a.py"]),
+        _turn_ran_command=True,
+        _verify_remind_count=0,
+    )
+    gen = maybe_soft_verify_nudge(session)
+    try:
+        while True:
+            next(gen)
+    except StopIteration as stop:
+        nudged = stop.value
+    assert nudged is False
+    assert session._history == []
+
+
+def test_drain_idle_turn_nudges_unverified_micro_edits():
+    session = SimpleNamespace(
+        drain_steer=lambda: [],
+        _history=[],
+        _steer_pending=False,
+        _next_queued_needs_driver_swap=lambda: False,
+        _pop_next_prompt=lambda: None,
+        _submit_housekeeping=lambda *_a, **_k: None,
+        _maybe_ingest="ingest",
+        _task_profile=MICRO,
+        _task_tx=note_files(new_transaction("typo"), ["README.md"]),
+        _turn_ran_command=False,
+        _verify_remind_count=0,
+        config=SimpleNamespace(state_dir="", repo=""),
+    )
+    events = []
+    gen = drain_idle_turn(
+        session,
+        user_message="typo",
+        step=0,
+        swarms=0,
+        turn_prose=[],
+        turn_findings=[],
+    )
+    try:
+        while True:
+            events.append(next(gen))
+    except StopIteration as stop:
+        disposition, _msg = stop.value
+    assert disposition == "continue"
+    assert events == []
+    assert session._verify_remind_count == 1
+
+
+def test_finalize_assistant_turn_emits_done_and_persists(tmp_path: Path):
+    submitted = []
+    session = SimpleNamespace(
+        config=SimpleNamespace(state_dir=str(tmp_path), repo="", driver=""),
+        harness_session_id="s",
+        _task_profile=MICRO,
+        _task_profile_source="heuristic",
+        _task_profile_escalated_from=None,
+        _task_tx=new_transaction("hi"),
+        _turn_ran_command=False,
+        _turn_verification="",
+        _turn_user_message="hi",
+        _submit_housekeeping=lambda fn, *a: submitted.append((fn, a)),
+        _maybe_ingest="ingest",
+        pilot=SimpleNamespace(model=""),
+    )
+    events = list(finalize_assistant_turn(
+        session,
+        user_message="hi",
+        step=1,
+        swarms=0,
+        turn_prose=["p"],
+        turn_findings=[],
+        extra={"stagnation_halt": True},
+    ))
+    assert events[0].kind == "assistant_done"
+    assert events[0].data["turns"] == 2
+    assert events[0].data["stagnation_halt"] is True
+    assert submitted == [("ingest", ("hi", ["p"], []))]
+    rows = load_receipts(str(tmp_path), limit=1)
+    assert rows[0]["task_id"] == "s"
+    assert rows[0]["profile"] == MICRO

--- a/tests/test_task_profile.py
+++ b/tests/test_task_profile.py
@@ -1,0 +1,142 @@
+"""Adaptive task-depth MICRO / STANDARD / DEEP (hermetic)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from harness.config import HarnessConfig
+from harness.conversation import ConversationalSession
+from harness.pilot_guards import check_swarm_gate, new_turn_guard_state
+from harness.task_profile import (
+    DEEP,
+    MICRO,
+    STANDARD,
+    classify_task_profile,
+    maybe_escalate,
+    micro_visible_tool_names,
+    profile_disables_swarm_gate,
+)
+from harness.tool_discovery import core_visible_names
+from harness.wiki import WikiClient
+
+
+def test_classify_typo_readme_is_micro():
+    assert classify_task_profile("typo in README.md") == MICRO
+
+
+def test_classify_add_oauth_is_standard():
+    assert classify_task_profile("add OAuth support") == STANDARD
+
+
+def test_classify_audit_architecture_is_deep():
+    assert classify_task_profile("audit authentication architecture") == DEEP
+
+
+def test_classify_override_beats_heuristics():
+    assert classify_task_profile("audit authentication architecture", override="micro") == MICRO
+    assert classify_task_profile("typo in README.md", override="deep") == DEEP
+    assert classify_task_profile("typo in README.md", override="auto") == MICRO
+    assert classify_task_profile("add OAuth support", override="STANDARD") == STANDARD
+
+
+def test_escalate_micro_three_files_to_standard():
+    assert maybe_escalate(MICRO, files_touched=3) == STANDARD
+
+
+def test_escalate_never_demotes():
+    assert maybe_escalate(DEEP, files_touched=0) == DEEP
+    assert maybe_escalate(STANDARD, files_touched=0) == STANDARD
+    assert maybe_escalate(STANDARD, files_touched=2, tests_failed=True) == STANDARD
+
+
+def test_escalate_standard_to_deep():
+    assert maybe_escalate(STANDARD, files_touched=8) == DEEP
+    assert maybe_escalate(STANDARD, user_wants_deep=True) == DEEP
+    assert maybe_escalate(MICRO, files_touched=8) == DEEP
+
+
+def test_micro_visible_tool_names_contract():
+    names = micro_visible_tool_names()
+    assert "search_tools" in names
+    assert "search_files" in names
+    assert "run_swarm" not in names
+    assert "query_wiki" not in names
+    assert "search_codegraph" not in names
+    assert "run_implement" not in names
+    assert "run_parallel" not in names
+
+
+def test_core_visible_names_micro_hides_orchestration():
+    names = core_visible_names(profile=MICRO)
+    assert "search_tools" in names
+    assert "read_file" in names
+    assert "run_swarm" not in names
+    assert "query_wiki" not in names
+    assert "run_implement" not in names
+    standard = core_visible_names(profile=STANDARD)
+    assert "run_swarm" in standard
+    assert "query_wiki" in standard
+
+
+def test_swarm_gate_allows_exploration_when_micro(monkeypatch):
+    monkeypatch.delenv("HARNESS_SWARM_GATE", raising=False)
+    prompt = "audit authentication architecture across the codebase"
+    state = new_turn_guard_state(prompt, task_profile=MICRO)
+    assert state.broad_intent is True
+    assert profile_disables_swarm_gate(state.task_profile) is True
+    verdict = check_swarm_gate(
+        state, "list_dir", SimpleNamespace(kind="list_dir", path=".")
+    )
+    assert verdict.suppress is False
+
+    # Same turn without MICRO still suppresses (sanity).
+    blocked = new_turn_guard_state(prompt, task_profile=STANDARD)
+    assert check_swarm_gate(
+        blocked, "list_dir", SimpleNamespace(kind="list_dir", path=".")
+    ).suppress is True
+
+
+def test_wiki_section_empty_when_micro_even_if_configured(tmp_path, monkeypatch):
+    cfg = HarnessConfig(
+        driver="stub-oracle-v2",
+        state_dir=str(tmp_path),
+        repo=str(tmp_path / "repo"),
+    )
+    s = ConversationalSession(cfg)
+    s._wiki = WikiClient(base_url="https://wiki.example.com", token="tok")
+    s._task_profile = MICRO
+
+    def boom(query, *, limit=5):
+        raise AssertionError("wiki search must not run on MICRO")
+
+    monkeypatch.setattr(s._wiki, "search_pages", boom)
+    assert s._wiki.configured is True
+    assert s._build_turn_wiki_section("what did we decide about auth?") == ""
+
+
+def test_cli_micro_sets_task_profile(monkeypatch):
+    captured = {}
+
+    class FakeSession:
+        def __init__(self, cfg):
+            captured["cfg"] = cfg
+
+        def preflight(self):
+            return None
+
+        def run(self, *a, **k):
+            return iter([])
+
+    monkeypatch.setattr("harness.cli.Session", FakeSession)
+    from harness.cli import main
+
+    code = main(["--micro", "--driver", "stub-oracle-v2", "typo in README.md"])
+    assert code == 2  # no final action from empty run
+    assert captured["cfg"].task_profile == "micro"
+
+
+def test_config_from_env_task_profile(monkeypatch, tmp_path):
+    monkeypatch.setenv("HARNESS_CONFIG", str(tmp_path / "missing.json"))
+    monkeypatch.delenv("HARNESS_TASK_PROFILE", raising=False)
+    assert HarnessConfig.from_env().task_profile == "auto"
+    monkeypatch.setenv("HARNESS_TASK_PROFILE", "deep")
+    assert HarnessConfig.from_env().task_profile == "deep"

--- a/tests/test_task_receipt.py
+++ b/tests/test_task_receipt.py
@@ -1,0 +1,115 @@
+"""Hermetic tests for compact MICRO/STANDARD task receipts."""
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+from harness.task_receipt import (
+    TaskReceipt,
+    append_receipt,
+    build_receipt,
+    compute_patch_hash,
+    git_branch,
+    load_receipts,
+    prompt_hash,
+)
+
+
+def test_prompt_hash_stable():
+    assert prompt_hash("hello") == prompt_hash("hello")
+    expected = hashlib.sha256(b"hello").hexdigest()[:16]
+    assert prompt_hash("hello") == expected
+    assert len(prompt_hash("hello")) == 16
+
+
+def test_empty_message_hash_still_hex():
+    digest = prompt_hash("")
+    assert len(digest) == 16
+    assert all(c in "0123456789abcdef" for c in digest)
+    assert digest == hashlib.sha256(b"").hexdigest()[:16]
+
+
+def test_git_branch_on_non_repo_returns_empty(tmp_path: Path):
+    assert git_branch(str(tmp_path)) == ""
+    assert git_branch(str(tmp_path / "missing")) == ""
+    assert git_branch("") == ""
+
+
+def test_build_receipt_omits_empty_values():
+    rec = build_receipt(
+        task_id="t1",
+        profile="MICRO",
+        model="",
+        adapter=None,
+        changed_files=[],
+        verification="pass",
+        created_at="2026-08-13T00:00:00+00:00",
+    )
+    assert rec["task_id"] == "t1"
+    assert rec["profile"] == "MICRO"
+    assert rec["verification"] == "pass"
+    assert "model" not in rec
+    assert "adapter" not in rec
+    assert "changed_files" not in rec
+    assert rec["created_at"] == "2026-08-13T00:00:00+00:00"
+
+
+def test_append_load_roundtrip(tmp_path: Path):
+    state = tmp_path / "state"
+    first = build_receipt(
+        task_id="a",
+        profile="MICRO",
+        prompt_hash=prompt_hash("msg-a"),
+        verification="pass",
+        created_at="2026-08-13T01:00:00+00:00",
+    )
+    second = build_receipt(
+        task_id="b",
+        profile="STANDARD",
+        prompt_hash=prompt_hash("msg-b"),
+        verification="skipped",
+        created_at="2026-08-13T02:00:00+00:00",
+    )
+    append_receipt(str(state), first)
+    append_receipt(str(state), second)
+
+    loaded = load_receipts(str(state), limit=20)
+    assert len(loaded) == 2
+    assert loaded[0]["task_id"] == "a"
+    assert loaded[1]["task_id"] == "b"
+    assert loaded[0]["prompt_hash"] == prompt_hash("msg-a")
+
+    # Dataclass path also appends.
+    append_receipt(
+        str(state),
+        TaskReceipt(
+            task_id="c",
+            profile="MICRO",
+            created_at="2026-08-13T03:00:00+00:00",
+        ),
+    )
+    loaded3 = load_receipts(str(state), limit=2)
+    assert len(loaded3) == 2
+    assert loaded3[0]["task_id"] == "b"
+    assert loaded3[1]["task_id"] == "c"
+
+
+def test_append_receipt_never_raises(tmp_path: Path):
+    # Invalid state_dir (file, not directory) should not raise.
+    bad = tmp_path / "not-a-dir"
+    bad.write_text("x", encoding="utf-8")
+    append_receipt(str(bad), {"task_id": "x"})
+    assert load_receipts(str(tmp_path / "missing"), limit=5) == []
+
+
+def test_compute_patch_hash_empty_and_stable(tmp_path: Path):
+    assert compute_patch_hash(None) == ""
+    assert compute_patch_hash([]) == ""
+    f = tmp_path / "a.py"
+    f.write_text("print(1)\n", encoding="utf-8")
+    h1 = compute_patch_hash([str(f)])
+    h2 = compute_patch_hash([str(f)])
+    assert h1 == h2
+    assert len(h1) == 64
+    assert all(c in "0123456789abcdef" for c in h1)

--- a/tests/test_task_transaction.py
+++ b/tests/test_task_transaction.py
@@ -1,0 +1,124 @@
+"""Hermetic tests for lightweight task transactions."""
+from __future__ import annotations
+
+from dataclasses import replace
+
+from harness.task_transaction import (
+    TaskTransaction,
+    as_dict,
+    context_block,
+    new_transaction,
+    note_files,
+    note_verification,
+)
+
+
+def test_new_transaction_strips_and_truncates():
+    tx = new_transaction("  ship the gate  ")
+    assert tx.goal == "ship the gate"
+    assert tx.phase == "intake"
+    assert tx.files == []
+    assert tx.constraints == []
+    assert tx.plan == ""
+    assert tx.invariants == []
+    assert tx.verification == ""
+
+    long_msg = "x" * 600
+    tx2 = new_transaction(long_msg)
+    assert len(tx2.goal) == 500
+    assert tx2.goal == "x" * 500
+
+
+def test_new_transaction_never_raises_on_none():
+    tx = new_transaction(None)  # type: ignore[arg-type]
+    assert tx.goal == ""
+    assert tx.phase == "intake"
+
+
+def test_note_files_unique_ordered_and_phase_acting():
+    tx = new_transaction("edit helpers")
+    assert tx.phase == "intake"
+
+    tx2 = note_files(tx, ["a.py", "b.py", "a.py", "  ", None, "b.py"])
+    assert tx2.files == ["a.py", "b.py"]
+    assert tx2.phase == "acting"
+    # Immutable: original unchanged.
+    assert tx.files == []
+    assert tx.phase == "intake"
+
+    tx3 = note_files(tx2, ["c.py", "a.py"])
+    assert tx3.files == ["a.py", "b.py", "c.py"]
+    assert tx3.phase == "acting"
+
+
+def test_note_files_does_not_demote_later_phase():
+    tx = replace(new_transaction("done-ish"), phase="verifying")
+    tx2 = note_files(tx, ["z.py"])
+    assert tx2.files == ["z.py"]
+    assert tx2.phase == "verifying"
+
+
+def test_note_verification_pass_ok_skipped_done():
+    tx = note_files(new_transaction("verify me"), ["t.py"])
+    for result in ("pass", "OK", " skipped ", "Pass"):
+        out = note_verification(tx, result)
+        assert out.phase == "done"
+        assert out.verification == result.strip()
+
+
+def test_note_verification_non_pass_is_verifying():
+    tx = new_transaction("still checking")
+    out = note_verification(tx, "fail: 1 test")
+    assert out.phase == "verifying"
+    assert out.verification == "fail: 1 test"
+
+    empty = note_verification(tx, "  ")
+    assert empty.phase == "verifying"
+    assert empty.verification == ""
+
+
+def test_as_dict_omits_empty_lists_and_strings():
+    bare = new_transaction("")
+    assert as_dict(bare) == {"phase": "intake"}
+
+    tx = note_files(new_transaction("goal text"), ["a.py"])
+    tx = replace(tx, plan="do the thing", constraints=["no bump"], invariants=[])
+    d = as_dict(tx)
+    assert d["goal"] == "goal text"
+    assert d["files"] == ["a.py"]
+    assert d["plan"] == "do the thing"
+    assert d["constraints"] == ["no bump"]
+    assert "invariants" not in d
+    assert "verification" not in d
+    assert d["phase"] == "acting"
+
+
+def test_context_block_empty_when_only_goal():
+    tx = new_transaction("only a goal")
+    assert context_block(tx) == ""
+
+    empty = new_transaction("")
+    assert context_block(empty) == ""
+
+
+def test_context_block_compact_markdown_with_extras():
+    tx = note_files(new_transaction("ship it"), ["harness/task_transaction.py"])
+    tx = replace(tx, plan="add module + tests", constraints=["no version bump"])
+    tx = note_verification(tx, "pass")
+    block = context_block(tx)
+    assert block.startswith("## Task transaction")
+    assert "goal: ship it" in block
+    assert "phase: done" in block
+    assert "plan: add module + tests" in block
+    assert "- harness/task_transaction.py" in block
+    assert "- no version bump" in block
+    assert "verification: pass" in block
+
+
+def test_helpers_tolerate_bad_tx():
+    assert as_dict(None) == {}  # type: ignore[arg-type]
+    assert context_block(None) == ""  # type: ignore[arg-type]
+    recovered = note_files(None, ["a.py"])  # type: ignore[arg-type]
+    assert isinstance(recovered, TaskTransaction)
+    assert recovered.files == ["a.py"]
+    assert recovered.phase == "acting"

--- a/tests/test_tool_requirement.py
+++ b/tests/test_tool_requirement.py
@@ -1,0 +1,89 @@
+"""Hermetic tests for SoftToolRequirement and MICRO/STANDARD schema compaction."""
+from __future__ import annotations
+
+from harness.mcp_client import McpTool
+from harness.task_profile import DEEP, MICRO, STANDARD
+from harness.tool_discovery import ToolCatalog
+from harness.tool_requirement import SoftToolRequirement
+
+
+def test_should_remind_micro_with_edits_no_command():
+    assert SoftToolRequirement.should_remind_verify(MICRO, 1, False, 0) is True
+    assert SoftToolRequirement.should_remind_verify(STANDARD, 2, False, 2) is True
+
+
+def test_should_remind_false_when_ran_command_or_no_edits():
+    assert SoftToolRequirement.should_remind_verify(MICRO, 1, True, 0) is False
+    assert SoftToolRequirement.should_remind_verify(MICRO, 0, False, 0) is False
+
+
+def test_should_remind_false_for_deep_or_none_or_exhausted():
+    assert SoftToolRequirement.should_remind_verify(DEEP, 1, False, 0) is False
+    assert SoftToolRequirement.should_remind_verify(None, 1, False, 0) is False
+    assert SoftToolRequirement.should_remind_verify(MICRO, 1, False, 3) is False
+    assert SoftToolRequirement.should_remind_verify(MICRO, 1, False, 4) is False
+
+
+def test_remind_message_asks_to_verify():
+    msg = SoftToolRequirement.remind_message()
+    assert isinstance(msg, str) and msg.strip()
+    lowered = msg.lower()
+    assert "verify" in lowered or "test" in lowered
+    assert "finish" in lowered or "before" in lowered
+
+
+def test_should_escalate_after_three_reminds_unverified():
+    assert SoftToolRequirement.should_escalate_unverified(MICRO, 1, False, 3) is True
+    assert SoftToolRequirement.should_escalate_unverified(STANDARD, 2, False, 5) is True
+
+
+def test_should_escalate_false_when_command_run_or_no_edits_or_under_budget():
+    assert SoftToolRequirement.should_escalate_unverified(MICRO, 1, True, 3) is False
+    assert SoftToolRequirement.should_escalate_unverified(MICRO, 0, False, 3) is False
+    assert SoftToolRequirement.should_escalate_unverified(MICRO, 1, False, 2) is False
+
+
+def test_micro_standard_compact_long_catalog_description():
+    long_desc = (
+        "First sentence about creating GitHub issues with a title and body. "
+        + ("Additional trailing detail about labels milestones assignees and projects. " * 8)
+    )
+    assert len(long_desc) > 160
+
+    tool = McpTool(
+        server="github",
+        name="create_issue",
+        description=long_desc,
+        input_schema={"type": "object", "properties": {}},
+    )
+
+    for profile in (MICRO, STANDARD):
+        catalog = ToolCatalog()
+        catalog.refresh(mcp_tools=[tool], profile=profile)
+        entry = next(e for e in catalog._entries.values() if e.source == "mcp")
+        assert len(entry.description) < len(long_desc)
+        assert len(entry.description) <= 160
+        assert entry.description.startswith("First sentence about creating GitHub issues")
+        assert "Additional trailing detail" not in entry.description
+        schema_desc = entry.schema_entry["function"]["description"]
+        assert schema_desc == entry.description
+
+
+def test_deep_and_none_keep_full_catalog_description():
+    long_desc = (
+        "First sentence about creating GitHub issues with a title and body. "
+        "Additional trailing detail about labels milestones assignees and projects."
+    )
+    tool = McpTool(
+        server="github",
+        name="create_issue",
+        description=long_desc,
+        input_schema={"type": "object", "properties": {}},
+    )
+
+    for profile in (DEEP, None):
+        catalog = ToolCatalog()
+        catalog.refresh(mcp_tools=[tool], profile=profile)
+        entry = next(e for e in catalog._entries.values() if e.source == "mcp")
+        assert entry.description == long_desc
+        assert "Additional trailing detail" in entry.description

--- a/tests/test_wiki_distill_mixin.py
+++ b/tests/test_wiki_distill_mixin.py
@@ -50,7 +50,28 @@ def test_mixin_defines_no_init():
 
 def test_wiki_grounding_max_chars_on_mixin():
     assert "_WIKI_GROUNDING_MAX_CHARS" in WikiDistillMixin.__dict__
+    assert "_WIKI_GROUNDING_STANDARD_MAX_CHARS" in WikiDistillMixin.__dict__
     assert ConversationalSession._WIKI_GROUNDING_MAX_CHARS == 8000
+    assert ConversationalSession._WIKI_GROUNDING_STANDARD_MAX_CHARS == 2500
+
+
+def test_wiki_grounding_budget_profile_aware():
+    from harness.task_profile import DEEP, MICRO, STANDARD
+
+    class _Stub(WikiDistillMixin):
+        pass
+
+    stub = _Stub()
+    stub._task_profile = STANDARD
+    assert stub._wiki_grounding_budget() == (3, 2500)
+    stub._task_profile = DEEP
+    assert stub._wiki_grounding_budget() == (5, 8000)
+    stub._task_profile = MICRO
+    assert stub._wiki_grounding_budget() == (5, 8000)
+    stub._task_profile = "unknown"
+    assert stub._wiki_grounding_budget() == (5, 8000)
+    stub._task_profile = ""
+    assert stub._wiki_grounding_budget() == (5, 8000)
 
 
 def test_send_and_busy_not_folded_into_wiki_distill():

--- a/tests/test_wiki_grounding.py
+++ b/tests/test_wiki_grounding.py
@@ -5,6 +5,7 @@ import tempfile
 
 from harness.config import HarnessConfig
 from harness.conversation import ConversationalSession
+from harness.task_profile import DEEP, STANDARD
 from harness.wiki import WikiClient
 from harness.wiki_grounding_savings import (
     JSONL_FILENAME,
@@ -169,6 +170,62 @@ def test_session_grounding_payload_shape(tmp_path):
     assert payload["wiki_tokens_fed"] == 200
     assert payload["wiki_pages_fed"] == 2
     assert "wiki_estimated_savings_usd" in payload
+
+
+def test_wiki_section_standard_profile_uses_tighter_budget(tmp_path, monkeypatch):
+    s = _session(
+        tmp_path,
+        wiki_url="https://wiki.example.com",
+        wiki_token="tok",
+        repo=str(tmp_path / "marionette"),
+    )
+    s._task_profile = STANDARD
+    captured = {}
+
+    def fake_search(query, *, limit=5):
+        captured["limit"] = limit
+        return [
+            {
+                "title": f"Hit {i}",
+                "slug": f"hit-{i}",
+                "snippet": "x" * 500,
+            }
+            for i in range(limit)
+        ]
+
+    monkeypatch.setattr(s._wiki, "search_pages", fake_search)
+    section = s._build_turn_wiki_section("what about the default driver?")
+    assert captured["limit"] == 3
+    assert section
+    assert len(section) <= s._WIKI_GROUNDING_STANDARD_MAX_CHARS
+
+
+def test_wiki_section_deep_profile_keeps_full_budget(tmp_path, monkeypatch):
+    s = _session(
+        tmp_path,
+        wiki_url="https://wiki.example.com",
+        wiki_token="tok",
+        repo=str(tmp_path / "marionette"),
+    )
+    s._task_profile = DEEP
+    captured = {}
+
+    def fake_search(query, *, limit=5):
+        captured["limit"] = limit
+        return [
+            {
+                "title": f"Hit {i}",
+                "slug": f"hit-{i}",
+                "snippet": "x" * 500,
+            }
+            for i in range(limit)
+        ]
+
+    monkeypatch.setattr(s._wiki, "search_pages", fake_search)
+    section = s._build_turn_wiki_section("audit authentication architecture")
+    assert captured["limit"] == 5
+    assert section
+    assert len(section) <= s._WIKI_GROUNDING_MAX_CHARS
 
 
 def test_wiki_client_search_pages_parses_results(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.196"
+version = "0.9.215"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.214",
+  "version": "0.9.215",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.214",
+      "version": "0.9.215",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.213",
+  "version": "0.9.214",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.213",
+      "version": "0.9.214",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.213",
+  "version": "0.9.214",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.214",
+  "version": "0.9.215",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/EditorTabStrip.test.tsx
+++ b/webapp/src/__tests__/EditorTabStrip.test.tsx
@@ -1,0 +1,131 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import EditorTabStrip, {
+  type OpenEditorTab,
+} from "../components/conversation/EditorTabStrip";
+
+vi.mock("../lib/transport", async () => {
+  const actual = await vi.importActual<typeof import("../lib/transport")>(
+    "../lib/transport",
+  );
+  return {
+    ...actual,
+    revealWorkspacePath: vi.fn().mockResolvedValue({ ok: true }),
+    toAbsoluteWorkspacePath: vi.fn((root: string, rel: string) => `${root}/${rel}`),
+  };
+});
+
+afterEach(() => cleanup());
+
+const tabs: OpenEditorTab[] = [
+  { path: "src/a.ts", isDirty: true },
+  { path: "docs/readme.md", isDirty: false },
+];
+
+function renderStrip(overrides: Partial<Parameters<typeof EditorTabStrip>[0]> = {}) {
+  const onSelectTab = vi.fn();
+  const onCloseTab = vi.fn();
+  const onCloseOtherTabs = vi.fn();
+  const onCloseAllTabs = vi.fn();
+  const onOpenContextMenu = vi.fn();
+  const onCloseContextMenu = vi.fn();
+
+  render(
+    <EditorTabStrip
+      openTabs={tabs}
+      activeTab="chat"
+      tabContextMenu={null}
+      repoRoot="/repo"
+      onSelectTab={onSelectTab}
+      onCloseTab={onCloseTab}
+      onCloseOtherTabs={onCloseOtherTabs}
+      onCloseAllTabs={onCloseAllTabs}
+      onOpenContextMenu={onOpenContextMenu}
+      onCloseContextMenu={onCloseContextMenu}
+      {...overrides}
+    />,
+  );
+
+  return {
+    onSelectTab,
+    onCloseTab,
+    onCloseOtherTabs,
+    onCloseAllTabs,
+    onOpenContextMenu,
+    onCloseContextMenu,
+  };
+}
+
+describe("EditorTabStrip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders chat plus open file tabs", () => {
+    renderStrip();
+    expect(screen.getByText("Chat")).toBeTruthy();
+    expect(screen.getByText("a.ts")).toBeTruthy();
+    expect(screen.getByText("readme.md")).toBeTruthy();
+  });
+
+  it("selects chat or a file tab on click", () => {
+    const { onSelectTab } = renderStrip();
+
+    fireEvent.click(screen.getByText("a.ts"));
+    expect(onSelectTab).toHaveBeenCalledWith("src/a.ts");
+
+    fireEvent.click(screen.getByText("Chat"));
+    expect(onSelectTab).toHaveBeenCalledWith("chat");
+  });
+
+  it("fires onCloseTab when the tab close control is clicked", () => {
+    const { onCloseTab } = renderStrip();
+    const tabLabel = screen.getByText("a.ts");
+    const tabRow = tabLabel.closest("div");
+    expect(tabRow).toBeTruthy();
+    const buttons = tabRow!.querySelectorAll("button");
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+    fireEvent.click(buttons[buttons.length - 1]);
+    expect(onCloseTab).toHaveBeenCalledWith("src/a.ts");
+  });
+
+  it("shows a dirty indicator only on unsaved tabs", () => {
+    renderStrip();
+    const dirtyDot = screen.getByText("a.ts").parentElement?.querySelector(".bg-warn");
+    expect(dirtyDot).toBeTruthy();
+    const cleanDot = screen.getByText("readme.md").parentElement?.querySelector(".bg-warn");
+    expect(cleanDot).toBeNull();
+  });
+
+  it("opens the context menu and routes close actions to callbacks", () => {
+    const { onOpenContextMenu, onCloseTab, onCloseOtherTabs, onCloseAllTabs, onCloseContextMenu } =
+      renderStrip({
+        tabContextMenu: { x: 10, y: 20, path: "src/a.ts" },
+      });
+
+    expect(onOpenContextMenu).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Close"));
+    expect(onCloseContextMenu).toHaveBeenCalled();
+    expect(onCloseTab).toHaveBeenCalledWith("src/a.ts");
+
+    fireEvent.click(screen.getByText("Close others"));
+    expect(onCloseOtherTabs).toHaveBeenCalledWith("src/a.ts");
+
+    fireEvent.click(screen.getByText("Close all"));
+    expect(onCloseAllTabs).toHaveBeenCalled();
+  });
+
+  it("calls onOpenContextMenu on right-click", () => {
+    const { onOpenContextMenu } = renderStrip();
+    const tabLabel = screen.getByText("readme.md");
+    const tabRow = tabLabel.closest("div");
+    expect(tabRow).toBeTruthy();
+    fireEvent.contextMenu(tabRow!, { clientX: 42, clientY: 84 });
+    expect(onOpenContextMenu).toHaveBeenCalledWith({
+      x: 42,
+      y: 84,
+      path: "docs/readme.md",
+    });
+  });
+});

--- a/webapp/src/__tests__/FileEditorPane.kind.test.ts
+++ b/webapp/src/__tests__/FileEditorPane.kind.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { detectEditorKind } from "../components/FileEditorPane";
+
+describe("detectEditorKind", () => {
+  const cases: Array<{
+    path: string;
+    binary?: boolean;
+    expected: ReturnType<typeof detectEditorKind>;
+  }> = [
+    { path: "README.md", expected: "markdown" },
+    { path: "notes.markdown", expected: "markdown" },
+    { path: "index.html", expected: "html" },
+    { path: "legacy.htm", expected: "html" },
+    { path: "doc.pdf", binary: true, expected: "pdf" },
+    { path: "photo.png", binary: true, expected: "image" },
+    { path: "archive.zip", binary: true, expected: "binary" },
+    { path: "src/app.ts", expected: "code" },
+    { path: "script.py", expected: "code" },
+  ];
+
+  it.each(cases)("maps $path (binary=$binary) to $expected", ({ path, binary, expected }) => {
+    expect(detectEditorKind(path, binary)).toBe(expected);
+  });
+});

--- a/webapp/src/components/FileEditorPane.tsx
+++ b/webapp/src/components/FileEditorPane.tsx
@@ -46,7 +46,7 @@ function fileExt(filePath: string): string {
   return i >= 0 ? base.slice(i + 1).toLowerCase() : "";
 }
 
-function detectEditorKind(filePath: string, binary?: boolean): EditorKind {
+export function detectEditorKind(filePath: string, binary?: boolean): EditorKind {
   const ext = fileExt(filePath);
   if (binary) {
     if (ext === "pdf") return "pdf";
@@ -95,7 +95,7 @@ function getLanguageExtension(filePath: string) {
 }
 
 /** Scroll CodeMirror to a 1-based line (and optional 1-based column). */
-function _scrollEditorToLine(view: EditorView, line: number, col?: number): void {
+export function scrollEditorToLine(view: EditorView, line: number, col?: number): void {
   try {
     const doc = view.state.doc;
     const ln = Math.max(1, Math.min(line, doc.lines));
@@ -111,6 +111,8 @@ function _scrollEditorToLine(view: EditorView, line: number, col?: number): void
     /* ignore */
   }
 }
+
+const _scrollEditorToLine = scrollEditorToLine;
 
 function getLanguageFromPath(filePath: string): string {
   const ext = fileExt(filePath);


### PR DESCRIPTION
## Summary
- Follow-on to v0.9.214 adaptive depth: compact JSONL task receipts, per-turn task transactions, MICRO/STANDARD schema compaction, and a remind-then-escalate verify gate for unverified file edits.
- STANDARD wiki auto-inject is tighter (3 hits / 2500 chars). MCP servers stay idle until first `call` / `ensure_server`. New `interrupt` delivery mode stops a busy turn then queues.
- Honest tag is **v0.9.215** after this PR is merged to `main` and `tests` is green on that SHA. Do not tag `dev`.

## Test plan
- [x] Local pytest: 4210 passed, 79 skipped
- [ ] CI `tests` workflow green on this `dev` SHA (3.9 + 3.11 + frontend-build, all OSes)
- [ ] After merge: `tests` green on the exact `main` SHA, then tag `v0.9.215`