### PR TITLE
Release v0.9.223: queue-only vision Enter, fold fence, command preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.2` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.222, deliberately pre-1.0. First-run is a Hermes-style provider connect: pick a Full stack tile, paste a key, start chatting. Rides puppetmaster-ai==1.22.2. Cursor CLI / `CURSOR_API_KEY` remain optional upgrades (Pilot only / platform workers).
+> Status: v0.9.223, deliberately pre-1.0. Vision+busy Enter queues the next turn (no steer+QUE). Prior Investigating folds seal; only the live fold spins. `run_command` preflights `.venv` / `webapp/` before doomed interpreter or cwd launches. Rides puppetmaster-ai==1.22.2.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.222"
+__version__ = "0.9.223"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/command_preflight.py
+++ b/harness/command_preflight.py
@@ -1,0 +1,276 @@
+"""Workspace-aware preflight for ``run_command``.
+
+Pilots routinely launch ``python -m pytest`` on the system interpreter and
+``npm test`` at a monorepo root whose frontend lives in ``webapp/``. Those
+commands are doomed before they start; post-failure hints in
+``command_hints`` never rewrite them.
+
+This module applies *unambiguous* rewrites only:
+
+* Bare ``python`` / ``python3`` / ``pytest`` (including ``python -m pytest``)
+  -> the workspace ``.venv`` interpreter, when that binary exists and the
+  command is not already using it.
+* ``npm`` / ``npx`` / ``pnpm`` / ``yarn`` when the repo has no root
+  ``package.json`` but ``webapp/package.json`` exists -> run in ``webapp/``.
+  Command text is left alone; scripts are never invented.
+
+Ambiguous commands (pipelines, ``cd``, explicit prefix/cwd flags) are left
+untouched. The functions never raise.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+from typing import Any, Dict, List, Optional
+
+# Error headers appear early; scanning further only adds false positives.
+_OUTPUT_SCAN_CHARS = 4000
+
+_BARE_PYTHONS = frozenset({"python", "python3"})
+_BARE_PYTEST = "pytest"
+_NODE_CLIENTS = frozenset({"npm", "npx", "pnpm", "yarn"})
+_NODE_DIR_FLAGS = frozenset({"--prefix", "--cwd", "--dir", "-C"})
+_SHELL_CONTROL = frozenset({"&&", "||", "|", ";", "&", ">", ">>", "<", "$(", "`"})
+_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_WIN_SUFFIXES = (".exe", ".cmd", ".bat")
+
+# Output shapes that mean "wrong interpreter / wrong cwd", not a product bug.
+_PYTEST_MODULE_RE = re.compile(
+    r"(?:ModuleNotFoundError|ImportError): No module named '?_?pytest",
+)
+_NPM_PACKAGE_JSON_RE = re.compile(
+    r"ENOENT[^\n]*package\.json|package\.json[^\n]*ENOENT|"
+    r"Could not (?:read|find) package\.json|"
+    r"Couldn't find a package\.json|"
+    r"No package\.json",
+    re.I,
+)
+_CMD_NOT_FOUND_RE = re.compile(
+    r"(?:bash: line \d+: |bash: |sh: \d*:? ?|zsh: )?(python3?|pytest): "
+    r"(?:command )?not found",
+)
+
+
+def _identity(command: str, repo: str, argv: Optional[List[str]] = None) -> Dict[str, Any]:
+    return {
+        "command": command or "",
+        "cwd": repo or "",
+        "argv": list(argv or []),
+        "rewritten": False,
+        "reason": None,
+        "kind": None,
+    }
+
+
+def _program_name(token: str) -> str:
+    base = (token or "").strip().strip("\"'").rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    if os.name == "nt":
+        lowered = base.lower()
+        for suffix in _WIN_SUFFIXES:
+            if lowered.endswith(suffix):
+                return base[: -len(suffix)]
+    return base
+
+
+def _is_bare(token: str, names: frozenset) -> bool:
+    raw = (token or "").strip().strip("\"'")
+    if not raw or "/" in raw or "\\" in raw:
+        return False
+    return _program_name(raw) in names
+
+
+def _tokenize(command: str) -> Optional[List[str]]:
+    text = command or ""
+    if not text.strip():
+        return []
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        return None
+    return tokens
+
+
+def _skip_env_assignments(tokens: List[str]) -> int:
+    idx = 0
+    while idx < len(tokens) and _ENV_ASSIGNMENT_RE.match(tokens[idx]):
+        idx += 1
+    return idx
+
+
+def _has_shell_control(tokens: List[str]) -> bool:
+    for token in tokens:
+        if token in _SHELL_CONTROL:
+            return True
+        if token.startswith(">") or token.startswith("<"):
+            return True
+    return False
+
+
+def _join_shell(tokens: List[str]) -> str:
+    if os.name == "nt":
+        return subprocess.list2cmdline(tokens)
+    return " ".join(shlex.quote(part) for part in tokens)
+
+
+def venv_python_path(repo: str) -> Optional[str]:
+    """Absolute path to ``repo/.venv``'s python, or None if it is absent."""
+    if not repo:
+        return None
+    if os.name == "nt":
+        rel = os.path.join(".venv", "Scripts", "python.exe")
+    else:
+        rel = os.path.join(".venv", "bin", "python")
+    path = os.path.join(repo, rel)
+    try:
+        if os.path.isfile(path):
+            return path
+    except Exception:
+        return None
+    return None
+
+
+def _same_interpreter(token: str, venv_python: str, repo: str) -> bool:
+    raw = (token or "").strip().strip("\"'")
+    if not raw:
+        return False
+    try:
+        candidate = raw if os.path.isabs(raw) else os.path.join(repo, raw)
+        return os.path.normcase(os.path.normpath(candidate)) == os.path.normcase(
+            os.path.normpath(venv_python)
+        )
+    except Exception:
+        return False
+
+
+def _rewrite_interpreter(
+    tokens: List[str],
+    prog_idx: int,
+    venv_python: str,
+) -> List[str]:
+    program = _program_name(tokens[prog_idx])
+    prefix = tokens[:prog_idx]
+    rest = tokens[prog_idx + 1 :]
+    if program == _BARE_PYTEST:
+        return prefix + [venv_python, "-m", "pytest"] + rest
+    return prefix + [venv_python] + rest
+
+
+def resolve_command_preflight(command: str, repo: str) -> Dict[str, Any]:
+    """Return an unambiguous rewrite of ``command`` for ``repo``, or the original.
+
+    Result keys: ``command``, ``cwd``, ``argv``, ``rewritten``, ``reason``,
+    ``kind`` (None, ``interpreter_rewrite``, or ``cwd_rewrite``).
+    ``env_prerequisite`` is a post-run failure class from
+    ``classify_env_prerequisite_failure``, not a rewrite kind.
+    """
+    try:
+        return _resolve_command_preflight(command, repo)
+    except Exception:
+        return _identity(command or "", repo or "")
+
+
+def _resolve_command_preflight(command: str, repo: str) -> Dict[str, Any]:
+    text = command if isinstance(command, str) else ""
+    workspace = repo if isinstance(repo, str) else ""
+    tokens = _tokenize(text)
+    if tokens is None:
+        return _identity(text, workspace)
+    if not tokens:
+        return _identity(text, workspace, [])
+
+    if "`" in text or "$(" in text or _has_shell_control(tokens):
+        return _identity(text, workspace, tokens)
+
+    prog_idx = _skip_env_assignments(tokens)
+    if prog_idx >= len(tokens):
+        return _identity(text, workspace, tokens)
+
+    program_token = tokens[prog_idx]
+    if _program_name(program_token) == "cd":
+        return _identity(text, workspace, tokens)
+
+    venv_python = venv_python_path(workspace)
+    if venv_python and (
+        _is_bare(program_token, _BARE_PYTHONS)
+        or _is_bare(program_token, frozenset({_BARE_PYTEST}))
+    ):
+        if not _same_interpreter(program_token, venv_python, workspace):
+            rewritten_tokens = _rewrite_interpreter(tokens, prog_idx, venv_python)
+            rewritten_command = _join_shell(rewritten_tokens)
+            return {
+                "command": rewritten_command,
+                "cwd": workspace,
+                "argv": rewritten_tokens,
+                "rewritten": True,
+                "reason": (
+                    "Using workspace .venv interpreter: " + rewritten_command
+                ),
+                "kind": "interpreter_rewrite",
+            }
+        return _identity(text, workspace, tokens)
+
+    if _is_bare(program_token, _NODE_CLIENTS):
+        if any(token in _NODE_DIR_FLAGS for token in tokens[prog_idx + 1 :]):
+            return _identity(text, workspace, tokens)
+        root_pkg = os.path.join(workspace, "package.json") if workspace else ""
+        webapp_pkg = (
+            os.path.join(workspace, "webapp", "package.json") if workspace else ""
+        )
+        try:
+            root_exists = bool(root_pkg) and os.path.isfile(root_pkg)
+            webapp_exists = bool(webapp_pkg) and os.path.isfile(webapp_pkg)
+        except Exception:
+            return _identity(text, workspace, tokens)
+        if (not root_exists) and webapp_exists:
+            webapp_cwd = os.path.join(workspace, "webapp")
+            return {
+                "command": text,
+                "cwd": webapp_cwd,
+                "argv": tokens,
+                "rewritten": True,
+                "reason": (
+                    "No package.json at workspace root; running in webapp/."
+                ),
+                "kind": "cwd_rewrite",
+            }
+
+    return _identity(text, workspace, tokens)
+
+
+def classify_env_prerequisite_failure(
+    command: str,
+    exit_code: int,
+    output: str,
+) -> Optional[str]:
+    """Return ``env_prerequisite`` when output matches a known env-gap shape.
+
+    Does not change ok/status semantics; callers attach this beside the
+    existing post-failure hint. Returns None for clean or informational exits.
+    """
+    try:
+        if int(exit_code) == 0:
+            return None
+    except (TypeError, ValueError):
+        return None
+    try:
+        from .command_hints import is_informational_exit
+
+        if is_informational_exit(command or "", int(exit_code)):
+            return None
+    except Exception:
+        pass
+    window = (output or "")[:_OUTPUT_SCAN_CHARS]
+    if not window:
+        return None
+    try:
+        if _PYTEST_MODULE_RE.search(window):
+            return "env_prerequisite"
+        if _NPM_PACKAGE_JSON_RE.search(window):
+            return "env_prerequisite"
+        if _CMD_NOT_FOUND_RE.search(window):
+            return "env_prerequisite"
+    except Exception:
+        return None
+    return None

--- a/harness/steer_mixin.py
+++ b/harness/steer_mixin.py
@@ -112,8 +112,9 @@ class SteerMixin:
 
         - Vision-capable pilots (gpt-5.6-luna, etc.): NEVER run the vision
           sidecar (weaker VLM paraphrase). Queue a follow-up turn via
-          ``enqueue_prompt`` so the next turn gets native multimodal pixels,
-          plus a short mid-turn nudge that images are queued.
+          ``enqueue_prompt`` so the next turn gets native multimodal pixels.
+          Do not enqueue a mid-turn steer notice — that would paint a second
+          chrome row (``steer:`` plus QUEUED TO SEND) for one Enter.
         - Text-only pilots: transcribe via sidecar into the steer text (same
           path as view_image for non-vision models).
         """
@@ -124,12 +125,9 @@ class SteerMixin:
                 from .vision import session_supports_native_images
                 if session_supports_native_images(self):
                     # Preserve pixels; do not degrade to a weaker sidecar VLM.
+                    # Queue-only: enqueue_prompt carries text + paths. A steer
+                    # notice here would double-paint chrome on busy Enter.
                     if hasattr(self, "enqueue_prompt"):
-                        if cleaned:
-                            self.enqueue_steer(
-                                "[User attached image(s) for native vision — "
-                                "full message queued for the next turn.]"
-                            )
                         self.enqueue_prompt(
                             cleaned or "(see attached image)",
                             images=paths,

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -1306,9 +1306,14 @@ class ToolDispatchMixin:
         - full-auto danger block →
           ``(False, "blocked", {message, category, reason, matched})``
 
-        Every payload also echoes the effective ``cwd``. Genuine failures carry
-        a one-line ``hint``; output beyond the inline cap carries ``spill_uri``
-        so it stays recoverable instead of being discarded.
+        Every payload also echoes the effective ``cwd``. Unambiguous interpreter
+        / package-root rewrites run before execution; when applied the payload
+        also carries ``rewritten`` and ``preflight_reason``. Full-auto danger
+        classify and the approval hash stay on the original ``act.command`` so
+        a rewrite cannot silently bypass a prior approval. Genuine failures
+        carry a one-line ``hint`` (and ``failure_class`` for env-prerequisite
+        shapes); output beyond the inline cap carries ``spill_uri`` so it stays
+        recoverable instead of being discarded.
         """
         if not self.config.repo:
             return False, "repo_not_open", "No workspace directory (config.repo) is open."
@@ -1354,10 +1359,19 @@ class ToolDispatchMixin:
             # Do not unlocked-discard again: a fresh same-hash re-approval raced
             # in after consume must survive for its own retry.
 
+        from .command_preflight import (
+            classify_env_prerequisite_failure,
+            resolve_command_preflight,
+        )
+
+        preflight = resolve_command_preflight(act.command or "", self.config.repo)
+        effective_command = preflight.get("command") or act.command or ""
+        effective_cwd = preflight.get("cwd") or self.config.repo
+
         cmd_timeout = effective_command_timeout()
         output, exit_code, run_status = run_cancellable(
-            act.command,
-            cwd=self.config.repo,
+            effective_command,
+            cwd=effective_cwd,
             timeout=cmd_timeout,
             cancel_event=getattr(self, "_cancel", None),
         )
@@ -1371,12 +1385,22 @@ class ToolDispatchMixin:
             "status": run_status,
             # Models routinely assume the cwd is wherever they last cd'd to.
             # Echoing it makes every relative-path failure self-diagnosing.
-            "cwd": self.config.repo,
+            "cwd": effective_cwd,
         }
+        if preflight.get("rewritten"):
+            payload["rewritten"] = True
+            reason = preflight.get("reason")
+            if reason:
+                payload["preflight_reason"] = reason
         payload.update(recovery)
-        hint = _command_failure_hint(act.command or "", exit_code, output)
+        hint = _command_failure_hint(effective_command, exit_code, output)
         if hint:
             payload["hint"] = hint
+        failure_class = classify_env_prerequisite_failure(
+            effective_command, exit_code, output
+        )
+        if failure_class:
+            payload["failure_class"] = failure_class
         # Terminal failures stay on the sync path but must not look like success.
         # truncated keeps ok=True so callers still get the capped output while
         # status remains distinct from a clean ok.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.222"
+version = "0.9.223"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_command_preflight.py
+++ b/tests/test_command_preflight.py
@@ -1,0 +1,334 @@
+"""Hermetic tests for workspace-aware run_command preflight.
+
+Rewrites must be unambiguous and filesystem-driven: a dummy .venv python
+or webapp/package.json in tmp_path is enough. No network, no real
+interpreters, no subprocess.
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from harness.command_preflight import (
+    classify_env_prerequisite_failure,
+    resolve_command_preflight,
+    venv_python_path,
+)
+from harness.pilot import PilotAction
+from harness.tool_dispatch import ToolDispatchMixin
+
+
+def _venv_python(repo):
+    if os.name == "nt":
+        path = repo / ".venv" / "Scripts" / "python.exe"
+    else:
+        path = repo / ".venv" / "bin" / "python"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
+    return path
+
+
+def _dispatch_session(repo_path, state_dir=""):
+    return SimpleNamespace(
+        config=SimpleNamespace(repo=str(repo_path), state_dir=state_dir),
+        state_dir=state_dir,
+        harness_session_id="sess-preflight",
+        _auto_mode=False,
+        _auto_command_guard=False,
+        _cancel=None,
+    )
+
+
+def test_python_m_pytest_rewrites_to_venv(tmp_path):
+    venv_py = _venv_python(tmp_path)
+    result = resolve_command_preflight("python -m pytest -q", str(tmp_path))
+    assert result["rewritten"] is True
+    assert result["kind"] == "interpreter_rewrite"
+    assert result["cwd"] == str(tmp_path)
+    assert result["command"].split()[0] == str(venv_py)
+    assert "-m pytest -q" in result["command"]
+    assert result["argv"][:3] == [str(venv_py), "-m", "pytest"]
+    assert result["reason"]
+
+
+def test_already_using_venv_path_is_not_rewritten(tmp_path):
+    venv_py = _venv_python(tmp_path)
+    command = "%s -m pytest -q" % venv_py
+    result = resolve_command_preflight(command, str(tmp_path))
+    assert result["rewritten"] is False
+    assert result["kind"] is None
+    assert result["command"] == command
+    assert result["cwd"] == str(tmp_path)
+
+
+def test_relative_venv_path_is_not_rewritten(tmp_path):
+    _venv_python(tmp_path)
+    if os.name == "nt":
+        rel = os.path.join(".venv", "Scripts", "python.exe")
+    else:
+        rel = os.path.join(".venv", "bin", "python")
+    command = "%s -m pytest" % rel
+    result = resolve_command_preflight(command, str(tmp_path))
+    assert result["rewritten"] is False
+    assert result["command"] == command
+
+
+def test_npm_test_uses_webapp_when_root_has_no_package_json(tmp_path):
+    webapp = tmp_path / "webapp"
+    webapp.mkdir()
+    (webapp / "package.json").write_text("{}", encoding="utf-8")
+    result = resolve_command_preflight("npm test", str(tmp_path))
+    assert result["rewritten"] is True
+    assert result["kind"] == "cwd_rewrite"
+    assert result["command"] == "npm test"
+    assert result["cwd"] == str(webapp)
+    assert result["argv"] == ["npm", "test"]
+
+
+def test_both_package_json_present_does_not_rewrite_cwd(tmp_path):
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    webapp = tmp_path / "webapp"
+    webapp.mkdir()
+    (webapp / "package.json").write_text("{}", encoding="utf-8")
+    result = resolve_command_preflight("npm test", str(tmp_path))
+    assert result["rewritten"] is False
+    assert result["command"] == "npm test"
+    assert result["cwd"] == str(tmp_path)
+
+
+def test_no_venv_does_not_rewrite_interpreter(tmp_path):
+    result = resolve_command_preflight("python -m pytest -q", str(tmp_path))
+    assert result["rewritten"] is False
+    assert result["kind"] is None
+    assert result["command"] == "python -m pytest -q"
+    assert result["cwd"] == str(tmp_path)
+    assert venv_python_path(str(tmp_path)) is None
+
+
+def test_bare_pytest_becomes_venv_module(tmp_path):
+    venv_py = _venv_python(tmp_path)
+    result = resolve_command_preflight("pytest tests/foo.py -q", str(tmp_path))
+    assert result["rewritten"] is True
+    assert result["kind"] == "interpreter_rewrite"
+    assert result["argv"] == [str(venv_py), "-m", "pytest", "tests/foo.py", "-q"]
+
+
+def test_python3_rewrites_to_venv(tmp_path):
+    venv_py = _venv_python(tmp_path)
+    result = resolve_command_preflight("python3 -m pytest -q", str(tmp_path))
+    assert result["rewritten"] is True
+    assert result["kind"] == "interpreter_rewrite"
+    assert result["argv"][:3] == [str(venv_py), "-m", "pytest"]
+    assert result["command"].split()[0] == str(venv_py)
+
+
+def test_env_assignment_prefix_python_rewrites(tmp_path):
+    venv_py = _venv_python(tmp_path)
+    result = resolve_command_preflight("FOO=1 python -m pytest -q", str(tmp_path))
+    assert result["rewritten"] is True
+    assert result["kind"] == "interpreter_rewrite"
+    assert result["argv"][:4] == ["FOO=1", str(venv_py), "-m", "pytest"]
+
+
+def test_cd_left_alone(tmp_path):
+    _venv_python(tmp_path)
+    command = "cd webapp"
+    result = resolve_command_preflight(command, str(tmp_path))
+    assert result["rewritten"] is False
+    assert result["command"] == command
+
+
+def test_shell_and_left_alone(tmp_path):
+    _venv_python(tmp_path)
+    command = "python -m pytest -q && echo done"
+    result = resolve_command_preflight(command, str(tmp_path))
+    assert result["rewritten"] is False
+    assert result["command"] == command
+
+
+def test_node_clients_use_webapp_when_root_has_no_package_json(tmp_path):
+    webapp = tmp_path / "webapp"
+    webapp.mkdir()
+    (webapp / "package.json").write_text("{}", encoding="utf-8")
+    for client in ("npx", "pnpm", "yarn"):
+        command = "%s test" % client
+        result = resolve_command_preflight(command, str(tmp_path))
+        assert result["rewritten"] is True, client
+        assert result["kind"] == "cwd_rewrite"
+        assert result["command"] == command
+        assert result["cwd"] == str(webapp)
+
+
+def test_root_only_package_json_does_not_rewrite_cwd(tmp_path):
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    result = resolve_command_preflight("npm test", str(tmp_path))
+    assert result["rewritten"] is False
+    assert result["command"] == "npm test"
+    assert result["cwd"] == str(tmp_path)
+
+
+def test_resolve_command_preflight_never_raises(tmp_path):
+    _venv_python(tmp_path)
+    for command, repo in (
+        (None, str(tmp_path)),
+        (12, str(tmp_path)),
+        ("python -m pytest", None),
+        ("python -m pytest", 7),
+        (object(), object()),
+    ):
+        result = resolve_command_preflight(command, repo)
+        assert isinstance(result, dict)
+        assert "rewritten" in result
+        assert "command" in result
+    assert classify_env_prerequisite_failure("python -m pytest", "nope", "x") is None
+    assert classify_env_prerequisite_failure("python -m pytest", None, None) is None
+
+
+def test_empty_and_malformed_commands_return_original(tmp_path):
+    empty = resolve_command_preflight("", str(tmp_path))
+    assert empty["rewritten"] is False
+    assert empty["command"] == ""
+    assert empty["cwd"] == str(tmp_path)
+
+    malformed = resolve_command_preflight('echo "unterminated', str(tmp_path))
+    assert malformed["rewritten"] is False
+    assert malformed["command"] == 'echo "unterminated'
+
+
+def test_pipeline_is_not_rewritten(tmp_path):
+    _venv_python(tmp_path)
+    command = "python -m pytest -q | tee out.log"
+    result = resolve_command_preflight(command, str(tmp_path))
+    assert result["rewritten"] is False
+    assert result["command"] == command
+
+
+def test_npm_prefix_flag_is_not_rewritten(tmp_path):
+    webapp = tmp_path / "webapp"
+    webapp.mkdir()
+    (webapp / "package.json").write_text("{}", encoding="utf-8")
+    command = "npm --prefix other test"
+    result = resolve_command_preflight(command, str(tmp_path))
+    assert result["rewritten"] is False
+    assert result["command"] == command
+    assert result["cwd"] == str(tmp_path)
+
+
+def test_env_prerequisite_failure_shapes():
+    assert (
+        classify_env_prerequisite_failure(
+            "python -m pytest",
+            1,
+            "ModuleNotFoundError: No module named 'pytest'",
+        )
+        == "env_prerequisite"
+    )
+    assert (
+        classify_env_prerequisite_failure(
+            "npm test",
+            1,
+            "npm ERR! enoent Could not read package.json: Error: ENOENT: "
+            "no such file or directory, open '/repo/package.json'",
+        )
+        == "env_prerequisite"
+    )
+    assert (
+        classify_env_prerequisite_failure(
+            "python x.py",
+            127,
+            "bash: python: command not found",
+        )
+        == "env_prerequisite"
+    )
+    assert (
+        classify_env_prerequisite_failure(
+            "python3 x.py",
+            1,
+            "ModuleNotFoundError: No module named 'yaml'",
+        )
+        is None
+    )
+    assert classify_env_prerequisite_failure("true", 0, "ok") is None
+    assert classify_env_prerequisite_failure("grep needle .", 1, "") is None
+
+
+def test_do_run_command_receives_rewritten_interpreter(tmp_path):
+    venv_py = _venv_python(tmp_path)
+    session = _dispatch_session(tmp_path)
+    act = PilotAction(kind="run_command", command="python -m pytest -q")
+    captured = {}
+
+    def fake_run(command, cwd=None, timeout=None, cancel_event=None):
+        captured["command"] = command
+        captured["cwd"] = cwd
+        return ("ok\n", 0, "ok")
+
+    with patch("harness.command_policy.run_cancellable", side_effect=fake_run):
+        ok, status, val = ToolDispatchMixin._do_run_command(session, act)
+
+    assert ok is True and status == "success"
+    assert captured["command"].split()[0] == str(venv_py)
+    assert "-m pytest -q" in captured["command"]
+    assert captured["cwd"] == str(tmp_path)
+    assert val["cwd"] == str(tmp_path)
+    assert val["rewritten"] is True
+    assert val.get("preflight_reason")
+    assert "failure_class" not in val
+
+
+def test_do_run_command_receives_webapp_cwd(tmp_path):
+    webapp = tmp_path / "webapp"
+    webapp.mkdir()
+    (webapp / "package.json").write_text("{}", encoding="utf-8")
+    session = _dispatch_session(tmp_path)
+    act = PilotAction(kind="run_command", command="npm test")
+    captured = {}
+
+    def fake_run(command, cwd=None, timeout=None, cancel_event=None):
+        captured["command"] = command
+        captured["cwd"] = cwd
+        return ("ok\n", 0, "ok")
+
+    with patch("harness.command_policy.run_cancellable", side_effect=fake_run):
+        ok, _status, val = ToolDispatchMixin._do_run_command(session, act)
+
+    assert ok is True
+    assert captured["command"] == "npm test"
+    assert captured["cwd"] == str(webapp)
+    assert val["cwd"] == str(webapp)
+    assert val["rewritten"] is True
+    assert "webapp" in (val.get("preflight_reason") or "")
+
+
+def test_do_run_command_sets_env_prerequisite_failure_class(tmp_path):
+    session = _dispatch_session(tmp_path)
+    act = PilotAction(kind="run_command", command="python -m pytest")
+    with patch(
+        "harness.command_policy.run_cancellable",
+        return_value=("ModuleNotFoundError: No module named 'pytest'\n", 1, "ok"),
+    ):
+        ok, status, val = ToolDispatchMixin._do_run_command(session, act)
+    assert ok is True and status == "success"
+    assert val["status"] == "ok" and val["exit_code"] == 1
+    assert val["failure_class"] == "env_prerequisite"
+    assert val.get("hint")
+    assert "rewritten" not in val
+
+
+def test_do_run_command_rewritten_and_failure_class_together(tmp_path):
+    venv_py = _venv_python(tmp_path)
+    session = _dispatch_session(tmp_path)
+    act = PilotAction(kind="run_command", command="python -m pytest")
+    captured = {}
+
+    def fake_run(command, cwd=None, timeout=None, cancel_event=None):
+        captured["command"] = command
+        return ("ModuleNotFoundError: No module named 'pytest'\n", 1, "ok")
+
+    with patch("harness.command_policy.run_cancellable", side_effect=fake_run):
+        ok, status, val = ToolDispatchMixin._do_run_command(session, act)
+    assert ok is True and status == "success"
+    assert captured["command"].split()[0] == str(venv_py)
+    assert val["rewritten"] is True
+    assert val["failure_class"] == "env_prerequisite"

--- a/tests/test_steer_images.py
+++ b/tests/test_steer_images.py
@@ -53,24 +53,43 @@ def test_text_only_steer_still_works(monkeypatch):
 def test_steer_native_vision_queues_prompt_skips_sidecar(monkeypatch):
     """gpt-5.6-luna-class pilots must not get a weaker sidecar paraphrase."""
     s = _session()
-    called = {"transcribe": 0}
-    queued = {}
+    called = {"transcribe": 0, "steer": 0}
+    queued = []
 
     def _boom(*_a, **_k):
         called["transcribe"] += 1
         raise AssertionError("sidecar must not run for native vision steer")
 
     def _queue(text, images=None, **_k):
-        queued["text"] = text
-        queued["images"] = list(images or [])
+        queued.append({"text": text, "images": list(images or [])})
         return {"id": "q1", "text": text}
+
+    def _steer(text):
+        called["steer"] += 1
+        raise AssertionError("vision busy Enter must not enqueue_steer a notice")
 
     monkeypatch.setattr("harness.vision.session_supports_native_images", lambda _s: True)
     monkeypatch.setattr("harness.vision.transcribe_images", _boom)
     s.enqueue_prompt = _queue
+    s.enqueue_steer = _steer
     s.steer_with_images("look at this", ["/tmp/shot.png"])
     assert called["transcribe"] == 0
-    assert queued.get("text") == "look at this"
-    assert queued.get("images") == ["/tmp/shot.png"]
-    nudge = s.drain_steer()
-    assert nudge and "native vision" in nudge[0].lower()
+    assert called["steer"] == 0
+    assert queued == [{"text": "look at this", "images": ["/tmp/shot.png"]}]
+    assert s.drain_steer() == []
+
+
+def test_steer_native_vision_images_only_is_queue_only(monkeypatch):
+    """Images-only on a vision pilot queues the placeholder; no steer chrome."""
+    s = _session()
+    queued = []
+
+    def _queue(text, images=None, **_k):
+        queued.append({"text": text, "images": list(images or [])})
+        return {"id": "q1", "text": text}
+
+    monkeypatch.setattr("harness.vision.session_supports_native_images", lambda _s: True)
+    s.enqueue_prompt = _queue
+    s.steer_with_images("", ["/tmp/shot.png"])
+    assert queued == [{"text": "(see attached image)", "images": ["/tmp/shot.png"]}]
+    assert s.drain_steer() == []

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.222",
+  "version": "0.9.223",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.222",
+      "version": "0.9.223",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.222",
+  "version": "0.9.223",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/investigationCollapser.seal.test.tsx
+++ b/webapp/src/__tests__/investigationCollapser.seal.test.tsx
@@ -254,3 +254,145 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
     expect(screen.getByText(/Still working/i)).toBeTruthy();
   });
 });
+
+describe("prior fold does not stay Investigating after steer flush", () => {
+  function runningCard(id: string, goal: string): Extract<Item, { kind: "card" }> {
+    return {
+      kind: "card",
+      card: {
+        id,
+        goal,
+        cwd: null,
+        kind: "read_file",
+        running: true,
+        open: false,
+      },
+    };
+  }
+
+  it("stale running / swarm_pending in the prior fold stay Explored while the live fold investigates", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "do the work" } },
+      runningCard("stale-card", "auth.ts"),
+      {
+        kind: "swarm_pending",
+        job_ids: ["job_stale"],
+        objective: "audit auth",
+        status: "running",
+      },
+      { kind: "steer", text: "also check billing" },
+      runningCard("live-card", "billing.ts"),
+    ];
+
+    render(
+      <TranscriptList
+        {...listProps(items, { turnOpen: true, status: "executing" })}
+      />,
+    );
+
+    const investigating = screen.getAllByText(/Investigating/i);
+    const explored = screen.getAllByText(/Explored/i);
+    expect(investigating).toHaveLength(1);
+    expect(explored).toHaveLength(1);
+  });
+
+  it("sealed prior cards never spin even when a later fold is live", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "do the work" } },
+      sealedCard("sealed-a", "auth.ts"),
+      sealedCard("sealed-b", "session.ts"),
+      { kind: "steer", text: "also check billing" },
+      runningCard("live-card", "billing.ts"),
+    ];
+
+    render(
+      <TranscriptList
+        {...listProps(items, { turnOpen: true, status: "executing" })}
+      />,
+    );
+
+    expect(screen.getAllByText(/Investigating/i)).toHaveLength(1);
+    expect(screen.getAllByText(/Explored/i)).toHaveLength(1);
+  });
+
+  it("prior-fold durable job shows quiet job still running, not a second Investigating", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "do the work" } },
+      {
+        kind: "card",
+        card: {
+          id: "durable-prior",
+          goal: "pytest",
+          cwd: null,
+          kind: "run_command",
+          running: true,
+          open: false,
+          result: { job_id: "local-cmd-1", status: "pending" },
+        },
+      },
+      { kind: "steer", text: "also check billing" },
+      runningCard("live-card", "billing.ts"),
+    ];
+
+    render(
+      <TranscriptList
+        {...listProps(items, { turnOpen: true, status: "executing" })}
+      />,
+    );
+
+    expect(screen.getAllByText(/Investigating/i)).toHaveLength(1);
+    expect(screen.getByText(/job still running/i)).toBeTruthy();
+    expect(screen.queryByText(/Explored/i)).toBeNull();
+  });
+
+  it("prior-fold swarm_pending only shows Swarm pending, not a second Investigating", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "do the work" } },
+      {
+        kind: "swarm_pending",
+        job_ids: ["job_stale"],
+        objective: "audit auth",
+        status: "running",
+      },
+      { kind: "steer", text: "also check billing" },
+      runningCard("live-card", "billing.ts"),
+    ];
+
+    render(
+      <TranscriptList
+        {...listProps(items, { turnOpen: true, status: "executing" })}
+      />,
+    );
+
+    expect(screen.getAllByText(/Investigating/i)).toHaveLength(1);
+    expect(screen.getByText(/Swarm · 1 pending/i)).toBeTruthy();
+    expect(screen.queryByText(/Explored/i)).toBeNull();
+  });
+
+  it("holdSwarmAwait cannot keep a prior swarm_pending fold Investigating", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "do the work" } },
+      {
+        kind: "swarm_pending",
+        job_ids: ["job_stale"],
+        objective: "audit auth",
+        status: "running",
+      },
+      { kind: "steer", text: "also check billing" },
+      runningCard("live-card", "billing.ts"),
+    ];
+
+    render(
+      <TranscriptList
+        {...listProps(items, {
+          turnOpen: true,
+          status: "awaiting_swarm",
+          holdSwarmAwait: true,
+        })}
+      />,
+    );
+
+    expect(screen.getAllByText(/Investigating/i)).toHaveLength(1);
+    expect(screen.getByText(/Swarm · 1 pending/i)).toBeTruthy();
+  });
+});

--- a/webapp/src/__tests__/thinkingStreamUx.test.ts
+++ b/webapp/src/__tests__/thinkingStreamUx.test.ts
@@ -9,6 +9,7 @@ import {
   upsertStreamingThinking,
 } from "../components/Conversation";
 import {
+  activityFoldInvestigating,
   activityGroupStableId,
   clearActivityFoldPrefs,
   groupAgentActivity,
@@ -965,6 +966,124 @@ describe("liveActivityGroupIndex fences prior turns", () => {
       },
     ];
     expect(liveActivityGroupIndex(grouped)).toBe(3);
+  });
+});
+
+describe("activityFoldInvestigating fences prior folds", () => {
+  const liveInputs = {
+    anyRunning: true,
+    liveThinking: false,
+    pausePoint: false,
+    swarmPendingRunning: true,
+    loopOpen: true,
+    hasFoldContent: true,
+  };
+
+  it("only the live fold reports Investigating from running / swarm leftover", () => {
+    expect(activityFoldInvestigating({ isLiveFold: true, ...liveInputs })).toBe(true);
+    expect(activityFoldInvestigating({ isLiveFold: false, ...liveInputs })).toBe(false);
+  });
+
+  it("stale running or swarm_pending on a prior fold never spins", () => {
+    expect(
+      activityFoldInvestigating({
+        isLiveFold: false,
+        anyRunning: true,
+        liveThinking: false,
+        pausePoint: false,
+        swarmPendingRunning: false,
+        loopOpen: false,
+        hasFoldContent: true,
+      }),
+    ).toBe(false);
+    expect(
+      activityFoldInvestigating({
+        isLiveFold: false,
+        anyRunning: false,
+        liveThinking: false,
+        pausePoint: false,
+        swarmPendingRunning: true,
+        loopOpen: false,
+        hasFoldContent: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("holdSwarmAwait / loopOpen cannot keep a prior fold Investigating", () => {
+    expect(
+      activityFoldInvestigating({
+        isLiveFold: false,
+        anyRunning: false,
+        liveThinking: true,
+        pausePoint: false,
+        swarmPendingRunning: true,
+        loopOpen: true,
+        hasFoldContent: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("steer flush: prior group with stale swarm, live group is the only Investigating fold", () => {
+    const staleSwarm: Item = {
+      kind: "swarm_pending",
+      job_ids: ["job_stale"],
+      objective: "audit auth",
+      status: "running",
+    };
+    const staleCard: Item = {
+      kind: "card",
+      card: {
+        id: "stale-card",
+        goal: "auth.ts",
+        cwd: null,
+        kind: "read_file",
+        running: true,
+        open: false,
+      },
+    };
+    const liveCard: Item = {
+      kind: "card",
+      card: {
+        id: "live-card",
+        goal: "billing.ts",
+        cwd: null,
+        kind: "read_file",
+        running: true,
+        open: false,
+      },
+    };
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "do the work" } },
+      staleCard,
+      staleSwarm,
+      { kind: "steer", text: "also check billing" },
+      liveCard,
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    const liveIdx = liveActivityGroupIndex(grouped);
+    const chrome = grouped.flatMap((g, idx) => {
+      if (g.kind !== "activity_group") return [];
+      const isLiveFold = idx === liveIdx;
+      const anyRunning = g.items.some((it) => it.kind === "card" && it.card.running);
+      const swarmPendingRunning = g.items.some(
+        (it) => it.kind === "swarm_pending" && (it.status || "running") === "running",
+      );
+      return [{
+        isLiveFold,
+        investigating: activityFoldInvestigating({
+          isLiveFold,
+          anyRunning,
+          liveThinking: false,
+          pausePoint: false,
+          swarmPendingRunning,
+          loopOpen: isLiveFold,
+          hasFoldContent: g.items.length > 0,
+        }),
+      }];
+    });
+    expect(chrome).toHaveLength(2);
+    expect(chrome[0]).toEqual({ isLiveFold: false, investigating: false });
+    expect(chrome[1]).toEqual({ isLiveFold: true, investigating: true });
   });
 });
 

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -33,6 +33,7 @@ import { splitStreamingMarkdown } from "../lib/streamMarkdown";
 import {
   aggregateExplorationSummary,
   cardEffectivelyRunning,
+  cardHasDurableJob,
   deriveBusyProgress,
   investigatingHeadline,
   resolveCardCliInput,
@@ -650,6 +651,34 @@ export function liveActivityGroupIndex(grouped: GroupedItem[]): number {
   return -1;
 }
 
+/**
+ * Investigating chrome is live-fold only. A prior fold may still hold a
+ * stale ``running`` card or leftover swarm_pending after a steer flush
+ * splits the turn — those must not keep a second Investigating spinner.
+ */
+export function activityFoldInvestigating(opts: {
+  isLiveFold: boolean;
+  anyRunning: boolean;
+  liveThinking: boolean;
+  pausePoint: boolean;
+  swarmPendingRunning: boolean;
+  loopOpen: boolean;
+  hasFoldContent: boolean;
+}): boolean {
+  if (!opts.isLiveFold) return false;
+  return (
+    opts.anyRunning
+    || opts.liveThinking
+    || (
+      !opts.pausePoint
+      && (
+        opts.swarmPendingRunning
+        || (opts.loopOpen && opts.hasFoldContent)
+      )
+    )
+  );
+}
+
 /** Stable React key for one investigation fold. Exported for unit tests. */
 export function activityGroupStableId(items: ActivityItem[], fallbackIndex: number): string {
   // Collect durable members (thinking ids first so a live reasoning stream that
@@ -1221,6 +1250,7 @@ export const TranscriptList = memo(function TranscriptList({
           key={key}
           groupId={openId}
           items={it.items}
+          isLiveFold={i === lastActivityGroupIdx}
           loopOpen={agentLoopOpen && i === lastActivityGroupIdx}
           pausePoint={pausePoint && i === lastActivityGroupIdx}
           onToggleCard={(card) => onSetCard(card.id, { open: !card.open })}
@@ -1407,6 +1437,7 @@ function ActivityGroup({
   groupId,
   loopOpen = false,
   pausePoint = false,
+  isLiveFold = false,
 }: {
   items: ActivityItem[];
   onToggleCard: (card: Card) => void;
@@ -1418,6 +1449,8 @@ function ActivityGroup({
    * do not keep a sticky Investigating spinner over settled tools.
    */
   pausePoint?: boolean;
+  /** True only for the live-index fold. Prior folds never show Investigating. */
+  isLiveFold?: boolean;
 }) {
   // Investigation chrome stays collapsed by default (Cursor/Hermes). The
   // headline still tracks Investigating / Explored while closed; the user
@@ -1473,16 +1506,19 @@ function ActivityGroup({
   // A running swarm_pending is itself live investigation chrome.
   // Pause-point (awaiting_swarm / hold): seal sticky Investigating so the fold
   // shows Explored while StatusPill / busy footer own Still working….
-  const investigating =
-    anyRunning
-    || liveThinking
-    || (
-      !pausePoint
-      && (
-        swarmPendingRunning
-        || (loopOpen && (actionCount > 0 || thinkingItems.length > 0 || swarmPendingItems.length > 0))
-      )
-    );
+  // Prior folds (steer-flushed leftover running / swarm cards) stay Explored.
+  const durableJobRunning = cards.some(
+    (c) => cardHasDurableJob(c.card) && cardEffectivelyRunning(c.card),
+  );
+  const investigating = activityFoldInvestigating({
+    isLiveFold,
+    anyRunning,
+    liveThinking,
+    pausePoint,
+    swarmPendingRunning,
+    loopOpen,
+    hasFoldContent: actionCount > 0 || thinkingItems.length > 0 || swarmPendingItems.length > 0,
+  });
 
   // A group with NO tool actions, no narration AND no reasoning (just a lone
   // CodeGraph chip from the per-step auto-injection) would render a misleading
@@ -1677,11 +1713,15 @@ function ActivityGroup({
   // disagreed with Cursor/Hermes (collapsed until the user opens them).
 
   const quietSummary = (() => {
+    if (!investigating && !isLiveFold && durableJobRunning) return "job still running";
     if (actionCount > 0) return stepHeadline;
     if (swarmResults.length > 0) {
       return `Swarm · ${swarmResults.length} result${swarmResults.length === 1 ? "" : "s"}`;
     }
     if (swarmPendingItems.length > 0) {
+      if (!isLiveFold) {
+        return `Swarm · ${swarmPendingItems.length} pending`;
+      }
       return swarmPendingRunning ? "Swarm · running" : `Swarm · ${swarmPendingItems.length} pending`;
     }
     if (investigating) return stepHeadline || "Investigating…";


### PR DESCRIPTION
## Summary
- Vision + busy Enter queues the next turn only (`enqueue_prompt`); no mid-turn steer notice, so STEER and QUE no longer paint together.
- Prior activity folds cannot stay Investigating from leftover running cards or `swarm_pending`; only the live fold spins. Quiet durable-job / Swarm pending cues remain.
- `run_command` preflights unambiguous `.venv` interpreter and `webapp/` cwd rewrites before launch, and tags env-gap failures as `failure_class=env_prerequisite`.

## Test plan
- [x] Focused pytest: `test_command_preflight.py`, `test_steer_images.py`, `test_version_consistency.py`, dispatch suites
- [x] Full local pytest: 4316 passed, 74 skipped
- [x] Focused vitest: investigationCollapser.seal + thinkingStreamUx (63)
- [x] `tsc -b`
- [ ] CI `tests` workflow green on the merged `main` SHA (3.9 + 3.11 + Windows + frontend-build) before tagging `v0.9.223`