### PR TITLE
Release v0.9.220: Send stays Send; compaction is one state doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.2` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.219, deliberately pre-1.0. One Full stack Settings key runs both chat and agentic workers; loop hygiene now reminds on identical tool repeats, times out hanging network tools, and refuses unpaired compaction cuts. Rides puppetmaster-ai==1.22.2. Cursor CLI / `CURSOR_API_KEY` remain optional upgrades (Pilot only / platform workers).
+> Status: v0.9.220, deliberately pre-1.0. The composer mouth stays Send while a Puppetmaster job flies; compaction overwrites one task-state document; the feed holds incomplete markdown fences and folds receipts into the activity strip. Rides puppetmaster-ai==1.22.2. Cursor CLI / `CURSOR_API_KEY` remain optional upgrades (Pilot only / platform workers).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.219"
+__version__ = "0.9.220"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/compaction_mixin.py
+++ b/harness/compaction_mixin.py
@@ -269,19 +269,23 @@ class CompactionContextMixin:
                 self._ctx_token_cache_len = cur_len
         except Exception:
             heuristic = self._estimate_context_tokens_for_list(self._history)
+        return self._usage_clock(heuristic)
+
+    def _usage_clock(self, heuristic: int) -> int:
+        """Billed prompt tokens plus heuristic growth since that sample.
+
+        chars//4 is the fallback clock when no usage exists, not a peer that
+        can win via max() and trip compact early or late.
+        """
         real = int(getattr(self, "_last_prompt_tokens", 0) or 0)
-        if real > 0:
-            # Usage is the clock. Heuristic only measures growth since that
-            # sample — it must not win via max() and trip compact early/late.
-            try:
-                baseline = int(getattr(self, "_last_prompt_heuristic", 0) or 0)
-            except Exception:
-                baseline = 0
-            growth = max(0, heuristic - baseline) if baseline > 0 else 0
-            return real + growth
-        # Offline / no real usage yet: fall back to the char heuristic so tests
-        # and pre-first-turn state still behave deterministically.
-        return heuristic
+        if real <= 0:
+            return int(heuristic or 0)
+        try:
+            baseline = int(getattr(self, "_last_prompt_heuristic", 0) or 0)
+        except Exception:
+            baseline = 0
+        growth = max(0, int(heuristic or 0) - baseline) if baseline > 0 else 0
+        return real + growth
 
     def _find_safe_split(self, start_idx: int) -> int:
         """Move ``start_idx`` to a cut that does not break tool pairing.
@@ -1152,10 +1156,9 @@ class CompactionContextMixin:
         self._invalidate_ctx_cache()
         self._reset_append_only_freeze()
         # The provider-reported prompt-token count refers to the PRE-compaction
-        # history; _estimate_context_tokens() takes max(real, heuristic), so a
-        # stale real count would mask the reduction we just made (after_tokens
-        # == before_tokens and the pressure advisor never clears). Drop it; the
-        # next billed turn repopulates it from actual usage.
+        # history. The usage clock is real + growth, so a stale real would
+        # mask the reduction (after_tokens == before_tokens and the pressure
+        # advisor never clears). Drop both; the next billed turn repopulates.
         try:
             self._last_prompt_tokens = 0
             self._last_prompt_heuristic = 0

--- a/harness/compaction_mixin.py
+++ b/harness/compaction_mixin.py
@@ -28,7 +28,6 @@ from typing import Iterator, Optional
 MIN_SUMMARY_SEED_CHARS = 200
 MIN_COMPACTABLE_TOKENS = 5000
 MAX_REDUCTION_RATIO = 0.8
-PREFERRED_RECENT_MESSAGES = 6
 # Verbatim recent-tail cap. Lifted from oh-my-pi keepRecentTokens=20000 and
 # Hermes ``tail_token_budget = threshold * summary_target_ratio`` (~20k on a
 # 200k/50% window). The old 64k floor left ~42% residual after "compaction"
@@ -249,16 +248,9 @@ class CompactionContextMixin:
             pass
 
     def _estimate_context_tokens(self) -> int:
-        # Prefer the driver's REAL last prompt-token count when available; the
-        # chars//4 heuristic (below) can UNDER-count code / tool-arg-heavy
-        # content (which tokenizes denser than 4 chars/token), which would trip
-        # the 75% compaction trigger too LATE and risk context overflow.
-        #
-        # Use max() rather than trusting either alone: the real count reflects
-        # the last billed turn but the history may have grown since, so the
-        # heuristic can be the larger (fresher) number. Taking the greater of
-        # the two biases toward safety -- we never under-estimate, only ever
-        # compact slightly early with a small safety margin.
+        # Prefer the driver's REAL last prompt-token count when available.
+        # chars//4 is the fallback clock, not a peer. Growth since that sample
+        # is added from the heuristic delta so a fat tool result still trips.
         #
         # HOT PATH: this method is called on every compaction check and on
         # every context-usage query, and the heuristic walks the WHOLE history.
@@ -279,7 +271,14 @@ class CompactionContextMixin:
             heuristic = self._estimate_context_tokens_for_list(self._history)
         real = int(getattr(self, "_last_prompt_tokens", 0) or 0)
         if real > 0:
-            return max(real, heuristic)
+            # Usage is the clock. Heuristic only measures growth since that
+            # sample — it must not win via max() and trip compact early/late.
+            try:
+                baseline = int(getattr(self, "_last_prompt_heuristic", 0) or 0)
+            except Exception:
+                baseline = 0
+            growth = max(0, heuristic - baseline) if baseline > 0 else 0
+            return real + growth
         # Offline / no real usage yet: fall back to the char heuristic so tests
         # and pre-first-turn state still behave deterministically.
         return heuristic
@@ -406,12 +405,10 @@ class CompactionContextMixin:
         return max(1, idx)
 
     def _choose_compaction_split(self, *, tail_budget: int) -> int | None:
-        """Pick a tool-safe split driven by token budget, not a fixed six-tail.
+        """Pick a tool-safe split driven by the live goal, not a six-message count.
 
-        Starts from a preferred six-message recent window, then moves the split
-        forward (fewer recent messages) until the kept tail fits ``tail_budget``,
-        stopping at one complete trailing user/assistant/tool group. When the
-        preferred window already fits, expands the tail while budget remains.
+        Starts at one complete trailing turn, then shrinks only when that tail
+        exceeds ``tail_budget``. Does not expand to fill the budget with acks.
         Returns None when nothing after the system message is compactable.
         """
         history = self._history
@@ -419,27 +416,19 @@ class CompactionContextMixin:
         if n < 2:
             return None
 
-        preferred_split = max(2, n - PREFERRED_RECENT_MESSAGES)
         min_recent_start = self._minimum_recent_start()
-        # min_recent_start == n → keep no recent messages (re-compact prior only).
+        # Live goal is the tail. Message count is the wrong unit — do not
+        # start from six and expand to fill 20k with acks.
         if min_recent_start >= n:
             split_idx = n
         else:
             if min_recent_start < 2:
                 min_recent_start = 2
-            split_idx = preferred_split
-            # Shrink oversized preferred tails toward the minimum recent group.
-            while split_idx < min_recent_start:
+            split_idx = min_recent_start
+            while split_idx < n:
                 if self._estimate_context_tokens_for_list(history[split_idx:]) <= tail_budget:
                     break
                 split_idx += 1
-            # Expand when there is spare budget (legacy direction).
-            while split_idx > 2:
-                proposed = history[split_idx - 1:]
-                if self._estimate_context_tokens_for_list(proposed) <= tail_budget:
-                    split_idx -= 1
-                else:
-                    break
 
         if split_idx < 2:
             split_idx = 2
@@ -471,8 +460,10 @@ class CompactionContextMixin:
         lines = []
         for m in messages:
             if m.get("_compressed_summary"):
+                # One state doc: pass the unwrapped body. Do not re-wrap
+                # PREVIOUS HISTORICAL — that is summary-of-summary sludge.
                 body = self._unwrap_prior_summary_content(m.get("content") or "")
-                lines.append(f"{_PRIOR_SUMMARY_WRAPPER}{body}")
+                lines.append(body)
                 continue
             role = m.get("role", "user").upper()
             content = m.get("content") or ""
@@ -617,6 +608,39 @@ class CompactionContextMixin:
             pruned.append(m_copy)
         return pruned
 
+    def _extract_task_facts(self, middle_block: list[dict]) -> dict:
+        """Pull paths, errors, and the last user ask — not head+tail chat."""
+        path_re = re.compile(
+            r"(?:[A-Za-z]:)?(?:[\w.-]+/)+\w[\w.-]*\.[A-Za-z0-9]+"
+        )
+        error_re = re.compile(
+            r"(?im)^(?:\s*(?:error|exception|failed|traceback|fatal)[:\s].+)$"
+        )
+        paths: list[str] = []
+        errors: list[str] = []
+        last_user = ""
+        seen_paths: set[str] = set()
+        seen_errors: set[str] = set()
+        for m in middle_block:
+            role = m.get("role") or ""
+            content = str(m.get("content") or "")
+            if role == "user" and not m.get("_compressed_summary"):
+                last_user = content.strip().split("\n", 1)[0][:240]
+            for match in path_re.findall(content):
+                if match not in seen_paths:
+                    seen_paths.add(match)
+                    paths.append(match)
+                    if len(paths) >= 12:
+                        break
+            for match in error_re.findall(content):
+                line = match.strip()
+                if line and line not in seen_errors:
+                    seen_errors.add(line)
+                    errors.append(line[:240])
+                    if len(errors) >= 8:
+                        break
+        return {"paths": paths, "errors": errors, "last_user": last_user}
+
     def _make_fallback_summary(
         self,
         middle_block: list[dict],
@@ -625,78 +649,40 @@ class CompactionContextMixin:
     ) -> str:
         """Deterministic extractive fallback bounded by ``char_budget``.
 
-        Never returns 1–4 huge messages verbatim — always keeps structured
-        first/last excerpts plus an explicit elision marker, and preserves the
-        required historical headings when practical.
+        Fail-closed: paths, errors, and the last user ask. Not head+tail of
+        the middle essay. Required headings stay; bodies are fact bullets.
         """
         n = len(middle_block)
         if char_budget is None:
             middle_tokens = self._estimate_context_tokens_for_list(middle_block)
             char_budget = summary_token_budget_for_middle(middle_tokens) * 4
-        # Floor so degenerate-summary guard still passes when material exists.
         char_budget = max(int(char_budget), MIN_SUMMARY_SEED_CHARS + 160)
 
-        head_n = min(2, n)
-        tail_n = min(2, n)
-        # Avoid double-including the same messages when the block is tiny.
-        if n <= 2:
-            first_part = self._format_block_for_summary(middle_block)
-            last_part = ""
-            elided_count = 0
-            content_elided = True  # still may truncate body below
-        elif n <= 4:
-            first_part = self._format_block_for_summary(middle_block[:head_n])
-            last_part = self._format_block_for_summary(middle_block[-tail_n:])
-            elided_count = 0
-            content_elided = True
-        else:
-            first_part = self._format_block_for_summary(middle_block[:head_n])
-            last_part = self._format_block_for_summary(middle_block[-tail_n:])
-            elided_count = n - head_n - tail_n
-            content_elided = elided_count > 0
-
-        # Reserve room for headings + elision note; split remainder head/tail.
-        overhead = 220
-        body_budget = max(MIN_SUMMARY_SEED_CHARS, char_budget - overhead)
-        head_budget = body_budget // 2 if last_part else body_budget
-        tail_budget = body_budget - head_budget if last_part else 0
-        first_part = self._clip_text(first_part, head_budget)
-        last_part = self._clip_text(last_part, tail_budget) if last_part else ""
-
-        if elided_count > 0:
-            note = (
-                f"[... {elided_count} messages were elided here to fit context window ...]"
-            )
-        elif content_elided:
-            note = "[... oversized turn content was elided here to fit context window ...]"
-        else:
-            note = "[... content elided to fit context window ...]"
-
-        if last_part and first_part:
-            excerpts = f"{first_part}\n\n{note}\n\n{last_part}"
-        else:
-            excerpts = f"{first_part}\n\n{note}" if first_part else note
+        facts = self._extract_task_facts(middle_block)
+        path_lines = "\n".join(f"- {p}" for p in facts["paths"]) or "- (no file pointers found)"
+        error_lines = "\n".join(f"- {e}" for e in facts["errors"]) or "- (no errors captured)"
+        last_ask = facts["last_user"] or "(no open user ask captured)"
+        note = f"[... {n} middle messages compressed to task facts ...]"
 
         summary = (
             f"{_REQUIRED_SUMMARY_HEADINGS[0]}\n"
-            f"{excerpts}\n"
+            f"{note}\n"
             f"{_REQUIRED_SUMMARY_HEADINGS[1]}\n"
-            "Earlier turns were extractively compressed; see excerpts above.\n"
+            f"{error_lines}\n"
             f"{_REQUIRED_SUMMARY_HEADINGS[2]}\n"
-            "See the latest excerpt for any still-open user ask.\n"
+            f"- {last_ask}\n"
             f"{_REQUIRED_SUMMARY_HEADINGS[3]}\n"
-            "Preserved high-value paths and decisions appear in the excerpts.\n"
+            f"{path_lines}\n"
         )
         if len(summary) > char_budget:
             summary = self._clip_text(summary, char_budget)
-        # Final safety: never ship a seed shorter than the quality floor when we
-        # still have source material — pad from the head excerpt if needed.
-        if len(summary.strip()) < MIN_SUMMARY_SEED_CHARS and first_part:
+        if len(summary.strip()) < MIN_SUMMARY_SEED_CHARS:
             pad = self._clip_text(
-                first_part,
+                self._format_block_for_summary(middle_block[-2:] if n else []),
                 MIN_SUMMARY_SEED_CHARS - len(summary.strip()) + 32,
             )
-            summary = summary.rstrip() + "\n" + pad
+            if pad:
+                summary = summary.rstrip() + "\n" + pad
             if len(summary) > char_budget:
                 summary = self._clip_text(summary, char_budget)
         return summary
@@ -921,7 +907,9 @@ class CompactionContextMixin:
             "## Pending / Open Questions\n"
             "## Key Facts / Decisions / Files\n"
             f"Be extremely concise (hard budget ~{summary_token_budget} tokens). "
-            "Preserve key file paths, decisions, and unresolved asks; drop boilerplate and repeated tool chatter."
+            "Each bullet must name a file, a decision, or an open question. "
+            "Drop jokes, failed tool dumps, and 'then I ran' recap. "
+            "Overwrite the current task state; do not wrap a previous summary."
         )
 
         content_to_summarize = self._format_block_for_summary(pruned_middle)
@@ -1170,6 +1158,7 @@ class CompactionContextMixin:
         # next billed turn repopulates it from actual usage.
         try:
             self._last_prompt_tokens = 0
+            self._last_prompt_heuristic = 0
         except Exception:
             pass
 

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -1927,12 +1927,9 @@ class ConversationalSession(
             + summarized_tokens
             + conversation_tokens
         )
-        # Prefer the driver's REAL last prompt-token count so the composer's
-        # context-usage % matches the actual billed context, not a chars//4
-        # estimate. Mirror _estimate_context_tokens: take the greater of the
-        # real number and the heuristic so we never under-report usage.
-        real_total = int(getattr(self, "_last_prompt_tokens", 0) or 0)
-        total_tokens = max(real_total, heuristic_total) if real_total > 0 else heuristic_total
+        # Same usage clock as compact: billed tokens plus growth since that
+        # sample. Heuristic is fallback, not a peer that can win via max().
+        total_tokens = self._usage_clock(heuristic_total)
 
         categories = [
             {"name": "System prompt", "tokens": system_prompt_tokens},

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -964,6 +964,12 @@ def meter_pilot_step(
     # the driver's actual number over the chars//4 heuristic.
     if _t_in > 0:
         session._last_prompt_tokens = _t_in
+        try:
+            session._last_prompt_heuristic = session._estimate_context_tokens_for_list(
+                getattr(session, "_history", []) or []
+            )
+        except Exception:
+            session._last_prompt_heuristic = 0
         # Schema-token EMA calibration (experiment-gated; telemetry-only).
         try:
             updater = getattr(session, "_maybe_update_schema_token_calibration", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.219"
+version = "0.9.220"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -124,10 +124,10 @@ def test_maybe_compact_history_above_trigger():
 def test_compaction_clears_stale_prompt_token_telemetry():
     """A stale provider prompt-token count must not mask the reduction.
 
-    ``_estimate_context_tokens()`` takes max(real, heuristic); after compaction
-    the "real" number still describes the PRE-compaction history, so keeping it
-    would report after_tokens == before_tokens and the pressure advisor would
-    never clear.
+    ``_estimate_context_tokens()`` uses billed usage plus heuristic growth;
+    after compaction the "real" number still describes the PRE-compaction
+    history, so keeping it would report after_tokens == before_tokens and
+    the pressure advisor would never clear.
     """
     cfg = HarnessConfig(max_context_tokens=1000)
     s = ConversationalSession(cfg)
@@ -182,11 +182,9 @@ def test_fallback_truncation_on_pilot_failure():
     # Verify we compacted and didn't crash
     assert s._history[1]["role"] == "user"
     assert "[Earlier conversation summarized to fit context]" in s._history[1]["content"]
-    # Fallback should keep first 2 and last 2 of the old block + note
-    assert "Msg 0:" in s._history[1]["content"]
-    assert "Msg 1:" in s._history[1]["content"]
-    assert "were elided here" in s._history[1]["content"]
+    assert "middle messages compressed to task facts" in s._history[1]["content"]
     assert "## Historical Task Snapshot" in s._history[1]["content"]
+    assert "## Key Facts / Decisions / Files" in s._history[1]["content"]
     
     after_tokens = s._estimate_context_tokens()
     assert after_tokens <= 750
@@ -216,8 +214,8 @@ def test_short_history_huge_prior_summary_compacts(monkeypatch):
     assert s._history[0]["role"] == "system"
     assert s._history[1].get("_compressed_summary") is True
     assert "Compaction fixture summary" in s._history[1]["content"]
-    # Nested prior-summary wrappers must not grow unbounded.
-    assert s._history[1]["content"].count("PREVIOUS HISTORICAL CONVERSATION SUMMARY:") <= 1
+    # One state doc: never re-wrap the prior summary.
+    assert "PREVIOUS HISTORICAL CONVERSATION SUMMARY:" not in s._history[1]["content"]
     after = s._estimate_context_tokens()
     assert after < before
     assert s._last_compaction_attempt.get("reason") == "ok"
@@ -244,9 +242,10 @@ def test_adaptive_tail_shrinks_when_six_recent_exceed_budget(monkeypatch):
     assert [e.kind for e in events] == ["compacting", "compaction"]
     after = s._estimate_context_tokens()
     assert after < before
-    # Kept recent window must be smaller than the preferred six when they blow the budget.
+    # Live-goal tail: a fat last turn may itself enter the state doc.
     assert len(s._history) < 8
-    assert s._history[-1]["content"].startswith("turn-5")
+    last = s._history[-1]["content"]
+    assert last.startswith("turn-5") or s._history[1].get("_compressed_summary")
 
 
 def test_adaptive_tail_keeps_tool_pairs_intact(monkeypatch):
@@ -316,8 +315,9 @@ def test_fallback_bounds_few_huge_messages(monkeypatch):
     events = list(s._maybe_compact_history(force=True))
     assert [e.kind for e in events] == ["compacting", "compaction"]
     injected = s._history[1]["content"]
-    assert "elided" in injected.lower()
+    assert "task facts" in injected.lower() or "elided" in injected.lower()
     assert "## Historical Task Snapshot" in injected
+    assert "## Key Facts / Decisions / Files" in injected
     assert len(injected) < 20000
     assert s._estimate_context_tokens() < before
 
@@ -887,3 +887,61 @@ def test_summarizer_input_aggregate_hard_cap(monkeypatch, tmp_path):
     # Cap is 4000; marker may add a little overhead beyond the clip target.
     assert len(summarizer_input) < 6_000
     assert "summarizer input" in summarizer_input or "middle elided" in summarizer_input
+
+
+def test_usage_clock_does_not_let_heuristic_win():
+    cfg = HarnessConfig(max_context_tokens=1000)
+    s = ConversationalSession(cfg)
+    s._history[0]["content"] = "sys"
+    s._history.append({"role": "user", "content": "A" * 400})
+    heuristic = s._estimate_context_tokens_for_list(s._history)
+    s._last_prompt_tokens = 80
+    s._last_prompt_heuristic = heuristic
+    # Same history as the sample: clock is billed usage, not chars//4.
+    assert s._estimate_context_tokens() == 80
+    s._history.append({"role": "assistant", "content": "B" * 400})
+    grown = s._estimate_context_tokens()
+    assert grown > 80
+    assert grown < s._estimate_context_tokens_for_list(s._history)
+
+
+def test_second_compact_does_not_rewrap_previous_historical(monkeypatch):
+    monkeypatch.setattr("harness.compaction_mixin.MIN_COMPACTABLE_TOKENS", 0)
+    cfg = HarnessConfig(max_context_tokens=4000)
+    s = ConversationalSession(cfg)
+    s.pilot = MockPilot(_GOOD_SUMMARY)  # type: ignore
+    s._history = [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "user",
+            "content": "[Earlier conversation summarized to fit context]\n"
+            + "## Key Facts / Decisions / Files\nharness/compaction_mixin.py\n"
+            + ("OLD " * 4000),
+            "_compressed_summary": True,
+        },
+        {"role": "user", "content": "latest ask " + ("x" * 200)},
+        {"role": "assistant", "content": "latest answer " + ("y" * 200)},
+    ]
+    list(s._maybe_compact_history(force=True))
+    assert s.pilot.chat_calls
+    summarizer_input = s.pilot.chat_calls[0][0][0]["content"]
+    assert "PREVIOUS HISTORICAL CONVERSATION SUMMARY:" not in summarizer_input
+    assert "PREVIOUS HISTORICAL CONVERSATION SUMMARY:" not in s._history[1]["content"]
+
+
+def test_live_goal_tail_does_not_expand_to_fill_acks(monkeypatch):
+    monkeypatch.setattr("harness.compaction_mixin.MIN_COMPACTABLE_TOKENS", 0)
+    cfg = HarnessConfig(max_context_tokens=80_000)
+    s = ConversationalSession(cfg)
+    s.pilot = MockPilot(_GOOD_SUMMARY)  # type: ignore
+    s._history = [{"role": "system", "content": "sys"}]
+    for i in range(20):
+        s._history.append({"role": "user", "content": f"ack {i}"})
+        s._history.append({"role": "assistant", "content": f"ok {i}"})
+    s._history.append({"role": "user", "content": "live goal: fix harness/compaction_mixin.py"})
+    s._history.append({"role": "assistant", "content": "working on it"})
+    split = s._choose_compaction_split(tail_budget=20_000)
+    assert split is not None
+    tail = s._history[split:]
+    assert any("live goal" in str(m.get("content") or "") for m in tail)
+    assert sum(1 for m in tail if "ack " in str(m.get("content") or "")) <= 1

--- a/tests/test_context_usage.py
+++ b/tests/test_context_usage.py
@@ -83,16 +83,20 @@ def test_estimate_prefers_real_when_it_exceeds_heuristic():
     assert s._estimate_context_tokens() > heuristic
 
 
-def test_estimate_keeps_heuristic_when_history_grew_past_real():
-    """Real count reflects the last billed turn; a since-grown history (larger
-    heuristic) still wins via max() so we don't under-estimate a fresher history."""
+def test_estimate_adds_growth_without_letting_heuristic_win():
+    """Billed usage is the clock. Growth since the sample is added; the
+    full chars//4 walk must not replace the real count via max()."""
     s = _session()
-    s._last_prompt_tokens = 20  # small, stale real number
-    # Add a big message so the heuristic exceeds the stale real count.
-    s._history.append({"role": "assistant", "content": "B" * 8000})  # ~2000 tokens
+    s._history.append({"role": "assistant", "content": "B" * 800})
+    baseline = s._estimate_context_tokens_for_list(s._history)
+    s._last_prompt_tokens = 20
+    s._last_prompt_heuristic = baseline
+    s._history.append({"role": "assistant", "content": "B" * 8000})
     heuristic = s._estimate_context_tokens_for_list(s._history)
     assert heuristic > 20
-    assert s._estimate_context_tokens() == heuristic
+    grown = s._estimate_context_tokens()
+    assert grown == 20 + (heuristic - baseline)
+    assert grown < heuristic
 
 
 def test_compaction_trigger_fires_on_real_value(monkeypatch):

--- a/tests/test_ctx_token_cache.py
+++ b/tests/test_ctx_token_cache.py
@@ -133,8 +133,8 @@ def test_cache_survives_multiple_appends_and_stays_correct():
 
 
 def test_last_prompt_tokens_max_still_applies_with_cache():
-    """When _last_prompt_tokens > heuristic, the return must still be max(),
-    identical to the pre-cache semantics."""
+    """When billed usage exceeds the walk and there is no sample baseline,
+    the clock is the real count (heuristic does not replace it)."""
     s = _new_session()
     s._history.append({"role": "user", "content": "tiny"})
     heuristic = s._estimate_context_tokens_for_list(s._history)

--- a/tests/test_task_profile.py
+++ b/tests/test_task_profile.py
@@ -14,6 +14,8 @@ from harness.task_profile import (
     maybe_escalate,
     micro_visible_tool_names,
     profile_disables_swarm_gate,
+    profile_skips_codegraph,
+    profile_skips_wiki,
 )
 from harness.tool_discovery import core_visible_names
 from harness.wiki import WikiClient
@@ -100,6 +102,20 @@ def test_swarm_gate_allows_exploration_when_micro(monkeypatch):
     assert check_swarm_gate(
         blocked, "list_dir", SimpleNamespace(kind="list_dir", path=".")
     ).suppress is True
+
+
+def test_micro_inject_inventory_skips_auto_grounding():
+    """MICRO must not auto-inject wiki or CodeGraph. New injects need a test."""
+    assert profile_skips_wiki(MICRO) is True
+    assert profile_skips_codegraph(MICRO) is True
+    assert profile_skips_wiki(STANDARD) is False
+    assert profile_skips_codegraph(STANDARD) is False
+    from harness.send_loop import profile_skips_auto_inject
+
+    session = SimpleNamespace(_task_profile=MICRO)
+    skip_cg, skip_wiki = profile_skips_auto_inject(session)
+    assert skip_cg is True
+    assert skip_wiki is True
 
 
 def test_wiki_section_empty_when_micro_even_if_configured(tmp_path, monkeypatch):

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.219",
+  "version": "0.9.220",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.219",
+      "version": "0.9.220",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.219",
+  "version": "0.9.220",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/Conversation.warmCache.test.ts
+++ b/webapp/src/__tests__/Conversation.warmCache.test.ts
@@ -285,11 +285,11 @@ describe("session switch detach (non-destructive)", () => {
   });
 });
 
-describe("busy runners keep Stop not Send", () => {
-  it("sets thinking when active session runner is running after SSE detach", () => {
+describe("busy runners do not replace Send", () => {
+  it("keeps Send when the active session runner is running after SSE detach", () => {
     const runners = { "sess-a": "idle" as const, "sess-b": "running" as const };
-    // Switch TO sess-b which is still running -- composer must show Stop.
-    expect(composerStatusFromRunner("sess-b", runners, false)).toBe("thinking");
+    // running ≠ busy: a flying PM job must not look like Stop.
+    expect(composerStatusFromRunner("sess-b", runners, false)).toBe("idle");
     expect(composerStatusFromRunner("sess-a", runners, false)).toBe("idle");
   });
 
@@ -298,9 +298,9 @@ describe("busy runners keep Stop not Send", () => {
     expect(composerStatusFromRunner("sess-a", runners, true)).toBeNull();
   });
 
-  it("returns to idle/Send when runner flips idle", () => {
+  it("stays idle/Send when the runner flips idle", () => {
     let runners: Record<string, "running" | "idle"> = { "sess-b": "running" };
-    expect(composerStatusFromRunner("sess-b", runners, false)).toBe("thinking");
+    expect(composerStatusFromRunner("sess-b", runners, false)).toBe("idle");
     runners = { "sess-b": "idle" };
     expect(composerStatusFromRunner("sess-b", runners, false)).toBe("idle");
   });
@@ -310,11 +310,11 @@ describe("busy runners keep Stop not Send", () => {
     expect(composerStatusFromRunner("sess-new", runners, false)).toBe("idle");
   });
 
-  it("on switch to running session: hydrate warm cache and keep busy chrome", () => {
+  it("on switch to a running session: hydrate warm cache without Stop chrome", () => {
     writeTranscriptCache("sess-busy", [makeMsg("user", "in flight")]);
     const runners = { "sess-busy": "running" as const };
     const status = composerStatusFromRunner("sess-busy", runners, false);
-    expect(status).toBe("thinking");
+    expect(status).toBe("idle");
     expect(peekTranscriptCache("sess-busy")).toEqual([makeMsg("user", "in flight")]);
     clearTranscriptCache();
   });

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -60,7 +60,7 @@ import {
   typewriterCharsPerFrame,
 } from "../components/conversation/streamBubbles";
 import { derivePillStatus } from "../components/conversation/pillStatus";
-import { isAgentLoopOpen } from "../components/conversation/runnersBusy";
+import { isAgentLoopOpen, isPilotMouthBusy } from "../components/conversation/runnersBusy";
 import { workspaceLeafName } from "../components/conversation/workspaceDisplay";
 import {
   statusPillClickable,
@@ -1044,6 +1044,14 @@ describe("pillStatus + workspaceDisplay + StatusPill chrome", () => {
     expect(isAgentLoopOpen(false, "idle")).toBe(false);
     expect(isAgentLoopOpen(true, "idle")).toBe(true);
     expect(isAgentLoopOpen(false, "streaming")).toBe(true);
+  });
+
+  it("isPilotMouthBusy excludes awaiting_swarm so Send stays Send", () => {
+    expect(isPilotMouthBusy(false, "awaiting_swarm")).toBe(false);
+    expect(isPilotMouthBusy(true, "idle")).toBe(true);
+    expect(isPilotMouthBusy(false, "thinking")).toBe(true);
+    expect(isPilotMouthBusy(false, "streaming")).toBe(true);
+    expect(isPilotMouthBusy(false, "idle")).toBe(false);
   });
 
   it("workspaceLeafName and StatusPill helpers stay calm Cursor chrome", () => {
@@ -2148,19 +2156,19 @@ describe("prompt queue session-switch honesty", () => {
 });
 
 describe("composerSend module", () => {
-  it("Enter busy latch matches composerBusy / agentLoopOpen (awaiting_swarm + turnOpen)", () => {
-    expect(composerEnterBusy({ turnOpen: false, status: "awaiting_swarm" })).toBe(true);
+  it("Enter busy latch is the pilot mouth, not awaiting_swarm", () => {
+    expect(composerEnterBusy({ turnOpen: false, status: "awaiting_swarm" })).toBe(false);
     expect(composerEnterBusy({ turnOpen: true, status: "idle" })).toBe(true);
+    expect(composerEnterBusy({ turnOpen: false, status: "thinking" })).toBe(true);
     expect(composerEnterBusy({ turnOpen: false, status: "idle" })).toBe(false);
     expect(composerEnterBusy({ turnOpen: false, status: "done" })).toBe(false);
-    // During awaiting_swarm, Cmd/Ctrl+Enter must queue (not start a new send).
+    // Flying PM job: Cmd/Ctrl+Enter is a normal send, not a queue latch.
     expect(
       composerEnterAction({
         busy: composerEnterBusy({ turnOpen: false, status: "awaiting_swarm" }),
         metaOrCtrl: true,
       }),
-    ).toBe("queue");
-    // Plain Enter stays "send" so send() can steer while composerBusy.
+    ).toBe("send");
     expect(
       composerEnterAction({
         busy: composerEnterBusy({ turnOpen: false, status: "awaiting_swarm" }),

--- a/webapp/src/__tests__/feedScroll.test.ts
+++ b/webapp/src/__tests__/feedScroll.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEED_REPIN_THRESHOLD_PX,
+  nextFeedPinState,
+  settleFrameResult,
+  shouldUnpinOnWheel,
+} from "../components/conversation/feedScroll";
+
+describe("feedScroll hysteresis", () => {
+  const height = 2000;
+  const client = 400;
+
+  it("does not re-pin a light upward nudge still inside the old near-bottom band", () => {
+    const lightUpTop = height - client - 40;
+    expect(
+      nextFeedPinState({
+        wasPinned: true,
+        releasedByGesture: true,
+        scrollHeight: height,
+        scrollTop: lightUpTop,
+        clientHeight: client,
+        prevScrollTop: lightUpTop + 8,
+        settling: false,
+        repinPx: FEED_REPIN_THRESHOLD_PX,
+      }),
+    ).toEqual({ pinned: false, releasedByGesture: true });
+  });
+
+  it("re-pins only after scrolling toward the tight bottom band", () => {
+    const lightUpTop = height - client - 40;
+    expect(
+      nextFeedPinState({
+        wasPinned: false,
+        releasedByGesture: true,
+        scrollHeight: height,
+        scrollTop: height - client - 10,
+        clientHeight: client,
+        prevScrollTop: lightUpTop,
+        settling: false,
+        repinPx: FEED_REPIN_THRESHOLD_PX,
+      }),
+    ).toEqual({ pinned: true, releasedByGesture: false });
+  });
+
+  it("settle glue must not force-true after a gesture release", () => {
+    expect(shouldUnpinOnWheel(-12, false)).toBe(true);
+    expect(shouldUnpinOnWheel(-12, true)).toBe(false);
+    const settle = settleFrameResult({
+      height: 2000,
+      lastHeight: 2000,
+      stableFrames: 4,
+      frame: 4,
+    });
+    expect(settle.done).toBe(true);
+  });
+});

--- a/webapp/src/__tests__/streamMarkdown.test.ts
+++ b/webapp/src/__tests__/streamMarkdown.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  reconstructStreamMarkdown,
+  splitStreamingMarkdown,
+} from "../lib/streamMarkdown";
+
+function split(text: string) {
+  const buf = splitStreamingMarkdown(text);
+  expect(reconstructStreamMarkdown(buf)).toBe(text);
+  return buf;
+}
+
+describe("splitStreamingMarkdown", () => {
+  it("flushes plain prose", () => {
+    const buf = split("Looking at the renderer. Packages first.");
+    expect(buf.flushed).toBe("Looking at the renderer. Packages first.");
+    expect(buf.hold).toBe("");
+    expect(buf.open).toBeNull();
+  });
+
+  it("holds a trailing fence opener until the language tag is done", () => {
+    expect(split("Packages.\n```").hold).toBe("```");
+    expect(split("Packages.\n```py").hold).toBe("```py");
+    const mid = split("Packages.\n```python");
+    expect(mid.hold).toBe("```python");
+    expect(mid.open).toBeNull();
+    expect(mid.flushed).toBe("Packages.\n");
+  });
+
+  it("does not treat ```py as a python fence when the next token is thon", () => {
+    const first = split("see\n```py");
+    expect(first.open).toBeNull();
+    expect(first.hold).toBe("```py");
+
+    const second = split("see\n```python\n");
+    expect(second.open?.lang).toBe("python");
+    expect(second.open?.body).toBe("");
+    expect(second.hold).toBe("");
+    expect(second.flushed).toBe("see\n");
+  });
+
+  it("opens the fence only after the newline that ends the opener", () => {
+    const buf = split("see\n```python\nprint(1)");
+    expect(buf.flushed).toBe("see\n");
+    expect(buf.open?.lang).toBe("python");
+    expect(buf.open?.body).toBe("");
+    expect(buf.hold).toBe("print(1)");
+  });
+
+  it("flushes complete lines inside an open fence and holds the partial line", () => {
+    const buf = split("see\n```python\nprint(1)\nprint(");
+    expect(buf.flushed).toBe("see\n");
+    expect(buf.open?.lang).toBe("python");
+    expect(buf.open?.body).toBe("print(1)\n");
+    expect(buf.hold).toBe("print(");
+  });
+
+  it("flushes a completed fence including the closer", () => {
+    const src = "see\n```python\nprint(1)\n```\nnext";
+    const buf = split(src);
+    expect(buf.flushed).toBe(src);
+    expect(buf.hold).toBe("");
+    expect(buf.open).toBeNull();
+  });
+
+  it("treats closer ticks at EOS as a completed fence", () => {
+    const src = "```js\nconst x = 1;\n```";
+    const buf = split(src);
+    expect(buf.open).toBeNull();
+    expect(buf.flushed).toBe(src);
+  });
+
+  it("does not close on backticks that are not a line-start fence", () => {
+    const buf = split("```python\nprint('```')\nmore");
+    expect(buf.open?.lang).toBe("python");
+    expect(buf.open?.body).toBe("print('```')\n");
+    expect(buf.hold).toBe("more");
+  });
+
+  it("holds a mid-line `` / ``` tail; a newline there is prose, not a fence", () => {
+    expect(split("hello ``").hold).toBe("``");
+    expect(split("hello ```").hold).toBe("```");
+    const joined = split("hello ```python\n");
+    expect(joined.open).toBeNull();
+    expect(joined.flushed).toBe("hello ```python\n");
+  });
+
+  it("completes a line-start opener split across tokens", () => {
+    expect(split("see\n``").hold).toBe("``");
+    const opened = split("see\n```python\n");
+    expect(opened.flushed).toBe("see\n");
+    expect(opened.open?.lang).toBe("python");
+  });
+
+  it("does not hold a single trailing backtick (complete inline code stays flushed)", () => {
+    const buf = split("use `code` here");
+    expect(buf.flushed).toBe("use `code` here");
+    expect(buf.hold).toBe("");
+  });
+
+  it("keeps a first complete fence flushed when a second is still open", () => {
+    const buf = split("```a\nx\n```\n```b\ny");
+    expect(buf.flushed).toBe("```a\nx\n```\n");
+    expect(buf.open?.lang).toBe("b");
+    expect(buf.hold).toBe("y");
+  });
+
+  it("supports tilde fences", () => {
+    const open = split("~~~\nbody");
+    expect(open.open?.ticks).toBe("~~~");
+    expect(open.hold).toBe("body");
+    const done = split("~~~\nbody\n~~~");
+    expect(done.open).toBeNull();
+    expect(done.flushed).toBe("~~~\nbody\n~~~");
+  });
+
+  it("returns an empty buffer for empty input", () => {
+    expect(split("")).toEqual({ flushed: "", hold: "", open: null });
+  });
+});

--- a/webapp/src/__tests__/thinkingStreamUx.test.ts
+++ b/webapp/src/__tests__/thinkingStreamUx.test.ts
@@ -275,6 +275,70 @@ describe("swarm terminal rows stay at the end of one investigation", () => {
   });
 });
 
+describe("feed collapse: telemetry joins the activity strip", () => {
+  const card: Item = {
+    kind: "card",
+    card: { id: "read-1", goal: "read file", running: false, open: false },
+  };
+
+  it("folds compaction, gate, and verify into the investigation", () => {
+    const items: Item[] = [
+      card,
+      { kind: "compaction", before_tokens: 12000, after_tokens: 4000, mode: "extractive" },
+      { kind: "quality_gate", outcome: "pass", passed: true, cmd: "pytest" },
+      { kind: "verification", passed: true, cmd: "pytest", output: "ok" },
+      { kind: "msg", msg: { role: "assistant", text: "The import path was wrong." } },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    expect(grouped.map((row) => row.kind)).toEqual(["activity_group", "msg"]);
+    if (grouped[0].kind !== "activity_group") return;
+    expect(grouped[0].items.map((item) => item.kind)).toEqual([
+      "card",
+      "compaction",
+      "quality_gate",
+      "verification",
+    ]);
+  });
+
+  it("keeps question, auth, and steer as conversation rows", () => {
+    const items: Item[] = [
+      card,
+      {
+        kind: "command_approval",
+        id: "appr-1",
+        command: "rm -rf /",
+        commandHash: "h",
+        sessionId: "s",
+        workspaceRoot: "/tmp",
+        category: "destructive",
+        reason: "needs a decision",
+        matched: "rm",
+        status: "pending",
+      },
+      { kind: "auth_failure", message: "OPENAI_API_KEY rejected", id: "auth-1" },
+      { kind: "steer", text: "try the other file", mode: "steer" },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    expect(grouped.map((row) => row.kind)).toEqual([
+      "activity_group",
+      "command_approval",
+      "auth_failure",
+      "steer",
+    ]);
+  });
+
+  it("does not let a lone compaction sit beside the sentence", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "assistant", text: "Done." } },
+      { kind: "compaction", before_tokens: 8000, after_tokens: 3000 },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    expect(grouped.map((row) => row.kind)).toEqual(["msg", "activity_group"]);
+    if (grouped[1].kind !== "activity_group") return;
+    expect(grouped[1].items.map((item) => item.kind)).toEqual(["compaction"]);
+  });
+});
+
 describe("createApplyStreamEvent task_profile", () => {
   it("publishes DEPTH chip from a live SSE task_profile frame", () => {
     const state = {

--- a/webapp/src/components/CheckpointsPane.tsx
+++ b/webapp/src/components/CheckpointsPane.tsx
@@ -10,7 +10,7 @@ export default function CheckpointsPane() {
   const [snapshotLabel, setSnapshotLabel] = useState("");
   const [isCreatingSnapshot, setIsCreatingSnapshot] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [success, setSuccess] = useState<{ text: string; undoId?: string } | null>(null);
 
   const [expandedDiffs, setExpandedDiffs] = useState<Record<string, boolean>>({});
   const [diffData, setDiffData] = useState<Record<string, CheckpointDiff>>({});
@@ -28,7 +28,7 @@ export default function CheckpointsPane() {
     setDiffData({});
     setLoadingDiffs({});
     setError(null);
-    setSuccessMsg(null);
+    setSuccess(null);
     setIsRestoring(null);
   }, []);
 
@@ -152,14 +152,14 @@ export default function CheckpointsPane() {
 
     setIsCreatingSnapshot(true);
     setError(null);
-    setSuccessMsg(null);
+    setSuccess(null);
     try {
       const res = await api.snapshotCheckpoint(snapshotLabel.trim());
       if (res.ok) {
         setSnapshotLabel("");
-        setSuccessMsg("Snapshot created successfully");
+        setSuccess({ text: "Snapshot created" });
         fetchCheckpoints();
-        setTimeout(() => setSuccessMsg(null), 3000);
+        setTimeout(() => setSuccess((cur) => (cur?.text === "Snapshot created" ? null : cur)), 3000);
       } else {
         setError("Failed to create snapshot");
       }
@@ -170,21 +170,20 @@ export default function CheckpointsPane() {
     }
   };
 
-  const handleRestore = async (cp: Checkpoint) => {
-    const confirmRestore = window.confirm(
-      `Are you sure you want to restore the workspace to: "${cp.label}"?\n\nThis will modify files in your working tree. Current uncommitted changes will be auto-saved in a new snapshot first, so you can undo this restore.`
-    );
-    if (!confirmRestore) return;
-
-    setIsRestoring(cp.id);
+  const runRestore = async (id: string, doneText: string) => {
+    // No confirm. Restore already writes an auto-snapshot first — that snapshot
+    // is the no. Asking "are you sure?" on top of a cheap undo is leftover fear.
+    setIsRestoring(id);
     setError(null);
-    setSuccessMsg(null);
+    setSuccess(null);
     try {
-      const res = await api.restoreCheckpoint(cp.id);
+      const res = await api.restoreCheckpoint(id);
       if (res.ok) {
-        setSuccessMsg(`Restored workspace. Created undo checkpoint: ${res.auto_snapshot_id.slice(0, 8)}`);
+        setSuccess({
+          text: doneText,
+          undoId: res.auto_snapshot_id || undefined,
+        });
         fetchCheckpoints();
-        // Since files restored, notify window to refresh file tree/source control if any listeners exist
         window.dispatchEvent(new Event("harness-repo-mutated"));
       } else {
         setError("Restore failed");
@@ -194,6 +193,10 @@ export default function CheckpointsPane() {
     } finally {
       setIsRestoring(null);
     }
+  };
+
+  const handleRestore = (cp: Checkpoint) => {
+    void runRestore(cp.id, `Restored "${cp.label}".`);
   };
 
   const formatTime = (timestamp: number) => {
@@ -257,10 +260,20 @@ export default function CheckpointsPane() {
           <span className="leading-snug">{error}</span>
         </div>
       )}
-      {successMsg && (
+      {success && (
         <div className="mx-2 mt-1.5 p-1.5 bg-accent2/10 border border-accent2/20 text-accent rounded flex items-start gap-1.5 shrink-0 text-[10px]">
           <Check size={12} className="shrink-0 mt-0.5" />
-          <span className="leading-snug">{successMsg}</span>
+          <span className="leading-snug flex-1 min-w-0">{success.text}</span>
+          {success.undoId ? (
+            <button
+              type="button"
+              disabled={isRestoring !== null}
+              onClick={() => void runRestore(success.undoId!, "Restore undone.")}
+              className="shrink-0 px-1.5 py-px rounded border border-accent/30 text-accent hover:bg-accent/10 disabled:opacity-40"
+            >
+              Undo
+            </button>
+          ) : null}
         </div>
       )}
 

--- a/webapp/src/components/CommandPalette.tsx
+++ b/webapp/src/components/CommandPalette.tsx
@@ -66,7 +66,16 @@ export default function CommandPalette({
       });
     };
     window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
+    const onOpen = () => {
+      setQuery("");
+      setActiveIndex(0);
+      setOpen(true);
+    };
+    window.addEventListener("harness-open-command-palette", onOpen);
+    return () => {
+      window.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("harness-open-command-palette", onOpen);
+    };
   }, []);
 
   useEffect(() => {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -41,7 +41,7 @@ import {
   derivePillStatus,
   isSwarmPausePoint,
 } from "./conversation/pillStatus";
-import { isAgentLoopOpen } from "./conversation/runnersBusy";
+import { isAgentLoopOpen, isPilotMouthBusy } from "./conversation/runnersBusy";
 import {
   appendPendingReview,
   appendStopHonestyNotice,
@@ -483,15 +483,15 @@ export default function Conversation({
   const processedSwarmJobIdsRef = useRef<string[]>([]);
   const [backendPendingSwarms, setBackendPendingSwarms] = useState(false);
 
-  // Hold Stop/Steer after switch/hydrate while background jobs fly, even if
-  // status briefly flaps idle before awaiting_swarm paints.
+  // Hold investigation / Still working… after switch/hydrate while background
+  // jobs fly, even if status briefly flaps idle before awaiting_swarm paints.
   const holdSwarmAwait = shouldHoldSwarmAwaitChrome({
     pendingJobIds,
     backendPendingSwarms,
     userStopped: userStoppedRef.current,
   });
-  // Bare holdSwarmAwait keeps agentLoopOpen / composerBusy / Stop-Steer.
-  // StatusPill pause chrome matches TranscriptList.pausePoint (gate on pilotBusy).
+  // Bare holdSwarmAwait keeps agentLoopOpen (investigation / Still working…).
+  // The mouth is a second bit: Stop/Steer only while the pilot turn is open.
   const agentLoopOpen =
     isAgentLoopOpen(turnOpen, status) || holdSwarmAwait;
   const liveInvestigation = turnHasLiveInvestigation(items, agentLoopOpen);
@@ -501,8 +501,8 @@ export default function Conversation({
   });
   // Runner/SSE can briefly report idle while a card is still running (or the
   // reverse). Prefer investigation / open-turn truth for the header pill.
-  // Idle/busy shares composerBusy / agentLoopOpen — do not early-idle the
-  // StatusPill on answer-complete SSE lag while Steer/Stop remain.
+  // StatusPill follows agentLoopOpen (workers still visible). The mouth is
+  // a second bit and may already be Send.
   const swarmPausePoint = isSwarmPausePoint({
     status,
     holdSwarmAwait,
@@ -517,8 +517,8 @@ export default function Conversation({
     awaitingSwarm: swarmPausePoint,
     agentLoopOpen,
   });
-  // Same latch as agentLoopOpen — Steer/Stop stay up for the whole turn.
-  const composerBusy = agentLoopOpen;
+  // Mouth ≠ runner. awaiting_swarm / holdSwarmAwait keep the fold, not Stop.
+  const composerBusy = isPilotMouthBusy(turnOpen, status);
   // Keep the busy footer clock alive while holdSwarmAwait outlives status flaps.
   useEffect(() => {
     if (holdSwarmAwait) {
@@ -1863,9 +1863,7 @@ export default function Conversation({
 
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      // Match composerBusy / agentLoopOpen (awaiting_swarm + holdSwarmAwait)
-      // so plain Enter steers during a background swarm wait instead of a new send.
-      // Cmd/Ctrl+Enter still queues while that latch is armed; Alt+Enter interrupts.
+      // Mouth is isPilotMouthBusy — awaiting_swarm stays Send, not Steer.
       const busy = composerBusy;
       // While a turn is running, plain Enter STEERS (redirects the current turn);
       // Cmd/Ctrl+Enter QUEUES (runs after the current turn finishes); Alt+Enter

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -65,7 +65,6 @@ import {
   formatCompactCompleteMessage,
   formatCompactErrorMessage,
   shouldApplyCompactSettle,
-  formatHelpSlashReply,
   formatRenderCommandErrorMessage,
   formatSteerErrorMessage,
   formatInterruptErrorMessage,
@@ -2580,18 +2579,8 @@ export default function Conversation({
     if (slash.kind === "help") {
       setInput("");
       setEditingIndex(null);
-      const helpText = formatHelpSlashReply(allSlashCommands);
-      setItems((p) => [
-        ...p,
-        { kind: "msg", msg: { role: "user", text: msg } },
-        {
-          kind: "msg",
-          msg: {
-            role: "assistant",
-            text: helpText
-          }
-        }
-      ]);
+      // Protocol stays in the palette. Do not dump /help as a fake assistant memo.
+      window.dispatchEvent(new Event("harness-open-command-palette"));
       return;
     }
     const paletteId = localSlashPaletteAction(slash);

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, useCallback, memo } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, memo } from "react";
 import { ChevronRight, Loader2, ChevronDown, ChevronUp, Play, Copy, Check, Pencil, RefreshCw, History, Share2, CheckCircle2, XCircle, Eye } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -28,6 +28,7 @@ import {
   tokenizeClickableOutput,
   isSingleShellCommandFence,
 } from "../lib/clickableOutput";
+import { splitStreamingMarkdown } from "../lib/streamMarkdown";
 import {
   aggregateExplorationSummary,
   cardEffectivelyRunning,
@@ -243,7 +244,44 @@ type ActivityItem =
   | { kind: "checkpoint"; id: string; label: string; trigger: string }
   | SwarmPendingItem
   | { kind: "swarm_result"; job_id: string; applied: boolean; files: string[]; summary: string; error: string | null; objective?: string; held_for_review?: boolean; analysis_ok?: boolean; reuse_status?: string; source_job_id?: string; reuse_reason?: string; invalidated_paths?: string[]; validation_fingerprint?: string; environment_fingerprint?: string; acceptance_criteria?: string[] }
-  | { kind: "msg"; msg: Msg };
+  | { kind: "msg"; msg: Msg }
+  | Extract<
+      Item,
+      | { kind: "compaction" }
+      | { kind: "command_blocked" }
+      | { kind: "auto_status" }
+      | { kind: "auto_halt" }
+      | { kind: "quality_gate" }
+      | { kind: "verifying" }
+      | { kind: "auto_verify" }
+      | { kind: "verification" }
+    >;
+
+/** Receipts that belong inside the activity strip, not beside the sentence. */
+function isActivityTelemetry(
+  item: ActivityItem | Item,
+): item is Extract<
+  Item,
+  | { kind: "compaction" }
+  | { kind: "command_blocked" }
+  | { kind: "auto_status" }
+  | { kind: "auto_halt" }
+  | { kind: "quality_gate" }
+  | { kind: "verifying" }
+  | { kind: "auto_verify" }
+  | { kind: "verification" }
+> {
+  return (
+    item.kind === "compaction"
+    || item.kind === "command_blocked"
+    || item.kind === "auto_status"
+    || item.kind === "auto_halt"
+    || item.kind === "quality_gate"
+    || item.kind === "verifying"
+    || item.kind === "auto_verify"
+    || item.kind === "verification"
+  );
+}
 
 
 /**
@@ -372,9 +410,11 @@ export function collectIntermediateAssistantItems(
 }
 
 export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>): GroupedItem[] {
-  // Mental model: a turn is [user msg] + sticky pre-tool bubbles +
-  // [investigation fold: thinking / tools / post-tool micro-narration] +
-  // [final answer]. Surfaces do not reclassify after first paint.
+  // The feed is a conversation, not an event log. Top-level rows are
+  // msg / steer, a question (command_approval), a file (pending_review),
+  // a loud auth failure, and one activity strip. Compaction, gates, verify,
+  // and auto receipts fold into that strip. Surfaces do not reclassify
+  // after first paint.
   const grouped: GroupedItem[] = [];
   let currentGroup: ActivityItem[] = [];
   let terminalSwarmItems: ActivityItem[] = [];
@@ -438,18 +478,12 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
           ? item
           : { ...item, job_ids: uncoveredJobIds },
       );
+    } else if (isActivityTelemetry(item)) {
+      currentGroup.push(item);
     } else if (
-      item.kind === "compaction"
-      || item.kind === "command_blocked"
-      || item.kind === "command_approval"
-      || item.kind === "auto_status"
-      || item.kind === "auto_halt"
+      item.kind === "command_approval"
       || item.kind === "auth_failure"
       || item.kind === "steer"
-      || item.kind === "quality_gate"
-      || item.kind === "verifying"
-      || item.kind === "auto_verify"
-      || item.kind === "verification"
     ) {
       flush();
       grouped.push(item);
@@ -1417,7 +1451,8 @@ function ActivityGroup({
   // "0 steps" box -- suppress it. But folded intermediate narration OR a reasoning
   // trace must still show (collapsed), so reasoning never silently vanishes from
   // the step list the way it used to.
-  if (actionCount === 0 && narrationMsgs.length === 0 && thinkingItems.length === 0 && checkpointItems.length === 0 && swarmResults.length === 0 && swarmPendingItems.length === 0) {
+  const telemetryItems = items.filter(isActivityTelemetry);
+  if (actionCount === 0 && narrationMsgs.length === 0 && thinkingItems.length === 0 && checkpointItems.length === 0 && swarmResults.length === 0 && swarmPendingItems.length === 0 && telemetryItems.length === 0) {
     return null;
   }
 
@@ -1535,6 +1570,62 @@ function ActivityGroup({
         />
       );
     }
+    if (it.kind === "compaction") {
+      const label = it.aborted
+        ? (it.message || (it.reason ? `Compaction aborted (${it.reason})` : "Compaction aborted"))
+        : `Context summarized: ${it.before_tokens} → ${it.after_tokens}${it.mode ? ` · ${it.mode}` : ""}`;
+      return (
+        <div key={`compact-${idx}`} className="flex items-center gap-1.5 py-0.5 text-[10px] text-faint/80 select-none font-mono">
+          <span>{label}</span>
+        </div>
+      );
+    }
+    if (it.kind === "command_blocked") {
+      const blocked = commandBlockedPresentation(it);
+      return (
+        <div key={`blocked-${idx}`} className="flex items-center gap-1.5 py-0.5 text-[10px] text-faint/80 select-none">
+          <span>{blocked.label}{blocked.detail ? ` · ${blocked.detail}` : ""}</span>
+        </div>
+      );
+    }
+    if (it.kind === "auto_status") {
+      const status = autoStatusPresentation(it.cycle, it.snapshot);
+      return (
+        <div key={`auto-status-${idx}`} className="flex items-center gap-1.5 py-0.5 text-[10px] text-faint/80 select-none font-mono">
+          <span>{status.label}{status.detail ? ` · ${status.detail}` : ""}</span>
+        </div>
+      );
+    }
+    if (it.kind === "auto_halt") {
+      const halt = autoHaltPresentation(it.reason, it.snapshot);
+      return (
+        <div key={`auto-halt-${idx}`} className="flex items-center gap-1.5 py-0.5 text-[10px] text-faint/80 select-none font-mono">
+          <span>{halt.label} · {halt.detail}</span>
+        </div>
+      );
+    }
+    if (it.kind === "quality_gate") {
+      const gate = qualityGatePresentation(it);
+      return (
+        <div key={`gate-${idx}`} className="flex items-center gap-1.5 py-0.5 text-[10px] text-faint/80 select-none font-mono" title={it.output ? it.output.slice(0, 400) : gate.label}>
+          <span>{gate.label}{gate.detail ? ` · ${gate.detail}` : ""}</span>
+        </div>
+      );
+    }
+    if (it.kind === "verifying" || it.kind === "auto_verify" || it.kind === "verification") {
+      const receipt = verificationReceiptPresentation(
+        it.kind === "verifying"
+          ? { kind: "verifying", cmd: it.cmd, auto: it.auto }
+          : it.kind === "auto_verify"
+            ? { kind: "auto_verify", passed: it.passed, command: it.command }
+            : { kind: "verification", passed: it.passed, cmd: it.cmd },
+      );
+      return (
+        <div key={`verify-${idx}`} className="flex items-center gap-1.5 py-0.5 text-[10px] text-faint/80 select-none font-mono">
+          <span>{receipt.label}{receipt.detail ? ` · ${receipt.detail}` : ""}</span>
+        </div>
+      );
+    }
     return null;
   };
 
@@ -1551,6 +1642,25 @@ function ActivityGroup({
       return swarmPendingRunning ? "Swarm · running" : `Swarm · ${swarmPendingItems.length} pending`;
     }
     if (investigating) return stepHeadline || "Investigating…";
+    if (telemetryItems.length > 0 && actionCount === 0 && thinkingItems.length === 0) {
+      const first = telemetryItems[0];
+      if (first.kind === "compaction") {
+        return first.aborted ? "Compaction aborted" : "Context summarized";
+      }
+      if (first.kind === "quality_gate") return qualityGatePresentation(first).label;
+      if (first.kind === "auto_halt") return autoHaltPresentation(first.reason, first.snapshot).label;
+      if (first.kind === "verifying" || first.kind === "auto_verify" || first.kind === "verification") {
+        return verificationReceiptPresentation(
+          first.kind === "verifying"
+            ? { kind: "verifying", cmd: first.cmd, auto: first.auto }
+            : first.kind === "auto_verify"
+              ? { kind: "auto_verify", passed: first.passed, command: first.command }
+              : { kind: "verification", passed: first.passed, cmd: first.cmd },
+        ).label;
+      }
+      if (first.kind === "command_blocked") return commandBlockedPresentation(first).label;
+      if (first.kind === "auto_status") return autoStatusPresentation(first.cycle, first.snapshot).label;
+    }
     const preview = normalizeReasoningPreview(narrationPreview, 72);
     return preview || "Thought";
   })();
@@ -1857,11 +1967,9 @@ function openMarkdownHref(href: string, e: React.MouseEvent): void {
   openAgentLink(href, e);
 }
 
-// Memoized so a streaming bubble only re-parses when the text actually changes.
-// The typewriter re-renders the parent every animation frame; without this the
-// full remark/rehype pipeline would run each frame even when no character was
-// added. Restores formatted-while-streaming without the old ~40% CPU cost.
-const Markdown = memo(function Markdown({ text }: { text: string }) {
+// Pretty tree only. Streaming wrappers pass a deferred `flushed` string so
+// highlight.js never remounts on a fence the next token can still extend.
+const PrettyMarkdown = memo(function PrettyMarkdown({ text }: { text: string }) {
   const linked = autolinkAgentText(text || "");
   return (
     <ReactMarkdown
@@ -1991,6 +2099,48 @@ const Markdown = memo(function Markdown({ text }: { text: string }) {
       {linked}
     </ReactMarkdown>
   );
+});
+
+function StreamingMarkdown({ text }: { text: string }) {
+  const buf = splitStreamingMarkdown(text || "");
+  const deferredFlushed = useDeferredValue(buf.flushed);
+  const lag = deferredFlushed !== buf.flushed
+    ? buf.flushed.slice(deferredFlushed.length)
+    : "";
+  return (
+    <>
+      <PrettyMarkdown text={deferredFlushed} />
+      {lag ? (
+        <span data-md-lag className="whitespace-pre-wrap">{lag}</span>
+      ) : null}
+      {buf.open ? (
+        <pre
+          data-md-pending
+          data-lang={buf.open.lang || undefined}
+          className="block bg-panel/80 border border-accent/20 rounded-md p-3 overflow-x-auto font-mono text-[0.719rem] leading-[1.55] text-txt/90 my-2 whitespace-pre"
+        >
+          {buf.open.body + buf.hold}
+        </pre>
+      ) : buf.hold ? (
+        <span data-md-hold className="font-mono">{buf.hold}</span>
+      ) : null}
+    </>
+  );
+}
+
+// Memoized so a streaming bubble only re-parses when the text actually changes.
+// The typewriter re-renders the parent every animation frame; without this the
+// full remark/rehype pipeline would run each frame even when no character was
+// added. Restores formatted-while-streaming without the old ~40% CPU cost.
+const Markdown = memo(function Markdown({
+  text,
+  streaming = false,
+}: {
+  text: string;
+  streaming?: boolean;
+}) {
+  if (streaming) return <StreamingMarkdown text={text} />;
+  return <PrettyMarkdown text={text} />;
 });
 
 function Bubble({
@@ -2152,7 +2302,7 @@ function Bubble({
             {normalizePlainTextNarration(displayedText)}
           </pre>
         ) : (
-          <Markdown text={displayedText} />
+          <Markdown text={displayedText} streaming={Boolean(msg.streaming)} />
         )}
         
         {/* Assistant copy & regenerate buttons */}

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -283,6 +283,19 @@ function isActivityTelemetry(
   );
 }
 
+function compactionRowChrome(it: Extract<Item, { kind: "compaction" }>): {
+  label: string;
+  title: string;
+} {
+  const tokens = `${it.before_tokens} → ${it.after_tokens}${it.mode ? ` · ${it.mode}` : ""}`;
+  if (it.aborted) {
+    const label = it.message
+      || (it.reason ? `Compaction aborted (${it.reason})` : "Compaction aborted");
+    return { label, title: it.reason ? `${tokens} · ${it.reason}` : tokens };
+  }
+  return { label: "Context summarized", title: tokens };
+}
+
 
 /**
  * Assistants that belong inside the investigation fold for this turn.
@@ -1091,26 +1104,19 @@ export const TranscriptList = memo(function TranscriptList({
         </div>
       );
     } else if (it.kind === "compaction") {
-      if (it.aborted) {
-        const abortText = it.message
-          || (it.reason ? `Context compaction aborted (${it.reason})` : "Context compaction aborted");
-        return (
-          <div
-            key={key}
-            role="status"
-            title={it.reason ? `compaction aborted: ${it.reason}` : "compaction aborted"}
-            className="flex items-center gap-1.5 py-1 px-3 rounded-full bg-amber-500/10 border border-amber-500/25 text-[10.5px] text-amber-200/90 w-fit my-1 select-none font-mono"
-          >
-            <span>{abortText}</span>
-          </div>
-        );
-      }
+      const chrome = compactionRowChrome(it);
       return (
-        <div key={key} className="flex items-center gap-1.5 py-1 px-3 rounded-full bg-panel2/10 border border-edge/10 text-[10.5px] text-faint w-fit my-1 select-none font-mono">
-          <span>
-            Context summarized: {it.before_tokens} → {it.after_tokens} tokens
-            {it.mode ? ` · ${it.mode}` : ""}
-          </span>
+        <div
+          key={key}
+          role="status"
+          title={chrome.title}
+          className={`flex items-center gap-1.5 py-1 px-3 rounded-full w-fit my-1 select-none font-mono text-[10.5px] ${
+            it.aborted
+              ? "bg-amber-500/10 border border-amber-500/25 text-amber-200/90"
+              : "bg-panel2/10 border border-edge/10 text-faint"
+          }`}
+        >
+          <span>{chrome.label}</span>
         </div>
       );
     } else if (it.kind === "steer") {
@@ -1571,12 +1577,17 @@ function ActivityGroup({
       );
     }
     if (it.kind === "compaction") {
-      const label = it.aborted
-        ? (it.message || (it.reason ? `Compaction aborted (${it.reason})` : "Compaction aborted"))
-        : `Context summarized: ${it.before_tokens} → ${it.after_tokens}${it.mode ? ` · ${it.mode}` : ""}`;
+      // Tokens are hover, not a peer of the sentence. Hide the row entirely
+      // when the strip already has tools — the fold title carries the hover.
+      if (actionCount > 0 && !it.aborted) return null;
+      const chrome = compactionRowChrome(it);
       return (
-        <div key={`compact-${idx}`} className="flex items-center gap-1.5 py-0.5 text-[10px] text-faint/80 select-none font-mono">
-          <span>{label}</span>
+        <div
+          key={`compact-${idx}`}
+          className="flex items-center gap-1.5 py-0.5 text-[10px] text-faint/80 select-none font-mono"
+          title={chrome.title}
+        >
+          <span>{chrome.label}</span>
         </div>
       );
     }
@@ -1664,6 +1675,13 @@ function ActivityGroup({
     const preview = normalizeReasoningPreview(narrationPreview, 72);
     return preview || "Thought";
   })();
+  const compactionHover = (() => {
+    const compact = telemetryItems.find((row) => row.kind === "compaction");
+    return compact && compact.kind === "compaction" ? compactionRowChrome(compact).title : "";
+  })();
+  const foldTitle = [investigating ? (runningCard?.goal || quietSummary) : quietSummary, compactionHover]
+    .filter(Boolean)
+    .join(" · ");
 
   return (
     <div className="my-1 w-full">
@@ -1677,7 +1695,7 @@ function ActivityGroup({
         {investigating ? <Loader2 size={11} className="animate-spin text-faint/60 shrink-0" /> : null}
         <span
           className="truncate max-w-[52ch] normal-case"
-          title={investigating ? (runningCard?.goal || quietSummary) : quietSummary}
+          title={foldTitle}
         >
           {quietSummary}
         </span>

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -55,7 +55,15 @@ export default function ConversationChatColumn({
 }) {
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <div ref={feedRef} className={`flex-1 overflow-y-auto ${panelOpacityClass(transcriptStale)}`}>
+      <div
+        ref={feedRef}
+        className={`flex-1 overflow-y-auto overscroll-contain [overflow-anchor:auto] [scrollbar-gutter:stable] ${panelOpacityClass(transcriptStale)}`}
+      >
+        {/* overflow-anchor keeps the row you are reading still when height
+            lands above it. scrollbar-gutter avoids a 15px jump when the bar
+            appears. overscroll-contain stops rubber-band from yanking the window.
+            Composer sits outside this scrollport, so scroll-padding-bottom is
+            not the last-bubble fix here — feedScroll pin/unpin still owns that. */}
         <div className="max-w-3xl mx-auto px-6 py-6 flex flex-col gap-1">
           <TranscriptEmptyState transcriptStale={transcriptStale} itemCount={items.length} />
           {/*

--- a/webapp/src/components/conversation/composerSend.ts
+++ b/webapp/src/components/conversation/composerSend.ts
@@ -3,18 +3,18 @@
  */
 
 import type { CommandPaletteActionId } from "../../lib/commandPalette";
-import { isAgentLoopOpen } from "./runnersBusy";
+import { isPilotMouthBusy } from "./runnersBusy";
 
 /**
- * Enter busy latch — same truth as composerBusy / agentLoopOpen.
- * Includes awaiting_swarm and turnOpen so plain Enter steers (and
- * Cmd/Ctrl+Enter queues) while a background swarm wait is still open.
+ * Enter busy latch — same truth as composerBusy / isPilotMouthBusy.
+ * awaiting_swarm does not shut the mouth; Send starts a new turn.
+ * Steer stays the piggyback inject until after Send stays Send.
  */
 export function composerEnterBusy(opts: {
   turnOpen: boolean;
   status: string;
 }): boolean {
-  return isAgentLoopOpen(opts.turnOpen, opts.status);
+  return isPilotMouthBusy(opts.turnOpen, opts.status);
 }
 
 /**

--- a/webapp/src/components/conversation/composerStatus.ts
+++ b/webapp/src/components/conversation/composerStatus.ts
@@ -1,7 +1,8 @@
 /**
  * Composer chrome from runners poll (no local SSE).
- * When the active session's runner is "running", show Stop/Steer (thinking);
- * otherwise allow Send (idle). Used by Conversation and mirrored in tests.
+ * running ≠ busy: a flying PM job / detached runner must not replace Send.
+ * Local SSE still owns the mouth (return null). Used by tests; live chrome
+ * uses isPilotMouthBusy(turnOpen, status).
  */
 export function composerStatusFromRunner(
   activeSessionId: string | null,
@@ -9,7 +10,6 @@ export function composerStatusFromRunner(
   localStreamActive: boolean,
 ): "thinking" | "idle" | null {
   if (localStreamActive || !activeSessionId) return null;
-  // "attaching" = deferred cold pilot build — not a user turn (no thinking chrome).
-  if (runners?.[activeSessionId] === "running") return "thinking";
+  void runners;
   return "idle";
 }

--- a/webapp/src/components/conversation/reexports.ts
+++ b/webapp/src/components/conversation/reexports.ts
@@ -235,6 +235,7 @@ export {
   staleLocalStreamTickDecision,
   RUNNERS_IDLE_CONFIRM_POLLS,
   isAgentLoopOpen,
+  isPilotMouthBusy,
 } from "./runnersBusy";
 export {
   CONTEXT_USAGE_COLORS,

--- a/webapp/src/components/conversation/runnersBusy.ts
+++ b/webapp/src/components/conversation/runnersBusy.ts
@@ -11,6 +11,7 @@ export type BusyStatus = "idle" | "thinking" | "executing" | "done" | "error" | 
 /**
  * Sticky agent-loop latch shared by Conversation + TranscriptList.
  * Includes awaiting_swarm so Investigating / absorption stay armed while workers fly.
+ * This is NOT the composer mouth — see isPilotMouthBusy.
  */
 export function isAgentLoopOpen(
   turnOpen: boolean,
@@ -22,6 +23,22 @@ export function isAgentLoopOpen(
     || status === "executing"
     || status === "streaming"
     || status === "awaiting_swarm"
+  );
+}
+
+/**
+ * Composer mouth: Stop/Steer only while the pilot's short turn is open.
+ * A flying PM job (awaiting_swarm) is running, not busy — Send stays Send.
+ */
+export function isPilotMouthBusy(
+  turnOpen: boolean,
+  status: BusyStatus | string,
+): boolean {
+  return (
+    turnOpen
+    || status === "thinking"
+    || status === "executing"
+    || status === "streaming"
   );
 }
 

--- a/webapp/src/lib/streamMarkdown.ts
+++ b/webapp/src/lib/streamMarkdown.ts
@@ -1,0 +1,141 @@
+/** Split streaming markdown so highlighters never see a fence they can still extend.
+
+Hold a tail (partial opener, last open-fence line). Flush every complete block.
+Pretty-render (react-markdown / highlight.js) may run only on `flushed`.
+The hold / open `<pre>` is the urgent path — cheap monospace, no highlight.
+
+Invariant: `reconstructStreamMarkdown(buf) === text` for any split of `text`.
+*/
+
+export type StreamFence = {
+  ticks: string;
+  lang: string;
+  body: string;
+  /** Exact opener line, including the trailing newline. */
+  opener: string;
+};
+
+export type StreamMarkdownBuf = {
+  flushed: string;
+  hold: string;
+  open: StreamFence | null;
+};
+
+const EMPTY_BUF: StreamMarkdownBuf = { flushed: "", hold: "", open: null };
+
+/** Trailing run that can still become a fence opener (` `` ` / ` ``` ` / ` ```py `). */
+const PARTIAL_FENCE_TAIL = /(`{2,}|~{3,})(\w*)$/;
+
+const FENCE_LINE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+const CLOSER_LINE = /^( {0,3})(`{3,}|~{3,})[ \t]*$/;
+
+export function splitStreamingMarkdown(text: string): StreamMarkdownBuf {
+  if (!text) return EMPTY_BUF;
+
+  let pos = 0;
+  let flushed = "";
+  const n = text.length;
+
+  while (pos < n) {
+    const nl = text.indexOf("\n", pos);
+    const isLastLine = nl === -1;
+    const line = isLastLine ? text.slice(pos) : text.slice(pos, nl);
+    const lineStart = pos;
+
+    const opener = parseOpenerLine(line);
+    if (opener) {
+      if (isLastLine) {
+        return { flushed, hold: text.slice(lineStart), open: null };
+      }
+      const openerLine = text.slice(lineStart, nl + 1);
+      const bodyStart = nl + 1;
+      const closed = findClosingFence(text, bodyStart, opener.ticks);
+      if (closed) {
+        flushed += text.slice(lineStart, closed.end);
+        pos = closed.end;
+        continue;
+      }
+      const body = text.slice(bodyStart);
+      const lastNl = body.lastIndexOf("\n");
+      if (lastNl === -1) {
+        return {
+          flushed,
+          hold: body,
+          open: { ticks: opener.ticks, lang: opener.lang, body: "", opener: openerLine },
+        };
+      }
+      return {
+        flushed,
+        hold: body.slice(lastNl + 1),
+        open: {
+          ticks: opener.ticks,
+          lang: opener.lang,
+          body: body.slice(0, lastNl + 1),
+          opener: openerLine,
+        },
+      };
+    }
+
+    if (isLastLine) {
+      const partial = line.match(PARTIAL_FENCE_TAIL);
+      if (partial && partial.index !== undefined) {
+        return {
+          flushed: flushed + line.slice(0, partial.index),
+          hold: partial[0],
+          open: null,
+        };
+      }
+      return { flushed: flushed + line, hold: "", open: null };
+    }
+
+    flushed += text.slice(pos, nl + 1);
+    pos = nl + 1;
+  }
+
+  return { flushed, hold: "", open: null };
+}
+
+/** Rebuild the source string from a split. Used by tests as the hold/flush contract. */
+export function reconstructStreamMarkdown(buf: StreamMarkdownBuf): string {
+  if (!buf.open) return buf.flushed + buf.hold;
+  return `${buf.flushed}${buf.open.opener}${buf.open.body}${buf.hold}`;
+}
+
+function parseOpenerLine(line: string): { ticks: string; lang: string } | null {
+  const m = line.match(FENCE_LINE);
+  if (!m) return null;
+  if (CLOSER_LINE.test(line) && !m[3].trim()) {
+    // A ticks-only line at the start of a scan is still an opener (empty lang).
+    return { ticks: m[2], lang: "" };
+  }
+  const info = m[3].trim();
+  const lang = info.split(/\s+/, 1)[0] || "";
+  return { ticks: m[2], lang };
+}
+
+function findClosingFence(
+  text: string,
+  from: number,
+  ticks: string,
+): { end: number } | null {
+  let pos = from;
+  const n = text.length;
+  while (pos <= n) {
+    if (pos === n) return null;
+    const nl = text.indexOf("\n", pos);
+    const isLastLine = nl === -1;
+    const line = isLastLine ? text.slice(pos) : text.slice(pos, nl);
+    if (isCloserLine(line, ticks)) {
+      if (isLastLine) return { end: n };
+      return { end: nl + 1 };
+    }
+    if (isLastLine) return null;
+    pos = nl + 1;
+  }
+  return null;
+}
+
+function isCloserLine(line: string, ticks: string): boolean {
+  const m = line.match(CLOSER_LINE);
+  return Boolean(m && m[2][0] === ticks[0] && m[2].length >= ticks.length);
+}


### PR DESCRIPTION
## Summary
- Composer mouth stays Send while a Puppetmaster job flies (`isPilotMouthBusy` vs `isAgentLoopOpen`). Compaction overwrites one task-state document (usage clock, live-goal tail, no PREVIOUS wrap). Live-turn `spill://` is unchanged.
- Feed holds incomplete markdown fences, folds receipts into the activity strip, and keeps compaction `N → M` on hover. `/help` opens the command palette instead of dumping the feed.
- Checkpoints restore uses Undo via `auto_snapshot_id` (no `window.confirm`). MICRO inject inventory skips auto-grounding.

## Test plan
- [ ] `tests` workflow green on the merge SHA: Python 3.9 + 3.11 + Windows + frontend-build
- [ ] Composer stays Send while `awaiting_swarm` / runners=running
- [ ] Activity strip shows "Context summarized" without an `N → M` sentence
- [ ] `/help` opens the command palette
- [ ] After green CI on `main`, tag `v0.9.220` on that SHA (never tag `dev`)