### PR TITLE
Release v0.9.217: Luna settle, n-way board stacks, session rename, floating chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Internal-first research rig and daily-driver app. stdlib-only backend (urllib +
 sqlite); Puppetmaster is the one real dependency, installed editable from a local
 checkout.
 
-> Status: v0.9.216, deliberately pre-1.0. Empty-composer Stop no longer invents a phantom steer; lazy MCP servers read as idle; self-edit resume stays on the owning session; MICRO/STANDARD/DEEP shows in the footer. Rides puppetmaster-ai==1.22.2.
+> Status: v0.9.217, deliberately pre-1.0. GPT Luna / Codex Responses settles a tool-free answer instead of hanging on Still working; pings classify as MICRO. Right-board cards stay in one stack until you drop one left to open a column, and every stacked card can resize. Session Rename is on the context menu. Shell chrome matches the chat surface so stacked panels float. Rides puppetmaster-ai==1.22.2.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.216"
+__version__ = "0.9.217"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/task_profile.py
+++ b/harness/task_profile.py
@@ -54,6 +54,13 @@ _FILENAME_RE = re.compile(
 _SHORT_MAX_CHARS = 120
 _SHORT_MAX_WORDS = 16
 
+# One-word pings / acks: never spend CodeGraph+wiki inject on "test".
+_TRIVIAL_MICRO_RE = re.compile(
+    r"^(?:test|testing|ok|okay|thanks|thank you|ping|pong|hi|hello|hey|yo|"
+    r"sup|got it|nm|never mind)[.!?]*$",
+    re.IGNORECASE,
+)
+
 _MICRO_VISIBLE: FrozenSet[str] = frozenset(
     {
         "read_file",
@@ -118,6 +125,8 @@ def _looks_micro(text: str) -> bool:
     words = text.split()
     if len(words) > _SHORT_MAX_WORDS:
         return False
+    if _TRIVIAL_MICRO_RE.match(text):
+        return True
     if _TYPO_RE.search(text):
         return True
     if _RENAME_COMMENT_RE.search(text):

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import socket
 import time
 import uuid
 import urllib.error
@@ -47,6 +48,14 @@ _CODEX_LENGTH_CONTINUE = (
     "prior text. Finish the answer directly.]"
 )
 _CODEX_MAX_INCOMPLETE_RETRIES = 3
+# After a visible final_answer with no tools, do not wait forever for
+# response.completed. Codex keepalives reset a long socket timeout, which
+# left Electron on Still working until Stop sealed the already-buffered
+# summary. Drain a short idle for in-flight summary tokens, then finish.
+_POST_ANSWER_SLICE_SECONDS = 0.25
+_POST_ANSWER_IDLE_SECONDS = 0.5
+_POST_ANSWER_MAX_SECONDS = 2.0
+_POST_ANSWER_KEEPALIVE_LIMIT = 3
 _CONTENT_FILTER_MSG = (
     "Model declined to respond (content filter). Try rephrasing the request "
     "or narrowing the context."
@@ -440,6 +449,41 @@ def _delta_payload(
     return payload
 
 
+def _arm_post_answer_idle_timeout(resp_fp, seconds=_POST_ANSWER_SLICE_SECONDS):
+    """Arm a short read timeout so keepalives cannot hold the runner open.
+
+    Walks urllib / http.client wrappers to the socket. Returns True when a
+    timeout was set. Lists and test iterators have no socket (returns False).
+    """
+    candidates = [resp_fp]
+    seen = set()
+    while candidates:
+        obj = candidates.pop()
+        ident = id(obj)
+        if ident in seen or obj is None:
+            continue
+        seen.add(ident)
+        setter = getattr(obj, "settimeout", None)
+        if callable(setter):
+            try:
+                setter(seconds)
+                return True
+            except Exception:
+                pass
+        for attr in ("fp", "raw", "_sock", "socket"):
+            try:
+                inner = getattr(obj, attr, None)
+            except Exception:
+                inner = None
+            if inner is not None:
+                candidates.append(inner)
+    return False
+
+
+def _is_live_http_fp(resp_fp):
+    return hasattr(resp_fp, "fp") or hasattr(resp_fp, "raw")
+
+
 def _consume_codex_sse(
     resp_fp,
     *,
@@ -474,6 +518,7 @@ def _consume_codex_sse(
     terminal_incomplete_details: Any = None
     saw_terminal = False
     stream_error: Optional[str] = None
+    answer_item_done = False
 
     def _remember_item(
         item: dict,
@@ -520,14 +565,112 @@ def _consume_codex_sse(
             sid = stream_id_by_output_index.get(oi_int, "") or _codex_stream_id(None, oi_int)
         return sid, channel, oi_int
 
-    for raw_line in resp_fp:
+    def _seal_open_channels(channels, except_sid):
+        if on_stream_item_done is None:
+            return
+        want = set(channels)
+        for prev_sid, prev_ch in list(phase_by_item_id.items()):
+            if prev_ch in want and prev_sid and prev_sid != except_sid:
+                _safe_cb(on_stream_item_done, {"stream_id": prev_sid})
+        for oi, prev_ch in list(phase_by_output_index.items()):
+            if prev_ch not in want:
+                continue
+            prev_sid = stream_id_by_output_index.get(oi, "")
+            if prev_sid and prev_sid != except_sid:
+                _safe_cb(on_stream_item_done, {"stream_id": prev_sid})
+
+    post_answer_drain = False
+    drain_started = 0.0
+    last_meaningful = 0.0
+    keepalive_streak = 0
+
+    def _finish_tool_free_answer():
+        nonlocal saw_terminal, terminal_status
+        saw_terminal = True
+        terminal_status = "completed"
+        _seal_open_channels(("progress", "reasoning", "answer"), "")
+
+    def _note_answer_text():
+        """Only answer tokens extend the idle clock. Trailing summary must not."""
+        nonlocal last_meaningful, keepalive_streak
+        last_meaningful = time.monotonic()
+        keepalive_streak = 0
+
+    def _should_finish_drain():
+        if not post_answer_drain or has_tool_calls:
+            return False
+        now = time.monotonic()
+        if now - last_meaningful >= _POST_ANSWER_IDLE_SECONDS:
+            return True
+        if now - drain_started >= _POST_ANSWER_MAX_SECONDS:
+            return True
+        return False
+
+    def _drain_tick():
+        if _should_finish_drain():
+            _finish_tool_free_answer()
+            return True
+        return False
+
+    def _begin_post_answer_drain():
+        """Start the short post-answer drain. False means caller should stop."""
+        nonlocal post_answer_drain, drain_started, last_meaningful
+        nonlocal keepalive_streak
+        if has_tool_calls:
+            return True
+        if post_answer_drain:
+            return True
+        post_answer_drain = True
+        drain_started = time.monotonic()
+        last_meaningful = drain_started
+        keepalive_streak = 0
+        armed = _arm_post_answer_idle_timeout(resp_fp, _POST_ANSWER_SLICE_SECONDS)
+        if not armed and _is_live_http_fp(resp_fp):
+            # Cannot wake from keepalives — finish now rather than hang.
+            _finish_tool_free_answer()
+            return False
+        return True
+
+    line_iter = iter(resp_fp)
+    while True:
+        try:
+            raw_line = next(line_iter)
+        except StopIteration:
+            break
+        except (TimeoutError, socket.timeout):
+            if (
+                not has_tool_calls
+                and (answer_item_done or text_deltas or collected_items)
+            ):
+                _finish_tool_free_answer()
+                break
+            if not collected_items and not text_deltas:
+                return {
+                    "status": "failed",
+                    "output": [],
+                    "output_text": "",
+                    "usage": {},
+                    "error": "Codex Responses stream timed out",
+                }
+            break
+
         line = raw_line.decode("utf-8", "replace").strip() if isinstance(raw_line, bytes) else str(raw_line).strip()
         if not line or not line.startswith("data:"):
+            if post_answer_drain and not has_tool_calls:
+                keepalive_streak += 1
+                if keepalive_streak >= _POST_ANSWER_KEEPALIVE_LIMIT or _should_finish_drain():
+                    _finish_tool_free_answer()
+                    break
             continue
         data_str = line[5:].strip()
         if not data_str or data_str == "[DONE]":
             if data_str == "[DONE]":
                 break
+            if post_answer_drain and not has_tool_calls:
+                keepalive_streak += 1
+                if keepalive_streak >= _POST_ANSWER_KEEPALIVE_LIMIT or _should_finish_drain():
+                    _finish_tool_free_answer()
+                    break
             continue
         try:
             event = json.loads(data_str)
@@ -557,18 +700,13 @@ def _consume_codex_sse(
                 itype = str(item.get("type") or "")
                 if "function_call" in itype:
                     has_tool_calls = True
-                # Final-answer item start is a lifecycle barrier for open
-                # progress streams — seal them before answer deltas land.
-                if channel == "answer" and on_stream_item_done is not None:
-                    for prev_sid, prev_ch in list(phase_by_item_id.items()):
-                        if prev_ch == "progress" and prev_sid and prev_sid != sid:
-                            _safe_cb(on_stream_item_done, {"stream_id": prev_sid})
-                    for oi, prev_ch in list(phase_by_output_index.items()):
-                        if prev_ch != "progress":
-                            continue
-                        prev_sid = stream_id_by_output_index.get(oi, "")
-                        if prev_sid and prev_sid != sid:
-                            _safe_cb(on_stream_item_done, {"stream_id": prev_sid})
+                # Final-answer item start seals open progress AND reasoning
+                # so a short reply cannot leave thinking streaming:true while
+                # Codex keeps the SSE open for a trailing summary.
+                if channel == "answer":
+                    _seal_open_channels(("progress", "reasoning"), sid)
+            if _drain_tick():
+                break
             continue
 
         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
@@ -600,11 +738,16 @@ def _consume_codex_sse(
                 has_tool_calls = True
             else:
                 text_deltas.append(delta_text)
+                _note_answer_text()
+                if not _begin_post_answer_drain():
+                    break
                 # Suppress anonymous mid-tool answer crumbs (legacy JSON
                 # envelopes). Identity-bearing final_answer streams must still
                 # paint after function_call items.
                 if not has_tool_calls or bool(sid) or channel == "answer":
                     _safe_cb(on_delta, payload)
+            if _drain_tick():
+                break
             continue
 
         if "function_call" in event_type:
@@ -630,10 +773,14 @@ def _consume_codex_sse(
                         channel="reasoning",
                     ),
                 )
+            if _drain_tick():
+                break
             continue
 
-        if event_type == "response.output_item.done":
+        if event_type in ("response.output_item.done", "response.output_text.done"):
             done_item = event.get("item")
+            sid = ""
+            _channel = ""
             if isinstance(done_item, dict):
                 collected_items.append(done_item)
                 out_idx = event.get("output_index")
@@ -645,8 +792,26 @@ def _consume_codex_sse(
                         done_item.get("id") or done_item.get("item_id"),
                         out_idx,
                     )
-                if sid:
-                    _safe_cb(on_stream_item_done, {"stream_id": sid})
+            else:
+                item_id = event.get("item_id") or event.get("id")
+                out_idx = event.get("output_index")
+                sid, _channel, _oi = _resolve_channel(
+                    item_id=item_id, output_index=out_idx,
+                )
+                if not _channel:
+                    _channel = "answer"
+            if sid:
+                _safe_cb(on_stream_item_done, {"stream_id": sid})
+            if _channel == "answer" or (
+                event_type == "response.output_text.done"
+                and bool(text_deltas)
+                and _channel not in ("progress", "tool")
+            ):
+                answer_item_done = True
+                if not _begin_post_answer_drain():
+                    break
+            if _drain_tick():
+                break
             continue
 
         if event_type in _TERMINAL_EVENT_TYPES:
@@ -671,6 +836,11 @@ def _consume_codex_sse(
                 terminal_status = terminal_status or "incomplete"
             elif event_type == "response.failed":
                 terminal_status = terminal_status or "failed"
+            break
+
+        # Luna keeps the SSE open with in_progress / heartbeat JSON after the
+        # visible answer. Those are data: events, so comment-streak never fires.
+        if _drain_tick():
             break
 
     if stream_error:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.216"
+version = "0.9.217"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_codex_responses_driver.py
+++ b/tests/test_codex_responses_driver.py
@@ -237,6 +237,105 @@ def test_chat_preserves_reasoning_only_response_for_terminal_synthesis(pool_dir,
     assert response.meta["reasoning"] == "The audit found one issue."
 
 
+def test_consume_sse_answer_start_seals_reasoning():
+    """A final_answer item must seal an open reasoning stream (not just commentary)."""
+    item_done = []
+    lines = [
+        b'data: {"type":"response.output_item.added","item":{"type":"reasoning","id":"rs_1"}}\n',
+        b'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","delta":"planning"}\n',
+        b'data: {"type":"response.output_item.added","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n',
+        b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"Test received."}\n',
+        b'data: {"type":"response.completed","response":{"status":"completed","usage":{}}}\n',
+    ]
+    raw = _consume_codex_sse(
+        lines,
+        on_stream_item_done=item_done.append,
+    )
+    assert raw["output_text"] == "Test received."
+    assert any(
+        isinstance(d, dict) and d.get("stream_id") == "rs_1" for d in item_done
+    )
+
+
+def test_consume_sse_answer_done_timeout_completes():
+    """Idle timeout after a tool-free answer must not hang the Electron turn."""
+
+    def lines():
+        yield b'data: {"type":"response.output_item.added","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"Test received."}\n'
+        yield b'data: {"type":"response.output_item.done","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        raise TimeoutError("timed out")
+
+    raw = _consume_codex_sse(lines())
+    assert raw["status"] == "completed"
+    assert raw["output_text"] == "Test received."
+    assert not raw.get("error")
+
+
+def test_consume_sse_keepalives_after_answer_complete():
+    """Codex SSE comments after a tool-free answer must not hold Still working."""
+    item_done = []
+
+    def lines():
+        yield b'data: {"type":"response.output_item.added","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"Test received."}\n'
+        yield b'data: {"type":"response.output_item.done","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b": keepalive\n"
+        yield b": keepalive\n"
+        yield b": keepalive\n"
+        yield b'data: {"type":"response.completed","response":{"status":"completed","usage":{}}}\n'
+
+    raw = _consume_codex_sse(lines(), on_stream_item_done=item_done.append)
+    assert raw["status"] == "completed"
+    assert raw["output_text"] == "Test received."
+    assert not raw.get("error")
+    # Must finish on keepalives — never reach the late completed event.
+    assert any(
+        isinstance(d, dict) and d.get("stream_id") == "msg_f" for d in item_done
+    )
+
+
+def test_consume_sse_in_progress_after_answer_text_completes(monkeypatch):
+    """Luna keeps the SSE open with JSON in_progress after the answer paints."""
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(
+        "pmharness.drivers.codex_responses.time.monotonic",
+        lambda: clock["now"],
+    )
+
+    def lines():
+        yield b'data: {"type":"response.output_item.added","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"Test received."}\n'
+        yield b'data: {"type":"response.in_progress"}\n'
+        clock["now"] += 2.5
+        yield b'data: {"type":"response.in_progress"}\n'
+        yield b'data: {"type":"response.completed","response":{"status":"completed","usage":{}}}\n'
+        raise AssertionError("must settle on in_progress, not wait for completed")
+
+    raw = _consume_codex_sse(lines())
+    assert raw["status"] == "completed"
+    assert raw["output_text"] == "Test received."
+    assert not raw.get("error")
+
+
+def test_consume_sse_trailing_summary_then_timeout():
+    """In-flight reasoning after the answer is kept; then the turn settles."""
+    reasoning = []
+
+    def lines():
+        yield b'data: {"type":"response.output_item.added","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"Test received."}\n'
+        yield b'data: {"type":"response.output_item.done","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","delta":"Short ping, no tools."}\n'
+        raise TimeoutError("timed out")
+
+    raw = _consume_codex_sse(lines(), on_reasoning_delta=reasoning.append)
+    assert raw["status"] == "completed"
+    assert raw["output_text"] == "Test received."
+    assert raw["reasoning"] == "Short ping, no tools."
+    assert reasoning and reasoning[0]["text"] == "Short ping, no tools."
+
+
 def test_consume_sse_routes_commentary_to_progress():
     """Commentary is visible progress — never the reasoning/thinking stream."""
     reasoning = []

--- a/tests/test_task_profile.py
+++ b/tests/test_task_profile.py
@@ -23,6 +23,13 @@ def test_classify_typo_readme_is_micro():
     assert classify_task_profile("typo in README.md") == MICRO
 
 
+def test_classify_trivial_ping_is_micro():
+    assert classify_task_profile("test") == MICRO
+    assert classify_task_profile("pong") == MICRO
+    assert classify_task_profile("ok") == MICRO
+    assert classify_task_profile("add OAuth support") == STANDARD
+
+
 def test_classify_add_oauth_is_standard():
     assert classify_task_profile("add OAuth support") == STANDARD
 

--- a/tests/test_v09216_live_path.py
+++ b/tests/test_v09216_live_path.py
@@ -1,0 +1,238 @@
+"""Live-path validation for v0.9.216 phantom-steer / session-scoped resume.
+
+Pins the operator regression: empty busy Stop must not invent a queued steer
+that interrupt then drops as ``steer_dropped``. Also covers empty steer 400,
+session-scoped resume latch peek over HTTP, and task_profile on send.
+
+HTTP coverage reuses the lifecycle helpers from ``test_self_dev_restart`` so
+we do not duplicate the ThreadingHTTPServer fixture.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from harness.config import HarnessConfig
+from harness.conversation import ConversationalSession
+from test_self_dev_restart import _harness_http_server, _session_state
+
+_HTTP_TIMEOUT = 10.0
+
+
+def _auth_headers(token: str) -> dict:
+    return {
+        "Content-Type": "application/json",
+        "X-Harness-Token": token,
+    }
+
+
+def _post_json(port: int, path: str, body: dict, token: str):
+    req = urllib.request.Request(
+        "http://127.0.0.1:%d%s" % (port, path),
+        data=json.dumps(body).encode("utf-8"),
+        headers=_auth_headers(token),
+        method="POST",
+    )
+    return urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT)
+
+
+def _clear_stop_markers(pilot) -> None:
+    """Leave the shared module pilot ready for later suite tests."""
+    pilot._stop_holds_idle = False
+    pilot._steer_boundary_drop_on_acquire = False
+    pilot._interrupt_requested = False
+    pilot._pending_steer_drop_notice = None
+    pilot._cancel.clear()
+    try:
+        if pilot._busy.locked():
+            pilot._busy.release()
+    except RuntimeError:
+        pass
+    pilot._state = "idle"
+    pilot.drain_steer()
+
+
+def _notices_have_steer_drop(notices) -> bool:
+    for notice in notices or []:
+        if not isinstance(notice, dict):
+            continue
+        if notice.get("reason") == "steer_dropped":
+            return True
+        message = str(notice.get("message") or "")
+        if "Dropped" in message and "queued steer" in message:
+            return True
+    return False
+
+
+def _wait_busy(pilot, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if pilot._busy.locked():
+                return
+        except Exception:
+            pass
+        time.sleep(0.02)
+    raise AssertionError("expected an open busy turn")
+
+
+def test_http_interrupt_empty_busy_turn_has_no_phantom_steer_drop():
+    """Open turn + Stop with no steer text must not paint steer_dropped."""
+    release = threading.Event()
+
+    with _harness_http_server() as (srv, port):
+        pilot = srv._pilot
+        _clear_stop_markers(pilot)
+        original_driver = pilot.pilot
+
+        class _SlowPilot:
+            name = "stub-oracle-v2"
+
+            def complete(self, prompt, *, system=None):
+                from pmharness.drivers.openai_compat import DriverResponse
+
+                release.wait(timeout=8.0)
+                return DriverResponse(
+                    text='{"say":"done","actions":[]}',
+                    tokens_out=10,
+                    latency_ms=1.0,
+                )
+
+        pilot.pilot = _SlowPilot()
+        errors = []
+
+        def _run_chat():
+            try:
+                msg = urllib.parse.quote("audit the repository please")
+                req = urllib.request.Request(
+                    "http://127.0.0.1:%d/api/chat?message=%s" % (port, msg),
+                    headers={"X-Harness-Token": srv._TOKEN},
+                    method="GET",
+                )
+                with urllib.request.urlopen(req, timeout=20.0) as resp:
+                    resp.read()
+            except Exception as exc:
+                errors.append(exc)
+
+        chat_thread = threading.Thread(target=_run_chat, name="v09216-chat", daemon=True)
+        chat_thread.start()
+        try:
+            _wait_busy(pilot)
+            assert list(pilot._steer_queue) == []
+
+            with _post_json(port, "/api/session/interrupt", {}, srv._TOKEN) as resp:
+                assert resp.status == 200
+                payload = json.loads(resp.read().decode("utf-8"))
+            assert payload.get("ok") is True
+            assert not _notices_have_steer_drop(payload.get("notices"))
+            assert list(pilot._steer_queue) == []
+            assert getattr(pilot, "_pending_steer_drop_notice", None) in (None, {})
+        finally:
+            release.set()
+            chat_thread.join(timeout=5.0)
+            pilot.pilot = original_driver
+            _clear_stop_markers(pilot)
+        assert not errors, "chat thread failed: %r" % (errors,)
+
+
+def test_http_empty_steer_rejected_interrupt_still_clean():
+    """Empty steer is 400; queue stays empty; Stop still has no drop notice."""
+    with _harness_http_server() as (srv, port):
+        pilot = srv._pilot
+        _clear_stop_markers(pilot)
+        try:
+            # Hold busy so this mirrors a mid-turn empty composer Stop path.
+            assert pilot._busy.acquire(blocking=False)
+            pilot._state = "executing"
+            assert list(pilot._steer_queue) == []
+
+            try:
+                _post_json(port, "/api/session/steer", {"text": ""}, srv._TOKEN)
+                assert False, "empty steer must return 400"
+            except urllib.error.HTTPError as err:
+                assert err.code == 400
+                body = json.loads(err.read().decode("utf-8"))
+                assert "missing text" in str(body.get("error") or "")
+
+            try:
+                _post_json(
+                    port,
+                    "/api/session/steer",
+                    {"text": "   ", "images": []},
+                    srv._TOKEN,
+                )
+                assert False, "whitespace-only steer must return 400"
+            except urllib.error.HTTPError as err:
+                assert err.code == 400
+
+            assert list(pilot._steer_queue) == []
+            assert pilot.drain_steer() == []
+
+            with _post_json(port, "/api/session/interrupt", {}, srv._TOKEN) as resp:
+                assert resp.status == 200
+                payload = json.loads(resp.read().decode("utf-8"))
+            assert payload.get("ok") is True
+            assert not _notices_have_steer_drop(payload.get("notices"))
+            assert getattr(pilot, "_pending_steer_drop_notice", None) in (None, {})
+        finally:
+            _clear_stop_markers(pilot)
+
+
+def test_http_resume_latch_armed_for_a_not_peek_true_for_b():
+    """Latch armed for session A must not peek true for session B over HTTP."""
+    with _harness_http_server() as (srv, port):
+        saved_history = list(srv._pilot._history)
+        saved_active = srv._sessions._active
+        try:
+            srv._clear_resume_latch()
+            sid_a = "sess-resume-a"
+            sid_b = "sess-resume-b"
+            srv._sessions._active = sid_a
+            srv._pilot._history = [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "please continue"},
+            ]
+            srv._set_resume_latch(sid_a)
+
+            data_a = _session_state(port, srv._TOKEN, session_id=sid_a)
+            assert data_a["resume_pending"] is True
+            data_b = _session_state(port, srv._TOKEN, session_id=sid_b)
+            assert data_b["resume_pending"] is False
+            # Wrong-session consume must not steal A's latch.
+            assert (
+                _session_state(
+                    port,
+                    srv._TOKEN,
+                    consume_resume=True,
+                    session_id=sid_b,
+                )["resume_pending"]
+                is False
+            )
+            assert srv._resume_latch is True
+            assert (
+                _session_state(port, srv._TOKEN, session_id=sid_a)["resume_pending"]
+                is True
+            )
+        finally:
+            srv._pilot._history = saved_history
+            srv._sessions._active = saved_active
+            srv._clear_resume_latch()
+
+
+def test_conversational_send_emits_task_profile(tmp_path):
+    """Cheap live-path pin: send still emits ConvEvent task_profile."""
+    cfg = HarnessConfig(
+        driver="stub-oracle-v2",
+        state_dir=str(tmp_path / "state"),
+        repo=str(tmp_path / "repo"),
+    )
+    (tmp_path / "repo").mkdir(exist_ok=True)
+    (tmp_path / "state").mkdir(exist_ok=True)
+    session = ConversationalSession(cfg)
+    session.harness_session_id = "live-216"
+    events = list(session.send("typo in README.md"))
+    assert "task_profile" in [e.kind for e in events]

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.216",
+  "version": "0.9.217",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.216",
+      "version": "0.9.217",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.216",
+  "version": "0.9.217",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -159,6 +159,17 @@ export default function App() {
     });
   };
   const closeEmptyRightPane = useCallback(() => setRightOpen(false), []);
+  const requestRightMinWidth = useCallback((minPx: number) => {
+    const next = reclampRailWidths(
+      leftWRef.current,
+      Math.max(rightWRef.current, minPx),
+      leftOpen,
+      true,
+      window.innerWidth,
+    );
+    setLeftW(next.leftW);
+    setRightW(next.rightW);
+  }, [leftOpen]);
 
   const [showWizard, setShowWizard] = useState(false);
 
@@ -361,7 +372,7 @@ export default function App() {
         <div
           className="relative flex-1 min-w-0 h-full flex flex-col rounded-[var(--shell-panel-radius)] overflow-hidden border border-[var(--shell-panel-border)]"
           style={{
-            backgroundColor: "#0f1113",
+            backgroundColor: "var(--shell-chat, #0f1113)",
             backgroundImage:
               "radial-gradient(120% 80% at 50% -10%, rgba(139,150,196,0.06), rgba(139,150,196,0) 60%)",
           }}
@@ -401,7 +412,7 @@ export default function App() {
         )}
         <div
           className={`shrink-0 h-full min-w-0 overflow-hidden ${rightOpen ? "" : "hidden"}`}
-          style={{ width: rightW }}
+          style={{ width: rightW, backgroundColor: "var(--shell-chat, #0f1113)" }}
         >
           <ErrorBoundary label="Tool board">
             <RightPane
@@ -410,6 +421,7 @@ export default function App() {
               onOpenWizard={() => setShowWizard(true)}
               initialTab={pendingRightTab.current}
               onEmpty={closeEmptyRightPane}
+              onRequestMinWidth={requestRightMinWidth}
             />
           </ErrorBoundary>
         </div>

--- a/webapp/src/__tests__/LeftRail.sessions.test.ts
+++ b/webapp/src/__tests__/LeftRail.sessions.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { clearSWRCache, readSWRCache, writeSWRCache } from "../lib/useStaleWhileRevalidate";
 import { repoPathsEqual } from "../lib/pathNormalize";
-import { buildProjectsList, canSettleSessionsForProject, collectUnreadFinishedSessionIds, filterForgottenRecent, formatLeaseExhaustedMessage, isLeaseExhaustedError, isRailWideSwitching, jobsCacheKey, partitionProjectSessions, patchSessionArchivedInCaches, patchSessionSettledInCaches, projectSessionsEmptyState, purgeSessionFromRootCaches, readSessionSettledFromCaches, SESSION_LEASE_EXHAUSTED_MESSAGE, shouldOfferBackgroundStop, workspacesCacheKey } from "../components/LeftRail";
+import { buildProjectsList, canSettleSessionsForProject, collectUnreadFinishedSessionIds, filterForgottenRecent, formatLeaseExhaustedMessage, isLeaseExhaustedError, isRailWideSwitching, jobsCacheKey, partitionProjectSessions, patchSessionArchivedInCaches, patchSessionSettledInCaches, patchSessionTitleInCaches, projectSessionsEmptyState, purgeSessionFromRootCaches, readSessionSettledFromCaches, SESSION_LEASE_EXHAUSTED_MESSAGE, shouldOfferBackgroundStop, workspacesCacheKey } from "../components/LeftRail";
 import type { Session } from "../lib/api";
 
 /**
@@ -580,5 +580,15 @@ describe("LeftRail session list contracts", () => {
     expect(patchSessionArchivedInCaches([marionette], "sess-a", false)).toBe(1);
     expect(readSWRCache<Session[]>(`sessions:${marionette}`)?.[0]?.archived).toBe(false);
     expect(readSWRCache<Session[]>(`sessions:${marionette}`)?.[0]?.settled).toBe(true);
+  });
+
+  it("patchSessionTitleInCaches updates the display title on matching root caches", () => {
+    const marionette = "C:\\Projects\\marionette";
+    writeSWRCache(`sessions:${marionette}`, [
+      { id: "sess-a", title: "portable-llm-wiki", created: 1, repo: marionette, workspace_root: marionette },
+    ]);
+
+    expect(patchSessionTitleInCaches([marionette], "sess-a", "Wiki ingest")).toBe(1);
+    expect(readSWRCache<Session[]>(`sessions:${marionette}`)?.[0]?.title).toBe("Wiki ingest");
   });
 });

--- a/webapp/src/__tests__/RightPane.collapse.test.tsx
+++ b/webapp/src/__tests__/RightPane.collapse.test.tsx
@@ -188,7 +188,7 @@ describe("RightPane Claude-style card packing", () => {
     seedBoardTabOrder();
   });
 
-  it("stacks the first two cards in column 2 and spans the third card across rows in column 1", () => {
+  it("keeps three cards in one full-width stack instead of auto-opening a column", () => {
     localStorage.setItem(
       "pmharness.board.openCards",
       JSON.stringify(["state", "terminal", "swarm"]),
@@ -201,13 +201,14 @@ describe("RightPane Claude-style card packing", () => {
       </>,
     );
 
-    expectCardGridPlacement("State", "7 / span 6", "1");
-    expectCardGridPlacement("Terminal", "7 / span 6", "2");
-    expectCardGridPlacement("Swarm", "1 / span 6", "1");
+    expectCardGridPlacement("State", "1 / span 12", "1");
+    expectCardGridPlacement("Terminal", "1 / span 12", "2");
+    expectCardGridPlacement("Swarm", "1 / span 12", "3");
+    expect(screen.queryAllByRole("separator", { name: "Resize stacked panel height" })).toHaveLength(2);
     expect(screen.queryByTestId("right-pane-toolbar")).toBeNull();
   });
 
-  it("keeps cards 1/2 stacked in column 2 and cards 3/4 stacked in column 1", () => {
+  it("keeps four cards in one full-width stack until a column is opened", () => {
     localStorage.setItem(
       "pmharness.board.openCards",
       JSON.stringify(["state", "terminal", "swarm", "files"]),
@@ -220,10 +221,11 @@ describe("RightPane Claude-style card packing", () => {
       </>,
     );
 
-    expectCardGridPlacement("State", "7 / span 6", "1");
-    expectCardGridPlacement("Terminal", "7 / span 6", "2");
-    expectCardGridPlacement("Swarm", "1 / span 6", "1");
-    expectCardGridPlacement("Files", "1 / span 6", "2");
+    expectCardGridPlacement("State", "1 / span 12", "1");
+    expectCardGridPlacement("Terminal", "1 / span 12", "2");
+    expectCardGridPlacement("Swarm", "1 / span 12", "3");
+    expectCardGridPlacement("Files", "1 / span 12", "4");
+    expect(screen.queryAllByRole("separator", { name: "Resize stacked panel height" })).toHaveLength(3);
     expect(screen.queryByTestId("right-pane-toolbar")).toBeNull();
   });
 
@@ -242,11 +244,9 @@ describe("RightPane Claude-style card packing", () => {
       gridTemplateRows: "minmax(0, 1fr)",
     });
     expect(screen.getAllByRole("region")).toHaveLength(cards.length);
-    expect(screen.queryAllByRole("separator", { name: "Resize tool columns" })).toHaveLength(
-      cards.length > 2 ? 2 : 0,
-    );
+    expect(screen.queryAllByRole("separator", { name: "Resize tool columns" })).toHaveLength(0);
     expect(screen.queryAllByRole("separator", { name: "Resize stacked panel height" })).toHaveLength(
-      Math.floor(cards.length / 2),
+      Math.max(0, cards.length - 1),
     );
     expect(screen.getAllByRole("region").every(card => !card.getAttribute("style")?.includes("height"))).toBe(true);
     expect(screen.getAllByRole("region").every(card => !card.style.width)).toBe(true);
@@ -256,6 +256,10 @@ describe("RightPane Claude-style card packing", () => {
     localStorage.setItem(
       "pmharness.board.openCards",
       JSON.stringify(["state", "terminal", "browser"]),
+    );
+    localStorage.setItem(
+      "pmharness.board.columns.v1",
+      JSON.stringify([["state", "terminal"], ["browser"]]),
     );
     localStorage.setItem(
       "pmharness.board.cardLayouts.v1",
@@ -290,15 +294,77 @@ describe("RightPane Claude-style card packing", () => {
 
     const stack = screen.getByRole("region", { name: "State panel" }).closest(".right-pane-card-stack") as HTMLElement;
     expect(stack.style.gridTemplateRows).toBe("minmax(0, 40fr) minmax(0, 60fr)");
-    expect(JSON.parse(localStorage.getItem("pmharness.board.stackSplits.v1") || "{}")).toMatchObject({
-      "state|terminal": 0.4,
+    expect(JSON.parse(localStorage.getItem("pmharness.board.stackFractions.v2") || "{}")).toMatchObject({
+      "state|terminal": [0.4, 0.6],
     });
+  });
+
+  it("resizes the third stacked card from the second row handle", () => {
+    localStorage.setItem(
+      "pmharness.board.openCards",
+      JSON.stringify(["state", "terminal", "swarm"]),
+    );
+    render(<RightPane {...baseProps} />);
+
+    const handles = screen.getAllByRole("separator", { name: "Resize stacked panel height" });
+    expect(handles).toHaveLength(2);
+    fireEvent.keyDown(handles[1], { key: "ArrowUp" });
+
+    const stack = screen.getByRole("region", { name: "State panel" }).closest(".right-pane-card-stack") as HTMLElement;
+    expect(stack.style.gridTemplateRows.match(/minmax/g)).toHaveLength(3);
+    expect(stack.style.gridTemplateRows).not.toBe("minmax(0, 33fr) minmax(0, 33fr) minmax(0, 33fr)");
+    expect(JSON.parse(localStorage.getItem("pmharness.board.stackFractions.v2") || "{}")["state|terminal|swarm"]).toHaveLength(3);
+  });
+
+  it("opens a left column when a stacked card is dropped on the new-column zone", () => {
+    localStorage.setItem(
+      "pmharness.board.openCards",
+      JSON.stringify(["review", "swarm", "browser"]),
+    );
+    const onRequestMinWidth = vi.fn();
+    render(<RightPane {...baseProps} onRequestMinWidth={onRequestMinWidth} />);
+
+    const dataTransfer = { effectAllowed: "", setData: vi.fn(), getData: vi.fn(() => "browser") };
+    fireEvent.dragStart(screen.getByRole("button", { name: "Drag Browser panel" }), { dataTransfer });
+    fireEvent.drop(screen.getByRole("region", { name: "Drop to open a column" }), { dataTransfer });
+
+    expectCardGridPlacement("Review", "7 / span 6", "1");
+    expectCardGridPlacement("Swarm", "7 / span 6", "2");
+    expectCardGridPlacement("Browser", "1 / span 6", "1");
+    expect(onRequestMinWidth).toHaveBeenCalledWith(420);
+    expect(JSON.parse(localStorage.getItem("pmharness.board.columns.v1") || "[]")).toEqual([
+      ["review", "swarm"],
+      ["browser"],
+    ]);
+  });
+
+  it("keeps a drop on another card in the same stack", () => {
+    localStorage.setItem(
+      "pmharness.board.openCards",
+      JSON.stringify(["review", "swarm", "browser"]),
+    );
+    render(<RightPane {...baseProps} />);
+
+    const dataTransfer = { effectAllowed: "", setData: vi.fn(), getData: vi.fn(() => "browser") };
+    fireEvent.dragStart(screen.getByRole("button", { name: "Drag Browser panel" }), { dataTransfer });
+    fireEvent.drop(screen.getByRole("region", { name: "Review panel" }), { dataTransfer });
+
+    expectCardGridPlacement("Browser", "1 / span 12", "1");
+    expectCardGridPlacement("Review", "1 / span 12", "2");
+    expectCardGridPlacement("Swarm", "1 / span 12", "3");
+    expect(JSON.parse(localStorage.getItem("pmharness.board.columns.v1") || "[]")).toEqual([
+      ["browser", "review", "swarm"],
+    ]);
   });
 
   it("keeps stacked column pairs on independent height splits", () => {
     localStorage.setItem(
       "pmharness.board.openCards",
       JSON.stringify(["terminal", "swarm", "state", "review"]),
+    );
+    localStorage.setItem(
+      "pmharness.board.columns.v1",
+      JSON.stringify([["terminal", "swarm"], ["state", "review"]]),
     );
     localStorage.setItem(
       "pmharness.board.stackSplits.v1",

--- a/webapp/src/__tests__/boardColumns.test.ts
+++ b/webapp/src/__tests__/boardColumns.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  canOpenLeftColumn,
+  defaultColumns,
+  extractCardToLeftColumn,
+  flattenColumns,
+  moveCardIntoColumn,
+  reconcileColumns,
+} from "../lib/boardColumns";
+
+describe("boardColumns", () => {
+  it("defaults every open card into one rightmost column", () => {
+    expect(defaultColumns(["review", "swarm", "browser"])).toEqual([
+      ["review", "swarm", "browser"],
+    ]);
+    expect(defaultColumns([])).toEqual([]);
+  });
+
+  it("reconciles saved columns with the live open-card list", () => {
+    expect(reconcileColumns(
+      ["review", "swarm", "browser"],
+      [["review", "gone"], ["browser"]],
+    )).toEqual([["review", "swarm"], ["browser"]]);
+  });
+
+  it("inserts a card into another column and drops empty stacks", () => {
+    const next = moveCardIntoColumn(
+      [["review", "swarm"], ["browser"]],
+      "browser",
+      0,
+      1,
+    );
+    expect(next).toEqual([["review", "browser", "swarm"]]);
+    expect(flattenColumns(next)).toEqual(["review", "browser", "swarm"]);
+  });
+
+  it("extracts a stacked card into a new leftmost column", () => {
+    expect(extractCardToLeftColumn(
+      [["review", "swarm", "browser"]],
+      "browser",
+    )).toEqual([["review", "swarm"], ["browser"]]);
+    expect(canOpenLeftColumn([["review", "swarm", "browser"]], "browser")).toBe(true);
+    expect(canOpenLeftColumn([["review"], ["browser"]], "browser")).toBe(false);
+  });
+});

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -2368,6 +2368,48 @@ describe("composerSend module", () => {
     expect(shouldClearSteerDraftOnResult(false)).toBe(false);
   });
 
+  it("composerBusy + empty input must not steerSession; Stop interrupts without prior steer", async () => {
+    // Mirrors Conversation.send busy branch + stop(): empty draft returns
+    // before api.steerSession; Stop goes stopLocal → interrupt only.
+    const order: string[] = [];
+    const steerSession = vi.fn(async () => {
+      order.push("steer");
+      return { ok: true };
+    });
+    const interruptSession = vi.fn(async () => {
+      order.push("interrupt");
+      return { ok: true, notices: [] };
+    });
+
+    const composerBusy = true;
+    const input = "";
+    const attachedImages: string[] = [];
+    if (
+      !shouldBlockEmptySend({
+        transcriptStale: false,
+        text: input.trim(),
+        imageCount: attachedImages.length,
+      })
+      && composerBusy
+      && shouldSteerWhileBusy({ text: input })
+    ) {
+      await steerSession(input);
+    }
+    expect(steerSession).not.toHaveBeenCalled();
+    expect(composerEnterAction({ busy: true, metaOrCtrl: false, hasText: false })).toBe(
+      "noop",
+    );
+
+    await runStopFlow({
+      stopLocal: () => {
+        order.push("stopLocal");
+      },
+      interruptSession,
+    });
+    expect(order).toEqual(["stopLocal", "interrupt"]);
+    expect(steerSession).not.toHaveBeenCalled();
+  });
+
   it("runEditMessageFlow stops locally, awaits interrupt, then rewinds when busy", async () => {
     const order: string[] = [];
     const stopLocal = vi.fn(() => { order.push("stopLocal"); });

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -2372,7 +2372,7 @@ describe("composerSend module", () => {
     // Mirrors Conversation.send busy branch + stop(): empty draft returns
     // before api.steerSession; Stop goes stopLocal → interrupt only.
     const order: string[] = [];
-    const steerSession = vi.fn(async () => {
+    const steerSession = vi.fn(async (_text?: string) => {
       order.push("steer");
       return { ok: true };
     });

--- a/webapp/src/__tests__/stackSplit.test.ts
+++ b/webapp/src/__tests__/stackSplit.test.ts
@@ -4,8 +4,13 @@ import {
   DEFAULT_STACK_SPLIT,
   MAX_STACK_SPLIT,
   MIN_STACK_SPLIT,
+  equalFractions,
+  fractionsFromBoundaryDrag,
+  fractionsFromKey,
+  normalizeFractions,
   stackPairKey,
   stackRowTemplate,
+  stackRowTemplateN,
   stackSplitFromDrag,
   stackSplitFromKey,
 } from "../lib/stackSplit";
@@ -52,5 +57,26 @@ describe("stackSplit", () => {
     expect(stackSplitFromKey(0.5, "ArrowUp")).toBe(0.45);
     expect(stackSplitFromKey(0.5, "ArrowDown")).toBe(0.55);
     expect(stackSplitFromKey(0.5, "ArrowLeft")).toBe(0.5);
+  });
+
+  it("keeps n-way stack fractions summing to one", () => {
+    expect(equalFractions(3)).toEqual([1 / 3, 1 / 3, 1 / 3]);
+    expect(normalizeFractions([0.2, 0.2, 0.6], 3).reduce((sum, value) => sum + value, 0)).toBeCloseTo(1);
+    expect(stackRowTemplateN([1 / 3, 1 / 3, 1 / 3])).toBe("minmax(0, 33fr) minmax(0, 33fr) minmax(0, 33fr)");
+  });
+
+  it("moves only the dragged boundary in a three-card stack", () => {
+    const next = fractionsFromBoundaryDrag({
+      fractions: [1 / 3, 1 / 3, 1 / 3],
+      boundaryIndex: 1,
+      startClientY: 100,
+      clientY: 80,
+      stackHeight: 400,
+    });
+    expect(next).toHaveLength(3);
+    expect(next[0]).toBeCloseTo(1 / 3, 5);
+    expect(next[1]).toBeLessThan(1 / 3);
+    expect(next[2]).toBeGreaterThan(1 / 3);
+    expect(fractionsFromKey([0.5, 0.5], 0, "ArrowUp")[0]).toBeCloseTo(0.45);
   });
 });

--- a/webapp/src/__tests__/thinkingStreamUx.test.ts
+++ b/webapp/src/__tests__/thinkingStreamUx.test.ts
@@ -19,6 +19,7 @@ import {
 import type { GroupedItem, Item } from "../components/TranscriptList";
 import { createApplyStreamEvent } from "../components/conversation/streamEventHandler";
 import { flushTypewriterBuffer } from "../components/conversation/streamTypewriter";
+import { subscribeTaskProfile } from "../lib/taskProfileChrome";
 
 function makeApplyDeps(opts: {
   items: Item[];
@@ -271,6 +272,28 @@ describe("swarm terminal rows stay at the end of one investigation", () => {
       "swarm_pending",
       "thinking",
     ]);
+  });
+});
+
+describe("createApplyStreamEvent task_profile", () => {
+  it("publishes DEPTH chip from a live SSE task_profile frame", () => {
+    const state = {
+      items: [] as Item[],
+      itemsRef: { current: [] as Item[] },
+      typeBufRef: { current: "" },
+    };
+    const seen: string[] = [];
+    const unsub = subscribeTaskProfile((chip) => seen.push(chip.profile));
+    try {
+      const apply = createApplyStreamEvent(makeApplyDeps(state));
+      apply({
+        kind: "task_profile",
+        data: { profile: "micro", source: "heuristic" },
+      });
+      expect(seen).toEqual(["MICRO"]);
+    } finally {
+      unsub();
+    }
   });
 });
 

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -169,6 +169,29 @@ export function patchSessionSettledInCaches(
   return touched;
 }
 
+/** Optimistically set the display title on every per-root sessions cache that holds the id. */
+export function patchSessionTitleInCaches(
+  roots: string[],
+  sessionId: string,
+  title: string,
+  read: (key: string) => Session[] | undefined = readSWRCache,
+  write: (key: string, data: Session[]) => void = writeSWRCache,
+): number {
+  let touched = 0;
+  for (const root of roots) {
+    if (!root) continue;
+    const key = `sessions:${root}`;
+    const cached = read(key);
+    if (!cached || !cached.some((s) => s.id === sessionId)) continue;
+    write(
+      key,
+      cached.map((s) => (s.id === sessionId ? { ...s, title } : s)),
+    );
+    touched += 1;
+  }
+  return touched;
+}
+
 /** Optimistically flip durable `archived` on every per-root sessions cache that holds the id. */
 export function patchSessionArchivedInCaches(
   roots: string[],
@@ -291,6 +314,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     x: number;
     y: number;
     sessionId: string;
+    title: string;
     settled: boolean;
     archived: boolean;
     running: boolean;
@@ -476,21 +500,6 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     return cgStatus;
   };
 
-  const handleRenameSubmit = async (id: string) => {
-    if (!renamingTitle.trim()) {
-      setRenamingId(null);
-      return;
-    }
-    try {
-      await api.renameSession(id, renamingTitle.trim());
-      await refreshSessionsRef.current();
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setRenamingId(null);
-    }
-  };
-
   const [opening, setOpening] = useState(false);
   const [switchingSessionId, setSwitchingSessionId] = useState<string | null>(null);
   const [sessionActivationNotice, setSessionActivationNotice] = useState<string | null>(null);
@@ -527,6 +536,31 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
   // re-render). Without this, deleting a session under an inactive project
   // left phantom titles until a full reload.
   const [sessionsCacheEpoch, setSessionsCacheEpoch] = useState(0);
+
+  const beginSessionRename = (id: string, title: string) => {
+    setRenamingId(id);
+    setRenamingTitle(title || "Untitled");
+  };
+
+  const handleRenameSubmit = async (id: string) => {
+    const title = renamingTitle.trim();
+    if (!title) {
+      setRenamingId(null);
+      return;
+    }
+    const roots = projectsRef.current.filter(Boolean);
+    patchSessionTitleInCaches(roots, id, title);
+    setSessionsCacheEpoch((n) => n + 1);
+    setBankSessions((prev) => prev.map((row) => (row.id === id ? { ...row, title } : row)));
+    setRenamingId(null);
+    try {
+      await api.renameSession(id, title);
+      await refreshSessionsRef.current();
+    } catch (err) {
+      console.error(err);
+      await refreshSessionsRef.current();
+    }
+  };
 
   const onSessionsLoaded = useCallback((sess: Session[], forRepo?: string) => {
     // Stale-response guard: a late payload for a different root must not
@@ -1097,6 +1131,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       x: e.clientX,
       y: e.clientY,
       sessionId: s.id,
+      title: s.title || "Untitled",
       settled: !!s.settled,
       archived: !!s.archived,
       running: runners[s.id] === "running",
@@ -1537,12 +1572,34 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                   const root = s.workspace_root || s.repo || "";
                   const label = getWorkspaceBasename(root) || "Home";
                   const isActive = !!s.active;
+                  if (renamingId === s.id) {
+                    return (
+                      <input
+                        key={s.id}
+                        type="text"
+                        value={renamingTitle}
+                        onChange={(e) => setRenamingTitle(e.target.value)}
+                        onBlur={() => handleRenameSubmit(s.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            handleRenameSubmit(s.id);
+                          } else if (e.key === "Escape") {
+                            setRenamingId(null);
+                          }
+                        }}
+                        autoFocus
+                        className="w-full bg-bg border border-accent rounded px-2 py-1 text-[12px] text-txt focus:outline-none"
+                      />
+                    );
+                  }
                   return (
                     <button
                       key={s.id}
                       type="button"
                       disabled={!!switchingSessionId || opening}
                       onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
+                      onDoubleClick={() => beginSessionRename(s.id, s.title || "Untitled")}
+                      onContextMenu={(e) => handleContextMenu(e, s, canSettleSessionsForProject(root, workspaceInfo?.repo))}
                       className={`w-full min-h-8 flex flex-col justify-center text-left px-2 rounded transition min-w-0 disabled:opacity-60 ${
                         isActive ? "bg-panel2/60 border-l-2 border-accent" : "hover:bg-panel2/30"
                       }`}
@@ -1713,10 +1770,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                                 onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
                                 disabled={!!switchingSessionId || opening}
                                 title={s.preview ? `${s.title || "Untitled"}\n${s.preview}` : (s.title || "Untitled")}
-                                onDoubleClick={() => {
-                                  setRenamingId(s.id);
-                                  setRenamingTitle(s.title || "Untitled");
-                                }}
+                                onDoubleClick={() => beginSessionRename(s.id, s.title || "Untitled")}
                                 onContextMenu={(e) => handleContextMenu(e, s, isCurrentActive)}
                                 className={`flex-1 min-w-0 h-7 text-left rounded pl-2.5 pr-1.5 flex items-center gap-1.5 text-[12px] transition disabled:opacity-60
                                   ${s.active ? "text-txt font-medium" : "text-muted group-hover:text-txt"}
@@ -1799,9 +1853,27 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                           <div className="space-y-0 motion-safe:transition-opacity">
                             {projectSettled.map((s) => (
                               <div key={s.id} className="group relative flex items-center gap-0.5 min-w-0">
+                                {renamingId === s.id ? (
+                                  <input
+                                    type="text"
+                                    value={renamingTitle}
+                                    onChange={(e) => setRenamingTitle(e.target.value)}
+                                    onBlur={() => handleRenameSubmit(s.id)}
+                                    onKeyDown={(e) => {
+                                      if (e.key === "Enter") {
+                                        handleRenameSubmit(s.id);
+                                      } else if (e.key === "Escape") {
+                                        setRenamingId(null);
+                                      }
+                                    }}
+                                    autoFocus
+                                    className="w-full bg-bg border border-accent rounded px-2 py-1 text-[12px] text-txt focus:outline-none"
+                                  />
+                                ) : (
                                 <button
                                   onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
                                   disabled={!!switchingSessionId || opening}
+                                  onDoubleClick={() => beginSessionRename(s.id, s.title || "Untitled")}
                                   onContextMenu={(e) => handleContextMenu(e, s, isCurrentActive)}
                                   className={`flex-1 min-w-0 h-6 text-left rounded px-1.5 flex items-center gap-1.5 text-[11px] motion-safe:transition opacity-45 hover:opacity-90 disabled:opacity-40
                                     ${s.active ? "bg-accent/10 text-accent" : "text-faint hover:bg-panel2/50 hover:text-muted"}
@@ -1811,6 +1883,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                                   <Square size={10} className="shrink-0" />
                                   <span className="truncate">{s.title || "Untitled"}</span>
                                 </button>
+                                )}
                                 {isCurrentActive ? (
                                   <button
                                     onClick={(e) => {
@@ -1876,10 +1949,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                       type="button"
                       onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
                       disabled={!!switchingSessionId || opening}
-                      onDoubleClick={() => {
-                        setRenamingId(s.id);
-                        setRenamingTitle(s.title || "Untitled");
-                      }}
+                      onDoubleClick={() => beginSessionRename(s.id, s.title || "Untitled")}
                       onContextMenu={(e) => handleContextMenu(e, s, true)}
                       className={`w-full h-7 text-left rounded px-2 flex items-center gap-1.5 text-[12.5px] transition opacity-60 hover:opacity-100 disabled:opacity-40
                         ${s.active ? "bg-accent/10 text-accent font-semibold" : "hover:bg-panel2/60 text-muted"}
@@ -2173,6 +2243,16 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
               <div className="border-t border-edge my-1" />
             </>
           )}
+          <button
+            onClick={() => {
+              beginSessionRename(contextMenu.sessionId, contextMenu.title);
+              setContextMenu(null);
+            }}
+            className="w-full text-left px-3 py-1.5 hover:bg-panel2 text-txt transition-colors"
+          >
+            Rename
+          </button>
+          <div className="border-t border-edge my-1" />
           <button
             onClick={() => {
               handleExport(contextMenu.sessionId, "md");

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -22,14 +22,28 @@ import {
 } from "../lib/rightPaneTabVisibility";
 import { beginColumnResize, beginRowResize, endColumnResize, endRowResize } from "../lib/columnResize";
 import {
-  clampStackSplit,
-  DEFAULT_STACK_SPLIT,
+  BOARD_COLUMNS_STORAGE_KEY,
+  MIN_MULTI_COLUMN_BOARD_PX,
+  NEW_COLUMN_DROP_LABEL,
+  canOpenLeftColumn,
+  columnIndexOf,
+  defaultColumns,
+  extractCardToLeftColumn,
+  flattenColumns,
+  moveCardIntoColumn,
+  reconcileColumns,
+} from "../lib/boardColumns";
+import {
+  STACK_FRACTIONS_STORAGE_KEY,
   STACK_ROW_RESIZE_LABEL,
   STACK_SPLIT_STORAGE_KEY,
+  clampStackSplit,
+  equalFractions,
+  fractionsFromBoundaryDrag,
+  fractionsFromKey,
+  normalizeFractions,
   stackPairKey,
-  stackRowTemplate,
-  stackSplitFromDrag,
-  stackSplitFromKey,
+  stackRowTemplateN,
 } from "../lib/stackSplit";
 
 type Tab = "state" | "files" | "git" | "worktrees" | "terminal" | "browser" | "settings" | "checkpoints" | "review" | "swarm";
@@ -157,14 +171,12 @@ function normalizeGroupWidths(requested: number[], preferredGroupIndex: number):
 }
 
 function buildCardPlacements(
-  openCards: Tab[],
+  columns: Tab[][],
   layouts: CardLayouts,
   preferredGroupIndex: number,
 ): Map<Tab, CardPlacement> {
-  const groupCount = Math.ceil(openCards.length / 2);
-  const groups = Array.from({ length: groupCount }, (_, index) =>
-    openCards.slice(index * 2, index * 2 + 2),
-  );
+  const groups = columns.filter((group) => group.length > 0);
+  const groupCount = groups.length;
   const requestedWidths = groups.map(group =>
     Math.max(...group.map(tab => cardColumnSpan(tab, layouts, groupCount))),
   );
@@ -181,12 +193,12 @@ function buildCardPlacements(
     group.forEach((tab, cardIndex) => {
       placements.set(tab, {
         gridColumn: `${groupStart} / span ${groupWidth}`,
-        gridRow: group.length === 1 ? "1" : String(cardIndex + 1),
+        gridRow: String(cardIndex + 1),
         // Left-edge splitter on every card in the rightmost column so the
         // grab target covers the full stack. A single column always fills
         // the board; the shell Resizer owns that width.
         showResizeHandle: groupCount > 1 && isRightmostGroup,
-        showRowResizeHandle: group.length === 2 && cardIndex === 0,
+        showRowResizeHandle: group.length > 1 && cardIndex < group.length - 1,
         columnSpan: groupWidth,
         groupIndex,
       });
@@ -204,18 +216,49 @@ function readTabList(key: string): string[] | null {
   }
 }
 
-function readStackSplits(): Record<string, number> {
+function readStackFractions(): Record<string, number[]> {
+  const fractions: Record<string, number[]> = {};
+  try {
+    const raw = JSON.parse(localStorage.getItem(STACK_FRACTIONS_STORAGE_KEY) || "null");
+    if (raw && typeof raw === "object") {
+      for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+        if (typeof key !== "string" || !Array.isArray(value)) continue;
+        const nums = value.map(Number).filter((item) => Number.isFinite(item));
+        if (nums.length >= 2) fractions[key] = normalizeFractions(nums, nums.length);
+      }
+    }
+  } catch {
+    /* fall through to v1 */
+  }
   try {
     const raw = JSON.parse(localStorage.getItem(STACK_SPLIT_STORAGE_KEY) || "null");
-    if (!raw || typeof raw !== "object") return {};
-    const splits: Record<string, number> = {};
-    for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
-      if (typeof key !== "string" || !key.includes("|")) continue;
-      splits[key] = clampStackSplit(Number(value));
+    if (raw && typeof raw === "object") {
+      for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+        if (fractions[key] || typeof key !== "string" || !key.includes("|")) continue;
+        const split = clampStackSplit(Number(value));
+        fractions[key] = [split, 1 - split];
+      }
     }
-    return splits;
   } catch {
-    return {};
+    /* ignore corrupt v1 */
+  }
+  return fractions;
+}
+
+function readBoardColumns(openCards: Tab[]): Tab[][] {
+  try {
+    const raw = JSON.parse(localStorage.getItem(BOARD_COLUMNS_STORAGE_KEY) || "null");
+    if (!Array.isArray(raw)) return defaultColumns(openCards);
+    const parsed = raw
+      .filter((col): col is unknown[] => Array.isArray(col))
+      .map((col) => col.filter((tab): tab is Tab => (
+        typeof tab === "string"
+        && CANONICAL_ORDER.includes(tab as Tab)
+        && tab !== PINNED_LAST
+      )));
+    return reconcileColumns(openCards, parsed);
+  } catch {
+    return defaultColumns(openCards);
   }
 }
 
@@ -232,20 +275,31 @@ function readLegacyOpenCards(): Tab[] {
   }
 }
 
-export default function RightPane({ visible, artifacts, onOpenWizard, initialTab, onEmpty }: {
+function readInitialOpenCards(): Tab[] {
+  const savedOpen = readTabList("pmharness.board.openCards");
+  const legacyCards = readLegacyOpenCards();
+  const initialCards = savedOpen ?? (legacyCards.length > 0 ? legacyCards : []);
+  return initialCards
+    .map(tab => tab === "mcp" ? "state" : tab)
+    .filter((tab, index, list): tab is Tab =>
+      CANONICAL_ORDER.includes(tab as Tab) && tab !== PINNED_LAST && list.indexOf(tab) === index);
+}
+
+export default function RightPane({ visible, artifacts, onOpenWizard, initialTab, onEmpty, onRequestMinWidth }: {
   visible: boolean;
   artifacts: { type: string; headline: string; confidence?: number }[];
   onOpenWizard: () => void;
   initialTab?: string | null;
   onEmpty?: () => void;
+  onRequestMinWidth?: (minPx: number) => void;
 }) {
   const tabVisibilityRef = useRef<RightPaneTabVisibility>(loadRightPaneTabVisibility());
   const [cardLayouts, setCardLayouts] = useState<CardLayouts>(() => readCardLayouts());
   const cardLayoutsRef = useRef(cardLayouts);
   cardLayoutsRef.current = cardLayouts;
-  const [stackSplits, setStackSplits] = useState<Record<string, number>>(() => readStackSplits());
-  const stackSplitsRef = useRef(stackSplits);
-  stackSplitsRef.current = stackSplits;
+  const [stackFractions, setStackFractions] = useState<Record<string, number[]>>(() => readStackFractions());
+  const stackFractionsRef = useRef(stackFractions);
+  stackFractionsRef.current = stackFractions;
   const boardRef = useRef<HTMLDivElement | null>(null);
   const preferredResizeGroupRef = useRef(-1);
   const [draggedTab, setDraggedTab] = useState<Tab | null>(null);
@@ -259,31 +313,33 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
       .map(tab => tab === "mcp" ? "state" : tab)
       .filter((tab, index, list): tab is Tab =>
         validTabs.includes(tab as Tab) && list.indexOf(tab) === index);
-    const savedOpen = readTabList("pmharness.board.openCards");
-    const openCards = (savedOpen || (legacySplit.length > 0 ? legacySplit : []))
-      .map(tab => tab === "mcp" ? "state" : tab)
-      .filter((tab, index, list): tab is Tab =>
-        validTabs.includes(tab as Tab) && list.indexOf(tab) === index);
-    if (!savedOpen) localStorage.setItem("pmharness.board.openCards", JSON.stringify(openCards));
+    const openCards = readInitialOpenCards();
+    if (!readTabList("pmharness.board.openCards")) {
+      localStorage.setItem("pmharness.board.openCards", JSON.stringify(openCards));
+    }
     return order;
   });
-  const [openCards, setOpenCards] = useState<Tab[]>(() => {
-    const savedOpen = readTabList("pmharness.board.openCards");
-    const legacyCards = readLegacyOpenCards();
-    const initialCards = savedOpen ?? (legacyCards.length > 0 ? legacyCards : []);
-    return initialCards
-      .map(tab => tab === "mcp" ? "state" : tab)
-      .filter((tab, index, list): tab is Tab =>
-        CANONICAL_ORDER.includes(tab as Tab) && tab !== PINNED_LAST && list.indexOf(tab) === index);
-  });
+  const [openCards, setOpenCards] = useState<Tab[]>(() => readInitialOpenCards());
+  const [columns, setColumns] = useState<Tab[][]>(() => readBoardColumns(readInitialOpenCards()));
+  const columnsRef = useRef(columns);
+  columnsRef.current = columns;
 
-  const persistBoard = useCallback((nextOrder: Tab[], nextOpenCards: Tab[]) => {
+  const persistBoard = useCallback((
+    nextOrder: Tab[],
+    nextOpenCards: Tab[],
+    nextColumns?: Tab[][],
+  ) => {
     preferredResizeGroupRef.current = -1;
+    const cols = reconcileColumns(nextOpenCards, nextColumns ?? columnsRef.current);
+    const flat = flattenColumns(cols);
+    columnsRef.current = cols;
     setTabOrder(nextOrder);
-    setOpenCards(nextOpenCards);
+    setOpenCards(flat);
+    setColumns(cols);
     localStorage.setItem("pmharness.tabOrder", JSON.stringify(nextOrder));
-    localStorage.setItem("pmharness.board.openCards", JSON.stringify(nextOpenCards));
-    if (nextOpenCards.length === 0) onEmpty?.();
+    localStorage.setItem("pmharness.board.openCards", JSON.stringify(flat));
+    localStorage.setItem(BOARD_COLUMNS_STORAGE_KEY, JSON.stringify(cols));
+    if (flat.length === 0) onEmpty?.();
   }, [onEmpty]);
 
   const addCard = useCallback((tabName: Tab) => {
@@ -311,26 +367,24 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     localStorage.setItem(CARD_LAYOUT_STORAGE_KEY, JSON.stringify(nextLayouts));
   }, []);
 
-  const persistStackSplits = useCallback((nextSplits: Record<string, number>) => {
-    stackSplitsRef.current = nextSplits;
-    setStackSplits(nextSplits);
-    localStorage.setItem(STACK_SPLIT_STORAGE_KEY, JSON.stringify(nextSplits));
+  const persistStackFractions = useCallback((nextFractions: Record<string, number[]>) => {
+    stackFractionsRef.current = nextFractions;
+    setStackFractions(nextFractions);
+    localStorage.setItem(STACK_FRACTIONS_STORAGE_KEY, JSON.stringify(nextFractions));
   }, []);
 
-  const setStackSplit = useCallback((pairKey: string, nextSplit: number) => {
-    persistStackSplits({
-      ...stackSplitsRef.current,
-      [pairKey]: clampStackSplit(nextSplit),
+  const setStackFractionsForKey = useCallback((pairKey: string, nextFractions: number[]) => {
+    persistStackFractions({
+      ...stackFractionsRef.current,
+      [pairKey]: normalizeFractions(nextFractions, nextFractions.length),
     });
-  }, [persistStackSplits]);
+  }, [persistStackFractions]);
 
   const setGroupColumnSpan = useCallback((groupIndex: number, nextSpan: number) => {
-    const groupCount = Math.ceil(openCards.length / 2);
+    const groups = columnsRef.current.filter((group) => group.length > 0);
+    const groupCount = groups.length;
     if (groupCount <= 1) return;
     preferredResizeGroupRef.current = groupIndex;
-    const groups = Array.from({ length: groupCount }, (_, index) =>
-      openCards.slice(index * 2, index * 2 + 2),
-    );
     const minWidth = groupCount <= 4 ? 2 : 1;
     const requested = groups.map((group, index) => {
       if (index === groupIndex) return clampCardColumnSpan(nextSpan, minWidth);
@@ -354,7 +408,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
       }
     });
     persistCardLayouts(nextLayouts);
-  }, [openCards, persistCardLayouts]);
+  }, [persistCardLayouts]);
 
   const resizeGroupFromPointer = useCallback((
     event: React.PointerEvent<HTMLSpanElement>,
@@ -394,6 +448,8 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
   const resizeStackFromPointer = useCallback((
     event: React.PointerEvent<HTMLSpanElement>,
     pairKey: string,
+    boundaryIndex: number,
+    stackLength: number,
   ) => {
     if (event.button !== 0) return;
     event.preventDefault();
@@ -404,13 +460,17 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     const handle = event.currentTarget;
     handle.setPointerCapture(event.pointerId);
     const startY = event.clientY;
-    const startSplit = stackSplitsRef.current[pairKey] ?? DEFAULT_STACK_SPLIT;
+    const startFractions = normalizeFractions(
+      stackFractionsRef.current[pairKey] ?? equalFractions(stackLength),
+      stackLength,
+    );
     beginRowResize();
 
     const onMove = (moveEvent: PointerEvent) => {
       if (!handle.hasPointerCapture(moveEvent.pointerId)) return;
-      setStackSplit(pairKey, stackSplitFromDrag({
-        startSplit,
+      setStackFractionsForKey(pairKey, fractionsFromBoundaryDrag({
+        fractions: startFractions,
+        boundaryIndex,
         startClientY: startY,
         clientY: moveEvent.clientY,
         stackHeight,
@@ -428,7 +488,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     handle.addEventListener("pointermove", onMove);
     handle.addEventListener("pointerup", onUp);
     handle.addEventListener("pointercancel", onUp);
-  }, [setStackSplit]);
+  }, [setStackFractionsForKey]);
 
   const handleDragStart = (event: React.DragEvent, tabId: Tab) => {
     setDraggedTab(tabId);
@@ -440,13 +500,25 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     event.preventDefault();
     const sourceTab = draggedTab || event.dataTransfer.getData("text/plain") as Tab;
     if (!sourceTab || sourceTab === targetTab) return;
-    const fromIndex = openCards.indexOf(sourceTab);
-    const toIndex = openCards.indexOf(targetTab);
-    if (fromIndex < 0 || toIndex < 0) return;
-    const next = [...openCards];
-    next.splice(fromIndex, 1);
-    next.splice(toIndex, 0, sourceTab);
-    persistBoard(tabOrder, next);
+    const destCol = columnIndexOf(columnsRef.current, targetTab);
+    if (destCol < 0) return;
+    const destIndex = columnsRef.current[destCol].indexOf(targetTab);
+    const nextCols = moveCardIntoColumn(columnsRef.current, sourceTab, destCol, destIndex);
+    persistBoard(tabOrder, flattenColumns(nextCols), nextCols);
+    setDraggedTab(null);
+  };
+
+  const handleDropNewColumn = (event: React.DragEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const sourceTab = draggedTab || event.dataTransfer.getData("text/plain") as Tab;
+    if (!sourceTab || !canOpenLeftColumn(columnsRef.current, sourceTab)) {
+      setDraggedTab(null);
+      return;
+    }
+    const nextCols = extractCardToLeftColumn(columnsRef.current, sourceTab);
+    persistBoard(tabOrder, flattenColumns(nextCols), nextCols);
+    onRequestMinWidth?.(MIN_MULTI_COLUMN_BOARD_PX);
     setDraggedTab(null);
   };
 
@@ -591,19 +663,28 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     }
   };
   const cardPlacements = buildCardPlacements(
-    openCards,
+    columns,
     cardLayouts,
     preferredResizeGroupRef.current,
   );
-  const cardStacks = Array.from(
-    { length: Math.ceil(openCards.length / 2) },
-    (_, index) => openCards.slice(index * 2, index * 2 + 2),
-  );
+  const cardStacks = columns.filter((group) => group.length > 0);
+  const showNewColumnDrop = Boolean(draggedTab && canOpenLeftColumn(columns, draggedTab));
 
   return (
     <>
       {visible && openCards.length > 0 && (
         <div ref={boardRef} className="right-pane-board h-full w-full overflow-y-auto">
+            {showNewColumnDrop && (
+              <div
+                role="region"
+                aria-label={NEW_COLUMN_DROP_LABEL}
+                className="right-pane-new-column-drop"
+                onDragOver={event => event.preventDefault()}
+                onDrop={handleDropNewColumn}
+              >
+                {NEW_COLUMN_DROP_LABEL}
+              </div>
+            )}
             <div
               className="right-pane-board-grid"
               style={{
@@ -615,7 +696,10 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
                 const stackPlacement = cardPlacements.get(stackTabs[0]);
                 if (!stackPlacement) return null;
                 const pairKey = stackPairKey(stackTabs);
-                const stackSplit = stackSplits[pairKey] ?? DEFAULT_STACK_SPLIT;
+                const stackRows = normalizeFractions(
+                  stackFractions[pairKey] ?? equalFractions(stackTabs.length),
+                  stackTabs.length,
+                );
                 return (
             <div
               key={pairKey}
@@ -625,7 +709,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
                 gridRow: "1",
                 gridTemplateRows: stackTabs.length === 1
                   ? "minmax(0, 1fr)"
-                  : stackRowTemplate(stackSplit),
+                  : stackRowTemplateN(stackRows),
               }}
             >
               {stackTabs.map((tabName) => {
@@ -672,11 +756,19 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
                 aria-label={STACK_ROW_RESIZE_LABEL}
                 tabIndex={0}
                 className="right-pane-card-row-resize-handle"
-                onPointerDown={event => resizeStackFromPointer(event, pairKey)}
+                onPointerDown={event => resizeStackFromPointer(
+                  event,
+                  pairKey,
+                  Number(placement.gridRow) - 1,
+                  stackTabs.length,
+                )}
                 onKeyDown={event => {
                   if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
                   event.preventDefault();
-                  setStackSplit(pairKey, stackSplitFromKey(stackSplit, event.key));
+                  setStackFractionsForKey(
+                    pairKey,
+                    fractionsFromKey(stackRows, Number(placement.gridRow) - 1, event.key),
+                  );
                 }}
               />
               )}
@@ -698,13 +790,18 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
                     onKeyDown={event => {
                       if (!event.altKey || (event.key !== "ArrowUp" && event.key !== "ArrowDown")) return;
                       event.preventDefault();
-                      const currentIndex = openCards.indexOf(tabName);
+                      const colIndex = columnIndexOf(columnsRef.current, tabName);
+                      if (colIndex < 0) return;
+                      const col = columnsRef.current[colIndex];
+                      const currentIndex = col.indexOf(tabName);
                       const targetIndex = currentIndex + (event.key === "ArrowUp" ? -1 : 1);
-                      if (currentIndex < 0 || targetIndex < 0 || targetIndex >= openCards.length) return;
-                      const next = [...openCards];
-                      next.splice(currentIndex, 1);
-                      next.splice(targetIndex, 0, tabName);
-                      persistBoard(tabOrder, next);
+                      if (currentIndex < 0 || targetIndex < 0 || targetIndex >= col.length) return;
+                      const nextCol = col.slice();
+                      nextCol.splice(currentIndex, 1);
+                      nextCol.splice(targetIndex, 0, tabName);
+                      const nextCols = columnsRef.current.slice();
+                      nextCols[colIndex] = nextCol;
+                      persistBoard(tabOrder, flattenColumns(nextCols), nextCols);
                     }}
                     className="right-pane-drag-handle"
                   >

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -35,7 +35,7 @@ html.app-idle *::after {
 html { font-size: clamp(11.5px, 0.62vw + 7.1px, 16px); }
 
 body {
-  background: var(--shell-chrome, #0b0d10); color: #ececef;
+  background: var(--shell-chrome, #0f1113); color: #ececef;
   overflow: hidden;
   font-size: 0.8125rem; /* was 13px; now scales with the responsive root */
   -webkit-font-smoothing: antialiased;
@@ -63,7 +63,8 @@ body {
   --titlebar-traffic-pad-sm: 112px;
   --titlebar-chrome-pad-x: 24px;
   /* Inset shell chrome (Claude Code-style floating panels). */
-  --shell-chrome: #0b0d10;
+  --shell-chrome: #0f1113;
+  --shell-chat: #0f1113;
   --shell-panel: #13161a;
   --shell-panel-border: rgba(255, 255, 255, 0.05);
   --shell-panel-radius: 12px;
@@ -87,9 +88,31 @@ body {
 }
 
 .right-pane-board {
+  position: relative;
   container-type: inline-size;
   scrollbar-width: none;
   border-left: 0;
+  background: var(--shell-chat, #0f1113);
+}
+
+.right-pane-new-column-drop {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: 4px;
+  z-index: 8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  padding: 8px 6px;
+  color: var(--text-muted, #b8bec8);
+  text-align: center;
+  font-size: 10px;
+  line-height: 1.3;
+  border: 1px dashed rgba(154, 168, 255, 0.45);
+  border-radius: 7px;
+  background: rgba(154, 168, 255, 0.08);
 }
 
 .right-pane-board-grid {
@@ -278,7 +301,7 @@ body.is-row-resizing iframe {
   animation: pulse 1.6s ease-in-out infinite;
 }
 
-@container (max-width: 399px) {
+@container (max-width: 279px) {
   .right-pane-board-grid {
     grid-template-columns: minmax(0, 1fr) !important;
     grid-template-rows: none !important;

--- a/webapp/src/lib/boardColumns.ts
+++ b/webapp/src/lib/boardColumns.ts
@@ -1,0 +1,70 @@
+/** Right-pane card columns. Index 0 is the rightmost column. */
+
+export const BOARD_COLUMNS_STORAGE_KEY = "pmharness.board.columns.v1";
+export const NEW_COLUMN_DROP_LABEL = "Drop to open a column";
+export const MIN_MULTI_COLUMN_BOARD_PX = 420;
+
+export function defaultColumns<T>(openCards: readonly T[]): T[][] {
+  if (openCards.length === 0) return [];
+  return [openCards.slice()];
+}
+
+export function flattenColumns<T>(columns: readonly T[][]): T[] {
+  return columns.flat();
+}
+
+export function reconcileColumns<T>(openCards: readonly T[], columns: readonly T[][]): T[][] {
+  const allowed = new Set(openCards);
+  const seen = new Set<T>();
+  const next: T[][] = [];
+  for (const col of columns) {
+    const kept = col.filter((tab) => allowed.has(tab) && !seen.has(tab));
+    for (const tab of kept) seen.add(tab);
+    if (kept.length) next.push(kept);
+  }
+  const missing = openCards.filter((tab) => !seen.has(tab));
+  if (missing.length === 0) return next;
+  if (next.length === 0) return [missing.slice()];
+  next[0] = [...next[0], ...missing];
+  return next;
+}
+
+export function columnIndexOf<T>(columns: readonly T[][], card: T): number {
+  return columns.findIndex((col) => col.includes(card));
+}
+
+export function moveCardIntoColumn<T>(
+  columns: readonly T[][],
+  card: T,
+  destCol: number,
+  destIndex: number,
+): T[][] {
+  const stripped = columns
+    .map((col) => col.filter((tab) => tab !== card))
+    .filter((col) => col.length > 0);
+  if (stripped.length === 0) return [[card]];
+  const target = Math.max(0, Math.min(destCol, stripped.length));
+  if (target === stripped.length) {
+    return [...stripped, [card]];
+  }
+  const col = stripped[target].slice();
+  const idx = Math.max(0, Math.min(destIndex, col.length));
+  col.splice(idx, 0, card);
+  const next = stripped.slice();
+  next[target] = col;
+  return next;
+}
+
+/** Pull a card out of its stack into a new leftmost column. */
+export function extractCardToLeftColumn<T>(columns: readonly T[][], card: T): T[][] {
+  const stripped = columns
+    .map((col) => col.filter((tab) => tab !== card))
+    .filter((col) => col.length > 0);
+  if (stripped.length === 0) return [[card]];
+  return [...stripped, [card]];
+}
+
+export function canOpenLeftColumn<T>(columns: readonly T[][], card: T): boolean {
+  const col = columns.find((c) => c.includes(card));
+  return Boolean(col && col.length > 1);
+}

--- a/webapp/src/lib/stackSplit.ts
+++ b/webapp/src/lib/stackSplit.ts
@@ -1,10 +1,12 @@
-/** Vertical split between two stacked right-pane cards (top fraction 0–1). */
+/** Vertical splits for stacked right-pane cards (per-card fractions). */
 
 export const DEFAULT_STACK_SPLIT = 0.5;
 export const MIN_STACK_SPLIT = 0.1;
 export const MAX_STACK_SPLIT = 0.9;
+export const MIN_STACK_FRACTION = 0.1;
 export const STACK_SPLIT_STEP = 0.05;
 export const STACK_SPLIT_STORAGE_KEY = "pmharness.board.stackSplits.v1";
+export const STACK_FRACTIONS_STORAGE_KEY = "pmharness.board.stackFractions.v2";
 export const STACK_ROW_RESIZE_LABEL = "Resize stacked panel height";
 
 export function clampStackSplit(value: number): number {
@@ -16,12 +18,36 @@ export function stackPairKey(tabs: readonly string[]): string {
   return tabs.filter(Boolean).join("|");
 }
 
+export function equalFractions(count: number): number[] {
+  if (count <= 0) return [];
+  if (count === 1) return [1];
+  return Array.from({ length: count }, () => 1 / count);
+}
+
+export function normalizeFractions(values: readonly number[], count: number): number[] {
+  if (count <= 0) return [];
+  if (count === 1) return [1];
+  const min = Math.min(MIN_STACK_FRACTION, 1 / count);
+  const raw = values.slice(0, count);
+  while (raw.length < count) raw.push(1 / count);
+  const clamped = raw.map((value) => (
+    Number.isFinite(value) ? Math.max(min, value) : 1 / count
+  ));
+  const sum = clamped.reduce((total, value) => total + value, 0) || 1;
+  return clamped.map((value) => value / sum);
+}
+
+export function stackRowTemplateN(fractions: readonly number[]): string {
+  const normalized = normalizeFractions(fractions, fractions.length);
+  return normalized
+    .map((value) => `minmax(0, ${Math.max(1, Math.round(value * 100))}fr)`)
+    .join(" ");
+}
+
 /** CSS grid-template-rows for a two-card stack. */
 export function stackRowTemplate(split: number): string {
   const clamped = clampStackSplit(split);
-  const top = Math.max(1, Math.round(clamped * 100));
-  const bottom = Math.max(1, 100 - top);
-  return `minmax(0, ${top}fr) minmax(0, ${bottom}fr)`;
+  return stackRowTemplateN([clamped, 1 - clamped]);
 }
 
 export function stackSplitFromDrag(opts: {
@@ -41,4 +67,41 @@ export function stackSplitFromKey(split: number, key: string): number {
   if (key === "ArrowUp") return clampStackSplit(split - STACK_SPLIT_STEP);
   if (key === "ArrowDown") return clampStackSplit(split + STACK_SPLIT_STEP);
   return clampStackSplit(split);
+}
+
+export function fractionsFromBoundaryDrag(opts: {
+  fractions: readonly number[];
+  boundaryIndex: number;
+  startClientY: number;
+  clientY: number;
+  stackHeight: number;
+}): number[] {
+  const next = normalizeFractions(opts.fractions, opts.fractions.length);
+  const boundary = opts.boundaryIndex;
+  if (boundary < 0 || boundary >= next.length - 1) return next;
+  if (!Number.isFinite(opts.stackHeight) || opts.stackHeight <= 0) return next;
+  const min = Math.min(MIN_STACK_FRACTION, 1 / next.length);
+  const pair = next[boundary] + next[boundary + 1];
+  const delta = (opts.clientY - opts.startClientY) / opts.stackHeight;
+  const top = Math.max(min, Math.min(pair - min, next[boundary] + delta));
+  next[boundary] = top;
+  next[boundary + 1] = pair - top;
+  return normalizeFractions(next, next.length);
+}
+
+export function fractionsFromKey(
+  fractions: readonly number[],
+  boundaryIndex: number,
+  key: string,
+): number[] {
+  if (key !== "ArrowUp" && key !== "ArrowDown") {
+    return normalizeFractions(fractions, fractions.length);
+  }
+  return fractionsFromBoundaryDrag({
+    fractions,
+    boundaryIndex,
+    startClientY: 0,
+    clientY: (key === "ArrowDown" ? 1 : -1) * STACK_SPLIT_STEP * 400,
+    stackHeight: 400,
+  });
 }


### PR DESCRIPTION
## Summary
- Codex Responses / GPT Luna seals a tool-free answer instead of hanging on Still working; pings classify as MICRO.
- Right-board cards stay in one stack by default. Drop a card left to open a column; drop on a card to keep stacking. Every stacked card can resize.
- Session context menu now includes Rename. Shell chrome matches the chat surface so stacked panel corners no longer flash black.

## Test plan
- [ ] Send `test` on openai-codex:gpt-5.6-luna and confirm Still working clears without Stop
- [ ] Open three right-board cards: they stack in one column; drag the third left onto "Drop to open a column"
- [ ] Resize cards 1/2 and 2/3 independently
- [ ] Right-click a session and Rename
- [ ] Confirm stack gaps match the chat charcoal, not black
- [ ] CI: Python 3.9 + 3.11 + frontend-build green on the merge SHA before tagging