### PR TITLE
Release v0.9.221: first-class steer, virtualized feed, store cursor, in-file hunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.2` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.220, deliberately pre-1.0. The composer mouth stays Send while a Puppetmaster job flies; compaction overwrites one task-state document; the feed holds incomplete markdown fences and folds receipts into the activity strip. Rides puppetmaster-ai==1.22.2. Cursor CLI / `CURSOR_API_KEY` remain optional upgrades (Pilot only / platform workers).
+> Status: v0.9.221, deliberately pre-1.0. Mid-turn steers are first-class user messages at a safe tool-pair boundary; the muted feed virtualizes with measureElement; session switch/reattach share one store cursor; pending review hunks Accept/Reject in the open file. Rides puppetmaster-ai==1.22.2. Cursor CLI / `CURSOR_API_KEY` remain optional upgrades (Pilot only / platform workers).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.220"
+__version__ = "0.9.221"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/session_events.py
+++ b/harness/api/session_events.py
@@ -1,0 +1,389 @@
+"""Session-scoped store event cursor (Puppetmaster ``read_events_since`` pattern).
+
+Unifies mid-turn chat ring frames and session/runners state onto one monotonic
+cursor so the GUI can subscribe once instead of running three pollers
+(``useSessionSwitch`` / ``chatEventsReattach`` / ``useRunnersBusyPoll``).
+
+Stdlib only. Mirror-on-read: each ``read_events_since`` call pulls retained SSE
+ring frames into the store and samples session state, appending a ``runners``
+event when the fingerprint changes.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Deque, Dict, Optional, Tuple, Union
+
+from harness.api.session_control import SessionControlServices, get_session_state
+from harness.api.sse import SseServices, get_chat_events
+
+_STORE_CAP = 1024
+_STORE_MAX_SESSIONS = 64
+
+JsonPayload = Union[dict, list]
+
+
+def _state_fingerprint(payload: dict) -> str:
+    """Stable fingerprint for runners / pilot state / pending swarms."""
+    runners = payload.get("runners") if isinstance(payload.get("runners"), dict) else {}
+    runners_items = sorted(
+        (str(k), str(v)) for k, v in runners.items()
+    )
+    blob = {
+        "state": str(payload.get("state") or ""),
+        "pending_swarms": bool(payload.get("pending_swarms")),
+        "runners": runners_items,
+        "active_view_id": str(payload.get("active_view_id") or ""),
+    }
+    return json.dumps(blob, separators=(",", ":"), sort_keys=True)
+
+
+class SessionEventStore:
+    """Bounded per-session append-only event log with a monotonic cursor."""
+
+    def __init__(self, *, cap: int = _STORE_CAP, max_sessions: int = _STORE_MAX_SESSIONS):
+        self.cap = max(1, int(cap))
+        self.max_sessions = max(1, int(max_sessions))
+        self._lock = threading.Lock()
+        self._sessions: Dict[str, Deque[Tuple[int, dict]]] = {}
+        self._cursors: Dict[str, int] = {}
+        self._mirrored_ring_cursor: Dict[str, int] = {}
+        self._mirrored_ring_generation: Dict[str, int] = {}
+        self._state_fp: Dict[str, str] = {}
+        self._last_ring_miss_fp: Dict[str, str] = {}
+
+    def clear_session(self, session_id: str) -> None:
+        sid = (session_id or "").strip()
+        if not sid:
+            return
+        with self._lock:
+            self._sessions.pop(sid, None)
+            self._cursors.pop(sid, None)
+            self._mirrored_ring_cursor.pop(sid, None)
+            self._mirrored_ring_generation.pop(sid, None)
+            self._state_fp.pop(sid, None)
+            self._last_ring_miss_fp.pop(sid, None)
+
+    def event_cursor(self, session_id: str) -> int:
+        sid = (session_id or "").strip()
+        with self._lock:
+            return int(self._cursors.get(sid, 0) or 0)
+
+    def append(self, session_id: str, kind: str, data: Any) -> int:
+        """Append one store event; returns its monotonic id."""
+        sid = (session_id or "").strip()
+        if not sid:
+            return 0
+        with self._lock:
+            return self._append_unlocked(sid, kind, data)
+
+    def _append_unlocked(self, sid: str, kind: str, data: Any) -> int:
+        self._evict_if_needed_unlocked(sid)
+        nxt = int(self._cursors.get(sid, 0) or 0) + 1
+        self._cursors[sid] = nxt
+        ev = {
+            "id": nxt,
+            "kind": str(kind or "event"),
+            "data": data if data is not None else {},
+            "session_id": sid,
+        }
+        bucket = self._sessions.get(sid)
+        if bucket is None:
+            bucket = deque()
+            self._sessions[sid] = bucket
+        bucket.append((nxt, ev))
+        while len(bucket) > self.cap:
+            bucket.popleft()
+        return nxt
+
+    def _evict_if_needed_unlocked(self, keep_sid: str) -> None:
+        while len(self._sessions) >= self.max_sessions and keep_sid not in self._sessions:
+            victim = next(
+                (k for k in self._sessions.keys() if k != keep_sid),
+                None,
+            )
+            if victim is None:
+                break
+            self._sessions.pop(victim, None)
+            self._cursors.pop(victim, None)
+            self._mirrored_ring_cursor.pop(victim, None)
+            self._mirrored_ring_generation.pop(victim, None)
+            self._state_fp.pop(victim, None)
+            self._last_ring_miss_fp.pop(victim, None)
+
+    def since(self, session_id: str, cursor: int = 0) -> dict:
+        """Return events with id > ``cursor`` plus the high-water cursor."""
+        sid = (session_id or "").strip()
+        try:
+            since_c = int(cursor or 0)
+        except (TypeError, ValueError):
+            since_c = 0
+        with self._lock:
+            bucket = self._sessions.get(sid) or deque()
+            events = [ev for eid, ev in bucket if eid > since_c]
+            return {
+                "session_id": sid,
+                "cursor": int(self._cursors.get(sid, 0) or 0),
+                "events": events,
+            }
+
+    def mirrored_ring_cursor(self, session_id: str) -> int:
+        sid = (session_id or "").strip()
+        with self._lock:
+            return int(self._mirrored_ring_cursor.get(sid, 0) or 0)
+
+    def set_mirrored_ring(self, session_id: str, ring_cursor: int, generation: int) -> None:
+        sid = (session_id or "").strip()
+        with self._lock:
+            self._mirrored_ring_cursor[sid] = max(0, int(ring_cursor or 0))
+            self._mirrored_ring_generation[sid] = max(0, int(generation or 0))
+
+    def mirrored_ring_generation(self, session_id: str) -> int:
+        sid = (session_id or "").strip()
+        with self._lock:
+            return int(self._mirrored_ring_generation.get(sid, 0) or 0)
+
+    def state_fingerprint(self, session_id: str) -> str:
+        sid = (session_id or "").strip()
+        with self._lock:
+            return self._state_fp.get(sid, "")
+
+    def set_state_fingerprint(self, session_id: str, fp: str) -> None:
+        sid = (session_id or "").strip()
+        with self._lock:
+            self._state_fp[sid] = fp or ""
+
+    def last_ring_miss_fp(self, session_id: str) -> str:
+        sid = (session_id or "").strip()
+        with self._lock:
+            return self._last_ring_miss_fp.get(sid, "")
+
+    def set_last_ring_miss_fp(self, session_id: str, fp: str) -> None:
+        sid = (session_id or "").strip()
+        with self._lock:
+            if fp:
+                self._last_ring_miss_fp[sid] = fp
+            else:
+                self._last_ring_miss_fp.pop(sid, None)
+
+
+_default_store = SessionEventStore()
+
+
+def get_default_store() -> SessionEventStore:
+    return _default_store
+
+
+def reset_default_store_for_tests() -> SessionEventStore:
+    """Replace the process-wide store (tests only)."""
+    global _default_store
+    _default_store = SessionEventStore()
+    return _default_store
+
+
+@dataclass
+class SessionEventsServices:
+    """Deps for ``read_events_since`` HTTP handler."""
+
+    sse_services: Any
+    session_control_services: Any
+    store: Optional[SessionEventStore] = None
+
+
+def _resolve_svc(maybe_factory: Any) -> Any:
+    if callable(maybe_factory) and not isinstance(maybe_factory, type):
+        try:
+            return maybe_factory()
+        except TypeError:
+            return maybe_factory
+    return maybe_factory
+
+
+def _mirror_ring_into_store(
+    store: SessionEventStore,
+    sse_svc: SseServices,
+    session_id: str,
+    generation: Optional[int],
+) -> Optional[dict]:
+    """Pull new ring frames / miss into the store. Returns ring miss payload if any."""
+    sid = (session_id or "").strip()
+    if not sid:
+        return None
+
+    live_gen = sse_svc.current_generation(sid)
+    mirrored_gen = store.mirrored_ring_generation(sid)
+    if live_gen is not None and int(live_gen) != mirrored_gen and mirrored_gen:
+        store.set_mirrored_ring(sid, 0, int(live_gen))
+
+    since_ring = store.mirrored_ring_cursor(sid)
+    status, payload = get_chat_events(sse_svc, sid, since_ring, generation)
+    if not isinstance(payload, dict):
+        return None
+    if status != 200:
+        return None
+
+    if not payload.get("ok"):
+        miss_code = str(payload.get("code") or "ring_miss")
+        miss_gen = int(payload.get("generation") or 0)
+        had_mirror = since_ring > 0 or mirrored_gen > 0
+        if had_mirror or miss_code in ("generation_mismatch", "cursor_gap"):
+            miss_fp = f"{miss_code}:{miss_gen}:{int(payload.get('cursor') or 0)}"
+            if miss_fp != store.last_ring_miss_fp(sid):
+                store.append(
+                    sid,
+                    "ring_miss",
+                    {
+                        "ok": False,
+                        "code": miss_code,
+                        "missed": True,
+                        "available": False,
+                        "generation": miss_gen,
+                        "cursor": int(payload.get("cursor") or 0),
+                        "session_id": sid,
+                    },
+                )
+                store.set_last_ring_miss_fp(sid, miss_fp)
+        if miss_code == "generation_mismatch" and miss_gen > 0:
+            store.set_mirrored_ring(sid, 0, miss_gen)
+        elif miss_code == "ring_miss":
+            store.set_mirrored_ring(sid, 0, 0)
+        elif miss_code == "cursor_gap":
+            store.set_mirrored_ring(
+                sid, 0, int(payload.get("generation") or mirrored_gen or 0),
+            )
+        return payload
+
+    store.set_last_ring_miss_fp(sid, "")
+
+    frames = payload.get("events") if isinstance(payload.get("events"), list) else []
+    ring_hw = int(payload.get("cursor") or since_ring or 0)
+    ring_gen = int(payload.get("generation") or 0)
+    for frame in frames:
+        if not isinstance(frame, dict):
+            continue
+        store.append(
+            sid,
+            "stream",
+            {
+                "cursor": frame.get("cursor"),
+                "kind": frame.get("kind") or "event",
+                "data": frame.get("data") if frame.get("data") is not None else {},
+                **({"turn": frame["turn"]} if "turn" in frame else {}),
+                "generation": ring_gen,
+            },
+        )
+    if ring_hw >= since_ring:
+        store.set_mirrored_ring(sid, ring_hw, ring_gen)
+    return None
+
+
+def _sample_runners_into_store(
+    store: SessionEventStore,
+    session_control_svc: SessionControlServices,
+    session_id: str,
+) -> None:
+    """Append a runners event when session state fingerprint changes."""
+    sid = (session_id or "").strip()
+    if not sid:
+        return
+    try:
+        _status, payload = get_session_state({"session_id": [sid]}, session_control_svc)
+    except Exception:
+        return
+    if not isinstance(payload, dict):
+        return
+    fp = _state_fingerprint(payload)
+    if fp == store.state_fingerprint(sid):
+        return
+    store.append(
+        sid,
+        "runners",
+        {
+            "state": payload.get("state"),
+            "pending_swarms": bool(payload.get("pending_swarms")),
+            "runners": payload.get("runners") if isinstance(payload.get("runners"), dict) else {},
+            "active_view_id": payload.get("active_view_id"),
+            "resume_pending": bool(payload.get("resume_pending")),
+            "goal": payload.get("goal") if isinstance(payload.get("goal"), dict) else {},
+        },
+    )
+    store.set_state_fingerprint(sid, fp)
+
+
+def read_events_since(
+    session_id: str,
+    cursor: int = 0,
+    *,
+    sse_svc: SseServices,
+    session_control_svc: SessionControlServices,
+    store: Optional[SessionEventStore] = None,
+    generation: Optional[int] = None,
+) -> tuple[int, JsonPayload]:
+    """Return store events after ``cursor`` and the new high-water cursor.
+
+    Mirrors the SSE chat ring and samples session state on each call so one
+    GUI subscription covers reattach frames and busy chrome.
+    """
+    store = store or get_default_store()
+    sid = (session_id or "").strip() or (
+        sse_svc.default_session_id() if sse_svc is not None else ""
+    )
+    try:
+        since_c = int(cursor or 0)
+    except (TypeError, ValueError):
+        since_c = 0
+
+    if not sid:
+        return 200, {
+            "ok": True,
+            "session_id": "",
+            "cursor": 0,
+            "events": [],
+        }
+
+    _mirror_ring_into_store(store, sse_svc, sid, generation)
+    _sample_runners_into_store(store, session_control_svc, sid)
+
+    batch = store.since(sid, since_c)
+    return 200, {
+        "ok": True,
+        "session_id": sid,
+        "cursor": int(batch.get("cursor") or 0),
+        "events": batch.get("events") if isinstance(batch.get("events"), list) else [],
+    }
+
+
+def read_events_since_http(
+    qs: dict,
+    svc: SessionEventsServices,
+) -> tuple[int, JsonPayload]:
+    """GET /api/session/events — query: session, since, generation."""
+    qs = qs or {}
+    session = (qs.get("session", [""])[0] or qs.get("session_id", [""])[0] or "").strip()
+    since_raw = qs.get("since", ["0"])[0]
+    try:
+        since_c = int(since_raw or 0)
+    except (TypeError, ValueError):
+        since_c = 0
+    gen_raw = qs.get("generation", [""])[0]
+    generation = None
+    if gen_raw not in ("", None):
+        try:
+            generation = int(gen_raw)
+        except (TypeError, ValueError):
+            return 400, {"ok": False, "error": "generation must be an integer"}
+
+    sse_svc = _resolve_svc(svc.sse_services)
+    sc_svc = _resolve_svc(svc.session_control_services)
+    store = svc.store if svc.store is not None else get_default_store()
+    return read_events_since(
+        session,
+        since_c,
+        sse_svc=sse_svc,
+        session_control_svc=sc_svc,
+        store=store,
+        generation=generation,
+    )

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -96,6 +96,7 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
     from .api import reviews as _rev_api
     from .api import schedules as _sched_api
     from .api import session_control as _sc_api
+    from .api import session_events as _session_events_api
     from .api import sessions as _sessions_api
     from .api import settings as _settings_api
     from .api import skills as _skills_api
@@ -417,6 +418,7 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
     from .api import reviews as _rev_api
     from .api import schedules as _sched_api
     from .api import session_control as _sc_api
+    from .api import session_events as _session_events_api
     from .api import sessions as _sessions_api
     from .api import settings as _settings_api
     from .api import skills as _skills_api
@@ -550,6 +552,17 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         )
         return send_json(handler, status, payload)
 
+    def _get_session_events(handler: Any, u: Any, qs: dict) -> Any:
+        """GET /api/session/events — unified store cursor (read_events_since)."""
+        status, payload = _session_events_api.read_events_since_http(
+            qs,
+            _session_events_api.SessionEventsServices(
+                sse_services=svc.sse_services,
+                session_control_services=svc.session_control_services,
+            ),
+        )
+        return send_json(handler, status, payload)
+
     def _get_terminal_stream(handler: Any, u: Any, qs: dict) -> Any:
         return handler._stream_terminal(qs.get("id", [""])[0])
 
@@ -586,6 +599,7 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
             _sc_api.get_session_state,
             services=svc.session_control_services,
             pass_qs=True),
+        "/api/session/events": _get_session_events,
         "/api/session/goal": get_json(
             _sc_api.get_session_goal, services=svc.session_control_services),
         "/api/session/context_at": _get_session_context_at,

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -1408,14 +1408,13 @@ class SendLoopMixin:
 
             # 3. No actions => the pilot is done talking. Before yielding back to
             # the user, drain any pending steer. A steer that arrives while the
-            # model is finalizing has no tool result to piggyback on (the last
-            # history message is this assistant turn), so the mid-spree path in
-            # _check_and_inject_steer cannot deliver it. We deliver it here as a
-            # genuine next-turn user message (valid assistant -> user alternation)
-            # and re-ask the model instead of terminating. This is the second of
-            # the two steer delivery points (the other being the mid-spree
-            # piggyback inside _check_and_inject_steer); together they guarantee
-            # any enqueued steer is eventually delivered and never stranded.
+            # model is finalizing has a safe assistant->user boundary (the last
+            # history message is this assistant turn). drain_idle_turn delivers
+            # it as a first-class user message and re-asks the model instead of
+            # terminating. Mid-spree / step-start inject in
+            # _check_and_inject_steer is the other delivery point; together they
+            # guarantee any enqueued steer is eventually delivered and never
+            # stranded.
             if not turn.has_actions:
                 synthesis_decision = post_swarm_synthesis_decision(
                     synchronous_swarms=synchronous_swarms,

--- a/harness/send_loop_actions.py
+++ b/harness/send_loop_actions.py
@@ -176,11 +176,10 @@ def execute_turn_actions(
             yield from session._check_and_inject_steer()
             if session._steer_pending:
                 # A user steer arrived mid-spree. Abandon the REMAINING queued
-                # actions and loop back to re-ask the model, which now sees the
-                # steer as its current instruction. Heal unanswered sibling
-                # tool_calls at this tool-batch boundary BEFORE the next
-                # provider request (same seam as cancel) so steer never leaves
-                # dangling tool_use ids.
+                # actions so sanitize can close open tool pairs, then loop back.
+                # Inject only happens at a safe boundary (after pairs are
+                # complete); if inject deferred, the next step-start drain
+                # appends the first-class user message before chat().
                 session._sanitize_tool_pairs()
                 break
         if session._cancel.is_set():

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -1133,15 +1133,24 @@ def drain_idle_turn(
 
     pending_steers = session.drain_steer()
     if pending_steers:
+        format_steer = getattr(
+            session, "_format_steer_user_content", None
+        )
         for steer in pending_steers:
             yield ConvEvent("steer", {"text": steer})
-            session._history.append({"role": "user", "content": session._steer_marker(steer)})
+            if callable(format_steer):
+                content = format_steer(steer)
+            else:
+                # Compatibility for hosts that still expose the legacy marker.
+                marker = getattr(session, "_steer_marker", None)
+                content = marker(steer) if callable(marker) else steer
+            session._history.append({"role": "user", "content": content})
         session._steer_pending = False
         return ("continue", user_message)
     # Steer took priority above; only if no steer was pending do we
     # look at the PROMPT QUEUE ("playlist"). A queued prompt runs as
-    # a genuine next-turn user message -- NOT wrapped in the OUT-OF-
-    # BAND marker used for steer -- so it flows through the pilot as
+    # a genuine next-turn user message — same first-class user shape as
+    # a steer at the idle boundary — so it flows through the pilot as
     # a normal fresh turn. The `continue` re-enters the same step
     # loop, which is bounded by the existing HARD_PILOT_STEPS /
     # max_steps cap; the queue cannot make the loop unbounded.

--- a/harness/steer_mixin.py
+++ b/harness/steer_mixin.py
@@ -107,7 +107,7 @@ class SteerMixin:
     def steer_with_images(self, text: str, images: Optional[list] = None) -> None:
         """Enqueue a steer with attached images.
 
-        Mid-turn steers inject as TEXT into the tool-output stream, so they
+        Mid-turn steers are text-only user messages at a safe boundary, so they
         cannot carry raw image blocks. Policy:
 
         - Vision-capable pilots (gpt-5.6-luna, etc.): NEVER run the vision
@@ -186,7 +186,7 @@ class SteerMixin:
             return True
 
     def enqueue_steer(self, text: str) -> None:
-        """Append an out-of-band user message.
+        """Append a pending mid-turn user steer.
 
         While an abandoned generator still holds ``_busy`` after Stop, refuse
         to queue: a steer has nowhere truthful to go. Ready/idle sessions keep
@@ -210,42 +210,90 @@ class SteerMixin:
             return items
 
     @staticmethod
-    def _steer_marker(text: str) -> str:
-        """Single definition of the OUT-OF-BAND USER MESSAGE marker wrapping a
-        steer. Shared by both delivery points (mid-spree piggyback in
-        _check_and_inject_steer, and finalization-time user-message append in
-        the step loop) so the literal is never duplicated.
+    def _format_steer_user_content(text: str) -> str:
+        """Clamp and hard-wrap steer text for a first-class role=user message.
 
-        The incoming text is clamped (bounded length) and any single unbroken
-        run of >200 non-whitespace chars (e.g. a pasted key/sha) is hard-wrapped
-        so it cannot overflow. This covers BOTH delivery points because both
-        route through this one helper."""
+        Shared by the safe-boundary inject path and finalization-time delivery
+        so both use the same bounded content rules without OUT-OF-BAND wrapping.
+        """
         # Lazy imports avoid a conversation <-> steer_mixin cycle at module load.
         from .conversation import _clamp_tool_result, _hardwrap_long_tokens
         text = _clamp_tool_result(text)
-        text = _hardwrap_long_tokens(text, width=200)
+        return _hardwrap_long_tokens(text, width=200)
+
+    @staticmethod
+    def _steer_marker(text: str) -> str:
+        """Legacy OUT-OF-BAND wrapper kept for reading old history / tests.
+
+        Happy-path inject no longer uses this. Prefer
+        ``_format_steer_user_content`` for new role=user steers.
+        """
+        body = SteerMixin._format_steer_user_content(text)
         return (
             "\n\n[OUT-OF-BAND USER MESSAGE - a direct message from the user, "
             "delivered mid-turn; not tool output. Stop your current line of work, "
             "address THIS now, and do not resume the previous task unless the user "
-            f"asks.]\n{text}\n[/OUT-OF-BAND USER MESSAGE]"
+            f"asks.]\n{body}\n[/OUT-OF-BAND USER MESSAGE]"
         )
 
+    def _steer_inject_boundary_is_safe(self) -> bool:
+        """True when appending role=user will not break tool_use/tool_result pairing.
+
+        Unsafe while the most recent assistant tool_use still has unanswered
+        tool_calls in its contiguous adjacent result run (mid-tool / unpaired).
+        Safe after that pair completes, after a prose-only assistant, or when
+        no open tool_use exists.
+        """
+        history = getattr(self, "_history", None) or []
+        if not history:
+            return True
+        last_tool_use = None
+        for i in range(len(history) - 1, -1, -1):
+            m = history[i]
+            role = m.get("role")
+            if role == "assistant":
+                if m.get("tool_calls"):
+                    last_tool_use = i
+                break
+        if last_tool_use is None:
+            return True
+        expected = {
+            tc.get("id")
+            for tc in (history[last_tool_use].get("tool_calls") or [])
+            if tc.get("id")
+        }
+        if not expected:
+            return True
+        answered: set[str] = set()
+        j = last_tool_use + 1
+        while j < len(history) and history[j].get("role") == "tool":
+            tcid = history[j].get("tool_call_id")
+            if tcid:
+                answered.add(tcid)
+            j += 1
+        # A non-tool message already sits between the tool_use and further
+        # results (or after a partial run). Only inject when every id is
+        # answered in the contiguous adjacent run — never wedge a user row
+        # into an open pair.
+        if j < len(history) and history[last_tool_use + 1].get("role") != "tool":
+            # Something non-tool already follows the assistant tool_use with
+            # no adjacent results — pairing is already broken; refuse inject.
+            return False
+        return answered == expected
+
     def _check_and_inject_steer(self) -> Iterator["ConvEvent"]:
-        """Drain pending steers and surface them to the model WITHOUT breaking
-        message role alternation or injecting a synthetic user turn mid-loop.
+        """Drain pending steers into a first-class user message at a safe boundary.
 
-        Mirrors the Hermes design (agent/conversation_loop.py pre-API steer
-        drain): a steer is appended to the LAST tool-result message's content,
-        so the model sees it as part of the tool output on its next iteration.
-        A synthetic user message mid-loop (what this used to do) breaks strict
-        user/assistant alternation -- providers like Moonshot reject it and
-        return empty content, wedging the loop. If there is no tool/result
-        message to piggyback on yet, the steer is put back as pending for the
-        next drain rather than forced in.
+        Safe boundary: after the current assistant+tool-pair step is complete
+        (all tool_calls answered by contiguous adjacent tool results), before
+        the next chat() call. Appends ``role=user`` with clamped/hardwrapped
+        content so the next model step sees a normal user message — not a
+        piggyback inside tool output.
 
-        Sets self._steer_pending so the action loop can stop the current spree
-        and re-ask the model, which now sees the steer in the tool output.
+        If the boundary is not yet safe (mid-tool / unpaired calls), steers
+        stay pending. ``_steer_pending`` is still set so the action loop can
+        abandon the remaining spree, sanitize dangling pairs, and retry inject
+        on the next step once the boundary is safe.
 
         After Stop / cooperative interrupt, queued steers are dropped (never
         injected into an abandoned generator) and a durable/streamed notice is
@@ -265,66 +313,46 @@ class SteerMixin:
         steers = self.drain_steer()
         if not steers:
             return
+        if not self._steer_inject_boundary_is_safe():
+            # Keep pending until pairs complete (or sanitize heals them). Signal
+            # the action loop to abandon remaining tools so the next step can
+            # inject at a safe boundary — do NOT insert a user row between
+            # assistant tool_use and tool_result.
+            with self._steer_lock:
+                for steer in reversed(steers):
+                    self._steer_queue.appendleft(steer)
+            self._steer_pending = True
+            return
         for steer in steers:
-            marker_text = self._steer_marker(steer)
+            content = self._format_steer_user_content(steer)
             try:
                 from .task_transaction import context_block
 
                 extra = context_block(getattr(self, "_task_tx", None))
                 if extra:
-                    marker_text = marker_text + "\n\n" + extra
+                    content = content + "\n\n" + extra
             except Exception:
                 pass
             yield ConvEvent("steer", {"text": steer})
-            # Inject into the last result-bearing message (tool role for native
-            # tool-calling, or the user-role result the JSON-envelope path appends).
-            #
-            # Adjacency safety: a tool-role result may only be piggybacked on
-            # when it belongs to the CONTIGUOUS run of tool results IMMEDIATELY
-            # following the last assistant tool_use. Injecting into a tool
-            # message that already has a non-tool message after it (before the
-            # next assistant) would leave that assistant tool_use no longer
-            # directly followed by its tool_result -- the steer itself would
-            # create the non-adjacent tool_use/tool_result Anthropic rejects. In
-            # that case defer the steer (put it back pending), exactly like the
-            # no-target case.
-            injected = False
-            for i in range(len(self._history) - 1, -1, -1):
-                m = self._history[i]
-                role = m.get("role")
-                if role == "tool":
-                    # Only safe if this tool message traces back through a
-                    # contiguous tool-result run to an assistant tool_use with no
-                    # non-tool gap. Since we scan from the end, a non-tool
-                    # message after it would have been hit first, so reaching a
-                    # tool message here means nothing non-tool follows it.
-                    if self._tool_result_is_adjacent(i):
-                        m["content"] = (m.get("content") or "") + marker_text
-                        injected = True
-                    break
-                if role == "user" and i > 0:
-                    m["content"] = (m.get("content") or "") + marker_text
-                    injected = True
-                    break
-                if role == "assistant":
-                    # Hit an assistant turn before any tool result -- nothing to
-                    # piggyback on this iteration; put the steer back as pending.
-                    break
-            if injected:
-                self._steer_pending = True
-            else:
-                # No result message to inject into yet -- keep it pending so the
-                # next drain (after a tool batch) picks it up. Never force a
-                # synthetic user turn.
-                with self._steer_lock:
-                    self._steer_queue.appendleft(steer)
+            self._history.append({"role": "user", "content": content})
+            try:
+                display = getattr(self, "_display_transcript", None)
+                if display is not None:
+                    display.append({
+                        "type": "message",
+                        "role": "user",
+                        "text": steer,
+                    })
+            except Exception:
+                pass
+            self._steer_pending = True
 
     def _tool_result_is_adjacent(self, i: int) -> bool:
         """True when the tool-role message at history index ``i`` is part of the
         contiguous run of tool results IMMEDIATELY following an assistant
         tool_use, with no non-tool message wedged between that assistant and
-        ``i``. Piggybacking a steer onto such a message keeps the tool_use ->
-        tool_result adjacency Anthropic requires."""
+        ``i``. Kept for pairing diagnostics / callers that still reason about
+        adjacent tool runs."""
         history = self._history
         if not (0 <= i < len(history)) or history[i].get("role") != "tool":
             return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.220"
+version = "0.9.221"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_safe_boundary_cancel_steer.py
+++ b/tests/test_safe_boundary_cancel_steer.py
@@ -345,9 +345,13 @@ def test_stop_then_late_inject_does_not_contaminate_history(monkeypatch):
 
     assert list(host._steer_queue) == []
     assert host._steer_pending is False
-    tool_content = host._history[-1].get("content") or ""
-    assert "OUT-OF-BAND" not in tool_content
-    assert "raced late steer" not in tool_content
+    history_blob = " ".join(str(m.get("content") or "") for m in host._history)
+    assert "OUT-OF-BAND" not in history_blob
+    assert "raced late steer" not in history_blob
+    assert not any(
+        m.get("role") == "user" and "raced late steer" in str(m.get("content") or "")
+        for m in host._history
+    )
     assert any(
         e.kind == "notice" and e.data.get("reason") == "steer_dropped"
         for e in events

--- a/tests/test_send_loop_phases.py
+++ b/tests/test_send_loop_phases.py
@@ -1161,7 +1161,7 @@ def test_drain_idle_turn_delivers_steers_and_continues():
     session = SimpleNamespace(
         drain_steer=lambda: list(steers),
         _history=history,
-        _steer_marker=lambda t: f"<steer>{t}</steer>",
+        _format_steer_user_content=lambda t: t,
         _steer_pending=True,
         _next_queued_needs_driver_swap=lambda: False,
         _pop_next_prompt=lambda: None,
@@ -1186,7 +1186,7 @@ def test_drain_idle_turn_delivers_steers_and_continues():
     assert user_message == "orig"
     assert session._steer_pending is False
     assert events[0].kind == "steer"
-    assert history[-1]["content"] == "<steer>course correct</steer>"
+    assert history[-1] == {"role": "user", "content": "course correct"}
     session._submit_housekeeping.assert_not_called()
 
 

--- a/tests/test_session_events_cursor.py
+++ b/tests/test_session_events_cursor.py
@@ -1,0 +1,161 @@
+"""Tests for harness.api.session_events.read_events_since."""
+
+from __future__ import annotations
+
+from harness.api.session_control import SessionControlServices
+from harness.api.session_events import (
+    SessionEventStore,
+    read_events_since,
+    reset_default_store_for_tests,
+)
+from harness.api.sse import SseEventRing, SseServices
+
+
+class _FakePilot:
+    def __init__(self, state: str = "idle", pending: bool = False):
+        self._state = state
+        self._pending = pending
+
+    def state(self):
+        return self._state
+
+    def has_pending_swarms(self):
+        return self._pending
+
+    def session_goal_dict(self):
+        return {}
+
+
+class _FakeRunners:
+    def __init__(self, statuses: dict, active_view_id: str = ""):
+        self._statuses = statuses
+        self.active_view_id = active_view_id
+
+    def statuses(self):
+        return dict(self._statuses)
+
+
+def _sse_svc(rings: dict, default_sid: str = "s1"):
+    gens = {sid: ring.generation for sid, ring in rings.items()}
+
+    def ring_lookup(session_id, generation):
+        ring = rings.get(session_id)
+        if ring is None:
+            return None
+        if generation is not None and int(generation) != ring.generation:
+            return None
+        return ring
+
+    return SseServices(
+        ring_lookup=ring_lookup,
+        current_generation=lambda sid: gens.get(sid),
+        default_session_id=lambda: default_sid,
+    )
+
+
+def _sc_svc(runners: dict, state: str = "idle", pending: bool = False):
+    pilot = _FakePilot(state=state, pending=pending)
+    run = _FakeRunners(runners)
+    return SessionControlServices(
+        cfg=None,
+        get_pilot=lambda: pilot,
+        get_runners=lambda: run,
+        gate_active_pilot_ready=lambda: None,
+        stash_put=lambda *_a, **_k: "",
+        save_active_transcript=lambda: None,
+        upload_dir="/tmp",
+        diag=lambda *_a, **_k: None,
+    )
+
+
+def test_read_events_since_mirrors_ring_and_advances_cursor():
+    reset_default_store_for_tests()
+    store = SessionEventStore()
+    ring = SseEventRing("s1", 1)
+    ring.append("message_delta", {"text": "a"})
+    ring.append("message_delta", {"text": "b"})
+    sse = _sse_svc({"s1": ring})
+    sc = _sc_svc({"s1": "running"}, state="thinking")
+
+    code, payload = read_events_since(
+        "s1",
+        0,
+        sse_svc=sse,
+        session_control_svc=sc,
+        store=store,
+    )
+    assert code == 200
+    assert payload["ok"] is True
+    assert payload["cursor"] >= 2
+    kinds = [e["kind"] for e in payload["events"]]
+    assert "stream" in kinds
+    assert "runners" in kinds
+    stream = [e for e in payload["events"] if e["kind"] == "stream"]
+    assert stream[0]["data"]["kind"] == "message_delta"
+    assert stream[0]["data"]["data"]["text"] == "a"
+
+    hw = payload["cursor"]
+    code2, payload2 = read_events_since(
+        "s1",
+        hw,
+        sse_svc=sse,
+        session_control_svc=sc,
+        store=store,
+    )
+    assert code2 == 200
+    assert payload2["events"] == []
+    assert payload2["cursor"] == hw
+
+
+def test_read_events_since_session_switch_isolation():
+    """Events for session A must not appear under B's cursor."""
+    store = SessionEventStore()
+    ring_a = SseEventRing("A", 1)
+    ring_a.append("message_delta", {"text": "from-A"})
+    ring_b = SseEventRing("B", 1)
+    ring_b.append("message_delta", {"text": "from-B"})
+    sse = _sse_svc({"A": ring_a, "B": ring_b}, default_sid="A")
+    sc = _sc_svc({"A": "running", "B": "idle"})
+
+    _, a_payload = read_events_since(
+        "A", 0, sse_svc=sse, session_control_svc=sc, store=store,
+    )
+    _, b_payload = read_events_since(
+        "B", 0, sse_svc=sse, session_control_svc=sc, store=store,
+    )
+    a_texts = [
+        e["data"]["data"].get("text")
+        for e in a_payload["events"]
+        if e["kind"] == "stream"
+    ]
+    b_texts = [
+        e["data"]["data"].get("text")
+        for e in b_payload["events"]
+        if e["kind"] == "stream"
+    ]
+    assert "from-A" in a_texts
+    assert "from-B" not in a_texts
+    assert "from-B" in b_texts
+    assert "from-A" not in b_texts
+
+
+def test_read_events_since_runners_fingerprint_dedupes():
+    store = SessionEventStore()
+    sse = _sse_svc({})
+    sc = _sc_svc({"s1": "idle"}, state="idle")
+    _, p1 = read_events_since(
+        "s1", 0, sse_svc=sse, session_control_svc=sc, store=store,
+    )
+    runners_events = [e for e in p1["events"] if e["kind"] == "runners"]
+    assert len(runners_events) == 1
+    hw = p1["cursor"]
+    _, p2 = read_events_since(
+        "s1", hw, sse_svc=sse, session_control_svc=sc, store=store,
+    )
+    assert p2["events"] == []
+
+    sc2 = _sc_svc({"s1": "running"}, state="thinking")
+    _, p3 = read_events_since(
+        "s1", hw, sse_svc=sse, session_control_svc=sc2, store=store,
+    )
+    assert any(e["kind"] == "runners" for e in p3["events"])

--- a/tests/test_steer.py
+++ b/tests/test_steer.py
@@ -68,19 +68,21 @@ def test_drive_turn_with_mid_turn_steer():
     assert "steer" in kinds
     assert kinds[-1] == "assistant_done"
     
-    # Check that the OUT-OF-BAND user message was injected into history
-    found_marker = False
+    # Steer is a first-class user message (not piggybacked into tool output).
+    found_steer = False
     for msg in s._history:
-        if msg["role"] == "user" and "[OUT-OF-BAND USER MESSAGE" in msg["content"]:
-            assert "Pay attention to the formatting rules please." in msg["content"]
-            found_marker = True
-            
-    assert found_marker, "Out of band steer message was not found in history"
-    
-    # Assert strict role alternation holds in history (excluding system prompt at index 0)
-    history_roles = [msg["role"] for msg in s._history if msg["role"] != "system"]
-    for idx in range(1, len(history_roles)):
-        assert history_roles[idx] != history_roles[idx - 1], f"Strict alternation broken: consecutive {history_roles[idx]} at index {idx}"
+        if msg["role"] == "user" and "Pay attention to the formatting rules please." in (msg.get("content") or ""):
+            assert "[OUT-OF-BAND USER MESSAGE" not in msg["content"]
+            found_steer = True
+            break
+    assert found_steer, "first-class steer user message was not found in history"
+
+    # Compatibility: legacy OUT-OF-BAND markers in old history remain readable
+    # but are not written on the happy path.
+    assert not any(
+        "[OUT-OF-BAND USER MESSAGE" in str(m.get("content") or "")
+        for m in s._history
+    )
 
 
 class _FinalizingPilot:
@@ -120,15 +122,77 @@ def test_steer_during_finalization_reasks_model():
     assert kinds[-1] == "assistant_done", "the run must still end cleanly after delivery"
 
     # The steer must be delivered as a genuine next-turn user message.
-    found_marker = False
+    found_steer = False
     for msg in s._history:
-        if msg["role"] == "user" and "[OUT-OF-BAND USER MESSAGE" in msg.get("content", ""):
-            assert "Actually, also check the README." in msg["content"]
-            found_marker = True
-    assert found_marker, "the finalization-time steer was not delivered as a user message"
+        if msg["role"] == "user" and "Actually, also check the README." in msg.get("content", ""):
+            assert "[OUT-OF-BAND USER MESSAGE" not in msg["content"]
+            found_steer = True
+    assert found_steer, "the finalization-time steer was not delivered as a user message"
 
     # No steer may be left stranded as pending.
     assert s.drain_steer() == [], "the steer must not remain pending"
+
+
+def test_steer_injects_as_user_at_safe_boundary():
+    """After a completed tool pair, steer becomes a plain role=user message."""
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
+    s = ConversationalSession(cfg)
+    s._history = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "list_dir", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "t1", "content": "ok"},
+    ]
+    s.enqueue_steer("pivot to auth")
+    events = list(s._check_and_inject_steer())
+    assert any(e.kind == "steer" and e.data.get("text") == "pivot to auth" for e in events)
+    assert s._steer_pending is True
+    assert s.drain_steer() == []
+    last = s._history[-1]
+    assert last["role"] == "user"
+    assert last["content"] == "pivot to auth"
+    assert "[OUT-OF-BAND" not in last["content"]
+    assert any(
+        row.get("role") == "user" and row.get("text") == "pivot to auth"
+        for row in s._display_transcript
+    )
+
+
+def test_steer_defers_when_tool_pair_unanswered():
+    """Mid-tool / unpaired calls must keep the steer pending — no user wedge."""
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
+    s = ConversationalSession(cfg)
+    s._history = [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "list_dir", "arguments": "{}"}},
+                {"id": "t2", "type": "function",
+                 "function": {"name": "list_dir", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "t1", "content": "partial"},
+    ]
+    before = list(s._history)
+    s.enqueue_steer("do not wedge me")
+    events = list(s._check_and_inject_steer())
+    assert events == []
+    assert s._steer_pending is True
+    assert s.drain_steer() == ["do not wedge me"]
+    assert s._history == before
+    assert not any(
+        "do not wedge me" in str(m.get("content") or "") for m in s._history
+    )
 
 
 def test_api_session_steer_auth(tmp_path):

--- a/tests/test_steer_interrupt.py
+++ b/tests/test_steer_interrupt.py
@@ -34,7 +34,12 @@ class _SpreePilot:
             # user steers mid-run, right after the first spree turn is issued
             self.session.enqueue_steer("hello stop")
         for m in hist:
-            if "OUT-OF-BAND" in str(m.get("content", "")):
+            content = str(m.get("content", ""))
+            # First-class steer is a plain user message; legacy OUT-OF-BAND
+            # markers in older history remain recognized for compatibility.
+            if m.get("role") == "user" and (
+                "hello stop" in content or "OUT-OF-BAND" in content
+            ):
                 self.saw_steer = True
         if self.saw_steer:
             return _Resp('{"say":"Stopping.","actions":[]}')

--- a/tests/test_steer_mixin.py
+++ b/tests/test_steer_mixin.py
@@ -17,7 +17,9 @@ MOVED_METHODS = (
     "_steer_boundary_blocks_inject",
     "_record_steer_drop_notice",
     "_flush_steer_drop_notice",
+    "_format_steer_user_content",
     "_steer_marker",
+    "_steer_inject_boundary_is_safe",
     "_check_and_inject_steer",
     "_tool_result_is_adjacent",
 )

--- a/tests/test_tool_pair_sanitizer.py
+++ b/tests/test_tool_pair_sanitizer.py
@@ -213,9 +213,9 @@ def test_load_history_heals_dangling_tool_use():
     assert s._history[idx + 1].get("role") == "tool"
 
 
-def test_steer_marker_hardwraps_long_unbroken_token():
+def test_steer_format_hardwraps_long_unbroken_token():
     long_token = "a" * 500
-    out = ConversationalSession._steer_marker(long_token)
+    out = ConversationalSession._format_steer_user_content(long_token)
     # The wrapped token lines are the lines made up solely of the run char.
     token_lines = [ln for ln in out.splitlines() if ln and set(ln) == {"a"}]
     assert token_lines, "the token must survive the wrap"
@@ -225,6 +225,10 @@ def test_steer_marker_hardwraps_long_unbroken_token():
     assert sum(len(ln) for ln in token_lines) == 500
     # The 500-char unbroken run was actually broken into multiple lines.
     assert len(token_lines) >= 3
+    # Legacy marker helper still wraps for old-history compatibility.
+    legacy = ConversationalSession._steer_marker(long_token)
+    assert "[OUT-OF-BAND USER MESSAGE" in legacy
+    assert sum(1 for ln in legacy.splitlines() if ln and set(ln) == {"a"}) >= 3
 
 
 def test_max_pilot_steps_env_unlimited(monkeypatch):
@@ -380,7 +384,10 @@ class _SteerMidSpreePilot:
     def chat(self, hist, tools=None, system=""):
         self.calls += 1
         for m in hist:
-            if "OUT-OF-BAND" in str(m.get("content", "")):
+            content = str(m.get("content", ""))
+            if m.get("role") == "user" and (
+                "change direction" in content or "OUT-OF-BAND" in content
+            ):
                 self.saw_steer = True
         if self.saw_steer:
             return _Resp('{"say":"Steered.","actions":[]}')
@@ -421,8 +428,14 @@ def test_steer_mid_tool_spree_heals_dangling_pairs(tmp_path):
     assert "toolu_B" in by_id and "toolu_C" in by_id
     assert "interrupted" in by_id["toolu_B"]["content"]
     assert "interrupted" in by_id["toolu_C"]["content"]
-    # Steer piggybacked on an adjacent tool result (not a synthetic user turn).
-    assert any("OUT-OF-BAND" in str(m.get("content", "")) for m in s._history)
+    # First-class steer is a user-role message after the healed tool pair.
+    assert any(
+        m.get("role") == "user" and "change direction" in str(m.get("content") or "")
+        for m in s._history
+    )
+    assert not any(
+        "OUT-OF-BAND" in str(m.get("content") or "") for m in s._history
+    )
 
 
 class _CallSitePilot:

--- a/tests/test_v09215_live_path.py
+++ b/tests/test_v09215_live_path.py
@@ -184,10 +184,12 @@ def test_steer_inject_includes_task_transaction_block(tmp_path):
     s.enqueue_steer("course correct")
     events = list(s._check_and_inject_steer())
     assert any(e.kind == "steer" for e in events)
-    injected = s._history[-1]["content"]
-    assert "course correct" in injected
-    assert "## Task transaction" in injected
-    assert "note.txt" in injected
+    injected = s._history[-1]
+    assert injected.get("role") == "user"
+    assert "course correct" in (injected.get("content") or "")
+    assert "[OUT-OF-BAND USER MESSAGE" not in (injected.get("content") or "")
+    assert "## Task transaction" in (injected.get("content") or "")
+    assert "note.txt" in (injected.get("content") or "")
 
 
 def test_session_steer_interrupt_delivery_stops_then_queues():

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.220",
+  "version": "0.9.221",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.220",
+      "version": "0.9.221",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",
@@ -14,6 +14,7 @@
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/lang-python": "^6.2.1",
+        "@tanstack/react-virtual": "^3.14.9",
         "@uiw/codemirror-theme-okaidia": "^4.25.10",
         "@uiw/react-codemirror": "^4.25.10",
         "@xterm/addon-fit": "^0.11.0",
@@ -2571,6 +2572,33 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.220",
+  "version": "0.9.221",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -23,6 +23,7 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-python": "^6.2.1",
+    "@tanstack/react-virtual": "^3.14.9",
     "@uiw/codemirror-theme-okaidia": "^4.25.10",
     "@uiw/react-codemirror": "^4.25.10",
     "@xterm/addon-fit": "^0.11.0",

--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -22,7 +22,8 @@ import {
 } from "../components/Conversation";
 import { api } from "../lib/api";
 import type { Item } from "../components/TranscriptList";
-import { chatEventsPath } from "../lib/transport";
+import { chatEventsPath, sessionEventsPath } from "../lib/transport";
+import { nextStoreCursor, shouldApplyStoreEvent } from "../components/conversation/storeEvents";
 
 /**
  * Mid-turn chatEvents reattach contracts (cursor + poll gating).
@@ -345,33 +346,48 @@ describe("detached-busy mid-tool-batch reattach", () => {
     const transcriptFpRef = { current: "" };
     const chatEventsPollTimerRef = { current: null as number | null };
 
-    const chatEvents = vi.spyOn(api, "chatEvents")
+    const readEventsSince = vi.spyOn(api, "readEventsSince")
       .mockResolvedValueOnce({
-        ok: false,
-        missed: true,
-        available: false,
-        code: "cursor_gap",
-        generation: 2,
-        cursor: 9,
-        events: [],
-        retained: 3,
+        ok: true,
+        session_id: "sess-mid",
+        cursor: 2,
+        events: [{
+          id: 2,
+          kind: "ring_miss",
+          data: {
+            ok: false,
+            missed: true,
+            available: false,
+            code: "cursor_gap",
+            generation: 2,
+            cursor: 9,
+          },
+        }],
       } as any)
       .mockResolvedValueOnce({
         ok: true,
-        missed: false,
-        available: true,
-        generation: 2,
-        cursor: 9,
+        session_id: "sess-mid",
+        cursor: 4,
         events: [
           {
-            cursor: 7,
-            kind: "action_start",
-            data: { id: "a9", goal: "tail tool", kind: "read_file" },
+            id: 3,
+            kind: "stream",
+            data: {
+              cursor: 7,
+              kind: "action_start",
+              data: { id: "a9", goal: "tail tool", kind: "read_file" },
+              generation: 2,
+            },
           },
           {
-            cursor: 8,
-            kind: "action_start",
-            data: { id: "a10", goal: "batch sibling", kind: "read_file" },
+            id: 4,
+            kind: "stream",
+            data: {
+              cursor: 8,
+              kind: "action_start",
+              data: { id: "a10", goal: "batch sibling", kind: "read_file" },
+              generation: 2,
+            },
           },
         ],
       } as any);
@@ -431,10 +447,10 @@ describe("detached-busy mid-tool-batch reattach", () => {
 
     const keepPolling = await pullChatEvents();
     expect(keepPolling).toBe(true);
-    expect(chatEvents).toHaveBeenCalledTimes(2);
-    // First miss used the stale since; retry after hydrate uses since=0.
-    expect(chatEvents.mock.calls[0][0]).toMatchObject({ since: 1, generation: 2 });
-    expect(chatEvents.mock.calls[1][0]).toMatchObject({ since: 0, generation: 2 });
+    expect(readEventsSince).toHaveBeenCalledTimes(2);
+    expect(readEventsSince.mock.calls[0][0]).toMatchObject({ since: 1, generation: 2 });
+    // Retry advances past the ring_miss store id (not ring since=0).
+    expect(readEventsSince.mock.calls[1][0]).toMatchObject({ since: 2, generation: 2 });
     expect(applied).toEqual(["action_start", "action_start"]);
     const cardIds = items
       .filter((i): i is Extract<Item, { kind: "card" }> => i.kind === "card")
@@ -442,8 +458,8 @@ describe("detached-busy mid-tool-batch reattach", () => {
     expect(cardIds).toContain("a1");
     expect(cardIds).toContain("a9");
     expect(cardIds).toContain("a10");
-    // Advances to the replay high-water (not a synthesized mid-gap cursor).
-    expect(lastAppliedCursorRef.current).toBe(9);
+    // Advances to the store high-water cursor.
+    expect(lastAppliedCursorRef.current).toBe(4);
     expect(ringGenerationRef.current).toBe(2);
     expect(detachedBusyRef.current).toBe(true);
   });
@@ -456,15 +472,22 @@ describe("detached-busy mid-tool-batch reattach", () => {
     const ringGenerationRef = { current: 3 as number | undefined };
     const detachedBusyRef = { current: true };
 
-    const chatEvents = vi.spyOn(api, "chatEvents").mockResolvedValue({
-      ok: false,
-      missed: true,
-      available: false,
-      code: "ring_miss",
-      generation: 0,
-      cursor: 0,
-      events: [],
-      retained: 0,
+    const readEventsSince = vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-long",
+      cursor: 41,
+      events: [{
+        id: 41,
+        kind: "ring_miss",
+        data: {
+          ok: false,
+          missed: true,
+          available: false,
+          code: "ring_miss",
+          generation: 0,
+          cursor: 0,
+        },
+      }],
     } as any);
 
     vi.spyOn(api, "sessionTranscript").mockResolvedValue({
@@ -514,9 +537,9 @@ describe("detached-busy mid-tool-batch reattach", () => {
 
     const keepPolling = await pullChatEvents();
     expect(keepPolling).toBe(true);
-    expect(chatEvents).toHaveBeenCalledTimes(1);
+    expect(readEventsSince).toHaveBeenCalledTimes(1);
     expect(applied).toEqual([]);
-    expect(lastAppliedCursorRef.current).toBe(0);
+    expect(lastAppliedCursorRef.current).toBe(41);
     expect(ringGenerationRef.current).toBeUndefined();
     expect(detachedBusyRef.current).toBe(true);
     expect(
@@ -555,15 +578,22 @@ describe("detached-busy mid-tool-batch reattach", () => {
     ];
     const itemsRef = { current: items };
 
-    vi.spyOn(api, "chatEvents").mockResolvedValue({
-      ok: false,
-      missed: true,
-      available: false,
-      code: "ring_miss",
-      generation: 0,
-      cursor: 0,
-      events: [],
-      retained: 0,
+    vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-appr",
+      cursor: 6,
+      events: [{
+        id: 6,
+        kind: "ring_miss",
+        data: {
+          ok: false,
+          missed: true,
+          available: false,
+          code: "ring_miss",
+          generation: 0,
+          cursor: 0,
+        },
+      }],
     } as any);
 
     // Equal card count, no approval on disk — merge must still preserve pending.
@@ -733,6 +763,19 @@ describe("Wave 4 command-job reattach fences", () => {
       cachedSessionId: "sess-b",
       reattachSid: "sess-a",
     })).toBe(false);
+    expect(shouldApplyStoreEvent({
+      streamGen: 2,
+      subscriptionGen: 2,
+      cachedSessionId: "sess-a",
+      subscriptionSid: "sess-a",
+    })).toBe(true);
+    expect(shouldApplyStoreEvent({
+      streamGen: 2,
+      subscriptionGen: 2,
+      cachedSessionId: "sess-b",
+      subscriptionSid: "sess-a",
+    })).toBe(false);
+    expect(nextStoreCursor(0, [{ id: 1 }, { id: 3 }], 3)).toBe(3);
   });
 
   it("drops late ring frames after a session switch (no cross-session merge)", async () => {
@@ -740,31 +783,34 @@ describe("Wave 4 command-job reattach fences", () => {
     const cachedSessionIdRef = { current: "sess-a" as string | null };
     const streamGenRef = { current: 1 };
 
-    vi.spyOn(api, "chatEvents").mockImplementation(async () => {
+    vi.spyOn(api, "readEventsSince").mockImplementation(async () => {
       // Session switch lands while the request is in flight.
       cachedSessionIdRef.current = "sess-b";
       streamGenRef.current = 2;
       return {
         ok: true,
-        missed: false,
-        available: true,
-        generation: 1,
+        session_id: "sess-a",
         cursor: 4,
         events: [
           {
-            cursor: 3,
-            kind: "action_result",
+            id: 3,
+            kind: "stream",
             data: {
-              id: "a-stale",
-              status: "completed",
-              job_id: "local-cmd-stale",
-              message: "must not apply",
+              cursor: 3,
+              kind: "action_result",
+              data: {
+                id: "a-stale",
+                status: "completed",
+                job_id: "local-cmd-stale",
+                message: "must not apply",
+              },
+              generation: 1,
             },
           },
           {
-            cursor: 4,
-            kind: "assistant_done",
-            data: {},
+            id: 4,
+            kind: "stream",
+            data: { cursor: 4, kind: "assistant_done", data: {}, generation: 1 },
           },
         ],
       } as any;
@@ -834,14 +880,15 @@ describe("Wave 4 command-job reattach fences", () => {
       },
     };
 
-    vi.spyOn(api, "chatEvents")
+    vi.spyOn(api, "readEventsSince")
       .mockResolvedValueOnce({
         ok: true,
-        missed: false,
-        available: true,
-        generation: 1,
-        cursor: 8,
-        events: [frame, frame],
+        session_id: "sess-dup",
+        cursor: 2,
+        events: [
+          { id: 1, kind: "stream", data: { ...frame, generation: 1 } },
+          { id: 2, kind: "stream", data: { ...frame, generation: 1 } },
+        ],
       } as any);
 
     const { pullChatEvents } = createChatEventsReattach({
@@ -891,7 +938,7 @@ describe("Wave 4 command-job reattach fences", () => {
   });
 });
 
-describe("mid-turn live chatEvents watch reattach", () => {
+describe("mid-turn store-event cursor reattach", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
@@ -958,65 +1005,18 @@ describe("mid-turn live chatEvents watch reattach", () => {
     };
   }
 
-  it("opens live watch path on busy reattach (not 1Hz poll first)", async () => {
-    const deps = reattachDeps();
-    let liveHandlers: {
-      onEvent: (e: any) => void;
-      onDone?: () => void;
-      onError?: (e: any) => void;
-    } | null = null;
-    const live = vi.spyOn(api, "chatEventsLive").mockImplementation(
-      (_opts, onEvent, onDone, onError) => {
-        liveHandlers = { onEvent, onDone, onError };
-        return () => {};
-      },
-    );
-    const chatEvents = vi.spyOn(api, "chatEvents");
-    vi.spyOn(api, "getSessionState").mockResolvedValue({
-      runners: { "sess-live": "running" },
-    } as any);
-
-    const { startChatEventsReattach } = createChatEventsReattach(deps as any);
-    await startChatEventsReattach();
-
-    expect(live).toHaveBeenCalledTimes(1);
-    expect(live.mock.calls[0][0]).toMatchObject({
-      session: "sess-live",
-      since: 0,
-      generation: 1,
-    });
-    expect(deps.chatEventsLiveCancelRef.current).not.toBeNull();
-    expect(deps.chatEventsPollTimerRef.current).toBeNull();
-    expect(chatEvents).not.toHaveBeenCalled();
-
-    liveHandlers!.onEvent({
-      kind: "message_delta",
-      data: { text: "hi" },
-      cursor: 4,
-    });
-    expect(deps.applied).toEqual(["message_delta"]);
-    expect(deps.lastAppliedCursorRef.current).toBe(4);
-  });
-
-  it("falls back to 1Hz poll when live watch open fails", async () => {
+  it("arms store cursor poll on busy reattach (not live watch)", async () => {
     vi.useFakeTimers();
     const deps = reattachDeps();
-    vi.spyOn(api, "chatEventsLive").mockImplementation(
-      (_opts, _onEvent, _onDone, onError) => {
-        queueMicrotask(() => onError?.(new Error("stream /api/chat/events -> 409")));
-        return () => {};
-      },
-    );
-    const chatEvents = vi.spyOn(api, "chatEvents").mockResolvedValue({
+    const live = vi.spyOn(api, "chatEventsLive");
+    const readEventsSince = vi.spyOn(api, "readEventsSince").mockResolvedValue({
       ok: true,
-      missed: false,
-      available: true,
-      generation: 1,
-      cursor: 2,
+      session_id: "sess-live",
+      cursor: 4,
       events: [{
-        cursor: 2,
-        kind: "message_delta",
-        data: { text: "fallback" },
+        id: 4,
+        kind: "stream",
+        data: { cursor: 4, kind: "message_delta", data: { text: "hi" }, generation: 1 },
       }],
     } as any);
     vi.spyOn(api, "getSessionState").mockResolvedValue({
@@ -1025,74 +1025,74 @@ describe("mid-turn live chatEvents watch reattach", () => {
 
     const { startChatEventsReattach } = createChatEventsReattach(deps as any);
     await startChatEventsReattach();
-    // Drain live onError microtask + the first poll pull; do not run the
-    // interval forever (detached-busy keeps shouldPollChatEvents true).
-    await Promise.resolve();
     await Promise.resolve();
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(chatEvents).toHaveBeenCalled();
-    expect(deps.applied).toContain("message_delta");
+    expect(live).not.toHaveBeenCalled();
+    expect(readEventsSince).toHaveBeenCalled();
+    expect(readEventsSince.mock.calls[0][0]).toMatchObject({
+      session: "sess-live",
+      since: 0,
+      generation: 1,
+    });
     expect(deps.chatEventsLiveCancelRef.current).toBeNull();
     expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+    expect(deps.applied).toEqual(["message_delta"]);
+    expect(deps.lastAppliedCursorRef.current).toBe(4);
   });
 
-  it("drops live frames after session switch (no cross-session bleed)", async () => {
+  it("drops store stream events after session switch (no cross-session bleed)", async () => {
     const deps = reattachDeps();
-    let onEvent: ((e: any) => void) | null = null;
-    vi.spyOn(api, "chatEventsLive").mockImplementation((_opts, handler) => {
-      onEvent = handler;
-      return () => {};
+    vi.spyOn(api, "readEventsSince").mockImplementation(async () => {
+      deps.cachedSessionIdRef.current = "sess-other";
+      deps.streamGenRef.current = 2;
+      return {
+        ok: true,
+        session_id: "sess-live",
+        cursor: 9,
+        events: [{
+          id: 9,
+          kind: "stream",
+          data: {
+            cursor: 9,
+            kind: "action_result",
+            data: { id: "stale", status: "completed" },
+            generation: 1,
+          },
+        }],
+      } as any;
     });
     vi.spyOn(api, "getSessionState").mockResolvedValue({
       runners: { "sess-live": "running" },
     } as any);
 
-    const { startChatEventsReattach } = createChatEventsReattach(deps as any);
-    await startChatEventsReattach();
-
-    // Session switch bumps gen + sid fence before late live frames arrive.
-    deps.cachedSessionIdRef.current = "sess-other";
-    deps.streamGenRef.current = 2;
-    onEvent!({
-      kind: "action_result",
-      data: { id: "stale", status: "completed" },
-      cursor: 9,
-    });
+    const { pullChatEvents } = createChatEventsReattach(deps as any);
+    const keep = await pullChatEvents();
+    expect(keep).toBe(false);
     expect(deps.applied).toEqual([]);
-    expect(deps.lastAppliedCursorRef.current).toBe(0);
   });
 
-  it("settles detached-busy on live terminal without arming poll", async () => {
+  it("settles detached-busy on store terminal while keeping poll armed", async () => {
     const deps = reattachDeps();
-    let handlers: {
-      onEvent: (e: any) => void;
-      onDone?: () => void;
-    } | null = null;
-    vi.spyOn(api, "chatEventsLive").mockImplementation(
-      (_opts, onEvent, onDone) => {
-        handlers = { onEvent, onDone };
-        return () => {};
-      },
-    );
-    const chatEvents = vi.spyOn(api, "chatEvents");
-    vi.spyOn(api, "getSessionState").mockResolvedValue({
-      runners: { "sess-live": "running" },
+    vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 5,
+      events: [{
+        id: 5,
+        kind: "stream",
+        data: { cursor: 5, kind: "assistant_done", data: {}, generation: 1 },
+      }],
     } as any);
 
-    const { startChatEventsReattach } = createChatEventsReattach(deps as any);
-    await startChatEventsReattach();
-    handlers!.onEvent({ kind: "assistant_done", data: {}, cursor: 5 });
-    handlers!.onDone?.();
-
+    const { pullChatEvents } = createChatEventsReattach(deps as any);
+    const keep = await pullChatEvents();
     expect(deps.applied).toEqual(["assistant_done"]);
     expect(deps.detachedBusyRef.current).toBe(false);
-    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
-    expect(deps.chatEventsPollTimerRef.current).toBeNull();
-    expect(chatEvents).not.toHaveBeenCalled();
+    expect(keep).toBe(true);
   });
 
-  it("on getSessionState failure retries then optimistic-busy arms live watch", async () => {
+  it("on getSessionState failure optimistic-busy arms store poll", async () => {
     vi.useFakeTimers();
     const turnOpen = vi.fn();
     const setStatus = vi.fn();
@@ -1100,21 +1100,37 @@ describe("mid-turn live chatEvents watch reattach", () => {
       setTurnOpen: turnOpen,
       setStatus,
     });
-    // Session-switch forces detachedBusy false before reattach probes runners.
     deps.detachedBusyRef.current = false;
-    const live = vi.spyOn(api, "chatEventsLive").mockImplementation(() => () => {});
+    const live = vi.spyOn(api, "chatEventsLive");
+    vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 0,
+      events: [],
+    } as any);
     const getSessionState = vi.spyOn(api, "getSessionState").mockRejectedValue(
       new Error("network"),
     );
 
     const { startChatEventsReattach } = createChatEventsReattach(deps as any);
     const done = startChatEventsReattach();
-    await vi.runAllTimersAsync();
+    // Retry uses setTimeout(100); do not runAllTimers (store poll interval loops).
+    await vi.advanceTimersByTimeAsync(250);
     await done;
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
 
     expect(getSessionState.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(deps.detachedBusyRef.current).toBe(true);
     expect(turnOpen).toHaveBeenCalledWith(true);
-    expect(live).toHaveBeenCalledTimes(1);
+    expect(live).not.toHaveBeenCalled();
+    expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+  });
+
+  it("sessionEventsPath builds the store cursor URL", () => {
+    expect(sessionEventsPath({ session: "s1", since: 3, generation: 2 })).toContain(
+      "/api/session/events",
+    );
+    expect(sessionEventsPath({ session: "s1", since: 3 })).toContain("since=3");
   });
 });

--- a/webapp/src/__tests__/inFileReview.test.ts
+++ b/webapp/src/__tests__/inFileReview.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PendingReview } from "../lib/api";
+import { api } from "../lib/api";
+import {
+  applyInFileHunkDecision,
+  buildInFileApplyDecisions,
+  collectInFilePendingHunks,
+  parseHunkGeometry,
+  parseHunkHeader,
+} from "../lib/inFileReview";
+import {
+  reviewHunkDecisionKey,
+  seedApplyDecisions,
+} from "../lib/reviewDecisions";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    applyReview: vi.fn(),
+    getReviews: vi.fn(),
+  },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeReview(overrides?: Partial<PendingReview>): PendingReview {
+  return {
+    id: "rev-a",
+    job_id: "job_aaaaaaaaaaaa",
+    objective: "patch it",
+    created_at: 1,
+    files: [
+      {
+        path: "src/a.ts",
+        hunks: [
+          {
+            id: "0:0",
+            header: "@@ -2,3 +2,4 @@",
+            lines: [" context", "-old", "+new", " more"],
+            status: "pending",
+          },
+          {
+            id: "0:1",
+            header: "@@ -20,1 +20,1 @@",
+            lines: ["-bye", "+hi"],
+            status: "pending",
+          },
+        ],
+      },
+      {
+        path: "src/b.ts",
+        hunks: [
+          {
+            id: "1:0",
+            header: "@@ -1,1 +1,2 @@",
+            lines: [" keep", "+extra"],
+            status: "pending",
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("review decision namespace helpers (shared with DiffReviewPane)", () => {
+  it("namespaces decisions per review", () => {
+    expect(reviewHunkDecisionKey("rev-a", "0:0")).toBe("rev-a::0:0");
+    expect(reviewHunkDecisionKey("rev-b", "0:0")).toBe("rev-b::0:0");
+  });
+
+  it("seedApplyDecisions fills every hunk id as accept by default", () => {
+    const review = makeReview();
+    expect(seedApplyDecisions(review, {})).toEqual({
+      "0:0": "accept",
+      "0:1": "accept",
+      "1:0": "accept",
+    });
+  });
+});
+
+describe("parseHunkHeader / parseHunkGeometry", () => {
+  it("parses unified hunk headers including omitted counts", () => {
+    expect(parseHunkHeader("@@ -10,0 +11,2 @@")).toEqual({
+      oldStart: 10,
+      oldCount: 0,
+      newStart: 11,
+      newCount: 2,
+    });
+    expect(parseHunkHeader("@@ -3 +3 @@")).toEqual({
+      oldStart: 3,
+      oldCount: 1,
+      newStart: 3,
+      newCount: 1,
+    });
+  });
+
+  it("maps body lines onto old-file geometry for paint", () => {
+    const geo = parseHunkGeometry({
+      id: "0:0",
+      header: "@@ -2,3 +2,4 @@",
+      lines: [" context", "-old", "+new", " more"],
+      status: "pending",
+    });
+    expect(geo).not.toBeNull();
+    expect(geo!.oldLines).toEqual([2, 3, 4]);
+    expect(geo!.anchorOldLine).toBe(2);
+    expect(geo!.lineKinds.map((l) => l.kind)).toEqual([
+      "context",
+      "del",
+      "add",
+      "context",
+    ]);
+  });
+
+  it("anchors pure inserts after the oldStart line", () => {
+    const geo = parseHunkGeometry({
+      id: "0:0",
+      header: "@@ -10,0 +11,1 @@",
+      lines: ["+inserted"],
+      status: "pending",
+    });
+    expect(geo!.oldLines).toEqual([]);
+    expect(geo!.anchorOldLine).toBe(10);
+  });
+});
+
+describe("collectInFilePendingHunks", () => {
+  it("returns only hunks whose path matches the open editor", () => {
+    const review = makeReview();
+    const forA = collectInFilePendingHunks([review], "src/a.ts");
+    expect(forA.map((h) => h.hunk.id)).toEqual(["0:0", "0:1"]);
+    expect(forA.every((h) => h.decisionKey.startsWith("rev-a::"))).toBe(true);
+
+    const forB = collectInFilePendingHunks([review], "/abs/repo/src/b.ts");
+    expect(forB.map((h) => h.hunk.id)).toEqual(["1:0"]);
+  });
+
+  it("skips non-pending hunks", () => {
+    const review = makeReview();
+    review.files[0].hunks[0].status = "accept";
+    const forA = collectInFilePendingHunks([review], "src/a.ts");
+    expect(forA.map((h) => h.hunk.id)).toEqual(["0:1"]);
+  });
+});
+
+describe("buildInFileApplyDecisions + applyInFileHunkDecision", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "dispatchEvent");
+  });
+
+  it("Accept seeds all review hunk keys (never omits other files)", () => {
+    const review = makeReview();
+    expect(buildInFileApplyDecisions(review, "0:0", "accept")).toEqual({
+      "0:0": "accept",
+      "0:1": "accept",
+      "1:0": "accept",
+    });
+  });
+
+  it("Reject of one hunk still seeds sibling hunks as accept", () => {
+    const review = makeReview();
+    expect(buildInFileApplyDecisions(review, "0:1", "reject")).toEqual({
+      "0:0": "accept",
+      "0:1": "reject",
+      "1:0": "accept",
+    });
+  });
+
+  it("applyInFileHunkDecision posts seeded payload and refreshes reviews", async () => {
+    vi.mocked(api.applyReview).mockResolvedValue({
+      ok: true,
+      message: "ok",
+      applied_files: ["src/a.ts"],
+      rejected_hunks: [],
+      checkpoint_id: null,
+    } as any);
+
+    const review = makeReview();
+    const res = await applyInFileHunkDecision(review, "0:0", "accept");
+    expect(res.ok).toBe(true);
+    expect(api.applyReview).toHaveBeenCalledWith("rev-a", {
+      "0:0": "accept",
+      "0:1": "accept",
+      "1:0": "accept",
+    });
+
+    const kinds = vi.mocked(window.dispatchEvent).mock.calls.map(
+      (c) => (c[0] as Event).type,
+    );
+    expect(kinds).toContain("harness-reviews-refresh");
+    expect(kinds).toContain("harness-repo-mutated");
+  });
+
+  it("Reject posts namespaced decision without dropping other keys", async () => {
+    vi.mocked(api.applyReview).mockResolvedValue({
+      ok: true,
+      message: "ok",
+      applied_files: ["src/a.ts", "src/b.ts"],
+      rejected_hunks: ["0:0"],
+      checkpoint_id: null,
+    } as any);
+
+    const review = makeReview();
+    await applyInFileHunkDecision(review, "0:0", "reject");
+    expect(api.applyReview).toHaveBeenCalledWith("rev-a", {
+      "0:0": "reject",
+      "0:1": "accept",
+      "1:0": "accept",
+    });
+  });
+});

--- a/webapp/src/__tests__/transcriptVirtualizer.test.tsx
+++ b/webapp/src/__tests__/transcriptVirtualizer.test.tsx
@@ -1,0 +1,183 @@
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  TranscriptList,
+  type Item,
+} from "../components/TranscriptList";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function listProps(
+  items: Item[],
+  scrollContainerRef: RefObject<HTMLDivElement | null>,
+) {
+  return {
+    items,
+    status: "done" as const,
+    compactingStatus: null as string | null,
+    editingIndex: null as number | null,
+    auto: false,
+    plan: false,
+    turnOpen: false,
+    scrollContainerRef,
+    onEditMessage: vi.fn(),
+    onExecuteSend: vi.fn(),
+    onImageClick: vi.fn(),
+    onSetCard: vi.fn(),
+    onExecutePlan: vi.fn(),
+    onCommandApproval: vi.fn(),
+  };
+}
+
+function longTranscript(count: number): Item[] {
+  const items: Item[] = [];
+  for (let i = 0; i < count; i++) {
+    items.push({
+      kind: "msg",
+      msg: { role: "user", text: `user turn ${i}` },
+    });
+    items.push({
+      kind: "msg",
+      msg: { role: "assistant", text: `assistant reply ${i}` },
+    });
+  }
+  return items;
+}
+
+/** TanStack reads offsetHeight first, then RO borderBoxSize — feed both. */
+class SizedResizeObserver {
+  private readonly callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+  observe(target: Element) {
+    const box = { inlineSize: 600, blockSize: 360 };
+    const rect = {
+      x: 0,
+      y: 0,
+      width: 600,
+      height: 360,
+      top: 0,
+      left: 0,
+      bottom: 360,
+      right: 600,
+      toJSON() {
+        return this;
+      },
+    };
+    this.callback(
+      [
+        {
+          target,
+          contentRect: rect as DOMRectReadOnly,
+          borderBoxSize: [box],
+          contentBoxSize: [box],
+          devicePixelContentBoxSize: [box],
+        } as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver,
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+function sizeFeedElement(el: HTMLDivElement) {
+  Object.defineProperty(el, "offsetHeight", {
+    configurable: true,
+    get: () => 360,
+  });
+  Object.defineProperty(el, "offsetWidth", {
+    configurable: true,
+    get: () => 600,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    get: () => 360,
+  });
+  Object.defineProperty(el, "clientWidth", {
+    configurable: true,
+    get: () => 600,
+  });
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    get: () => 80 * 72,
+  });
+  el.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      width: 600,
+      height: 360,
+      top: 0,
+      left: 0,
+      bottom: 360,
+      right: 600,
+      toJSON() {
+        return this;
+      },
+    }) as DOMRect;
+}
+
+function VirtualFeedHarness({ items }: { items: Item[] }) {
+  const feedRef = useRef<HTMLDivElement>(null);
+  const [, setReady] = useState(0);
+  useLayoutEffect(() => {
+    const el = feedRef.current;
+    if (!el) return;
+    sizeFeedElement(el);
+    setReady((n) => n + 1);
+  }, []);
+  return (
+    <div
+      ref={feedRef}
+      data-testid="virtual-feed"
+      style={{ height: 360, overflow: "auto" }}
+    >
+      <TranscriptList {...listProps(items, feedRef)} />
+    </div>
+  );
+}
+
+describe("transcript feed virtualizer", () => {
+  it("does not keep a Show-earlier / RENDER_WINDOW=40 live path", () => {
+    const items = longTranscript(50);
+    render(
+      <TranscriptList
+        {...listProps(items, { current: null })}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /Show earlier messages/i })).toBeNull();
+    expect(screen.getByText("user turn 0")).toBeTruthy();
+    expect(screen.getByText("user turn 49")).toBeTruthy();
+  });
+
+  it("mounts only a viewport-sized window when the feed scroll parent is sized", async () => {
+    vi.stubGlobal("ResizeObserver", SizedResizeObserver);
+    const items = longTranscript(60);
+    render(<VirtualFeedHarness items={items} />);
+
+    await waitFor(() => {
+      const rows = screen.getAllByTestId("transcript-virtual-row");
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows.length).toBeLessThan(80);
+    });
+
+    expect(screen.queryByRole("button", { name: /Show earlier messages/i })).toBeNull();
+    expect(screen.getByTestId("transcript-virtual-list")).toBeTruthy();
+  });
+});

--- a/webapp/src/__tests__/useInFileReview.test.tsx
+++ b/webapp/src/__tests__/useInFileReview.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, renderHook, waitFor, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PendingReview } from "../lib/api";
+import { api } from "../lib/api";
+import { useInFileReview } from "../components/useInFileReview";
+import { reviewHunkDecisionKey } from "../lib/reviewDecisions";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    getReviews: vi.fn(),
+    applyReview: vi.fn(),
+  },
+}));
+
+afterEach(() => cleanup());
+
+const review: PendingReview = {
+  id: "rev-infile",
+  job_id: "job_infileinfile",
+  objective: "in-file",
+  created_at: 1,
+  files: [
+    {
+      path: "src/target.ts",
+      hunks: [
+        {
+          id: "0:0",
+          header: "@@ -1,2 +1,2 @@",
+          lines: [" keep", "-a", "+b"],
+          status: "pending",
+        },
+        {
+          id: "0:1",
+          header: "@@ -8,1 +8,1 @@",
+          lines: ["-x", "+y"],
+          status: "pending",
+        },
+      ],
+    },
+  ],
+};
+
+describe("useInFileReview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getReviews).mockResolvedValue([review]);
+  });
+
+  it("loads matching pending hunks for the open path", async () => {
+    const { result } = renderHook(() => useInFileReview("src/target.ts"));
+    await waitFor(() => expect(result.current.pendingCount).toBe(2));
+    expect(result.current.extension).toBeTruthy();
+  });
+
+  it("Accept calls apply_review with fully seeded namespaced decisions", async () => {
+    vi.mocked(api.applyReview).mockResolvedValue({
+      ok: true,
+      message: "ok",
+      applied_files: ["src/target.ts"],
+      rejected_hunks: [],
+      checkpoint_id: null,
+    } as any);
+
+    const { result } = renderHook(() => useInFileReview("src/target.ts"));
+    await waitFor(() => expect(result.current.pendingCount).toBe(2));
+
+    // Drive the same helper path the widget buttons use.
+    const { applyInFileHunkDecision } = await import("../lib/inFileReview");
+    await act(async () => {
+      await applyInFileHunkDecision(review, "0:0", "accept");
+    });
+
+    expect(api.applyReview).toHaveBeenCalledWith("rev-infile", {
+      "0:0": "accept",
+      "0:1": "accept",
+    });
+    expect(reviewHunkDecisionKey("rev-infile", "0:0")).toBe("rev-infile::0:0");
+  });
+
+  it("Reject seeds sibling hunks as accept so they are not silently dropped", async () => {
+    vi.mocked(api.applyReview).mockResolvedValue({
+      ok: true,
+      message: "ok",
+      applied_files: ["src/target.ts"],
+      rejected_hunks: ["0:1"],
+      checkpoint_id: null,
+    } as any);
+
+    const { applyInFileHunkDecision } = await import("../lib/inFileReview");
+    await applyInFileHunkDecision(review, "0:1", "reject");
+
+    expect(api.applyReview).toHaveBeenCalledWith("rev-infile", {
+      "0:0": "accept",
+      "0:1": "reject",
+    });
+  });
+});

--- a/webapp/src/__tests__/workspaceFreshness.test.tsx
+++ b/webapp/src/__tests__/workspaceFreshness.test.tsx
@@ -24,6 +24,7 @@ vi.mock("../lib/api", () => ({
     readFile: vi.fn(),
     writeFile: vi.fn(),
     fileRawUrl: vi.fn((p: string) => `raw:${p}`),
+    getReviews: vi.fn().mockResolvedValue([]),
   },
 }));
 

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -193,13 +193,13 @@ export default function Conversation({
   // SSE ownership: ignore late events after detach / session switch.
   const streamSessionIdRef = useRef<string | null>(null);
   const streamGenRef = useRef(0);
-  // Mid-turn reattach: last applied /api/chat/events ring cursor (incremental).
+  // Mid-turn reattach: last applied /api/session/events store cursor (unified).
   const lastAppliedCursorRef = useRef(0);
-  // Ring generation from the last successful chatEvents replay (pin subsequent polls).
+  // Ring generation from the last successful stream event (pin subsequent polls).
   const ringGenerationRef = useRef<number | undefined>(undefined);
-  // setInterval handle for light chatEvents poll while detached-busy (no EventSource).
+  // setInterval handle for the single store-event cursor poll.
   const chatEventsPollTimerRef = useRef<number | null>(null);
-  // Cancel for live ``/api/chat/events?watch=1`` reattach (preferred over 1Hz poll).
+  // Legacy live-watch cancel slot (store cursor owns reattach; kept for armed()).
   const chatEventsLiveCancelRef = useRef<null | (() => void)>(null);
   // Shared live-SSE + reattach event applicator (assigned where handlers live).
   const applyStreamEventRef = useRef<(ev: { kind: string; data?: any }) => void>(() => {});
@@ -1199,6 +1199,7 @@ export default function Conversation({
     detachedBusyRef,
     userStoppedRef,
     turnSettledRef,
+    abandonStaleLocalStreamRef,
     resumeQueuedRef,
     approvedCommandRetryRef,
     runnerBusyPollGenRef,

--- a/webapp/src/components/DiffReviewPane.tsx
+++ b/webapp/src/components/DiffReviewPane.tsx
@@ -1,30 +1,12 @@
 import { useState, useEffect } from "react";
 import { api, type PendingReview, type PendingReviewFile } from "../lib/api";
 import { Check, X, Eye, AlertCircle, RefreshCw } from "lucide-react";
+import {
+  reviewHunkDecisionKey,
+  seedApplyDecisions,
+} from "../lib/reviewDecisions";
 
-/** Namespace hunk decisions per review so concurrent pending reviews cannot collide. */
-export function reviewHunkDecisionKey(reviewId: string, hunkId: string): string {
-  return `${reviewId}::${hunkId}`;
-}
-
-/**
- * Build the apply_review payload: every hunk id is seeded to match the painted
- * UI default (accept). Harness defaults missing keys to reject — omitting keys
- * would silently drop hunks the pane still shows as accepted.
- */
-export function seedApplyDecisions(
-  review: PendingReview,
-  decisions: Record<string, "accept" | "reject">,
-): Record<string, "accept" | "reject"> {
-  const out: Record<string, "accept" | "reject"> = {};
-  for (const file of review.files) {
-    for (const hunk of file.hunks) {
-      const key = reviewHunkDecisionKey(review.id, hunk.id);
-      out[hunk.id] = decisions[key] ?? "accept";
-    }
-  }
-  return out;
-}
+export { reviewHunkDecisionKey, seedApplyDecisions };
 
 export default function DiffReviewPane({ reviews, onRefresh, loadError = null }: {
   reviews: PendingReview[];

--- a/webapp/src/components/FileEditorPane.tsx
+++ b/webapp/src/components/FileEditorPane.tsx
@@ -18,6 +18,7 @@ import {
   pathsReferToSameFile,
   subscribeWorkspaceMutations,
 } from "../lib/workspaceMutationEvents";
+import { useInFileReview } from "./useInFileReview";
 
 interface FileEditorPaneProps {
   path: string;
@@ -191,6 +192,12 @@ export default function FileEditorPane({ path, line, col, onClose, onDirtyChange
   const rawUrl = useMemo(() => api.fileRawUrl(path), [path]);
   const canPreview = kind === "markdown" || kind === "html";
   const isTextEditable = kind === "code" || kind === "markdown" || kind === "html";
+  const {
+    extension: inFileReviewExtension,
+    pendingCount: inFilePendingCount,
+    applyError: inFileApplyError,
+    clearApplyError: clearInFileApplyError,
+  } = useInFileReview(path);
 
   // Agent-loop links may re-open the same file at a new line.
   useEffect(() => {
@@ -508,6 +515,9 @@ export default function FileEditorPane({ path, line, col, onClose, onDirtyChange
   if (langExt) {
     extensions.push(langExt);
   }
+  if (inFilePendingCount > 0) {
+    extensions.push(inFileReviewExtension);
+  }
 
   extensions.push(
     keymap.of([
@@ -728,6 +738,35 @@ export default function FileEditorPane({ path, line, col, onClose, onDirtyChange
               Keep mine
             </button>
           </div>
+        </div>
+      )}
+
+      {inFileApplyError && (
+        <div
+          data-testid="infile-review-apply-error"
+          className="flex items-center justify-between gap-3 px-4 py-2 border-b border-risk/40 bg-risk/10 shrink-0"
+          role="status"
+        >
+          <span className="text-[11px] text-risk min-w-0">{inFileApplyError}</span>
+          <button
+            type="button"
+            onClick={clearInFileApplyError}
+            className="px-2 py-1 rounded text-[11px] border border-edge text-muted hover:text-txt hover:bg-panel2 transition-colors shrink-0"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {inFilePendingCount > 0 && showCodeMirror && (
+        <div
+          data-testid="infile-review-banner"
+          className="flex items-center gap-2 px-4 py-1.5 border-b border-accent/30 bg-accent/5 shrink-0"
+          role="status"
+        >
+          <span className="text-[11px] text-muted">
+            {inFilePendingCount} pending review hunk{inFilePendingCount === 1 ? "" : "s"} in this file — Accept or Reject on the hunk markers (no confirm).
+          </span>
         </div>
       )}
 

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { GitBranch, Plus, MessageSquare, Check, Loader2, ChevronDown, ChevronRight, SquarePen, Folder, FolderGit2, CheckCircle2, Circle, XCircle, Trash2, Brush, Search, X, Square } from "lucide-react";
+import { GitBranch, Plus, MessageSquare, Check, Loader2, ChevronDown, ChevronRight, SquarePen, Folder, FolderGit2, CheckCircle2, Circle, Trash2, Brush, Search, X, Square } from "lucide-react";
 import { api, type Workspace, type WorkspaceInfo, type Session, type Job, type Artifact } from "../lib/api";
 import { pickFolder } from "../lib/transport";
 import { dispatchProjectSelected, dispatchProjectSwitching, panelOpacityClass } from "../lib/panelTransition";
@@ -9,301 +9,49 @@ import { usePolling } from "../lib/usePolling";
 import { readSWRCache, writeSWRCache, useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
 import { writeTranscriptCache } from "./Conversation";
 
-/** User-facing copy when concurrent session runner leases are full. */
-export const SESSION_LEASE_EXHAUSTED_MESSAGE =
-  "This session could not start — too many sessions are busy right now. Wait a moment or stop another turn, then try again.";
+export {
+  SESSION_LEASE_EXHAUSTED_MESSAGE,
+  type LeaseExhaustedPayload,
+  isLeaseExhaustedError,
+  formatLeaseExhaustedMessage,
+  buildProjectsList,
+  filterForgottenRecent,
+  canSettleSessionsForProject,
+  partitionProjectSessions,
+  readSessionSettledFromCaches,
+  patchSessionSettledInCaches,
+  patchSessionTitleInCaches,
+  patchSessionArchivedInCaches,
+  purgeSessionFromRootCaches,
+  workspacesCacheKey,
+  jobsCacheKey,
+  shouldOfferBackgroundStop,
+  collectUnreadFinishedSessionIds,
+  isRailWideSwitching,
+  projectSessionsEmptyState,
+} from "./leftRailSessions";
 
-export type LeaseExhaustedPayload = {
-  code?: string;
-  error?: string;
-  message?: string;
-  status?: number;
-  max_concurrent?: number;
-  active_count?: number;
-  busy_session_ids?: string[];
-  busy_session_titles?: string[];
-};
-
-/** True when switch/open/create failed because all session runner leases are busy. */
-export function isLeaseExhaustedError(err: unknown): boolean {
-  if (!err) return false;
-  const e = err as LeaseExhaustedPayload;
-  if (e.code === "lease_exhausted") return true;
-  const msg = String(e.message || e.error || err || "");
-  // Message-only fallbacks (older servers / bridge quirks). Do NOT treat a bare
-  // "... -> 409" as lease exhaustion — other conflicts share that status.
-  if (/lease_exhausted/i.test(msg)) return true;
-  if (/session runner lease exhausted/i.test(msg)) return true;
-  return false;
-}
-
-/** Hermes-style toast: name busy sessions and show capacity when the 409 body has them. */
-export function formatLeaseExhaustedMessage(err: unknown): string {
-  const e = (err || {}) as LeaseExhaustedPayload;
-  const max = typeof e.max_concurrent === "number" ? e.max_concurrent : null;
-  const active = typeof e.active_count === "number" ? e.active_count : null;
-  const titles = (e.busy_session_titles || []).map((t) => String(t).trim()).filter(Boolean);
-  const capacity =
-    max != null
-      ? active != null
-        ? `${active}/${max}`
-        : `${max}`
-      : null;
-  if (titles.length && capacity) {
-    return `Too many sessions are busy (${capacity}). Stop one of: ${titles.map((t) => `"${t}"`).join(", ")} — then try again.`;
-  }
-  if (titles.length) {
-    return `Too many sessions are busy. Stop one of: ${titles.map((t) => `"${t}"`).join(", ")} — then try again.`;
-  }
-  if (capacity) {
-    return `This session could not start — session capacity is full (${capacity}). Wait a moment or stop another turn, then try again.`;
-  }
-  return SESSION_LEASE_EXHAUSTED_MESSAGE;
-}
-
-/**
- * Stable PROJECTS rail order: pin durable Home first (when provided), keep
- * remaining recents as-is, append currentRepo only when it is not already
- * present (slash/case-insensitive). Never force the active path to index 0 —
- * Home is the only synthetic pin.
- */
-export function buildProjectsList(
-  currentRepo: string,
-  rawRecents: string[],
-  home?: string,
-): string[] {
-  const seen: string[] = [];
-  const out: string[] = [];
-  if (home) {
-    seen.push(home);
-    out.push(home);
-  }
-  for (const p of rawRecents) {
-    if (!p || seen.some((s) => repoPathsEqual(s, p))) continue;
-    seen.push(p);
-    out.push(p);
-  }
-  if (currentRepo && !seen.some((s) => repoPathsEqual(s, currentRepo))) {
-    out.push(currentRepo);
-  }
-  return out;
-}
-
-/** Drop a path (and slash/case siblings) from a recents list. */
-export function filterForgottenRecent(recents: string[], path: string): string[] {
-  return (recents || []).filter((r) => !repoPathsEqual(r, path));
-}
-
-/**
- * Settle/Unsettle only work for sessions under the active workspace
- * (POST /api/sessions/settle 403s foreign roots). Hide affordances elsewhere.
- */
-export function canSettleSessionsForProject(
-  projectPath: string,
-  activeRepo: string | undefined | null,
-): boolean {
-  return !!(activeRepo && projectPath && repoPathsEqual(projectPath, activeRepo));
-}
-
-/**
- * Split project-scoped sessions into open (inbox) vs settled.
- * `settled` and `archived` are independent durable flags. Archived rows are
- * excluded here — they live in the global Archived section, not the project tree.
- * Rootless orphans only appear under the active workspace row.
- */
-export function partitionProjectSessions(
-  rows: Session[],
-  projectPath: string,
-  isActiveRow: boolean,
-): { open: Session[]; settled: Session[] } {
-  const scoped = (rows || []).filter((s) => {
-    const root = (s.workspace_root || s.repo || "").trim();
-    if (!root) return isActiveRow;
-    return repoPathsEqual(root, projectPath);
-  });
-  const open: Session[] = [];
-  const settled: Session[] = [];
-  for (const s of scoped) {
-    if (s.archived) continue;
-    if (s.settled) settled.push(s);
-    else open.push(s);
-  }
-  return { open, settled };
-}
-
-/** Read current settled flag for a session id from per-root caches (first hit). */
-export function readSessionSettledFromCaches(
-  roots: string[],
-  sessionId: string,
-  read: (key: string) => Session[] | undefined = readSWRCache,
-): boolean | undefined {
-  for (const root of roots) {
-    if (!root) continue;
-    const cached = read(`sessions:${root}`);
-    const hit = cached?.find((s) => s.id === sessionId);
-    if (hit) return !!hit.settled;
-  }
-  return undefined;
-}
-
-/** Optimistically flip durable `settled` on every per-root sessions cache that holds the id. */
-export function patchSessionSettledInCaches(
-  roots: string[],
-  sessionId: string,
-  settled: boolean,
-  read: (key: string) => Session[] | undefined = readSWRCache,
-  write: (key: string, data: Session[]) => void = writeSWRCache,
-): number {
-  let touched = 0;
-  for (const root of roots) {
-    if (!root) continue;
-    const key = `sessions:${root}`;
-    const cached = read(key);
-    if (!cached || !cached.some((s) => s.id === sessionId)) continue;
-    write(
-      key,
-      cached.map((s) => (s.id === sessionId ? { ...s, settled } : s)),
-    );
-    touched += 1;
-  }
-  return touched;
-}
-
-/** Optimistically set the display title on every per-root sessions cache that holds the id. */
-export function patchSessionTitleInCaches(
-  roots: string[],
-  sessionId: string,
-  title: string,
-  read: (key: string) => Session[] | undefined = readSWRCache,
-  write: (key: string, data: Session[]) => void = writeSWRCache,
-): number {
-  let touched = 0;
-  for (const root of roots) {
-    if (!root) continue;
-    const key = `sessions:${root}`;
-    const cached = read(key);
-    if (!cached || !cached.some((s) => s.id === sessionId)) continue;
-    write(
-      key,
-      cached.map((s) => (s.id === sessionId ? { ...s, title } : s)),
-    );
-    touched += 1;
-  }
-  return touched;
-}
-
-/** Optimistically flip durable `archived` on every per-root sessions cache that holds the id. */
-export function patchSessionArchivedInCaches(
-  roots: string[],
-  sessionId: string,
-  archived: boolean,
-  read: (key: string) => Session[] | undefined = readSWRCache,
-  write: (key: string, data: Session[]) => void = writeSWRCache,
-): number {
-  let touched = 0;
-  for (const root of roots) {
-    if (!root) continue;
-    const key = `sessions:${root}`;
-    const cached = read(key);
-    if (!cached || !cached.some((s) => s.id === sessionId)) continue;
-    write(
-      key,
-      cached.map((s) => (s.id === sessionId ? { ...s, archived } : s)),
-    );
-    touched += 1;
-  }
-  return touched;
-}
-
-/** Drop a session id from every per-root sessions SWR cache. Returns how many
- *  caches were rewritten. Used on delete so inactive projects do not keep
- *  phantom titles (the "merged dir" ghost). */
-export function purgeSessionFromRootCaches(
-  roots: string[],
-  sessionId: string,
-  read: (key: string) => Session[] | undefined = readSWRCache,
-  write: (key: string, data: Session[]) => void = writeSWRCache,
-): number {
-  let touched = 0;
-  for (const root of roots) {
-    if (!root) continue;
-    const key = `sessions:${root}`;
-    const cached = read(key);
-    if (!cached) continue;
-    const next = cached.filter((s) => s.id !== sessionId);
-    if (next.length === cached.length) continue;
-    write(key, next);
-    touched += 1;
-  }
-  return touched;
-}
-
-/** SWR cache key for the Branches list -- keyed by repo so project switches
- *  do not flash another project's branches, and revisits stay warm. */
-export function workspacesCacheKey(repo: string): string {
-  return `workspaces:${repo || "__none__"}`;
-}
-
-/** SWR cache key for jobs scoped to both the selected project and active session. */
-export function jobsCacheKey(projectPath: string, activeSessionId?: string): string {
-  return `jobs:${projectPath || "__none__"}:${activeSessionId || "__none__"}`;
-}
-
-/** True when LeftRail should offer Stop without forcing a view attach. */
-export function shouldOfferBackgroundStop(
-  status: "running" | "idle" | "attaching" | "missing" | undefined,
-  isActive: boolean,
-): boolean {
-  return status === "running" && !isActive;
-}
-
-type RunnerStatus = "running" | "idle" | "attaching" | "missing";
-
-/** Sessions that finished a background turn while the user looked elsewhere. */
-export function collectUnreadFinishedSessionIds(
-  prev: Record<string, RunnerStatus>,
-  next: Record<string, RunnerStatus>,
-  activeSessionId: string | undefined,
-): string[] {
-  const out: string[] = [];
-  for (const [id, status] of Object.entries(next)) {
-    if (id === activeSessionId) continue;
-    if (status === "idle" && prev[id] === "running") out.push(id);
-  }
-  return out;
-}
-
-/**
- * Rail-wide dim / project-switching signal. Browse-selecting an already-listed
- * project must not trip this — jobs SWR key changes on select and used to flash
- * the whole PROJECTS tree. Only real open/switch/session activation dims the rail.
- */
-export function isRailWideSwitching(flags: {
-  opening: boolean;
-  switchingSessionId: string | null;
-  workspaceTransitioning: boolean;
-  sessionsTransitioning: boolean;
-}): boolean {
-  return (
-    flags.opening
-    || !!flags.switchingSessionId
-    || flags.workspaceTransitioning
-    || flags.sessionsTransitioning
-  );
-}
-
-/**
- * Per-project empty-state: spinner only until that root's sessions resolve.
- * Never gate on rail-wide / jobs transitioning (that hid the New session CTA
- * and blinked "Loading sessions..." on first expand of a listed project).
- */
-export function projectSessionsEmptyState(
-  sessionsReady: boolean,
-  showRowLoading: boolean,
-): "loading" | "pending" | "empty" {
-  if (sessionsReady) return "empty";
-  return showRowLoading ? "loading" : "pending";
-}
+import {
+  isLeaseExhaustedError,
+  formatLeaseExhaustedMessage,
+  buildProjectsList,
+  filterForgottenRecent,
+  canSettleSessionsForProject,
+  partitionProjectSessions,
+  readSessionSettledFromCaches,
+  patchSessionSettledInCaches,
+  patchSessionTitleInCaches,
+  patchSessionArchivedInCaches,
+  purgeSessionFromRootCaches,
+  workspacesCacheKey,
+  jobsCacheKey,
+  shouldOfferBackgroundStop,
+  collectUnreadFinishedSessionIds,
+  isRailWideSwitching,
+  projectSessionsEmptyState,
+  type RunnerStatus,
+} from "./leftRailSessions";
+import { Section, IconBtn, Empty, JobStatusIcon, RunnerStatusDot, type JobStatus } from "./leftRailPrimitives";
 
 export default function LeftRail({ jobsRefresh, onSessionChange }: {
   jobsRefresh: number;
@@ -2376,8 +2124,6 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
   );
 }
 
-type JobStatus = "pending" | "in_progress" | "completed" | "cancelled";
-
 const SESSION_JOBS_COLLAPSED_KEY = "pmharness.leftRail.sessionJobsCollapsed";
 const SETTLED_EXPANDED_KEY = "pmharness.leftRail.settledExpanded";
 const SESSION_JOBS_HEIGHT_KEY = "pmharness.leftRail.sessionJobsHeight.v1";
@@ -2510,85 +2256,3 @@ function jobDiffstat(artifacts: Artifact[]): { files: number; insertions: number
   if (!(files || insertions || deletions)) return null;
   return { files, insertions, deletions };
 }
-
-function JobStatusIcon({ status }: { status: JobStatus }) {
-  if (status === "completed") return <CheckCircle2 size={12} className="text-good shrink-0" />;
-  if (status === "in_progress") return <Loader2 size={12} className="animate-spin text-accent shrink-0" />;
-  if (status === "cancelled") return <XCircle size={12} className="text-red-400 shrink-0" />;
-  return <Circle size={12} className="text-muted shrink-0" />;
-}
-
-/** Compact running/idle indicator for a session row. Hidden when status unknown.
- *  When stoppable (running + non-active), click Stops that runner without view attach. */
-function RunnerStatusDot({
-  status,
-  stoppable,
-  onStop,
-}: {
-  status?: "running" | "idle" | "attaching" | "missing";
-  stoppable?: boolean;
-  onStop?: () => void;
-}) {
-  if (!status || status === "missing") return null;
-  const running = status === "running";
-  if (stoppable && running && onStop) {
-    return (
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          onStop();
-        }}
-        className="w-1.5 h-1.5 rounded-full shrink-0 bg-accent hover:ring-2 hover:ring-accent/40 transition"
-        title="Stop (free lease slot)"
-        aria-label="Stop background session"
-      />
-    );
-  }
-  const title =
-    status === "attaching" ? "Attaching" : running ? "Running" : "Idle";
-  return (
-    <span
-      className={`w-1.5 h-1.5 rounded-full shrink-0 ${running ? "bg-accent" : "bg-muted/50"}`}
-      title={title}
-    />
-  );
-}
-
-function Section({ title, action, headerSpinner, children, className }: {
-  title: string;
-  action?: React.ReactNode;
-  headerSpinner?: boolean;
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return (
-    <div className={`px-2 shrink-0 min-w-0 ${className || "pt-3"}`}>
-      <div className="flex items-center justify-between px-1.5 mb-1.5 mt-0.5">
-        <span className="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.12em] text-faint font-semibold">
-          {title}
-          {headerSpinner && <Loader2 size={10} className="animate-spin text-muted shrink-0" />}
-        </span>
-        {action}
-      </div>
-      {children}
-    </div>
-  );
-}
-const IconBtn = ({ onClick, children, title, disabled }: {
-  onClick?: () => void;
-  children?: React.ReactNode;
-  title?: string;
-  disabled?: boolean;
-}) => (
-  <button
-    onClick={onClick}
-    title={title}
-    disabled={disabled}
-    className="text-faint hover:text-txt p-1 rounded hover:bg-panel2/60 disabled:opacity-50 disabled:pointer-events-none"
-  >
-    {children}
-  </button>
-);
-const Empty = ({ children }: any) => <div className="text-[11px] text-faint italic px-1.5 py-1">{children}</div>;

--- a/webapp/src/components/SettingsCollapse.tsx
+++ b/webapp/src/components/SettingsCollapse.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { ChevronRight, ChevronDown } from "lucide-react";
+
+const SETTINGS_SECTION_OPEN_KEY = "pmharness.settings.sectionOpen";
+
+function loadSettingsSectionOpen(id: string, defaultOpen: boolean): boolean {
+  try {
+    const raw = localStorage.getItem(SETTINGS_SECTION_OPEN_KEY);
+    if (!raw) return defaultOpen;
+    const map = JSON.parse(raw) as Record<string, boolean>;
+    if (typeof map[id] === "boolean") return map[id];
+  } catch {
+    /* ignore */
+  }
+  return defaultOpen;
+}
+
+function persistSettingsSectionOpen(id: string, open: boolean) {
+  try {
+    const raw = localStorage.getItem(SETTINGS_SECTION_OPEN_KEY);
+    const map = (raw ? JSON.parse(raw) : {}) as Record<string, boolean>;
+    map[id] = open;
+    localStorage.setItem(SETTINGS_SECTION_OPEN_KEY, JSON.stringify(map));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Collapsible settings block — chevron title + optional summary; persists open state. */
+export function SettingsCollapse({
+  id,
+  title,
+  summary,
+  defaultOpen = true,
+  forceOpen = false,
+  className = "space-y-2 border-t border-edge pt-3",
+  onFirstOpen,
+  children,
+}: {
+  id: string;
+  title: string;
+  summary?: string;
+  defaultOpen?: boolean;
+  forceOpen?: boolean;
+  className?: string;
+  onFirstOpen?: () => void;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(() => loadSettingsSectionOpen(id, defaultOpen));
+  const shown = forceOpen || open;
+  const firstOpenCalled = useRef(false);
+
+  useEffect(() => {
+    if (shown && onFirstOpen && !firstOpenCalled.current) {
+      firstOpenCalled.current = true;
+      onFirstOpen();
+    }
+  }, [shown, onFirstOpen]);
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => {
+          setOpen((v) => {
+            const next = !v;
+            persistSettingsSectionOpen(id, next);
+            return next;
+          });
+        }}
+        className="w-full flex items-center justify-between gap-2 text-left focus:outline-none group"
+      >
+        <span className="uppercase tracking-wider text-[10px] text-faint font-semibold flex items-center gap-1.5 min-w-0 group-hover:text-txt transition">
+          {shown ? <ChevronDown size={12} className="shrink-0" /> : <ChevronRight size={12} className="shrink-0" />}
+          <span className="truncate">{title}</span>
+          {summary ? (
+            <span className="normal-case tracking-normal font-normal text-faint/80 shrink-0">
+              · {summary}
+            </span>
+          ) : null}
+        </span>
+      </button>
+      {shown ? <div className="space-y-2">{children}</div> : null}
+    </div>
+  );
+}

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChevronRight, ChevronDown, Plus, Trash2, ExternalLink, Search, X } from "lucide-react";
 import {
   api,
@@ -14,175 +14,20 @@ import SkillsPane from "./SkillsPane";
 import MemoryPane from "./MemoryPane";
 import SchedulesPane from "./SchedulesPane";
 import { takePendingExpandMemory } from "../lib/memoryDeepLink";
+import {
+  readSettingsSnapshot,
+  writeSettingsSnapshot,
+} from "./settingsSnapshot";
+import { SettingsCollapse } from "./SettingsCollapse";
 
 export type SettingsSection = "general" | "safety" | "providers" | "notifications" | "plugins" | "advanced";
 
-const SETTINGS_SNAPSHOT_KEY = "pmharness.settings.snapshot";
-let memorySettingsSnapshot: Settings | null = null;
-
-/** Persist only safe display/config fields — never raw keys or tokens. */
-export function toSafeSettingsSnapshot(s: Settings): Settings {
-  return {
-    driver: s.driver,
-    reach: s.reach,
-    budget: s.budget,
-    models: s.models,
-    auto_distill: s.auto_distill,
-    reviewEditsBeforeApply: s.reviewEditsBeforeApply,
-    autoVerify: s.autoVerify,
-    autoCommandGuard: s.autoCommandGuard,
-    hash_edit_enabled: s.hash_edit_enabled,
-    commandTimeout: s.commandTimeout,
-    maxPilotSteps: s.maxPilotSteps,
-    pilotToolBudget: s.pilotToolBudget,
-    workerTokenBudget: s.workerTokenBudget,
-    reasoning_effort: s.reasoning_effort,
-    wiki_auto: s.wiki_auto,
-    state_dir: s.state_dir,
-    repo: s.repo,
-    has_api_key: s.has_api_key,
-    api_key_masked: s.api_key_masked,
-    key_env_var: s.key_env_var,
-    preflight_ok: s.preflight_ok,
-    bedrock: s.bedrock
-      ? {
-          configured: s.bedrock.configured,
-          has_key: s.bedrock.has_key,
-          auth_mode: s.bedrock.auth_mode,
-          masked: s.bedrock.masked,
-          has_bearer: s.bedrock.has_bearer,
-          has_access_key: s.bedrock.has_access_key,
-          has_session_token: s.bedrock.has_session_token,
-          region: s.bedrock.region,
-          aws_region: s.bedrock.aws_region,
-          bedrock_region: s.bedrock.bedrock_region,
-          model_id: s.bedrock.model_id,
-          disconnected: s.bedrock.disconnected,
-        }
-      : undefined,
-  };
-}
-
-export function clearSettingsSnapshot() {
-  memorySettingsSnapshot = null;
-  try {
-    localStorage.removeItem(SETTINGS_SNAPSHOT_KEY);
-  } catch {
-    /* ignore */
-  }
-}
-
-export function readSettingsSnapshot(): Settings | null {
-  if (memorySettingsSnapshot) return memorySettingsSnapshot;
-  try {
-    const raw = localStorage.getItem(SETTINGS_SNAPSHOT_KEY);
-    const parsed = raw ? JSON.parse(raw) : null;
-    if (parsed?.settings && typeof parsed.settings === "object") {
-      memorySettingsSnapshot = parsed.settings as Settings;
-      return memorySettingsSnapshot;
-    }
-  } catch {
-    /* stale/corrupt cache is disposable */
-  }
-  return null;
-}
-
-export function writeSettingsSnapshot(settings: Settings) {
-  const safe = toSafeSettingsSnapshot(settings);
-  memorySettingsSnapshot = safe;
-  try {
-    localStorage.setItem(
-      SETTINGS_SNAPSHOT_KEY,
-      JSON.stringify({ settings: safe, savedAt: Date.now() }),
-    );
-  } catch {
-    /* storage pressure must not break Settings */
-  }
-}
-
-const SETTINGS_SECTION_OPEN_KEY = "pmharness.settings.sectionOpen";
-
-function loadSettingsSectionOpen(id: string, defaultOpen: boolean): boolean {
-  try {
-    const raw = localStorage.getItem(SETTINGS_SECTION_OPEN_KEY);
-    if (!raw) return defaultOpen;
-    const map = JSON.parse(raw) as Record<string, boolean>;
-    if (typeof map[id] === "boolean") return map[id];
-  } catch {
-    /* ignore */
-  }
-  return defaultOpen;
-}
-
-function persistSettingsSectionOpen(id: string, open: boolean) {
-  try {
-    const raw = localStorage.getItem(SETTINGS_SECTION_OPEN_KEY);
-    const map = (raw ? JSON.parse(raw) : {}) as Record<string, boolean>;
-    map[id] = open;
-    localStorage.setItem(SETTINGS_SECTION_OPEN_KEY, JSON.stringify(map));
-  } catch {
-    /* ignore */
-  }
-}
-
-/** Collapsible settings block — chevron title + optional summary; persists open state. */
-function SettingsCollapse({
-  id,
-  title,
-  summary,
-  defaultOpen = true,
-  forceOpen = false,
-  className = "space-y-2 border-t border-edge pt-3",
-  onFirstOpen,
-  children,
-}: {
-  id: string;
-  title: string;
-  summary?: string;
-  defaultOpen?: boolean;
-  forceOpen?: boolean;
-  className?: string;
-  onFirstOpen?: () => void;
-  children: ReactNode;
-}) {
-  const [open, setOpen] = useState(() => loadSettingsSectionOpen(id, defaultOpen));
-  const shown = forceOpen || open;
-  const firstOpenCalled = useRef(false);
-
-  useEffect(() => {
-    if (shown && onFirstOpen && !firstOpenCalled.current) {
-      firstOpenCalled.current = true;
-      onFirstOpen();
-    }
-  }, [shown, onFirstOpen]);
-
-  return (
-    <div className={className}>
-      <button
-        type="button"
-        onClick={() => {
-          setOpen((v) => {
-            const next = !v;
-            persistSettingsSectionOpen(id, next);
-            return next;
-          });
-        }}
-        className="w-full flex items-center justify-between gap-2 text-left focus:outline-none group"
-      >
-        <span className="uppercase tracking-wider text-[10px] text-faint font-semibold flex items-center gap-1.5 min-w-0 group-hover:text-txt transition">
-          {shown ? <ChevronDown size={12} className="shrink-0" /> : <ChevronRight size={12} className="shrink-0" />}
-          <span className="truncate">{title}</span>
-          {summary ? (
-            <span className="normal-case tracking-normal font-normal text-faint/80 shrink-0">
-              · {summary}
-            </span>
-          ) : null}
-        </span>
-      </button>
-      {shown ? <div className="space-y-2">{children}</div> : null}
-    </div>
-  );
-}
+export {
+  toSafeSettingsSnapshot,
+  clearSettingsSnapshot,
+  readSettingsSnapshot,
+  writeSettingsSnapshot,
+} from "./settingsSnapshot";
 
 export default function SettingsPane({ onOpenWizard, section = "general" }: { onOpenWizard: () => void; section?: SettingsSection }) {
   const show = (s: SettingsSection) => section === s;

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, memo } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronRight, Loader2, ChevronDown, ChevronUp, Play, Copy, Check, Pencil, RefreshCw, History, Share2, CheckCircle2, XCircle, Eye } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -304,9 +305,8 @@ function compactionRowChrome(it: Extract<Item, { kind: "compaction" }>): {
  * thinking) applies ONLY to the current turn — the span after the last user
  * message. Prior turns always use the sealed rule: fold only assistants that
  * still have a later tool card. Without that scope, a live turn would re-fold
- * every historical finale into its Explored group, shrink the render-window
- * group count, then peel those finales back out on seal and shove older
- * Explored / swarm-done rows behind "Show earlier messages" (the disappear).
+ * every historical finale into its Explored group, then peel those finales
+ * back out on seal (row remount churn / flicker in the virtualized feed).
  *
  * Current turn while open: fold streaming + sealed narration once there is
  * investigation activity (or while streaming before the first tool).
@@ -738,22 +738,14 @@ function stableItemKey(it: GroupedItem, i: number): string {
 }
 
 // PERF: Long sessions grow the transcript without bound, and every displayed
-// group is an expensive subtree (markdown + syntax highlight + tool cards). Cap
-// the DOM at the newest RENDER_WINDOW groups; a "Show earlier messages" affordance
-// prepends another window on demand. This is pure rendering -- older groups are
-// simply not mounted -- so it never touches scrollTop and can't fight the
-// parent's stick-to-bottom autoscroll. Adapted from the Hermes desktop thread's
-// render-budget windowing (which counts message parts; Marionette counts the
-// coarser display groups, one rendered subtree each). Short sessions render in
-// full and never show the button.
-//
-// Sized so a LONG session actually windows: at 200 the cap effectively never
-// fired (a session needs 200+ grouped turns before anything collapses), so long
-// sessions never cut off and never showed "Show earlier messages" -- the exact
-// symptom users hit. 40 groups keeps a comfortably long recent window mounted
-// (each group is a full user-turn subtree) while genuinely long sessions cap and
-// surface the button; "Show earlier" prepends another 40 on demand.
-const RENDER_WINDOW = 40;
+// group is an expensive subtree (markdown + syntax highlight + tool cards).
+// Virtualize the muted four-surface feed (msg / question / file / activity fold)
+// with @tanstack/react-virtual + measureElement so only the viewport (plus
+// overscan) stays mounted. Parent stick-to-bottom (nextFeedPinState hysteresis
+// in Conversation) still owns pin/unpin — this list only reports real total
+// height via the spacer; it never fakes a 40-row render cap.
+const FEED_ROW_ESTIMATE_PX = 72;
+const FEED_VIRTUAL_OVERSCAN = 8;
 
 // PERF: Memoized transcript renderer. Its props are intentionally free of the
 // composer `input` (or any per-keystroke state), so React.memo lets typing skip
@@ -824,36 +816,54 @@ export const TranscriptList = memo(function TranscriptList({
   const intermediateItems = collectIntermediateAssistantItems(items, agentLoopOpen);
   const grouped = groupAgentActivity(items, intermediateItems);
 
-  // PERF: window to the newest RENDER_WINDOW display groups. Walk newest-first,
-  // counting groups until the window is filled; everything before that is hidden
-  // behind the "Show earlier messages" button. Short sessions never fill the
-  // window, so hiddenCount stays 0 and nothing changes for them.
-  const [renderWindow, setRenderWindow] = useState(RENDER_WINDOW);
-  let firstVisible = grouped.length;
-  for (let i = grouped.length - 1, shown = 0; i >= 0; i--) {
-    shown += 1;
-    firstVisible = i;
-    if (shown >= renderWindow) break;
-  }
-  const hiddenCount = firstVisible;
-
-  // Prepend an older window while preserving the reading position: capture the
-  // distance from the bottom before the content grows, restore it once the taller
-  // content has laid out. The user is scrolled up here, so the parent's
-  // stick-to-bottom autoscroll is already released and won't fight this.
-  const restoreFromBottomRef = useRef<number | null>(null);
-  const showEarlier = useCallback(() => {
-    const el = scrollContainerRef.current;
-    restoreFromBottomRef.current = el ? el.scrollHeight - el.scrollTop : null;
-    setRenderWindow((w) => w + RENDER_WINDOW);
+  // Virtualizer scroll parent is the feed column (composer is a sibling). The
+  // list sits below empty-state / padding, so scrollMargin tracks that offset.
+  // scrollEpoch re-renders once feedRef attaches / resizes so getScrollElement
+  // is observed (refs alone do not trigger React updates).
+  const listAnchorRef = useRef<HTMLDivElement>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+  const [scrollEpoch, setScrollEpoch] = useState(0);
+  useLayoutEffect(() => {
+    const scrollEl = scrollContainerRef.current;
+    if (!scrollEl) return;
+    setScrollEpoch((n) => n + 1);
+    const onResize = () => setScrollEpoch((n) => n + 1);
+    const ro = typeof ResizeObserver !== "undefined" ? new ResizeObserver(onResize) : null;
+    ro?.observe(scrollEl);
+    return () => ro?.disconnect();
   }, [scrollContainerRef]);
   useLayoutEffect(() => {
-    const el = scrollContainerRef.current;
-    if (el && restoreFromBottomRef.current != null) {
-      el.scrollTop = el.scrollHeight - restoreFromBottomRef.current;
-      restoreFromBottomRef.current = null;
-    }
-  }, [renderWindow, scrollContainerRef]);
+    const scrollEl = scrollContainerRef.current;
+    const anchor = listAnchorRef.current;
+    if (!scrollEl || !anchor) return;
+    const syncMargin = () => {
+      const next =
+        anchor.getBoundingClientRect().top -
+        scrollEl.getBoundingClientRect().top +
+        scrollEl.scrollTop;
+      setScrollMargin((prev) => (Math.abs(prev - next) > 0.5 ? next : prev));
+    };
+    syncMargin();
+    const ro = typeof ResizeObserver !== "undefined" ? new ResizeObserver(syncMargin) : null;
+    ro?.observe(scrollEl);
+    ro?.observe(anchor);
+    return () => ro?.disconnect();
+  }, [scrollContainerRef, grouped.length, scrollEpoch]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: grouped.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => FEED_ROW_ESTIMATE_PX,
+    overscan: FEED_VIRTUAL_OVERSCAN,
+    scrollMargin,
+    getItemKey: (index) => stableItemKey(grouped[index]!, index),
+    measureElement:
+      typeof window !== "undefined" &&
+      !/firefox/i.test(window.navigator.userAgent)
+        ? (element) => element.getBoundingClientRect().height
+        : undefined,
+  });
+  void scrollEpoch;
 
   // Find the last assistant message inside the original items array
   let lastAssistantRawIdx = -1;
@@ -886,8 +896,9 @@ export const TranscriptList = memo(function TranscriptList({
   // reactivates the previous Investigating pill until turn-2 tools land.
   const lastActivityGroupIdx = liveActivityGroupIndex(grouped);
 
-  const list = grouped.map((it, i) => {
-    if (i < hiddenCount) return null;
+  const renderGroupedItem = (i: number) => {
+    const it = grouped[i];
+    if (!it) return null;
     const key = stableItemKey(it, i);
     if (it.kind === "msg") {
       const rawIdx = items.findIndex(raw => raw.kind === "msg" && (raw as { kind: "msg"; msg: Msg }).msg === it.msg);
@@ -1217,23 +1228,52 @@ export const TranscriptList = memo(function TranscriptList({
       );
     }
     return null;
-  });
+  };
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+  // jsdom / pre-layout: scroll parent missing or unsized → mount full flow so
+  // presentation tests keep working without faking a 40-row window.
+  const scrollReady = Boolean(
+    scrollContainerRef.current &&
+      (scrollContainerRef.current.clientHeight > 0 ||
+        scrollContainerRef.current.offsetHeight > 0),
+  );
+  const useVirtualWindow = scrollReady && virtualItems.length > 0;
+  const list = useVirtualWindow ? (
+    <div
+      ref={listAnchorRef}
+      data-testid="transcript-virtual-list"
+      className="relative w-full"
+      style={{ height: rowVirtualizer.getTotalSize() }}
+    >
+      {virtualItems.map((virtualRow) => (
+        <div
+          key={virtualRow.key}
+          data-index={virtualRow.index}
+          ref={rowVirtualizer.measureElement}
+          data-testid="transcript-virtual-row"
+          className="absolute top-0 left-0 w-full pb-1"
+          style={{
+            transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+          }}
+        >
+          {renderGroupedItem(virtualRow.index)}
+        </div>
+      ))}
+    </div>
+  ) : (
+    <div ref={listAnchorRef} data-testid="transcript-virtual-list" className="flex flex-col gap-1 w-full">
+      {grouped.map((_, i) => renderGroupedItem(i))}
+    </div>
+  );
 
   const busyProgress = deriveBusyProgress(items, status, busyElapsedMs);
-  // Hide flat busy footer while investigation rows own the status surface (T1),
-  // or when the assistant answer already looks complete despite SSE lag (T5).
-  // Pause-point: do not hide Still working… under sticky loopOpen investigation —
-  // only real running tools / streaming thought suppress the footer.
   const hideBusyFooter = turnHasLiveInvestigation(
     items,
     pausePoint ? false : agentLoopOpen,
   );
   const showBusyFooter =
     (shouldShowBusyFooter(items, status) || pausePoint) && !hideBusyFooter;
-  // Quiet "Still working…" cue: only when the turn is busy and nothing else
-  // already signals work — including a live Investigating fold (sticky across
-  // tool gaps via agentLoopOpen). The under-fold cue must not blink on/off
-  // while collapsed investigation chrome already owns the busy signal.
   const showStall = quietWorkingCueVisible(
     items,
     status,
@@ -1244,15 +1284,6 @@ export const TranscriptList = memo(function TranscriptList({
 
   return (
     <>
-      {hiddenCount > 0 && (
-        <button
-          type="button"
-          onClick={showEarlier}
-          className="mx-auto mb-1 rounded-full border border-edge/60 bg-panel2/40 px-3 py-1 text-[11px] text-muted hover:text-txt hover:bg-panel2/70 transition-colors select-none"
-        >
-          Show earlier messages ({hiddenCount})
-        </button>
-      )}
       {list}
       {compactingStatus && (
         <div className="flex items-center gap-1.5 py-1 px-3 rounded-full bg-panel2/15 border border-edge/20 text-[11px] text-faint w-fit my-1 select-none animate-pulse">
@@ -1285,6 +1316,7 @@ export const TranscriptList = memo(function TranscriptList({
     </>
   );
 });
+
 
 function cleanAssistantText(text: string): string {
   const lines = text.split("\n");

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -63,7 +63,9 @@ export default function ConversationChatColumn({
             lands above it. scrollbar-gutter avoids a 15px jump when the bar
             appears. overscroll-contain stops rubber-band from yanking the window.
             Composer sits outside this scrollport, so scroll-padding-bottom is
-            not the last-bubble fix here — feedScroll pin/unpin still owns that. */}
+            not the last-bubble fix here — feedScroll pin/unpin still owns that.
+            TranscriptList virtualizes rows (measureElement) against this feedRef
+            scroll parent; do not move the composer inside the scrollport. */}
         <div className="max-w-3xl mx-auto px-6 py-6 flex flex-col gap-1">
           <TranscriptEmptyState transcriptStale={transcriptStale} itemCount={items.length} />
           {/*
@@ -73,7 +75,8 @@ export default function ConversationChatColumn({
             this parent) and none of TranscriptList's props change per keystroke,
             React skips re-rendering the transcript on every keystroke. This
             breaks the old coupling where items.map ran on the ENTIRE transcript
-            for each character typed (cost grew with message count).
+            for each character typed (cost grew with message count). Row mounting
+            is further bounded by @tanstack/react-virtual inside TranscriptList.
           */}
           <TranscriptList
             items={items}

--- a/webapp/src/components/conversation/chatEventsReattach.ts
+++ b/webapp/src/components/conversation/chatEventsReattach.ts
@@ -1,32 +1,48 @@
 /**
- * Mid-turn chatEvents reattach for session-switch / bridge.
- * Prefers a live SSE ring watch; falls back to JSON pull + 1Hz poll.
+ * Unified store-event subscription for session-switch / reattach / busy.
+ * One cursor via ``api.readEventsSince`` — not a third poller beside runners.
  */
 
 import { api } from "../../lib/api";
 import type { Item } from "../TranscriptList";
 import {
-  CHAT_EVENTS_POLL_MS,
-  chatFrameToStreamEvent,
   cursorAfterReplayMiss,
-  isChatEventReplayMiss,
+  isChatEventsReattachArmed,
   isTerminalStreamKind,
-  nextAppliedCursor,
   ringGenerationAfterReplayMiss,
-  shouldAdvanceReplayCursor,
-  shouldApplyReattachFrame,
   shouldHydrateTranscriptOnReplayMiss,
   shouldPollChatEvents,
   shouldRetryRingAfterReplayMiss,
 } from "./chatEvents";
+import {
+  STORE_EVENTS_POLL_MS,
+  isStoreRingMissEvent,
+  nextStoreCursor,
+  shouldApplyStoreEvent,
+  storeBatchSawTerminal,
+  storeRingMissFields,
+  storeStreamToStreamEvent,
+} from "./storeEvents";
 import {
   mergeTranscriptItems,
   transcriptFingerprint,
   transcriptResponseToItems,
 } from "./transcriptItems";
 import { writeTranscriptCache } from "./transcriptCache";
-import { preserveOrThinking } from "./runnersBusy";
+import {
+  preserveOrThinking,
+  runnersBusyTickDecision,
+  staleLocalStreamTickDecision,
+  userStoppedBusyChrome,
+  RUNNERS_IDLE_CONFIRM_POLLS,
+} from "./runnersBusy";
 import { reattachSessionStateFailureDecision } from "./sessionHydrate";
+import { shouldApplySwarmLiveMerge } from "./streamApply";
+import {
+  sessionStateShowsAwaitingSwarm,
+  SWARM_AWAIT_HINT,
+} from "./swarmPoll";
+import type { SessionStatus } from "./useSessionSwitch";
 
 export type ChatEventsReattachDeps = {
   cancelled: () => boolean;
@@ -38,6 +54,7 @@ export type ChatEventsReattachDeps = {
   cachedSessionIdRef: { current: string | null };
   localStreamActiveRef: { current: boolean };
   userStoppedRef: { current: boolean };
+  /** Unified store cursor (read_events_since), not the SSE ring cursor. */
   lastAppliedCursorRef: { current: number };
   ringGenerationRef: { current: number | undefined };
   detachedBusyRef: { current: boolean };
@@ -45,7 +62,7 @@ export type ChatEventsReattachDeps = {
   itemsRef: { current: Item[] };
   transcriptFpRef: { current: string };
   chatEventsPollTimerRef: { current: number | null };
-  /** Cancel for live ``?watch=1`` SSE; cleared with poll on session switch/Stop. */
+  /** Legacy live-watch cancel slot; store cursor owns the turn (kept for armed()). */
   chatEventsLiveCancelRef: { current: null | (() => void) };
   applyStreamEventRef: { current: (ev: { kind: string; data?: any }) => void };
   flushTypewriterRef: { current: () => void };
@@ -56,6 +73,11 @@ export type ChatEventsReattachDeps = {
   setTranscriptStale: (v: boolean) => void;
   setTurnOpen: (v: boolean) => void;
   setStatus: (updater: any) => void;
+  setCompactingStatus?: (v: string | null) => void;
+  setWaitHint?: (v: string | null) => void;
+  setBackendPendingSwarms?: (v: boolean | ((prev: boolean) => boolean)) => void;
+  turnSettledRef?: { current: boolean };
+  abandonStaleLocalStreamRef?: { current: () => void };
 };
 
 export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
@@ -86,19 +108,30 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
     setTranscriptStale,
     setTurnOpen,
     setStatus,
+    setCompactingStatus,
+    setWaitHint,
+    setBackendPendingSwarms,
+    turnSettledRef,
+    abandonStaleLocalStreamRef,
   } = deps;
 
-  const fenceOk = () => shouldApplyReattachFrame({
+  let consecutiveIdlePolls = 0;
+  let staleStreamIdlePolls = 0;
+  let sawRunnerBusyThisStream = false;
+
+  const fenceOk = () => shouldApplyStoreEvent({
     streamGen: streamGenRef.current,
-    reattachGen,
+    subscriptionGen: reattachGen,
     cachedSessionId: cachedSessionIdRef.current,
-    reattachSid,
+    subscriptionSid: reattachSid,
+  });
+
+  const chatEventsReattachArmed = () => isChatEventsReattachArmed({
+    pollTimer: chatEventsPollTimerRef.current,
+    liveCancel: chatEventsLiveCancelRef.current,
   });
 
   const hydrateDurableTranscript = async (): Promise<void> => {
-    // Busy-poll skips disk refresh while chatEvents poll is armed — await a
-    // durable baseline before any ring retry so tool/activity tails merge
-    // coherently (transcript first, then retained frames).
     const missHydrateGen = ++runnerBusyPollGenRef.current;
     const missSid = reattachSid;
     try {
@@ -118,21 +151,202 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
       itemsRef.current = next;
       writeTranscriptCache(missSid, next);
       setTranscriptStale(false);
-      // Keep detached-busy chrome; do not clear status / poll.
     } catch {
-      // Disk hydrate is best-effort; ring retry / poll may still catch up.
+      // Disk hydrate is best-effort.
     }
+  };
+
+  const refreshTranscriptFromDisk = async (sid: string): Promise<void> => {
+    const pollGen = ++runnerBusyPollGenRef.current;
+    try {
+      const tres = await api.sessionTranscript(sid);
+      if (!shouldApplySwarmLiveMerge({
+        pollGen,
+        currentGen: runnerBusyPollGenRef.current,
+        pollSessionId: sid,
+        cachedSessionId: cachedSessionIdRef.current,
+        activeSessionId: cachedSessionIdRef.current,
+      })) {
+        return;
+      }
+      if (localStreamActiveRef.current) return;
+      const loadedItems = transcriptResponseToItems(tres);
+      let applied = false;
+      setItems((prev) => {
+        if (!shouldApplySwarmLiveMerge({
+          pollGen,
+          currentGen: runnerBusyPollGenRef.current,
+          pollSessionId: sid,
+          cachedSessionId: cachedSessionIdRef.current,
+          activeSessionId: cachedSessionIdRef.current,
+        })) {
+          return prev;
+        }
+        if (localStreamActiveRef.current) return prev;
+        const next = mergeTranscriptItems(prev, loadedItems);
+        const fp = transcriptFingerprint(next);
+        if (fp === transcriptFpRef.current) return prev;
+        transcriptFpRef.current = fp;
+        itemsRef.current = next;
+        writeTranscriptCache(sid, next);
+        applied = true;
+        return next;
+      });
+      if (applied) setTranscriptStale(false);
+    } catch {
+      // best-effort
+    }
+  };
+
+  const applyRunnersEvent = async (data: {
+    state?: string | null;
+    pending_swarms?: boolean;
+    runners?: Record<string, string>;
+  }): Promise<boolean> => {
+    if (!fenceOk()) return false;
+    if (userStoppedRef.current) {
+      consecutiveIdlePolls = 0;
+      staleStreamIdlePolls = 0;
+      sawRunnerBusyThisStream = false;
+      detachedBusyRef.current = false;
+      clearChatEventsPoll();
+      setBackendPendingSwarms?.(false);
+      setStatus((prev: SessionStatus) => userStoppedBusyChrome(prev));
+      return false;
+    }
+
+    const sid = reattachSid;
+    const runners = data?.runners || {};
+    const running = runners[sid] === "running";
+    const awaitingSwarm = sessionStateShowsAwaitingSwarm({
+      state: data?.state,
+      pendingSwarms: !!data?.pending_swarms,
+      userStopped: userStoppedRef.current,
+    });
+
+    if (localStreamActiveRef.current) {
+      if (running || awaitingSwarm) {
+        sawRunnerBusyThisStream = true;
+        staleStreamIdlePolls = 0;
+        return true;
+      }
+      const nextIdlePolls = staleStreamIdlePolls + 1;
+      const staleTick = staleLocalStreamTickDecision({
+        localStreamActive: true,
+        userStopped: userStoppedRef.current,
+        runnerBusy: running,
+        awaitingSwarm,
+        turnSettled: turnSettledRef?.current ?? false,
+        sawRunnerBusyThisStream,
+        consecutiveIdlePolls: nextIdlePolls,
+      });
+      if (staleTick.kind === "hold_unconfirmed") {
+        staleStreamIdlePolls = nextIdlePolls;
+        return true;
+      }
+      if (staleTick.kind === "abandon") {
+        staleStreamIdlePolls = 0;
+        sawRunnerBusyThisStream = false;
+        abandonStaleLocalStreamRef?.current();
+      }
+      return true;
+    }
+
+    if (running || awaitingSwarm) {
+      consecutiveIdlePolls = 0;
+      if (awaitingSwarm) {
+        detachedBusyRef.current = running;
+        setTurnOpen(false);
+        setStatus("awaiting_swarm");
+        setWaitHint?.(SWARM_AWAIT_HINT);
+        setBackendPendingSwarms?.(true);
+      } else {
+        detachedBusyRef.current = true;
+        setTurnOpen(true);
+        setStatus((prev: SessionStatus) => preserveOrThinking(prev));
+      }
+      if (!running) {
+        return true;
+      }
+      const tick = runnersBusyTickDecision({
+        userStopped: userStoppedRef.current,
+        localStreamActive: localStreamActiveRef.current,
+        runnerBusy: true,
+        detachedBusy: true,
+        chatEventsPollArmed: chatEventsReattachArmed(),
+        items: itemsRef.current,
+        consecutiveIdlePolls: 0,
+      });
+      if (tick.kind === "arm_reattach") {
+        return true;
+      }
+      if (tick.kind === "skip_disk_while_reattach") return true;
+      await refreshTranscriptFromDisk(sid);
+      return true;
+    }
+
+    if (detachedBusyRef.current) {
+      consecutiveIdlePolls += 1;
+      const tick = runnersBusyTickDecision({
+        userStopped: userStoppedRef.current,
+        localStreamActive: localStreamActiveRef.current,
+        runnerBusy: false,
+        detachedBusy: true,
+        chatEventsPollArmed: chatEventsReattachArmed(),
+        items: itemsRef.current,
+        consecutiveIdlePolls,
+        idleConfirmPolls: RUNNERS_IDLE_CONFIRM_POLLS,
+      });
+      if (
+        tick.kind === "hold_live_investigation"
+        || tick.kind === "hold_idle_unconfirmed"
+      ) {
+        return true;
+      }
+      consecutiveIdlePolls = 0;
+      detachedBusyRef.current = false;
+      // Do not clearChatEventsPoll here — store cursor stays armed for the session.
+      setTurnOpen(false);
+      setStatus("idle");
+      setCompactingStatus?.(null);
+      setBackendPendingSwarms?.(false);
+      await refreshTranscriptFromDisk(sid);
+      return true;
+    }
+
+    return true;
+  };
+
+  const handleRingMiss = async (ev: {
+    kind: string;
+    data?: any;
+  }, missRetried: boolean): Promise<"retry" | "continue" | "stop"> => {
+    const replay = storeRingMissFields(ev as any);
+    const prevGen = ringGenerationRef.current;
+    ringGenerationRef.current = ringGenerationAfterReplayMiss(replay, prevGen);
+    void cursorAfterReplayMiss(replay, 0);
+    if (shouldHydrateTranscriptOnReplayMiss(replay)) {
+      await hydrateDurableTranscript();
+    }
+    if (
+      shouldRetryRingAfterReplayMiss(replay, {
+        alreadyRetried: missRetried,
+        prevGeneration: prevGen,
+        nextGeneration: ringGenerationRef.current,
+      })
+    ) {
+      return "retry";
+    }
+    return "continue";
   };
 
   const pullChatEvents = async (missRetried = false): Promise<boolean> => {
     if (cancelled()) return false;
     if (loadGen !== transcriptLoadGenRef.current) return false;
     if (!fenceOk()) return false;
-    if (localStreamActiveRef.current || userStoppedRef.current) return false;
-    // Live watch owns the turn — do not double-apply via poll.
-    if (chatEventsLiveCancelRef.current != null) return false;
+    if (userStoppedRef.current) return false;
     try {
-      const replay = await api.chatEvents({
+      const batch = await api.readEventsSince({
         session: reattachSid,
         since: lastAppliedCursorRef.current,
         ...(ringGenerationRef.current != null
@@ -142,208 +356,117 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
       if (cancelled()) return false;
       if (loadGen !== transcriptLoadGenRef.current) return false;
       if (!fenceOk()) return false;
-      if (localStreamActiveRef.current || userStoppedRef.current) return false;
-      if (chatEventsLiveCancelRef.current != null) return false;
+      if (userStoppedRef.current) return false;
 
-      if (isChatEventReplayMiss(replay)) {
-        const prevGen = ringGenerationRef.current;
-        ringGenerationRef.current = ringGenerationAfterReplayMiss(replay, prevGen);
-        // Evicted / wrong-generation frames: do not treat as catch-up.
-        lastAppliedCursorRef.current = cursorAfterReplayMiss(
-          replay,
-          lastAppliedCursorRef.current,
-        );
-        if (shouldHydrateTranscriptOnReplayMiss(replay)) {
-          await hydrateDurableTranscript();
-        }
-        // cursor_gap / refreshed generation_mismatch: retry once with the
-        // recovered cursor/gen so the retained tool/activity tail applies now.
-        // ring_miss stays hydrate-only — never synthesize missing frames.
-        if (
-          shouldRetryRingAfterReplayMiss(replay, {
-            alreadyRetried: missRetried,
-            prevGeneration: prevGen,
-            nextGeneration: ringGenerationRef.current,
-          })
-        ) {
-          return pullChatEvents(true);
-        }
-        return shouldPollChatEvents({
-          detachedBusy: detachedBusyRef.current,
-          localStreamActive: localStreamActiveRef.current,
-          userStopped: userStoppedRef.current,
-          sawTerminal: false,
-        });
-      }
-
-      if (typeof replay.generation === "number" && replay.generation > 0) {
-        ringGenerationRef.current = replay.generation;
-      }
-
+      const events = Array.isArray(batch.events) ? batch.events : [];
       let sawTerminal = false;
-      const frames = Array.isArray(replay.events) ? replay.events : [];
-      for (const frame of frames) {
+      let wantRetry = false;
+
+      for (const ev of events) {
         if (!fenceOk()) return false;
-        applyStreamEventRef.current(chatFrameToStreamEvent(frame));
-        if (isTerminalStreamKind(frame.kind)) sawTerminal = true;
-      }
-      if (shouldAdvanceReplayCursor(replay)) {
-        lastAppliedCursorRef.current = nextAppliedCursor(
-          lastAppliedCursorRef.current,
-          frames,
-          replay.cursor,
-        );
+        if (ev.kind === "ring_miss" && isStoreRingMissEvent(ev)) {
+          const decision = await handleRingMiss(ev, missRetried);
+          if (decision === "retry") wantRetry = true;
+          continue;
+        }
+        if (ev.kind === "runners") {
+          const keep = await applyRunnersEvent(ev.data || {});
+          if (!keep) {
+            lastAppliedCursorRef.current = nextStoreCursor(
+              lastAppliedCursorRef.current,
+              events,
+              batch.cursor,
+            );
+            return false;
+          }
+          continue;
+        }
+        if (ev.kind === "stream") {
+          if (localStreamActiveRef.current) continue;
+          const frame = ev.data || {};
+          if (typeof frame.generation === "number" && frame.generation > 0) {
+            ringGenerationRef.current = frame.generation;
+          }
+          applyStreamEventRef.current(storeStreamToStreamEvent(frame));
+          if (isTerminalStreamKind(String(frame.kind || ""))) sawTerminal = true;
+        }
       }
 
-      if (sawTerminal) {
+      lastAppliedCursorRef.current = nextStoreCursor(
+        lastAppliedCursorRef.current,
+        events,
+        batch.cursor,
+      );
+
+      if (wantRetry && !missRetried) {
+        return pullChatEvents(true);
+      }
+
+      if (sawTerminal || storeBatchSawTerminal(events)) {
         flushTypewriterRef.current();
         detachedBusyRef.current = false;
-        clearChatEventsPoll();
         maybeRunQueuedResumeRef.current();
         maybeDrainQueueRef.current();
-        return false;
+        return true;
       }
+
       return shouldPollChatEvents({
-        detachedBusy: detachedBusyRef.current,
-        localStreamActive: localStreamActiveRef.current,
+        detachedBusy: true,
+        localStreamActive: false,
         userStopped: userStoppedRef.current,
         sawTerminal: false,
       });
     } catch {
-      return shouldPollChatEvents({
-        detachedBusy: detachedBusyRef.current,
-        localStreamActive: localStreamActiveRef.current,
-        userStopped: userStoppedRef.current,
-        sawTerminal: false,
-      });
+      return !userStoppedRef.current;
     }
   };
 
   const startChatEventsPoll = () => {
-    if (cancelled() || localStreamActiveRef.current || userStoppedRef.current) return;
-    if (chatEventsLiveCancelRef.current != null) return;
+    if (cancelled() || userStoppedRef.current) return;
     if (chatEventsPollTimerRef.current != null) return;
     void pullChatEvents().then((keepPolling) => {
       if (!keepPolling || cancelled()) return;
       if (streamGenRef.current !== reattachGen) return;
-      if (chatEventsLiveCancelRef.current != null) return;
       if (chatEventsPollTimerRef.current != null) return;
       chatEventsPollTimerRef.current = window.setInterval(() => {
         void pullChatEvents().then((cont) => {
           if (!cont) clearChatEventsPoll();
         });
-      }, CHAT_EVENTS_POLL_MS);
+      }, STORE_EVENTS_POLL_MS);
     });
   };
 
-  const settleLiveTerminal = () => {
-    flushTypewriterRef.current();
-    detachedBusyRef.current = false;
-    clearChatEventsPoll();
-    maybeRunQueuedResumeRef.current();
-    maybeDrainQueueRef.current();
-  };
-
-  /**
-   * Prefer live ``?watch=1`` SSE while the turn is open.
-   * Returns true when a live cancel was installed (poll must wait for
-   * onError/onDone). Open miss / transport error falls back to 1Hz poll.
-   */
-  const startLiveChatEventsWatch = (): boolean => {
-    if (cancelled() || localStreamActiveRef.current || userStoppedRef.current) {
-      return false;
-    }
-    if (!fenceOk()) return false;
-    if (chatEventsLiveCancelRef.current != null) return true;
-    // Already on poll fallback — do not open a racing live stream.
-    if (chatEventsPollTimerRef.current != null) return false;
-
-    let sawTerminal = false;
-    let settled = false;
-    // Install cancel before stream callbacks can fire (sync onError/onDone).
-    let streamCancel: (() => void) | null = null;
-    const cancel = () => { streamCancel?.(); };
-    chatEventsLiveCancelRef.current = cancel;
-    const finishLiveCancel = () => {
-      if (chatEventsLiveCancelRef.current === cancel) {
-        chatEventsLiveCancelRef.current = null;
-      }
-    };
-    const fallBackToPoll = () => {
-      if (settled || cancelled()) return;
-      if (!fenceOk()) return;
-      if (localStreamActiveRef.current || userStoppedRef.current) return;
-      if (sawTerminal) return;
-      finishLiveCancel();
-      startChatEventsPoll();
-    };
-
-    streamCancel = api.chatEventsLive(
-      {
-        session: reattachSid,
-        since: lastAppliedCursorRef.current,
-        ...(ringGenerationRef.current != null
-          ? { generation: ringGenerationRef.current }
-          : {}),
-      },
-      (ev) => {
-        if (cancelled() || settled) return;
-        if (!fenceOk()) return;
-        if (localStreamActiveRef.current || userStoppedRef.current) return;
-        // Framing done is handled by transport onDone (not delivered here).
-        const kind = String(ev?.kind || "");
-        if (kind === "done") return;
-        // Live watch frames may carry a ring cursor; StreamEvent types it optional.
-        const liveCursor = (ev as { cursor?: unknown }).cursor;
-        if (typeof liveCursor === "number" && liveCursor > lastAppliedCursorRef.current) {
-          lastAppliedCursorRef.current = liveCursor;
-        }
-        applyStreamEventRef.current(chatFrameToStreamEvent(ev));
-        if (isTerminalStreamKind(kind)) sawTerminal = true;
-      },
-      () => {
-        // Wave 3: framing done / body EOF — settle only when we saw a terminal.
-        // Early drop without terminal → poll fallback.
-        finishLiveCancel();
-        if (settled || cancelled()) return;
-        if (!fenceOk()) return;
-        if (sawTerminal) {
-          settled = true;
-          settleLiveTerminal();
-          return;
-        }
-        // Open miss / mid-watch disconnect: keep catching up via poll.
-        fallBackToPoll();
-      },
-      () => {
-        finishLiveCancel();
-        if (settled || cancelled()) return;
-        if (sawTerminal) {
-          settled = true;
-          settleLiveTerminal();
-          return;
-        }
-        fallBackToPoll();
-      },
-    );
-    return true;
-  };
+  /** Live watch collapsed — store cursor owns reattach. */
+  const startLiveChatEventsWatch = (): boolean => false;
 
   const startChatEventsReattach = async () => {
-    if (cancelled() || localStreamActiveRef.current || userStoppedRef.current) return;
-    let running = detachedBusyRef.current;
-    if (!running) {
+    if (cancelled() || userStoppedRef.current) return;
+    if (streamGenRef.current !== reattachGen) return;
+    if (!detachedBusyRef.current && !localStreamActiveRef.current) {
       const maxAttempts = 2;
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
           const st = await api.getSessionState();
           if (cancelled()) return;
           if (cachedSessionIdRef.current !== reattachSid) return;
-          running = st?.runners?.[reattachSid] === "running";
-          if (running) {
-            detachedBusyRef.current = true;
-            setTurnOpen(true);
-            setStatus((prev: any) => preserveOrThinking(prev));
+          const running = st?.runners?.[reattachSid] === "running";
+          const awaiting = sessionStateShowsAwaitingSwarm({
+            state: st?.state,
+            pendingSwarms: !!st?.pending_swarms,
+            userStopped: userStoppedRef.current,
+          });
+          if (running || awaiting) {
+            if (awaiting) {
+              detachedBusyRef.current = running;
+              setTurnOpen(false);
+              setStatus("awaiting_swarm");
+              setWaitHint?.(SWARM_AWAIT_HINT);
+              setBackendPendingSwarms?.(true);
+            } else {
+              detachedBusyRef.current = true;
+              setTurnOpen(true);
+              setStatus((prev: any) => preserveOrThinking(prev));
+            }
           }
           break;
         } catch {
@@ -355,20 +478,14 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
             await new Promise((r) => setTimeout(r, 100 * attempt));
             continue;
           }
-          // Optimistic busy + poll/watch: Ready must not lie while a turn runs.
-          // useRunnersBusyPoll clears chrome if the target is actually idle.
-          running = true;
+          // Optimistic busy; store poll clears if idle.
           detachedBusyRef.current = true;
           setTurnOpen(true);
           setStatus((prev: any) => preserveOrThinking(prev));
         }
       }
     }
-    if (!running) return;
     if (streamGenRef.current !== reattachGen) return;
-
-    // Prefer live SSE while the turn is open; poll only if live attach fails.
-    if (startLiveChatEventsWatch()) return;
     startChatEventsPoll();
   };
 

--- a/webapp/src/components/conversation/storeEvents.ts
+++ b/webapp/src/components/conversation/storeEvents.ts
@@ -1,0 +1,89 @@
+/**
+ * Unified session store event cursor helpers (read_events_since).
+ * One cursor covers mid-turn stream frames + runners/busy chrome.
+ */
+
+import type { StoreEvent } from "../../lib/transport";
+import {
+  chatFrameToStreamEvent,
+  isChatEventReplayMiss,
+  isTerminalStreamKind,
+} from "./chatEvents";
+
+/** Poll cadence for the single store-event subscription. */
+export const STORE_EVENTS_POLL_MS = 1000;
+
+/** Advance last-applied store cursor after a read_events_since batch. */
+export function nextStoreCursor(
+  lastApplied: number,
+  events: { id?: number }[],
+  responseCursor?: number,
+): number {
+  let next = lastApplied;
+  for (const ev of events) {
+    if (typeof ev.id === "number" && ev.id > next) next = ev.id;
+  }
+  if (typeof responseCursor === "number" && responseCursor > next) {
+    next = responseCursor;
+  }
+  return next;
+}
+
+/**
+ * Generation + session fence for store-event apply.
+ * Late events from a prior stream generation or switched session must not paint.
+ */
+export function shouldApplyStoreEvent(opts: {
+  streamGen: number;
+  subscriptionGen: number;
+  cachedSessionId: string | null | undefined;
+  subscriptionSid: string;
+}): boolean {
+  if (opts.streamGen !== opts.subscriptionGen) return false;
+  if (!opts.subscriptionSid) return false;
+  return opts.cachedSessionId === opts.subscriptionSid;
+}
+
+/** Map a store ``stream`` event payload to the live stream-event shape. */
+export function storeStreamToStreamEvent(data: {
+  kind?: string;
+  data?: any;
+}): { kind: string; data?: any } {
+  return chatFrameToStreamEvent({
+    kind: String(data?.kind || "event"),
+    data: data?.data,
+  });
+}
+
+/** Whether a store event batch contained a terminal stream kind. */
+export function storeBatchSawTerminal(events: StoreEvent[]): boolean {
+  for (const ev of events) {
+    if (ev.kind !== "stream") continue;
+    const kind = String(ev.data?.kind || "");
+    if (isTerminalStreamKind(kind)) return true;
+  }
+  return false;
+}
+
+/** Extract ring_miss payload fields for existing miss helpers. */
+export function storeRingMissFields(ev: StoreEvent): {
+  ok?: boolean;
+  missed?: boolean;
+  available?: boolean;
+  code?: string;
+  generation?: number;
+} {
+  const data = ev.data && typeof ev.data === "object" ? ev.data : {};
+  return {
+    ok: data.ok,
+    missed: data.missed,
+    available: data.available,
+    code: data.code,
+    generation: data.generation,
+  };
+}
+
+export function isStoreRingMissEvent(ev: StoreEvent): boolean {
+  if (ev.kind !== "ring_miss") return false;
+  return isChatEventReplayMiss(storeRingMissFields(ev));
+}

--- a/webapp/src/components/conversation/useRunnersBusyPoll.ts
+++ b/webapp/src/components/conversation/useRunnersBusyPoll.ts
@@ -1,30 +1,13 @@
 /**
- * Poll runners so composer shows Stop/Steer while the active session's
- * backend runner is busy -- even after SSE detach on session switch.
+ * Busy chrome for the active session.
+ *
+ * Collapsed onto the unified store-event cursor (``read_events_since`` via
+ * ``createChatEventsReattach``). This hook no longer runs a third getSessionState
+ * poller — it only ensures the store subscription is armed on session change.
  */
 
-import { useEffect, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
-import { api } from "../../lib/api";
-import { usePolling } from "../../lib/usePolling";
+import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 import type { Item } from "../TranscriptList";
-import {
-  mergeTranscriptItems,
-  transcriptFingerprint,
-  transcriptResponseToItems,
-} from "./transcriptItems";
-import { writeTranscriptCache } from "./transcriptCache";
-import {
-  preserveOrThinking,
-  runnersBusyTickDecision,
-  staleLocalStreamTickDecision,
-  userStoppedBusyChrome,
-} from "./runnersBusy";
-import { isChatEventsReattachArmed } from "./chatEvents";
-import { shouldApplySwarmLiveMerge } from "./streamApply";
-import {
-  sessionStateShowsAwaitingSwarm,
-  SWARM_AWAIT_HINT,
-} from "./swarmPoll";
 import type { SessionStatus } from "./useSessionSwitch";
 
 export type UseRunnersBusyPollDeps = {
@@ -48,271 +31,21 @@ export type UseRunnersBusyPollDeps = {
   setStatus: Dispatch<SetStateAction<SessionStatus>>;
   setCompactingStatus: Dispatch<SetStateAction<string | null>>;
   setWaitHint: Dispatch<SetStateAction<string | null>>;
-  /** Re-arm / clear swarm-results poll gate with awaiting chrome (see useSessionSwitch). */
   setBackendPendingSwarms: Dispatch<SetStateAction<boolean>>;
 };
 
+/**
+ * Ensure the store-event cursor stays subscribed while a session is active.
+ * Runners / stream / ring_miss apply lives in createChatEventsReattach.
+ */
 export function useRunnersBusyPoll(deps: UseRunnersBusyPollDeps) {
   const {
     activeSessionId,
-    clearChatEventsPoll,
-    itemsRef,
-    cachedSessionIdRef,
-    transcriptFpRef,
-    localStreamActiveRef,
-    detachedBusyRef,
-    userStoppedRef,
-    runnerBusyPollGenRef,
-    chatEventsPollTimerRef,
-    chatEventsLiveCancelRef,
     ensureChatEventsReattachRef,
-    turnSettledRef,
-    abandonStaleLocalStreamRef,
-    setItems,
-    setTranscriptStale,
-    setTurnOpen,
-    setStatus,
-    setCompactingStatus,
-    setWaitHint,
-    setBackendPendingSwarms,
   } = deps;
 
-  const chatEventsReattachArmed = () => isChatEventsReattachArmed({
-    pollTimer: chatEventsPollTimerRef.current,
-    liveCancel: chatEventsLiveCancelRef.current,
-  });
-
-  // Consecutive idle sightings while detachedBusy; reset whenever runners busy.
-  const consecutiveIdlePollsRef = useRef(0);
-  // Separate counter: zombie EventSource while runner already idle.
-  const staleStreamIdlePollsRef = useRef(0);
-  const sawRunnerBusyThisStreamRef = useRef(false);
-  // Track gen so a bump from useSessionSwitch (or a late A poll) drops A's
-  // idle-confirm credit before B can finalize early.
-  const seenRunnerBusyPollGenRef = useRef(runnerBusyPollGenRef.current);
-
   useEffect(() => {
-    consecutiveIdlePollsRef.current = 0;
-    staleStreamIdlePollsRef.current = 0;
-    sawRunnerBusyThisStreamRef.current = false;
-    seenRunnerBusyPollGenRef.current = runnerBusyPollGenRef.current;
-  }, [activeSessionId]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Poll runners so composer shows Stop/Steer while the active session's
-  // backend runner is busy -- even after SSE detach on session switch.
-  usePolling(() => {
     if (!activeSessionId) return;
-    if (!localStreamActiveRef.current) {
-      staleStreamIdlePollsRef.current = 0;
-      sawRunnerBusyThisStreamRef.current = false;
-    }
-    if (seenRunnerBusyPollGenRef.current !== runnerBusyPollGenRef.current) {
-      seenRunnerBusyPollGenRef.current = runnerBusyPollGenRef.current;
-      consecutiveIdlePollsRef.current = 0;
-      staleStreamIdlePollsRef.current = 0;
-    }
-    if (userStoppedRef.current) {
-      // Stop must stick: ignore runners=running while the abandoned generator
-      // unwinds; keep chrome idle until the user sends again.
-      consecutiveIdlePollsRef.current = 0;
-      staleStreamIdlePollsRef.current = 0;
-      sawRunnerBusyThisStreamRef.current = false;
-      detachedBusyRef.current = false;
-      clearChatEventsPoll();
-      setBackendPendingSwarms(false);
-      setStatus((prev) => userStoppedBusyChrome(prev));
-      return;
-    }
-    const sid = activeSessionId;
-    return api.getSessionState().then((res) => {
-      if (cachedSessionIdRef.current !== sid) return;
-      if (userStoppedRef.current) return;
-      const runners = res?.runners || {};
-      const running = runners[sid] === "running";
-      const awaitingSwarm = sessionStateShowsAwaitingSwarm({
-        state: res?.state,
-        pendingSwarms: !!res?.pending_swarms,
-        userStopped: userStoppedRef.current,
-      });
-      if (localStreamActiveRef.current) {
-        if (running || awaitingSwarm) {
-          sawRunnerBusyThisStreamRef.current = true;
-          staleStreamIdlePollsRef.current = 0;
-          return;
-        }
-        const nextIdlePolls = staleStreamIdlePollsRef.current + 1;
-        const staleTick = staleLocalStreamTickDecision({
-          localStreamActive: true,
-          userStopped: userStoppedRef.current,
-          runnerBusy: running,
-          awaitingSwarm,
-          turnSettled: turnSettledRef.current,
-          sawRunnerBusyThisStream: sawRunnerBusyThisStreamRef.current,
-          consecutiveIdlePolls: nextIdlePolls,
-        });
-        if (staleTick.kind === "hold_unconfirmed") {
-          staleStreamIdlePollsRef.current = nextIdlePolls;
-          return;
-        }
-        if (staleTick.kind === "abandon") {
-          staleStreamIdlePollsRef.current = 0;
-          sawRunnerBusyThisStreamRef.current = false;
-          abandonStaleLocalStreamRef.current();
-        }
-        return;
-      }
-      if (running || awaitingSwarm) {
-        consecutiveIdlePollsRef.current = 0;
-        // Pause-point: prefer awaiting_swarm over thinking even while runners
-        // report running (do not collapse Still working… on the busy poll).
-        if (awaitingSwarm) {
-          detachedBusyRef.current = running;
-          setTurnOpen(false);
-          setStatus("awaiting_swarm");
-          setWaitHint(SWARM_AWAIT_HINT);
-          // Match useSessionSwitch: chrome restore must also enable the results
-          // poller (pendingJobIds may still be empty until hydrate seeds).
-          setBackendPendingSwarms(true);
-        } else {
-          detachedBusyRef.current = true;
-          setTurnOpen(true);
-          setStatus((prev) => preserveOrThinking(prev));
-        }
-        if (!running) {
-          // Runner idle at pause-point — swarm-results poll owns job drain;
-          // do not fall through to detached-busy finalize → idle.
-          return;
-        }
-        const tick = runnersBusyTickDecision({
-          userStopped: userStoppedRef.current,
-          localStreamActive: localStreamActiveRef.current,
-          runnerBusy: true,
-          detachedBusy: true,
-          chatEventsPollArmed: chatEventsReattachArmed(),
-          items: itemsRef.current,
-          consecutiveIdlePolls: 0,
-        });
-        // Queue/bridge turns start without this tab's EventSource. Arm the
-        // chatEvents ring watch/poll so tokens paint live (not only after restart).
-        if (tick.kind === "arm_reattach") {
-          ensureChatEventsReattachRef.current();
-          return;
-        }
-        // While chatEvents reattach owns mid-turn UI, skip disk replace
-        // that would wipe in-flight deltas not yet persisted.
-        if (tick.kind === "skip_disk_while_reattach") return;
-        // Slice C: while detached-but-busy, refresh transcript so eventual
-        // dump lands without blanking thinking chrome.
-        const pollGen = ++runnerBusyPollGenRef.current;
-        return api.sessionTranscript(sid).then((tres) => {
-          // Live active id is the cached fence (useSessionSwitch keeps them
-          // aligned); do not trust a render-scoped activeSessionId closure.
-          if (!shouldApplySwarmLiveMerge({
-            pollGen,
-            currentGen: runnerBusyPollGenRef.current,
-            pollSessionId: sid,
-            cachedSessionId: cachedSessionIdRef.current,
-            activeSessionId: cachedSessionIdRef.current,
-          })) {
-            return;
-          }
-          if (localStreamActiveRef.current) return;
-          const loadedItems = transcriptResponseToItems(tres);
-          let applied = false;
-          setItems((prev) => {
-            // Re-fence inside the updater: a session switch between the await
-            // and React applying this update must not mutate session B.
-            if (!shouldApplySwarmLiveMerge({
-              pollGen,
-              currentGen: runnerBusyPollGenRef.current,
-              pollSessionId: sid,
-              cachedSessionId: cachedSessionIdRef.current,
-              activeSessionId: cachedSessionIdRef.current,
-            })) {
-              return prev;
-            }
-            if (localStreamActiveRef.current) return prev;
-            const next = mergeTranscriptItems(prev, loadedItems);
-            const fp = transcriptFingerprint(next);
-            // Identical payload: keep existing object identities so React does
-            // not remount every Investigated/card row (the periodic blink).
-            if (fp === transcriptFpRef.current) return prev;
-            transcriptFpRef.current = fp;
-            itemsRef.current = next;
-            writeTranscriptCache(sid, next);
-            applied = true;
-            return next;
-          });
-          if (applied) setTranscriptStale(false);
-        }).catch(() => {});
-      } else if (detachedBusyRef.current) {
-        // Runner went idle after a detached busy view -- finalize + refresh.
-        // Require consecutive idle polls so a single false not-running blip
-        // cannot clear Stop; live surfaces still hold immediately.
-        consecutiveIdlePollsRef.current += 1;
-        const tick = runnersBusyTickDecision({
-          userStopped: userStoppedRef.current,
-          localStreamActive: localStreamActiveRef.current,
-          runnerBusy: false,
-          detachedBusy: true,
-          chatEventsPollArmed: chatEventsReattachArmed(),
-          items: itemsRef.current,
-          consecutiveIdlePolls: consecutiveIdlePollsRef.current,
-        });
-        if (
-          tick.kind === "hold_live_investigation"
-          || tick.kind === "hold_idle_unconfirmed"
-        ) {
-          return;
-        }
-        consecutiveIdlePollsRef.current = 0;
-        detachedBusyRef.current = false;
-        clearChatEventsPoll();
-        setTurnOpen(false);
-        setStatus("idle");
-        setCompactingStatus(null);
-        // Idle finalize with no pending_swarms/await — drop poller gate so it
-        // cannot stick true across sessions after switch restore.
-        setBackendPendingSwarms(false);
-        const pollGen = ++runnerBusyPollGenRef.current;
-        return api.sessionTranscript(sid)
-          .then((tres) => {
-            if (!shouldApplySwarmLiveMerge({
-              pollGen,
-              currentGen: runnerBusyPollGenRef.current,
-              pollSessionId: sid,
-              cachedSessionId: cachedSessionIdRef.current,
-              activeSessionId: cachedSessionIdRef.current,
-            })) {
-              return;
-            }
-            if (localStreamActiveRef.current) return;
-            const loadedItems = transcriptResponseToItems(tres);
-            let applied = false;
-            setItems((prev) => {
-              if (!shouldApplySwarmLiveMerge({
-                pollGen,
-                currentGen: runnerBusyPollGenRef.current,
-                pollSessionId: sid,
-                cachedSessionId: cachedSessionIdRef.current,
-                activeSessionId: cachedSessionIdRef.current,
-              })) {
-                return prev;
-              }
-              if (localStreamActiveRef.current) return prev;
-              const next = mergeTranscriptItems(prev, loadedItems);
-              const fp = transcriptFingerprint(next);
-              if (fp === transcriptFpRef.current) return prev;
-              transcriptFpRef.current = fp;
-              itemsRef.current = next;
-              writeTranscriptCache(sid, next);
-              applied = true;
-              return next;
-            });
-            if (applied) setTranscriptStale(false);
-          })
-          .catch(() => {});
-      }
-    });
-  }, 1500, { enabled: !!activeSessionId });
+    ensureChatEventsReattachRef.current();
+  }, [activeSessionId]); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/webapp/src/components/conversation/useSessionSwitch.ts
+++ b/webapp/src/components/conversation/useSessionSwitch.ts
@@ -85,6 +85,8 @@ export type UseSessionSwitchDeps = {
   userStoppedRef: MutableRefObject<boolean>;
   /** Session-global; must reset on switch so settled A cannot suppress B chrome. */
   turnSettledRef: MutableRefObject<boolean>;
+  /** Drop a zombie local EventSource after runners go idle (store cursor). */
+  abandonStaleLocalStreamRef: MutableRefObject<() => void>;
   /** Keep-alive resume queued on A must not fire into B after switch. */
   resumeQueuedRef: MutableRefObject<boolean>;
   /** Approved-command retry queued on A must not execute into B after switch. */
@@ -153,6 +155,7 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
     detachedBusyRef,
     userStoppedRef,
     turnSettledRef,
+    abandonStaleLocalStreamRef,
     resumeQueuedRef,
     approvedCommandRetryRef,
     runnerBusyPollGenRef,
@@ -579,6 +582,11 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
           setTranscriptStale,
           setTurnOpen,
           setStatus,
+          setCompactingStatus,
+          setWaitHint,
+          setBackendPendingSwarms,
+          turnSettledRef,
+          abandonStaleLocalStreamRef,
         });
         ensureChatEventsReattachRef.current = () => {
           void startChatEventsReattach();

--- a/webapp/src/components/inFileReviewExtension.ts
+++ b/webapp/src/components/inFileReviewExtension.ts
@@ -1,0 +1,227 @@
+import {
+  Decoration,
+  EditorView,
+  ViewPlugin,
+  WidgetType,
+  type DecorationSet,
+  type ViewUpdate,
+} from "@codemirror/view";
+import { RangeSetBuilder, type Extension } from "@codemirror/state";
+import type { InFilePendingHunk } from "../lib/inFileReview";
+
+export type InFileReviewHandlers = {
+  onAccept: (item: InFilePendingHunk) => void;
+  onReject: (item: InFilePendingHunk) => void;
+  applyingKey: string | null;
+};
+
+class HunkActionWidget extends WidgetType {
+  private readonly item: InFilePendingHunk;
+  private readonly handlers: InFileReviewHandlers;
+
+  constructor(item: InFilePendingHunk, handlers: InFileReviewHandlers) {
+    super();
+    this.item = item;
+    this.handlers = handlers;
+  }
+
+  eq(other: HunkActionWidget): boolean {
+    return (
+      this.item.decisionKey === other.item.decisionKey &&
+      this.handlers.applyingKey === other.handlers.applyingKey &&
+      this.item.hunk.header === other.item.hunk.header
+    );
+  }
+
+  toDOM(): HTMLElement {
+    const root = document.createElement("div");
+    root.className = "cm-infile-hunk-actions";
+    root.setAttribute("data-testid", "infile-hunk-actions");
+    root.setAttribute("data-hunk-key", this.item.decisionKey);
+
+    const label = document.createElement("span");
+    label.className = "cm-infile-hunk-label";
+    label.textContent = (this.item.hunk.header || "").trim() || "pending hunk";
+    root.appendChild(label);
+
+    const busy = this.handlers.applyingKey === this.item.decisionKey;
+    const disabled = this.handlers.applyingKey != null;
+
+    const accept = document.createElement("button");
+    accept.type = "button";
+    accept.className = "cm-infile-hunk-btn cm-infile-hunk-accept";
+    accept.textContent = busy ? "Applying…" : "Accept";
+    accept.title = "Accept hunk";
+    accept.disabled = disabled;
+    accept.setAttribute("data-testid", "infile-hunk-accept");
+    accept.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    accept.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (disabled) return;
+      this.handlers.onAccept(this.item);
+    });
+
+    const reject = document.createElement("button");
+    reject.type = "button";
+    reject.className = "cm-infile-hunk-btn cm-infile-hunk-reject";
+    reject.textContent = "Reject";
+    reject.title = "Reject hunk";
+    reject.disabled = disabled;
+    reject.setAttribute("data-testid", "infile-hunk-reject");
+    reject.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    reject.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (disabled) return;
+      this.handlers.onReject(this.item);
+    });
+
+    root.appendChild(accept);
+    root.appendChild(reject);
+    return root;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+function buildDecorations(
+  view: EditorView,
+  hunks: InFilePendingHunk[],
+  handlers: InFileReviewHandlers,
+): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const doc = view.state.doc;
+  const lineCount = doc.lines;
+  const pending: { from: number; to: number; deco: Decoration }[] = [];
+
+  for (const item of hunks) {
+    const anchorLine = Math.max(1, Math.min(item.geometry.anchorOldLine, lineCount));
+    const lineObj = doc.line(anchorLine);
+    pending.push({
+      from: lineObj.from,
+      to: lineObj.from,
+      deco: Decoration.widget({
+        widget: new HunkActionWidget(item, handlers),
+        side: -1,
+        block: true,
+      }),
+    });
+
+    const marked = new Set<number>();
+    for (const oldLine of item.geometry.oldLines) {
+      if (oldLine < 1 || oldLine > lineCount || marked.has(oldLine)) continue;
+      marked.add(oldLine);
+      const kindEntry = item.geometry.lineKinds.find(
+        (lk) => lk.oldLine === oldLine && (lk.kind === "del" || lk.kind === "context"),
+      );
+      const cls =
+        kindEntry?.kind === "del" ? "cm-infile-hunk-del" : "cm-infile-hunk-ctx";
+      const target = doc.line(oldLine);
+      pending.push({
+        from: target.from,
+        to: target.from,
+        deco: Decoration.line({ class: cls }),
+      });
+    }
+  }
+
+  pending.sort((a, b) => a.from - b.from || a.to - b.to);
+  for (const row of pending) {
+    builder.add(row.from, row.to, row.deco);
+  }
+
+  return builder.finish();
+}
+
+const infileReviewTheme = EditorView.baseTheme({
+  ".cm-infile-hunk-actions": {
+    display: "flex",
+    alignItems: "center",
+    gap: "6px",
+    padding: "4px 8px",
+    margin: "2px 0",
+    fontSize: "11px",
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+    backgroundColor: "rgba(63, 185, 80, 0.08)",
+    border: "1px solid rgba(63, 185, 80, 0.25)",
+    borderRadius: "4px",
+  },
+  ".cm-infile-hunk-label": {
+    flex: "1 1 auto",
+    minWidth: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    color: "var(--cm-infile-muted, #8b949e)",
+  },
+  ".cm-infile-hunk-btn": {
+    flex: "0 0 auto",
+    borderRadius: "3px",
+    border: "1px solid rgba(110, 118, 129, 0.4)",
+    background: "transparent",
+    color: "inherit",
+    fontSize: "10px",
+    fontWeight: 600,
+    padding: "2px 8px",
+    cursor: "pointer",
+  },
+  ".cm-infile-hunk-btn:disabled": {
+    opacity: 0.45,
+    cursor: "not-allowed",
+  },
+  ".cm-infile-hunk-accept": {
+    color: "#3fb950",
+    borderColor: "rgba(63, 185, 80, 0.45)",
+  },
+  ".cm-infile-hunk-reject": {
+    color: "#f85149",
+    borderColor: "rgba(248, 81, 73, 0.45)",
+  },
+  ".cm-infile-hunk-del": {
+    backgroundColor: "rgba(248, 81, 73, 0.12)",
+  },
+  ".cm-infile-hunk-ctx": {
+    backgroundColor: "rgba(63, 185, 80, 0.06)",
+  },
+});
+
+/**
+ * CodeMirror extension that paints pending review hunks and Accept/Reject
+ * controls inside the open file. No confirm dialogs — revert remains cheap.
+ */
+export function createInFileReviewExtension(
+  hunks: InFilePendingHunk[],
+  handlers: InFileReviewHandlers,
+): Extension {
+  if (!hunks.length) return [];
+
+  const plugin = ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+
+      constructor(view: EditorView) {
+        this.decorations = buildDecorations(view, hunks, handlers);
+      }
+
+      update(update: ViewUpdate) {
+        if (update.docChanged || update.viewportChanged) {
+          this.decorations = buildDecorations(update.view, hunks, handlers);
+        }
+      }
+    },
+    {
+      decorations: (v) => v.decorations,
+    },
+  );
+
+  return [infileReviewTheme, plugin];
+}

--- a/webapp/src/components/leftRailPrimitives.tsx
+++ b/webapp/src/components/leftRailPrimitives.tsx
@@ -1,0 +1,86 @@
+import type { ReactNode } from "react";
+import { CheckCircle2, Circle, Loader2, XCircle } from "lucide-react";
+
+export type JobStatus = "pending" | "in_progress" | "completed" | "cancelled";
+
+export function JobStatusIcon({ status }: { status: JobStatus }) {
+  if (status === "completed") return <CheckCircle2 size={12} className="text-good shrink-0" />;
+  if (status === "in_progress") return <Loader2 size={12} className="animate-spin text-accent shrink-0" />;
+  if (status === "cancelled") return <XCircle size={12} className="text-red-400 shrink-0" />;
+  return <Circle size={12} className="text-muted shrink-0" />;
+}
+
+/** Compact running/idle indicator for a session row. Hidden when status unknown.
+ *  When stoppable (running + non-active), click Stops that runner without view attach. */
+export function RunnerStatusDot({
+  status,
+  stoppable,
+  onStop,
+}: {
+  status?: "running" | "idle" | "attaching" | "missing";
+  stoppable?: boolean;
+  onStop?: () => void;
+}) {
+  if (!status || status === "missing") return null;
+  const running = status === "running";
+  if (stoppable && running && onStop) {
+    return (
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          onStop();
+        }}
+        className="w-1.5 h-1.5 rounded-full shrink-0 bg-accent hover:ring-2 hover:ring-accent/40 transition"
+        title="Stop (free lease slot)"
+        aria-label="Stop background session"
+      />
+    );
+  }
+  const title =
+    status === "attaching" ? "Attaching" : running ? "Running" : "Idle";
+  return (
+    <span
+      className={`w-1.5 h-1.5 rounded-full shrink-0 ${running ? "bg-accent" : "bg-muted/50"}`}
+      title={title}
+    />
+  );
+}
+
+export function Section({ title, action, headerSpinner, children, className }: {
+  title: string;
+  action?: ReactNode;
+  headerSpinner?: boolean;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`px-2 shrink-0 min-w-0 ${className || "pt-3"}`}>
+      <div className="flex items-center justify-between px-1.5 mb-1.5 mt-0.5">
+        <span className="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.12em] text-faint font-semibold">
+          {title}
+          {headerSpinner && <Loader2 size={10} className="animate-spin text-muted shrink-0" />}
+        </span>
+        {action}
+      </div>
+      {children}
+    </div>
+  );
+}
+export const IconBtn = ({ onClick, children, title, disabled }: {
+  onClick?: () => void;
+  children?: ReactNode;
+  title?: string;
+  disabled?: boolean;
+}) => (
+  <button
+    onClick={onClick}
+    title={title}
+    disabled={disabled}
+    className="text-faint hover:text-txt p-1 rounded hover:bg-panel2/60 disabled:opacity-50 disabled:pointer-events-none"
+  >
+    {children}
+  </button>
+);
+export const Empty = ({ children }: any) => <div className="text-[11px] text-faint italic px-1.5 py-1">{children}</div>;

--- a/webapp/src/components/leftRailSessions.ts
+++ b/webapp/src/components/leftRailSessions.ts
@@ -1,0 +1,299 @@
+import { type Session } from "../lib/api";
+import { repoPathsEqual } from "../lib/pathNormalize";
+import { readSWRCache, writeSWRCache } from "../lib/useStaleWhileRevalidate";
+
+/** User-facing copy when concurrent session runner leases are full. */
+export const SESSION_LEASE_EXHAUSTED_MESSAGE =
+  "This session could not start — too many sessions are busy right now. Wait a moment or stop another turn, then try again.";
+
+export type LeaseExhaustedPayload = {
+  code?: string;
+  error?: string;
+  message?: string;
+  status?: number;
+  max_concurrent?: number;
+  active_count?: number;
+  busy_session_ids?: string[];
+  busy_session_titles?: string[];
+};
+
+/** True when switch/open/create failed because all session runner leases are busy. */
+export function isLeaseExhaustedError(err: unknown): boolean {
+  if (!err) return false;
+  const e = err as LeaseExhaustedPayload;
+  if (e.code === "lease_exhausted") return true;
+  const msg = String(e.message || e.error || err || "");
+  // Message-only fallbacks (older servers / bridge quirks). Do NOT treat a bare
+  // "... -> 409" as lease exhaustion — other conflicts share that status.
+  if (/lease_exhausted/i.test(msg)) return true;
+  if (/session runner lease exhausted/i.test(msg)) return true;
+  return false;
+}
+
+/** Hermes-style toast: name busy sessions and show capacity when the 409 body has them. */
+export function formatLeaseExhaustedMessage(err: unknown): string {
+  const e = (err || {}) as LeaseExhaustedPayload;
+  const max = typeof e.max_concurrent === "number" ? e.max_concurrent : null;
+  const active = typeof e.active_count === "number" ? e.active_count : null;
+  const titles = (e.busy_session_titles || []).map((t) => String(t).trim()).filter(Boolean);
+  const capacity =
+    max != null
+      ? active != null
+        ? `${active}/${max}`
+        : `${max}`
+      : null;
+  if (titles.length && capacity) {
+    return `Too many sessions are busy (${capacity}). Stop one of: ${titles.map((t) => `"${t}"`).join(", ")} — then try again.`;
+  }
+  if (titles.length) {
+    return `Too many sessions are busy. Stop one of: ${titles.map((t) => `"${t}"`).join(", ")} — then try again.`;
+  }
+  if (capacity) {
+    return `This session could not start — session capacity is full (${capacity}). Wait a moment or stop another turn, then try again.`;
+  }
+  return SESSION_LEASE_EXHAUSTED_MESSAGE;
+}
+
+/**
+ * Stable PROJECTS rail order: pin durable Home first (when provided), keep
+ * remaining recents as-is, append currentRepo only when it is not already
+ * present (slash/case-insensitive). Never force the active path to index 0 —
+ * Home is the only synthetic pin.
+ */
+export function buildProjectsList(
+  currentRepo: string,
+  rawRecents: string[],
+  home?: string,
+): string[] {
+  const seen: string[] = [];
+  const out: string[] = [];
+  if (home) {
+    seen.push(home);
+    out.push(home);
+  }
+  for (const p of rawRecents) {
+    if (!p || seen.some((s) => repoPathsEqual(s, p))) continue;
+    seen.push(p);
+    out.push(p);
+  }
+  if (currentRepo && !seen.some((s) => repoPathsEqual(s, currentRepo))) {
+    out.push(currentRepo);
+  }
+  return out;
+}
+
+/** Drop a path (and slash/case siblings) from a recents list. */
+export function filterForgottenRecent(recents: string[], path: string): string[] {
+  return (recents || []).filter((r) => !repoPathsEqual(r, path));
+}
+
+/**
+ * Settle/Unsettle only work for sessions under the active workspace
+ * (POST /api/sessions/settle 403s foreign roots). Hide affordances elsewhere.
+ */
+export function canSettleSessionsForProject(
+  projectPath: string,
+  activeRepo: string | undefined | null,
+): boolean {
+  return !!(activeRepo && projectPath && repoPathsEqual(projectPath, activeRepo));
+}
+
+/**
+ * Split project-scoped sessions into open (inbox) vs settled.
+ * `settled` and `archived` are independent durable flags. Archived rows are
+ * excluded here — they live in the global Archived section, not the project tree.
+ * Rootless orphans only appear under the active workspace row.
+ */
+export function partitionProjectSessions(
+  rows: Session[],
+  projectPath: string,
+  isActiveRow: boolean,
+): { open: Session[]; settled: Session[] } {
+  const scoped = (rows || []).filter((s) => {
+    const root = (s.workspace_root || s.repo || "").trim();
+    if (!root) return isActiveRow;
+    return repoPathsEqual(root, projectPath);
+  });
+  const open: Session[] = [];
+  const settled: Session[] = [];
+  for (const s of scoped) {
+    if (s.archived) continue;
+    if (s.settled) settled.push(s);
+    else open.push(s);
+  }
+  return { open, settled };
+}
+
+/** Read current settled flag for a session id from per-root caches (first hit). */
+export function readSessionSettledFromCaches(
+  roots: string[],
+  sessionId: string,
+  read: (key: string) => Session[] | undefined = readSWRCache,
+): boolean | undefined {
+  for (const root of roots) {
+    if (!root) continue;
+    const cached = read(`sessions:${root}`);
+    const hit = cached?.find((s) => s.id === sessionId);
+    if (hit) return !!hit.settled;
+  }
+  return undefined;
+}
+
+/** Optimistically flip durable `settled` on every per-root sessions cache that holds the id. */
+export function patchSessionSettledInCaches(
+  roots: string[],
+  sessionId: string,
+  settled: boolean,
+  read: (key: string) => Session[] | undefined = readSWRCache,
+  write: (key: string, data: Session[]) => void = writeSWRCache,
+): number {
+  let touched = 0;
+  for (const root of roots) {
+    if (!root) continue;
+    const key = `sessions:${root}`;
+    const cached = read(key);
+    if (!cached || !cached.some((s) => s.id === sessionId)) continue;
+    write(
+      key,
+      cached.map((s) => (s.id === sessionId ? { ...s, settled } : s)),
+    );
+    touched += 1;
+  }
+  return touched;
+}
+
+/** Optimistically set the display title on every per-root sessions cache that holds the id. */
+export function patchSessionTitleInCaches(
+  roots: string[],
+  sessionId: string,
+  title: string,
+  read: (key: string) => Session[] | undefined = readSWRCache,
+  write: (key: string, data: Session[]) => void = writeSWRCache,
+): number {
+  let touched = 0;
+  for (const root of roots) {
+    if (!root) continue;
+    const key = `sessions:${root}`;
+    const cached = read(key);
+    if (!cached || !cached.some((s) => s.id === sessionId)) continue;
+    write(
+      key,
+      cached.map((s) => (s.id === sessionId ? { ...s, title } : s)),
+    );
+    touched += 1;
+  }
+  return touched;
+}
+
+/** Optimistically flip durable `archived` on every per-root sessions cache that holds the id. */
+export function patchSessionArchivedInCaches(
+  roots: string[],
+  sessionId: string,
+  archived: boolean,
+  read: (key: string) => Session[] | undefined = readSWRCache,
+  write: (key: string, data: Session[]) => void = writeSWRCache,
+): number {
+  let touched = 0;
+  for (const root of roots) {
+    if (!root) continue;
+    const key = `sessions:${root}`;
+    const cached = read(key);
+    if (!cached || !cached.some((s) => s.id === sessionId)) continue;
+    write(
+      key,
+      cached.map((s) => (s.id === sessionId ? { ...s, archived } : s)),
+    );
+    touched += 1;
+  }
+  return touched;
+}
+
+/** Drop a session id from every per-root sessions SWR cache. Returns how many
+ *  caches were rewritten. Used on delete so inactive projects do not keep
+ *  phantom titles (the "merged dir" ghost). */
+export function purgeSessionFromRootCaches(
+  roots: string[],
+  sessionId: string,
+  read: (key: string) => Session[] | undefined = readSWRCache,
+  write: (key: string, data: Session[]) => void = writeSWRCache,
+): number {
+  let touched = 0;
+  for (const root of roots) {
+    if (!root) continue;
+    const key = `sessions:${root}`;
+    const cached = read(key);
+    if (!cached) continue;
+    const next = cached.filter((s) => s.id !== sessionId);
+    if (next.length === cached.length) continue;
+    write(key, next);
+    touched += 1;
+  }
+  return touched;
+}
+
+/** SWR cache key for the Branches list -- keyed by repo so project switches
+ *  do not flash another project's branches, and revisits stay warm. */
+export function workspacesCacheKey(repo: string): string {
+  return `workspaces:${repo || "__none__"}`;
+}
+
+/** SWR cache key for jobs scoped to both the selected project and active session. */
+export function jobsCacheKey(projectPath: string, activeSessionId?: string): string {
+  return `jobs:${projectPath || "__none__"}:${activeSessionId || "__none__"}`;
+}
+
+/** True when LeftRail should offer Stop without forcing a view attach. */
+export function shouldOfferBackgroundStop(
+  status: "running" | "idle" | "attaching" | "missing" | undefined,
+  isActive: boolean,
+): boolean {
+  return status === "running" && !isActive;
+}
+
+export type RunnerStatus = "running" | "idle" | "attaching" | "missing";
+
+/** Sessions that finished a background turn while the user looked elsewhere. */
+export function collectUnreadFinishedSessionIds(
+  prev: Record<string, RunnerStatus>,
+  next: Record<string, RunnerStatus>,
+  activeSessionId: string | undefined,
+): string[] {
+  const out: string[] = [];
+  for (const [id, status] of Object.entries(next)) {
+    if (id === activeSessionId) continue;
+    if (status === "idle" && prev[id] === "running") out.push(id);
+  }
+  return out;
+}
+
+/**
+ * Rail-wide dim / project-switching signal. Browse-selecting an already-listed
+ * project must not trip this — jobs SWR key changes on select and used to flash
+ * the whole PROJECTS tree. Only real open/switch/session activation dims the rail.
+ */
+export function isRailWideSwitching(flags: {
+  opening: boolean;
+  switchingSessionId: string | null;
+  workspaceTransitioning: boolean;
+  sessionsTransitioning: boolean;
+}): boolean {
+  return (
+    flags.opening
+    || !!flags.switchingSessionId
+    || flags.workspaceTransitioning
+    || flags.sessionsTransitioning
+  );
+}
+
+/**
+ * Per-project empty-state: spinner only until that root's sessions resolve.
+ * Never gate on rail-wide / jobs transitioning (that hid the New session CTA
+ * and blinked "Loading sessions..." on first expand of a listed project).
+ */
+export function projectSessionsEmptyState(
+  sessionsReady: boolean,
+  showRowLoading: boolean,
+): "loading" | "pending" | "empty" {
+  if (sessionsReady) return "empty";
+  return showRowLoading ? "loading" : "pending";
+}

--- a/webapp/src/components/settingsSnapshot.ts
+++ b/webapp/src/components/settingsSnapshot.ts
@@ -1,0 +1,84 @@
+import type { Settings } from "../lib/api";
+
+const SETTINGS_SNAPSHOT_KEY = "pmharness.settings.snapshot";
+let memorySettingsSnapshot: Settings | null = null;
+
+/** Persist only safe display/config fields — never raw keys or tokens. */
+export function toSafeSettingsSnapshot(s: Settings): Settings {
+  return {
+    driver: s.driver,
+    reach: s.reach,
+    budget: s.budget,
+    models: s.models,
+    auto_distill: s.auto_distill,
+    reviewEditsBeforeApply: s.reviewEditsBeforeApply,
+    autoVerify: s.autoVerify,
+    autoCommandGuard: s.autoCommandGuard,
+    hash_edit_enabled: s.hash_edit_enabled,
+    commandTimeout: s.commandTimeout,
+    maxPilotSteps: s.maxPilotSteps,
+    pilotToolBudget: s.pilotToolBudget,
+    workerTokenBudget: s.workerTokenBudget,
+    reasoning_effort: s.reasoning_effort,
+    wiki_auto: s.wiki_auto,
+    state_dir: s.state_dir,
+    repo: s.repo,
+    has_api_key: s.has_api_key,
+    api_key_masked: s.api_key_masked,
+    key_env_var: s.key_env_var,
+    preflight_ok: s.preflight_ok,
+    bedrock: s.bedrock
+      ? {
+          configured: s.bedrock.configured,
+          has_key: s.bedrock.has_key,
+          auth_mode: s.bedrock.auth_mode,
+          masked: s.bedrock.masked,
+          has_bearer: s.bedrock.has_bearer,
+          has_access_key: s.bedrock.has_access_key,
+          has_session_token: s.bedrock.has_session_token,
+          region: s.bedrock.region,
+          aws_region: s.bedrock.aws_region,
+          bedrock_region: s.bedrock.bedrock_region,
+          model_id: s.bedrock.model_id,
+          disconnected: s.bedrock.disconnected,
+        }
+      : undefined,
+  };
+}
+
+export function clearSettingsSnapshot() {
+  memorySettingsSnapshot = null;
+  try {
+    localStorage.removeItem(SETTINGS_SNAPSHOT_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function readSettingsSnapshot(): Settings | null {
+  if (memorySettingsSnapshot) return memorySettingsSnapshot;
+  try {
+    const raw = localStorage.getItem(SETTINGS_SNAPSHOT_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    if (parsed?.settings && typeof parsed.settings === "object") {
+      memorySettingsSnapshot = parsed.settings as Settings;
+      return memorySettingsSnapshot;
+    }
+  } catch {
+    /* stale/corrupt cache is disposable */
+  }
+  return null;
+}
+
+export function writeSettingsSnapshot(settings: Settings) {
+  const safe = toSafeSettingsSnapshot(settings);
+  memorySettingsSnapshot = safe;
+  try {
+    localStorage.setItem(
+      SETTINGS_SNAPSHOT_KEY,
+      JSON.stringify({ settings: safe, savedAt: Date.now() }),
+    );
+  } catch {
+    /* storage pressure must not break Settings */
+  }
+}

--- a/webapp/src/components/useInFileReview.ts
+++ b/webapp/src/components/useInFileReview.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, type PendingReview } from "../lib/api";
+import {
+  applyInFileHunkDecision,
+  collectInFilePendingHunks,
+  type InFilePendingHunk,
+} from "../lib/inFileReview";
+import { createInFileReviewExtension } from "./inFileReviewExtension";
+import type { Extension } from "@codemirror/state";
+
+/**
+ * Load pending reviews for the open editor path and build the in-file
+ * Accept/Reject CodeMirror extension (same apply_review + seeded keys as the pane).
+ */
+export function useInFileReview(editorPath: string): {
+  extension: Extension;
+  pendingCount: number;
+  applyError: string | null;
+  clearApplyError: () => void;
+} {
+  const [reviews, setReviews] = useState<PendingReview[]>([]);
+  const [applyingKey, setApplyingKey] = useState<string | null>(null);
+  const [applyError, setApplyError] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    void api
+      .getReviews()
+      .then((data) => {
+        if (Array.isArray(data)) setReviews(data);
+      })
+      .catch(() => {
+        /* keep last-known; editor paint is best-effort */
+      });
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const onRefresh = () => refresh();
+    window.addEventListener("harness-reviews-refresh", onRefresh);
+    const timer = window.setInterval(refresh, 4000);
+    return () => {
+      window.removeEventListener("harness-reviews-refresh", onRefresh);
+      window.clearInterval(timer);
+    };
+  }, [refresh]);
+
+  const hunks = collectInFilePendingHunks(reviews, editorPath);
+
+  const onAccept = useCallback(async (item: InFilePendingHunk) => {
+    setApplyError(null);
+    setApplyingKey(item.decisionKey);
+    try {
+      const res = await applyInFileHunkDecision(item.review, item.hunk.id, "accept");
+      if (!res.ok) setApplyError(res.message);
+      else refresh();
+    } catch (err: any) {
+      setApplyError(err?.message || "Error applying review");
+    } finally {
+      setApplyingKey(null);
+    }
+  }, [refresh]);
+
+  const onReject = useCallback(async (item: InFilePendingHunk) => {
+    setApplyError(null);
+    setApplyingKey(item.decisionKey);
+    try {
+      const res = await applyInFileHunkDecision(item.review, item.hunk.id, "reject");
+      if (!res.ok) setApplyError(res.message);
+      else refresh();
+    } catch (err: any) {
+      setApplyError(err?.message || "Error applying review");
+    } finally {
+      setApplyingKey(null);
+    }
+  }, [refresh]);
+
+  const extension = createInFileReviewExtension(hunks, {
+    onAccept,
+    onReject,
+    applyingKey,
+  });
+
+  return {
+    extension,
+    pendingCount: hunks.length,
+    applyError,
+    clearApplyError: () => setApplyError(null),
+  };
+}

--- a/webapp/src/components/useInFileReview.ts
+++ b/webapp/src/components/useInFileReview.ts
@@ -23,8 +23,9 @@ export function useInFileReview(editorPath: string): {
   const [applyError, setApplyError] = useState<string | null>(null);
 
   const refresh = useCallback(() => {
-    void api
-      .getReviews()
+    const fetchReviews = api.getReviews;
+    if (typeof fetchReviews !== "function") return;
+    void fetchReviews()
       .then((data) => {
         if (Array.isArray(data)) setReviews(data);
       })

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -7,8 +7,10 @@ import {
   withToken,
   uploadFile,
   chatEventsPath,
+  sessionEventsPath,
   type StreamEvent,
   type ChatEventReplay as TransportChatEventReplay,
+  type StoreEventsSince as TransportStoreEventsSince,
 } from "./transport";
 import {
   buildSessionSearchQuery,
@@ -16,7 +18,7 @@ import {
   type SessionSearchHit,
 } from "./sessionSearch";
 
-export type { ChatEventFrame } from "./transport";
+export type { ChatEventFrame, StoreEvent } from "./transport";
 export type { SessionSearchHit } from "./sessionSearch";
 
 /** Mid-turn SSE ring replay payload (miss fields from GET /api/chat/events). */
@@ -25,6 +27,9 @@ export type ChatEventReplay = TransportChatEventReplay & {
   available?: boolean;
   code?: "ring_miss" | "generation_mismatch" | string;
 };
+
+/** Unified store cursor payload (GET /api/session/events). */
+export type StoreEventsSince = TransportStoreEventsSince;
 
 export type Config = {
   driver: string; reach: string; budget: number;
@@ -1263,6 +1268,12 @@ export const api = {
   /** Mid-turn SSE reattach: replay retained frames since ``since`` cursor. */
   chatEvents: (opts?: { session?: string; since?: number; generation?: number }) =>
     getJSON<ChatEventReplay>(chatEventsPath(opts || {})),
+  /**
+   * Unified session store cursor (``read_events_since``).
+   * Returns stream + runners (+ ring_miss) events after ``since`` and the new cursor.
+   */
+  readEventsSince: (opts?: { session?: string; since?: number; generation?: number }) =>
+    getJSON<StoreEventsSince>(sessionEventsPath(opts || {})),
   /**
    * Live ring watch for mid-turn reattach (``?watch=1``).
    * Returns cancel(); on open miss the transport errors so callers fall back

--- a/webapp/src/lib/inFileReview.ts
+++ b/webapp/src/lib/inFileReview.ts
@@ -1,0 +1,165 @@
+import {
+  api,
+  type PendingReview,
+  type PendingReviewFile,
+  type PendingReviewHunk,
+} from "./api";
+import { pathsReferToSameFile } from "./workspaceMutationEvents";
+import { reviewHunkDecisionKey, seedApplyDecisions } from "./reviewDecisions";
+
+export type HunkLineKind = "context" | "add" | "del" | "meta";
+
+export type ParsedHunkGeometry = {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+  /** 1-based old-file lines covered by context/delete rows (empty for pure inserts). */
+  oldLines: number[];
+  /** 1-based old-file line to anchor widgets (insert-after when oldCount is 0). */
+  anchorOldLine: number;
+  lineKinds: { oldLine: number | null; kind: HunkLineKind; text: string }[];
+};
+
+const HUNK_HEADER_RE =
+  /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s@@/;
+
+/** Parse a unified-diff hunk header into old/new ranges. */
+export function parseHunkHeader(header: string): {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+} | null {
+  const m = header.trim().match(HUNK_HEADER_RE);
+  if (!m) return null;
+  const oldStart = Number(m[1]);
+  const oldCount = m[2] != null ? Number(m[2]) : 1;
+  const newStart = Number(m[3]);
+  const newCount = m[4] != null ? Number(m[4]) : 1;
+  if (![oldStart, oldCount, newStart, newCount].every((n) => Number.isFinite(n))) {
+    return null;
+  }
+  return { oldStart, oldCount, newStart, newCount };
+}
+
+/** Map hunk body lines onto old-file geometry for in-editor paint. */
+export function parseHunkGeometry(hunk: PendingReviewHunk): ParsedHunkGeometry | null {
+  const ranges = parseHunkHeader(hunk.header || "");
+  if (!ranges) return null;
+
+  const oldLines: number[] = [];
+  const lineKinds: ParsedHunkGeometry["lineKinds"] = [];
+  let oldCursor = ranges.oldStart;
+
+  for (const raw of hunk.lines || []) {
+    const line = raw.replace(/\n$/, "");
+    if (line.startsWith("\\")) {
+      lineKinds.push({ oldLine: null, kind: "meta", text: line });
+      continue;
+    }
+    if (line.startsWith("+")) {
+      lineKinds.push({ oldLine: null, kind: "add", text: line.slice(1) });
+      continue;
+    }
+    if (line.startsWith("-")) {
+      oldLines.push(oldCursor);
+      lineKinds.push({ oldLine: oldCursor, kind: "del", text: line.slice(1) });
+      oldCursor += 1;
+      continue;
+    }
+    // Context (leading space) or bare context.
+    const text = line.startsWith(" ") ? line.slice(1) : line;
+    oldLines.push(oldCursor);
+    lineKinds.push({ oldLine: oldCursor, kind: "context", text });
+    oldCursor += 1;
+  }
+
+  const anchorOldLine =
+    ranges.oldCount === 0
+      ? Math.max(1, ranges.oldStart)
+      : oldLines[0] ?? Math.max(1, ranges.oldStart);
+
+  return {
+    ...ranges,
+    oldLines,
+    anchorOldLine,
+    lineKinds,
+  };
+}
+
+export type InFilePendingHunk = {
+  review: PendingReview;
+  file: PendingReviewFile;
+  hunk: PendingReviewHunk;
+  geometry: ParsedHunkGeometry;
+  decisionKey: string;
+};
+
+/** Collect pending hunks whose file path matches the open editor path. */
+export function collectInFilePendingHunks(
+  reviews: PendingReview[],
+  editorPath: string,
+): InFilePendingHunk[] {
+  const out: InFilePendingHunk[] = [];
+  if (!editorPath) return out;
+
+  for (const review of reviews) {
+    for (const file of review.files || []) {
+      if (!pathsReferToSameFile(file.path, editorPath)) continue;
+      for (const hunk of file.hunks || []) {
+        if (hunk.status && hunk.status !== "pending") continue;
+        const geometry = parseHunkGeometry(hunk);
+        if (!geometry) continue;
+        out.push({
+          review,
+          file,
+          hunk,
+          geometry,
+          decisionKey: reviewHunkDecisionKey(review.id, hunk.id),
+        });
+      }
+    }
+  }
+
+  out.sort((a, b) => a.geometry.anchorOldLine - b.geometry.anchorOldLine);
+  return out;
+}
+
+/**
+ * Build a fully seeded apply_review payload for one in-file Accept/Reject.
+ * Other hunks keep the pane default (accept) so harness reject-default cannot
+ * silently drop them.
+ */
+export function buildInFileApplyDecisions(
+  review: PendingReview,
+  hunkId: string,
+  decision: "accept" | "reject",
+): Record<string, "accept" | "reject"> {
+  const namespaced: Record<string, "accept" | "reject"> = {
+    [reviewHunkDecisionKey(review.id, hunkId)]: decision,
+  };
+  return seedApplyDecisions(review, namespaced);
+}
+
+export type InFileApplyResult = {
+  ok: boolean;
+  message: string;
+};
+
+/** Apply one in-file hunk decision via the shared apply_review API. */
+export async function applyInFileHunkDecision(
+  review: PendingReview,
+  hunkId: string,
+  decision: "accept" | "reject",
+): Promise<InFileApplyResult> {
+  const payload = buildInFileApplyDecisions(review, hunkId, decision);
+  const res = await api.applyReview(review.id, payload);
+  if (!res.ok) {
+    return { ok: false, message: res.message || "Failed to apply" };
+  }
+  window.dispatchEvent(new Event("harness-repo-mutated"));
+  window.dispatchEvent(new Event("harness-config-changed"));
+  window.dispatchEvent(new Event("harness-reviews-refresh"));
+  return { ok: true, message: res.message || "Applied successfully" };
+}

--- a/webapp/src/lib/reviewDecisions.ts
+++ b/webapp/src/lib/reviewDecisions.ts
@@ -1,0 +1,25 @@
+import type { PendingReview } from "./api";
+
+/** Namespace hunk decisions per review so concurrent pending reviews cannot collide. */
+export function reviewHunkDecisionKey(reviewId: string, hunkId: string): string {
+  return `${reviewId}::${hunkId}`;
+}
+
+/**
+ * Build the apply_review payload: every hunk id is seeded to match the painted
+ * UI default (accept). Harness defaults missing keys to reject — omitting keys
+ * would silently drop hunks the pane still shows as accepted.
+ */
+export function seedApplyDecisions(
+  review: PendingReview,
+  decisions: Record<string, "accept" | "reject">,
+): Record<string, "accept" | "reject"> {
+  const out: Record<string, "accept" | "reject"> = {};
+  for (const file of review.files) {
+    for (const hunk of file.hunks) {
+      const key = reviewHunkDecisionKey(review.id, hunk.id);
+      out[hunk.id] = decisions[key] ?? "accept";
+    }
+  }
+  return out;
+}

--- a/webapp/src/lib/transport.ts
+++ b/webapp/src/lib/transport.ts
@@ -40,6 +40,22 @@ export type ChatEventReplay = {
   retained?: number;
 };
 
+/** One store event from GET /api/session/events (unified cursor). */
+export type StoreEvent = {
+  id: number;
+  kind: "stream" | "runners" | "ring_miss" | string;
+  data: any;
+  session_id?: string;
+};
+
+/** Payload for GET /api/session/events (read_events_since). */
+export type StoreEventsSince = {
+  ok?: boolean;
+  session_id: string;
+  cursor: number;
+  events: StoreEvent[];
+};
+
 /** Build the tokened URL for chat event replay / reattach. */
 export function chatEventsPath(opts: {
   session?: string;
@@ -55,6 +71,20 @@ export function chatEventsPath(opts: {
   if (opts.watch) params.set("watch", "1");
   const q = params.toString();
   return withToken(`/api/chat/events${q ? `?${q}` : ""}`);
+}
+
+/** Build the tokened URL for the unified session store event cursor. */
+export function sessionEventsPath(opts: {
+  session?: string;
+  since?: number;
+  generation?: number;
+} = {}): string {
+  const params = new URLSearchParams();
+  if (opts.session) params.set("session", opts.session);
+  if (opts.since != null) params.set("since", String(opts.since));
+  if (opts.generation != null) params.set("generation", String(opts.generation));
+  const q = params.toString();
+  return withToken(`/api/session/events${q ? `?${q}` : ""}`);
 }
 
 /** Live Electron preload bridge (do not freeze at module import). */


### PR DESCRIPTION
## Summary
- Mid-turn steers inject as `role=user` after a complete tool pair (not `[OUT-OF-BAND…]` on the last tool result). Live feed still paints the muted `steer:` chip; Stop still drops queued steers.
- Muted transcript virtualizes with `@tanstack/react-virtual` + `measureElement`. `RENDER_WINDOW = 40` / Show-earlier is gone. `nextFeedPinState` hysteresis is unchanged.
- Session switch/reattach/busy share one `read_events_since` store cursor (`GET /api/session/events`) with generation + session fences. Settings/LeftRail peeled into sibling modules. Pending review hunks Accept/Reject in the open file via the same seeded `apply_review` keys.

## Test plan
- [x] Steer + session-events pytest (145)
- [x] Feed / reattach / Settings / LeftRail / in-file vitest (257)
- [x] Checkout Electron: edit-README turn, mid-turn steer redirect, remaining surfaces checked by Cary
- [ ] `tests` workflow green on the merge SHA (3.9 + 3.11 + Windows + frontend-build) before tag