### PR TITLE
Release v0.9.216: phantom-steer Stop, session-scoped resume, and depth chip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Internal-first research rig and daily-driver app. stdlib-only backend (urllib +
 sqlite); Puppetmaster is the one real dependency, installed editable from a local
 checkout.
 
-> Status: v0.9.215, deliberately pre-1.0. MICRO/STANDARD/DEEP depth now records compact JSONL receipts, defers MCP connect until first use, tightens STANDARD wiki inject, and reminds unverified file edits. Rides puppetmaster-ai==1.22.2.
+> Status: v0.9.216, deliberately pre-1.0. Empty-composer Stop no longer invents a phantom steer; lazy MCP servers read as idle; self-edit resume stays on the owning session; MICRO/STANDARD/DEEP shows in the footer. Rides puppetmaster-ai==1.22.2.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.215"
+__version__ = "0.9.216"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/session_control.py
+++ b/harness/api/session_control.py
@@ -29,12 +29,14 @@ class SessionControlServices:
     # persist / compact / state / context_at / swarm-results / restart-prepare
     get_sessions: Optional[Callable[[], Any]] = None
     save_transcript: Optional[Callable[..., None]] = None
-    set_resume_latch: Optional[Callable[[], None]] = None
+    # Arms for the active view; optional session_id stamps the latch owner.
+    set_resume_latch: Optional[Callable[..., None]] = None
     persist_boot_usage: Optional[Callable[..., None]] = None
     # Peek leaves the latch armed so StatusBar / LeftRail / runners polls cannot
     # steal the one-shot; consume is opt-in via ?consume_resume=1 (Conversation).
-    peek_resume_pending: Optional[Callable[[bool], bool]] = None
-    consume_resume_pending: Optional[Callable[[bool], bool]] = None
+    # Both take (idle, session_id) and fail closed on owner mismatch.
+    peek_resume_pending: Optional[Callable[..., bool]] = None
+    consume_resume_pending: Optional[Callable[..., bool]] = None
     checkpoint_transcript: Optional[Callable[[], None]] = None
     context_at: Optional[Callable[..., Any]] = None
 
@@ -77,7 +79,10 @@ def prepare_session_restart(svc: SessionControlServices) -> tuple[bool, Optional
                 pilot.export_transcript_data(),
             )
         if svc.set_resume_latch is not None:
-            svc.set_resume_latch()
+            sid = ""
+            if sessions is not None:
+                sid = (getattr(sessions, "active", None) or "").strip()
+            svc.set_resume_latch(sid)
         if svc.persist_boot_usage is not None:
             svc.persist_boot_usage(fold_live=True, force=True)
         return True, None
@@ -260,6 +265,10 @@ def _truthy_qs_flag(qs: dict, key: str) -> bool:
     return raw in ("1", "true", "yes")
 
 
+def _qs_session_id(qs: dict) -> str:
+    return (qs.get("session_id", [""])[0] or "").strip()
+
+
 def get_session_state(qs: dict, svc: SessionControlServices) -> tuple[int, JsonPayload]:
     """GET /api/session/state.
 
@@ -267,7 +276,8 @@ def get_session_state(qs: dict, svc: SessionControlServices) -> tuple[int, JsonP
     self-edit restart latch. Pass ``?consume_resume=1`` to consume once (the
     Conversation resume-schedule path). Pass ``?rearm_resume=1`` to restore the
     latch after a consume that was abandoned by a session switch / cancelled
-    kick (Conversation stillCurrent fence).
+    kick (Conversation stillCurrent fence). Pass ``?session_id=`` so peek /
+    consume / rearm only apply to the latch owner (fail closed on mismatch).
     """
     pilot = svc.get_pilot()
     runners = svc.get_runners()
@@ -275,18 +285,19 @@ def get_session_state(qs: dict, svc: SessionControlServices) -> tuple[int, JsonP
     idle = state == "idle"
     resume_pending = False
     qs = qs or {}
+    session_id = _qs_session_id(qs)
     if _truthy_qs_flag(qs, "rearm_resume"):
         if svc.set_resume_latch is not None:
-            svc.set_resume_latch()
+            svc.set_resume_latch(session_id)
         if svc.peek_resume_pending is not None:
-            resume_pending = svc.peek_resume_pending(idle)
+            resume_pending = svc.peek_resume_pending(idle, session_id)
         else:
             resume_pending = bool(idle)
     elif _truthy_qs_flag(qs, "consume_resume"):
         if svc.consume_resume_pending is not None:
-            resume_pending = svc.consume_resume_pending(idle)
+            resume_pending = svc.consume_resume_pending(idle, session_id)
     elif svc.peek_resume_pending is not None:
-        resume_pending = svc.peek_resume_pending(idle)
+        resume_pending = svc.peek_resume_pending(idle, session_id)
     elif svc.consume_resume_pending is not None:
         # Legacy services without peek: never consume on a plain state read.
         resume_pending = False

--- a/harness/mcp_manager.py
+++ b/harness/mcp_manager.py
@@ -142,6 +142,8 @@ class McpManager:
         self._tools: Dict[str, McpTool] = {}   # qualified name -> tool
         self._lock = threading.Lock()
         self._errors: Dict[str, str] = {}
+        # Names the operator explicitly stopped (lazy-boot idle until cleared).
+        self._operator_stopped = set()
         # Generation token per server: stop/refresh bumps it so an in-flight
         # refresh that finishes after a concurrent stop does not resurrect
         # a client the operator just halted.
@@ -367,6 +369,7 @@ class McpManager:
                 raise McpError(f"MCP server '{name}' start superseded by stop/refresh")
             self._clients[name] = client
             self._errors.pop(name, None)
+            self._operator_stopped.discard(name)
             for t in tools:
                 self._tools[t.qualified] = t
             return list(tools)
@@ -374,6 +377,7 @@ class McpManager:
     def stop_server(self, name: str) -> None:
         with self._lock:
             self._lifecycle_gen[name] = self._lifecycle_gen.get(name, 0) + 1
+            self._operator_stopped.add(name)
             c = self._clients.pop(name, None)
             for q in [q for q, t in self._tools.items() if t.server == name]:
                 del self._tools[q]
@@ -552,11 +556,21 @@ class McpManager:
             clients = dict(self._clients)
             tools = list(self._tools.values())
             errors = dict(self._errors)
+            operator_stopped = set(self._operator_stopped)
             invocations = {k: dict(v) for k, v in self._last_invocations.items()}
         out = []
         for name, server in cfg.items():
             client = clients.get(name)
             alive = client is not None and client.alive
+            err = errors.get(name, "")
+            if alive:
+                lifecycle = "running"
+            elif err:
+                lifecycle = "error"
+            elif name in operator_stopped:
+                lifecycle = "stopped"
+            else:
+                lifecycle = "idle"
             ntools = (
                 sum(1 for t in tools if t.server == name)
                 if alive
@@ -566,8 +580,8 @@ class McpManager:
             row = {
                 "name": name, "command": server.get("command", "") or server.get("url", ""),
                 "transport": "http" if server.get("url") else "stdio",
-                "running": alive, "tools": ntools,
-                "error": errors.get(name, ""),
+                "running": alive, "lifecycle": lifecycle, "tools": ntools,
+                "error": err,
             }
             last = invocations.get(name)
             if last:

--- a/harness/server.py
+++ b/harness/server.py
@@ -1143,6 +1143,8 @@ _pilot_swap_lock = threading.Lock()
 # quit / update relaunch mints a new app-run id so a leftover latch cannot
 # ghost-resume the last turn on reopen.
 _resume_latch = False
+# Owning view / harness session id for the armed latch (empty = unbound legacy).
+_resume_latch_session_id = ""
 from .pty_manager import PtyManager
 _pty = PtyManager()
 _pilot._mcp = _mcp
@@ -1162,16 +1164,44 @@ def _resume_latch_app_run_id() -> str:
     return (os.environ.get("HARNESS_APP_RUN_ID") or "").strip()
 
 
-def _set_resume_latch() -> None:
-    """Arm the one-shot auto-resume signal for the next process / state poll."""
-    global _resume_latch
+def _resume_latch_sole_session_id() -> str:
+    """Return the only session id when exactly one row exists; else empty."""
+    try:
+        rows = _sessions.rows()
+    except Exception:
+        return ""
+    if len(rows) != 1:
+        return ""
+    return str(rows[0].get("id") or "").strip()
+
+
+def _resolve_resume_latch_session_id(session_id: Optional[str] = None) -> str:
+    """Prefer explicit id, then active view / harness session id."""
+    sid = (session_id or "").strip()
+    if sid:
+        return sid
+    try:
+        active = (_sessions.active or "").strip()
+    except Exception:
+        active = ""
+    if active:
+        return active
+    return (getattr(_pilot, "harness_session_id", None) or "").strip()
+
+
+def _set_resume_latch(session_id: Optional[str] = None) -> None:
+    """Arm the one-shot auto-resume signal for the owning session view."""
+    global _resume_latch, _resume_latch_session_id
+    sid = _resolve_resume_latch_session_id(session_id)
     _resume_latch = True
+    _resume_latch_session_id = sid
     try:
         p = _resume_latch_path()
         payload = {
             "v": 1,
             "armed": True,
             "app_run_id": _resume_latch_app_run_id(),
+            "session_id": sid,
         }
         with open(p, "w", encoding="utf-8", newline="\n") as f:
             json.dump(payload, f, separators=(",", ":"))
@@ -1183,8 +1213,9 @@ def _set_resume_latch() -> None:
 
 def _clear_resume_latch() -> None:
     """Consume the latch (in-memory + on disk) so a later view cannot re-fire."""
-    global _resume_latch
+    global _resume_latch, _resume_latch_session_id
     _resume_latch = False
+    _resume_latch_session_id = ""
     try:
         p = _resume_latch_path()
         if os.path.exists(p):
@@ -1193,33 +1224,56 @@ def _clear_resume_latch() -> None:
         _diag("server.resume_latch_clear", e)
 
 
-def _parse_resume_latch_file(raw: str) -> tuple[bool, str]:
-    """Return ``(armed, stored_app_run_id)`` from on-disk latch contents."""
+def _parse_resume_latch_file(raw: str) -> Tuple[bool, str, str]:
+    """Return ``(armed, stored_app_run_id, session_id)`` from on-disk latch."""
     text = (raw or "").strip()
     if not text:
-        return False, ""
+        return False, "", ""
     # Legacy plain flag from pre-fence builds.
     if text == "1":
-        return True, ""
+        return True, "", ""
     try:
         data = json.loads(text)
     except Exception:
-        return False, ""
+        return False, "", ""
     if not isinstance(data, dict) or not data.get("armed"):
-        return False, ""
-    return True, str(data.get("app_run_id") or "").strip()
+        return False, "", ""
+    return (
+        True,
+        str(data.get("app_run_id") or "").strip(),
+        str(data.get("session_id") or "").strip(),
+    )
+
+
+def _resume_latch_owner_matches(request_session_id: str) -> bool:
+    """Fail closed unless the request names the latch owner.
+
+    Unbound (missing session_id) latches are honored only when a single session
+    exists and the request names that session.
+    """
+    if not _resume_latch:
+        return False
+    req = (request_session_id or "").strip()
+    if not req:
+        return False
+    owner = (_resume_latch_session_id or "").strip()
+    if owner:
+        return req == owner
+    sole = _resume_latch_sole_session_id()
+    return bool(sole) and req == sole
 
 
 def _load_resume_latch() -> None:
     """Adopt a same-app-run latch left by an intentional backend restart."""
-    global _resume_latch
+    global _resume_latch, _resume_latch_session_id
     try:
         p = _resume_latch_path()
         if not os.path.exists(p):
             _resume_latch = False
+            _resume_latch_session_id = ""
             return
         with open(p, encoding="utf-8", errors="replace") as f:
-            armed, stored_run_id = _parse_resume_latch_file(f.read())
+            armed, stored_run_id, stored_sid = _parse_resume_latch_file(f.read())
         current_run_id = _resume_latch_app_run_id()
         # Electron stamps HARNESS_APP_RUN_ID once per shell process. Same-process
         # backend respawn (self-edit restart) keeps the id; update relaunch /
@@ -1232,23 +1286,33 @@ def _load_resume_latch() -> None:
             adopt = not stored_run_id
         else:
             adopt = False
+        if adopt and not stored_sid:
+            # Pre-session-scope disk latch: bind only when a sole session exists.
+            stored_sid = _resume_latch_sole_session_id()
+            if not stored_sid:
+                adopt = False
         _resume_latch = bool(adopt)
+        _resume_latch_session_id = stored_sid if adopt else ""
         if not _resume_latch:
             _clear_resume_latch()
     except Exception as e:
         _diag("server.resume_latch_load", e)
         _resume_latch = False
+        _resume_latch_session_id = ""
 
 
-def _peek_resume_pending(idle: bool) -> bool:
-    """True when the latch is armed and the pilot is idle (does not clear)."""
-    return bool(_resume_latch and idle)
+def _peek_resume_pending(idle: bool, session_id: str = "") -> bool:
+    """True when the latch is armed for ``session_id`` and the pilot is idle."""
+    return bool(
+        _resume_latch and idle and _resume_latch_owner_matches(session_id)
+    )
 
 
-def _consume_resume_pending(idle: bool) -> bool:
-    """True once when the latch is armed and the pilot is idle; then clear it."""
-    global _resume_latch
-    if not (_resume_latch and idle):
+def _consume_resume_pending(idle: bool, session_id: str = "") -> bool:
+    """True once when armed for ``session_id`` and idle; then clear it."""
+    if not (
+        _resume_latch and idle and _resume_latch_owner_matches(session_id)
+    ):
         return False
     _clear_resume_latch()
     return True

--- a/harness/steer_mixin.py
+++ b/harness/steer_mixin.py
@@ -60,7 +60,7 @@ class SteerMixin:
             self._steer_pending = False
         except Exception:
             pass
-        return items
+        return [item for item in items if str(item or "").strip()]
 
     @staticmethod
     def _steer_drop_notice_text(dropped: list[str]) -> str:
@@ -193,12 +193,14 @@ class SteerMixin:
         standard enqueue/drain even if ``_stop_holds_idle`` is still sticky for
         runners chrome (cleared on the next real user send).
         """
+        cleaned = (text or "").strip()
+        if not cleaned:
+            return
         if self._abandoned_turn_blocks_steer_enqueue():
-            if text:
-                self._record_steer_drop_notice([text])
+            self._record_steer_drop_notice([cleaned])
             return
         with self._steer_lock:
-            self._steer_queue.append(text)
+            self._steer_queue.append(cleaned)
 
     def drain_steer(self) -> list[str]:
         """Atomically pop and return all pending steer messages (empty list if none)."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.215"
+version = "0.9.216"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_session_control_peel.py
+++ b/tests/test_api_session_control_peel.py
@@ -37,10 +37,10 @@ def _svc(pilot=None, runners=None, upload_dir="/uploads", sessions=None):
         diag=lambda *a: None,
         get_sessions=lambda: sessions or SimpleNamespace(active=None),
         save_transcript=lambda *a, **k: None,
-        set_resume_latch=lambda: None,
+        set_resume_latch=lambda *a, **k: None,
         persist_boot_usage=lambda **k: None,
-        peek_resume_pending=lambda idle: False,
-        consume_resume_pending=lambda idle: False,
+        peek_resume_pending=lambda idle, session_id="": False,
+        consume_resume_pending=lambda idle, session_id="": False,
         checkpoint_transcript=lambda: None,
         context_at=lambda *a: None,
     )
@@ -151,7 +151,7 @@ def test_rewind_requires_target():
 
 
 def test_persist_and_restart_prepare():
-    calls = {"latch": 0, "usage": 0, "save": 0}
+    calls = {"latch": 0, "usage": 0, "save": 0, "sid": None}
 
     class _Pilot:
         def export_transcript_data(self):
@@ -159,7 +159,12 @@ def test_persist_and_restart_prepare():
 
     sessions = SimpleNamespace(active="s1")
     svc = _svc(pilot=_Pilot(), sessions=sessions)
-    svc.set_resume_latch = lambda: calls.__setitem__("latch", calls["latch"] + 1)
+
+    def _set_latch(session_id=""):
+        calls["latch"] = calls["latch"] + 1
+        calls["sid"] = session_id
+
+    svc.set_resume_latch = _set_latch
     svc.persist_boot_usage = lambda **k: calls.__setitem__(
         "usage", calls["usage"] + 1
     )
@@ -168,7 +173,8 @@ def test_persist_and_restart_prepare():
     )
 
     assert prepare_session_restart(svc) == (True, None)
-    assert calls == {"latch": 1, "usage": 1, "save": 1}
+    assert calls["latch"] == 1 and calls["usage"] == 1 and calls["save"] == 1
+    assert calls["sid"] == "s1"
     code, payload = post_session_persist(svc)
     assert code == 200 and payload["ok"] is True
 
@@ -260,15 +266,17 @@ def test_compact_and_state():
 def test_session_state_resume_pending_peek_vs_consume():
     """Plain GET peeks; only ?consume_resume=1 clears the latch."""
     calls = {"peek": 0, "consume": 0}
-    latch = {"armed": True}
+    latch = {"armed": True, "owner": "sess-a"}
 
-    def peek(idle: bool) -> bool:
+    def peek(idle: bool, session_id: str = "") -> bool:
         calls["peek"] += 1
-        return bool(latch["armed"] and idle)
+        return bool(
+            latch["armed"] and idle and session_id == latch["owner"]
+        )
 
-    def consume(idle: bool) -> bool:
+    def consume(idle: bool, session_id: str = "") -> bool:
         calls["consume"] += 1
-        if not (latch["armed"] and idle):
+        if not (latch["armed"] and idle and session_id == latch["owner"]):
             return False
         latch["armed"] = False
         return True
@@ -278,43 +286,87 @@ def test_session_state_resume_pending_peek_vs_consume():
     svc.peek_resume_pending = peek
     svc.consume_resume_pending = consume
 
-    code, state = get_session_state({}, svc)
+    code, state = get_session_state({"session_id": ["sess-a"]}, svc)
     assert code == 200 and state["resume_pending"] is True
     assert calls == {"peek": 1, "consume": 0}
     assert latch["armed"] is True
 
-    code, state = get_session_state({"consume_resume": ["0"]}, svc)
+    code, state = get_session_state(
+        {"consume_resume": ["0"], "session_id": ["sess-a"]}, svc
+    )
     assert code == 200 and state["resume_pending"] is True
     assert calls == {"peek": 2, "consume": 0}
     assert latch["armed"] is True
 
-    code, state = get_session_state({"consume_resume": ["1"]}, svc)
+    code, state = get_session_state(
+        {"consume_resume": ["1"], "session_id": ["sess-a"]}, svc
+    )
     assert code == 200 and state["resume_pending"] is True
     assert calls == {"peek": 2, "consume": 1}
     assert latch["armed"] is False
 
-    code, state = get_session_state({"consume_resume": ["1"]}, svc)
+    code, state = get_session_state(
+        {"consume_resume": ["1"], "session_id": ["sess-a"]}, svc
+    )
     assert code == 200 and state["resume_pending"] is False
     assert calls["consume"] == 2
 
 
-def test_session_state_rearm_resume_restores_latch():
-    """?rearm_resume=1 restores latch after a consume abandoned by switch."""
-    latch = {"armed": False}
-    rearm_calls = {"n": 0}
+def test_session_state_resume_pending_fail_closed_wrong_session():
+    """Latch armed for A must not peek/consume for B."""
+    latch = {"armed": True, "owner": "sess-a"}
 
-    def peek(idle: bool) -> bool:
-        return bool(latch["armed"] and idle)
+    def peek(idle: bool, session_id: str = "") -> bool:
+        return bool(
+            latch["armed"] and idle and session_id == latch["owner"]
+        )
 
-    def consume(idle: bool) -> bool:
-        if not (latch["armed"] and idle):
+    def consume(idle: bool, session_id: str = "") -> bool:
+        if not (latch["armed"] and idle and session_id == latch["owner"]):
             return False
         latch["armed"] = False
         return True
 
-    def set_latch() -> None:
+    pilot = _CompactingPilot()
+    svc = _svc(pilot=pilot)
+    svc.peek_resume_pending = peek
+    svc.consume_resume_pending = consume
+
+    code, state = get_session_state({"session_id": ["sess-b"]}, svc)
+    assert code == 200 and state["resume_pending"] is False
+    assert latch["armed"] is True
+
+    code, state = get_session_state(
+        {"consume_resume": ["1"], "session_id": ["sess-b"]}, svc
+    )
+    assert code == 200 and state["resume_pending"] is False
+    assert latch["armed"] is True
+
+    code, state = get_session_state({"session_id": ["sess-a"]}, svc)
+    assert code == 200 and state["resume_pending"] is True
+
+
+def test_session_state_rearm_resume_restores_latch():
+    """?rearm_resume=1 restores latch after a consume abandoned by switch."""
+    latch = {"armed": False, "owner": ""}
+    rearm_calls = {"n": 0, "sid": ""}
+
+    def peek(idle: bool, session_id: str = "") -> bool:
+        return bool(
+            latch["armed"] and idle and session_id == latch["owner"]
+        )
+
+    def consume(idle: bool, session_id: str = "") -> bool:
+        if not (latch["armed"] and idle and session_id == latch["owner"]):
+            return False
+        latch["armed"] = False
+        return True
+
+    def set_latch(session_id: str = "") -> None:
         rearm_calls["n"] += 1
+        rearm_calls["sid"] = session_id
         latch["armed"] = True
+        latch["owner"] = session_id
 
     pilot = _CompactingPilot()
     svc = _svc(pilot=pilot)
@@ -322,16 +374,22 @@ def test_session_state_rearm_resume_restores_latch():
     svc.consume_resume_pending = consume
     svc.set_resume_latch = set_latch
 
-    code, state = get_session_state({"rearm_resume": ["1"]}, svc)
+    code, state = get_session_state(
+        {"rearm_resume": ["1"], "session_id": ["sess-a"]}, svc
+    )
     assert code == 200 and state["resume_pending"] is True
-    assert rearm_calls["n"] == 1
+    assert rearm_calls == {"n": 1, "sid": "sess-a"}
     assert latch["armed"] is True
 
-    code, state = get_session_state({"consume_resume": ["1"]}, svc)
+    code, state = get_session_state(
+        {"consume_resume": ["1"], "session_id": ["sess-a"]}, svc
+    )
     assert code == 200 and state["resume_pending"] is True
     assert latch["armed"] is False
 
-    code, state = get_session_state({"rearm_resume": ["1"]}, svc)
+    code, state = get_session_state(
+        {"rearm_resume": ["1"], "session_id": ["sess-a"]}, svc
+    )
     assert code == 200 and state["resume_pending"] is True
     assert latch["armed"] is True
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -112,9 +112,44 @@ def test_lazy_boot_status_idle_and_discovered_empty(tmp_path):
     assert len(st) == 1
     assert st[0]["name"] == "fake"
     assert st[0]["running"] is False
+    assert st[0]["lifecycle"] == "idle"
     assert st[0]["tools"] == 0
     assert not st[0].get("error")
     assert m.discovered_tools() == []
+
+
+def test_status_lifecycle_running_stopped_and_error(tmp_path):
+    """lifecycle distinguishes idle, running, operator-stopped, and start errors."""
+    cfgp = tmp_path / "mcp.json"
+    m = McpManager(config_path=str(cfgp))
+    m.save_server("fake", {"command": sys.executable, "args": [FAKE]})
+    m.save_server("bad", {"command": "no-such-cmd-xyz-lifecycle"})
+    try:
+        idle = next(s for s in m.status() if s["name"] == "fake")
+        assert idle["lifecycle"] == "idle"
+        assert idle["running"] is False
+
+        m.start_server("fake")
+        running = next(s for s in m.status() if s["name"] == "fake")
+        assert running["lifecycle"] == "running"
+        assert running["running"] is True
+
+        m.stop_server("fake")
+        stopped = next(s for s in m.status() if s["name"] == "fake")
+        assert stopped["lifecycle"] == "stopped"
+        assert stopped["running"] is False
+        assert not stopped["error"]
+
+        try:
+            m.start_server("bad")
+        except McpError:
+            pass
+        errored = next(s for s in m.status() if s["name"] == "bad")
+        assert errored["lifecycle"] == "error"
+        assert errored["running"] is False
+        assert errored["error"]
+    finally:
+        m.stop_all()
 
 
 def test_ensure_server_starts_only_when_not_alive(tmp_path):

--- a/tests/test_self_dev_restart.py
+++ b/tests/test_self_dev_restart.py
@@ -92,8 +92,24 @@ def _harness_http_server():
             thread.join(timeout=_JOIN_TIMEOUT)
 
 
-def _session_state(port: int, token: str, *, consume_resume: bool = False) -> dict:
-    qs = "?consume_resume=1" if consume_resume else ""
+def _session_state(
+    port: int,
+    token: str,
+    *,
+    consume_resume: bool = False,
+    rearm_resume: bool = False,
+    session_id: Optional[str] = None,
+) -> dict:
+    from urllib.parse import quote
+
+    params = []
+    if consume_resume:
+        params.append("consume_resume=1")
+    if rearm_resume:
+        params.append("rearm_resume=1")
+    if session_id:
+        params.append(f"session_id={quote(session_id)}")
+    qs = ("?" + "&".join(params)) if params else ""
     req = urllib.request.Request(
         f"http://127.0.0.1:{port}/api/session/state{qs}",
         headers={"X-Harness-Token": token},
@@ -142,22 +158,26 @@ def test_trailing_user_turn_alone_does_not_report_resume_pending():
 
     saved = list(srv._pilot._history)
     saved_latch = srv._resume_latch
+    saved_active = srv._sessions._active
     try:
         with _harness_http_server() as (srv, port):
             srv._clear_resume_latch()
+            sid = "sess-resume-idle"
+            srv._sessions._active = sid
             srv._pilot._history = [
                 {"role": "system", "content": "sys"},
                 {"role": "user", "content": "please continue"},
             ]
             assert srv._pilot.has_pending_user_turn() is True
-            data = _session_state(port, srv._TOKEN)
+            data = _session_state(port, srv._TOKEN, session_id=sid)
             assert data["resume_pending"] is False
             # Second poll still false (nothing to consume).
-            data2 = _session_state(port, srv._TOKEN)
+            data2 = _session_state(port, srv._TOKEN, session_id=sid)
             assert data2["resume_pending"] is False
     finally:
         # Restore only after the serve thread and handlers have settled.
         srv._pilot._history = saved
+        srv._sessions._active = saved_active
         if saved_latch:
             srv._set_resume_latch()
         else:
@@ -169,9 +189,12 @@ def test_session_state_reports_resume_pending_after_explicit_latch():
     import harness.server as srv
 
     saved = list(srv._pilot._history)
+    saved_active = srv._sessions._active
     try:
         with _harness_http_server() as (srv, port):
             srv._clear_resume_latch()
+            sid = "sess-resume-latch"
+            srv._sessions._active = sid
             srv._pilot._history = [
                 {"role": "system", "content": "sys"},
                 {"role": "user", "content": "please continue"},
@@ -180,22 +203,39 @@ def test_session_state_reports_resume_pending_after_explicit_latch():
             status, payload = _post_session_persist(port, srv._TOKEN)
             assert status == 200
             assert payload["ok"] is True
+            assert srv._resume_latch_session_id == sid
 
             # Plain state polls (StatusBar / runners / switch) must peek only.
-            data = _session_state(port, srv._TOKEN)
+            data = _session_state(port, srv._TOKEN, session_id=sid)
             assert data["resume_pending"] is True
-            data_peek2 = _session_state(port, srv._TOKEN)
+            data_peek2 = _session_state(port, srv._TOKEN, session_id=sid)
             assert data_peek2["resume_pending"] is True
+            # Wrong session must not see or steal the latch.
+            assert _session_state(
+                port, srv._TOKEN, session_id="sess-other"
+            )["resume_pending"] is False
+            assert _session_state(
+                port,
+                srv._TOKEN,
+                consume_resume=True,
+                session_id="sess-other",
+            )["resume_pending"] is False
+            assert srv._resume_latch is True
 
             # Conversation resume path consumes once.
-            data_consume = _session_state(port, srv._TOKEN, consume_resume=True)
+            data_consume = _session_state(
+                port, srv._TOKEN, consume_resume=True, session_id=sid
+            )
             assert data_consume["resume_pending"] is True
-            data2 = _session_state(port, srv._TOKEN, consume_resume=True)
+            data2 = _session_state(
+                port, srv._TOKEN, consume_resume=True, session_id=sid
+            )
             assert data2["resume_pending"] is False
-            data_peek_after = _session_state(port, srv._TOKEN)
+            data_peek_after = _session_state(port, srv._TOKEN, session_id=sid)
             assert data_peek_after["resume_pending"] is False
     finally:
         srv._pilot._history = saved
+        srv._sessions._active = saved_active
         srv._clear_resume_latch()
 
 
@@ -207,11 +247,14 @@ def test_resume_latch_survives_same_app_run_reload(monkeypatch, tmp_path):
     monkeypatch.setattr(srv._cfg, "state_dir", str(tmp_path), raising=False)
     srv._clear_resume_latch()
     try:
-        srv._set_resume_latch()
+        srv._set_resume_latch("sess-a")
         assert srv._resume_latch is True
+        assert srv._resume_latch_session_id == "sess-a"
         srv._resume_latch = False
+        srv._resume_latch_session_id = ""
         srv._load_resume_latch()
         assert srv._resume_latch is True
+        assert srv._resume_latch_session_id == "sess-a"
         assert (tmp_path / ".resume_latch").is_file()
     finally:
         srv._clear_resume_latch()
@@ -225,13 +268,82 @@ def test_resume_latch_rejected_after_app_relaunch(monkeypatch, tmp_path):
     monkeypatch.setattr(srv._cfg, "state_dir", str(tmp_path), raising=False)
     srv._clear_resume_latch()
     try:
-        srv._set_resume_latch()
+        srv._set_resume_latch("sess-a")
         assert (tmp_path / ".resume_latch").is_file()
         monkeypatch.setenv("HARNESS_APP_RUN_ID", "run-new")
         srv._resume_latch = False
+        srv._resume_latch_session_id = ""
         srv._load_resume_latch()
         assert srv._resume_latch is False
+        assert srv._resume_latch_session_id == ""
         assert not (tmp_path / ".resume_latch").exists()
+    finally:
+        srv._clear_resume_latch()
+
+
+def test_resume_latch_session_scoped_peek_and_consume(monkeypatch, tmp_path):
+    """Latch armed for A must not peek true for B; B consume must not clear A."""
+    import harness.server as srv
+
+    monkeypatch.setattr(srv._cfg, "state_dir", str(tmp_path), raising=False)
+    srv._clear_resume_latch()
+    try:
+        srv._set_resume_latch("sess-a")
+        assert srv._peek_resume_pending(True, "sess-a") is True
+        assert srv._peek_resume_pending(True, "sess-b") is False
+        assert srv._peek_resume_pending(True, "") is False
+        assert srv._consume_resume_pending(True, "sess-b") is False
+        assert srv._peek_resume_pending(True, "sess-a") is True
+        assert srv._consume_resume_pending(True, "sess-a") is True
+        assert srv._peek_resume_pending(True, "sess-a") is False
+    finally:
+        srv._clear_resume_latch()
+
+
+def test_legacy_resume_latch_without_session_id_sole_session_only(
+    monkeypatch, tmp_path
+):
+    """v1 disk latch missing session_id: honor only when a single session exists."""
+    import harness.server as srv
+    import json as _json
+
+    monkeypatch.setenv("HARNESS_APP_RUN_ID", "run-legacy")
+    monkeypatch.setattr(srv._cfg, "state_dir", str(tmp_path), raising=False)
+    latch = tmp_path / ".resume_latch"
+    latch.write_text(
+        _json.dumps(
+            {"v": 1, "armed": True, "app_run_id": "run-legacy"},
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rows = [{"id": "only-one"}, {"id": "two"}]
+    monkeypatch.setattr(
+        srv._sessions, "rows", lambda: list(rows), raising=False
+    )
+    try:
+        srv._resume_latch = False
+        srv._resume_latch_session_id = ""
+        srv._load_resume_latch()
+        assert srv._resume_latch is False
+
+        rows[:] = [{"id": "only-one"}]
+        latch.write_text(
+            _json.dumps(
+                {"v": 1, "armed": True, "app_run_id": "run-legacy"},
+                separators=(",", ":"),
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        srv._resume_latch = False
+        srv._resume_latch_session_id = ""
+        srv._load_resume_latch()
+        assert srv._resume_latch is True
+        assert srv._resume_latch_session_id == "only-one"
+        assert srv._peek_resume_pending(True, "only-one") is True
+        assert srv._peek_resume_pending(True, "other") is False
     finally:
         srv._clear_resume_latch()
 
@@ -248,6 +360,7 @@ def test_legacy_plain_resume_latch_rejected_when_app_run_id_set(
     latch.write_text("1\n", encoding="utf-8")
     try:
         srv._resume_latch = False
+        srv._resume_latch_session_id = ""
         srv._load_resume_latch()
         assert srv._resume_latch is False
         assert not latch.exists()
@@ -294,7 +407,9 @@ def test_http_server_lifecycle_stress_no_leaks():
         for round_idx in range(_STRESS_ROUNDS):
             with _harness_http_server() as (srv, port):
                 srv._clear_resume_latch()
-                data = _session_state(port, srv._TOKEN)
+                data = _session_state(
+                    port, srv._TOKEN, session_id=srv._sessions.active or "s"
+                )
                 assert "resume_pending" in data
                 status, payload = _post_session_persist(port, srv._TOKEN)
                 assert status == 200, f"persist failed on stress round {round_idx}"

--- a/tests/test_steer.py
+++ b/tests/test_steer.py
@@ -25,6 +25,20 @@ def test_steer_queue_round_trip():
     assert s.drain_steer() == []
 
 
+def test_enqueue_steer_ignores_blank_and_stop_does_not_notice():
+    """Empty composer must not become a phantom steer that Stop then errors on."""
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
+    s = ConversationalSession(cfg)
+    s.enqueue_steer("")
+    s.enqueue_steer("   ")
+    assert s.drain_steer() == []
+    s.enqueue_steer("")
+    dropped = s.drop_queued_steers()
+    assert dropped == []
+    assert s._record_steer_drop_notice(dropped) is None
+    assert getattr(s, "_pending_steer_drop_notice", None) in (None, {})
+
+
 class _SteeringPilot:
     def __init__(self, session):
         self.session = session

--- a/tests/test_v09215_live_path.py
+++ b/tests/test_v09215_live_path.py
@@ -223,10 +223,10 @@ def test_session_steer_interrupt_delivery_stops_then_queues():
         diag=lambda *a: None,
         get_sessions=lambda: SimpleNamespace(active=None),
         save_transcript=lambda *a, **k: None,
-        set_resume_latch=lambda: None,
+        set_resume_latch=lambda *a, **k: None,
         persist_boot_usage=lambda **k: None,
-        peek_resume_pending=lambda idle: False,
-        consume_resume_pending=lambda idle: False,
+        peek_resume_pending=lambda idle, session_id="": False,
+        consume_resume_pending=lambda idle, session_id="": False,
         checkpoint_transcript=lambda: None,
         context_at=lambda *a: None,
     )

--- a/tests/test_v09215_live_path.py
+++ b/tests/test_v09215_live_path.py
@@ -1,0 +1,243 @@
+"""Live-path validation for v0.9.215 kernel features.
+
+These go through ConversationalSession.send / the session-control API — not
+just the isolated helpers — so a disconnected module cannot go green.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from harness.api.session_control import SessionControlServices, post_session_steer
+from harness.config import HarnessConfig
+from harness.conversation import ConversationalSession
+from harness.mcp_client import McpTool
+from harness.task_profile import MICRO, STANDARD
+from harness.task_receipt import JSONL_FILENAME, load_receipts, prompt_hash
+from harness.task_transaction import as_dict, context_block
+from harness.tool_requirement import SoftToolRequirement
+from harness.wiki import WikiClient
+
+
+class _FakePilotWithActions:
+    name = "fake_actions"
+
+    def __init__(self, actions):
+        self.actions = actions
+        self.calls = 0
+
+    def chat(self, messages, tools=None, system=None):
+        from pmharness.drivers.openai_compat import DriverResponse
+
+        self.calls += 1
+        if self.calls == 1:
+            txt = json.dumps({"say": "Executing actions.", "actions": self.actions})
+        else:
+            txt = json.dumps({"say": "Done.", "actions": []})
+        return DriverResponse(text=txt, tokens_out=10, latency_ms=1.0)
+
+
+def _session(tmp_path, *, repo=None, auto_verify=False, task_profile="auto"):
+    cfg = HarnessConfig(
+        driver="stub-oracle-v2",
+        state_dir=str(tmp_path / "state"),
+        repo=str(repo or (tmp_path / "repo")),
+        auto_verify=auto_verify,
+        task_profile=task_profile,
+    )
+    (tmp_path / "repo").mkdir(exist_ok=True)
+    (tmp_path / "state").mkdir(exist_ok=True)
+    s = ConversationalSession(cfg)
+    s.harness_session_id = "live-215"
+    return s
+
+
+def test_send_writes_compact_receipt_for_micro_prose(tmp_path):
+    s = _session(tmp_path)
+    s.pilot = _FakePilotWithActions([])
+    events = list(s.send("typo in README.md"))
+    kinds = [e.kind for e in events]
+    assert "task_profile" in kinds
+    assert "assistant_done" in kinds
+    prof = next(e for e in events if e.kind == "task_profile")
+    assert prof.data["profile"] == MICRO
+
+    rows = load_receipts(s.config.state_dir, limit=5)
+    assert len(rows) == 1
+    rec = rows[0]
+    assert rec["task_id"] == "live-215"
+    assert rec["profile"] == MICRO
+    assert rec["prompt_hash"] == prompt_hash("typo in README.md")
+    assert rec["adapter"] == "stub-oracle-v2"
+    assert (tmp_path / "state" / JSONL_FILENAME).is_file()
+
+
+def test_send_write_notes_transaction_reminds_and_receipt(tmp_path):
+    s = _session(tmp_path, auto_verify=False)
+    s.pilot = _FakePilotWithActions([
+        {"kind": "write_file", "path": "note.txt", "content": "hello"},
+    ])
+    events = list(s.send("typo in README.md"))
+    written = tmp_path / "repo" / "note.txt"
+    assert written.is_file()
+    assert written.read_text(encoding="utf-8") == "hello"
+
+    tx = as_dict(s._task_tx)
+    assert any(str(p).endswith("note.txt") for p in tx.get("files") or [])
+    assert tx["phase"] in ("acting", "verifying", "done")
+
+    remind = SoftToolRequirement.remind_message()
+    assert any(
+        h.get("role") == "user" and remind in (h.get("content") or "")
+        for h in s._history
+    )
+
+    rows = load_receipts(s.config.state_dir, limit=5)
+    assert rows
+    rec = rows[-1]
+    assert rec["profile"] == MICRO
+    assert rec.get("changed_files")
+    assert rec.get("verification") in ("skipped", "unverified")
+
+
+def test_send_write_plus_command_skips_remind_and_marks_pass(tmp_path):
+    s = _session(tmp_path, auto_verify=False)
+    s.pilot = _FakePilotWithActions([
+        {"kind": "write_file", "path": "note.txt", "content": "hello"},
+        {"kind": "run_command", "command": "echo hi"},
+    ])
+    list(s.send("typo in README.md"))
+    remind = SoftToolRequirement.remind_message()
+    assert not any(
+        h.get("role") == "user" and remind in (h.get("content") or "")
+        for h in s._history
+    )
+    assert s._turn_ran_command is True
+    rec = load_receipts(s.config.state_dir, limit=1)[-1]
+    assert rec.get("verification") == "pass"
+    assert rec.get("changed_files")
+
+
+def test_send_micro_skips_wiki_search(tmp_path, monkeypatch):
+    s = _session(tmp_path)
+    s._wiki = WikiClient(base_url="https://wiki.example.com", token="tok")
+    s.pilot = _FakePilotWithActions([])
+
+    def boom(query, *, limit=5):
+        raise AssertionError("wiki search must not run on MICRO send")
+
+    monkeypatch.setattr(s._wiki, "search_pages", boom)
+    list(s.send("typo in README.md"))
+
+
+def test_send_standard_wiki_uses_tighter_budget(tmp_path, monkeypatch):
+    s = _session(tmp_path)
+    s._wiki = WikiClient(base_url="https://wiki.example.com", token="tok")
+    s.pilot = _FakePilotWithActions([])
+    captured = {}
+
+    def fake_search(query, *, limit=5):
+        captured["limit"] = limit
+        return [
+            {"title": f"Hit {i}", "slug": f"hit-{i}", "snippet": "x" * 200}
+            for i in range(limit)
+        ]
+
+    monkeypatch.setattr(s._wiki, "search_pages", fake_search)
+    events = list(s.send("add OAuth support"))
+    prof = next(e for e in events if e.kind == "task_profile")
+    assert prof.data["profile"] == STANDARD
+    assert captured.get("limit") == 3
+
+
+def test_send_micro_compacts_live_catalog_descriptions(tmp_path):
+    long_desc = (
+        "First sentence about creating GitHub issues with a title and body. "
+        + ("Additional trailing detail about labels milestones. " * 8)
+    )
+    assert len(long_desc) > 160
+    tool = McpTool(
+        server="github",
+        name="create_issue",
+        description=long_desc,
+        input_schema={"type": "object", "properties": {}},
+    )
+    s = _session(tmp_path)
+    s._mcp = SimpleNamespace(discovered_tools=lambda: [tool])
+    s.pilot = _FakePilotWithActions([])
+    list(s.send("typo in README.md"))
+    entry = next(e for e in s._tool_catalog._entries.values() if e.source == "mcp")
+    assert len(entry.description) <= 160
+    assert entry.description.startswith("First sentence about creating GitHub issues")
+    assert "Additional trailing detail" not in entry.description
+
+
+def test_steer_inject_includes_task_transaction_block(tmp_path):
+    s = _session(tmp_path, auto_verify=False)
+    s.pilot = _FakePilotWithActions([
+        {"kind": "write_file", "path": "note.txt", "content": "hello"},
+    ])
+    list(s.send("typo in README.md"))
+    block = context_block(s._task_tx)
+    assert "## Task transaction" in block
+    s._history.append({"role": "user", "content": "(tool result)"})
+    s.enqueue_steer("course correct")
+    events = list(s._check_and_inject_steer())
+    assert any(e.kind == "steer" for e in events)
+    injected = s._history[-1]["content"]
+    assert "course correct" in injected
+    assert "## Task transaction" in injected
+    assert "note.txt" in injected
+
+
+def test_session_steer_interrupt_delivery_stops_then_queues():
+    class _Pilot:
+        def __init__(self):
+            self.interrupts = 0
+            self.prompts = []
+            self.steers = []
+
+        def is_turn_busy(self):
+            return True
+
+        def interrupt(self):
+            self.interrupts += 1
+
+        def enqueue_prompt(self, text, images=None, model=None):
+            item = {"id": "p1", "text": text, "images": images or []}
+            self.prompts.append(item)
+            return item
+
+        def enqueue_steer(self, text):
+            self.steers.append(text)
+
+    p = _Pilot()
+    svc = SessionControlServices(
+        cfg=SimpleNamespace(driver="m1", state_dir=None, max_context_tokens=96000),
+        get_pilot=lambda: p,
+        get_runners=lambda: SimpleNamespace(get=lambda sid: None),
+        gate_active_pilot_ready=lambda: None,
+        stash_put=lambda msg, imgs: "mid1",
+        save_active_transcript=lambda: None,
+        upload_dir="/uploads",
+        diag=lambda *a: None,
+        get_sessions=lambda: SimpleNamespace(active=None),
+        save_transcript=lambda *a, **k: None,
+        set_resume_latch=lambda: None,
+        persist_boot_usage=lambda **k: None,
+        peek_resume_pending=lambda idle: False,
+        consume_resume_pending=lambda idle: False,
+        checkpoint_transcript=lambda: None,
+        context_at=lambda *a: None,
+    )
+    code, payload = post_session_steer(
+        {"text": "stop and do this", "delivery_mode": "interrupt"},
+        svc,
+    )
+    assert code == 200
+    assert payload["ok"] is True
+    assert payload["action"] == "interrupt_then_queue"
+    assert payload.get("interrupted") is True
+    assert p.interrupts == 1
+    assert p.prompts[0]["text"] == "stop and do this"
+    assert p.steers == []

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.215",
+  "version": "0.9.216",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.215",
+      "version": "0.9.216",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.215",
+  "version": "0.9.216",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/ComposerDock.busyChrome.test.tsx
+++ b/webapp/src/__tests__/ComposerDock.busyChrome.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Empty busy composer must not default to Steer. Stop is the only send-row
+ * action until the operator types a redirect.
+ */
+import { createRef } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ComposerDock from "../components/conversation/ComposerDock";
+
+vi.mock("../lib/api", () => ({
+  api: {},
+}));
+vi.mock("../components/PilotPicker", () => ({
+  default: () => <div data-testid="pilot-picker" />,
+}));
+vi.mock("../components/conversation/WorkspaceChip", () => ({
+  default: () => <div data-testid="workspace-chip" />,
+}));
+
+const noop = () => {};
+
+function renderBusyDock(input: string) {
+  return render(
+    <ComposerDock
+      config={null}
+      taRef={createRef<HTMLTextAreaElement>()}
+      input={input}
+      auto={false}
+      plan={false}
+      composerBusy={true}
+      transcriptStale={false}
+      wikiPrepared={null}
+      memoryProposals={[]}
+      distillNotice={null}
+      msgQueue={[]}
+      dragIndex={null}
+      dragOverIndex={null}
+      queueItems={[]}
+      queueDragIndex={null}
+      queueDragOverIndex={null}
+      editingIndex={null}
+      canRevertEdit={false}
+      editNotice={null}
+      editBusy={false}
+      showContextPanel={false}
+      contextUsage={null}
+      mentionSearch={null}
+      filteredFiles={[]}
+      filteredFolders={[]}
+      symbolResults={[]}
+      mentionListingCap={null}
+      selectedFileIndex={0}
+      codegraphStatus={null}
+      slashSearch={null}
+      selectedSlashIndex={0}
+      allSlashCommands={[]}
+      attachedImages={[]}
+      isDragOver={false}
+      uploadError={null}
+      onSetWikiPrepared={noop}
+      onSetMemoryProposals={noop}
+      onSetDistillNotice={noop}
+      onSetMsgQueue={noop}
+      onSetInput={noop}
+      onSetAuto={noop}
+      onSetPlan={noop}
+      onSetCanRevertEdit={noop}
+      onSetEditNotice={noop}
+      onSetShowContextPanel={noop}
+      onSetSelectedFileIndex={noop}
+      onSetSelectedSlashIndex={noop}
+      onSetAttachedImages={noop}
+      onSetUploadError={noop}
+      onSetLightboxUrl={noop}
+      setSafeTimeout={noop}
+      fetchContextUsage={noop}
+      handleDragStart={noop}
+      handleDragOver={noop}
+      handleDragLeave={noop}
+      handleDrop={noop}
+      handleDragEnd={noop}
+      moveQueueItem={noop}
+      handleQueueClearAll={noop}
+      handleQueueDragStart={noop}
+      handleQueueDragOver={noop}
+      handleQueueDragLeave={noop}
+      handleQueueDrop={noop}
+      handleQueueDragEnd={noop}
+      handleQueueEdit={noop}
+      handleQueueRemove={noop}
+      handleComposerDragOver={noop}
+      handleComposerDragLeave={noop}
+      handleComposerDrop={noop}
+      handleRevertEdit={noop}
+      handleCancelEdit={noop}
+      handleInputChange={noop}
+      handleKeyDown={noop}
+      handlePaste={noop}
+      insertMention={noop}
+      insertFolder={noop}
+      insertSymbol={noop}
+      insertCodebase={noop}
+      showCodebaseMention={false}
+      insertSlashCommand={noop}
+      handleQueueAdd={noop}
+      stop={noop}
+      send={noop}
+    />,
+  );
+}
+
+describe("ComposerDock busy chrome", () => {
+  it("shows only Stop when the busy composer is empty", () => {
+    renderBusyDock("");
+    expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /steer/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /interrupt/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /queue/i })).toBeNull();
+  });
+
+  it("reveals Steer, Interrupt, and Queue once a redirect is typed", () => {
+    renderBusyDock("pivot to auth");
+    expect(screen.getByRole("button", { name: /steer/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /interrupt/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /queue/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
+  });
+});

--- a/webapp/src/__tests__/Conversation.resume.test.ts
+++ b/webapp/src/__tests__/Conversation.resume.test.ts
@@ -146,11 +146,75 @@ describe("Conversation ghost-resume gate", () => {
       resume,
       stillCurrent: () => current,
       schedule: setTimeout,
+      sessionId: "sess-a",
     });
     await vi.advanceTimersByTimeAsync(300);
     expect(resume).not.toHaveBeenCalled();
-    expect(getSessionState).toHaveBeenCalledWith({ consumeResume: true });
-    expect(getSessionState).toHaveBeenCalledWith({ rearmResume: true });
+    expect(getSessionState).toHaveBeenCalledWith({
+      consumeResume: true,
+      sessionId: "sess-a",
+    });
+    expect(getSessionState).toHaveBeenCalledWith({
+      rearmResume: true,
+      sessionId: "sess-a",
+    });
+  });
+
+  it("re-schedules after abandon rearm when owner session is active again", async () => {
+    const resume = vi.fn();
+    let current = true;
+    let ownerActive = true;
+    const getSessionState = vi.fn()
+      .mockResolvedValueOnce({
+        state: "idle",
+        pending_swarms: false,
+        resume_pending: true,
+      })
+      .mockImplementationOnce(async () => {
+        current = false;
+        return {
+          state: "idle",
+          pending_swarms: false,
+          resume_pending: true,
+        };
+      })
+      // rearm
+      .mockResolvedValueOnce({
+        state: "idle",
+        pending_swarms: false,
+        resume_pending: true,
+      })
+      // scheduleResumeIfPending peek after rearm
+      .mockResolvedValueOnce({
+        state: "idle",
+        pending_swarms: false,
+        resume_pending: true,
+      })
+      // delayed consume for the rescheduled kick
+      .mockResolvedValueOnce({
+        state: "idle",
+        pending_swarms: false,
+        resume_pending: true,
+      });
+
+    await scheduleResumeIfPending({
+      getSessionState,
+      resume,
+      stillCurrent: () => current,
+      ownerStillActive: () => ownerActive,
+      schedule: setTimeout,
+      sessionId: "sess-a",
+    });
+    await vi.advanceTimersByTimeAsync(300);
+    expect(resume).not.toHaveBeenCalled();
+    expect(getSessionState).toHaveBeenCalledWith({
+      rearmResume: true,
+      sessionId: "sess-a",
+    });
+    // Owner is active again — rescheduled kick consumes and resumes.
+    current = true;
+    await vi.advanceTimersByTimeAsync(300);
+    expect(resume).toHaveBeenCalledTimes(1);
   });
 
   it("clearSafeTimeouts cancel after peek does not consume (owning session keeps latch)", async () => {

--- a/webapp/src/__tests__/McpPane.test.tsx
+++ b/webapp/src/__tests__/McpPane.test.tsx
@@ -66,6 +66,7 @@ describe("McpPane last_invocation and action errors", () => {
           name: "aws",
           command: "uvx aws",
           running: false,
+          lifecycle: "error",
           tools: 0,
           error: "spawn failed",
           last_invocation: {
@@ -84,6 +85,48 @@ describe("McpPane last_invocation and action errors", () => {
     expect(screen.getByText("Server: spawn failed")).toBeInTheDocument();
     expect(screen.getByText(/Last call: list ok/)).toBeInTheDocument();
     expect(screen.getByText("stopped")).toBeInTheDocument();
+  });
+
+  it("shows idle vs operator-stopped labels and compact header counts", async () => {
+    mockMcp.mockResolvedValue({
+      servers: [
+        {
+          name: "github",
+          command: "npx github",
+          transport: "stdio",
+          running: true,
+          lifecycle: "running",
+          tools: 3,
+          error: "",
+        },
+        {
+          name: "aws",
+          command: "uvx aws",
+          transport: "stdio",
+          running: false,
+          lifecycle: "idle",
+          tools: 0,
+          error: "",
+        },
+        {
+          name: "vercel",
+          command: "npx vercel",
+          transport: "stdio",
+          running: false,
+          lifecycle: "stopped",
+          tools: 0,
+          error: "",
+        },
+      ],
+      tools: [],
+    });
+
+    render(<McpPane embedded />);
+    await waitFor(() => expect(screen.getByText("github")).toBeInTheDocument());
+    expect(screen.getByText("3 tools")).toBeInTheDocument();
+    expect(screen.getByText("idle")).toBeInTheDocument();
+    expect(screen.getByText("stopped")).toBeInTheDocument();
+    expect(screen.getByText("1 running, 1 idle, 1 stopped")).toBeInTheDocument();
   });
 
   it("surfaces HTTP 200 {ok:false} start failures as role=alert", async () => {

--- a/webapp/src/__tests__/StatusBar.test.tsx
+++ b/webapp/src/__tests__/StatusBar.test.tsx
@@ -6,6 +6,7 @@ import StatusBar, {
   sessionGoalForChip,
 } from "../components/StatusBar";
 import { api } from "../lib/api";
+import { publishTaskProfile } from "../lib/taskProfileChrome";
 
 vi.mock("../lib/api", () => ({
   api: {
@@ -745,6 +746,55 @@ describe("StatusBar update progress mirror", () => {
 
     await waitFor(() => {
       expect(screen.queryByText("Preparing update")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("StatusBar task profile chip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWorkspaces.mockResolvedValue([]);
+    mockGetUsage.mockResolvedValue({ session: emptyUsageSession, jobs: [] });
+    mockGetSessionState.mockResolvedValue({
+      state: "idle",
+      pending_swarms: false,
+      runners: {},
+    });
+    mockSessions.mockResolvedValue([]);
+  });
+
+  it("stays hidden until a task_profile event arrives", async () => {
+    render(<StatusBar {...statusBarProps} />);
+    await waitFor(() => {
+      expect(mockGetSessionState).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("task-profile-chip")).not.toBeInTheDocument();
+
+    act(() => {
+      publishTaskProfile({ profile: "micro", source: "heuristic" });
+    });
+
+    const chip = await screen.findByTestId("task-profile-chip");
+    expect(chip).toHaveTextContent("DEPTH");
+    expect(chip).toHaveTextContent("MICRO");
+    expect(chip).toHaveAttribute(
+      "title",
+      expect.stringContaining("skipped wiki and CodeGraph auto-inject"),
+    );
+  });
+
+  it("clears the chip on session change", async () => {
+    render(<StatusBar {...statusBarProps} />);
+    act(() => {
+      publishTaskProfile({ profile: "standard" });
+    });
+    expect(await screen.findByTestId("task-profile-chip")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new Event("harness-session-changed"));
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("task-profile-chip")).not.toBeInTheDocument();
     });
   });
 });

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -203,6 +203,44 @@ describe("SwarmPane pin attribution", () => {
     expect(screen.queryByText("Router pick")).not.toBeInTheDocument();
   });
 
+  it("does not paint a missing routing estimate as $0", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "ROUTING",
+            headline: "",
+            task_id: "task-1",
+            model: "agentic/meta/muse-spark-1.1",
+            policy: "explicit_pin",
+            provider: "openrouter",
+            adapter: "agentic",
+            created_by: "router",
+          },
+        ],
+        tasks: [
+          {
+            id: "task-1",
+            status: "running",
+            role: "Worker",
+            instruction: "",
+            adapter: "agentic",
+          },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Explicit pin · not auto-routed")).toBeInTheDocument();
+    });
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.queryByText("$0")).not.toBeInTheDocument();
+  });
+
   it("fail-closes missing policy as Pin attribution unknown (not Router pick)", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -157,6 +157,7 @@ import {
   runEditMessageFlow,
   runStopFlow,
   shouldBlockEmptySend,
+  shouldSteerWhileBusy,
   shouldClearSteerDraftOnResult,
   showStandaloneEditNoticeDismiss,
   userOrdinalBeforeIndex,
@@ -2196,6 +2197,21 @@ describe("composerSend module", () => {
     expect(
       composerEnterAction({ busy: false, metaOrCtrl: false, altKey: true }),
     ).toBe("send");
+    // Empty composer while busy must not invent a steer.
+    expect(
+      composerEnterAction({ busy: true, metaOrCtrl: false, hasText: false }),
+    ).toBe("noop");
+    expect(
+      composerEnterAction({
+        busy: true,
+        metaOrCtrl: false,
+        altKey: true,
+        hasText: false,
+      }),
+    ).toBe("noop");
+    expect(shouldSteerWhileBusy({ text: "" })).toBe(false);
+    expect(shouldSteerWhileBusy({ text: "   " })).toBe(false);
+    expect(shouldSteerWhileBusy({ text: "pivot" })).toBe(true);
     expect(
       executeSendGate({ transcriptStale: true, resume: false, userStopped: false }),
     ).toBe("stale");

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -2184,6 +2184,18 @@ describe("composerSend module", () => {
   it("gates enter/send and formats slash replies", () => {
     expect(composerEnterAction({ busy: true, metaOrCtrl: true })).toBe("queue");
     expect(composerEnterAction({ busy: true, metaOrCtrl: false })).toBe("send");
+    // Alt+Enter while busy interrupts (stop turn, then queue typed prompt).
+    expect(
+      composerEnterAction({ busy: true, metaOrCtrl: false, altKey: true }),
+    ).toBe("interrupt");
+    // Cmd/Ctrl wins over Alt when both are held.
+    expect(
+      composerEnterAction({ busy: true, metaOrCtrl: true, altKey: true }),
+    ).toBe("queue");
+    // Idle: Alt+Enter is a normal send (no interrupt latch).
+    expect(
+      composerEnterAction({ busy: false, metaOrCtrl: false, altKey: true }),
+    ).toBe("send");
     expect(
       executeSendGate({ transcriptStale: true, resume: false, userStopped: false }),
     ).toBe("stale");

--- a/webapp/src/__tests__/sessionStateConsume.test.ts
+++ b/webapp/src/__tests__/sessionStateConsume.test.ts
@@ -27,4 +27,20 @@ describe("api.getSessionState consume_resume query", () => {
     await api.getSessionState({ rearmResume: true });
     expect(getJSON).toHaveBeenCalledWith(withToken("/api/session/state?rearm_resume=1"));
   });
+
+  it("threads session_id for session-scoped latch peek/consume/rearm", async () => {
+    const { api } = await import("../lib/api");
+    await api.getSessionState({ sessionId: "sess-a" });
+    expect(getJSON).toHaveBeenCalledWith(
+      withToken("/api/session/state?session_id=sess-a"),
+    );
+    await api.getSessionState({ consumeResume: true, sessionId: "sess-a" });
+    expect(getJSON).toHaveBeenCalledWith(
+      withToken("/api/session/state?consume_resume=1&session_id=sess-a"),
+    );
+    await api.getSessionState({ rearmResume: true, sessionId: "sess-b" });
+    expect(getJSON).toHaveBeenCalledWith(
+      withToken("/api/session/state?rearm_resume=1&session_id=sess-b"),
+    );
+  });
 });

--- a/webapp/src/__tests__/taskProfileChrome.test.ts
+++ b/webapp/src/__tests__/taskProfileChrome.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeTaskProfile,
+  publishTaskProfile,
+  subscribeTaskProfile,
+  taskProfileTitle,
+} from "../lib/taskProfileChrome";
+
+describe("taskProfileChrome", () => {
+  it("normalizes known depths and rejects junk", () => {
+    expect(normalizeTaskProfile("micro")).toBe("MICRO");
+    expect(normalizeTaskProfile("STANDARD")).toBe("STANDARD");
+    expect(normalizeTaskProfile("deep")).toBe("DEEP");
+    expect(normalizeTaskProfile("")).toBe("");
+    expect(normalizeTaskProfile("turbo")).toBe("");
+  });
+
+  it("titles MICRO with the skipped auto-inject stack", () => {
+    expect(
+      taskProfileTitle({
+        profile: "micro",
+        source: "classifier",
+      }),
+    ).toBe("MICRO — source classifier — skipped wiki and CodeGraph auto-inject");
+  });
+
+  it("publishes only valid profiles to subscribers", () => {
+    const seen: string[] = [];
+    const unsub = subscribeTaskProfile((chip) => seen.push(chip.profile));
+    publishTaskProfile({ profile: "deep", source: "escalation", escalated_from: "standard" });
+    publishTaskProfile({ profile: "nope" });
+    unsub();
+    expect(seen).toEqual(["DEEP"]);
+  });
+});

--- a/webapp/src/__tests__/workspaceFreshness.test.tsx
+++ b/webapp/src/__tests__/workspaceFreshness.test.tsx
@@ -163,6 +163,61 @@ describe("workspace freshness fan-out", () => {
     });
   });
 
+  it("FileEditorPane reloads a clean buffer on pathless workspace mutation", async () => {
+    vi.mocked(api.readFile)
+      .mockResolvedValueOnce({ ok: true, content: "v1\n" } as any)
+      .mockResolvedValueOnce({ ok: true, content: "v2-from-restore\n" } as any);
+
+    const { getByTestId } = render(
+      <FileEditorPane
+        path="src/a.ts"
+        onClose={() => {}}
+        onDirtyChange={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("cm-value").textContent).toContain("v1");
+    });
+
+    await act(async () => {
+      notifyWorkspaceMutated();
+    });
+
+    await waitFor(() => {
+      expect(api.readFile).toHaveBeenCalledTimes(2);
+      expect(getByTestId("cm-value").textContent).toContain("v2-from-restore");
+    });
+  });
+
+  it("FileEditorPane dirty buffer conflicts on pathless workspace mutation", async () => {
+    const onDirtyChange = vi.fn();
+    const { getByTestId } = render(
+      <FileEditorPane
+        path="src/a.ts"
+        onClose={() => {}}
+        onDirtyChange={onDirtyChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("cm-value").textContent).toContain("v1");
+    });
+
+    await act(async () => {
+      getByTestId("cm-dirty").click();
+    });
+    expect(onDirtyChange).toHaveBeenCalledWith(true);
+
+    await act(async () => {
+      notifyWorkspaceMutated();
+    });
+
+    expect(getByTestId("disk-conflict-banner")).toBeTruthy();
+    expect(api.readFile).toHaveBeenCalledTimes(1);
+    expect(getByTestId("cm-value").textContent).toContain("local-edit");
+  });
+
   it("FileEditorPane ignores mutation events for other paths", async () => {
     render(
       <FileEditorPane

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -68,6 +68,7 @@ import {
   formatHelpSlashReply,
   formatRenderCommandErrorMessage,
   formatSteerErrorMessage,
+  formatInterruptErrorMessage,
   localSlashChromeAction,
   localSlashPaletteAction,
   runEditMessageFlow,
@@ -1861,13 +1862,23 @@ export default function Conversation({
       e.preventDefault();
       // Match composerBusy / agentLoopOpen (awaiting_swarm + holdSwarmAwait)
       // so plain Enter steers during a background swarm wait instead of a new send.
-      // Cmd/Ctrl+Enter still queues while that latch is armed.
+      // Cmd/Ctrl+Enter still queues while that latch is armed; Alt+Enter interrupts.
       const busy = composerBusy;
       // While a turn is running, plain Enter STEERS (redirects the current turn);
-      // Cmd/Ctrl+Enter QUEUES (runs after the current turn finishes). When idle,
+      // Cmd/Ctrl+Enter QUEUES (runs after the current turn finishes); Alt+Enter
+      // INTERRUPTS (stop this turn, then run the typed prompt next). When idle,
       // Enter always sends a normal turn.
-      if (composerEnterAction({ busy, metaOrCtrl: e.metaKey || e.ctrlKey }) === "queue") {
+      const enterAction = composerEnterAction({
+        busy,
+        metaOrCtrl: e.metaKey || e.ctrlKey,
+        altKey: e.altKey,
+      });
+      if (enterAction === "queue") {
         handleQueueAdd();
+        return;
+      }
+      if (enterAction === "interrupt") {
+        send("interrupt");
         return;
       }
       send();
@@ -2462,7 +2473,7 @@ export default function Conversation({
   };
   resumeTriggerRef.current = triggerResume;
 
-  const send = () => {
+  const send = (mode?: "interrupt") => {
     if (editBusy) return;
     const msg = input.trim();
     // Allow a send/steer that is only attached image(s) with no text -- the
@@ -2629,26 +2640,42 @@ export default function Conversation({
     if (composerBusy && !resubmitEdit) {
       // Snapshot the attached image paths BEFORE the async call so we never
       // read a stale/cleared closure value and images are never silently
-      // dropped from the steer request. Clear the draft only on success
-      // (Cursor parity — keep operator text when steer 4xx/network fails).
+      // dropped from the steer/interrupt request. Clear the draft only on
+      // success (Cursor parity — keep operator text when 4xx/network fails).
       const steerImages = attachedImages.map((img) => img.path).filter(Boolean);
-      api.steerSession(msg, steerImages)
+      const deliveryMode = mode === "interrupt" ? "interrupt" as const : undefined;
+      api.steerSession(msg, steerImages, deliveryMode)
         .then(() => {
           if (shouldClearSteerDraftOnResult(true)) {
             setInput("");
             setAttachedImages([]);
           }
-          setItems((prev) => [...prev, { kind: "steer", text: msg }]);
+          setItems((prev) => [
+            ...prev,
+            {
+              kind: "steer",
+              text: msg,
+              ...(mode === "interrupt" ? { mode: "interrupt" as const } : {}),
+            },
+          ]);
         })
         .catch((err) => {
-          console.error("Failed to steer session:", err);
+          console.error(
+            mode === "interrupt"
+              ? "Failed to interrupt session:"
+              : "Failed to steer session:",
+            err,
+          );
           setItems((prev) => [
             ...prev,
             {
               kind: "msg",
               msg: {
                 role: "assistant",
-                text: formatSteerErrorMessage(err),
+                text:
+                  mode === "interrupt"
+                    ? formatInterruptErrorMessage(err)
+                    : formatSteerErrorMessage(err),
               }
             }
           ]);

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -75,6 +75,7 @@ import {
   runStopFlow,
   shouldBlockEmptySend,
   shouldClearSteerDraftOnResult,
+  shouldSteerWhileBusy,
   userOrdinalBeforeIndex,
 } from "./conversation/composerSend";
 import { runCommandPaletteAction } from "../lib/commandPalette";
@@ -1872,7 +1873,11 @@ export default function Conversation({
         busy,
         metaOrCtrl: e.metaKey || e.ctrlKey,
         altKey: e.altKey,
+        hasText: Boolean(input.trim()),
       });
+      if (enterAction === "noop") {
+        return;
+      }
       if (enterAction === "queue") {
         handleQueueAdd();
         return;
@@ -2638,6 +2643,9 @@ export default function Conversation({
     setEditNotice(editNoticeAfterSend(false));
 
     if (composerBusy && !resubmitEdit) {
+      // Images-only is a new-turn send. Mid-turn steer/interrupt needs words
+      // or Stop invents a phantom steer and then drops it as an error.
+      if (!shouldSteerWhileBusy({ text: msg })) return;
       // Snapshot the attached image paths BEFORE the async call so we never
       // read a stale/cleared closure value and images are never silently
       // dropped from the steer/interrupt request. Clear the draft only on

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -1268,7 +1268,7 @@ export default function Conversation({
         activeSessionIdRef.current === requestSid
         && transcriptLoadGenRef.current === requestGen
       );
-      api.getSessionState()
+      api.getSessionState({ sessionId: requestSid })
         .then((res) => {
           if (!stillCurrent() || !res) return;
           setBackendPendingSwarms(!!res.pending_swarms);
@@ -1294,6 +1294,8 @@ export default function Conversation({
             getSessionState: api.getSessionState,
             resume: () => resumeTriggerRef.current(),
             stillCurrent,
+            ownerStillActive: () => activeSessionIdRef.current === requestSid,
+            sessionId: requestSid,
             schedule: setSafeTimeout,
           });
         })

--- a/webapp/src/components/FileEditorPane.tsx
+++ b/webapp/src/components/FileEditorPane.tsx
@@ -402,8 +402,11 @@ export default function FileEditorPane({ path, line, col, onClose, onDirtyChange
   useEffect(() => {
     return subscribeWorkspaceMutations((event) => {
       const mutated = mutationEventPath(event);
-      if (!mutated) return;
-      if (!pathsReferToSameFile(mutated, pathRef.current)) return;
+      // Pathless events (checkpoint restore / rewind) mean the workspace
+      // changed but the emitter does not know which files. Reload this
+      // clean tab; dirty tabs get a conflict notice instead of a silent
+      // overwrite.
+      if (mutated && !pathsReferToSameFile(mutated, pathRef.current)) return;
       if (isDirtyRef.current) {
         setDiskConflict(true);
         return;

--- a/webapp/src/components/McpPane.tsx
+++ b/webapp/src/components/McpPane.tsx
@@ -58,6 +58,48 @@ function formatLastInvocation(inv: McpLastInvocation | undefined): string {
   return `Last call: ${inv.tool} failed — ${err}${when}`;
 }
 
+type McpLifecycle = "running" | "idle" | "stopped" | "error";
+
+function serverLifecycle(s: { running?: boolean; lifecycle?: string; error?: string }): McpLifecycle {
+  if (s.lifecycle === "running" || s.lifecycle === "idle" || s.lifecycle === "stopped" || s.lifecycle === "error") {
+    return s.lifecycle;
+  }
+  if (s.running) return "running";
+  if (s.error) return "error";
+  return "idle";
+}
+
+function lifecycleStatusLabel(s: { running?: boolean; lifecycle?: string; error?: string; tools?: number }): string {
+  const lc = serverLifecycle(s);
+  if (lc === "running") return `${s.tools ?? 0} tools`;
+  if (lc === "idle") return "idle";
+  return "stopped";
+}
+
+function lifecycleDotClass(s: { running?: boolean; lifecycle?: string; error?: string }): string {
+  const lc = serverLifecycle(s);
+  if (lc === "running") return "bg-good";
+  if (lc === "error") return "bg-risk";
+  return "bg-faint";
+}
+
+function formatMcpHeaderSummary(servers: { running?: boolean; lifecycle?: string; error?: string }[]): string {
+  if (servers.length === 0) return "No servers";
+  const counts = { running: 0, idle: 0, stopped: 0, error: 0 };
+  for (const s of servers) {
+    counts[serverLifecycle(s)] += 1;
+  }
+  if (counts.idle > 0) {
+    const parts: string[] = [];
+    if (counts.running) parts.push(`${counts.running} running`);
+    if (counts.idle) parts.push(`${counts.idle} idle`);
+    if (counts.stopped) parts.push(`${counts.stopped} stopped`);
+    if (counts.error) parts.push(`${counts.error} error`);
+    return parts.join(", ");
+  }
+  return `${counts.running}/${servers.length} running`;
+}
+
 export default function McpPane({ embedded = false }: { embedded?: boolean }) {
   const [servers, setServers] = useState<any[]>([]);
   const [tools, setTools] = useState<any[]>([]);
@@ -218,9 +260,7 @@ export default function McpPane({ embedded = false }: { embedded?: boolean }) {
           </span>
         ) : (
           <span className="text-[9px] text-faint">
-            {servers.length === 0
-              ? "No servers"
-              : `${servers.filter((s) => s.running).length}/${servers.length} running`}
+            {formatMcpHeaderSummary(servers)}
           </span>
         )}
         <button
@@ -259,7 +299,7 @@ export default function McpPane({ embedded = false }: { embedded?: boolean }) {
           return (
           <div key={s.name} className="border border-edge rounded-lg p-2 bg-panel2/40">
             <div className="flex items-center gap-2">
-              <span className={`w-1.5 h-1.5 rounded-full ${s.running ? "bg-good" : "bg-faint"}`} />
+              <span className={`w-1.5 h-1.5 rounded-full ${lifecycleDotClass(s)}`} />
               <span className="font-medium text-txt flex-1 truncate flex items-center gap-1.5">
                 <span>{s.name}</span>
                 {s.transport && (
@@ -268,7 +308,7 @@ export default function McpPane({ embedded = false }: { embedded?: boolean }) {
                   </span>
                 )}
               </span>
-              <span className="text-faint text-[10px]">{s.running ? `${s.tools} tools` : "stopped"}</span>
+              <span className="text-faint text-[10px]">{lifecycleStatusLabel(s)}</span>
               <button
                 onClick={() => refreshServer(s.name)}
                 disabled={busy === s.name}

--- a/webapp/src/components/StatusBar.tsx
+++ b/webapp/src/components/StatusBar.tsx
@@ -16,6 +16,11 @@ import {
   X,
 } from "lucide-react";
 import { api, type Config, type SessionGoal, type SessionState, type UsageData } from "../lib/api";
+import {
+  subscribeTaskProfile,
+  taskProfileTitle,
+  type TaskProfileChip,
+} from "../lib/taskProfileChrome";
 import { isDesktop } from "../lib/transport";
 import { usePolling } from "../lib/usePolling";
 import CostBreakdown, {
@@ -88,6 +93,7 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
     actionEvent?: string;
   } | null>(null);
   const [sessionState, setSessionState] = useState<SessionState | null>(null);
+  const [taskProfile, setTaskProfile] = useState<TaskProfileChip | null>(null);
   const [goalBusy, setGoalBusy] = useState(false);
   // Dedup runtime-stale notes across the 5-minute focus throttle and 30-minute polls.
   const lastRuntimeNoteRef = useRef<string | null>(null);
@@ -144,6 +150,8 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
     window.addEventListener("harness-toast", onToast);
     return () => window.removeEventListener("harness-toast", onToast);
   }, []);
+
+  useEffect(() => subscribeTaskProfile(setTaskProfile), []);
 
   // Self-update check: how far behind the tracked branch we are (desktop only).
   // Silent on failure -- an update nudge must never get in the way. Re-checks
@@ -299,6 +307,7 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
     const onSessionChanged = () => {
       acceptZeroUsageRef.current = true;
       setUsage(null);
+      setTaskProfile(null);
       fetchUsage();
       // Session/view swaps carry a different sticky GOAL — refresh immediately
       // rather than waiting for the next 4s poll tick.
@@ -377,6 +386,17 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
         {footerRuntimeStatusLabel(runtimeStatus)}
       </span>
       {branch && <span className="flex items-center gap-1"><GitBranch size={10} />{branch}</span>}
+      {taskProfile && (
+        <span
+          data-testid="task-profile-chip"
+          className="inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-panel2 border border-edge text-txt/90"
+          title={taskProfileTitle(taskProfile)}
+        >
+          <Zap size={10} className="shrink-0 text-accent" aria-hidden="true" />
+          <span className="uppercase tracking-wide text-faint shrink-0">DEPTH</span>
+          <span>{taskProfile.profile}</span>
+        </span>
+      )}
       {sessionGoal && (
         <span
           data-testid="session-goal-chip"

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -391,6 +391,12 @@ function formatCost(cost: number, estimated?: boolean): string {
   return estimated ? `~${body}` : body;
 }
 
+/** Missing/unpriceable estimates must not paint as measured $0. */
+function formatKnownCost(cost: unknown, estimated?: boolean): string {
+  if (typeof cost !== "number" || !isFinite(cost)) return "—";
+  return formatCost(cost, estimated);
+}
+
 function positiveUsd(n?: number): number {
   return typeof n === "number" && isFinite(n) && n > 0 ? n : 0;
 }
@@ -1040,8 +1046,8 @@ export default function SwarmPane() {
                     <span className="text-accent/90">{jobCompactTokens(j).toLocaleString()} compact</span>
                   )}
                   <span className="text-good/90">
-                    {formatCost(
-                      jobCost(j),
+                    {formatKnownCost(
+                      j.est_cost_usd,
                       j.estimated !== false && j.cost_provenance !== "provider",
                     )}
                   </span>
@@ -1245,9 +1251,7 @@ export default function SwarmPane() {
                           )}
                         </span>
                         <span className="font-mono text-good shrink-0 font-semibold">
-                          {art.est_cost_usd !== undefined && art.est_cost_usd > 0
-                            ? `~$${Number(art.est_cost_usd).toFixed(4)}`
-                            : "$0"}
+                          {formatKnownCost(art.est_cost_usd, true)}
                         </span>
                       </div>
                       {/* One plain-language line on why this model won. */}

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -175,7 +175,7 @@ export type Item =
   | { kind: "auto_status"; cycle: number; snapshot: AutoBudgetSnapshot }
   | { kind: "auto_halt"; reason: string; snapshot: AutoBudgetSnapshot }
   | { kind: "auth_failure"; message: string; id?: string }
-  | { kind: "steer"; text: string }
+  | { kind: "steer"; text: string; mode?: "steer" | "interrupt" }
   | {
       kind: "quality_gate";
       outcome: string;
@@ -216,7 +216,7 @@ export type GroupedItem =
   | { kind: "auto_status"; cycle: number; snapshot: AutoBudgetSnapshot }
   | { kind: "auto_halt"; reason: string; snapshot: AutoBudgetSnapshot }
   | { kind: "auth_failure"; message: string; id?: string }
-  | { kind: "steer"; text: string }
+  | { kind: "steer"; text: string; mode?: "steer" | "interrupt" }
   | {
       kind: "quality_gate";
       outcome: string;
@@ -1082,7 +1082,7 @@ export const TranscriptList = memo(function TranscriptList({
     } else if (it.kind === "steer") {
       return (
         <div key={key} className="flex items-center gap-1.5 py-1 px-3 rounded-full bg-panel2/15 border border-edge/20 text-[10.5px] text-faint w-fit my-1 select-none font-mono animate-in fade-in duration-200">
-          <span className="text-muted">steer:</span>
+          <span className="text-muted">{it.mode === "interrupt" ? "interrupt:" : "steer:"}</span>
           <span>{it.text}</span>
         </div>
       );

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -1015,11 +1015,23 @@ export default function ComposerDock({
             )}
             {composerBusy
               ? <>
-                  <button onClick={stop} className="px-2 h-[20px] rounded-md bg-risk/15 text-risk text-[10.5px] font-medium flex items-center gap-1"><Square size={9} />Stop</button>
-                  <button onClick={() => send()} disabled={editBusy || transcriptStale || (!input.trim() && attachedImages.length === 0)}
-                    title="Steer: redirect the current turn now (Enter). Cmd/Ctrl+Enter or Queue = run after this turn finishes. Alt+Enter or Interrupt = stop this turn, then run this prompt next."
-                    className="px-2.5 h-[20px] rounded-md bg-accent text-black/90 text-[10.5px] font-semibold flex items-center gap-1 hover:brightness-110 disabled:opacity-40 disabled:cursor-default transition">
-                    <Send size={9} />Steer</button>
+                  {input.trim() ? (
+                    <button
+                      onClick={() => send()}
+                      disabled={editBusy || transcriptStale}
+                      title="Steer: redirect the current turn now (Enter). Cmd/Ctrl+Enter or Queue = run after this turn finishes. Alt+Enter or Interrupt = stop this turn, then run this prompt next."
+                      className="px-2 h-[20px] rounded-md bg-panel2/60 border border-edge/60 text-faint hover:text-muted hover:border-edge2 text-[10.5px] font-medium flex items-center gap-1 transition disabled:opacity-40 disabled:cursor-default"
+                    >
+                      <Send size={9} />Steer
+                    </button>
+                  ) : null}
+                  <button
+                    onClick={stop}
+                    className="px-2.5 h-[20px] rounded-md bg-risk/15 text-risk text-[10.5px] font-semibold flex items-center gap-1 hover:brightness-110"
+                    title="Stop this turn. Does not steer or queue an empty prompt."
+                  >
+                    <Square size={9} />Stop
+                  </button>
                 </>
               : <button onClick={() => send()} disabled={editBusy || transcriptStale || (!input.trim() && attachedImages.length === 0)}
                   className="px-2.5 h-[20px] rounded-md bg-accent text-black/90 text-[10.5px] font-semibold flex items-center gap-1 hover:brightness-110 disabled:opacity-40 disabled:cursor-default transition">

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -226,7 +226,7 @@ export default function ComposerDock({
   insertSlashCommand: (cmd: string) => void;
   handleQueueAdd: () => void;
   stop: () => void;
-  send: () => void;
+  send: (mode?: "interrupt") => void;
 }) {
   const matchingSlash =
     slashSearch !== null
@@ -1003,15 +1003,25 @@ export default function ComposerDock({
                 <ListChecks size={9} />Queue
               </button>
             )}
+            {composerBusy && input.trim() && (
+              <button
+                onClick={() => send("interrupt")}
+                disabled={editBusy || transcriptStale}
+                title="Stop this turn, then run this prompt next (Alt+Enter)"
+                className="px-2 h-[20px] rounded-md bg-panel2/60 border border-edge/60 text-faint hover:text-muted hover:border-edge2 text-[10.5px] font-medium flex items-center gap-1 transition disabled:opacity-40 disabled:cursor-default"
+              >
+                Interrupt
+              </button>
+            )}
             {composerBusy
               ? <>
                   <button onClick={stop} className="px-2 h-[20px] rounded-md bg-risk/15 text-risk text-[10.5px] font-medium flex items-center gap-1"><Square size={9} />Stop</button>
-                  <button onClick={send} disabled={editBusy || transcriptStale || (!input.trim() && attachedImages.length === 0)}
-                    title="Steer: redirect the current turn now (Enter). Cmd/Ctrl+Enter or Queue = run after this turn finishes."
+                  <button onClick={() => send()} disabled={editBusy || transcriptStale || (!input.trim() && attachedImages.length === 0)}
+                    title="Steer: redirect the current turn now (Enter). Cmd/Ctrl+Enter or Queue = run after this turn finishes. Alt+Enter or Interrupt = stop this turn, then run this prompt next."
                     className="px-2.5 h-[20px] rounded-md bg-accent text-black/90 text-[10.5px] font-semibold flex items-center gap-1 hover:brightness-110 disabled:opacity-40 disabled:cursor-default transition">
                     <Send size={9} />Steer</button>
                 </>
-              : <button onClick={send} disabled={editBusy || transcriptStale || (!input.trim() && attachedImages.length === 0)}
+              : <button onClick={() => send()} disabled={editBusy || transcriptStale || (!input.trim() && attachedImages.length === 0)}
                   className="px-2.5 h-[20px] rounded-md bg-accent text-black/90 text-[10.5px] font-semibold flex items-center gap-1 hover:brightness-110 disabled:opacity-40 disabled:cursor-default transition">
                   <Send size={9} />{auto ? "Run" : plan ? "Plan" : "Send"}</button>}
           </div>

--- a/webapp/src/components/conversation/composerSend.ts
+++ b/webapp/src/components/conversation/composerSend.ts
@@ -20,15 +20,23 @@ export function composerEnterBusy(opts: {
 /**
  * Enter while busy: Cmd/Ctrl+Enter queues; Alt+Enter interrupts then queues
  * the typed prompt; plain Enter steers/sends. Meta/ctrl wins over alt.
+ * Empty composer while busy is a no-op — never invent a steer.
  */
 export function composerEnterAction(opts: {
   busy: boolean;
   metaOrCtrl: boolean;
   altKey?: boolean;
-}): "queue" | "send" | "interrupt" {
+  hasText?: boolean;
+}): "queue" | "send" | "interrupt" | "noop" {
+  if (opts.busy && opts.hasText === false) return "noop";
   if (opts.busy && opts.metaOrCtrl) return "queue";
   if (opts.busy && opts.altKey) return "interrupt";
   return "send";
+}
+
+/** Mid-turn steer/interrupt requires typed text. Images-only is a new turn. */
+export function shouldSteerWhileBusy(opts: { text: string }): boolean {
+  return Boolean(opts.text.trim());
 }
 
 /**

--- a/webapp/src/components/conversation/composerSend.ts
+++ b/webapp/src/components/conversation/composerSend.ts
@@ -17,12 +17,17 @@ export function composerEnterBusy(opts: {
   return isAgentLoopOpen(opts.turnOpen, opts.status);
 }
 
-/** Enter while busy: Cmd/Ctrl+Enter queues; plain Enter steers/sends. */
+/**
+ * Enter while busy: Cmd/Ctrl+Enter queues; Alt+Enter interrupts then queues
+ * the typed prompt; plain Enter steers/sends. Meta/ctrl wins over alt.
+ */
 export function composerEnterAction(opts: {
   busy: boolean;
   metaOrCtrl: boolean;
-}): "queue" | "send" {
+  altKey?: boolean;
+}): "queue" | "send" | "interrupt" {
   if (opts.busy && opts.metaOrCtrl) return "queue";
+  if (opts.busy && opts.altKey) return "interrupt";
   return "send";
 }
 
@@ -111,6 +116,14 @@ export function formatSteerErrorMessage(err: unknown): string {
       ? String((err as { message?: unknown }).message || err)
       : String(err || "");
   return "[error] Steer failed: " + message;
+}
+
+export function formatInterruptErrorMessage(err: unknown): string {
+  const message =
+    err && typeof err === "object" && "message" in err
+      ? String((err as { message?: unknown }).message || err)
+      : String(err || "");
+  return "[error] Interrupt failed: " + message;
 }
 
 /**

--- a/webapp/src/components/conversation/reexports.ts
+++ b/webapp/src/components/conversation/reexports.ts
@@ -174,6 +174,7 @@ export {
   formatCompactErrorMessage,
   shouldApplyCompactSettle,
   formatSteerErrorMessage,
+  formatInterruptErrorMessage,
   shouldClearSteerDraftOnResult,
   formatRenderCommandErrorMessage,
   editNoticeAfterSend,

--- a/webapp/src/components/conversation/reexports.ts
+++ b/webapp/src/components/conversation/reexports.ts
@@ -169,6 +169,7 @@ export {
   composerEnterBusy,
   executeSendGate,
   shouldBlockEmptySend,
+  shouldSteerWhileBusy,
   formatHelpSlashReply,
   formatCompactCompleteMessage,
   formatCompactErrorMessage,

--- a/webapp/src/components/conversation/sessionResumeLatch.ts
+++ b/webapp/src/components/conversation/sessionResumeLatch.ts
@@ -4,7 +4,8 @@
  * Consuming before the 300ms kick lets clearSafeTimeouts / session switch
  * abandon the timeout after the latch is already gone. Consume only after
  * stillCurrent inside the timeout; re-arm if we leave the owning session
- * between consume and the resume trigger.
+ * between consume and the resume trigger. Latch peek/consume/rearm are
+ * session-scoped on the backend — always pass the owning sessionId.
  */
 
 export type ResumeLatchSessionState = {
@@ -14,6 +15,7 @@ export type ResumeLatchSessionState = {
 export type ResumeLatchGetSessionState = (opts?: {
   consumeResume?: boolean;
   rearmResume?: boolean;
+  sessionId?: string;
 }) => Promise<ResumeLatchSessionState>;
 
 export type ArmResumeKickOpts = {
@@ -23,7 +25,22 @@ export type ArmResumeKickOpts = {
   /** Conversation uses setSafeTimeout so switchedSession can cancel the kick. */
   schedule: (fn: () => void, ms: number) => unknown;
   delayMs?: number;
+  /** Owning session id for peek/consume/rearm (required for session-scoped latch). */
+  sessionId?: string;
+  /**
+   * Session-only fence used after abandon rearm. Ignores transcript-load gen
+   * so a remount that raced the rearm can still scheduleResumeIfPending.
+   */
+  ownerStillActive?: () => boolean;
 };
+
+function bindSessionId(
+  getSessionState: ResumeLatchGetSessionState,
+  sessionId: string | undefined,
+): ResumeLatchGetSessionState {
+  if (!sessionId) return getSessionState;
+  return (opts) => getSessionState({ ...opts, sessionId });
+}
 
 /**
  * Schedule a delayed consume+resume. Caller must have already peeked
@@ -31,12 +48,13 @@ export type ArmResumeKickOpts = {
  */
 export function armResumeKick(opts: ArmResumeKickOpts): void {
   const delayMs = opts.delayMs ?? 300;
+  const getSessionState = bindSessionId(opts.getSessionState, opts.sessionId);
   opts.schedule(() => {
     void (async () => {
       if (!opts.stillCurrent()) return;
       let consumed: ResumeLatchSessionState;
       try {
-        consumed = await opts.getSessionState({ consumeResume: true });
+        consumed = await getSessionState({ consumeResume: true });
       } catch {
         return;
       }
@@ -44,7 +62,18 @@ export function armResumeKick(opts: ArmResumeKickOpts): void {
         // Consumed after leaving the owning session — restore continuity.
         if (consumed?.resume_pending) {
           try {
-            await opts.getSessionState({ rearmResume: true });
+            await getSessionState({ rearmResume: true });
+            // Mount effect may have already peeked before rearm finished.
+            // Re-schedule with the session-only fence so the current view can
+            // pick the latch up when it owns it again (do not leave it stuck).
+            const ownerActive = opts.ownerStillActive ?? opts.stillCurrent;
+            if (ownerActive()) {
+              await scheduleResumeIfPending({
+                ...opts,
+                getSessionState,
+                stillCurrent: ownerActive,
+              });
+            }
           } catch {
             /* best-effort; next open may still miss if rearm fails */
           }
@@ -59,7 +88,8 @@ export function armResumeKick(opts: ArmResumeKickOpts): void {
 
 /** Peek then arm the delayed consume+kick when the latch is present. */
 export async function scheduleResumeIfPending(opts: ArmResumeKickOpts): Promise<void> {
-  const res = await opts.getSessionState();
+  const getSessionState = bindSessionId(opts.getSessionState, opts.sessionId);
+  const res = await getSessionState();
   if (!opts.stillCurrent() || !res?.resume_pending) return;
-  armResumeKick(opts);
+  armResumeKick({ ...opts, getSessionState });
 }

--- a/webapp/src/components/conversation/streamEventHandler.ts
+++ b/webapp/src/components/conversation/streamEventHandler.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Dispatch, SetStateAction } from "react";
+import { publishTaskProfile } from "../../lib/taskProfileChrome";
 import type { Card, Item } from "../TranscriptList";
 import {
   hoistCardsBeforeTrailingFinals,
@@ -141,7 +142,13 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
 
   return (ev: StreamEvent) => {
     const d = ev.data || {};
-    if (ev.kind === "compacting") {
+    if (ev.kind === "task_profile") {
+      publishTaskProfile({
+        profile: d.profile,
+        source: d.source,
+        escalated_from: d.escalated_from,
+      });
+    } else if (ev.kind === "compacting") {
       setCompactingStatus(d.message || "Summarizing chat context");
     } else if (ev.kind === "command_blocked") {
       setItems((p) => appendCommandBlocked(p, d));

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1059,13 +1059,20 @@ export const api = {
   sessionTranscript: (session: string) => getJSON<{ history: any[]; display?: any[]; job_ids?: string[] }>(withToken(`/api/sessions/transcript?session=${encodeURIComponent(session)}`)),
   /** Session runners/state. Pass ``consumeResume`` only from the Conversation
    * resume-kick path — plain polls must peek so they cannot steal the latch.
-   * ``rearmResume`` restores the latch after a consume abandoned by switch. */
-  getSessionState: (opts?: { consumeResume?: boolean; rearmResume?: boolean }) => {
-    const path = opts?.rearmResume
-      ? "/api/session/state?rearm_resume=1"
-      : opts?.consumeResume
-        ? "/api/session/state?consume_resume=1"
-        : "/api/session/state";
+   * ``rearmResume`` restores the latch after a consume abandoned by switch.
+   * ``sessionId`` scopes peek/consume/rearm to the latch owner (required for
+   * resume_pending honesty across view switches). */
+  getSessionState: (opts?: {
+    consumeResume?: boolean;
+    rearmResume?: boolean;
+    sessionId?: string;
+  }) => {
+    const params = new URLSearchParams();
+    if (opts?.rearmResume) params.set("rearm_resume", "1");
+    else if (opts?.consumeResume) params.set("consume_resume", "1");
+    if (opts?.sessionId) params.set("session_id", opts.sessionId);
+    const qs = params.toString();
+    const path = qs ? `/api/session/state?${qs}` : "/api/session/state";
     return getJSON<SessionState>(withToken(path));
   },
   getSessionGoal: () =>

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -452,7 +452,7 @@ export type SessionGoal = {
   token_budget?: number | null;
 };
 
-export type DeliveryMode = "auto" | "steer" | "follow_up";
+export type DeliveryMode = "auto" | "steer" | "follow_up" | "interrupt";
 
 export type SessionState = {
   state: "idle" | "thinking" | "awaiting_swarm";

--- a/webapp/src/lib/taskProfileChrome.ts
+++ b/webapp/src/lib/taskProfileChrome.ts
@@ -1,0 +1,55 @@
+/**
+ * Live task-depth chip. Kernel emits ConvEvent("task_profile"); the webapp
+ * had no handler. StatusBar subscribes so MICRO/STANDARD/DEEP is visible.
+ */
+
+export type TaskProfileChip = {
+  profile: string;
+  source?: string;
+  escalated_from?: string | null;
+};
+
+export const HARNESS_TASK_PROFILE = "harness-task-profile";
+
+export function normalizeTaskProfile(raw: unknown): string {
+  const profile = String(raw || "").trim().toUpperCase();
+  if (profile === "MICRO" || profile === "STANDARD" || profile === "DEEP") {
+    return profile;
+  }
+  return "";
+}
+
+export function taskProfileTitle(chip: TaskProfileChip): string {
+  const profile = normalizeTaskProfile(chip.profile);
+  const source = (chip.source || "").trim();
+  const escalated = (chip.escalated_from || "").trim();
+  const parts = [profile || "task profile"];
+  if (source) parts.push(`source ${source}`);
+  if (escalated) parts.push(`escalated from ${escalated}`);
+  if (profile === "MICRO") parts.push("skipped wiki and CodeGraph auto-inject");
+  return parts.join(" — ");
+}
+
+export function publishTaskProfile(chip: TaskProfileChip): void {
+  const profile = normalizeTaskProfile(chip.profile);
+  if (!profile || typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent(HARNESS_TASK_PROFILE, {
+      detail: { ...chip, profile },
+    }),
+  );
+}
+
+export function subscribeTaskProfile(
+  handler: (chip: TaskProfileChip) => void,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+  const onEvent = (event: Event) => {
+    const detail = (event as CustomEvent<TaskProfileChip>).detail;
+    const profile = normalizeTaskProfile(detail?.profile);
+    if (!profile) return;
+    handler({ ...detail, profile });
+  };
+  window.addEventListener(HARNESS_TASK_PROFILE, onEvent);
+  return () => window.removeEventListener(HARNESS_TASK_PROFILE, onEvent);
+}


### PR DESCRIPTION
## Summary
- Empty busy composer no longer defaults to Steer; Stop on a blank box cannot invent a queued steer and then error.
- Self-edit resume latch is session-scoped so a keep-alive cannot fire into the session you switched to.
- MCP never-started servers read as idle; missing swarm estimates paint em-dash not $0; pathless editor mutations reload; MICRO/STANDARD/DEEP shows as a footer DEPTH chip; Interrupt (Alt+Enter) is in the composer.

## Test plan
- [ ] Local: `pytest tests -q` (4223 passed) and `webapp` vitest (894 passed)
- [ ] CI `tests` green on the merge SHA: Python 3.9 + 3.11 + frontend-build
- [ ] Empty busy composer: only Stop visible; Enter is a no-op; Stop does not paint a steer-drop PILOT notice
- [ ] Typed mid-turn text: Steer / Interrupt / Queue appear; Stop still drops a real queued steer honestly
- [ ] Self-edit restart: resume stays on the owning session after a view switch
- [ ] After CI green on `main`, tag `v0.9.216` (never tag `dev`)