### PR TITLE
Release v0.9.222: Hermes-style first-run provider connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.2` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.221, deliberately pre-1.0. Mid-turn steers are first-class user messages at a safe tool-pair boundary; the muted feed virtualizes with measureElement; session switch/reattach share one store cursor; pending review hunks Accept/Reject in the open file. Rides puppetmaster-ai==1.22.2. Cursor CLI / `CURSOR_API_KEY` remain optional upgrades (Pilot only / platform workers).
+> Status: v0.9.222, deliberately pre-1.0. First-run is a Hermes-style provider connect: pick a Full stack tile, paste a key, start chatting. Rides puppetmaster-ai==1.22.2. Cursor CLI / `CURSOR_API_KEY` remain optional upgrades (Pilot only / platform workers).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.221"
+__version__ = "0.9.222"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.221"
+version = "0.9.222"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.221",
+  "version": "0.9.222",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.221",
+      "version": "0.9.222",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.221",
+  "version": "0.9.222",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -7,7 +7,6 @@ import RightDock from "./components/RightDock";
 import StatusBar from "./components/StatusBar";
 import UpdateBanner from "./components/UpdateBanner";
 import ProviderKeyBanner from "./components/ProviderKeyBanner";
-import { focusSettingsPage } from "./components/SettingsShell";
 import Resizer from "./components/Resizer";
 import RegistryWizard from "./components/RegistryWizard";
 import ErrorBoundary from "./components/ErrorBoundary";
@@ -346,10 +345,7 @@ export default function App() {
               ? "workers"
               : "keyless"
           }
-          onAddKey={() => {
-            focusSettingsPage("providers");
-            openRightTo("settings");
-          }}
+          onAddKey={() => setShowWizard(true)}
         />
       )}
       {/* Left rail and tool cards sit on the conversation surface. */}

--- a/webapp/src/__tests__/RegistryWizard.test.tsx
+++ b/webapp/src/__tests__/RegistryWizard.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RegistryWizard from "../components/RegistryWizard";
+import { api } from "../lib/api";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    providers: vi.fn(),
+    setProviderKey: vi.fn(),
+  },
+}));
+
+const providers = [
+  {
+    name: "openrouter",
+    display_name: "OpenRouter",
+    env_var: "OPENROUTER_API_KEY",
+    base_url: "https://openrouter.ai/api/v1",
+    has_key: false,
+    api_mode: "chat_completions",
+    worker_capability: "full_stack" as const,
+  },
+  {
+    name: "anthropic",
+    display_name: "Anthropic",
+    env_var: "ANTHROPIC_API_KEY",
+    base_url: "https://api.anthropic.com",
+    has_key: false,
+    api_mode: "anthropic_messages",
+    worker_capability: "full_stack" as const,
+  },
+  {
+    name: "cursor-cli",
+    display_name: "Cursor CLI (plan)",
+    env_var: "CURSOR_CLI_LOGIN",
+    base_url: "",
+    has_key: false,
+    api_mode: "cursor_cli",
+    worker_capability: "pilot_only" as const,
+  },
+];
+
+describe("RegistryWizard first-run connect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.providers).mockResolvedValue(providers);
+    vi.mocked(api.setProviderKey).mockResolvedValue({
+      ok: true,
+      provider: "openrouter",
+      has_key: true,
+      masked: "sk-or-…",
+    });
+  });
+
+  it("shows the connect title and defaults to OpenRouter", async () => {
+    render(<RegistryWizard onClose={vi.fn()} />);
+    expect(await screen.findByText(/set up with Marionette/i)).toBeTruthy();
+    expect(screen.getByText(/one key runs chat and swarms/i)).toBeTruthy();
+    const openrouter = screen.getByRole("option", { name: /OpenRouter/i });
+    expect(openrouter.getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByText(/Hosts hundreds of models/i)).toBeTruthy();
+    expect(screen.queryByText(/Cursor CLI/i)).toBeNull();
+  });
+
+  it("switches copy when another provider is selected", async () => {
+    render(<RegistryWizard onClose={vi.fn()} />);
+    await screen.findByText(/set up with Marionette/i);
+    fireEvent.click(screen.getByRole("option", { name: /Anthropic/i }));
+    expect(screen.getByText(/Direct Anthropic API/i)).toBeTruthy();
+    expect(screen.getByRole("option", { name: /Anthropic/i }).getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("saves the selected provider key and closes", async () => {
+    const onClose = vi.fn();
+    render(<RegistryWizard onClose={onClose} />);
+    await screen.findByText(/set up with Marionette/i);
+    fireEvent.change(screen.getByPlaceholderText("OPENROUTER_API_KEY"), {
+      target: { value: "sk-or-test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Connect/i }));
+    await waitFor(() => {
+      expect(api.setProviderKey).toHaveBeenCalledWith("openrouter", "sk-or-test");
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("skips without saving a key", async () => {
+    const onClose = vi.fn();
+    render(<RegistryWizard onClose={onClose} />);
+    await screen.findByText(/set up with Marionette/i);
+    fireEvent.click(screen.getByRole("button", { name: /choose a provider later/i }));
+    expect(api.setProviderKey).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/webapp/src/__tests__/onboardingProviders.test.ts
+++ b/webapp/src/__tests__/onboardingProviders.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderInfo } from "../lib/api";
+import {
+  defaultOnboardingProvider,
+  isOnboardableProvider,
+  onboardableProviders,
+  onboardingCopy,
+} from "../lib/onboardingProviders";
+
+function provider(name: string, extra: Partial<ProviderInfo> = {}): ProviderInfo {
+  return {
+    name,
+    display_name: name,
+    env_var: "KEY",
+    base_url: "",
+    has_key: false,
+    api_mode: "chat_completions",
+    worker_capability: "full_stack",
+    ...extra,
+  };
+}
+
+describe("onboardingProviders", () => {
+  it("hides cursor-cli and bedrock from first-run", () => {
+    expect(isOnboardableProvider(provider("cursor-cli", { worker_capability: "pilot_only" }))).toBe(false);
+    expect(isOnboardableProvider(provider("bedrock"))).toBe(false);
+  });
+
+  it("keeps Full stack providers and sorts OpenRouter first", () => {
+    const list = onboardableProviders([
+      provider("xai"),
+      provider("openrouter"),
+      provider("cursor-cli", { worker_capability: "pilot_only" }),
+      provider("anthropic"),
+    ]);
+    expect(list.map((p) => p.name)).toEqual(["openrouter", "anthropic", "xai"]);
+  });
+
+  it("defaults to OpenRouter when present", () => {
+    expect(defaultOnboardingProvider([provider("anthropic"), provider("openrouter")])).toBe("openrouter");
+    expect(defaultOnboardingProvider([provider("xai")])).toBe("xai");
+  });
+
+  it("ships a Get-a-key URL for OpenRouter", () => {
+    expect(onboardingCopy("openrouter").keyUrl).toBe("https://openrouter.ai/keys");
+    expect(onboardingCopy("openrouter").tagline).toMatch(/one key/i);
+  });
+});

--- a/webapp/src/components/ProviderKeyBanner.tsx
+++ b/webapp/src/components/ProviderKeyBanner.tsx
@@ -7,10 +7,11 @@ import { TITLEBAR_TRAFFIC_PAD_PX } from "../lib/titlebarSafe";
 // picking the model live from its registry. Until a key is visible, agentic
 // can't route, so this thin, dismissible strip points the user at Settings.
 //
-// Distinct from the one-time first-run RegistryWizard: this is the persistent
-// "you're still keyless" reminder that reappears each launch until a key is added
-// (adding one fires harness-config-changed -> App refetches -> agentic_ready flips
-// true -> this unmounts on its own).
+// Distinct from the one-time first-run provider connect screen: this is the
+// persistent "you're still keyless" reminder that reappears each launch until a
+// key is added (Add key reopens that screen; saving a key fires
+// harness-config-changed -> App refetches -> workers_ready flips true -> this
+// unmounts on its own).
 export default function ProviderKeyBanner({
   onAddKey,
   variant = "keyless",

--- a/webapp/src/components/RegistryWizard.tsx
+++ b/webapp/src/components/RegistryWizard.tsx
@@ -1,640 +1,219 @@
-import { useEffect, useState } from "react";
-import { X, Check, AlertCircle, Sparkles } from "lucide-react";
-import { api, type ProviderInfo, type RegistryModel, type PilotValidateResult } from "../lib/api";
+import { useEffect, useMemo, useState } from "react";
+import { ExternalLink, KeyRound } from "lucide-react";
+import { api, type ProviderInfo } from "../lib/api";
+import {
+  defaultOnboardingProvider,
+  onboardableProviders,
+  onboardingCopy,
+  openOnboardingKeyUrl,
+} from "../lib/onboardingProviders";
 
 interface RegistryWizardProps {
   onClose: () => void;
 }
 
+function markWizardSeen(): void {
+  try {
+    localStorage.setItem("pmharness.wizardSeen", "1");
+  } catch {
+    // Private mode / quota — closing still works.
+  }
+}
+
 export default function RegistryWizard({ onClose }: RegistryWizardProps) {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
-  const [settingsModels, setSettingsModels] = useState<string[]>([]);
-  const [probedModels, setProbedModels] = useState<Record<string, { id: string }[]>>({});
-  const [probeStatus, setProbeStatus] = useState<Record<string, { source: "live" | "static"; error?: string }>>({});
-  const [probing, setProbing] = useState<Record<string, boolean>>({});
-  const [probeErrors, setProbeErrors] = useState<Record<string, string>>({});
+  const [selected, setSelected] = useState("");
+  const [keyValue, setKeyValue] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
 
-  // Pilot State
-  const [pilot, setPilot] = useState<string>("");
-  const [pilotValidation, setPilotValidation] = useState<PilotValidateResult | null>(null);
+  const tiles = useMemo(() => onboardableProviders(providers), [providers]);
+  const copy = onboardingCopy(selected);
+  const selectedProvider = tiles.find((p) => p.name === selected);
+  const canConnect = Boolean(keyValue.trim()) && !saving && Boolean(selected);
 
-  // Roles State
-  const [roles, setRoles] = useState<Record<string, number>>({});
-  const [roleModels, setRoleModels] = useState<Record<string, string>>({});
-  const [routingPolicy, setRoutingPolicy] = useState<string>("balanced");
-  const [policies] = useState<string[]>(["balanced", "cheap", "quality", "escalating"]);
-
-  // Registry State
-  const [registryModels, setRegistryModels] = useState<RegistryModel[]>([]);
-  const [showRegistryScores, setShowRegistryScores] = useState<boolean>(false);
-
-  // General UI state
-  const [loading, setLoading] = useState<boolean>(true);
-  const [saving, setSaving] = useState<boolean>(false);
-  const [loadingRecommend, setLoadingRecommend] = useState<boolean>(false);
-  const [status, setStatus] = useState<string>("");
-  const [error, setError] = useState<string>("");
-  
-  // API Key Inputs
-  const [keyInputs, setKeyInputs] = useState<Record<string, string>>({});
-  const [savingKey, setSavingKey] = useState<Record<string, boolean>>({});
-
-  // Close on Escape key
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
+    const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
+        markWizardSeen();
         onClose();
       }
     };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  // Load initial data
-  const loadInitialData = async () => {
-    setLoading(true);
-    setError("");
-    try {
-      const [provs, settingsData, rolesData, registryData] = await Promise.all([
-        api.providers(),
-        api.settings(),
-        api.getRoles(),
-        api.getRegistry(),
-      ]);
-      setProviders(provs);
-      setPilot(settingsData.driver);
-      setSettingsModels(settingsData.models || []);
-      setRoles(rolesData.roles || {});
-      setRoutingPolicy(rolesData.routing_policy || "balanced");
-      setRegistryModels(registryData.models || []);
-
-      // Pre-fill some default roleModels from registry models if scores align
-      const initialRoleModels: Record<string, string> = {};
-      Object.keys(rolesData.roles || {}).forEach((role) => {
-        const threshold = rolesData.roles[role];
-        // find a registry model that has a score closest/appropriate to this threshold
-        const matchingModel = registryData.models?.find(
-          (m) => m.capability_score >= threshold
-        );
-        if (matchingModel) {
-          initialRoleModels[role] = matchingModel.id;
-        }
-      });
-      setRoleModels(initialRoleModels);
-    } catch (err: any) {
-      console.error("Failed to load setup wizard data", err);
-      setError("Failed to load initial configuration. Please verify server status.");
-    } finally {
-      setLoading(false);
-    }
-  };
-
   useEffect(() => {
-    loadInitialData();
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const list = await api.providers();
+        if (cancelled) return;
+        setProviders(list);
+        setSelected(defaultOnboardingProvider(list));
+      } catch (err: unknown) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : "Failed to load providers.";
+        setError(message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  // Validate pilot on change
-  useEffect(() => {
-    if (pilot) {
-      api.validatePilot(pilot)
-        .then(setPilotValidation)
-        .catch(() => {
-          setPilotValidation({
-            valid: false,
-            resolved_model_id: null,
-            provider: null,
-            reason: "Validation service unavailable",
-          });
-        });
-    }
-  }, [pilot]);
-
-  // Probe provider
-  const handleProbe = async (providerName: string) => {
-    setProbing((prev) => ({ ...prev, [providerName]: true }));
-    setProbeErrors((prev) => ({ ...prev, [providerName]: "" }));
-    try {
-      const res = await api.probeProvider(providerName);
-      setProbedModels((prev) => ({ ...prev, [providerName]: res.models }));
-      setProbeStatus((prev) => ({
-        ...prev,
-        [providerName]: { source: res.source, error: res.error },
-      }));
-    } catch (err: any) {
-      setProbeErrors((prev) => ({ ...prev, [providerName]: err?.message || "Probe failed" }));
-    } finally {
-      setProbing((prev) => ({ ...prev, [providerName]: false }));
-    }
+  const skip = () => {
+    markWizardSeen();
+    onClose();
   };
 
-  // Save key
-  const handleSaveKey = async (providerName: string) => {
-    const keyVal = keyInputs[providerName]?.trim();
-    if (!keyVal) return;
-
-    setSavingKey((prev) => ({ ...prev, [providerName]: true }));
-    try {
-      await api.updateSettings({ reach: providerName, api_key: keyVal });
-      setKeyInputs((prev) => ({ ...prev, [providerName]: "" }));
-      
-      // Refresh providers list
-      const updatedProvs = await api.providers();
-      setProviders(updatedProvs);
-      
-      // Auto-probe after adding key
-      handleProbe(providerName);
-    } catch (err: any) {
-      alert(`Failed to save key: ${err?.message || err}`);
-    } finally {
-      setSavingKey((prev) => ({ ...prev, [providerName]: false }));
-    }
-  };
-
-  // Recommend defaults
-  const handleRecommend = async () => {
-    setLoadingRecommend(true);
-    setStatus("");
-    setError("");
-    try {
-      const rec = await api.recommend();
-      
-      if (rec.pilot || rec.pilot_driver) {
-        setPilot(rec.pilot || rec.pilot_driver);
-      }
-      
-      if (rec.roles) {
-        // rec.roles maps role -> model ID. We set roleModels selection
-        setRoleModels((prev) => ({
-          ...prev,
-          ...rec.roles,
-        }));
-        
-        // Ensure any recommended models exist in registry with appropriate scores
-        setRegistryModels((prevRegistry) => {
-          const updatedRegistry = [...prevRegistry];
-          Object.entries(rec.roles).forEach(([role, modelId]) => {
-            const threshold = roles[role] || 50;
-            const existingIdx = updatedRegistry.findIndex((m) => m.id === modelId);
-            if (existingIdx >= 0) {
-              // Ensure its score is at least the role's score
-              if (updatedRegistry[existingIdx].capability_score < threshold) {
-                updatedRegistry[existingIdx] = {
-                  ...updatedRegistry[existingIdx],
-                  capability_score: threshold,
-                };
-              }
-            } else {
-              // Add recommended model to registry
-              updatedRegistry.push({
-                id: modelId,
-                adapter: "openai",
-                capability_score: threshold,
-                tags: ["worker", role],
-                notes: "auto-added via recommendation",
-              });
-            }
-          });
-          return updatedRegistry;
-        });
-      }
-
-      setStatus("Recommended setup populated! Review and click Save All.");
-      setTimeout(() => setStatus(""), 4000);
-    } catch (err: any) {
-      setError(`Failed to fetch recommendations: ${err?.message || err}`);
-    } finally {
-      setLoadingRecommend(false);
-    }
-  };
-
-  // Save everything
-  const handleSaveAll = async () => {
-    if (pilotValidation && !pilotValidation.valid) {
-      setError("Cannot save with an invalid pilot model.");
-      return;
-    }
-
+  const connect = async () => {
+    const key = keyValue.trim();
+    if (!selected || !key) return;
     setSaving(true);
-    setStatus("Saving configuration...");
     setError("");
-
     try {
-      // 1. Sync roleModels into registryModels scores to ensure eligibility
-      const finalRegistryModels = [...registryModels];
-      Object.entries(roleModels).forEach(([role, modelId]) => {
-        if (!modelId) return;
-        const threshold = roles[role] || 50;
-        const idx = finalRegistryModels.findIndex((m) => m.id === modelId);
-        if (idx >= 0) {
-          if (finalRegistryModels[idx].capability_score < threshold) {
-            finalRegistryModels[idx].capability_score = threshold;
-          }
-        } else {
-          finalRegistryModels.push({
-            id: modelId,
-            adapter: "openai",
-            capability_score: threshold,
-            tags: ["worker", role],
-          });
-        }
-      });
-
-      // 2. Perform sequential POST saves
-      await api.saveRoles({ overrides: roles, routing_policy: routingPolicy });
-      await api.saveRegistry(finalRegistryModels);
-      await api.updateSettings({ driver: pilot });
-
-      // Mark wizard as completed
-      localStorage.setItem("pmharness.wizardSeen", "1");
-
-      setStatus("All settings saved successfully!");
-      setTimeout(() => {
-        onClose();
-      }, 1500);
-    } catch (err: any) {
-      console.error("Save all failed", err);
-      setError(`Failed to save configuration: ${err?.message || err}`);
+      const res = await api.setProviderKey(selected, key);
+      if (!res?.ok) {
+        throw new Error("Could not save that key.");
+      }
+      window.dispatchEvent(new Event("harness-config-changed"));
+      markWizardSeen();
+      onClose();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Could not save that key.";
+      setError(message);
     } finally {
       setSaving(false);
     }
   };
 
-  // Combine probed + static models for dropdown choices
-  const allProbedModels = Object.values(probedModels).flatMap((models) => models.map((m) => m.id));
-  const modelOptions = Array.from(new Set([...settingsModels, ...allProbedModels])).filter(Boolean);
-
-  if (loading) {
-    return (
-      <div className="fixed inset-0 bg-black/60 backdrop-blur-xs flex items-center justify-center z-50">
-        <div className="bg-panel border border-edge rounded-lg p-6 max-w-sm w-full text-center space-y-3">
-          <p className="text-muted font-medium">Loading wizard components...</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="fixed inset-0 bg-black/70 backdrop-blur-xs flex items-center justify-center z-50 p-4">
-      <div 
-        className="bg-panel border border-edge rounded-lg shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col text-[12px] text-txt"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-edge">
-          <div className="flex items-center gap-2">
-            <span className="font-bold text-[14px] uppercase tracking-wider text-txt">
-              Add a key — pilots and workers
-            </span>
-            <span className="text-[10px] text-faint uppercase font-medium">first run</span>
-          </div>
-          <button 
-            onClick={onClose}
-            className="text-faint hover:text-txt transition-colors p-1"
-          >
-            <X size={16} />
-          </button>
-        </div>
+    <div
+      data-testid="provider-onboarding"
+      className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6"
+      style={{
+        background:
+          "radial-gradient(ellipse at 50% 38%, rgba(224,164,90,0.08) 0%, transparent 52%), #0f1113",
+      }}
+    >
+      <div className="onboarding-card w-full max-w-[34rem] max-h-full overflow-y-auto rounded-2xl border border-edge bg-panel px-7 py-8 shadow-[0_24px_80px_rgba(0,0,0,0.45)]">
+        <header className="text-center mb-6">
+          <h1 className="text-[1.45rem] font-semibold tracking-tight text-txt leading-tight">
+            Let&apos;s get you set up with Marionette
+          </h1>
+          <p className="mt-2 text-[13px] text-muted leading-relaxed">
+            Connect a model provider to start chatting. One key runs chat and swarms.
+          </p>
+        </header>
 
-        {/* Scrollable Content */}
-        <div className="flex-1 overflow-y-auto p-4 space-y-6">
-          {error && (
-            <div className="bg-risk/10 border border-risk/30 text-risk rounded p-3 flex items-start gap-2">
-              <AlertCircle size={14} className="mt-0.5 shrink-0" />
-              <div>{error}</div>
-            </div>
-          )}
-
-          {status && (
-            <div className="bg-accent/10 border border-accent/30 text-accent rounded p-3 flex items-start gap-2">
-              <Check size={14} className="mt-0.5 shrink-0" />
-              <div>{status}</div>
-            </div>
-          )}
-
-          {/* Section A & B: Providers & Probe */}
-          <div className="space-y-3">
-            <div className="flex items-center justify-between border-b border-edge/60 pb-1.5">
-              <span className="uppercase tracking-wider text-[11px] text-faint font-bold">
-                1. Full stack API keys
-              </span>
-              <span className="text-[10px] text-muted">One key runs chat and swarms. No Cursor install.</span>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              {[...providers]
-                .filter((p) => p.name !== "cursor-cli")
-                .sort((a, b) => {
-                  if (a.name === "openrouter") return -1;
-                  if (b.name === "openrouter") return 1;
-                  const aFull = a.worker_capability === "full_stack" ? 0 : 1;
-                  const bFull = b.worker_capability === "full_stack" ? 0 : 1;
-                  return aFull - bFull;
-                })
-                .map((p) => {
-                const isProbing = probing[p.name];
-                const probeRes = probeStatus[p.name];
-                const hasProbedModels = probedModels[p.name]?.length > 0;
-                
+        {loading ? (
+          <p className="text-center text-muted text-[13px] py-10">Loading providers…</p>
+        ) : tiles.length === 0 ? (
+          <p className="text-center text-muted text-[13px] py-8">
+            No Full stack providers available. You can add a key later from Settings.
+          </p>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-2" role="listbox" aria-label="Model providers">
+              {tiles.map((p) => {
+                const active = p.name === selected;
+                const tileCopy = onboardingCopy(p.name);
                 return (
-                  <div key={p.name} className="bg-panel2 border border-edge rounded p-3 flex flex-col justify-between space-y-2">
-                    <div>
-                      <div className="flex items-center justify-between">
-                        <span className="font-semibold text-txt text-[12px] uppercase">{p.name}</span>
-                        <span className={`px-2 py-0.5 rounded-full text-[9px] uppercase font-bold ${
-                          p.has_key 
-                            ? "bg-accent/10 border border-accent/20 text-accent" 
-                            : "bg-edge text-faint"
-                        }`}>
-                          {p.has_key ? "key set" : "no key"}
-                        </span>
-                      </div>
-                      <div className="text-[10px] text-faint mt-0.5 font-mono">{p.env_var}</div>
+                  <button
+                    key={p.name}
+                    type="button"
+                    role="option"
+                    aria-selected={active}
+                    onClick={() => {
+                      setSelected(p.name);
+                      setKeyValue("");
+                      setError("");
+                    }}
+                    className={`relative text-left rounded-lg border px-3 py-2.5 transition-colors ${
+                      active
+                        ? "border-accent bg-accent/10"
+                        : "border-edge/70 bg-panel2 hover:border-edge2"
+                    }`}
+                  >
+                    {active ? (
+                      <span className="absolute inset-y-0 right-0 w-[3px] rounded-r-lg bg-accent" />
+                    ) : null}
+                    <div className="text-[13px] font-semibold text-txt leading-tight pr-2">
+                      {p.display_name || p.name}
                     </div>
-
-                    {/* Inline password setter */}
-                    <div className="flex gap-1.5 mt-2">
-                      <input
-                        type="password"
-                        placeholder={p.has_key ? "replace key..." : "enter key..."}
-                        value={keyInputs[p.name] || ""}
-                        onChange={(e) => setKeyInputs({ ...keyInputs, [p.name]: e.target.value })}
-                        className="flex-1 bg-panel border border-edge rounded px-2 py-1 text-[11px] font-mono text-txt focus:outline-none"
-                      />
-                      <button
-                        onClick={() => handleSaveKey(p.name)}
-                        disabled={savingKey[p.name] || !keyInputs[p.name]}
-                        className="bg-accent/10 hover:bg-accent/20 text-accent border border-accent/30 hover:border-accent/50 rounded px-2.5 py-1 text-[11px] font-medium disabled:opacity-30 transition-colors"
-                      >
-                        {savingKey[p.name] ? "saving" : "save"}
-                      </button>
+                    <div className="text-[11px] text-muted mt-0.5 leading-snug pr-2">
+                      {tileCopy.tagline}
                     </div>
-
-                    {/* Probing block */}
-                    {p.has_key && (
-                      <div className="pt-2 border-t border-edge/40 flex items-center justify-between">
-                        <button
-                          onClick={() => handleProbe(p.name)}
-                          disabled={isProbing}
-                          className="bg-edge hover:bg-edge/80 text-txt rounded px-2.5 py-1 text-[10px] transition-colors font-medium"
-                        >
-                          {isProbing ? "Loading..." : "Load models"}
-                        </button>
-
-                        <div className="text-right text-[10px]">
-                          {probeRes && (
-                            <div className="flex flex-col">
-                              <span className="text-muted">
-                                Source: <span className="font-semibold text-txt uppercase">{probeRes.source}</span>
-                              </span>
-                              {hasProbedModels && (
-                                <span className="text-accent">
-                                  {probedModels[p.name].length} models found
-                                </span>
-                              )}
-                              {probeRes.error && (
-                                <span className="text-risk text-[9px] block max-w-[150px] truncate" title={probeRes.error}>
-                                  {probeRes.error}
-                                </span>
-                              )}
-                            </div>
-                          )}
-                          {probeErrors[p.name] && (
-                            <span className="text-risk text-[9px]">{probeErrors[p.name]}</span>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </div>
+                  </button>
                 );
               })}
             </div>
-          </div>
 
-          {/* Section C: Pilot Driver */}
-          <div className="space-y-3 bg-panel2 border border-edge rounded p-3">
-            <div className="flex items-center justify-between border-b border-edge pb-1.5">
-              <span className="uppercase tracking-wider text-[11px] text-faint font-bold">
-                2. Conversational Pilot Driver
-              </span>
-              <span className="text-[10px] text-muted">The main model you chat with</span>
-            </div>
-
-            <div className="space-y-2">
-              <label className="block text-faint font-medium">Select Pilot Model</label>
-              <select
-                value={pilot}
-                onChange={(e) => setPilot(e.target.value)}
-                className="w-full bg-panel border border-edge rounded px-2.5 py-2 text-txt focus:outline-none focus:border-accent"
-              >
-                <option value="">-- select pilot model --</option>
-                {modelOptions.map((opt) => (
-                  <option key={opt} value={opt}>
-                    {opt}
-                  </option>
-                ))}
-              </select>
-
-              {pilotValidation && (
-                <div className="text-[11px] flex items-center gap-1.5 mt-1">
-                  <span className="text-faint">Status:</span>
-                  <span className={pilotValidation.valid ? "text-good font-semibold" : "text-risk font-semibold"}>
-                    {pilotValidation.valid 
-                      ? `valid -> ${pilotValidation.resolved_model_id}` 
-                      : pilotValidation.reason}
-                  </span>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Section D: Roles */}
-          <div className="space-y-3">
-            <div className="flex items-center justify-between border-b border-edge/60 pb-1.5">
-              <span className="uppercase tracking-wider text-[11px] text-faint font-bold">
-                3. Task Worker Models & Capability thresholds
-              </span>
-              <div className="flex items-center gap-3">
+            <div className="mt-5 flex items-start justify-between gap-3">
+              <p className="text-[12.5px] text-muted leading-relaxed min-h-[2.5rem]">
+                {copy.blurb}
+              </p>
+              {copy.keyUrl ? (
                 <button
-                  onClick={handleRecommend}
-                  disabled={loadingRecommend}
-                  className="bg-accent/15 hover:bg-accent/25 text-accent border border-accent/30 hover:border-accent/50 rounded-full px-3 py-1 text-[10px] font-semibold flex items-center gap-1 transition-colors"
+                  type="button"
+                  onClick={() => openOnboardingKeyUrl(copy.keyUrl!)}
+                  className="shrink-0 inline-flex items-center gap-1 text-[12px] text-accent hover:underline pt-0.5"
                 >
-                  <Sparkles size={11} />
-                  {loadingRecommend ? "fetching recommendations" : "Recommended Setup"}
+                  Get a key
+                  <ExternalLink size={11} />
+                </button>
+              ) : null}
+            </div>
+
+            <form
+              className="mt-3"
+              onSubmit={(e) => {
+                e.preventDefault();
+                void connect();
+              }}
+            >
+              <input
+                type="password"
+                autoComplete="off"
+                spellCheck={false}
+                placeholder={selectedProvider?.env_var || "API key"}
+                value={keyValue}
+                onChange={(e) => setKeyValue(e.target.value)}
+                disabled={saving || !selected}
+                className="w-full bg-bg border border-edge rounded-lg px-3 py-2.5 text-[13px] font-mono text-txt placeholder:text-faint focus:outline-none focus:border-accent disabled:opacity-50"
+              />
+              {error ? (
+                <p className="mt-2 text-[12px] text-risk" role="alert">
+                  {error}
+                </p>
+              ) : null}
+              <div className="mt-3 flex justify-end">
+                <button
+                  type="submit"
+                  disabled={!canConnect}
+                  className="inline-flex items-center gap-1.5 bg-accent text-panel font-semibold rounded-lg px-4 py-2 text-[13px] hover:brightness-110 disabled:opacity-35 disabled:hover:brightness-100 transition"
+                >
+                  <KeyRound size={14} />
+                  {saving ? "Connecting…" : "Connect"}
                 </button>
               </div>
-            </div>
+            </form>
+          </>
+        )}
 
-            <div className="space-y-2.5">
-              {Object.keys(roles).length === 0 ? (
-                <div className="text-center py-4 text-faint">No task roles returned from server</div>
-              ) : (
-                Object.keys(roles).map((role) => {
-                  const threshold = roles[role];
-                  const selectedModel = roleModels[role] || "";
-                  
-                  return (
-                    <div key={role} className="grid grid-cols-1 md:grid-cols-12 gap-3 items-center bg-panel2 border border-edge/40 p-2 rounded">
-                      {/* Role Label */}
-                      <div className="md:col-span-3 font-semibold text-txt uppercase text-[11px]">
-                        {role}
-                      </div>
-
-                      {/* Worker Model Select */}
-                      <div className="md:col-span-5">
-                        <select
-                          value={selectedModel}
-                          onChange={(e) => setRoleModels({ ...roleModels, [role]: e.target.value })}
-                          className="w-full bg-panel border border-edge rounded px-2 py-1 text-[11px] text-txt focus:outline-none"
-                        >
-                          <option value="">-- auto-select by capability --</option>
-                          {modelOptions.map((opt) => (
-                            <option key={opt} value={opt}>
-                              {opt}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-
-                      {/* Threshold Slider + Input */}
-                      <div className="md:col-span-4 flex items-center gap-2">
-                        <input
-                          type="range"
-                          min="0"
-                          max="100"
-                          value={threshold}
-                          onChange={(e) => setRoles({ ...roles, [role]: parseInt(e.target.value) || 0 })}
-                          className="flex-1 accent-accent"
-                        />
-                        <input
-                          type="number"
-                          min="0"
-                          max="100"
-                          value={threshold}
-                          onChange={(e) => {
-                            const val = Math.max(0, Math.min(100, parseInt(e.target.value) || 0));
-                            setRoles({ ...roles, [role]: val });
-                          }}
-                          className="w-12 text-center bg-panel border border-edge rounded p-0.5 font-mono text-[11px] text-txt"
-                        />
-                      </div>
-                    </div>
-                  );
-                })
-              )}
-            </div>
-          </div>
-
-          {/* Section E: Routing Policy */}
-          <div className="space-y-3 bg-panel2 border border-edge rounded p-3">
-            <div className="flex items-center justify-between border-b border-edge pb-1.5">
-              <span className="uppercase tracking-wider text-[11px] text-faint font-bold">
-                4. Global Routing Policy
-              </span>
-              <span className="text-[10px] text-muted">How model selection is optimized</span>
-            </div>
-
-            <div className="space-y-2">
-              <label className="block text-faint font-medium">Select Policy</label>
-              <select
-                value={routingPolicy}
-                onChange={(e) => setRoutingPolicy(e.target.value)}
-                className="w-full bg-panel border border-edge rounded px-2.5 py-2 text-txt focus:outline-none focus:border-accent"
-              >
-                {policies.map((p) => (
-                  <option key={p} value={p}>
-                    {p}
-                  </option>
-                ))}
-              </select>
-              <p className="text-[10px] text-muted">
-                Balanced: selects appropriate strength for cost. Cheap: aggressively favors low-cost models. Quality: maximizes accuracy. Escalating: starts cheap and upgrades on failure.
-              </p>
-            </div>
-          </div>
-
-          {/* Section F: Registry Scores (Collapsible Advanced) */}
-          <div className="border border-edge rounded overflow-hidden">
-            <button
-              onClick={() => setShowRegistryScores(!showRegistryScores)}
-              className="w-full bg-panel2 px-3 py-2 text-left uppercase tracking-wider text-[10px] text-faint font-semibold flex justify-between items-center hover:bg-edge/40 transition-colors"
-            >
-              <span>5. Registry Capability Scores (Advanced)</span>
-              <span>{showRegistryScores ? "collapse" : "expand"}</span>
-            </button>
-
-            {showRegistryScores && (
-              <div className="p-3 space-y-2.5 bg-panel border-t border-edge">
-                {registryModels.length === 0 ? (
-                  <div className="text-center py-2 text-faint">No model records in local registry.json</div>
-                ) : (
-                  registryModels.map((m, idx) => (
-                    <div key={m.id} className="grid grid-cols-1 md:grid-cols-12 gap-3 items-center border-b border-edge/30 pb-2 last:border-b-0">
-                      <div className="md:col-span-5 font-mono text-[11px] text-txt truncate" title={m.id}>
-                        {m.id}
-                      </div>
-
-                      {/* Read only tags */}
-                      <div className="md:col-span-3 flex flex-wrap gap-1">
-                        {m.tags && m.tags.map((t) => (
-                          <span key={t} className="bg-edge text-faint px-1.5 py-0.5 rounded text-[9px] uppercase">
-                            {t}
-                          </span>
-                        ))}
-                      </div>
-
-                      {/* Capability slider */}
-                      <div className="md:col-span-4 flex items-center gap-2">
-                        <input
-                          type="range"
-                          min="0"
-                          max="100"
-                          value={m.capability_score}
-                          onChange={(e) => {
-                            const val = parseInt(e.target.value) || 0;
-                            const updated = [...registryModels];
-                            updated[idx] = { ...m, capability_score: val };
-                            setRegistryModels(updated);
-                          }}
-                          className="flex-1 accent-accent"
-                        />
-                        <input
-                          type="number"
-                          min="0"
-                          max="100"
-                          value={m.capability_score}
-                          onChange={(e) => {
-                            const val = Math.max(0, Math.min(100, parseInt(e.target.value) || 0));
-                            const updated = [...registryModels];
-                            updated[idx] = { ...m, capability_score: val };
-                            setRegistryModels(updated);
-                          }}
-                          className="w-12 text-center bg-panel2 border border-edge rounded p-0.5 font-mono text-[11px]"
-                        />
-                      </div>
-                    </div>
-                  ))
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Footer/Save action */}
-        <div className="px-4 py-3 border-t border-edge bg-panel2 flex items-center justify-between gap-4">
+        <div className="mt-6 text-center">
           <button
-            onClick={onClose}
-            className="border border-edge hover:bg-edge/40 text-txt rounded px-4 py-2 font-medium transition-colors"
+            type="button"
+            onClick={skip}
+            className="text-[12.5px] text-muted hover:text-txt transition-colors"
           >
-            Close
-          </button>
-
-          <button
-            onClick={handleSaveAll}
-            disabled={saving || (pilotValidation !== null && !pilotValidation.valid)}
-            className="bg-accent text-txt hover:bg-accent/90 border border-accent/20 rounded px-5 py-2 font-bold disabled:opacity-30 transition-colors"
-          >
-            {saving ? "saving configuration" : "Save All"}
+            I&apos;ll choose a provider later
           </button>
         </div>
       </div>

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -976,10 +976,10 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
             onClick={onOpenWizard}
             className="w-full bg-accent/15 hover:bg-accent/25 text-accent border border-accent/30 hover:border-accent/50 rounded py-2 font-bold transition-colors text-[11px]"
           >
-            Open Provider & Model Setup
+            Connect a provider
           </button>
           <p className="text-[10px] text-muted">
-            Configure API keys, probe models, select conversational pilots, and adjust routing scores.
+            Pick a provider, paste a key, start chatting. One Full stack key runs chat and swarms.
           </p>
         </div>
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -347,6 +347,14 @@ body.is-row-resizing iframe {
   padding-right: var(--titlebar-chrome-pad-x);
 }
 
+@keyframes onboarding-rise {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.onboarding-card {
+  animation: onboarding-rise 320ms ease-out;
+}
+
 .scrollbar-none {
   scrollbar-width: none;
 }

--- a/webapp/src/lib/onboardingProviders.ts
+++ b/webapp/src/lib/onboardingProviders.ts
@@ -1,0 +1,132 @@
+import type { ProviderInfo } from "./api";
+
+export type OnboardingCopy = {
+  tagline: string;
+  blurb: string;
+  keyUrl?: string;
+};
+
+/** First-run tile order. OpenRouter is the keys-only default. */
+export const ONBOARDING_ORDER = [
+  "openrouter",
+  "anthropic",
+  "openai",
+  "gemini",
+  "xai",
+  "deepseek",
+  "opencode-go",
+  "openai-codex",
+  "nous",
+  "zai",
+  "minimax",
+  "nvidia",
+] as const;
+
+/** Too much ceremony for first-run (pilot-only plan, or multi-cred). Settings still has them. */
+export const ONBOARDING_SKIP = new Set(["cursor-cli", "bedrock"]);
+
+export const ONBOARDING_COPY: Record<string, OnboardingCopy> = {
+  openrouter: {
+    tagline: "one key, many models",
+    blurb: "Hosts hundreds of models behind a single key. Good default for new installs.",
+    keyUrl: "https://openrouter.ai/keys",
+  },
+  anthropic: {
+    tagline: "Claude models",
+    blurb: "Direct Anthropic API. Claude for chat and agentic workers.",
+    keyUrl: "https://console.anthropic.com/settings/keys",
+  },
+  openai: {
+    tagline: "GPT-class models",
+    blurb: "Official OpenAI API. GPT-class pilots and workers on your key.",
+    keyUrl: "https://platform.openai.com/api-keys",
+  },
+  gemini: {
+    tagline: "Gemini models",
+    blurb: "Google AI Studio key. Gemini for chat and swarms.",
+    keyUrl: "https://aistudio.google.com/apikey",
+  },
+  xai: {
+    tagline: "Grok models",
+    blurb: "Direct xAI API. Grok for chat and agentic workers.",
+    keyUrl: "https://console.x.ai/",
+  },
+  deepseek: {
+    tagline: "DeepSeek models",
+    blurb: "Direct DeepSeek API. Strong coding models at API rates.",
+    keyUrl: "https://platform.deepseek.com/api_keys",
+  },
+  "opencode-go": {
+    tagline: "one subscription, many models",
+    blurb: "OpenCode Go subscription key. Reseller catalog for chat and workers.",
+    keyUrl: "https://opencode.ai/docs/go/",
+  },
+  "openai-codex": {
+    tagline: "ChatGPT plan",
+    blurb: "Paste a Codex token, or sign in from Settings after you skip. Full stack either way.",
+    keyUrl: "https://chatgpt.com",
+  },
+  nous: {
+    tagline: "Hermes / Nous Portal",
+    blurb: "Nous Portal key or OAuth token. Hermes-class models for chat and workers.",
+    keyUrl: "https://portal.nousresearch.com",
+  },
+  zai: {
+    tagline: "GLM models",
+    blurb: "Z.AI / GLM API key. Full stack chat and swarms.",
+    keyUrl: "https://z.ai",
+  },
+  minimax: {
+    tagline: "MiniMax models",
+    blurb: "MiniMax API key. Full stack chat and swarms.",
+    keyUrl: "https://www.minimax.io",
+  },
+  nvidia: {
+    tagline: "NIM models",
+    blurb: "NVIDIA NIM key. Hosted open models for chat and workers.",
+    keyUrl: "https://build.nvidia.com",
+  },
+};
+
+const FALLBACK_COPY: OnboardingCopy = {
+  tagline: "API key",
+  blurb: "One Full stack key runs chat and swarms. No other platform install.",
+};
+
+export function onboardingCopy(name: string): OnboardingCopy {
+  return ONBOARDING_COPY[name] || FALLBACK_COPY;
+}
+
+export function isOnboardableProvider(provider: ProviderInfo): boolean {
+  if (ONBOARDING_SKIP.has(provider.name)) return false;
+  if (provider.worker_capability === "full_stack") return true;
+  if (provider.worker_capability == null && ONBOARDING_COPY[provider.name]) return true;
+  return false;
+}
+
+export function onboardableProviders(providers: ProviderInfo[]): ProviderInfo[] {
+  return providers.filter(isOnboardableProvider).sort((a, b) => {
+    const ai = ONBOARDING_ORDER.indexOf(a.name as (typeof ONBOARDING_ORDER)[number]);
+    const bi = ONBOARDING_ORDER.indexOf(b.name as (typeof ONBOARDING_ORDER)[number]);
+    return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi);
+  });
+}
+
+export function defaultOnboardingProvider(providers: ProviderInfo[]): string {
+  const list = onboardableProviders(providers);
+  if (list.some((p) => p.name === "openrouter")) return "openrouter";
+  return list[0]?.name || "";
+}
+
+export function openOnboardingKeyUrl(url: string): void {
+  const ipc = (window as unknown as { harnessIPC?: { openExternal?: (href: string) => void } }).harnessIPC;
+  if (ipc && typeof ipc.openExternal === "function") {
+    try {
+      ipc.openExternal(url);
+      return;
+    } catch {
+      // Fall through to window.open.
+    }
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}


### PR DESCRIPTION
## Summary
- Replace the first-run registry/roles dump with a Hermes-style provider connect screen (pick a Full stack tile, paste a key, start chatting).
- OpenRouter is the default; Cursor CLI and Bedrock stay in Settings. Banner Add key reopens this screen.
- Version stamps and README status move to v0.9.222.

## Test plan
- [x] `webapp` vitest: RegistryWizard + onboardingProviders
- [x] Local pytest green (4293 passed)
- [ ] CI `tests` green on the merge SHA (3.9 + 3.11 + Windows + frontend-build) before tagging `v0.9.222`