### PR TITLE
Release v0.9.219: keys-only full stack and loop hygiene

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -398,9 +398,10 @@ synthesis of wiki pages from session output, accumulating reusable project
 knowledge over time. Paired with the skill store, this is how the harness
 learns from its own runs instead of starting cold each time.
 
-## 10. Non-goals (v1, internal-first)
+## 10. Non-goals (v1)
 
-- Not Cursor parity. Not a model-training pipeline. Not public.
+- Not Cursor parity. Not a model-training pipeline. Public path is GitHub
+  install plus one Full stack Settings key.
 - Vision sidecar uses a frontier VLM as a stand-in; swapping an open VLM
   (GLM-OCR / Kimi-VL / Qwen-VL) is a config change, not a redesign.
 - The "no black box" enterprise claim requires self-hosted open weights; the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,6 +26,10 @@ explicit:
   `route_task`, …) are tools the pilot calls; they are not a separate product
   loop.
 
+Default execution is keys-only: the agentic adapter runs pilots and workers
+against whatever Full stack Settings credential the user pasted. Platform CLIs
+(Cursor, Claude Code, Codex CLI) are opt-in via Settings, not a requirement.
+
 Two consequences of that lane-B framing:
 
 - **Any model can drive.** Hot-swap the pilot by task. A cheap open-weights

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Marionette
 
-Welcome. This is an internal-first research rig + Electron desktop app. These are
+Welcome. This is the Marionette desktop app plus its research/eval rig. These are
 the conventions that keep the codebase coherent -- please follow them.
 
 ## Ground rules (non-negotiable)

--- a/DEMO.md
+++ b/DEMO.md
@@ -31,8 +31,8 @@ open weights and the black box disappears.
   data stays in-network, needs GPUs) OR a hosted open-weights provider (cheap,
   but data leaves your network). Same architecture, different trade-off. Say
   which one you mean.
-- This is internal-first and deliberately v0.x. It is not Cursor parity and not
-  a public product. It is a working proof that the inversion holds.
+- This is deliberately v0.x, not Cursor parity. The public path is GitHub
+  install plus one Full stack Settings key — no Cursor or other CLI required.
 
 ## The receipt (why a cheap open model is enough)
 
@@ -108,7 +108,7 @@ Prereqts: an OpenRouter key in OPENROUTER_API_KEY (or use the no-key stub).
 
 ## What it is NOT (yet)
 
-- Not Cursor parity. Not public. Not a model-training pipeline.
+- Not Cursor parity. Not a model-training pipeline. Public path is install plus a Full stack key.
 - The vision sidecar default is a frontier stand-in unless you set the open VLM
   env; both are one flag apart.
 - The eval ranks competent-vs-lazy drivers; splitting the very top tier would

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.2` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.218, deliberately pre-1.0. Left rail and tool cards sit on the conversation surface so they read as floating; n-way board columns resize pairwise so a middle pane is not squeezed by its neighbors; Autopilot only routes models the live catalog and Models toggles actually allow. Rides puppetmaster-ai==1.22.2. Cursor CLI / `CURSOR_API_KEY` remain optional upgrades (Pilot only / platform workers).
+> Status: v0.9.219, deliberately pre-1.0. One Full stack Settings key runs both chat and agentic workers; loop hygiene now reminds on identical tool repeats, times out hanging network tools, and refuses unpaired compaction cuts. Rides puppetmaster-ai==1.22.2. Cursor CLI / `CURSOR_API_KEY` remain optional upgrades (Pilot only / platform workers).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Marionette
 
 A desktop AI coding harness where the LLM is a **component inside** the kernel,
-not the platform. Marionette drives any model -- frontier or cheap open-weights --
-through a structured pilot loop over [Puppetmaster](https://github.com/professorpalmer/Puppetmaster)
-durable state, with CodeGraph-aware retrieval, a portable cross-session knowledge
-wiki, and multi-worker delegation.
+not the platform. Install from GitHub, paste any Full stack API key in Settings
+(OpenRouter, Anthropic, OpenAI, Gemini, Bedrock, Codex OAuth, OpenCode Go, …),
+and both the chat **pilot** and agentic **workers** (swarm / implement) run on
+that credential. No Cursor, Claude, or Codex CLI install is required.
 
-Internal-first research rig and daily-driver app. stdlib-only backend (urllib +
-sqlite); Puppetmaster is the one real dependency, installed editable from a local
-checkout.
+Puppetmaster is the bundled kernel — not a second product to set up.
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.2` is the one
+real dependency the installer puts in the venv.
 
-> Status: v0.9.218, deliberately pre-1.0. Left rail and tool cards sit on the conversation surface so they read as floating; n-way board columns resize pairwise so a middle pane is not squeezed by its neighbors; Autopilot only routes models the live catalog and Models toggles actually allow. Rides puppetmaster-ai==1.22.2.
+> Status: v0.9.218, deliberately pre-1.0. Left rail and tool cards sit on the conversation surface so they read as floating; n-way board columns resize pairwise so a middle pane is not squeezed by its neighbors; Autopilot only routes models the live catalog and Models toggles actually allow. Rides puppetmaster-ai==1.22.2. Cursor CLI / `CURSOR_API_KEY` remain optional upgrades (Pilot only / platform workers).
 
 ## Documentation
 
@@ -236,7 +236,7 @@ The driver and keys are set in the app (Settings pane) or via env. Key vars:
 
 | Env var | Purpose |
 |---|---|
-| `OPENROUTER_API_KEY` | Default reach: the whole field through one endpoint. |
+| `OPENROUTER_API_KEY` | Default Full stack key: chat pilot and agentic workers through one endpoint. No other platform required. |
 | `GEMINI_API_KEY` | Optional dedicated vision key. Not required -- vision also falls back to any provider key you already have that exposes a vision model. |
 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_BEARER_TOKEN_BEDROCK` | AWS Bedrock BYOK (Settings can also load `~/.aws`). Pilots and agentic swarms use Converse + ConverseStream (live thinking/tool/text deltas); model pickers discover the account allow-list; prompt-cache hits feed the same token/cost/`cache_savings_usd` meters as Anthropic/OpenRouter. |
 | `HARNESS_VLM_REACH` / `HARNESS_VLM_MODEL` | Explicit vision-sidecar override (e.g. `openrouter` for an open VLM) and its model. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.218"
+__version__ = "0.9.219"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/settings.py
+++ b/harness/api/settings.py
@@ -34,14 +34,16 @@ def get_config(svc: SettingsServices) -> tuple[int, JsonPayload]:
     cfg = svc.cfg
     session = svc.get_session()
     try:
-        from ..edit_engines import pilot_keys_ready, select_edit_engine
+        from ..edit_engines import pilot_keys_ready, select_edit_engine, workers_ready
         edit_engine = select_edit_engine(cfg)
-        # UI keyless-banner signal: any keyed harness pilot (incl. OpenCode Go /
-        # Codex). Distinct from agentic_available(), which only covers
-        # Puppetmaster's agentic worker registry.
-        agentic_ready = pilot_keys_ready()
+        # workers_ready / agentic_ready: Full stack key or CURSOR_API_KEY — the
+        # banner that claims swarms can run. pilot_ready is the broader chat
+        # lane (includes Pilot-only cursor-cli login).
+        workers = workers_ready()
+        pilot = pilot_keys_ready()
+        agentic_ready = workers
     except Exception:
-        edit_engine, agentic_ready = "native", False
+        edit_engine, agentic_ready, workers, pilot = "native", False, False, False
     try:
         from ..reasoning_effort import current_reasoning_effort
         reasoning_effort = current_reasoning_effort()
@@ -58,6 +60,8 @@ def get_config(svc: SettingsServices) -> tuple[int, JsonPayload]:
         "swarm_adapter": cfg.swarm_adapter,
         "edit_engine": edit_engine,
         "agentic_ready": agentic_ready,
+        "workers_ready": workers,
+        "pilot_ready": pilot,
         "preflight": session.preflight(),
         "reasoning_effort": reasoning_effort,
         "package_version": identity.get("package_version", ""),

--- a/harness/auto_registry.py
+++ b/harness/auto_registry.py
@@ -342,17 +342,6 @@ def _promote_openrouter_snapshots(
     return promoted
 
 
-def _has_picker_curation() -> bool:
-    """True when Settings -> Models has any enabled spec for an agentic provider.
-
-    Uses ``_enabled_picker_models`` so tests that patch that helper stay hermetic.
-    """
-    names = set(_CURATED_MODELS)
-    names.update(_AGENTIC_PROVIDER_SLUGS.keys())
-    names.update(_AGENTIC_PROVIDER_SLUGS.values())
-    return any(_enabled_picker_models(name) for name in names)
-
-
 def _in_live_catalog(name: str, slug: str, live_models: list[str]) -> bool:
     """True when *name* or *slug* is in the live listing, including dated siblings."""
     if not live_models:
@@ -440,8 +429,8 @@ def _get_provider_models_from_discovery(
                 ]
             return selected
 
-        if _has_picker_curation():
-            return []
+        # Per-provider only: another provider's Models toggles must not empty
+        # this keyed Full stack catalog. Fall through to curated ∩ live.
 
         # Try live discovery
         live_models = fetch_models(provider, provider_key, force=force)

--- a/harness/compaction_mixin.py
+++ b/harness/compaction_mixin.py
@@ -285,32 +285,21 @@ class CompactionContextMixin:
         return heuristic
 
     def _find_safe_split(self, start_idx: int) -> int:
-        split_idx = start_idx
-        if split_idx < 2:
-            split_idx = 2
+        """Move ``start_idx`` to a cut that does not break tool pairing.
 
-        while split_idx < len(self._history):
-            middle_tool_calls = set()
-            for msg in self._history[1:split_idx]:
-                if msg.get("tool_calls"):
-                    for tc in msg["tool_calls"]:
-                        if tc.get("id"):
-                            middle_tool_calls.add(tc["id"])
+        Keeps the id-based orphan-in-kept check and additionally requires
+        in-progress tool-call count == 0 at the cut (DeepSeek pairing balance).
+        Mid-turn unanswered calls stay in the tail rather than the summary.
+        """
+        from .tool_pairing import nearest_balanced_split, orphan_tool_result_in_kept
 
-            has_orphaned = False
-            for msg in self._history[split_idx:]:
-                if msg.get("role") == "tool":
-                    tc_id = msg.get("tool_call_id")
-                    if tc_id in middle_tool_calls:
-                        has_orphaned = True
-                        break
-
-            if not has_orphaned:
-                break
-
-            split_idx += 1
-
-        return split_idx
+        history = self._history
+        return nearest_balanced_split(
+            history,
+            start_idx,
+            min_idx=2,
+            orphan_in_kept=lambda idx: orphan_tool_result_in_kept(history, idx),
+        )
 
     def _set_compaction_attempt(self, reason: str, **extra) -> None:
         """Record the latest compaction attempt outcome (diagnostic; never raises)."""

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -584,6 +584,7 @@ class ConversationalSession(
             )
         # workspace rules (auto-loaded from repository if available)
         ws_rules = load_workspace_rules(config.repo)
+        self._workspace_rules_block = ws_rules or ""
         if ws_rules:
             system = system + ws_rules
         # the running transcript with the pilot (conversation memory)
@@ -848,6 +849,7 @@ class ConversationalSession(
         # Cleared on fresh user messages; preserved across model steps and
         # keep-alive resume for the same originating turn.
         self._turn_guard_state = None
+        self._repeat_tool_chain = None
         self._stagnation_last_prose = None
         self._stagnation_last_actions = None
         self._stagnation_streak = 0
@@ -2560,6 +2562,13 @@ class ConversationalSession(
                 read_path = str(act.path)
         except Exception:
             read_path = None
+
+        try:
+            from .repeat_tool_reminder import note_repeat_and_maybe_nudge
+
+            clamped_content = note_repeat_and_maybe_nudge(self, act, clamped_content)
+        except Exception:
+            pass
 
         if is_native:
             msg = {"role": "tool", "tool_call_id": tc_id, "content": clamped_content}

--- a/harness/edit_engines.py
+++ b/harness/edit_engines.py
@@ -188,28 +188,64 @@ def cursor_platform_available() -> bool:
         return bool(os.environ.get("CURSOR_API_KEY", "").strip())
 
 
+def _provider_has_usable_key(provider) -> bool:
+    """Stored / env / OAuth key present and not disconnected (``has_key`` truth)."""
+    from harness.registry_wizard import get_provider_key
+    from harness.keys import get_api_key_status
+
+    status = get_api_key_status(provider.name)
+    return (get_provider_key(provider) is not None) or bool(status.get("has_key"))
+
+
+def workers_ready() -> bool:
+    """True when swarm/implement workers can run without a platform CLI install.
+
+    Full stack Settings auths (OpenRouter, Codex OAuth, …) drive the agentic
+    adapter. ``CURSOR_API_KEY`` is an optional platform-worker upgrade.
+    cursor-cli agent login does **not** count — that path is Pilot only.
+    """
+    if cursor_platform_available():
+        return True
+    try:
+        from harness.provider_capabilities import worker_capability
+        from harness.registry_wizard import PROVIDERS
+        from harness.keys import get_disconnected
+
+        disconnected = get_disconnected()
+        for p in PROVIDERS:
+            if p.name in disconnected:
+                continue
+            if worker_capability(p.name) != "full_stack":
+                continue
+            if _provider_has_usable_key(p):
+                return True
+        return False
+    except Exception as exc:
+        _diag("edit_engines.workers_ready", exc)
+        return agentic_available() or cursor_platform_available()
+
+
 def pilot_keys_ready() -> bool:
     """True when Marionette has at least one usable keyed harness provider.
 
-    Powers ``/api/config`` ``agentic_ready`` (the ProviderKeyBanner gate). Broader
-    than :func:`agentic_available`: a keyed OpenCode Go or Codex OAuth pilot is
-    enough to dismiss the keyless nudge, without claiming Puppetmaster agentic
-    workers can run on those providers.
+    Chat-lane signal (``/api/config`` ``pilot_ready``). Broader than
+    :func:`workers_ready`: a cursor-cli agent login counts here, but does not
+    make agentic workers runnable. Use :func:`workers_ready` for the banner
+    that claims swarms can run.
 
     Authoritative semantics match ``GET /api/providers`` ``has_key``: stored keys,
     env keys, and credential-pool OAuth (ChatGPT Codex) all count, and explicit
     disconnects hide a provider even when its key remains on disk / in the shell.
     """
     try:
-        from harness.registry_wizard import PROVIDERS, get_provider_key
-        from harness.keys import get_api_key_status, get_disconnected
+        from harness.registry_wizard import PROVIDERS
+        from harness.keys import get_disconnected
 
         disconnected = get_disconnected()
         for p in PROVIDERS:
             if p.name in disconnected:
                 continue
-            status = get_api_key_status(p.name)
-            if (get_provider_key(p) is not None) or status.get("has_key"):
+            if _provider_has_usable_key(p):
                 return True
         return False
     except Exception as exc:

--- a/harness/log_reconstruction.py
+++ b/harness/log_reconstruction.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+"""Cheap outbound-request honesty check.
+
+DeepSeek's agent-loop invariant: a frozen request must match
+``deriveMessages()`` plus folded headers. Marionette has no
+``deriveMessages``; the equivalent is the just-built
+``_messages_for_provider()`` payload versus a rebuild from the already
+sanitized history (``_elide_stale_reads(history[1:])``) plus the system
+prompt passed to ``pilot.chat`` / ``chat_stream``.
+
+The check must not call ``_messages_for_provider`` again — that seam
+sanitizes and is counted once per dispatch. Mismatch is logged and never
+fails the turn.
+"""
+
+import json
+from typing import Any, Optional
+
+
+def _canon_messages(messages: Any) -> str:
+    if not isinstance(messages, list):
+        return ""
+    slim = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            slim.append(str(msg))
+            continue
+        row = {
+            "role": msg.get("role"),
+            "content": msg.get("content"),
+        }
+        if msg.get("tool_call_id"):
+            row["tool_call_id"] = msg.get("tool_call_id")
+        if msg.get("tool_calls"):
+            row["tool_calls"] = msg.get("tool_calls")
+        slim.append(row)
+    return json.dumps(slim, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def _rebuild_from_history(session: Any, outbound: Any) -> Any:
+    history = getattr(session, "_history", None)
+    elide = getattr(session, "_elide_stale_reads", None)
+    if callable(elide) and isinstance(history, list) and history:
+        return elide(history[1:])
+    return outbound
+
+
+def check_outbound_reconstruction(
+    session: Any,
+    outbound: Any,
+    sys_prompt: Optional[str] = None,
+) -> bool:
+    """Compare the about-to-send payload to a fresh history rebuild.
+
+    Returns True when honest (or when the check itself fails). Returns False
+    on a logged mismatch. Never raises into the turn.
+    """
+    try:
+        rebuild = _rebuild_from_history(session, outbound)
+        if _canon_messages(outbound) != _canon_messages(rebuild):
+            try:
+                from .diag import note as _diag_note
+
+                _diag_note(
+                    "log_reconstruction.messages",
+                    "outbound messages diverge from sanitized history",
+                )
+            except Exception:
+                pass
+            session._last_log_reconstruction = {
+                "ok": False,
+                "reason": "messages",
+            }
+            return False
+
+        append_only = bool(getattr(session, "_append_only", False))
+        frozen = getattr(session, "_frozen_system_prompt", None)
+        if (
+            append_only
+            and isinstance(frozen, str)
+            and sys_prompt is not None
+            and sys_prompt != frozen
+        ):
+            try:
+                from .diag import note as _diag_note
+
+                _diag_note(
+                    "log_reconstruction.system",
+                    "append-only system prompt diverges from the frozen header",
+                )
+            except Exception:
+                pass
+            session._last_log_reconstruction = {
+                "ok": False,
+                "reason": "system",
+            }
+            return False
+
+        session._last_log_reconstruction = {"ok": True, "reason": ""}
+        return True
+    except Exception:
+        try:
+            session._last_log_reconstruction = {"ok": True, "reason": "skipped"}
+        except Exception:
+            pass
+        return True

--- a/harness/provider_capabilities.py
+++ b/harness/provider_capabilities.py
@@ -70,7 +70,8 @@ def capability_hint(capability: str) -> str:
         )
     return (
         "Powers the chat pilot only. Swarm/implement workers need a Full stack "
-        "provider (OpenRouter, Codex OAuth, OpenCode Go, …) or a Cursor API key."
+        "API key or OAuth (OpenRouter, Codex, OpenCode Go, …). Cursor CLI is "
+        "optional and not required. A Cursor API key is a separate platform-worker upgrade."
     )
 
 

--- a/harness/repeat_tool_reminder.py
+++ b/harness/repeat_tool_reminder.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+"""Advisory consecutive-identical tool-call reminder.
+
+DeepSeek ``repeat-tool-reminder`` adapted to Marionette: canonicalize
+(tool, args), count consecutive identical attempts (including loop-guard
+replay/suppress), and suffix the tool-result content at 3/5/8. Never vetoes.
+
+A separate history row would break native tool pairing. The nudge rides on
+the result already being appended.
+"""
+
+import json
+import os
+import re
+from typing import Any, Optional, Sequence, Tuple
+
+PLUGIN_SOURCE = "repeat-tool-reminder"
+
+DEFAULT_THRESHOLDS = (3, 5, 8)
+DEFAULT_ARGUMENTS_PREVIEW_CHARS = 500
+
+GENTLE_REMINDER = (
+    "You are repeating the exact same tool call with identical arguments. "
+    "Carefully analyze the previous result before calling again: if the task is "
+    "not complete, try a different approach or different arguments instead of "
+    "repeating the call."
+)
+
+
+def _sort_json_value(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_sort_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _sort_json_value(value[key]) for key in sorted(value)}
+    return value
+
+
+def canonicalize_arguments(arguments_value: Any) -> str:
+    """Deep key-sort, then JSON. Detection always uses the full string."""
+    try:
+        return json.dumps(_sort_json_value(arguments_value), ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return json.dumps(str(arguments_value), ensure_ascii=False)
+
+
+def canonicalize_call(kind: str, act: Any) -> Tuple[str, str]:
+    """Return ``(kind, canonical_args)`` using the loop-guard fingerprint."""
+    try:
+        from .pilot_guards import normalize_action_args
+
+        return (str(kind or ""), normalize_action_args(kind, act))
+    except Exception:
+        args = getattr(act, "arguments", None)
+        return (str(kind or ""), canonicalize_arguments(args))
+
+
+def _wildcard_to_regex(pattern: str) -> re.Pattern:
+    escaped = re.escape(pattern).replace(r"\*", ".*")
+    return re.compile(r"^" + escaped + r"$")
+
+
+def _csv_patterns(env_name: str) -> Tuple[re.Pattern, ...]:
+    raw = os.environ.get(env_name, "").strip()
+    if not raw:
+        return ()
+    return tuple(_wildcard_to_regex(part.strip()) for part in raw.split(",") if part.strip())
+
+
+def is_tracked(tool_name: str) -> bool:
+    """Untracked tools are transparent: they neither count nor reset the chain."""
+    include = _csv_patterns("HARNESS_REPEAT_TOOL_INCLUDE")
+    exclude = _csv_patterns("HARNESS_REPEAT_TOOL_EXCLUDE")
+    if include and not any(pat.search(tool_name) for pat in include):
+        return False
+    if any(pat.search(tool_name) for pat in exclude):
+        return False
+    return True
+
+
+def thresholds() -> Tuple[int, ...]:
+    raw = os.environ.get("HARNESS_REPEAT_TOOL_THRESHOLDS", "").strip()
+    if not raw:
+        return DEFAULT_THRESHOLDS
+    try:
+        values = tuple(int(part.strip()) for part in raw.split(",") if part.strip())
+    except ValueError:
+        return DEFAULT_THRESHOLDS
+    cleaned = tuple(sorted({v for v in values if v >= 2}))
+    return cleaned or DEFAULT_THRESHOLDS
+
+
+def preview_arguments(canonical: str, cap: int = DEFAULT_ARGUMENTS_PREVIEW_CHARS) -> str:
+    if len(canonical) <= cap:
+        return canonical
+    return "%s... (+%d more chars)" % (canonical[:cap], len(canonical) - cap)
+
+
+def detailed_reminder(tool_name: str, count: int, canonical_arguments: str) -> str:
+    return (
+        "Repeated tool call detected:\n"
+        "- tool: %s\n"
+        "- consecutive_calls: %d\n"
+        "- arguments: %s\n"
+        "The repeated calls are not making progress. Do not call this tool with "
+        "these exact arguments again. Inspect the latest result and choose a "
+        "different action, different arguments, or finish the task if enough "
+        "evidence has been gathered."
+        % (tool_name, count, preview_arguments(canonical_arguments))
+    )
+
+
+def format_nudge(tool_name: str, count: int, canonical_arguments: str, *, gentle_at: int) -> str:
+    body = (
+        GENTLE_REMINDER
+        if count == gentle_at
+        else detailed_reminder(tool_name, count, canonical_arguments)
+    )
+    return "[%s] %s" % (PLUGIN_SOURCE, body)
+
+
+def observe_repeat(session: Any, kind: str, act: Any) -> Optional[str]:
+    """Advance the session chain. Return a nudge string at 3/5/8, else None."""
+    tool_name = str(kind or "").strip()
+    if not tool_name or not is_tracked(tool_name):
+        return None
+    key_kind, canonical = canonicalize_call(tool_name, act)
+    key = json.dumps([key_kind, canonical], ensure_ascii=False, separators=(",", ":"))
+    chain = getattr(session, "_repeat_tool_chain", None)
+    if isinstance(chain, dict) and chain.get("key") == key:
+        count = int(chain.get("count") or 0) + 1
+    else:
+        count = 1
+    session._repeat_tool_chain = {"key": key, "count": count}
+    marks = thresholds()
+    if count not in marks:
+        return None
+    return format_nudge(tool_name, count, canonical, gentle_at=marks[0])
+
+
+def reset_repeat_chain(session: Any) -> None:
+    """User interjection resets the chain. Repetition across a turn is not a loop."""
+    try:
+        session._repeat_tool_chain = None
+    except Exception:
+        pass
+
+
+def suffix_repeat_nudge(content: str, nudge: Optional[str]) -> str:
+    if not nudge:
+        return content
+    base = content if content is not None else ""
+    return base + "\n\n" + nudge
+
+
+def note_repeat_and_maybe_nudge(session: Any, act: Any, content: str) -> str:
+    """Post-execute seam: count this attempt and suffix a nudge when due."""
+    try:
+        kind = getattr(act, "kind", "") or ""
+        nudge = observe_repeat(session, kind, act)
+        return suffix_repeat_nudge(content, nudge)
+    except Exception:
+        return content

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -857,6 +857,12 @@ class SendLoopMixin:
             self._turn_budget = None
             # Fresh turn: clear guard / stagnation / failed-objective resume state.
             self._turn_guard_state = None
+            try:
+                from .repeat_tool_reminder import reset_repeat_chain
+
+                reset_repeat_chain(self)
+            except Exception:
+                self._repeat_tool_chain = None
             self._stagnation_last_prose = None
             self._stagnation_last_actions = None
             self._stagnation_streak = 0
@@ -1136,8 +1142,15 @@ class SendLoopMixin:
                                 self.pilot.chat,
                                 getattr(self, "harness_session_id", None),
                             )
+                            outbound = self._messages_for_provider()
+                            try:
+                                from .log_reconstruction import check_outbound_reconstruction
+
+                                check_outbound_reconstruction(self, outbound, sys_prompt)
+                            except Exception:
+                                pass
                             resp = self.pilot.chat(
-                                self._messages_for_provider(),
+                                outbound,
                                 **chat_kwargs,
                             )
                     else:

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -47,7 +47,9 @@ from .pilot import (
 )
 from .send_image_prep import prepare_turn_images
 from .send_loop_actions import execute_turn_actions
+from .repeat_tool_reminder import reset_repeat_chain
 from .send_loop_phases import (
+    dispatch_sync_pilot_chat,
     drain_idle_turn,
     drain_stream_queue,
     finalize_assistant_turn,
@@ -857,12 +859,7 @@ class SendLoopMixin:
             self._turn_budget = None
             # Fresh turn: clear guard / stagnation / failed-objective resume state.
             self._turn_guard_state = None
-            try:
-                from .repeat_tool_reminder import reset_repeat_chain
-
-                reset_repeat_chain(self)
-            except Exception:
-                self._repeat_tool_chain = None
+            reset_repeat_chain(self)
             self._stagnation_last_prose = None
             self._stagnation_last_actions = None
             self._stagnation_streak = 0
@@ -1133,26 +1130,7 @@ class SendLoopMixin:
                             self._streamed_prose = streamed_prose
                             step_emitted_user_prose = bool(streamed_prose.strip())
                         else:
-                            chat_kwargs = {
-                                "tools": tools_schema,
-                                "system": sys_prompt,
-                            }
-                            maybe_attach_pilot_session_id(
-                                chat_kwargs,
-                                self.pilot.chat,
-                                getattr(self, "harness_session_id", None),
-                            )
-                            outbound = self._messages_for_provider()
-                            try:
-                                from .log_reconstruction import check_outbound_reconstruction
-
-                                check_outbound_reconstruction(self, outbound, sys_prompt)
-                            except Exception:
-                                pass
-                            resp = self.pilot.chat(
-                                outbound,
-                                **chat_kwargs,
-                            )
+                            resp = dispatch_sync_pilot_chat(self, tools_schema, sys_prompt)
                     else:
                         # Same affinity helper as chat — only when complete()
                         # declares session_id. Compaction summarizers call

--- a/harness/send_loop_actions.py
+++ b/harness/send_loop_actions.py
@@ -84,6 +84,13 @@ def execute_turn_actions(
     # same originating user turn (execution counts, result cache, broad-intent,
     # delegation/swarm progress). Fresh user messages clear the session attr.
     prior_guard = getattr(session, "_turn_guard_state", None)
+    if prior_guard is None:
+        try:
+            from .repeat_tool_reminder import reset_repeat_chain
+
+            reset_repeat_chain(session)
+        except Exception:
+            pass
     nested_implement = bool(getattr(session, "_nested_implement_worker", False))
     guard_state = reuse_or_new_turn_guard_state(
         prior_guard,

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -349,6 +349,25 @@ def maybe_attach_pilot_session_id(
     kwargs["session_id"] = sid
 
 
+def dispatch_sync_pilot_chat(session: Any, tools_schema: Any, sys_prompt: str) -> Any:
+    """Non-streaming ``pilot.chat`` with the shared sanitize + honesty check."""
+    chat_kwargs = {
+        "tools": tools_schema,
+        "system": sys_prompt,
+    }
+    maybe_attach_pilot_session_id(
+        chat_kwargs,
+        session.pilot.chat,
+        getattr(session, "harness_session_id", None),
+    )
+    outbound = session._messages_for_provider()
+    try:
+        check_outbound_reconstruction(session, outbound, sys_prompt)
+    except Exception:
+        pass
+    return session.pilot.chat(outbound, **chat_kwargs)
+
+
 def run_stream(
     session: Any,
     q: Any,

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -26,8 +26,11 @@ from typing import Any, Dict, Iterator, Optional
 
 from pmharness.bridge import execute_intent
 
+from .log_reconstruction import check_outbound_reconstruction
 from .pilot import PilotAction, StreamingSayExtractor
 from .stream_identity import StreamDeltaBatch, normalize_delta_payload
+from .tool_timeout import invoke_do, run_with_tool_deadline
+from .workspace_rules_refresh import maybe_refresh_workspace_rules
 from .url_safety import sanitize_url_for_display
 
 # job_XXXXXXXXXXXX — same pattern the parallel-dispatch stdout scanner used
@@ -379,8 +382,13 @@ def run_stream(
             getattr(session, "harness_session_id", None),
         )
         # Sanitize immediately before dispatch (same seam as sync chat).
+        outbound = session._messages_for_provider()
+        try:
+            check_outbound_reconstruction(session, outbound, sys_prompt)
+        except Exception:
+            pass
         r = session.pilot.chat_stream(
-            session._messages_for_provider(),
+            outbound,
             **kwargs,
         )
         q.put(("done", r))
@@ -401,15 +409,15 @@ def run_prefetch(
         elif kind == "list_dir":
             return idx, session._do_list_dir(act)
         elif kind == "search_codegraph":
-            return idx, session._do_search_codegraph(act)
+            return idx, invoke_do(session, act, lambda: session._do_search_codegraph(act))
         elif kind == "search_files":
-            return idx, session._do_search_files(act)
+            return idx, invoke_do(session, act, lambda: session._do_search_files(act))
         elif kind == "web_search":
-            return idx, session._do_web_search(act)
+            return idx, invoke_do(session, act, lambda: session._do_web_search(act))
         elif kind == "web_fetch":
-            return idx, session._do_web_fetch(act)
+            return idx, invoke_do(session, act, lambda: session._do_web_fetch(act))
         elif kind == "read_pdf":
-            return idx, session._do_read_pdf(act)
+            return idx, invoke_do(session, act, lambda: session._do_read_pdf(act))
         elif kind == "view_image":
             return idx, session._do_view_image(act)
         elif kind == "lsp":
@@ -1239,6 +1247,7 @@ def dispatch_readonly_action(
                 "artifacts": [{"type": "file", "headline": f"Read {len(content)} chars from {act.path}"}],
             })
             session._append_action_result(act, aid, f"(read_file {act.path} returned)\n{content}", is_native)
+            maybe_refresh_workspace_rules(session, act.path)
         else:
             if status == "repo_not_open":
                 yield ConvEvent("action_result", {"id": aid, "error": val})
@@ -1322,7 +1331,7 @@ def dispatch_readonly_action(
         if idx in prefetch:
             ok, status, val = prefetch[idx]
         else:
-            ok, status, val = session._do_web_search(act)
+            ok, status, val = invoke_do(session, act, lambda: session._do_web_search(act))
 
         if ok:
             result_text = val
@@ -1340,7 +1349,7 @@ def dispatch_readonly_action(
         if idx in prefetch:
             ok, status, val = prefetch[idx]
         else:
-            ok, status, val = session._do_web_fetch(act)
+            ok, status, val = invoke_do(session, act, lambda: session._do_web_fetch(act))
 
         if ok:
             result_text = val
@@ -1360,7 +1369,7 @@ def dispatch_readonly_action(
         if idx in prefetch:
             ok, status, val = prefetch[idx]
         else:
-            ok, status, val = session._do_read_pdf(act)
+            ok, status, val = invoke_do(session, act, lambda: session._do_read_pdf(act))
 
         if ok:
             result_text = val
@@ -1397,7 +1406,7 @@ def dispatch_readonly_action(
         if idx in prefetch:
             ok, status, val = prefetch[idx]
         else:
-            ok, status, val = session._do_search_codegraph(act)
+            ok, status, val = invoke_do(session, act, lambda: session._do_search_codegraph(act))
 
         if ok:
             kind, output = val
@@ -1422,7 +1431,7 @@ def dispatch_readonly_action(
         if idx in prefetch:
             ok, status, val = prefetch[idx]
         else:
-            ok, status, val = session._do_search_files(act)
+            ok, status, val = invoke_do(session, act, lambda: session._do_search_files(act))
 
         if ok:
             output = val
@@ -1865,6 +1874,7 @@ def dispatch_local_action(
                 "artifacts": [{"type": "file", "headline": f"Wrote {bytes_written} bytes to {act.path}"}],
             })
             session._append_action_result(act, aid, f"(write_file {act.path} successfully wrote {bytes_written} bytes)", is_native)
+            maybe_refresh_workspace_rules(session, act.path)
             turn_changed_files.append(target_path)
             yield from _yield_task_profile_escalation(session, turn_changed_files)
         except Exception as e:
@@ -1923,6 +1933,7 @@ def dispatch_local_action(
                 "artifacts": [{"type": "file", "headline": headline}],
             })
             session._append_action_result(act, aid, f"(edit_file {act.path} successfully edited: {headline})", is_native)
+            maybe_refresh_workspace_rules(session, act.path)
             turn_changed_files.append(target_path)
             yield from _yield_task_profile_escalation(session, turn_changed_files)
         except Exception as e:
@@ -1988,6 +1999,7 @@ def dispatch_local_action(
             session._last_ast_preview = None
             yield ConvEvent("action_result", hash_edit_result)
             session._append_action_result(act, aid, f"(hash_edit {act.path} successfully applied: {headline})", is_native)
+            maybe_refresh_workspace_rules(session, act.path)
             turn_changed_files.append(target_path)
             yield from _yield_task_profile_escalation(session, turn_changed_files)
         except Exception as e:
@@ -2429,7 +2441,11 @@ def dispatch_local_action(
             return
 
         try:
-            res = session._wiki.query(question)
+            res, timed_out = run_with_tool_deadline(
+                session, "query_wiki", lambda: session._wiki.query(question),
+            )
+            if timed_out:
+                raise TimeoutError("tool call timed out after %dms" % timed_out)
             # Grounded synthesis: fold the raw wiki result through
             # harness.nl_memory.answer_from_memory so the surfaced
             # text is a concise, cited answer instead of a raw dump.
@@ -2478,7 +2494,11 @@ def dispatch_local_action(
         try:
             if act.tool:
                 session._tool_catalog.activate([act.tool])
-            out = session._mcp.call(act.tool, act.arguments)
+            out, timed_out = run_with_tool_deadline(
+                session, "call_mcp", lambda: session._mcp.call(act.tool, act.arguments),
+            )
+            if timed_out:
+                raise TimeoutError("tool call timed out after %dms" % timed_out)
             text = _mcp_result_text(out)
         except Exception as e:
             yield ConvEvent("action_result", {"id": aid, "error": f"mcp: {e}"})

--- a/harness/tool_pairing.py
+++ b/harness/tool_pairing.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+"""Pairing-balanced compaction cuts.
+
+A cut immediately before ``history[index]`` is safe only when the in-progress
+tool-call count over ``history[:index]`` is 0. This is the DeepSeek
+``toolPairingBalancedBefore`` contract, adapted to Marionette history dicts.
+
+Distinct from ``ConversationalSession._sanitize_tool_pairs``, which heals
+outbound wire-format 400s. This module only answers "may we cut here?"
+
+Corrupt surfaces (a tool result with no open call) are unbalanced. Live
+history must never raise.
+"""
+
+from typing import Any, List, Mapping, Sequence
+
+
+def event_delta(msg: Mapping[str, Any]) -> int:
+    """How one history message changes the in-progress tool-call count."""
+    if not isinstance(msg, Mapping):
+        return 0
+    role = msg.get("role")
+    if role == "assistant":
+        calls = msg.get("tool_calls") or ()
+        if isinstance(calls, (list, tuple)):
+            return len(calls)
+        return 0
+    if role == "tool":
+        return -1
+    return 0
+
+
+def in_progress_count(history_prefix: Sequence[Mapping[str, Any]]) -> int:
+    """In-progress tool-call count after folding ``history_prefix``.
+
+    Returns -1 when a tool result arrives with no matching open call
+    (corrupt / unbalanced). Never raises.
+    """
+    count = 0
+    for msg in history_prefix:
+        count += event_delta(msg)
+        if count < 0:
+            return -1
+    return count
+
+
+def pairing_balanced_before(history: Sequence[Mapping[str, Any]], index: int) -> bool:
+    """True when the cut immediately before ``history[index]`` is balanced."""
+    if index < 0 or index > len(history):
+        return False
+    return in_progress_count(history[:index]) == 0
+
+
+def pairing_balanced_after(history: Sequence[Mapping[str, Any]], index: int) -> bool:
+    """True when the cut immediately after ``history[index]`` is balanced."""
+    return pairing_balanced_before(history, index + 1)
+
+
+def nearest_balanced_split(
+    history: Sequence[Mapping[str, Any]],
+    start_idx: int,
+    *,
+    min_idx: int = 2,
+    orphan_in_kept=None,
+) -> int:
+    """Walk from ``start_idx`` to a pairing-balanced cut.
+
+    Prefer advancing (keep an in-progress pair entirely in the tail). If the
+    surface ends still unbalanced (mid-turn unanswered calls), walk backward
+    so those open calls stay in the tail instead of being summarized.
+
+    ``orphan_in_kept(idx)`` is an optional extra predicate (existing id-based
+    orphan check). When provided, a candidate must also make it false.
+    """
+    n = len(history)
+    if n < 2:
+        return n
+    if min_idx < 2:
+        min_idx = 2
+    split_idx = start_idx
+    if split_idx < min_idx:
+        split_idx = min_idx
+    if split_idx > n:
+        split_idx = n
+
+    def _ok(idx: int) -> bool:
+        if not pairing_balanced_before(history, idx):
+            return False
+        if orphan_in_kept is not None:
+            try:
+                if orphan_in_kept(idx):
+                    return False
+            except Exception:
+                return False
+        return True
+
+    while split_idx < n and not _ok(split_idx):
+        split_idx += 1
+    if _ok(split_idx):
+        return split_idx
+
+    candidate = min(split_idx, n)
+    while candidate > min_idx:
+        candidate -= 1
+        if _ok(candidate):
+            return candidate
+    if _ok(min_idx):
+        return min_idx
+    return split_idx
+
+
+def orphan_tool_result_in_kept(
+    history: List[Mapping[str, Any]],
+    split_idx: int,
+) -> bool:
+    """True when a kept-tail tool result references a call still in the prefix.
+
+    This is the existing ``_find_safe_split`` id check, extracted so pairing
+    walk and the mixin share one definition.
+    """
+    middle_ids = set()
+    for msg in history[1:split_idx]:
+        for tc in msg.get("tool_calls") or ():
+            if isinstance(tc, Mapping) and tc.get("id"):
+                middle_ids.add(tc["id"])
+    for msg in history[split_idx:]:
+        if msg.get("role") == "tool" and msg.get("tool_call_id") in middle_ids:
+            return True
+    return False

--- a/harness/tool_timeout.py
+++ b/harness/tool_timeout.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+"""Cooperative per-tool deadline.
+
+A tool may declare ``timeoutMs``. This wrapper arms ``session._cancel`` for
+that budget, restores the upstream event, and only *this* wrapper's expiry
+becomes structured ``TOOL_TIMEOUT``. Inner command/ipython/worker timeouts
+are not remapped — those kinds declare no budget here.
+"""
+
+import os
+import threading
+from typing import Any, Callable, Optional, Tuple
+
+TOOL_TIMEOUT = "TOOL_TIMEOUT"
+
+# Kinds that already honor their own deadline. Declaring a second wrapper
+# would race their status and mislabel a command timeout as TOOL_TIMEOUT.
+INNER_TIMEOUT_KINDS = frozenset(
+    (
+        "run_command",
+        "run_command_batch",
+        "run_ipython",
+        "run_swarm",
+        "run_implement",
+        "run_parallel",
+        "route_task",
+    )
+)
+
+# Default budgets (ms) for tools that can block on network / index / MCP.
+DEFAULT_TIMEOUT_MS = {
+    "web_fetch": 45000,
+    "web_search": 30000,
+    "read_pdf": 45000,
+    "search_codegraph": 30000,
+    "search_files": 30000,
+    "call_mcp": 45000,
+    "query_wiki": 30000,
+}
+
+
+def declared_timeout_ms(kind: str) -> Optional[int]:
+    """Return this wrapper's budget, or None when we must not arm a timer."""
+    name = str(kind or "").strip()
+    if not name or name in INNER_TIMEOUT_KINDS:
+        return None
+    env_key = "HARNESS_TOOL_TIMEOUT_%s_MS" % name.upper()
+    raw = os.environ.get(env_key, "").strip()
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        return value if value > 0 else None
+    default = DEFAULT_TIMEOUT_MS.get(name)
+    if default is None:
+        return None
+    return int(default)
+
+
+def tool_timeout_message(timeout_ms: int) -> str:
+    return "tool call timed out after %dms" % int(timeout_ms)
+
+
+def tool_timeout_triple(timeout_ms: int) -> Tuple[bool, str, str]:
+    return (False, TOOL_TIMEOUT, tool_timeout_message(timeout_ms))
+
+
+def run_with_tool_deadline(
+    session: Any,
+    kind: str,
+    fn: Callable[[], Any],
+    timeout_ms: Optional[int] = None,
+) -> Tuple[Any, Optional[int]]:
+    """Run ``fn`` under a scoped cancel.
+
+    Returns ``(result, None)`` on a normal finish (including inner timeout or
+    user Stop). Returns ``(result, timeout_ms)`` only when *this* timer fired.
+    Never remaps an inner status. Restores ``session._cancel`` when we set it
+    and the user did not also request interrupt.
+    """
+    if timeout_ms is None:
+        timeout_ms = declared_timeout_ms(kind)
+    if not timeout_ms:
+        return fn(), None
+
+    cancel = getattr(session, "_cancel", None)
+    if cancel is None or not hasattr(cancel, "is_set"):
+        return fn(), None
+
+    already = bool(cancel.is_set())
+    owned = []
+
+    def _expire() -> None:
+        try:
+            if cancel.is_set():
+                return
+            owned.append(True)
+            cancel.set()
+        except Exception:
+            pass
+
+    timer = threading.Timer(float(timeout_ms) / 1000.0, _expire)
+    timer.daemon = True
+    timer.start()
+    try:
+        result = fn()
+    finally:
+        try:
+            timer.cancel()
+        except Exception:
+            pass
+        user_stop = bool(getattr(session, "_interrupt_requested", False))
+        if owned and not already and not user_stop:
+            try:
+                cancel.clear()
+            except Exception:
+                pass
+    if owned:
+        return result, int(timeout_ms)
+    return result, None
+
+
+def invoke_do(session: Any, act: Any, fn: Callable[[], Any]) -> Any:
+    """Wrap a ``_do_*`` triple. Our expiry becomes ``(False, TOOL_TIMEOUT, ...)``."""
+    kind = getattr(act, "kind", "") or ""
+    result, timed_out = run_with_tool_deadline(session, kind, fn)
+    if timed_out:
+        return tool_timeout_triple(timed_out)
+    return result

--- a/harness/workspace_rules_refresh.py
+++ b/harness/workspace_rules_refresh.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Live workspace-instruction refresh without restarting the session.
+
+Baseline ``load_workspace_rules`` still injects at session init. After a
+read/write/edit of an instruction file, reload that block and splice it into
+the live system prompt (and the frozen append-only copy when present).
+"""
+
+import os
+from typing import Any, Optional
+
+_INSTRUCTION_BASENAMES = frozenset(("AGENTS.md", "CLAUDE.md", ".cursorrules"))
+
+
+def is_instruction_path(path: str, repo: Optional[str]) -> bool:
+    """True for the files ``load_workspace_rules`` already consults."""
+    raw = (path or "").strip()
+    if not raw:
+        return False
+    base = os.path.basename(raw)
+    if base in _INSTRUCTION_BASENAMES:
+        return True
+    norm = raw.replace("\\", "/")
+    if norm.endswith(".github/copilot-instructions.md") or base == "copilot-instructions.md":
+        if ".github/" in norm or norm.endswith(".github/copilot-instructions.md"):
+            return True
+        if repo:
+            try:
+                rel = os.path.relpath(os.path.abspath(raw), os.path.abspath(repo))
+            except Exception:
+                rel = norm
+            if rel.replace("\\", "/") == ".github/copilot-instructions.md":
+                return True
+    if "/.cursor/rules/" in ("/" + norm) and base.endswith(".md"):
+        return True
+    if repo:
+        try:
+            rel = os.path.relpath(os.path.abspath(raw), os.path.abspath(repo)).replace("\\", "/")
+        except Exception:
+            return False
+        if rel.startswith(".cursor/rules/") and rel.endswith(".md"):
+            return True
+        if rel == ".github/copilot-instructions.md":
+            return True
+        if os.path.basename(rel) in _INSTRUCTION_BASENAMES:
+            return True
+    return False
+
+
+def _swap_rules_block(text: str, old: str, new: str) -> str:
+    body = text if isinstance(text, str) else ""
+    if old and old in body:
+        return body.replace(old, new, 1)
+    if old and not new:
+        return body
+    if new and old != new:
+        return body + new
+    return body
+
+
+def reconcile_workspace_rules(session: Any) -> bool:
+    """Reload repo instruction files into the live system prompt.
+
+    Updates ``history[0]`` and ``_frozen_system_prompt`` in place so append-only
+    freeze is not rebuilt (rebuilding would double-append identity/MCP). Returns
+    True when the block changed. Never raises.
+    """
+    try:
+        from .conversation import load_workspace_rules
+
+        repo = getattr(getattr(session, "config", None), "repo", None)
+        new_block = load_workspace_rules(repo) or ""
+        old_block = getattr(session, "_workspace_rules_block", None)
+        if old_block is None:
+            old_block = ""
+        if new_block == old_block:
+            return False
+        history = getattr(session, "_history", None)
+        if isinstance(history, list) and history:
+            first = history[0]
+            if isinstance(first, dict) and first.get("role") == "system":
+                first["content"] = _swap_rules_block(
+                    first.get("content") or "", old_block, new_block,
+                )
+        frozen = getattr(session, "_frozen_system_prompt", None)
+        if isinstance(frozen, str):
+            session._frozen_system_prompt = _swap_rules_block(frozen, old_block, new_block)
+        session._workspace_rules_block = new_block
+        return True
+    except Exception:
+        return False
+
+
+def maybe_refresh_workspace_rules(session: Any, path: Optional[str]) -> bool:
+    """Reconcile only when ``path`` is an instruction file we already load."""
+    try:
+        repo = getattr(getattr(session, "config", None), "repo", None)
+        if not is_instruction_path(path or "", repo):
+            return False
+        return reconcile_workspace_rules(session)
+    except Exception:
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.218"
+version = "0.9.219"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -58,6 +58,7 @@ if (Test-Path $dist) { Ok "renderer built (webapp/dist)" } else { Bad "renderer 
 # --- optional external tools -------------------------------------------------
 $rg = Get-Command rg -ErrorAction SilentlyContinue
 if ($rg) { Ok "ripgrep (rg) present" } else { Note "ripgrep (rg) not found -- some search is slower without it" }
+Note "Cursor / Claude / Codex CLI are optional -- a Full stack API key is enough"
 
 # --- CodeGraph binding -------------------------------------------------------
 if ((Test-Path $Py) -and (& $Py -c "import puppetmaster" 2>$null; $LASTEXITCODE -eq 0)) {

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -55,6 +55,7 @@ if [ -f webapp/dist/index.html ]; then ok "renderer built (webapp/dist)"; else b
 # --- optional external tools -------------------------------------------------
 command -v rg     >/dev/null 2>&1 && ok "ripgrep (rg) present"     || note "ripgrep (rg) not found -- some search is slower without it"
 command -v ffmpeg >/dev/null 2>&1 && ok "ffmpeg present"           || note "ffmpeg not found -- optional (media features)"
+note "Cursor / Claude / Codex CLI are optional -- a Full stack API key is enough"
 
 # --- CodeGraph binding -------------------------------------------------------
 if [ -x "$PY" ] && $PY -c "import puppetmaster" 2>/dev/null; then

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -300,5 +300,8 @@ Launch it:
 If 'marionette' is not found, open a new terminal (PATH was updated) or run:
   $CmdLauncher
 
-Set your API keys in the app's Settings pane, or in $env:USERPROFILE\.pmharness\keys.json.
+Open Marionette, then Settings: paste any Full stack API key (OpenRouter,
+Anthropic, OpenAI, Gemini, ...) or sign in with Codex / OpenCode Go. That one
+credential runs the chat pilot and agentic workers. Cursor / Claude / Codex
+CLI installs are optional — not required.
 "@

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -188,5 +188,8 @@ Launch it:
 If 'marionette' is not found, add this to your shell profile:
   export PATH="$BIN_DIR:\$PATH"
 
-Set your API keys in the app's Settings pane, or in ~/.pmharness/keys.json.
+Open Marionette, then Settings: paste any Full stack API key (OpenRouter,
+Anthropic, OpenAI, Gemini, …) or sign in with Codex / OpenCode Go. That one
+credential runs the chat pilot and agentic workers. Cursor / Claude / Codex
+CLI installs are optional — not required.
 EOF

--- a/tests/test_api_settings_peel.py
+++ b/tests/test_api_settings_peel.py
@@ -56,6 +56,9 @@ def test_get_config_and_settings(monkeypatch):
         "harness.edit_engines.pilot_keys_ready", lambda: False, raising=False
     )
     monkeypatch.setattr(
+        "harness.edit_engines.workers_ready", lambda: False, raising=False
+    )
+    monkeypatch.setattr(
         "harness.reasoning_effort.current_reasoning_effort",
         lambda: "low",
         raising=False,
@@ -65,6 +68,9 @@ def test_get_config_and_settings(monkeypatch):
     assert code == 200
     assert payload["driver"] == cfg.driver
     assert payload["models"] == ["anthropic:claude-opus-4-8"]
+    assert payload["workers_ready"] is False
+    assert payload["pilot_ready"] is False
+    assert payload["agentic_ready"] is False
     assert get_settings(svc)[1]["budget"] == 3
 
 

--- a/tests/test_auto_registry.py
+++ b/tests/test_auto_registry.py
@@ -976,3 +976,34 @@ def test_known_spec_follows_dated_family():
     assert _known_spec_for(
         "deepseek/deepseek-v4-pro-0813", "deepseek/deepseek-v4-pro",
     ) == rolling
+
+
+def test_keyed_openrouter_not_starved_by_other_provider_toggles(monkeypatch, tmp_path):
+    """Stale anthropic Models toggles must not empty a keyed OpenRouter catalog."""
+    models_path = tmp_path / "models.json"
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+
+    live = ["moonshotai/kimi-k3", "z-ai/glm-5.2", "xiaomi/mimo-v2-flash"]
+
+    def mock_get_provider_key(provider):
+        return "fake-openrouter" if provider.name == "openrouter" else None
+
+    def mock_enabled(name):
+        if name == "anthropic":
+            return ["claude-opus-4-8"]
+        return []
+
+    with patch("harness.registry_wizard.get_provider_key", mock_get_provider_key), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda *_a, **_k: list(live)), \
+         patch("harness.auto_registry._enabled_picker_models", mock_enabled):
+        from harness.auto_registry import sync_agentic_registry
+        result = sync_agentic_registry()
+
+    assert result["synced"] is True
+    ids = {m["id"] for m in json.loads(models_path.read_text())["models"]}
+    assert "agentic/moonshotai/kimi-k3" in ids
+    assert "agentic/z-ai/glm-5.2" in ids
+    assert not any("mimo" in mid for mid in ids)
+    assert not any("claude" in mid for mid in ids)

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -404,6 +404,28 @@ def test_no_orphaned_tool_messages_in_kept_window():
             assert m.get("tool_call_id") != "call_123"
 
 
+def test_unanswered_mid_turn_call_stays_in_tail():
+    cfg = HarnessConfig(max_context_tokens=1000)
+    s = ConversationalSession(cfg)
+    s._history = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "old"},
+        {
+            "role": "assistant",
+            "content": "call",
+            "tool_calls": [{
+                "id": "open",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }],
+        },
+    ]
+    # Preferred cut after the unanswered call would summarize it. Walk back
+    # so the in-progress pair stays in the tail.
+    assert s._find_safe_split(3) == 3
+
+
 def test_single_writer_synchronous_compaction():
     cfg = HarnessConfig(max_context_tokens=1000)
     s = ConversationalSession(cfg)

--- a/tests/test_edit_engines.py
+++ b/tests/test_edit_engines.py
@@ -22,6 +22,7 @@ from harness.edit_engines import (
     finalize_worktree_patch,
     managed_worktree,
     pilot_keys_ready,
+    workers_ready,
     run_agentic_edit,
     run_edit_worker,
     run_native_edit,
@@ -314,6 +315,59 @@ def test_pilot_keys_ready_false_when_truly_keyless(monkeypatch, tmp_path):
     )
     monkeypatch.setattr("harness.keys.get_disconnected", lambda: set(), raising=False)
     assert pilot_keys_ready() is False
+
+
+def test_workers_ready_false_for_cursor_cli_only(monkeypatch, tmp_path):
+    """Pilot-only Cursor Agent login must not claim swarms can run."""
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+    for k in (
+        "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+        "OPENROUTER_API_KEY", "OPENCODE_GO_API_KEY", "OPENAI_CODEX_TOKEN",
+        "AWS_BEARER_TOKEN_BEDROCK", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+    def _key(provider):
+        return "cursor-cli-login" if provider.name == "cursor-cli" else None
+
+    monkeypatch.setattr("harness.registry_wizard.get_provider_key", _key)
+    monkeypatch.setattr(
+        "harness.keys.get_api_key_status",
+        lambda name: {"has_key": name == "cursor-cli", "masked": "****"},
+    )
+    monkeypatch.setattr("harness.keys.get_disconnected", lambda: set())
+    monkeypatch.setattr(
+        "harness.edit_engines.cursor_platform_available", lambda: False
+    )
+    assert workers_ready() is False
+    assert pilot_keys_ready() is True
+
+
+def test_workers_ready_true_for_stored_openrouter(monkeypatch, tmp_path):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+    for k in (
+        "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+        "OPENROUTER_API_KEY", "OPENCODE_GO_API_KEY", "OPENAI_CODEX_TOKEN",
+        "AWS_BEARER_TOKEN_BEDROCK", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+    def _key(provider):
+        return "sk-or-stored" if provider.name == "openrouter" else None
+
+    monkeypatch.setattr("harness.registry_wizard.get_provider_key", _key)
+    monkeypatch.setattr(
+        "harness.keys.get_api_key_status",
+        lambda name: {"has_key": name == "openrouter", "masked": "****"},
+    )
+    monkeypatch.setattr("harness.keys.get_disconnected", lambda: set())
+    monkeypatch.setattr(
+        "harness.edit_engines.cursor_platform_available", lambda: False
+    )
+    assert workers_ready() is True
+    assert pilot_keys_ready() is True
 
 
 # --- worktree helpers (real git, no network) ---

--- a/tests/test_keys_only_full_stack.py
+++ b/tests/test_keys_only_full_stack.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+"""Keys-only product contract: one Full stack Settings key, no Cursor install.
+
+Hermetic — no network, no cursor/claude binary, no CURSOR_API_KEY.
+"""
+
+import json
+from unittest.mock import patch
+
+from harness.config import HarnessConfig
+from harness.edit_engines import select_edit_engine, workers_ready, pilot_keys_ready
+from harness.provider_capabilities import worker_capability
+from harness.swarm_worker_allowlist import resolve_swarm_worker_allowlist
+
+
+def _clear_platform_env(monkeypatch):
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+    monkeypatch.delenv("HARNESS_EDIT_ENGINE", raising=False)
+    for k in (
+        "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+        "OPENROUTER_API_KEY", "OPENCODE_GO_API_KEY", "OPENAI_CODEX_TOKEN",
+        "AWS_BEARER_TOKEN_BEDROCK", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+        "DEEPSEEK_API_KEY", "XAI_API_KEY", "ZAI_API_KEY", "GLM_API_KEY",
+        "MINIMAX_API_KEY", "NVIDIA_API_KEY", "NOUS_API_KEY", "HERMES_API_KEY",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+def _only(*names):
+    keyed = set(names)
+
+    def _get_provider_key(provider):
+        return ("fake-key-" + provider.name) if provider.name in keyed else None
+
+    return _get_provider_key
+
+
+def test_full_stack_map_covers_settings_keys():
+    for name in (
+        "openrouter", "anthropic", "openai", "gemini", "openai-codex",
+        "opencode-go", "nous", "bedrock", "minimax", "nvidia",
+    ):
+        assert worker_capability(name) == "full_stack", name
+    assert worker_capability("cursor-cli") == "pilot_only"
+    assert worker_capability("cursor") == "platform_worker"
+
+
+def test_openrouter_only_selects_agentic_and_allowlist(monkeypatch, tmp_path):
+    _clear_platform_env(monkeypatch)
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.setattr(
+        "harness.edit_engines.cursor_platform_available", lambda: False
+    )
+    monkeypatch.setattr(
+        "harness.edit_engines.agentic_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._agentic_eligible", lambda: True
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._cursor_platform_ready", lambda: False
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._platform_locked_adapters",
+        lambda: frozenset({"agentic"}),
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._enabled_or_visible_specs",
+        lambda: ["openrouter:moonshotai/kimi-k3"],
+    )
+
+    cfg = HarnessConfig(repo=str(tmp_path), driver="openrouter:moonshotai/kimi-k3")
+    assert select_edit_engine(cfg) == "agentic"
+    out = resolve_swarm_worker_allowlist()
+    assert out["allowed_adapters"] == ["agentic"]
+    assert out["prefer_plan_billed"] is False
+    assert out["primary_adapter"] == "agentic"
+
+
+def test_codex_oauth_only_is_full_stack_workers(monkeypatch, tmp_path):
+    _clear_platform_env(monkeypatch)
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
+    monkeypatch.setattr("harness.registry_wizard.get_provider_key", _only("openai-codex"))
+    monkeypatch.setattr(
+        "harness.keys.get_api_key_status",
+        lambda name: {"has_key": name == "openai-codex", "masked": "****"},
+    )
+    monkeypatch.setattr("harness.keys.get_disconnected", lambda: set())
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._agentic_eligible", lambda: True
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._cursor_platform_ready", lambda: False
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._platform_locked_adapters",
+        lambda: frozenset({"agentic"}),
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._enabled_or_visible_specs",
+        lambda: ["openai-codex:gpt-5.4"],
+    )
+
+    assert workers_ready() is True
+    assert pilot_keys_ready() is True
+    out = resolve_swarm_worker_allowlist()
+    assert out["allowed_adapters"] == ["agentic"]
+    assert out["prefer_plan_billed"] is False
+
+
+def test_cursor_cli_only_is_not_workers_ready(monkeypatch, tmp_path):
+    _clear_platform_env(monkeypatch)
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
+    monkeypatch.setattr("harness.registry_wizard.get_provider_key", _only("cursor-cli"))
+    monkeypatch.setattr(
+        "harness.keys.get_api_key_status",
+        lambda name: {"has_key": name == "cursor-cli", "masked": "****"},
+    )
+    monkeypatch.setattr("harness.keys.get_disconnected", lambda: set())
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._agentic_eligible", lambda: False
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._cursor_platform_ready", lambda: False
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._platform_locked_adapters",
+        lambda: frozenset({"agentic"}),
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._enabled_or_visible_specs",
+        lambda: ["cursor-cli:cursor-grok-4.5-high"],
+    )
+
+    assert workers_ready() is False
+    assert pilot_keys_ready() is True
+    out = resolve_swarm_worker_allowlist()
+    assert "cursor" not in out["allowed_adapters"]
+    assert out["prefer_plan_billed"] is False
+
+
+def test_stale_cursor_cli_toggles_do_not_starve_openrouter_catalog(monkeypatch, tmp_path):
+    models_path = tmp_path / "models.json"
+    vis_store = tmp_path / "visibility.json"
+    vis_store.write_text(json.dumps({
+        "enabled": ["cursor-cli:cursor-grok-4.5-high", "cursor-cli:composer-2.5"],
+    }), encoding="utf-8")
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setattr(
+        "harness.model_visibility._store_path", lambda: str(vis_store),
+    )
+    _clear_platform_env(monkeypatch)
+
+    live = ["moonshotai/kimi-k3", "z-ai/glm-5.2", "xiaomi/mimo-v2-flash"]
+
+    with patch("harness.registry_wizard.get_provider_key", _only("openrouter")), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda *_a, **_k: list(live)):
+        from harness.auto_registry import ensure_keyed_provider_registry_health
+        report = ensure_keyed_provider_registry_health()
+
+    assert report["ready"] is True
+    assert "openrouter" in report["providers"]
+    models = json.loads(models_path.read_text(encoding="utf-8"))["models"]
+    agentic = [m for m in models if m.get("adapter") == "agentic"]
+    assert agentic
+    assert {m["payload_defaults"]["provider"] for m in agentic} == {"openrouter"}
+    ids = {m["id"] for m in agentic}
+    assert any("kimi" in mid or "glm" in mid or "deepseek" in mid for mid in ids)
+    assert not any("mimo" in mid for mid in ids)
+
+
+def test_get_config_exposes_split_readiness(monkeypatch):
+    from types import SimpleNamespace
+    import threading
+    from harness.api.settings import SettingsServices, get_config
+
+    monkeypatch.setattr(
+        "harness.edit_engines.select_edit_engine", lambda cfg: "agentic", raising=False
+    )
+    monkeypatch.setattr(
+        "harness.edit_engines.workers_ready", lambda: True, raising=False
+    )
+    monkeypatch.setattr(
+        "harness.edit_engines.pilot_keys_ready", lambda: True, raising=False
+    )
+    monkeypatch.setattr(
+        "harness.reasoning_effort.current_reasoning_effort",
+        lambda: "low",
+        raising=False,
+    )
+    busy = threading.Lock()
+    svc = SettingsServices(
+        cfg=SimpleNamespace(
+            driver="openrouter:moonshotai/kimi-k3",
+            reach="openrouter",
+            budget=3,
+            repo="/r",
+            swarm_adapter="agentic",
+        ),
+        get_pilot=lambda: SimpleNamespace(_busy=busy),
+        get_session=lambda: SimpleNamespace(state_dir="/state", preflight=lambda: {"ok": True}),
+        parse_bool=lambda v: bool(v),
+        set_api_key=lambda *_a: None,
+        clear_api_key=lambda *_a: None,
+        rebuild_pilot_and_session=lambda: None,
+        available_pilots=lambda: ["openrouter:moonshotai/kimi-k3"],
+        save_workspace_driver=lambda *_a: None,
+        persist_env_setting=lambda *_a: None,
+        get_settings_dict=lambda: {},
+    )
+    code, payload = get_config(svc)
+    assert code == 200
+    assert payload["workers_ready"] is True
+    assert payload["pilot_ready"] is True
+    assert payload["agentic_ready"] is True
+    assert payload["edit_engine"] == "agentic"

--- a/tests/test_log_reconstruction.py
+++ b/tests/test_log_reconstruction.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from harness.log_reconstruction import check_outbound_reconstruction
+
+
+def test_matching_rebuild_is_honest():
+    messages = [{"role": "user", "content": "hi"}]
+    session = SimpleNamespace(
+        _append_only=True,
+        _frozen_system_prompt="sys",
+        _history=[{"role": "system", "content": "sys"}] + messages,
+        _elide_stale_reads=lambda msgs: list(msgs),
+    )
+    assert check_outbound_reconstruction(session, messages, "sys") is True
+    assert session._last_log_reconstruction["ok"] is True
+
+
+def test_message_drift_is_logged_not_raised():
+    session = SimpleNamespace(
+        _append_only=True,
+        _frozen_system_prompt="sys",
+        _history=[{"role": "system", "content": "sys"}, {"role": "user", "content": "rebuilt"}],
+        _elide_stale_reads=lambda msgs: list(msgs),
+    )
+    assert check_outbound_reconstruction(
+        session, [{"role": "user", "content": "stale"}], "sys",
+    ) is False
+    assert session._last_log_reconstruction["reason"] == "messages"
+
+
+def test_frozen_system_mismatch_is_logged_when_append_only():
+    messages = [{"role": "user", "content": "hi"}]
+    session = SimpleNamespace(
+        _append_only=True,
+        _frozen_system_prompt="frozen",
+        _history=[{"role": "system", "content": "frozen"}] + messages,
+        _elide_stale_reads=lambda msgs: list(msgs),
+    )
+    assert check_outbound_reconstruction(session, messages, "other") is False
+    assert session._last_log_reconstruction["reason"] == "system"
+
+
+def test_check_never_raises_into_the_turn():
+    session = SimpleNamespace(
+        _append_only=True,
+        _frozen_system_prompt="sys",
+        _history=[{"role": "system", "content": "sys"}],
+    )
+
+    def _boom(_msgs):
+        raise RuntimeError("elide failed")
+
+    session._elide_stale_reads = _boom
+    assert check_outbound_reconstruction(session, [], "sys") is True
+
+
+def test_stub_without_history_does_not_call_messages_for_provider():
+    seen = {"n": 0}
+
+    class _Session:
+        _append_only = False
+        _frozen_system_prompt = None
+
+        def _messages_for_provider(self):
+            seen["n"] += 1
+            return [{"role": "user", "content": "hi"}]
+
+    session = _Session()
+    outbound = [{"role": "user", "content": "hi"}]
+    assert check_outbound_reconstruction(session, outbound, "sys") is True
+    assert seen["n"] == 0

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -4,9 +4,18 @@ from __future__ import annotations
 
 
 def test_cursor_cli_is_pilot_only():
-    from harness.provider_capabilities import worker_capability
+    from harness.provider_capabilities import worker_capability, capability_hint
 
     assert worker_capability("cursor-cli") == "pilot_only"
+    hint = capability_hint("pilot_only").lower()
+    assert "full stack" in hint
+    assert "not required" in hint
+
+
+def test_openrouter_is_full_stack():
+    from harness.provider_capabilities import worker_capability
+
+    assert worker_capability("openrouter") == "full_stack"
 
 
 def test_openai_codex_and_nous_are_full_stack():

--- a/tests/test_repeat_tool_reminder.py
+++ b/tests/test_repeat_tool_reminder.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from harness.pilot import PilotAction
+from harness.repeat_tool_reminder import (
+    GENTLE_REMINDER,
+    PLUGIN_SOURCE,
+    canonicalize_call,
+    note_repeat_and_maybe_nudge,
+    observe_repeat,
+    reset_repeat_chain,
+)
+
+
+def _session():
+    return SimpleNamespace(_repeat_tool_chain=None)
+
+
+def _act(kind="web_search", query="foo"):
+    return PilotAction(kind=kind, query=query, arguments={"query": query})
+
+
+def test_canonicalize_reuses_loop_guard_fingerprint():
+    a = _act("web_search", "hello")
+    b = _act("web_search", "hello")
+    assert canonicalize_call("web_search", a) == canonicalize_call("web_search", b)
+
+
+def test_nudge_at_three_five_eight_not_two():
+    session = _session()
+    act = _act()
+    assert observe_repeat(session, "web_search", act) is None
+    assert observe_repeat(session, "web_search", act) is None
+    third = observe_repeat(session, "web_search", act)
+    assert third is not None
+    assert PLUGIN_SOURCE in third
+    assert GENTLE_REMINDER in third
+    assert observe_repeat(session, "web_search", act) is None
+    fifth = observe_repeat(session, "web_search", act)
+    assert fifth is not None
+    assert "consecutive_calls: 5" in fifth
+    assert observe_repeat(session, "web_search", act) is None
+    assert observe_repeat(session, "web_search", act) is None
+    eighth = observe_repeat(session, "web_search", act)
+    assert eighth is not None
+    assert "consecutive_calls: 8" in eighth
+
+
+def test_different_tracked_tool_resets_chain():
+    session = _session()
+    first = _act("web_search", "a")
+    other = _act("web_fetch", "https://example.com")
+    other.url = "https://example.com"
+    observe_repeat(session, "web_search", first)
+    observe_repeat(session, "web_search", first)
+    observe_repeat(session, "web_fetch", other)
+    assert observe_repeat(session, "web_search", first) is None
+    assert observe_repeat(session, "web_search", first) is None
+    assert observe_repeat(session, "web_search", first) is not None
+
+
+def test_untracked_tool_neither_counts_nor_resets(monkeypatch):
+    monkeypatch.setenv("HARNESS_REPEAT_TOOL_EXCLUDE", "read_file")
+    session = _session()
+    search = _act("web_search", "q")
+    read = PilotAction(kind="read_file", path="AGENTS.md", arguments={"path": "AGENTS.md"})
+    observe_repeat(session, "web_search", search)
+    observe_repeat(session, "web_search", search)
+    assert observe_repeat(session, "read_file", read) is None
+    third = observe_repeat(session, "web_search", search)
+    assert third is not None
+    assert GENTLE_REMINDER in third
+
+
+def test_user_turn_resets_chain():
+    session = _session()
+    act = _act()
+    observe_repeat(session, "web_search", act)
+    observe_repeat(session, "web_search", act)
+    reset_repeat_chain(session)
+    assert observe_repeat(session, "web_search", act) is None
+    assert observe_repeat(session, "web_search", act) is None
+    assert observe_repeat(session, "web_search", act) is not None
+
+
+def test_suffix_does_not_veto_and_lands_on_content():
+    session = _session()
+    act = _act()
+    note_repeat_and_maybe_nudge(session, act, "ok")
+    note_repeat_and_maybe_nudge(session, act, "ok")
+    third = note_repeat_and_maybe_nudge(session, act, "ok")
+    assert third.startswith("ok")
+    assert PLUGIN_SOURCE in third
+    assert GENTLE_REMINDER in third
+
+
+def test_append_action_result_suffixes_nudge_without_extra_row(tmp_path):
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+
+    cfg = HarnessConfig(state_dir=str(tmp_path))
+    session = ConversationalSession(cfg)
+    act = PilotAction(
+        kind="web_search",
+        query="foo",
+        arguments={"query": "foo"},
+    )
+    session._append_action_result(act, "c1", "ok-1", True)
+    session._append_action_result(act, "c2", "ok-2", True)
+    before = len(session._history)
+    session._append_action_result(act, "c3", "ok-3", True)
+    assert len(session._history) == before + 1
+    last = session._history[-1]
+    assert last["role"] == "tool"
+    assert last["tool_call_id"] == "c3"
+    assert PLUGIN_SOURCE in last["content"]
+    assert GENTLE_REMINDER in last["content"]
+
+
+def test_reminder_does_not_replace_loop_guard_veto():
+    from harness.pilot_guards import (
+        LOOP_REPEAT_CAP,
+        TurnGuardState,
+        check_loop_guard,
+        record_action_execution,
+        record_successful_result,
+    )
+
+    state = TurnGuardState(user_message="x")
+    act = _act()
+    record_action_execution(state, "web_search", act)
+    record_successful_result(state, "web_search", act, "cached")
+    record_action_execution(state, "web_search", act)
+    verdict = check_loop_guard(state, "web_search", act)
+    assert verdict.suppress is True
+    assert LOOP_REPEAT_CAP >= 2

--- a/tests/test_tool_pairing.py
+++ b/tests/test_tool_pairing.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from harness.compaction_mixin import CompactionContextMixin
+from harness.tool_pairing import (
+    event_delta,
+    in_progress_count,
+    nearest_balanced_split,
+    pairing_balanced_after,
+    pairing_balanced_before,
+)
+
+
+def _asst(*ids):
+    return {
+        "role": "assistant",
+        "content": "call",
+        "tool_calls": [
+            {"id": i, "type": "function", "function": {"name": "read_file", "arguments": "{}"}}
+            for i in ids
+        ],
+    }
+
+
+def _tool(call_id, content="ok"):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def test_empty_and_no_tools_are_balanced():
+    history = [{"role": "system", "content": "s"}, {"role": "user", "content": "hi"}]
+    assert in_progress_count([]) == 0
+    assert pairing_balanced_before(history, 0)
+    assert pairing_balanced_before(history, 1)
+    assert pairing_balanced_before(history, 2)
+    assert pairing_balanced_after(history, 1)
+
+
+def test_two_calls_balanced_only_after_both_results():
+    history = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "q"},
+        _asst("a", "b"),
+        _tool("a"),
+        _tool("b"),
+    ]
+    assert event_delta(history[2]) == 2
+    assert pairing_balanced_before(history, 2)
+    assert not pairing_balanced_before(history, 3)
+    assert not pairing_balanced_before(history, 4)
+    assert pairing_balanced_before(history, 5)
+    assert pairing_balanced_after(history, 4)
+
+
+def test_cut_that_keeps_result_and_summarizes_call_is_unbalanced():
+    history = [
+        {"role": "system", "content": "s"},
+        _asst("a"),
+        {"role": "user", "content": "gap"},
+        _tool("a"),
+    ]
+    # Cut before the result: call is in the prefix, result would stay in tail.
+    assert not pairing_balanced_before(history, 3)
+    assert pairing_balanced_before(history, 4)
+
+
+def test_extra_result_without_call_is_unbalanced_no_raise():
+    history = [
+        {"role": "system", "content": "s"},
+        _tool("orphan"),
+    ]
+    assert in_progress_count(history) == -1
+    assert pairing_balanced_before(history, 2) is False
+
+
+def test_nearest_split_advances_past_open_pair():
+    history = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "q"},
+        _asst("a"),
+        _tool("a"),
+        {"role": "assistant", "content": "done"},
+    ]
+    # Preferred cut between call and result.
+    assert nearest_balanced_split(history, 3) == 4
+
+
+def test_nearest_split_walks_back_for_unanswered_mid_turn_call():
+    history = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "old"},
+        _asst("open"),
+    ]
+    # No result yet: advancing hits the end still unbalanced; walk back so
+    # the open call stays in the tail.
+    assert nearest_balanced_split(history, 3) == 3
+    assert pairing_balanced_before(history, 3)
+
+
+class _SplitHost(CompactionContextMixin):
+    def __init__(self, history):
+        self._history = history
+
+
+def test_find_safe_split_refuses_unanswered_call_in_prefix():
+    history = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "old"},
+        _asst("open"),
+    ]
+    host = _SplitHost(history)
+    assert host._find_safe_split(3) == 3

--- a/tests/test_tool_timeout.py
+++ b/tests/test_tool_timeout.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from harness.tool_timeout import (
+    TOOL_TIMEOUT,
+    declared_timeout_ms,
+    invoke_do,
+    run_with_tool_deadline,
+)
+
+
+def _session():
+    return SimpleNamespace(_cancel=threading.Event(), _interrupt_requested=False)
+
+
+def test_inner_timeout_kinds_declare_nothing():
+    for kind in (
+        "run_command",
+        "run_ipython",
+        "run_swarm",
+        "run_implement",
+        "run_parallel",
+        "route_task",
+    ):
+        assert declared_timeout_ms(kind) is None
+
+
+def test_network_tools_declare_a_budget():
+    for kind in (
+        "web_fetch",
+        "web_search",
+        "read_pdf",
+        "search_codegraph",
+        "search_files",
+        "call_mcp",
+        "query_wiki",
+    ):
+        budget = declared_timeout_ms(kind)
+        assert budget is not None
+        assert budget > 0
+
+
+def test_invoke_do_maps_only_this_wrapper_expiry(monkeypatch):
+    monkeypatch.setenv("HARNESS_TOOL_TIMEOUT_WEB_SEARCH_MS", "40")
+    session = _session()
+    act = SimpleNamespace(kind="web_search")
+
+    def _slow():
+        session._cancel.wait(2.0)
+        return (True, "ok", "late")
+
+    triple = invoke_do(session, act, _slow)
+    assert triple[0] is False
+    assert triple[1] == TOOL_TIMEOUT
+    assert "40ms" in triple[2]
+    assert not session._cancel.is_set()
+
+
+def test_user_stop_is_not_remapped_to_tool_timeout():
+    session = _session()
+    session._interrupt_requested = True
+    session._cancel.set()
+
+    def _already_cancelled():
+        return (False, "cancelled", "user stop")
+
+    result, timed_out = run_with_tool_deadline(
+        session, "web_search", _already_cancelled, timeout_ms=20,
+    )
+    assert timed_out is None
+    assert result[1] == "cancelled"
+
+
+def test_inner_command_timeout_status_stays_honest():
+    session = _session()
+
+    def _command():
+        return (False, "timeout", "command timed out")
+
+    result, timed_out = run_with_tool_deadline(session, "run_command", _command)
+    assert timed_out is None
+    assert result == (False, "timeout", "command timed out")
+
+
+def test_no_budget_does_not_arm_a_timer():
+    session = _session()
+    called = []
+
+    def _fn():
+        called.append(True)
+        return (True, "ok", "x")
+
+    result, timed_out = run_with_tool_deadline(session, "read_file", _fn)
+    assert timed_out is None
+    assert result[0] is True
+    assert called == [True]

--- a/tests/test_workspace_rules_refresh.py
+++ b/tests/test_workspace_rules_refresh.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from harness.config import HarnessConfig
+from harness.conversation import ConversationalSession, load_workspace_rules
+from harness.workspace_rules_refresh import (
+    is_instruction_path,
+    maybe_refresh_workspace_rules,
+    reconcile_workspace_rules,
+)
+
+
+def test_instruction_path_matches_loaded_files(tmp_path):
+    repo = str(tmp_path)
+    assert is_instruction_path(str(tmp_path / "AGENTS.md"), repo)
+    assert is_instruction_path("CLAUDE.md", repo)
+    assert is_instruction_path(str(tmp_path / ".cursorrules"), repo)
+    assert is_instruction_path(str(tmp_path / ".cursor" / "rules" / "foo.md"), repo)
+    assert is_instruction_path(str(tmp_path / ".github" / "copilot-instructions.md"), repo)
+    assert not is_instruction_path(str(tmp_path / "README.md"), repo)
+
+
+def test_reconcile_replaces_live_and_frozen_prompt(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("rule-one\n", encoding="utf-8")
+    cfg = HarnessConfig(repo=str(tmp_path), state_dir=str(tmp_path / "state"))
+    session = ConversationalSession(cfg)
+    assert "rule-one" in session._history[0]["content"]
+    session._frozen_system_prompt = session._history[0]["content"]
+    (tmp_path / "AGENTS.md").write_text("rule-two\n", encoding="utf-8")
+    assert reconcile_workspace_rules(session) is True
+    assert "rule-two" in session._history[0]["content"]
+    assert "rule-one" not in session._history[0]["content"]
+    assert "rule-two" in session._frozen_system_prompt
+    assert session._workspace_rules_block == load_workspace_rules(str(tmp_path))
+
+
+def test_reconcile_is_noop_when_unchanged(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("stable\n", encoding="utf-8")
+    cfg = HarnessConfig(repo=str(tmp_path), state_dir=str(tmp_path / "state"))
+    session = ConversationalSession(cfg)
+    assert reconcile_workspace_rules(session) is False
+
+
+def test_maybe_refresh_ignores_ordinary_files(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("keep\n", encoding="utf-8")
+    cfg = HarnessConfig(repo=str(tmp_path), state_dir=str(tmp_path / "state"))
+    session = ConversationalSession(cfg)
+    (tmp_path / "src.py").write_text("x = 1\n", encoding="utf-8")
+    assert maybe_refresh_workspace_rules(session, str(tmp_path / "src.py")) is False
+    assert "keep" in session._history[0]["content"]

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.218",
+  "version": "0.9.219",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.218",
+      "version": "0.9.219",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.218",
+  "version": "0.9.219",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -339,8 +339,13 @@ export default function App() {
       {/* Keyless nudge: agentic is the shipped default, so instead of a demo run
           we tell the user to plug in a key. Suppressed while the first-run wizard
           is up (it already covers key setup) to avoid stacking two prompts. */}
-      {config?.agentic_ready === false && !showWizard && (
+      {config && (config.workers_ready ?? config.agentic_ready) === false && !showWizard && (
         <ProviderKeyBanner
+          variant={
+            config.pilot_ready && (config.workers_ready ?? config.agentic_ready) === false
+              ? "workers"
+              : "keyless"
+          }
           onAddKey={() => {
             focusSettingsPage("providers");
             openRightTo("settings");

--- a/webapp/src/__tests__/ProviderKeyBanner.test.tsx
+++ b/webapp/src/__tests__/ProviderKeyBanner.test.tsx
@@ -15,6 +15,13 @@ describe("ProviderKeyBanner", () => {
     expect(screen.getByText(/Add a provider key to run real analysis/i)).toBeTruthy();
   });
 
+  it("tells a pilot-only user to add a Full stack key for swarms", () => {
+    render(<ProviderKeyBanner onAddKey={vi.fn()} variant="workers" />);
+    const banner = screen.getByTestId("provider-key-banner");
+    expect(banner.getAttribute("data-variant")).toBe("workers");
+    expect(screen.getByText(/Chat works. Add an API key for swarms/i)).toBeTruthy();
+  });
+
   it("invokes onAddKey when Add key is clicked", () => {
     const onAddKey = vi.fn();
     render(<ProviderKeyBanner onAddKey={onAddKey} />);

--- a/webapp/src/__tests__/SettingsPane.keysFirst.test.tsx
+++ b/webapp/src/__tests__/SettingsPane.keysFirst.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SettingsPane, { clearSettingsSnapshot } from "../components/SettingsPane";
+import { api } from "../lib/api";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    settings: vi.fn().mockResolvedValue({
+      driver: "cursor",
+      reach: "repo",
+      budget: 100,
+      models: [],
+      auto_distill: false,
+      state_dir: "/tmp/state",
+      repo: "/tmp/repo",
+      has_api_key: false,
+    }),
+    updateSettings: vi.fn(),
+    getUsage: vi.fn().mockResolvedValue(null),
+    getWikiConfig: vi.fn().mockResolvedValue({ api_base: "", has_token: false }),
+    getHooks: vi.fn().mockResolvedValue({ hooks: [], events: [] }),
+    providers: vi.fn().mockResolvedValue([]),
+    authPools: vi.fn().mockResolvedValue({ pools: [] }),
+    bedrockStatus: vi.fn().mockResolvedValue(null),
+    cursorCliStatus: vi.fn().mockResolvedValue(null),
+    gitStatus: vi.fn().mockResolvedValue(null),
+    platformAdapters: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../components/SkillsPane", () => ({ default: () => <div /> }));
+vi.mock("../components/MemoryPane", () => ({ default: () => <div /> }));
+vi.mock("../components/SchedulesPane", () => ({ default: () => <div /> }));
+
+describe("SettingsPane keys-first providers order", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearSettingsSnapshot();
+    vi.mocked(api.settings).mockResolvedValue({
+      driver: "cursor",
+      reach: "repo",
+      budget: 100,
+      models: [],
+      auto_distill: false,
+      state_dir: "/tmp/state",
+      repo: "/tmp/repo",
+      has_api_key: false,
+    } as never);
+  });
+
+  it("shows API keys before optional plan sign-in", () => {
+    render(<SettingsPane onOpenWizard={vi.fn()} section="providers" />);
+    const keys = screen.getByText("API keys");
+    const signIn = screen.getByText("Optional plan sign-in");
+    expect(keys.compareDocumentPosition(signIn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/webapp/src/components/ProviderKeyBanner.tsx
+++ b/webapp/src/components/ProviderKeyBanner.tsx
@@ -11,22 +11,36 @@ import { TITLEBAR_TRAFFIC_PAD_PX } from "../lib/titlebarSafe";
 // "you're still keyless" reminder that reappears each launch until a key is added
 // (adding one fires harness-config-changed -> App refetches -> agentic_ready flips
 // true -> this unmounts on its own).
-export default function ProviderKeyBanner({ onAddKey }: { onAddKey: () => void }) {
+export default function ProviderKeyBanner({
+  onAddKey,
+  variant = "keyless",
+}: {
+  onAddKey: () => void;
+  variant?: "keyless" | "workers";
+}) {
   const [dismissed, setDismissed] = useState(false);
   if (dismissed) return null;
+  const workersOnly = variant === "workers";
 
   return (
     // Fixed px paddingLeft clears macOS traffic lights (hiddenInset). Rem-based
     // Tailwind pl-24 shrinks with the responsive root font-size on resize.
     <div
       data-testid="provider-key-banner"
+      data-variant={variant}
       className="flex items-center gap-2.5 pr-4 py-1.5 bg-accent/10 border-b border-accent/25 text-[11.5px] text-txt select-none shrink-0"
       style={{ paddingLeft: TITLEBAR_TRAFFIC_PAD_PX }}
     >
       <KeyRound size={13} className="text-accent shrink-0" />
-      <span className="font-medium">Add a provider key to run real analysis.</span>
+      <span className="font-medium">
+        {workersOnly
+          ? "Chat works. Add an API key for swarms."
+          : "Add a provider key to run real analysis."}
+      </span>
       <span className="text-muted hidden sm:inline">
-        Marionette routes directly through your own keys -- add one and it works out of the box.
+        {workersOnly
+          ? "Pilot-only login cannot drive workers. Paste a Full stack key (OpenRouter, Codex, …) — no Cursor install."
+          : "Marionette routes pilots and workers through your own keys -- add one and it works out of the box."}
       </span>
       <div className="flex-1" />
       <button

--- a/webapp/src/components/RegistryWizard.tsx
+++ b/webapp/src/components/RegistryWizard.tsx
@@ -283,9 +283,9 @@ export default function RegistryWizard({ onClose }: RegistryWizardProps) {
         <div className="flex items-center justify-between px-4 py-3 border-b border-edge">
           <div className="flex items-center gap-2">
             <span className="font-bold text-[14px] uppercase tracking-wider text-txt">
-              Provider & Model Setup
+              Add a key — pilots and workers
             </span>
-            <span className="text-[10px] text-faint uppercase font-medium">wizard</span>
+            <span className="text-[10px] text-faint uppercase font-medium">first run</span>
           </div>
           <button 
             onClick={onClose}
@@ -315,13 +315,22 @@ export default function RegistryWizard({ onClose }: RegistryWizardProps) {
           <div className="space-y-3">
             <div className="flex items-center justify-between border-b border-edge/60 pb-1.5">
               <span className="uppercase tracking-wider text-[11px] text-faint font-bold">
-                1. API Key Providers & Live Probing
+                1. Full stack API keys
               </span>
-              <span className="text-[10px] text-muted">Configure keys to load real models</span>
+              <span className="text-[10px] text-muted">One key runs chat and swarms. No Cursor install.</span>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              {providers.map((p) => {
+              {[...providers]
+                .filter((p) => p.name !== "cursor-cli")
+                .sort((a, b) => {
+                  if (a.name === "openrouter") return -1;
+                  if (b.name === "openrouter") return 1;
+                  const aFull = a.worker_capability === "full_stack" ? 0 : 1;
+                  const bFull = b.worker_capability === "full_stack" ? 0 : 1;
+                  return aFull - bFull;
+                })
+                .map((p) => {
                 const isProbing = probing[p.name];
                 const probeRes = probeStatus[p.name];
                 const hasProbedModels = probedModels[p.name]?.length > 0;

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -1404,6 +1404,125 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
         </div>
 
         </>)}
+        {gate("providers", "providers api keys connect disconnect per-provider key management") && (<>
+        {/* Per-provider key management: connect/disconnect each provider independently */}
+        <SettingsCollapse
+          id="api-keys"
+          title="API keys"
+          defaultOpen={true}
+          forceOpen={!!q}
+          onFirstOpen={loadProvidersList}
+          className="space-y-2"
+          summary={(() => {
+            if (!providersLoaded) return "…";
+            const list = providers.filter((p) => p.name !== "bedrock");
+            const n = list.filter((p) => p.has_key && !p.disconnected).length;
+            return `${n}/${list.length} connected`;
+          })()}
+        >
+          <div className="text-[10px] text-muted">
+            One Full stack key (OpenRouter, Anthropic, OpenAI, Gemini, …) runs the chat
+            pilot and agentic swarm/implement workers. No other platform install.
+            Env-imported keys get an on/off toggle so you can swap without losing the key.
+          </div>
+          <div className="space-y-1.5">
+            {providers.filter((p) => p.name !== "bedrock").map((p) => {
+              // A provider can carry a key from the environment (e.g. a
+              // shell-exported OPENROUTER_API_KEY) rather than one stored in the
+              // app. Env-backed providers get an on/off toggle instead of a
+              // destructive Disconnect: flipping it off scrubs the key from the
+              // running process (so no worker/router uses it) but preserves it
+              // for a one-click re-enable -- painless swapping between, say, a
+              // work key and a personal one.
+              const envBacked = !!p.has_env;
+              const enabled = !p.disconnected;
+              const connected = p.has_key;
+              const busy = provBusy === p.name;
+              return (
+              <div key={p.name} className="bg-panel2 border border-edge/50 rounded p-2">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${connected ? "bg-good" : "bg-faint"}`} />
+                    <span className="text-txt font-medium text-[11px]">{p.display_name || p.name}</span>
+                    {p.worker_capability_label ? (
+                      <span
+                        title={p.worker_capability_hint || undefined}
+                        className={`text-[10px] shrink-0 ${
+                          p.worker_capability === "full_stack"
+                            ? "text-good/80"
+                            : p.worker_capability === "platform_worker"
+                              ? "text-accent/80"
+                              : "text-warn/90"
+                        }`}
+                      >
+                        {p.worker_capability_label}
+                      </span>
+                    ) : null}
+                    <span
+                      title={envBacked ? `Key imported from your environment (${p.env_var || "env var"})` : undefined}
+                      className="text-faint text-[10px] font-mono truncate"
+                    >
+                      {envBacked
+                        ? `${enabled ? "connected" : "disabled"} - via env`
+                        : p.has_key
+                          ? "connected - via key"
+                          : "not connected"}
+                    </span>
+                  </div>
+                  {envBacked ? (
+                    <button
+                      role="switch"
+                      aria-checked={enabled}
+                      title={enabled ? "Enabled -- click to turn off (key is kept for easy re-enable)" : "Disabled -- click to turn on"}
+                      onClick={() => handleToggleProvider(p.name, !enabled)}
+                      disabled={busy}
+                      className={`relative shrink-0 w-9 h-5 rounded-full border transition-colors disabled:opacity-40 ${
+                        enabled ? "bg-good/30 border-good/50" : "bg-panel border-edge"
+                      }`}
+                    >
+                      <span
+                        className={`absolute top-[1px] w-[15px] h-[15px] rounded-full transition-all ${
+                          enabled ? "left-[18px] bg-good" : "left-[2px] bg-faint"
+                        }`}
+                      />
+                    </button>
+                  ) : p.has_key ? (
+                    <button
+                      onClick={() => handleClearProviderKey(p.name)}
+                      disabled={busy}
+                      className="bg-risk/10 hover:bg-risk/20 text-risk border border-risk/30 hover:border-risk/50 rounded px-2 py-0.5 font-medium text-[10px] disabled:opacity-30 transition-colors shrink-0"
+                    >
+                      Disconnect
+                    </button>
+                  ) : null}
+                </div>
+                {!connected && !envBacked && (
+                  <div className="flex gap-2 mt-1.5">
+                    <input
+                      type="password"
+                      placeholder={`${p.env_var || "API key"}...`}
+                      value={provKeyInput[p.name] || ""}
+                      onChange={(e) => setProvKeyInput((prev) => ({ ...prev, [p.name]: e.target.value }))}
+                      disabled={busy}
+                      className="flex-1 bg-panel border border-edge rounded px-2 py-0.5 text-txt text-[11px] focus:outline-none focus:border-accent disabled:opacity-50 font-mono"
+                    />
+                    <button
+                      onClick={() => handleSetProviderKey(p.name)}
+                      disabled={busy || !(provKeyInput[p.name] || "").trim()}
+                      className="bg-accent/15 hover:bg-accent/25 text-accent border border-accent/30 hover:border-accent/50 rounded px-2.5 py-0.5 font-medium text-[10px] disabled:opacity-30 transition-colors shrink-0"
+                    >
+                      Connect
+                    </button>
+                  </div>
+                )}
+              </div>
+              );
+            })}
+          </div>
+        </SettingsCollapse>
+
+        </>)}
+
         {gate("providers", "sign in subscription oauth chatgpt codex claude max cursor xai grok nous plan account login") && (<>
         <SettingsCollapse
           id="sign-in"
@@ -1702,124 +1821,6 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
             <p className="text-[10px] text-accent font-mono leading-normal">{oauthHint}</p>
           ) : null}
         </SettingsCollapse>
-        </>)}
-        {gate("providers", "providers api keys connect disconnect per-provider key management") && (<>
-        {/* Per-provider key management: connect/disconnect each provider independently */}
-        <SettingsCollapse
-          id="api-keys"
-          title="API keys"
-          defaultOpen={true}
-          forceOpen={!!q}
-          onFirstOpen={loadProvidersList}
-          className="space-y-2"
-          summary={(() => {
-            if (!providersLoaded) return "…";
-            const list = providers.filter((p) => p.name !== "bedrock");
-            const n = list.filter((p) => p.has_key && !p.disconnected).length;
-            return `${n}/${list.length} connected`;
-          })()}
-        >
-          <div className="text-[10px] text-muted">
-            One Full stack key (OpenRouter, Anthropic, OpenAI, Gemini, …) runs the chat
-            pilot and agentic swarm/implement workers. No other platform install.
-            Env-imported keys get an on/off toggle so you can swap without losing the key.
-          </div>
-          <div className="space-y-1.5">
-            {providers.filter((p) => p.name !== "bedrock").map((p) => {
-              // A provider can carry a key from the environment (e.g. a
-              // shell-exported OPENROUTER_API_KEY) rather than one stored in the
-              // app. Env-backed providers get an on/off toggle instead of a
-              // destructive Disconnect: flipping it off scrubs the key from the
-              // running process (so no worker/router uses it) but preserves it
-              // for a one-click re-enable -- painless swapping between, say, a
-              // work key and a personal one.
-              const envBacked = !!p.has_env;
-              const enabled = !p.disconnected;
-              const connected = p.has_key;
-              const busy = provBusy === p.name;
-              return (
-              <div key={p.name} className="bg-panel2 border border-edge/50 rounded p-2">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${connected ? "bg-good" : "bg-faint"}`} />
-                    <span className="text-txt font-medium text-[11px]">{p.display_name || p.name}</span>
-                    {p.worker_capability_label ? (
-                      <span
-                        title={p.worker_capability_hint || undefined}
-                        className={`text-[10px] shrink-0 ${
-                          p.worker_capability === "full_stack"
-                            ? "text-good/80"
-                            : p.worker_capability === "platform_worker"
-                              ? "text-accent/80"
-                              : "text-warn/90"
-                        }`}
-                      >
-                        {p.worker_capability_label}
-                      </span>
-                    ) : null}
-                    <span
-                      title={envBacked ? `Key imported from your environment (${p.env_var || "env var"})` : undefined}
-                      className="text-faint text-[10px] font-mono truncate"
-                    >
-                      {envBacked
-                        ? `${enabled ? "connected" : "disabled"} - via env`
-                        : p.has_key
-                          ? "connected - via key"
-                          : "not connected"}
-                    </span>
-                  </div>
-                  {envBacked ? (
-                    <button
-                      role="switch"
-                      aria-checked={enabled}
-                      title={enabled ? "Enabled -- click to turn off (key is kept for easy re-enable)" : "Disabled -- click to turn on"}
-                      onClick={() => handleToggleProvider(p.name, !enabled)}
-                      disabled={busy}
-                      className={`relative shrink-0 w-9 h-5 rounded-full border transition-colors disabled:opacity-40 ${
-                        enabled ? "bg-good/30 border-good/50" : "bg-panel border-edge"
-                      }`}
-                    >
-                      <span
-                        className={`absolute top-[1px] w-[15px] h-[15px] rounded-full transition-all ${
-                          enabled ? "left-[18px] bg-good" : "left-[2px] bg-faint"
-                        }`}
-                      />
-                    </button>
-                  ) : p.has_key ? (
-                    <button
-                      onClick={() => handleClearProviderKey(p.name)}
-                      disabled={busy}
-                      className="bg-risk/10 hover:bg-risk/20 text-risk border border-risk/30 hover:border-risk/50 rounded px-2 py-0.5 font-medium text-[10px] disabled:opacity-30 transition-colors shrink-0"
-                    >
-                      Disconnect
-                    </button>
-                  ) : null}
-                </div>
-                {!connected && !envBacked && (
-                  <div className="flex gap-2 mt-1.5">
-                    <input
-                      type="password"
-                      placeholder={`${p.env_var || "API key"}...`}
-                      value={provKeyInput[p.name] || ""}
-                      onChange={(e) => setProvKeyInput((prev) => ({ ...prev, [p.name]: e.target.value }))}
-                      disabled={busy}
-                      className="flex-1 bg-panel border border-edge rounded px-2 py-0.5 text-txt text-[11px] focus:outline-none focus:border-accent disabled:opacity-50 font-mono"
-                    />
-                    <button
-                      onClick={() => handleSetProviderKey(p.name)}
-                      disabled={busy || !(provKeyInput[p.name] || "").trim()}
-                      className="bg-accent/15 hover:bg-accent/25 text-accent border border-accent/30 hover:border-accent/50 rounded px-2.5 py-0.5 font-medium text-[10px] disabled:opacity-30 transition-colors shrink-0"
-                    >
-                      Connect
-                    </button>
-                  </div>
-                )}
-              </div>
-              );
-            })}
-          </div>
-        </SettingsCollapse>
-
         </>)}
         {gate("providers", "credential pool rotate cursor openrouter anthropic openai api key accounts") && (<>
         <SettingsCollapse

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -1407,8 +1407,8 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
         {gate("providers", "sign in subscription oauth chatgpt codex claude max cursor xai grok nous plan account login") && (<>
         <SettingsCollapse
           id="sign-in"
-          title="Sign in"
-          defaultOpen={true}
+          title="Optional plan sign-in"
+          defaultOpen={false}
           forceOpen={!!q}
           onFirstOpen={loadSignInData}
           className="space-y-2"
@@ -1423,8 +1423,9 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
           })()}
         >
           <p className="text-[10px] text-muted leading-normal">
-            Log in with the subscription you already pay for. Labels mark Full stack
-            (pilot + workers) vs Pilot only (chat only until another Full stack auth is connected).
+            Optional. A Full stack API key below is enough for chat and swarms — no
+            Cursor, Claude, or Codex CLI install. Plan logins that are Full stack
+            (Codex, Claude Max, OpenCode Go, Nous) also drive workers. Cursor CLI is Pilot only.
           </p>
           <div className="space-y-1.5">
             <div className="bg-panel2 border border-edge/50 rounded p-2">
@@ -1560,7 +1561,8 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
                 </span>
               </div>
               <p className="text-[10px] text-muted mt-1 leading-normal">
-                Burns Cursor plan credits via the local Agent CLI. Requires the `agent` binary on PATH.
+                Optional. Burns Cursor plan credits via the local Agent CLI when the
+                `agent` binary is on PATH. Not required — paste a Full stack API key instead.
               </p>
               <div className="flex items-center gap-2 flex-wrap mt-1.5">
                 <button
@@ -1706,7 +1708,7 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
         <SettingsCollapse
           id="api-keys"
           title="API keys"
-          defaultOpen={false}
+          defaultOpen={true}
           forceOpen={!!q}
           onFirstOpen={loadProvidersList}
           className="space-y-2"
@@ -1718,7 +1720,9 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
           })()}
         >
           <div className="text-[10px] text-muted">
-            Connect or disconnect each provider independently. Keys imported from your environment get an on/off toggle -- flip one off to stop using it without losing the key, for easy swapping (e.g. work vs. personal).
+            One Full stack key (OpenRouter, Anthropic, OpenAI, Gemini, …) runs the chat
+            pilot and agentic swarm/implement workers. No other platform install.
+            Env-imported keys get an on/off toggle so you can swap without losing the key.
           </div>
           <div className="space-y-1.5">
             {providers.filter((p) => p.name !== "bedrock").map((p) => {
@@ -1835,7 +1839,8 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
             Add multiple API keys for the same provider. On plan-limit / 429 / 402 the pilot
             rotates to the next healthy entry (prompt cache may reset on rotate).
             Plan accounts (ChatGPT Codex, Claude Max, Cursor CLI, xAI, Nous) come from
-            Sign in above — pools are for multi-key rotate only. When every entry is
+            Optional plan sign-in above — pools are for multi-key rotate only. Cursor CLI
+            is Pilot only; a single Full stack API key is enough. When every entry is
             exhausted, the turn fails until a cooldown expires or you add another key.
           </p>
           <div className="flex flex-wrap gap-1.5">

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -33,6 +33,10 @@ export type Config = {
   swarm_adapter?: string;
   edit_engine?: "agentic" | "native";
   agentic_ready?: boolean;
+  /** Full stack key or CURSOR_API_KEY — swarms/implement can run. */
+  workers_ready?: boolean;
+  /** Any keyed harness provider, including Pilot-only cursor-cli. */
+  pilot_ready?: boolean;
   reasoning_effort?: ReasoningEffort;
 };
 export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max";


### PR DESCRIPTION
## Summary
- One Full stack Settings key runs both the chat pilot and agentic workers. Cursor CLI stays optional.
- DeepSeek loop-hygiene: repeat-tool reminder, cooperative `TOOL_TIMEOUT`, pairing-balanced compaction cuts, live AGENTS.md refresh, outbound reconstruction check.
- Version bump to 0.9.219.

## Test plan
- [x] Local pytest keys-only + loop-hygiene (296) and version consistency
- [x] Live Electron smoke (no-tool + read_file AGENTS.md)
- [ ] CI tests workflow green on the merge SHA (3.9 + 3.11 + frontend-build) before tag