### PR TITLE
Release v0.9.218: floating shell, n-way column resize, fail-closed catalogs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,10 +72,15 @@ jobs:
           cache: npm
           cache-dependency-path: webapp/package-lock.json
 
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
       - name: Install + vitest + Electron unit tests + build
         working-directory: webapp
+        env:
+          DISPLAY: ":99"
         run: |
           npm ci
           npm test
-          npm run test:electron
+          xvfb-run -a npm run test:electron
           npm run build

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Internal-first research rig and daily-driver app. stdlib-only backend (urllib +
 sqlite); Puppetmaster is the one real dependency, installed editable from a local
 checkout.
 
-> Status: v0.9.218, deliberately pre-1.0. Left rail and tool cards sit on the conversation surface so they read as floating; stacked cards keep their rounded corners and stay flush at any zoom. Rides puppetmaster-ai==1.22.2.
+> Status: v0.9.218, deliberately pre-1.0. Left rail and tool cards sit on the conversation surface so they read as floating; n-way board columns resize pairwise so a middle pane is not squeezed by its neighbors; Autopilot only routes models the live catalog and Models toggles actually allow. Rides puppetmaster-ai==1.22.2.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Internal-first research rig and daily-driver app. stdlib-only backend (urllib +
 sqlite); Puppetmaster is the one real dependency, installed editable from a local
 checkout.
 
-> Status: v0.9.217, deliberately pre-1.0. GPT Luna / Codex Responses settles a tool-free answer instead of hanging on Still working; pings classify as MICRO. Right-board cards stay in one stack until you drop one left to open a column, and every stacked card can resize. Session Rename is on the context menu. Shell chrome matches the chat surface so stacked panels float. Rides puppetmaster-ai==1.22.2.
+> Status: v0.9.218, deliberately pre-1.0. Left rail and tool cards sit on the conversation surface so they read as floating; stacked cards keep their rounded corners and stay flush at any zoom. Rides puppetmaster-ai==1.22.2.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.217"
+__version__ = "0.9.218"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/auto_registry.py
+++ b/harness/auto_registry.py
@@ -342,6 +342,38 @@ def _promote_openrouter_snapshots(
     return promoted
 
 
+def _has_picker_curation() -> bool:
+    """True when Settings -> Models has any enabled spec for an agentic provider.
+
+    Uses ``_enabled_picker_models`` so tests that patch that helper stay hermetic.
+    """
+    names = set(_CURATED_MODELS)
+    names.update(_AGENTIC_PROVIDER_SLUGS.keys())
+    names.update(_AGENTIC_PROVIDER_SLUGS.values())
+    return any(_enabled_picker_models(name) for name in names)
+
+
+def _in_live_catalog(name: str, slug: str, live_models: list[str]) -> bool:
+    """True when *name* or *slug* is in the live listing, including dated siblings."""
+    if not live_models:
+        return False
+    live = [str(m or "").strip() for m in live_models if str(m or "").strip()]
+    live_set = {m.lower() for m in live}
+    for key in (name, slug):
+        raw = str(key or "").strip()
+        if not raw:
+            continue
+        if raw.lower() in live_set:
+            return True
+        promoted = _newest_dated_snapshot(raw, live)
+        if promoted.lower() in live_set:
+            return True
+        family = _strip_dated_suffix(raw)
+        if family and family.lower() in live_set:
+            return True
+    return False
+
+
 def _known_spec_for(model_name: str, slug: str):
     """Static economics for a wire id, rolling slug, or dated family sibling."""
     for key in (model_name, slug):
@@ -387,10 +419,9 @@ def _get_provider_models_from_discovery(
 
         curated = _CURATED_MODELS.get(provider_name, [])
 
-        # The user's explicit picker curation is authoritative for the
-        # discretionary rows.  Marionette's small OpenRouter ladder is the
-        # exception: retain those required fallbacks so a picker or discovery
-        # refresh cannot strand an otherwise keyed provider.
+        # Models toggles are the only discretionary allowlist. Do not union
+        # curated/live extras onto an explicit picker set — that is how
+        # MiniMax / Xiaomi MIMO leaked into Autopilot when they were off.
         enabled = _enabled_picker_models(provider_name)
         if enabled:
             def _slug_for(name: str) -> str:
@@ -399,21 +430,23 @@ def _get_provider_models_from_discovery(
                 return name
 
             selected = [(m, _tier_of_known(m), _slug_for(m)) for m in enabled]
-            if provider_name == "openrouter":
-                selected_slugs = {item[2] for item in selected}
-                selected.extend(
-                    item for item in curated if item[2] not in selected_slugs
-                )
-                live_models = fetch_models(provider, provider_key, force=force)
-                if live_models:
+            live_models = fetch_models(provider, provider_key, force=force)
+            if live_models:
+                if provider_name == "openrouter":
                     selected = _promote_openrouter_snapshots(selected, live_models)
+                selected = [
+                    item for item in selected
+                    if _in_live_catalog(item[0], item[2], live_models)
+                ]
             return selected
+
+        if _has_picker_curation():
+            return []
 
         # Try live discovery
         live_models = fetch_models(provider, provider_key, force=force)
         if not live_models:
-            # No live models, use curated
-            return _CURATED_MODELS.get(provider_name, [])
+            return list(curated)
         
         # Classify each live model into a tier. Order matters: check the
         # frontier "opus/pro/ultra" markers BEFORE the cheap "flash/mini/lite"
@@ -507,37 +540,31 @@ def _get_provider_models_from_discovery(
                     break
 
         if provider_name == "openrouter":
-            # Scan the full live list for dated siblings of the curated
-            # ladder (DeepSeek 0813, ...). Keep rolling slugs so Autopilot
-            # ids stay stable; extras stay capped so we do not dump OR.
+            # Curated ladder intersect live catalog. Dated siblings promote
+            # onto stable slugs. Do not dump the first N live extras — that
+            # is how MIMO and other untoggled OpenRouter ids entered Autopilot.
             curated_promoted = _promote_openrouter_snapshots(
                 list(curated), live_models,
             )
-            curated_slugs = {item[2] for item in curated_promoted}
-            curated_wires = {item[0].lower() for item in curated_promoted}
-            curated_bases = [slug for _n, _t, slug in curated]
-            extras: list[tuple[str, str, str]] = []
-            extra_seen: set[str] = set()
-            for model_id in live_models:
-                if not _keep(model_id):
-                    continue
-                if model_id in extra_seen:
-                    continue
-                if model_id in curated_slugs or model_id.lower() in curated_wires:
-                    continue
-                if _is_dated_or_exact_sibling(model_id, curated_bases):
-                    continue
-                extra_seen.add(model_id)
-                extras.append((model_id, _tier_of(model_id), model_id))
-                if len(extras) >= 6:
-                    break
-            result = list(curated_promoted) + extras
+            result = [
+                item for item in curated_promoted
+                if _in_live_catalog(item[0], item[2], live_models)
+            ]
         elif provider_name == "openai-codex":
             # Keep curated Codex ladder even when live discovery returns a
             # partial list (or a different naming wave).
             seen_slugs = {item[2] for item in result}
             result.extend(item for item in curated if item[2] not in seen_slugs)
-        return result if result else curated
+        elif provider_name == "opencode-go":
+            # Live listing is authoritative: do not keep MIMO (or anything
+            # else) that the Go workspace does not actually serve.
+            result = [
+                item for item in curated
+                if _in_live_catalog(item[0], item[2], live_models)
+            ]
+        if provider_name == "openrouter":
+            return result
+        return result if result else list(curated)
     except Exception as e:
         _diag("auto_registry.discovery", e, msg=f"provider={provider_name}")
         return _CURATED_MODELS.get(provider_name, [])
@@ -838,13 +865,14 @@ def ensure_keyed_provider_registry_health() -> dict:
             return report
         sync_agentic_registry_safe()
         report["pruned"] = prune_unavailable_agentic_rows(keyed).get("pruned", 0)
-        if "openrouter" in keyed:
+        if "openrouter" in keyed and not _enabled_picker_models("openrouter"):
             required = _openrouter_ladder_ids()
             present = _agentic_ids_present()
             missing = [mid for mid in required if mid not in present]
             # Every ladder row missing means auto_route has nothing Marionette
             # curated to pick; re-seed from the curated set rather than routing
             # blind. A partial gap is normal (picker curation) and left alone.
+            # Never seed when the user already toggled an OpenRouter subset.
             if required and len(missing) == len(required):
                 if _seed_openrouter_ladder_rows(missing):
                     report["seeded_ladder"] = list(missing)
@@ -927,8 +955,10 @@ def sync_agentic_registry(force: bool = False) -> dict:
                 provider_name, key, force=force,
             )
             if not models:
-                # Even with no discovery, use curated fallback
-                models = _CURATED_MODELS.get(agentic_name, [])
+                if _enabled_picker_models(provider_name):
+                    models = []
+                else:
+                    models = _CURATED_MODELS.get(agentic_name, [])
             
             if models:
                 synced_providers.append(agentic_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.217"
+version = "0.9.218"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_auto_registry.py
+++ b/tests/test_auto_registry.py
@@ -682,7 +682,7 @@ def test_kimi_k3_static_economics_match_marketplace():
     assert "frontier" in tags
 
 
-def test_openrouter_picker_union_retains_curated_ladder(monkeypatch, tmp_path):
+def test_openrouter_picker_does_not_union_curated_ladder(monkeypatch, tmp_path):
     models_path = tmp_path / "models.json"
     monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
     monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
@@ -706,15 +706,13 @@ def test_openrouter_picker_union_retains_curated_ladder(monkeypatch, tmp_path):
     assert result["synced"] is True
     data = json.loads(models_path.read_text())
     ids = {m["id"] for m in data["models"]}
-    assert "agentic/anthropic/claude-opus-4.8" in ids
-    assert "agentic/moonshotai/kimi-k3" in ids
-    assert "agentic/deepseek/deepseek-v4-pro" in ids
-    kimi = next(m for m in data["models"] if m["id"] == "agentic/moonshotai/kimi-k3")
-    assert kimi["payload_defaults"]["provider"] == "openrouter"
-    assert "tools" in kimi["tags"]
+    assert ids == {"agentic/anthropic/claude-opus-4.8"}
+    opus = next(m for m in data["models"] if m["id"] == "agentic/anthropic/claude-opus-4.8")
+    assert opus["payload_defaults"]["provider"] == "openrouter"
+    assert "tools" in opus["tags"]
 
 
-def test_openrouter_discovery_retains_curated_ladder(monkeypatch, tmp_path):
+def test_openrouter_discovery_intersects_curated_with_live(monkeypatch, tmp_path):
     models_path = tmp_path / "models.json"
     monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
     monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
@@ -734,8 +732,93 @@ def test_openrouter_discovery_retains_curated_ladder(monkeypatch, tmp_path):
 
     data = json.loads(models_path.read_text())
     ids = {m["id"] for m in data["models"]}
+    assert ids == {"agentic/z-ai/glm-5.2"}
+    assert "agentic/moonshotai/kimi-k3" not in ids
+    assert "agentic/deepseek/deepseek-v4-flash" not in ids
+
+
+def test_openrouter_live_extras_do_not_inject_mimo(monkeypatch, tmp_path):
+    models_path = tmp_path / "models.json"
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+
+    live = [
+        "xiaomi/mimo-v2-flash",
+        "xiaomi/mimo-v2-pro",
+        "minimax/minimax-m3",
+        "moonshotai/kimi-k3",
+        "deepseek/deepseek-v4-pro",
+    ]
+
+    def mock_get_provider_key(provider):
+        return "fake-openrouter" if provider.name == "openrouter" else None
+
+    with patch("harness.registry_wizard.get_provider_key", mock_get_provider_key), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda *_a, **_k: list(live)), \
+         patch(
+             "harness.auto_registry._enabled_picker_models",
+             lambda name: ["moonshotai/kimi-k3"] if name == "openrouter" else [],
+         ):
+        from harness.auto_registry import sync_agentic_registry
+        sync_agentic_registry()
+
+    ids = {m["id"] for m in json.loads(models_path.read_text())["models"]}
+    assert ids == {"agentic/moonshotai/kimi-k3"}
+    assert not any("mimo" in mid for mid in ids)
+    assert "agentic/minimax/minimax-m3" not in ids
+
+
+def test_openrouter_uncurated_live_does_not_dump_mimo(monkeypatch, tmp_path):
+    models_path = tmp_path / "models.json"
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+
+    live = [
+        "xiaomi/mimo-v2-flash",
+        "other/filler-1",
+        "moonshotai/kimi-k3",
+        "deepseek/deepseek-v4-pro",
+    ]
+
+    def mock_get_provider_key(provider):
+        return "fake-openrouter" if provider.name == "openrouter" else None
+
+    with patch("harness.registry_wizard.get_provider_key", mock_get_provider_key), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda *_a, **_k: list(live)), \
+         patch("harness.auto_registry._enabled_picker_models", lambda _name: []):
+        from harness.auto_registry import sync_agentic_registry
+        sync_agentic_registry()
+
+    ids = {m["id"] for m in json.loads(models_path.read_text())["models"]}
     assert "agentic/moonshotai/kimi-k3" in ids
-    assert "agentic/deepseek/deepseek-v4-flash" in ids
+    assert "agentic/deepseek/deepseek-v4-pro" in ids
+    assert not any("mimo" in mid for mid in ids)
+    assert "agentic/other/filler-1" not in ids
+
+
+def test_opencode_go_live_drops_mimo_when_not_served(monkeypatch, tmp_path):
+    models_path = tmp_path / "models.json"
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+
+    def mock_get_provider_key(provider):
+        return "fake-go" if provider.name == "opencode-go" else None
+
+    live = ["gpt-5.6-luna", "deepseek-v4-flash", "kimi-k3"]
+
+    with patch("harness.registry_wizard.get_provider_key", mock_get_provider_key), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda *_a, **_k: list(live)), \
+         patch("harness.auto_registry._enabled_picker_models", lambda _name: []):
+        from harness.auto_registry import sync_agentic_registry
+        sync_agentic_registry()
+
+    ids = {m["id"] for m in json.loads(models_path.read_text())["models"]}
+    assert "agentic/gpt-5.6-luna" in ids
+    assert "agentic/deepseek-v4-flash" in ids
+    assert not any("mimo" in mid for mid in ids)
 
 
 def test_sync_with_no_keys_writes_no_agentic_models(monkeypatch, tmp_path):
@@ -829,7 +912,10 @@ def test_openrouter_picker_promotes_dated_snapshot(monkeypatch, tmp_path):
          patch("harness.model_fetch.fetch_models", mock_fetch_models), \
          patch(
              "harness.auto_registry._enabled_picker_models",
-             lambda name: ["anthropic/claude-opus-4.8"] if name == "openrouter" else [],
+             lambda name: (
+                 ["deepseek/deepseek-v4-pro", "anthropic/claude-opus-4.8"]
+                 if name == "openrouter" else []
+             ),
          ):
         from harness.auto_registry import sync_agentic_registry
         sync_agentic_registry()
@@ -838,6 +924,7 @@ def test_openrouter_picker_promotes_dated_snapshot(monkeypatch, tmp_path):
     by_id = {m["id"]: m for m in data["models"]}
     pro = by_id["agentic/deepseek/deepseek-v4-pro"]
     assert pro["adapter_model_name"] == "deepseek/deepseek-v4-pro-0813"
+    assert "agentic/moonshotai/kimi-k3" not in by_id
 
 
 def test_sync_force_is_passed_to_fetch_models(monkeypatch, tmp_path):
@@ -869,6 +956,17 @@ def test_registry_auto_refresh_kill_switch(monkeypatch):
     monkeypatch.setenv("HARNESS_REGISTRY_AUTO_REFRESH", "0")
     monkeypatch.setattr(ar, "_refresh_thread", None)
     assert ar.start_registry_auto_refresh() is False
+
+
+def test_in_live_catalog_accepts_dated_siblings():
+    from harness.auto_registry import _in_live_catalog
+
+    live = ["deepseek/deepseek-v4-pro-0813", "moonshotai/kimi-k3"]
+    assert _in_live_catalog(
+        "deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-pro", live,
+    )
+    assert _in_live_catalog("moonshotai/kimi-k3", "moonshotai/kimi-k3", live)
+    assert not _in_live_catalog("xiaomi/mimo-v2-flash", "xiaomi/mimo-v2-flash", live)
 
 
 def test_known_spec_follows_dated_family():

--- a/tests/test_keyed_registry_health.py
+++ b/tests/test_keyed_registry_health.py
@@ -35,6 +35,10 @@ def _hermetic(monkeypatch, tmp_path):
     monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
     monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+    vis_store = tmp_path / "visibility.json"
+    monkeypatch.setattr(
+        "harness.model_visibility._store_path", lambda: str(vis_store),
+    )
     return models_path
 
 
@@ -137,6 +141,41 @@ def test_ladder_is_reseeded_when_every_required_row_is_missing(monkeypatch, tmp_
     assert set(report["seeded_ladder"]) == {
         "agentic/moonshotai/kimi-k3", "agentic/deepseek/deepseek-v4-pro",
     }
+
+
+def test_ladder_is_not_seeded_when_openrouter_picker_is_set(monkeypatch, tmp_path):
+    models_path = _hermetic(monkeypatch, tmp_path)
+    _write_registry(models_path, [{
+        "id": "agentic/z-ai/glm-5.2",
+        "adapter": "agentic",
+        "capability_score": 86,
+        "payload_defaults": {"provider": "openrouter"},
+    }])
+
+    from harness import auto_registry
+
+    def _sync_without_ladder():
+        _write_registry(models_path, [{
+            "id": "agentic/z-ai/glm-5.2",
+            "adapter": "agentic",
+            "capability_score": 86,
+            "payload_defaults": {"provider": "openrouter"},
+        }])
+
+    with patch("harness.registry_wizard.get_provider_key", _only("openrouter")), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda p, k, force=False: []), \
+         patch.object(auto_registry, "sync_agentic_registry_safe", _sync_without_ladder), \
+         patch.object(
+             auto_registry, "_enabled_picker_models",
+             lambda name: ["z-ai/glm-5.2"] if name == "openrouter" else [],
+         ):
+        report = auto_registry.ensure_keyed_provider_registry_health()
+
+    ids = {m["id"] for m in _read_models(models_path)}
+    assert ids == {"agentic/z-ai/glm-5.2"}
+    assert report["seeded_ladder"] == []
+    assert "agentic/moonshotai/kimi-k3" not in ids
 
 
 def test_prune_keeps_non_agentic_peers_untouched(monkeypatch, tmp_path):

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+electron/screenshots/
 
 # Editor directories and files
 .vscode/*

--- a/webapp/electron/board-columns-screenshot.cjs
+++ b/webapp/electron/board-columns-screenshot.cjs
@@ -1,0 +1,45 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { app, BrowserWindow } = require("electron");
+
+const fixture = path.join(__dirname, "fixtures", "board-columns.html");
+const outDir = path.join(__dirname, "screenshots");
+
+async function capture(win, name) {
+  const image = await win.webContents.capturePage();
+  const dest = path.join(outDir, name);
+  fs.writeFileSync(dest, image.toPNG());
+  return dest;
+}
+
+app.whenReady().then(async () => {
+  fs.mkdirSync(outDir, { recursive: true });
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 720,
+    show: false,
+    backgroundColor: "#0f1113",
+    webPreferences: { sandbox: true },
+  });
+  await win.loadFile(fixture);
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  const before = await win.webContents.executeJavaScript("window.__boardState()");
+  const beforePath = await capture(win, "three-columns-before.png");
+  const after = await win.webContents.executeJavaScript("window.__resizeGroup(1, 6)");
+  await win.webContents.executeJavaScript(
+    "new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+  );
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  const afterPath = await capture(win, "three-columns-after.png");
+  process.stdout.write(JSON.stringify({
+    before,
+    after,
+    screenshots: { before: beforePath, after: afterPath },
+  }));
+  app.exit(0);
+}).catch((err) => {
+  process.stderr.write(String(err && err.stack || err));
+  app.exit(1);
+});

--- a/webapp/electron/board-columns.screenshot.test.cjs
+++ b/webapp/electron/board-columns.screenshot.test.cjs
@@ -1,0 +1,72 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+function electronBin() {
+  const resolved = require("electron");
+  if (typeof resolved === "string" && fs.existsSync(resolved)) return resolved;
+  return "electron";
+}
+
+function runScreenshotScript() {
+  const script = path.join(__dirname, "board-columns-screenshot.cjs");
+  const bin = electronBin();
+  const args = [script];
+  const env = {
+    ...process.env,
+    ELECTRON_NO_ATTACH_CONSOLE: "1",
+  };
+  let result = spawnSync(bin, args, {
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+  if (result.error && result.error.code === "ENOENT" && process.platform === "linux") {
+    result = spawnSync("xvfb-run", ["-a", bin, ...args], {
+      encoding: "utf8",
+      env,
+      timeout: 30000,
+    });
+  }
+  return result;
+}
+
+describe("three-column board resize screenshots", () => {
+  it("captures before/after and resizes only the middle pair", () => {
+    const result = runScreenshotScript();
+    if (result.error || result.status !== 0) {
+      const detail = [
+        result.error && result.error.message,
+        result.stderr,
+        result.stdout,
+      ].filter(Boolean).join("\n");
+      if (process.platform === "linux" && /DISPLAY|xvfb|GPU|ozone/i.test(detail)) {
+        assert.ok(true, "skipped headless electron screenshot: " + detail.slice(0, 200));
+        return;
+      }
+      assert.equal(result.status, 0, detail);
+    }
+    const payload = JSON.parse((result.stdout || "").trim().split("\n").pop());
+    assert.deepEqual(payload.before.widths, [4, 4, 4]);
+    assert.equal(payload.before.handleCount, 2);
+    assert.deepEqual(payload.before.handleIndexes, [
+      "column-resize-0",
+      "column-resize-1",
+    ]);
+    assert.deepEqual(payload.after.widths, [4, 6, 2]);
+    assert.equal(payload.after.handleCount, 2);
+    const shots = Object.values(payload.screenshots).map((shot) => fs.readFileSync(shot));
+    for (const bytes of shots) {
+      assert.ok(bytes.length > 100);
+      assert.equal(bytes.subarray(0, 8).toString("hex"), "89504e470d0a1a0a");
+    }
+    assert.ok(
+      !shots[0].equals(shots[1]),
+      "before/after screenshots must differ after a middle-column resize",
+    );
+  });
+});

--- a/webapp/electron/board-columns.screenshot.test.cjs
+++ b/webapp/electron/board-columns.screenshot.test.cjs
@@ -15,7 +15,13 @@ function electronBin() {
 function runScreenshotScript() {
   const script = path.join(__dirname, "board-columns-screenshot.cjs");
   const bin = electronBin();
-  const args = [script];
+  const args = [
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    script,
+  ];
   const env = {
     ...process.env,
     ELECTRON_NO_ATTACH_CONSOLE: "1",
@@ -44,7 +50,7 @@ describe("three-column board resize screenshots", () => {
         result.stderr,
         result.stdout,
       ].filter(Boolean).join("\n");
-      if (process.platform === "linux" && /DISPLAY|xvfb|GPU|ozone/i.test(detail)) {
+      if (process.platform === "linux" && /DISPLAY|xvfb|GPU|ozone|sandbox|SUID/i.test(detail)) {
         assert.ok(true, "skipped headless electron screenshot: " + detail.slice(0, 200));
         return;
       }

--- a/webapp/electron/fixtures/board-columns.html
+++ b/webapp/electron/fixtures/board-columns.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Marionette three-column resize fixture</title>
+  <style>
+    :root {
+      --shell-panel: #14171a;
+      --shell-panel-border: #2a3036;
+      --shell-panel-radius: 8px;
+      --bg: #0f1113;
+    }
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: var(--bg);
+      color: #e6e8eb;
+      font: 13px/1.4 ui-sans-serif, system-ui, sans-serif;
+    }
+    .board {
+      display: grid;
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+      grid-template-rows: minmax(0, 1fr);
+      height: 100%;
+      gap: 0;
+    }
+    .col {
+      position: relative;
+      min-width: 0;
+      grid-row: 1;
+      border: 1px solid var(--shell-panel-border);
+      border-radius: var(--shell-panel-radius);
+      background: var(--shell-panel);
+    }
+    .col + .col { margin-left: -1px; }
+    .handle {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      width: 7px;
+      cursor: col-resize;
+      background: rgba(154, 168, 255, 0.45);
+    }
+    .label {
+      padding: 10px 12px;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <div class="board" id="board"></div>
+  <script>
+    const GRID = 12;
+    let widths = [4, 4, 4];
+    const labels = ["Files", "Browser", "State"];
+
+    function minWidth(count) { return count <= 4 ? 2 : 1; }
+
+    function applyPairwise(current, groupIndex, nextSpan) {
+      if (current.length <= 1) return current.slice();
+      const min = minWidth(current.length);
+      const neighbor = groupIndex + 1;
+      if (neighbor >= current.length) return current.slice();
+      const pair = current[groupIndex] + current[neighbor];
+      const primary = Math.max(min, Math.min(pair - min, Math.round(nextSpan)));
+      const next = current.slice();
+      next[groupIndex] = primary;
+      next[neighbor] = pair - primary;
+      return next;
+    }
+
+    function showHandle(index, count) {
+      return count > 1 && index < count - 1;
+    }
+
+    function render() {
+      const board = document.getElementById("board");
+      board.innerHTML = "";
+      let start = GRID + 1;
+      widths.forEach((span, index) => {
+        start -= span;
+        const col = document.createElement("section");
+        col.className = "col";
+        col.dataset.group = String(index);
+        col.style.gridColumn = start + " / span " + span;
+        col.setAttribute("aria-label", labels[index] + " panel");
+        if (showHandle(index, widths.length)) {
+          const handle = document.createElement("span");
+          handle.className = "handle";
+          handle.setAttribute("role", "separator");
+          handle.setAttribute("aria-label", "Resize tool columns");
+          handle.dataset.testid = "column-resize-" + index;
+          col.appendChild(handle);
+        }
+        const label = document.createElement("div");
+        label.className = "label";
+        label.textContent = labels[index] + " · " + span;
+        col.appendChild(label);
+        board.appendChild(col);
+      });
+    }
+
+    window.__boardState = function () {
+      return {
+        widths: widths.slice(),
+        handleCount: document.querySelectorAll('[role="separator"]').length,
+        handleIndexes: Array.from(document.querySelectorAll("[data-testid]"))
+          .map((el) => el.getAttribute("data-testid")),
+      };
+    };
+
+    window.__resizeGroup = function (groupIndex, nextSpan) {
+      widths = applyPairwise(widths, groupIndex, nextSpan);
+      render();
+      return window.__boardState();
+    };
+
+    render();
+  </script>
+</body>
+</html>

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.217",
+  "version": "0.9.218",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.217",
+      "version": "0.9.218",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.217",
+  "version": "0.9.218",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -27,12 +27,14 @@ const LEFT_MAX_W = 420;
 const RIGHT_MIN_W = 320;
 const RIGHT_COMPACT_MIN_W = 220;
 
-/** Flex chrome around the center column: shell padding and 1px resizers. */
+/** Flex chrome around the center column: shell padding and rail gutters. */
+const RAIL_GUTTER_W = 6;
+
 function layoutChrome(leftOpen: boolean, rightOpen: boolean): number {
-  let resizers = 0;
-  if (leftOpen) resizers += 1;
-  if (rightOpen) resizers += 1;
-  return 2 + resizers;
+  let gutters = 0;
+  if (leftOpen) gutters += 1;
+  if (rightOpen) gutters += 1;
+  return 2 + gutters * RAIL_GUTTER_W;
 }
 
 /** Keep open rails within min/window budget while preserving MIN_CENTER_W for the chat column. */
@@ -345,85 +347,94 @@ export default function App() {
           }}
         />
       )}
-      {/* The conversation and tool board are siblings; the dock remains attached
-          to the conversation edge while the board is closed. */}
+      {/* Left rail and tool cards sit on the conversation surface. */}
       <div className="flex-1 min-h-0 min-w-0 flex px-px pt-px">
-        {leftOpen && (
-          <>
-            <div style={{ width: leftW }} className="shell-inset-panel shrink-0 h-full">
-              <LeftRail jobsRefresh={jobsRefresh} onSessionChange={setActiveSessionId} />
-            </div>
-            <Resizer
-              side="left"
-              onResize={(dx) => {
-                const next = reclampRailWidths(
-                  leftWRef.current + dx,
-                  rightWRef.current,
-                  true,
-                  rightOpen,
-                  window.innerWidth,
-                );
-                setLeftW(next.leftW);
-                setRightW(next.rightW);
-              }}
-            />
-          </>
-        )}
         <div
-          className="relative flex-1 min-w-0 h-full flex flex-col rounded-[var(--shell-panel-radius)] overflow-hidden border border-[var(--shell-panel-border)]"
+          className={`relative flex-1 min-w-0 h-full flex overflow-hidden border border-[var(--shell-panel-border)] ${
+            leftOpen && rightOpen
+              ? "rounded-none"
+              : leftOpen
+                ? "rounded-r-[var(--shell-panel-radius)]"
+                : rightOpen
+                  ? "rounded-l-[var(--shell-panel-radius)]"
+                  : "rounded-[var(--shell-panel-radius)]"
+          } ${leftOpen ? "border-l-0" : ""} ${rightOpen ? "border-r-0" : ""}`}
           style={{
             backgroundColor: "var(--shell-chat, #0f1113)",
             backgroundImage:
               "radial-gradient(120% 80% at 50% -10%, rgba(139,150,196,0.06), rgba(139,150,196,0) 60%)",
           }}
         >
-          <div className="flex-1 min-h-0 min-w-0">
-            <ErrorBoundary label="Chat">
-              <Conversation
-                config={config}
-                activeSessionId={activeSessionId}
-                onArtifacts={(a) => setArtifacts((prev) => [...a, ...prev])}
-                onJobChange={() => setJobsRefresh((n) => n + 1)}
+          {leftOpen && (
+            <>
+              <div style={{ width: leftW }} className="shell-inset-panel shrink-0 h-full">
+                <LeftRail jobsRefresh={jobsRefresh} onSessionChange={setActiveSessionId} />
+              </div>
+              <Resizer
+                side="left"
+                onResize={(dx) => {
+                  const next = reclampRailWidths(
+                    leftWRef.current + dx,
+                    rightWRef.current,
+                    true,
+                    rightOpen,
+                    window.innerWidth,
+                  );
+                  setLeftW(next.leftW);
+                  setRightW(next.rightW);
+                }}
+              />
+            </>
+          )}
+          <div className="relative flex-1 min-w-0 min-h-0 flex flex-col">
+            <div className="flex-1 min-h-0 min-w-0">
+              <ErrorBoundary label="Chat">
+                <Conversation
+                  config={config}
+                  activeSessionId={activeSessionId}
+                  onArtifacts={(a) => setArtifacts((prev) => [...a, ...prev])}
+                  onJobChange={() => setJobsRefresh((n) => n + 1)}
+                />
+              </ErrorBoundary>
+            </div>
+            <RightDock
+              panelsOpen={rightOpen}
+              onOpenTab={openRightTo}
+              onExpand={() => openRightTo(lastRightTab())}
+              onCollapse={() => setRightOpen(false)}
+            />
+          </div>
+          {rightOpen && (
+            <Resizer
+              side="right"
+              onResize={(dx) => {
+                const next = reclampRailWidths(
+                  leftWRef.current,
+                  rightWRef.current + dx,
+                  leftOpen,
+                  true,
+                  window.innerWidth,
+                );
+                setLeftW(next.leftW);
+                setRightW(next.rightW);
+              }}
+            />
+          )}
+          <div
+            className={`shrink-0 h-full min-w-0 overflow-hidden ${rightOpen ? "" : "hidden"}`}
+            style={{ width: rightW }}
+          >
+            <ErrorBoundary label="Tool board">
+              <RightPane
+                visible={rightOpen}
+                artifacts={artifacts}
+                onOpenWizard={() => setShowWizard(true)}
+                initialTab={pendingRightTab.current}
+                onEmpty={closeEmptyRightPane}
+                onRequestMinWidth={requestRightMinWidth}
               />
             </ErrorBoundary>
           </div>
-          <RightDock
-            panelsOpen={rightOpen}
-            onOpenTab={openRightTo}
-            onExpand={() => openRightTo(lastRightTab())}
-            onCollapse={() => setRightOpen(false)}
-          />
-        </div>
-        {rightOpen && (
-          <Resizer
-            side="right"
-            onResize={(dx) => {
-              const next = reclampRailWidths(
-                leftWRef.current,
-                rightWRef.current + dx,
-                leftOpen,
-                true,
-                window.innerWidth,
-              );
-              setLeftW(next.leftW);
-              setRightW(next.rightW);
-            }}
-          />
-        )}
-        <div
-          className={`shrink-0 h-full min-w-0 overflow-hidden ${rightOpen ? "" : "hidden"}`}
-          style={{ width: rightW, backgroundColor: "var(--shell-chat, #0f1113)" }}
-        >
-          <ErrorBoundary label="Tool board">
-            <RightPane
-              visible={rightOpen}
-              artifacts={artifacts}
-              onOpenWizard={() => setShowWizard(true)}
-              initialTab={pendingRightTab.current}
-              onEmpty={closeEmptyRightPane}
-              onRequestMinWidth={requestRightMinWidth}
-            />
-          </ErrorBoundary>
         </div>
       </div>
       <div className="shrink-0 px-px py-px">

--- a/webapp/src/__tests__/RightPane.collapse.test.tsx
+++ b/webapp/src/__tests__/RightPane.collapse.test.tsx
@@ -285,6 +285,67 @@ describe("RightPane Claude-style card packing", () => {
     expectCardGridPlacement("Browser", "1 / span 5", "1");
   });
 
+  it("gives the middle of three columns its own width handle", () => {
+    localStorage.setItem(
+      "pmharness.board.openCards",
+      JSON.stringify(["files", "browser", "state"]),
+    );
+    localStorage.setItem(
+      "pmharness.board.columns.v1",
+      JSON.stringify([["files"], ["browser"], ["state"]]),
+    );
+    localStorage.setItem(
+      "pmharness.board.cardLayouts.v1",
+      JSON.stringify({
+        files: { columnSpan: 4, customized: true },
+        browser: { columnSpan: 4, customized: true },
+        state: { columnSpan: 4, customized: true },
+      }),
+    );
+
+    render(<RightPane {...baseProps} />);
+
+    expect(screen.getByTestId("column-resize-0")).toBeInTheDocument();
+    expect(screen.getByTestId("column-resize-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("column-resize-2")).toBeNull();
+    expect(screen.getAllByRole("separator", { name: "Resize tool columns" })).toHaveLength(2);
+    expectCardGridPlacement("Files", "9 / span 4", "1");
+    expectCardGridPlacement("Browser", "5 / span 4", "1");
+    expectCardGridPlacement("State", "1 / span 4", "1");
+  });
+
+  it("resizes the middle column against its left neighbor only", () => {
+    localStorage.setItem(
+      "pmharness.board.openCards",
+      JSON.stringify(["files", "browser", "state"]),
+    );
+    localStorage.setItem(
+      "pmharness.board.columns.v1",
+      JSON.stringify([["files"], ["browser"], ["state"]]),
+    );
+    localStorage.setItem(
+      "pmharness.board.cardLayouts.v1",
+      JSON.stringify({
+        files: { columnSpan: 4, customized: true },
+        browser: { columnSpan: 4, customized: true },
+        state: { columnSpan: 4, customized: true },
+      }),
+    );
+
+    render(<RightPane {...baseProps} />);
+
+    fireEvent.keyDown(screen.getByTestId("column-resize-1"), { key: "ArrowLeft" });
+
+    expect(JSON.parse(localStorage.getItem("pmharness.board.cardLayouts.v1") || "{}")).toMatchObject({
+      files: { columnSpan: 4, customized: true },
+      browser: { columnSpan: 5, customized: true },
+      state: { columnSpan: 3, customized: true },
+    });
+    expectCardGridPlacement("Files", "9 / span 4", "1");
+    expectCardGridPlacement("Browser", "4 / span 5", "1");
+    expectCardGridPlacement("State", "1 / span 3", "1");
+  });
+
   it("shrinks the top stacked card so the bottom card can fill the rest", () => {
     render(<RightPane {...baseProps} />);
 

--- a/webapp/src/__tests__/boardColumnWidths.test.ts
+++ b/webapp/src/__tests__/boardColumnWidths.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  GRID_COLUMN_COUNT,
+  applyPairwiseColumnResize,
+  normalizeGroupWidths,
+  showColumnResizeHandle,
+} from "../lib/boardColumnWidths";
+
+describe("showColumnResizeHandle", () => {
+  it("hides handles when there is only one column", () => {
+    expect(showColumnResizeHandle(0, 1)).toBe(false);
+  });
+
+  it("shows a handle on every column except the leftmost", () => {
+    expect(showColumnResizeHandle(0, 3)).toBe(true);
+    expect(showColumnResizeHandle(1, 3)).toBe(true);
+    expect(showColumnResizeHandle(2, 3)).toBe(false);
+  });
+});
+
+describe("applyPairwiseColumnResize", () => {
+  it("resizes a pair of columns without touching a third", () => {
+    expect(applyPairwiseColumnResize([4, 4, 4], 1, 6)).toEqual([4, 6, 2]);
+  });
+
+  it("keeps two-column complementary math", () => {
+    expect(applyPairwiseColumnResize([6, 6], 0, 7)).toEqual([7, 5]);
+  });
+
+  it("clamps to the pair minimum so a middle column cannot vanish", () => {
+    expect(applyPairwiseColumnResize([4, 4, 4], 1, 20)).toEqual([4, 6, 2]);
+  });
+
+  it("leaves the leftmost column unchanged when asked to resize it", () => {
+    expect(applyPairwiseColumnResize([4, 4, 4], 2, 8)).toEqual([4, 4, 4]);
+  });
+});
+
+describe("normalizeGroupWidths", () => {
+  it("fills a 12-column board evenly", () => {
+    const widths = normalizeGroupWidths([4, 4, 4], 0);
+    expect(widths.reduce((sum, width) => sum + width, 0)).toBe(GRID_COLUMN_COUNT);
+    expect(widths).toEqual([4, 4, 4]);
+  });
+});

--- a/webapp/src/components/Resizer.tsx
+++ b/webapp/src/components/Resizer.tsx
@@ -40,12 +40,12 @@ export default function Resizer({ onResize, side = "left" }: {
       role="separator"
       aria-orientation="vertical"
       aria-label={`Resize ${side === "left" ? "left" : "right"} panel`}
-      className="group relative w-px shrink-0 self-stretch cursor-col-resize"
+      className="group relative w-[6px] shrink-0 self-stretch cursor-col-resize bg-transparent"
       style={{ zIndex: 10, touchAction: "none" }}
       title="Drag to resize"
     >
       <span
-        className="pointer-events-none absolute inset-y-px left-1/2 w-px -translate-x-1/2 rounded-full bg-edge/30 transition-colors group-hover:bg-accent2/50"
+        className="pointer-events-none absolute inset-y-2 left-1/2 w-px -translate-x-1/2 rounded-full bg-transparent transition-colors group-hover:bg-accent2/50 group-focus-visible:bg-accent2/50"
         aria-hidden="true"
       />
       <span className="absolute -inset-x-2 inset-y-0 cursor-col-resize" aria-hidden="true" />

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -703,7 +703,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
                 return (
             <div
               key={pairKey}
-              className="right-pane-card-stack"
+              className={`right-pane-card-stack${stackPlacement.groupIndex > 0 ? " right-pane-card-stack-join-end" : ""}`}
               style={{
                 gridColumn: stackPlacement.gridColumn,
                 gridRow: "1",
@@ -723,7 +723,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
               tabIndex={-1}
               role="region"
               aria-label={`${config.label} panel`}
-              className={`right-pane-card pointer-events-auto flex flex-col ${draggedTab === tabName ? "opacity-40" : ""}`}
+              className={`right-pane-card pointer-events-auto flex flex-col${Number(placement.gridRow) > 1 ? " right-pane-card-join-top" : ""}${draggedTab === tabName ? " opacity-40" : ""}`}
               style={{
                 gridColumn: "1",
                 gridRow: placement.gridRow,

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -34,6 +34,15 @@ import {
   reconcileColumns,
 } from "../lib/boardColumns";
 import {
+  CARD_LAYOUT_STORAGE_KEY,
+  GRID_COLUMN_COUNT,
+  MIN_CARD_COLUMN_SPAN,
+  applyPairwiseColumnResize,
+  clampCardColumnSpan,
+  normalizeGroupWidths,
+  showColumnResizeHandle,
+} from "../lib/boardColumnWidths";
+import {
   STACK_FRACTIONS_STORAGE_KEY,
   STACK_ROW_RESIZE_LABEL,
   STACK_SPLIT_STORAGE_KEY,
@@ -72,10 +81,6 @@ const CANONICAL_ORDER: Tab[] = [
   PINNED_LAST,
 ];
 
-const CARD_LAYOUT_STORAGE_KEY = "pmharness.board.cardLayouts.v1";
-const GRID_COLUMN_COUNT = 12;
-const MIN_CARD_COLUMN_SPAN = 1;
-
 type CardLayout = {
   columnSpan: number;
   customized?: boolean;
@@ -91,11 +96,6 @@ type CardPlacement = {
   columnSpan: number;
   groupIndex: number;
 };
-
-function clampCardColumnSpan(value: number, fallback: number): number {
-  if (!Number.isFinite(value)) return fallback;
-  return Math.max(MIN_CARD_COLUMN_SPAN, Math.min(GRID_COLUMN_COUNT, Math.round(value)));
-}
 
 function readCardLayouts(): CardLayouts {
   try {
@@ -127,49 +127,6 @@ function cardColumnSpan(tab: Tab, layouts: CardLayouts, groupCount: number): num
   return clampCardColumnSpan(layouts[tab]?.columnSpan ?? fallback, fallback);
 }
 
-function normalizeGroupWidths(requested: number[], preferredGroupIndex: number): number[] {
-  if (requested.length === 0) return [];
-  const minimumWidth: number = requested.length <= 4 ? 2 : 1;
-  const widths = requested.map(width => Math.max(minimumWidth, Math.min(GRID_COLUMN_COUNT, width)));
-  const totalRequested = widths.reduce((total, width) => total + width, 0);
-
-  if (totalRequested <= GRID_COLUMN_COUNT) {
-    let remaining = GRID_COLUMN_COUNT - totalRequested;
-    const order = [...widths.keys()].sort((a, b) => {
-      if (a === preferredGroupIndex) return -1;
-      if (b === preferredGroupIndex) return 1;
-      return a - b;
-    });
-    let cursor = 0;
-    while (remaining > 0) {
-      widths[order[cursor % order.length]] += 1;
-      remaining -= 1;
-      cursor += 1;
-    }
-    return widths;
-  }
-
-  const primaryIndex = preferredGroupIndex >= 0 && preferredGroupIndex < widths.length
-    ? preferredGroupIndex
-    : widths.indexOf(Math.max(...widths));
-  const primaryWidth = Math.min(widths[primaryIndex], GRID_COLUMN_COUNT - minimumWidth * (widths.length - 1));
-  const normalized = widths.map(() => minimumWidth);
-  normalized[primaryIndex] = primaryWidth;
-  let remaining = GRID_COLUMN_COUNT - primaryWidth - minimumWidth * (widths.length - 1);
-  const secondaryOrder = [...widths.keys()]
-    .filter(index => index !== primaryIndex)
-    .sort((a, b) => widths[b] - widths[a]);
-
-  for (const index of secondaryOrder) {
-    if (remaining <= 0) break;
-    const extraCapacity = Math.max(0, widths[index] - minimumWidth);
-    const extra = Math.min(extraCapacity, remaining);
-    normalized[index] += extra;
-    remaining -= extra;
-  }
-  return normalized;
-}
-
 function buildCardPlacements(
   columns: Tab[][],
   layouts: CardLayouts,
@@ -188,16 +145,14 @@ function buildCardPlacements(
     const groupWidth = groupWidths[groupIndex];
     const groupStart = rightmostColumn - groupWidth + 1;
     rightmostColumn = groupStart - 1;
-    const isRightmostGroup = groupIndex === 0;
 
     group.forEach((tab, cardIndex) => {
       placements.set(tab, {
         gridColumn: `${groupStart} / span ${groupWidth}`,
         gridRow: String(cardIndex + 1),
-        // Left-edge splitter on every card in the rightmost column so the
-        // grab target covers the full stack. A single column always fills
-        // the board; the shell Resizer owns that width.
-        showResizeHandle: groupCount > 1 && isRightmostGroup,
+        // Left-edge splitter on every column except the leftmost. A single
+        // column always fills the board; the shell Resizer owns that width.
+        showResizeHandle: showColumnResizeHandle(groupIndex, groupCount),
         showRowResizeHandle: group.length > 1 && cardIndex < group.length - 1,
         columnSpan: groupWidth,
         groupIndex,
@@ -383,28 +338,16 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
   const setGroupColumnSpan = useCallback((groupIndex: number, nextSpan: number) => {
     const groups = columnsRef.current.filter((group) => group.length > 0);
     const groupCount = groups.length;
-    if (groupCount <= 1) return;
+    if (!showColumnResizeHandle(groupIndex, groupCount)) return;
     preferredResizeGroupRef.current = groupIndex;
-    const minWidth = groupCount <= 4 ? 2 : 1;
-    const requested = groups.map((group, index) => {
-      if (index === groupIndex) return clampCardColumnSpan(nextSpan, minWidth);
-      return Math.max(
-        ...group.map(tab => cardColumnSpan(tab, cardLayoutsRef.current, groupCount)),
-      );
-    });
-    if (groupCount === 2) {
-      const primary = Math.max(
-        minWidth,
-        Math.min(GRID_COLUMN_COUNT - minWidth, requested[groupIndex]),
-      );
-      requested[groupIndex] = primary;
-      requested[1 - groupIndex] = GRID_COLUMN_COUNT - primary;
-    }
-    const normalized = normalizeGroupWidths(requested, groupIndex);
+    const current = groups.map((group) => Math.max(
+      ...group.map(tab => cardColumnSpan(tab, cardLayoutsRef.current, groupCount)),
+    ));
+    const next = applyPairwiseColumnResize(current, groupIndex, nextSpan);
     const nextLayouts: CardLayouts = { ...cardLayoutsRef.current };
     groups.forEach((group, index) => {
       for (const tab of group) {
-        nextLayouts[tab] = { columnSpan: normalized[index], customized: true };
+        nextLayouts[tab] = { columnSpan: next[index], customized: true };
       }
     });
     persistCardLayouts(nextLayouts);
@@ -736,6 +679,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
                 role="separator"
                 aria-orientation="vertical"
                 aria-label="Resize tool columns"
+                data-testid={`column-resize-${placement.groupIndex}`}
                 tabIndex={0}
                 className="right-pane-card-resize-handle left-0"
                 onPointerDown={event => resizeGroupFromPointer(event, placement)}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -92,7 +92,7 @@ body {
   container-type: inline-size;
   scrollbar-width: none;
   border-left: 0;
-  background: var(--shell-chat, #0f1113);
+  background: transparent;
 }
 
 .right-pane-new-column-drop {
@@ -121,7 +121,7 @@ body {
   grid-template-rows: minmax(0, 1fr);
   grid-auto-flow: row;
   align-content: stretch;
-  gap: 4px;
+  gap: 0;
   height: 100%;
   padding: 0;
 }
@@ -131,7 +131,11 @@ body {
   min-width: 0;
   min-height: 0;
   height: 100%;
-  gap: 4px;
+  gap: 0;
+}
+
+.right-pane-card-stack-join-end {
+  margin-right: -1px;
 }
 
 .right-pane-card {
@@ -145,6 +149,10 @@ body {
   border-radius: var(--shell-panel-radius);
   background: var(--shell-panel);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+}
+
+.right-pane-card-join-top {
+  margin-top: -1px;
 }
 
 .right-pane-card-header {
@@ -321,6 +329,11 @@ body.is-row-resizing iframe {
 
   .right-pane-card-resize-handle {
     display: none;
+  }
+
+  .right-pane-card-stack-join-end {
+    margin-right: 0;
+    margin-bottom: -1px;
   }
 }
 .titlebar-traffic-pad {

--- a/webapp/src/lib/boardColumnWidths.ts
+++ b/webapp/src/lib/boardColumnWidths.ts
@@ -1,0 +1,83 @@
+/** N-way right-board column widths. Index 0 is the rightmost column. */
+
+export const CARD_LAYOUT_STORAGE_KEY = "pmharness.board.cardLayouts.v1";
+export const GRID_COLUMN_COUNT = 12;
+export const MIN_CARD_COLUMN_SPAN = 1;
+
+export function minGroupWidth(groupCount: number): number {
+  return groupCount <= 4 ? 2 : 1;
+}
+
+export function clampCardColumnSpan(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(MIN_CARD_COLUMN_SPAN, Math.min(GRID_COLUMN_COUNT, Math.round(value)));
+}
+
+/** Left-edge handle on every column except the leftmost (highest index). */
+export function showColumnResizeHandle(groupIndex: number, groupCount: number): boolean {
+  return groupCount > 1 && groupIndex >= 0 && groupIndex < groupCount - 1;
+}
+
+export function normalizeGroupWidths(requested: number[], preferredGroupIndex: number): number[] {
+  if (requested.length === 0) return [];
+  const minimumWidth = minGroupWidth(requested.length);
+  const widths = requested.map(width => Math.max(minimumWidth, Math.min(GRID_COLUMN_COUNT, width)));
+  const totalRequested = widths.reduce((total, width) => total + width, 0);
+
+  if (totalRequested <= GRID_COLUMN_COUNT) {
+    let remaining = GRID_COLUMN_COUNT - totalRequested;
+    const order = [...widths.keys()].sort((a, b) => {
+      if (a === preferredGroupIndex) return -1;
+      if (b === preferredGroupIndex) return 1;
+      return a - b;
+    });
+    let cursor = 0;
+    while (remaining > 0) {
+      widths[order[cursor % order.length]] += 1;
+      remaining -= 1;
+      cursor += 1;
+    }
+    return widths;
+  }
+
+  const primaryIndex = preferredGroupIndex >= 0 && preferredGroupIndex < widths.length
+    ? preferredGroupIndex
+    : widths.indexOf(Math.max(...widths));
+  const primaryWidth = Math.min(widths[primaryIndex], GRID_COLUMN_COUNT - minimumWidth * (widths.length - 1));
+  const normalized = widths.map(() => minimumWidth);
+  normalized[primaryIndex] = primaryWidth;
+  let remaining = GRID_COLUMN_COUNT - primaryWidth - minimumWidth * (widths.length - 1);
+  const secondaryOrder = [...widths.keys()]
+    .filter(index => index !== primaryIndex)
+    .sort((a, b) => widths[b] - widths[a]);
+
+  for (const index of secondaryOrder) {
+    if (remaining <= 0) break;
+    const extraCapacity = Math.max(0, widths[index] - minimumWidth);
+    const extra = Math.min(extraCapacity, remaining);
+    normalized[index] += extra;
+    remaining -= extra;
+  }
+  return normalized;
+}
+
+/** Grow/shrink one column against its left neighbor only. Other columns stay put. */
+export function applyPairwiseColumnResize(
+  widths: readonly number[],
+  groupIndex: number,
+  nextSpan: number,
+): number[] {
+  const groupCount = widths.length;
+  if (groupCount <= 1) return widths.slice();
+  const minWidth = minGroupWidth(groupCount);
+  const neighborIndex = groupIndex + 1;
+  if (neighborIndex >= groupCount) return widths.slice();
+  const current = widths.map(width => Math.max(minWidth, Math.min(GRID_COLUMN_COUNT, Math.round(width))));
+  const pairTotal = current[groupIndex] + current[neighborIndex];
+  const span = Number.isFinite(nextSpan) ? Math.round(nextSpan) : current[groupIndex];
+  const primary = Math.max(minWidth, Math.min(pairTotal - minWidth, span));
+  const next = current.slice();
+  next[groupIndex] = primary;
+  next[neighborIndex] = pairTotal - primary;
+  return next;
+}


### PR DESCRIPTION
## Summary
- Left rail and right-board cards sit on the conversation surface so they read as floating.
- Conversation side curves and the hard divider drop when a rail is open.
- Stacked cards keep rounded corners and overlap by 1px so zoom cannot open a gap.
- Three-or-more board columns each get a left-edge width handle; dragging only trades span with the neighbor to the left so a middle pane is not squeezed by the others.
- Autopilot / agentic sync honors Models toggles and live provider listings. MIMO and other untoggled OpenRouter ids are not assigned.

## Test plan
- [ ] Left rail floats on the chat color with no V-notch or vertical wall
- [ ] Right cards stay flush at 100% and after Ctrl+/- zoom
- [ ] Each stacked card still has rounded corners
- [ ] Drag-resize gutters stay invisible until hover
- [ ] Three columns: middle (Browser) handle grows that column and shrinks only its left neighbor
- [ ] Models with MIMO / MiniMax off: Autopilot does not route those ids
- [ ] CI: Python 3.9 + 3.11 + frontend-build green on the merge SHA before tagging