### PR TITLE
Release v0.9.224: live-first catalogs, GLM-5.3, orphaned-pilot swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.2` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.223, deliberately pre-1.0. Vision+busy Enter queues the next turn (no steer+QUE). Prior Investigating folds seal; only the live fold spins. `run_command` preflights `.venv` / `webapp/` before doomed interpreter or cwd launches. Rides puppetmaster-ai==1.22.2.
+> Status: v0.9.224, deliberately pre-1.0. Settings catalogs are live-first and promote family version bumps (glm-5.2 → glm-5.3) without a per-provider curated edit. Turning a provider off reseats the composer onto a still-listed model. Z.AI defaults to the GLM Coding Plan host. Rides puppetmaster-ai==1.22.2.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.223"
+__version__ = "0.9.224"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/providers.py
+++ b/harness/api/providers.py
@@ -99,7 +99,7 @@ def get_providers() -> tuple[int, list]:
             "name": p.name,
             "display_name": getattr(p, "display_name", "") or p.name,
             "env_var": p.env_vars[0] if p.env_vars else "",
-            "base_url": p.base_url,
+            "base_url": p.resolved_base_url() if hasattr(p, "resolved_base_url") else p.base_url,
             "has_key": (get_provider_key(p) is not None) or status["has_key"],
             "masked": status["masked"],
             "api_mode": p.api_mode,
@@ -167,12 +167,12 @@ def post_providers_key(body: dict, svc: ProviderServices) -> tuple[int, dict]:
         # models.json is pruned without a backend restart.
         from ..auto_registry import sync_agentic_registry_safe
         sync_agentic_registry_safe()
-        # Keep the active driver honest: enabling may make a better model
-        # reachable; disabling may kill the current one.
+        # Always re-seat the active driver against the live picker. Disabling
+        # OpenRouter must not leave deepseek-v4-flash selected when only GLM
+        # remains; enabling a provider may also make the saved driver valid.
+        sync = {}
         try:
-            if not svc.driver_provider_available(svc.cfg.driver):
-                svc.resolve_available_driver()
-                svc.rebuild_pilot_and_session()
+            sync = svc.resync_driver_after_model_curation() or {}
         except Exception as e:
             svc.diag("server.provider_toggle_driver_rebuild", e)
         status = get_api_key_status(p.name)
@@ -183,6 +183,8 @@ def post_providers_key(body: dict, svc: ProviderServices) -> tuple[int, dict]:
             "has_key": status["has_key"],
             "masked": status["masked"],
             "disconnected": p.name in get_disconnected(),
+            "driver": sync.get("driver") or svc.cfg.driver,
+            "driver_changed": bool(sync.get("changed")),
         }
     if action == "clear" or body.get("clear") is True:
         clear_api_key(p.name)
@@ -192,15 +194,10 @@ def post_providers_key(body: dict, svc: ProviderServices) -> tuple[int, dict]:
         scrub_provider_env(p.name)
         from ..auto_registry import sync_agentic_registry_safe
         sync_agentic_registry_safe()
-        # If the active driver's provider is no longer available (we just
-        # disconnected the provider backing it -- whether a 'provider:model'
-        # spec OR a bare name routed through the reach), re-resolve to the
-        # first available enabled model and rebuild, so the app never sits
-        # on a dead driver.
+        # Clearing a key is the same as disable for the picker: drop a
+        # now-unlistable driver instead of leaving it selected.
         try:
-            if not svc.driver_provider_available(svc.cfg.driver):
-                svc.resolve_available_driver()
-                svc.rebuild_pilot_and_session()
+            svc.resync_driver_after_model_curation()
         except Exception as e:
             svc.diag("server.provider_clear_driver_rebuild", e)
     else:
@@ -217,12 +214,17 @@ def post_providers_key(body: dict, svc: ProviderServices) -> tuple[int, dict]:
         # Resync agentic registry when a provider key is set
         from ..auto_registry import sync_agentic_registry_safe
         sync_agentic_registry_safe()
+        try:
+            svc.resync_driver_after_model_curation()
+        except Exception as e:
+            svc.diag("server.provider_set_driver_rebuild", e)
     status = get_api_key_status(p.name)
     return 200, {
         "ok": True,
         "provider": p.name,
         "has_key": status["has_key"],
         "masked": status["masked"],
+        "driver": svc.cfg.driver,
     }
 
 

--- a/harness/api/settings.py
+++ b/harness/api/settings.py
@@ -138,7 +138,11 @@ def post_settings(body: dict, svc: SettingsServices) -> tuple[int, JsonPayload]:
                 svc.resolve_available_driver()
         except Exception:
             pass
-        svc.rebuild_pilot_and_session()
+        # Clearing the last key can leave no runnable replacement. Skip
+        # rebuild so Settings disconnect returns 200 instead of 500.
+        driver = str(getattr(svc.cfg, "driver", "") or "")
+        if driver.startswith("stub") or svc.driver_provider_available(driver):
+            svc.rebuild_pilot_and_session()
         from ..auto_registry import sync_agentic_registry_safe
         sync_agentic_registry_safe()
 

--- a/harness/auto_registry.py
+++ b/harness/auto_registry.py
@@ -103,7 +103,9 @@ _KNOWN_MODEL_SPECS = {
     "deepseek/deepseek-v4-pro": (80, 0.435, 0.87, 1000000, ["balanced", "code", "reasoning", "long-context"]),
     "minimax/minimax-m3": (79, 0.098, 1.21, 1000000, ["balanced", "code", "vision", "long-context"]),
     "moonshotai/kimi-k3": (98, 3.0, 15.0, 1000000, ["frontier", "code", "vision", "agent-loop"]),
+    "z-ai/glm-5.3": (86, 1.0, 3.5, 1000000, ["quality", "code", "reasoning", "long-context"]),
     "z-ai/glm-5.2": (86, 1.0, 3.5, 1000000, ["quality", "code", "reasoning", "long-context"]),
+    "glm-5.3": (86, 1.0, 3.5, 1000000, ["quality", "code", "reasoning", "long-context"]),
     "anthropic/claude-opus-4.8": (99, 5.0, 25.0, 1000000, ["frontier", "reasoning", "code", "vision", "long-context"]),
 }
 
@@ -132,6 +134,7 @@ _CURATED_MODELS = {
         ("minimax/minimax-m3", "balanced", "minimax/minimax-m3"),
         ("deepseek/deepseek-v4-pro", "balanced", "deepseek/deepseek-v4-pro"),
         ("moonshotai/kimi-k3", "frontier", "moonshotai/kimi-k3"),
+        ("z-ai/glm-5.3", "frontier", "z-ai/glm-5.3"),
         ("z-ai/glm-5.2", "balanced", "z-ai/glm-5.2"),
     ],
     "deepseek": [
@@ -139,6 +142,7 @@ _CURATED_MODELS = {
         ("deepseek-reasoner", "balanced", "deepseek-reasoner"),
     ],
     "zai": [
+        ("glm-5.3", "frontier", "glm-5.3"),
         ("glm-5.2", "balanced", "glm-5.2"),
         ("glm-4.7-flash", "cheap", "glm-4.7-flash"),
     ],
@@ -195,7 +199,7 @@ def _opencode_go_curated() -> list[tuple[str, str, str]]:
         if not bare:
             continue
         n = bare.lower()
-        if any(tok in n for tok in ("kimi-k3", "grok-4.6", "grok-4.5", "gpt-5.6-sol", "glm-5.2")):
+        if any(tok in n for tok in ("kimi-k3", "grok-4.6", "grok-4.5", "gpt-5.6-sol", "glm-5.3", "glm-5.2")):
             tier = "frontier"
         elif "flash" in n or n.endswith("-plus") or n in ("hy3", "mimo-v2.5"):
             tier = "cheap"
@@ -364,7 +368,8 @@ def _in_live_catalog(name: str, slug: str, live_models: list[str]) -> bool:
 
 
 def _known_spec_for(model_name: str, slug: str):
-    """Static economics for a wire id, rolling slug, or dated family sibling."""
+    """Static economics for a wire id, rolling slug, dated sibling, or
+    a newer dotted/hyphen family bump (``glm-5.3`` inherits ``glm-5.2``)."""
     for key in (model_name, slug):
         spec = _KNOWN_MODEL_SPECS.get(key)
         if spec:
@@ -375,7 +380,41 @@ def _known_spec_for(model_name: str, slug: str):
             spec = _KNOWN_MODEL_SPECS.get(family)
             if spec:
                 return spec
-    return None
+    try:
+        from .model_visibility import inherit_family_spec
+        return inherit_family_spec(model_name, slug, _KNOWN_MODEL_SPECS)
+    except Exception:
+        return None
+
+
+def _with_family_promotions(
+    result: list,
+    curated: list,
+    live_models: list,
+    tier_of,
+    *,
+    slug_fn=None,
+) -> list:
+    """Append live ids that are a newer X.Y of a curated or already-selected family."""
+    try:
+        from .model_visibility import promote_newer_family_versions
+    except Exception:
+        return list(result)
+    known = []
+    seen = set()
+    for name, _tier, slug in list(result) + list(curated):
+        known.append(name)
+        known.append(slug)
+        seen.add(name)
+        seen.add(slug)
+    extra = []
+    for newer in promote_newer_family_versions(known, live_models):
+        if newer in seen:
+            continue
+        seen.add(newer)
+        slug = slug_fn(newer) if slug_fn else newer
+        extra.append((newer, tier_of(newer), slug))
+    return list(result) + extra
 
 
 def _get_provider_models_from_discovery(
@@ -530,8 +569,9 @@ def _get_provider_models_from_discovery(
 
         if provider_name == "openrouter":
             # Curated ladder intersect live catalog. Dated siblings promote
-            # onto stable slugs. Do not dump the first N live extras — that
-            # is how MIMO and other untoggled OpenRouter ids entered Autopilot.
+            # onto stable slugs. Newer family versions of those curated
+            # rows (glm-5.2 → glm-5.3) come in from live. Do not dump the
+            # first N live extras — that is how MIMO entered Autopilot.
             curated_promoted = _promote_openrouter_snapshots(
                 list(curated), live_models,
             )
@@ -539,6 +579,8 @@ def _get_provider_models_from_discovery(
                 item for item in curated_promoted
                 if _in_live_catalog(item[0], item[2], live_models)
             ]
+            result = _with_family_promotions(result, curated, live_models, _tier_of)
+            return result
         elif provider_name == "openai-codex":
             # Keep curated Codex ladder even when live discovery returns a
             # partial list (or a different naming wave).
@@ -551,8 +593,19 @@ def _get_provider_models_from_discovery(
                 item for item in curated
                 if _in_live_catalog(item[0], item[2], live_models)
             ]
-        if provider_name == "openrouter":
-            return result
+            result = _with_family_promotions(result, curated, live_models, _tier_of)
+        else:
+            result = _with_family_promotions(
+                result, curated, live_models, _tier_of,
+            )
+            if provider_name != "bedrock":
+                # Curated seeds that /models has not listed yet (Coding Plan
+                # serving glm-5.3 while the listing still stops at 5.2).
+                seen_ids = {item[0] for item in result} | {item[2] for item in result}
+                result.extend(
+                    item for item in curated
+                    if item[0] not in seen_ids and item[2] not in seen_ids
+                )
         return result if result else list(curated)
     except Exception as e:
         _diag("auto_registry.discovery", e, msg=f"provider={provider_name}")
@@ -604,6 +657,15 @@ def _reset_live_price_stats() -> None:
     global _LIVE_PRICE_APPLIED, _LIVE_PRICE_FALLBACK
     _LIVE_PRICE_APPLIED = 0
     _LIVE_PRICE_FALLBACK = 0
+
+
+def _zai_coding_plan_billing() -> bool:
+    """GLM Coding Plan is subscription credits — $0 marginal like OpenCode Go."""
+    try:
+        from .providers import zai_uses_coding_plan
+        return bool(zai_uses_coding_plan())
+    except Exception:
+        return True
 
 
 def _build_agentic_spec(provider_name: str, model_name: str, tier: str, slug: str) -> dict:
@@ -660,7 +722,10 @@ def _build_agentic_spec(provider_name: str, model_name: str, tier: str, slug: st
         # Plan OAuth / subscription providers: $0 marginal; nominal rates above
         # are for router ranking only. Cash API keys stay billing=api.
         "billing": (
-            "plan" if provider_name in ("openai-codex", "opencode-go") else "api"
+            "plan"
+            if provider_name in ("openai-codex", "opencode-go")
+            or (provider_name == "zai" and _zai_coding_plan_billing())
+            else "api"
         ),
     }
 

--- a/harness/credential_pool.py
+++ b/harness/credential_pool.py
@@ -597,6 +597,9 @@ _ENV_TO_PROVIDER = {
     "DEEPSEEK_API_KEY": "deepseek",
     "MISTRAL_API_KEY": "mistral",
     "OPENCODE_GO_API_KEY": "opencode-go",
+    "GLM_API_KEY": "zai",
+    "ZAI_API_KEY": "zai",
+    "Z_AI_API_KEY": "zai",
 }
 
 # Extra pools that also satisfy a driver env (OAuth sibling ids).
@@ -616,6 +619,7 @@ _PROVIDER_TO_ENV = {
     "cursor": "CURSOR_API_KEY",
     "xai": "XAI_API_KEY",
     "opencode-go": "OPENCODE_GO_API_KEY",
+    "zai": "GLM_API_KEY",
 }
 
 # Additional env vars to mirror so classic pilots see OAuth tokens.

--- a/harness/keys.py
+++ b/harness/keys.py
@@ -526,6 +526,12 @@ def set_provider_enabled(reach: str, enabled: bool) -> None:
                     os.environ[ev] = val
         elif stored and isinstance(stored, str):
             os.environ[get_env_var_for_reach(reach)] = stored
+            if reach == "zai":
+                try:
+                    from .providers import ensure_zai_worker_base_url
+                    ensure_zai_worker_base_url()
+                except Exception:
+                    pass
         else:
             for ev, val in _ENV_KEY_CACHE.get(reach, {}).items():
                 os.environ[ev] = val
@@ -646,6 +652,12 @@ def set_api_key(reach: str, value: str):
                 del os.environ[env_var]
         else:
             os.environ[env_var] = value
+            if reach == "zai":
+                try:
+                    from .providers import ensure_zai_worker_base_url
+                    ensure_zai_worker_base_url()
+                except Exception:
+                    pass
             # Reconnecting clears the explicit-disconnect flag.
             unmark_disconnected(reach)
             # Keep the credential pool in sync so multi-key rotation can include
@@ -768,6 +780,16 @@ def load_api_keys_on_startup(reach: str):
             env_var = get_env_var_for_reach(name)
             if env_var:
                 os.environ[env_var] = value
+    if any(
+        isinstance(value, str) and value.strip() and not is_placeholder_credential(value)
+        for name, value in keys.items()
+        if name == "zai"
+    ):
+        try:
+            from .providers import ensure_zai_worker_base_url
+            ensure_zai_worker_base_url()
+        except Exception:
+            pass
     # Capture env-provided keys before scrubbing so a toggled-off provider can be
     # re-enabled later in the same session without re-pasting the key.
     snapshot_env_keys()

--- a/harness/model_fetch.py
+++ b/harness/model_fetch.py
@@ -298,10 +298,12 @@ def _fetch_provider_models(provider, key: str) -> list[Any]:
                 )
             return ids
         if name in ("openai", "deepseek", "zai", "xai", "nvidia"):
-            # OpenAI-compatible /models listing.
-            base = provider.base_url.rstrip("/")
+            # OpenAI-compatible /models listing. Accept id or name so a
+            # vendor envelope that only stamps `name` still surfaces.
+            resolver = getattr(provider, "resolved_base_url", None)
+            base = (resolver() if callable(resolver) else provider.base_url).rstrip("/")
             data = _get(base + "/models", {"Authorization": f"Bearer {key}"})
-            return [m["id"] for m in data.get("data", []) if m.get("id")]
+            return _flat_catalog_ids(data)
         if name == "gemini":
             # Gemini native listing (not the OpenAI-compat shim base_url).
             data = _get(
@@ -435,3 +437,96 @@ def fetch_models(provider, key: str, *, force: bool = False) -> list[str]:
     """Live model ids for a keyed provider, memoized in-process and cached on
     disk with a TTL. Returns [] on total failure (caller merges with curated)."""
     return [record["id"] for record in fetch_model_records(provider, key, force=force)]
+
+
+# Direct-vendor Settings lists can lag the model the account already serves
+# (Z.AI Coding Plan listing glm-5.2 while glm-5.3 is live). OpenRouter's
+# public catalog is a second discovery source; we only take the vendor
+# namespace, never dump the whole OR field.
+_OR_VENDOR_PREFIX = {
+    "zai": "z-ai/",
+    "anthropic": "anthropic/",
+    "openai": "openai/",
+    "deepseek": "deepseek/",
+    "xai": "x-ai/",
+    "minimax": "minimax/",
+    "gemini": "google/",
+}
+
+_OPENROUTER_PUBLIC_CACHE = "openrouter_public"
+
+
+def _openrouter_cached_ids() -> list[str]:
+    records = _RECORD_MEM.get("openrouter") or []
+    if records:
+        return [record["id"] for record in records if record.get("id")]
+    return [
+        record["id"]
+        for record in _cached_records(_read_cache().get("openrouter"))
+        if record.get("id")
+    ]
+
+
+def _fetch_openrouter_public_ids() -> list[str]:
+    """Unauthenticated OpenRouter /models; cached like other provider lists."""
+    if os.environ.get("PMHARNESS_LIVE_MODELS", "1") == "0":
+        return []
+    now = time.time()
+    disk = _read_cache()
+    entry = disk.get(_OPENROUTER_PUBLIC_CACHE)
+    cached = _cached_records(entry)
+    if cached and (now - entry.get("fetched_at", 0)) < _CACHE_TTL:
+        return [record["id"] for record in cached if record.get("id")]
+    try:
+        data = _get(
+            "https://openrouter.ai/api/v1/models",
+            {"User-Agent": "pm-harness"},
+        )
+        items = data.get("data") if isinstance(data, dict) else None
+        if not isinstance(items, list):
+            return [record["id"] for record in cached if record.get("id")]
+        fresh = [
+            record
+            for item in items
+            if isinstance(item, dict)
+            for record in [_normalize_openrouter_record(item, source="live")]
+            if record and _is_chat_model(record["id"])
+        ]
+        if fresh:
+            disk[_OPENROUTER_PUBLIC_CACHE] = {"fetched_at": now, "models": fresh}
+            _write_cache(disk)
+            return [record["id"] for record in fresh]
+    except Exception as e:
+        _diag("model_fetch.openrouter_public", e)
+    return [record["id"] for record in cached if record.get("id")]
+
+
+def vendor_ids_from_openrouter(provider_name: str, *, force: bool = False) -> list[str]:
+    """Bare vendor ids from a cached or public OpenRouter catalog.
+
+    Cache-only on a normal load (no extra network). Settings refresh
+    (``force=True``) may hit the public listing when no keyed OR cache
+    exists so a Z.AI-only install can still see ``glm-5.3``.
+    """
+    prefix = _OR_VENDOR_PREFIX.get(provider_name)
+    if not prefix:
+        return []
+    try:
+        ids = _openrouter_cached_ids()
+        if not ids and force:
+            ids = _fetch_openrouter_public_ids()
+        out = []
+        seen = set()
+        for mid in ids:
+            raw = str(mid or "").strip()
+            if not raw.lower().startswith(prefix):
+                continue
+            bare = raw[len(prefix):]
+            if not bare or not _is_chat_model(bare) or bare in seen:
+                continue
+            seen.add(bare)
+            out.append(bare)
+        return out
+    except Exception as e:
+        _diag("model_fetch.or_vendor_overlay", e, msg=f"provider={provider_name}")
+        return []

--- a/harness/model_visibility.py
+++ b/harness/model_visibility.py
@@ -13,10 +13,127 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import threading
 from typing import Optional
 
 _LOCK = threading.Lock()
+
+# Dotted (glm-5.2, grok-4.6-fast) then hyphen (claude-opus-4-8). Prefix +
+# suffix are the family; only a higher (major, minor) is a promotion.
+_DOTTED_FAMILY = re.compile(
+    r"^(?P<prefix>.*?)(?P<major>\d+)\.(?P<minor>\d+)(?P<suffix>.*)$"
+)
+_HYPHEN_FAMILY = re.compile(
+    r"^(?P<prefix>.*?)(?P<major>\d+)-(?P<minor>\d+)(?P<suffix>.*)$"
+)
+
+
+def bare_model_id(model_id: str) -> str:
+    """Strip a vendor namespace (``z-ai/glm-5.3`` → ``glm-5.3``)."""
+    raw = str(model_id or "").strip()
+    if "/" in raw:
+        return raw.rsplit("/", 1)[-1]
+    return raw
+
+
+def parse_family_version(model_id: str):
+    """Return ``(prefix, major, minor, suffix)`` or None.
+
+    Matching is on the bare id so ``z-ai/glm-5.2`` and ``glm-5.2`` are the
+    same family. ``kimi-k3`` and ``xiaomi/mimo-v2-flash`` do not parse.
+    """
+    bare = bare_model_id(model_id)
+    if not bare:
+        return None
+    match = _DOTTED_FAMILY.match(bare) or _HYPHEN_FAMILY.match(bare)
+    if not match:
+        return None
+    return (
+        match.group("prefix").lower(),
+        int(match.group("major")),
+        int(match.group("minor")),
+        match.group("suffix").lower(),
+    )
+
+
+def _emit_in_known_form(known_id: str, candidate_id: str) -> str:
+    """Keep the provider's id shape: prefixed for OpenRouter, bare for vendors."""
+    cand_bare = bare_model_id(candidate_id)
+    known = str(known_id or "").strip()
+    if "/" in known and "/" not in candidate_id:
+        return known.rsplit("/", 1)[0] + "/" + cand_bare
+    if "/" not in known and "/" in candidate_id:
+        return cand_bare
+    return str(candidate_id or "").strip() or cand_bare
+
+
+def promote_newer_family_versions(known_ids, candidate_ids) -> list:
+    """Live (or overlay) ids that are a newer X.Y of an already-known family.
+
+    ``glm-5.2`` + live ``glm-5.3`` → ``glm-5.3``. Different families
+    (``moonshotai/kimi-k3`` vs ``xiaomi/mimo-v2-flash``) never promote.
+    """
+    parsed_known = []
+    known_set = set()
+    for kid in known_ids or []:
+        raw = str(kid or "").strip()
+        if not raw:
+            continue
+        known_set.add(raw)
+        known_set.add(bare_model_id(raw))
+        parsed = parse_family_version(raw)
+        if parsed:
+            parsed_known.append((raw, parsed))
+    if not parsed_known:
+        return []
+    out = []
+    seen = set()
+    for cid in candidate_ids or []:
+        raw = str(cid or "").strip()
+        if not raw:
+            continue
+        parsed = parse_family_version(raw)
+        if not parsed:
+            continue
+        prefix, major, minor, suffix = parsed
+        for known_id, (kprefix, kmajor, kminor, ksuffix) in parsed_known:
+            if prefix != kprefix or suffix != ksuffix:
+                continue
+            if (major, minor) <= (kmajor, kminor):
+                continue
+            emitted = _emit_in_known_form(known_id, raw)
+            if not emitted or emitted in seen or emitted in known_set:
+                continue
+            if bare_model_id(emitted) in known_set:
+                continue
+            seen.add(emitted)
+            out.append(emitted)
+            break
+    return out
+
+
+def inherit_family_spec(model_name: str, slug: str, specs: dict):
+    """Newest known spec in the same family at or below this version."""
+    target = parse_family_version(model_name) or parse_family_version(slug)
+    if not target or not specs:
+        return None
+    prefix, major, minor, suffix = target
+    best = None
+    best_ver = None
+    for key, spec in specs.items():
+        parsed = parse_family_version(key)
+        if not parsed:
+            continue
+        kprefix, kmajor, kminor, ksuffix = parsed
+        if kprefix != prefix or ksuffix != suffix:
+            continue
+        if (kmajor, kminor) <= (major, minor) and (
+            best_ver is None or (kmajor, kminor) > best_ver
+        ):
+            best_ver = (kmajor, kminor)
+            best = spec
+    return best
 
 
 def _store_path() -> str:
@@ -91,11 +208,14 @@ def toggle(spec: str, on: bool) -> list:
 
 
 def provider_models(p, *, force: bool = False) -> list:
-    """All selectable model ids for a provider: its LIVE catalog (fetched from
-    the provider's own listing endpoint when a key is present) merged with the
-    curated pilot_models fallback for providers that support it. OpenRouter's
-    keyed catalog is authoritative and therefore never gains curated entries
-    after an empty or failed live fetch."""
+    """Selectable model ids for a provider.
+
+    Keyed providers are live-first: the vendor listing leads, then newer
+    family versions discovered via live or an OpenRouter vendor overlay
+    (``glm-5.2`` → ``glm-5.3``), then curated ids that listing has not
+    published yet. OpenRouter stays live-only once keyed — an empty or
+    failed fetch must not be disguised with the static list.
+    """
     curated = list(p.pilot_models)
     live = []
     keyed = False
@@ -111,15 +231,28 @@ def provider_models(p, *, force: bool = False) -> list:
     # failed response must not be disguised with the curated static list.
     if p.name == "openrouter" and keyed:
         return list(dict.fromkeys(m for m in live if m))
+    extras = []
+    if keyed:
+        try:
+            from .model_fetch import vendor_ids_from_openrouter
+            extras = vendor_ids_from_openrouter(p.name, force=force)
+        except Exception:
+            extras = []
+    live_set = set(live)
+    known = list(dict.fromkeys([m for m in list(curated) + list(live) if m]))
+    promoted = promote_newer_family_versions(
+        known, list(dict.fromkeys([m for m in list(live) + list(extras) if m])),
+    )
+    if live:
+        ordered = (
+            list(live)
+            + [m for m in promoted if m not in live_set]
+            + [m for m in curated if m not in live_set and m not in set(promoted)]
+        )
+    else:
+        ordered = list(curated)
     seen = set()
     merged = []
-    # Plan/subscription catalogs (Cursor CLI, OpenCode Go) rotate faster than
-    # the curated fallback, so a successful live listing leads and curated only
-    # backfills. An empty or failed listing still leaves curated in place.
-    if getattr(p, "api_mode", "") in ("cursor_cli", "opencode_go") and live:
-        ordered = list(live) + [m for m in curated if m not in set(live)]
-    else:
-        ordered = list(curated) + list(live)
     for m in ordered:
         if m and m not in seen:
             seen.add(m)
@@ -132,8 +265,8 @@ def catalog(available_only: bool = True, *, force: bool = False) -> list:
         {provider, provider_display, model, spec, available, enabled}
 
     spec is the 'provider:model' string the picker uses. When available_only is
-    True, only providers with a present key are included. Non-OpenRouter
-    providers retain their curated fallback; keyed OpenRouter uses live data.
+    True, only providers with a present key are included. Keyed providers are
+    live-first with curated backfill; keyed OpenRouter uses live data only.
     """
     from . import providers as prov
     enabled = set(get_enabled())

--- a/harness/opencode_go.py
+++ b/harness/opencode_go.py
@@ -43,6 +43,7 @@ OPENAI_RESPONSES = "openai_responses"
 CURATED_MODELS = (
     "grok-4.6",
     "grok-4.5",
+    "glm-5.3",
     "glm-5.2",
     "glm-5.1",
     "gpt-5.6-luna",
@@ -156,8 +157,15 @@ def temperature_for_model(model: Optional[str], requested: float = 0.0) -> float
     return float(requested)
 
 
+def _is_glm_5_3(bare: str) -> bool:
+    """GLM-5.3 across the alias spellings config files carry."""
+    return any(token in bare for token in ("glm-5.3", "glm-5-3", "glm-5p3"))
+
+
 def _is_glm_5_2(bare: str) -> bool:
     """GLM-5.2 across the alias spellings config files carry."""
+    if _is_glm_5_3(bare):
+        return False
     return any(token in bare for token in ("glm-5.2", "glm-5-2", "glm-5p2"))
 
 
@@ -178,6 +186,9 @@ def reasoning_body_extras(model: Optional[str], effort: Optional[str] = None) ->
     Each family speaks a different dialect and rejects the others, so the
     mapping is per-family rather than one shared knob:
 
+    - GLM-5.3 requires ``thinking.type=enabled`` and accepts
+      ``reasoning_effort`` of ``low`` / ``high`` / ``max``. UI ``none``
+      maps to ``low`` — omitting thinking fails the request.
     - GLM-5.2 exposes ``reasoning_effort`` with only ``high`` and ``max``
       enabled, so Marionette's richer scale collapses onto those two.
     - Kimi K2 and DeepSeek accept ``thinking`` (a binary toggle) OR
@@ -195,6 +206,15 @@ def reasoning_body_extras(model: Optional[str], effort: Optional[str] = None) ->
     level = normalize_reasoning_effort(
         effort if effort is not None else current_reasoning_effort()
     )
+
+    if _is_glm_5_3(bare):
+        if level in ("none", "low"):
+            effort = "low"
+        elif level in _MAXED_EFFORTS:
+            effort = "max"
+        else:
+            effort = "high"
+        return {"thinking": {"type": "enabled"}, "reasoning_effort": effort}
 
     if _is_glm_5_2(bare):
         if level == "none":

--- a/harness/providers.py
+++ b/harness/providers.py
@@ -28,6 +28,40 @@ from typing import Optional
 
 from . import opencode_go as _opencode_go
 
+# GLM Coding Plan (subscription credits) vs pay-as-you-go API. Official docs:
+# Coding Plan OpenAI Chat Completions must use /api/coding/paas/v4 — the
+# general /api/paas/v4 host cannot burn weekly plan credits.
+ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+ZAI_PAYG_BASE_URL = "https://api.z.ai/api/paas/v4"
+ZAI_BASE_URL_ENVS = ("ZAI_BASE_URL", "GLM_BASE_URL")
+
+
+def zai_resolved_base_url() -> str:
+    """Z.AI OpenAI-compat root: env override, else the Coding Plan host."""
+    for ev in ZAI_BASE_URL_ENVS:
+        override = (os.environ.get(ev) or "").strip()
+        if override:
+            return override.rstrip("/")
+    return ZAI_CODING_BASE_URL
+
+
+def zai_uses_coding_plan(base_url=None) -> bool:
+    """True when the resolved Z.AI URL is the Coding Plan Chat Completions host."""
+    url = (base_url or zai_resolved_base_url()).rstrip("/").lower()
+    return "/coding/" in url
+
+
+def ensure_zai_worker_base_url() -> None:
+    """Stamp ZAI_BASE_URL so Puppetmaster workers share the pilot host.
+
+    The desktop pin still defaults Z.AI to pay-as-you-go. Setting this env
+    (when the user has not already overridden it) points workers at Coding
+    Plan credits without waiting for a kernel bump.
+    """
+    if any((os.environ.get(ev) or "").strip() for ev in ZAI_BASE_URL_ENVS):
+        return
+    os.environ["ZAI_BASE_URL"] = ZAI_CODING_BASE_URL
+
 
 @dataclass(frozen=True)
 class Provider:
@@ -128,6 +162,12 @@ class Provider:
     @property
     def available(self) -> bool:
         return self.key() is not None
+
+    def resolved_base_url(self) -> str:
+        """Wire root for this provider, honoring Z.AI Coding Plan overrides."""
+        if self.name == "zai":
+            return zai_resolved_base_url()
+        return self.base_url
 
 # ── Provider profiles (data adapted from Hermes model-provider plugins, MIT) ──
 # OpenRouter intentionally first: one key fans out to the whole open field.
@@ -255,9 +295,9 @@ PROVIDERS = (
     Provider(
         name="zai", aliases=("glm", "z-ai", "zhipu"),
         env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
-        base_url="https://api.z.ai/api/paas/v4",
+        base_url=ZAI_CODING_BASE_URL,
         api_mode="chat_completions", display_name="Z.AI (GLM)",
-        pilot_models=("glm-5.2", "glm-4.7-flash"),
+        pilot_models=("glm-5.3", "glm-5.2", "glm-4.7-flash"),
     ),
     Provider(
         name="minimax", aliases=("mini-max",),
@@ -532,9 +572,19 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
                 name=spec, model=model, max_tokens=max_tokens, cwd=cwd,
             )
         )
+    extra_body = None
+    bare = (model or "").lower().replace("_", "-")
+    if any(tok in bare for tok in ("glm-5.3", "glm-5-3", "glm-5p3")):
+        extra_body = _opencode_go.reasoning_body_extras(model) or None
     return _finalize_driver(
-        OpenAICompatDriver(name=spec, model=model, base_url=provider.base_url,
-                           api_key_env=key_env, max_tokens=max_tokens)
+        OpenAICompatDriver(
+            name=spec,
+            model=model,
+            base_url=provider.resolved_base_url(),
+            api_key_env=key_env,
+            max_tokens=max_tokens,
+            extra_body=extra_body,
+        )
     )
 
 

--- a/harness/server.py
+++ b/harness/server.py
@@ -1043,33 +1043,32 @@ def _driver_in_enabled_set(driver: str, enabled: list) -> bool:
     return False
 
 
+def _driver_in_picker(driver: str, pilots: list) -> bool:
+    """True when *driver* is a live picker spec (or a bare/alias of one)."""
+    if not driver or not pilots:
+        return False
+    return driver in pilots or _driver_in_enabled_set(driver, pilots)
+
+
 def _resolve_available_driver():
-    """Make sure the active driver is one the user can actually use: its
-    provider must have a key AND, when the user has curated an enabled picker
-    set, the driver must be in that set. Otherwise fall back to the first
-    available enabled model -- so a fresh boot never lands on the compiled-in
-    default (qwen3-coder-30b) when the user disabled it, and never lands on a
-    dead provider."""
+    """Keep the active driver inside the live picker catalog.
+
+    The picker list (``enabled_pilots``) is the source of truth: a provider
+    disconnect, Models toggle, or keyed-catalog change that drops the current
+    spec must land on the first still-runnable model. An empty curated set is
+    not a free pass to keep a driver that is no longer listed.
+    """
     global _cfg
     try:
-        if not _driver_provider_available(_cfg.driver):
-            driver_ok = False
-        elif _cfg.driver.startswith("stub") or "HARNESS_DRIVER" in os.environ:
-            # Stub/offline drivers and an explicit env override are deliberate
-            # choices -- never second-guess them against the picker curation.
-            driver_ok = True
-        else:
-            from . import model_visibility as _mv
-            enabled = _mv.get_enabled()
-            driver_ok = not enabled or _driver_in_enabled_set(_cfg.driver, enabled)
-        if driver_ok:
+        if _cfg.driver.startswith("stub"):
             return
         from . import model_visibility as _mv
-        # Pick the first available pilot (enabled set, key-filtered).
-        # enabled_pilots() is ordered by provider then catalog — first toggled
-        # model on the first keyed provider wins when the compiled-in default
-        # is not in the curated set.
         candidates = _mv.enabled_pilots()
+        provider_ok = _driver_provider_available(_cfg.driver)
+        if provider_ok and "HARNESS_DRIVER" in os.environ:
+            return
+        if provider_ok and _driver_in_picker(_cfg.driver, candidates):
+            return
         for spec in candidates:
             if _driver_provider_available(spec):
                 _cfg.driver = spec
@@ -2893,25 +2892,15 @@ def _available_pilots():
     FULL live catalog (incl. newly released models like gpt-5.5) as toggles; the
     picker shows only what is toggled on there, so the two always agree.
 
-    The current driver is forced first when it is still in the enabled set so
-    the picker shows it selected. A stale compiled-in default (e.g. qwen) that
-    the user never toggled on is NOT injected — that made the composer look
-    like it was on a model that could not run.
+    The current driver is forced first only when it is still in the live
+    picker catalog. A disconnected provider's spec is never injected just
+    because it remains in the Models toggle store — that left DeepSeek
+    selected after OpenRouter was turned off.
     """
     from . import model_visibility as _mv
     cur = _cfg.driver
     pilots = _mv.enabled_pilots()
-    curated = _mv.get_enabled()
-    cur_allowed = False
-    if cur:
-        if cur in pilots:
-            cur_allowed = True
-        elif curated and _driver_in_enabled_set(cur, curated):
-            cur_allowed = True
-        elif not curated:
-            # No curation yet: full available set — keep current first if present.
-            cur_allowed = cur in pilots or _driver_in_enabled_set(cur, pilots)
-    if cur_allowed:
+    if cur and _driver_in_picker(cur, pilots):
         ordered = [cur] + [p for p in pilots if p != cur]
     else:
         ordered = list(pilots)
@@ -2922,7 +2911,7 @@ def _available_pilots():
         if s and s not in seen:
             seen.add(s)
             out.append(s)
-    return out or ([cur] if cur else [])
+    return out
 
 
 def _get_settings_dict():

--- a/pmharness/catalog.json
+++ b/pmharness/catalog.json
@@ -33,7 +33,7 @@
       "price_out": 4.4,
       "openrouter": "z-ai/glm-5.2",
       "native": {
-        "base_url": "https://api.z.ai/api/paas/v4",
+        "base_url": "https://api.z.ai/api/coding/paas/v4",
         "model": "glm-5.2",
         "api_key_env": "ZAI_API_KEY"
       },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.223"
+version = "0.9.224"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_auto_registry.py
+++ b/tests/test_auto_registry.py
@@ -188,6 +188,66 @@ def test_sync_with_openai_codex_only(monkeypatch, tmp_path):
         assert "/" not in str(model.get("adapter_model_name") or "")
 
 
+def test_sync_zai_coding_plan_is_plan_billed(monkeypatch, tmp_path):
+    """Direct Z.AI Coding Plan rows are subscription-billed, not cash API."""
+    models_path = tmp_path / "models.json"
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+    monkeypatch.delenv("ZAI_BASE_URL", raising=False)
+    monkeypatch.delenv("GLM_BASE_URL", raising=False)
+
+    def mock_get_provider_key(provider):
+        if provider.name == "zai":
+            return "fake-key-zai"
+        return None
+
+    with patch("harness.registry_wizard.get_provider_key", mock_get_provider_key), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda *_a, **_k: []), \
+         patch("harness.auto_registry._enabled_picker_models", lambda *_a, **_k: []):
+        from harness.auto_registry import sync_agentic_registry
+
+        result = sync_agentic_registry()
+
+    assert result["synced"] is True
+    assert result["providers"] == ["zai"]
+    with open(models_path, encoding="utf-8") as f:
+        data = json.load(f)
+    agentic = [m for m in data["models"] if m.get("adapter") == "agentic"]
+    assert agentic
+    for model in agentic:
+        assert (model.get("payload_defaults") or {}).get("provider") == "zai"
+        assert model.get("billing") == "plan"
+    ids = {m["id"] for m in agentic}
+    assert "agentic/glm-5.2" in ids
+    assert "agentic/glm-5.3" in ids
+
+
+def test_zai_discovery_backfills_glm_53_when_listing_lags(monkeypatch, tmp_path):
+    models_path = tmp_path / "models.json"
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+
+    live = [
+        "glm-5.2", "glm-4.7-flash", "glm-4.5", "glm-4.5-air",
+        "glm-4.6", "glm-4.7", "glm-5.1",
+    ]
+
+    def mock_get_provider_key(provider):
+        return "fake-zai" if provider.name == "zai" else None
+
+    with patch("harness.registry_wizard.get_provider_key", mock_get_provider_key), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda *_a, **_k: list(live)), \
+         patch("harness.auto_registry._enabled_picker_models", lambda *_a, **_k: []):
+        from harness.auto_registry import sync_agentic_registry
+        sync_agentic_registry()
+
+    ids = {m["id"] for m in json.loads(models_path.read_text())["models"]}
+    assert "agentic/glm-5.2" in ids
+    assert "agentic/glm-5.3" in ids
+
+
 def test_sync_with_nous_minimax_nvidia(monkeypatch, tmp_path):
     """HTTP pilots that were previously catalog-orphans must seed agentic rows."""
     models_path = tmp_path / "models.json"
@@ -735,6 +795,36 @@ def test_openrouter_discovery_intersects_curated_with_live(monkeypatch, tmp_path
     assert ids == {"agentic/z-ai/glm-5.2"}
     assert "agentic/moonshotai/kimi-k3" not in ids
     assert "agentic/deepseek/deepseek-v4-flash" not in ids
+    assert "agentic/z-ai/glm-5.3" not in ids
+
+
+def test_openrouter_discovery_promotes_newer_family_version(monkeypatch, tmp_path):
+    """Live glm-5.3 joins Autopilot as a sibling of curated glm-5.2; MIMO does not."""
+    models_path = tmp_path / "models.json"
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+
+    live = [
+        "z-ai/glm-5.2",
+        "z-ai/glm-5.3",
+        "xiaomi/mimo-v2-flash",
+        "anthropic/claude-opus-4.8",
+    ]
+
+    def mock_get_provider_key(provider):
+        return "fake-openrouter" if provider.name == "openrouter" else None
+
+    with patch("harness.registry_wizard.get_provider_key", mock_get_provider_key), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda *_a, **_k: list(live)), \
+         patch("harness.auto_registry._enabled_picker_models", lambda _name: []):
+        from harness.auto_registry import sync_agentic_registry
+        sync_agentic_registry()
+
+    ids = {m["id"] for m in json.loads(models_path.read_text())["models"]}
+    assert "agentic/z-ai/glm-5.2" in ids
+    assert "agentic/z-ai/glm-5.3" in ids
+    assert not any("mimo" in mid for mid in ids)
 
 
 def test_openrouter_live_extras_do_not_inject_mimo(monkeypatch, tmp_path):

--- a/tests/test_driver_resolution_fallback.py
+++ b/tests/test_driver_resolution_fallback.py
@@ -151,6 +151,42 @@ def test_opencode_go_driver_survives_openrouter_disconnect(monkeypatch):
     assert srv._cfg.driver == "opencode-go:deepseek-v4-flash"
 
 
+def test_orphaned_openrouter_driver_swaps_to_remaining_picker(monkeypatch):
+    """Turning OpenRouter off must not leave DeepSeek selected when only GLM remains."""
+    _install_cfg(
+        monkeypatch,
+        enabled=["zai:glm-5.3", "zai:glm-5.2"],
+        driver="openrouter:deepseek/deepseek-v4-flash",
+        disconnect=["openrouter"],
+    )
+    monkeypatch.setenv("GLM_API_KEY", "sk-zai-test")
+    srv._resolve_available_driver()
+    assert srv._cfg.driver.startswith("zai:")
+    assert srv._cfg.driver in ("zai:glm-5.3", "zai:glm-5.2")
+
+
+def test_available_pilots_does_not_pin_disconnected_curated_spec(monkeypatch):
+    """A Models toggle left on for a disconnected provider is not a picker row."""
+    _install_cfg(
+        monkeypatch,
+        enabled=["zai:glm-5.2", "openrouter:deepseek/deepseek-v4-flash"],
+        driver="openrouter:deepseek/deepseek-v4-flash",
+        disconnect=["openrouter"],
+    )
+    monkeypatch.setenv("GLM_API_KEY", "sk-zai-test")
+    monkeypatch.setattr(
+        "harness.model_visibility.enabled_pilots",
+        lambda: ["zai:glm-5.2"],
+    )
+    monkeypatch.setattr(
+        "harness.model_visibility.get_enabled",
+        lambda: ["zai:glm-5.2", "openrouter:deepseek/deepseek-v4-flash"],
+    )
+    pilots = srv._available_pilots()
+    assert "openrouter:deepseek/deepseek-v4-flash" not in pilots
+    assert pilots == ["zai:glm-5.2"]
+
+
 def test_bare_go_catalog_id_available_when_openrouter_disconnected(monkeypatch):
     """Bare deepseek-v4-flash resolves via keyed OpenCode Go, not dead reach."""
     state = os.environ["HARNESS_STATE_DIR"]

--- a/tests/test_model_fetch.py
+++ b/tests/test_model_fetch.py
@@ -39,6 +39,28 @@ def test_fetch_success_clears_prior_error(monkeypatch):
     assert mf.last_fetch_error("anthropic") is None
 
 
+def test_zai_models_accept_name_when_id_missing(monkeypatch):
+    monkeypatch.setattr(
+        mf, "_get",
+        lambda url, headers: {"data": [{"name": "glm-5.3"}, {"id": "glm-5.2"}]},
+    )
+    out = mf._fetch_provider_models(prov.get_provider("zai"), "good-key")
+    assert out == ["glm-5.3", "glm-5.2"]
+
+
+def test_vendor_ids_from_openrouter_use_cached_namespace(monkeypatch):
+    mf._RECORD_MEM["openrouter"] = [
+        {"id": "z-ai/glm-5.3", "source": "live"},
+        {"id": "z-ai/glm-ocr", "source": "live"},
+        {"id": "moonshotai/kimi-k3", "source": "live"},
+    ]
+    try:
+        assert mf.vendor_ids_from_openrouter("zai") == ["glm-5.3", "glm-ocr"]
+        assert mf.vendor_ids_from_openrouter("anthropic") == []
+    finally:
+        mf._RECORD_MEM.pop("openrouter", None)
+
+
 def test_provider_models_merges_live_with_curated(monkeypatch):
     # Curated list for anthropic is 3; simulate a live fetch returning more.
     p = prov.get_provider("anthropic")
@@ -47,13 +69,47 @@ def test_provider_models_merges_live_with_curated(monkeypatch):
         mf, "fetch_models",
         lambda provider, key, **kw: ["claude-opus-4-8", "claude-fable-5", "claude-opus-4-7"],
     )
+    monkeypatch.setattr(mf, "vendor_ids_from_openrouter", lambda *_a, **_k: [])
     merged = mv.provider_models(p)
-    # Curated entries come first, then new live ones, de-duplicated.
+    # Live listing leads; curated ids that are not live still backfill.
     assert merged[0] == "claude-opus-4-8"
     assert "claude-fable-5" in merged
     assert "claude-opus-4-7" in merged
     # No duplicate of the curated opus-4-8 even though it is in both.
     assert merged.count("claude-opus-4-8") == 1
+    for curated in p.pilot_models:
+        assert curated in merged
+
+
+def test_provider_models_promotes_newer_family_from_overlay(monkeypatch):
+    """Vendor /models can lag; an OpenRouter sibling still surfaces glm-5.3."""
+    p = prov.get_provider("zai")
+    monkeypatch.setattr(p.__class__, "key", lambda self: "fake-key")
+    monkeypatch.setattr(
+        mf, "fetch_models",
+        lambda provider, key, **kw: ["glm-5.2", "glm-4.7-flash", "glm-5.1"],
+    )
+    monkeypatch.setattr(
+        mf, "vendor_ids_from_openrouter",
+        lambda name, **kw: ["glm-5.3", "glm-ocr"] if name == "zai" else [],
+    )
+    merged = mv.provider_models(p)
+    assert merged[0] == "glm-5.2"
+    assert "glm-5.3" in merged
+    assert "glm-ocr" not in merged
+
+
+def test_provider_models_backfills_curated_when_listing_lags(monkeypatch):
+    p = prov.get_provider("zai")
+    monkeypatch.setattr(p.__class__, "key", lambda self: "fake-key")
+    monkeypatch.setattr(
+        mf, "fetch_models",
+        lambda provider, key, **kw: ["glm-5.2", "glm-4.7-flash"],
+    )
+    monkeypatch.setattr(mf, "vendor_ids_from_openrouter", lambda *_a, **_k: [])
+    merged = mv.provider_models(p)
+    assert "glm-5.3" in merged
+    assert merged.index("glm-5.2") < merged.index("glm-5.3")
 
 
 def test_cursor_cli_provider_models_prefers_live_order(monkeypatch):

--- a/tests/test_model_visibility.py
+++ b/tests/test_model_visibility.py
@@ -76,6 +76,30 @@ def test_enabled_pilots_filters_to_available(mv, monkeypatch):
     assert "anthropic:claude-opus-4-8" not in pilots  # no anthropic key -> filtered
 
 
+def test_promote_newer_family_versions_glm_and_not_mimo(mv):
+    promoted = mv.promote_newer_family_versions(
+        ["glm-5.2", "z-ai/glm-5.2", "moonshotai/kimi-k3"],
+        ["glm-5.3", "z-ai/glm-5.3", "xiaomi/mimo-v2-flash", "glm-4.7"],
+    )
+    assert "glm-5.3" in promoted
+    assert not any("mimo" in item for item in promoted)
+    assert "glm-4.7" not in promoted
+
+
+def test_promote_newer_family_keeps_openrouter_prefix(mv):
+    promoted = mv.promote_newer_family_versions(
+        ["z-ai/glm-5.2"],
+        ["z-ai/glm-5.3"],
+    )
+    assert promoted == ["z-ai/glm-5.3"]
+
+
+def test_inherit_family_spec_uses_older_sibling(mv):
+    specs = {"z-ai/glm-5.2": (86, 1.0, 3.5, 1000000, ["quality"])}
+    assert mv.inherit_family_spec("z-ai/glm-5.3", "z-ai/glm-5.3", specs) == specs["z-ai/glm-5.2"]
+    assert mv.inherit_family_spec("xiaomi/mimo-v2-flash", "xiaomi/mimo-v2-flash", specs) is None
+
+
 def test_enabled_pilots_falls_back_when_empty(mv, monkeypatch):
     import harness.providers as prov
     monkeypatch.setattr(prov, "available_providers", lambda: [prov.get_provider("openrouter")])

--- a/tests/test_opencode_go.py
+++ b/tests/test_opencode_go.py
@@ -52,7 +52,7 @@ def test_deepseek_entry_is_v4_flash_not_a_stale_alias():
 
 def test_curated_catalog_covers_the_published_endpoint_table():
     for model in (
-        "grok-4.6", "grok-4.5", "gpt-5.6-luna", "glm-5.2", "glm-5.1", "kimi-k3",
+        "grok-4.6", "grok-4.5", "gpt-5.6-luna", "glm-5.3", "glm-5.2", "glm-5.1", "kimi-k3",
         "kimi-k2.7-code", "kimi-k2.6", "mimo-v2.5", "mimo-v2.5-pro",
         "minimax-m3", "minimax-m2.7", "qwen3.7-max", "qwen3.7-plus",
         "qwen3.6-plus", "deepseek-v4-pro", "deepseek-v4-flash", "hy3",
@@ -150,6 +150,24 @@ def test_glm_5_2_reasoning_collapses_onto_its_two_enabled_levels(effort, expecte
 def test_glm_5_2_alias_spellings_are_recognized():
     for alias in ("glm-5-2", "glm-5p2", "opencode-go/glm-5.2"):
         assert go.reasoning_body_extras(alias, "high") == {"reasoning_effort": "high"}
+
+
+@pytest.mark.parametrize("effort,expected", [
+    ("none", {"thinking": {"type": "enabled"}, "reasoning_effort": "low"}),
+    ("low", {"thinking": {"type": "enabled"}, "reasoning_effort": "low"}),
+    ("high", {"thinking": {"type": "enabled"}, "reasoning_effort": "high"}),
+    ("xhigh", {"thinking": {"type": "enabled"}, "reasoning_effort": "max"}),
+    ("max", {"thinking": {"type": "enabled"}, "reasoning_effort": "max"}),
+])
+def test_glm_5_3_requires_thinking_and_maps_effort(effort, expected):
+    assert go.reasoning_body_extras("glm-5.3", effort) == expected
+
+
+def test_glm_5_3_alias_spellings_are_recognized():
+    for alias in ("glm-5-3", "glm-5p3", "opencode-go/glm-5.3", "z-ai/glm-5.3"):
+        extras = go.reasoning_body_extras(alias, "high")
+        assert extras["thinking"] == {"type": "enabled"}
+        assert extras["reasoning_effort"] == "high"
 
 
 @pytest.mark.parametrize("effort,expected", [

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -77,6 +77,55 @@ def test_provider_aliases():
     assert prov.get_provider("cursor-agent").name == "cursor-cli"
 
 
+def test_zai_defaults_to_coding_plan_endpoint(monkeypatch):
+    """GLM Coding Plan keys must hit /api/coding/paas/v4, not pay-as-you-go."""
+    monkeypatch.delenv("ZAI_BASE_URL", raising=False)
+    monkeypatch.delenv("GLM_BASE_URL", raising=False)
+    p = prov.get_provider("zai")
+    assert p is not None
+    assert p.base_url == prov.ZAI_CODING_BASE_URL
+    assert p.resolved_base_url() == "https://api.z.ai/api/coding/paas/v4"
+    assert prov.zai_uses_coding_plan() is True
+    monkeypatch.setenv("ZAI_BASE_URL", "https://api.z.ai/api/paas/v4")
+    assert p.resolved_base_url() == "https://api.z.ai/api/paas/v4"
+    assert prov.zai_uses_coding_plan() is False
+
+
+def test_build_pilot_zai_uses_coding_plan_url(monkeypatch):
+    from pmharness.drivers.openai_compat import OpenAICompatDriver
+
+    _clear_provider_env(monkeypatch)
+    monkeypatch.delenv("ZAI_BASE_URL", raising=False)
+    monkeypatch.delenv("GLM_BASE_URL", raising=False)
+    monkeypatch.setenv("GLM_API_KEY", "sk-zai-test")
+    d = prov.build_pilot("zai:glm-5.2")
+    assert isinstance(d, OpenAICompatDriver)
+    assert d.base_url == "https://api.z.ai/api/coding/paas/v4"
+    assert d.model == "glm-5.2"
+
+
+def test_build_pilot_zai_glm_53_sends_required_thinking(monkeypatch):
+    from pmharness.drivers.openai_compat import OpenAICompatDriver
+
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("GLM_API_KEY", "sk-zai-test")
+    d = prov.build_pilot("zai:glm-5.3")
+    assert isinstance(d, OpenAICompatDriver)
+    assert d.model == "glm-5.3"
+    assert d.extra_body.get("thinking") == {"type": "enabled"}
+    assert d.extra_body.get("reasoning_effort") in {"low", "high", "max"}
+
+
+def test_ensure_zai_worker_base_url_does_not_clobber_override(monkeypatch):
+    monkeypatch.setenv("ZAI_BASE_URL", "https://api.z.ai/api/paas/v4")
+    prov.ensure_zai_worker_base_url()
+    assert os.environ["ZAI_BASE_URL"] == "https://api.z.ai/api/paas/v4"
+    monkeypatch.delenv("ZAI_BASE_URL", raising=False)
+    monkeypatch.delenv("GLM_BASE_URL", raising=False)
+    prov.ensure_zai_worker_base_url()
+    assert os.environ["ZAI_BASE_URL"] == prov.ZAI_CODING_BASE_URL
+
+
 def test_build_pilot_selects_cursor_cli_driver(monkeypatch):
     from pmharness.drivers.cursor_acp import CursorAcpDriver
     from pmharness.drivers.cursor_cli import CursorCliDriver

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.223",
+  "version": "0.9.224",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.223",
+      "version": "0.9.224",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.223",
+  "version": "0.9.224",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/onboardingProviders.test.ts
+++ b/webapp/src/__tests__/onboardingProviders.test.ts
@@ -45,4 +45,9 @@ describe("onboardingProviders", () => {
     expect(onboardingCopy("openrouter").keyUrl).toBe("https://openrouter.ai/keys");
     expect(onboardingCopy("openrouter").tagline).toMatch(/one key/i);
   });
+
+  it("points Z.AI at the Coding Plan key page", () => {
+    expect(onboardingCopy("zai").keyUrl).toBe("https://z.ai/manage-apikey/apikey-list");
+    expect(onboardingCopy("zai").tagline).toMatch(/coding plan/i);
+  });
 });

--- a/webapp/src/__tests__/pilotPickerModels.test.ts
+++ b/webapp/src/__tests__/pilotPickerModels.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   filterPilotModels,
   groupPilotModelsByProvider,
+  fallbackPilot,
   organizePilotModels,
   pinCurrentPilot,
   providerOf,
@@ -67,6 +68,27 @@ describe("groupPilotModelsByProvider", () => {
       "anthropic:claude-opus-4-8",
       "anthropic:claude-sonnet-4-6",
     ]);
+  });
+});
+
+describe("fallbackPilot", () => {
+  it("keeps the current spec when it is still listed", () => {
+    expect(fallbackPilot(MODELS, "openai:gpt-5.2")).toBe("openai:gpt-5.2");
+  });
+
+  it("swaps to the first live model when the current provider is gone", () => {
+    expect(
+      fallbackPilot(
+        ["zai:glm-5.3", "zai:glm-5.2"],
+        "openrouter:deepseek/deepseek-v4-flash",
+      ),
+    ).toBe("zai:glm-5.3");
+  });
+
+  it("keeps a bare id that still matches a live provider spec", () => {
+    expect(
+      fallbackPilot(["opencode-go:deepseek-v4-flash", "zai:glm-5.2"], "deepseek-v4-flash"),
+    ).toBe("opencode-go:deepseek-v4-flash");
   });
 });
 

--- a/webapp/src/components/PilotPicker.tsx
+++ b/webapp/src/components/PilotPicker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, useRef } from "react";
 import { ChevronDown, Check, Search } from "lucide-react";
 import { api, type Config, type ReasoningEffort } from "../lib/api";
-import { organizePilotModels } from "../lib/pilotPickerModels";
+import { fallbackPilot, organizePilotModels } from "../lib/pilotPickerModels";
 
 const REASONING_LEVELS: { value: ReasoningEffort; label: string }[] = [
   { value: "none", label: "None" },
@@ -43,10 +43,18 @@ export default function PilotPicker({ config }: {
   const filterRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (config) {
-      setModels(config.models || [config.driver]);
-      setCurrent(config.driver);
-      setReasoning(config.reasoning_effort || "low");
+    if (!config) return;
+    const nextModels = config.models?.length ? config.models : [config.driver].filter(Boolean);
+    setModels(nextModels);
+    setReasoning(config.reasoning_effort || "low");
+    const next = fallbackPilot(nextModels, config.driver);
+    setCurrent(next);
+    if (next && next !== config.driver) {
+      api.swapPilot(next).then(() => {
+        window.dispatchEvent(new Event("harness-config-changed"));
+      }).catch(() => {
+        /* next config fetch retries; keep the local fallback label */
+      });
     }
   }, [config]);
 

--- a/webapp/src/lib/onboardingProviders.ts
+++ b/webapp/src/lib/onboardingProviders.ts
@@ -72,9 +72,9 @@ export const ONBOARDING_COPY: Record<string, OnboardingCopy> = {
     keyUrl: "https://portal.nousresearch.com",
   },
   zai: {
-    tagline: "GLM models",
-    blurb: "Z.AI / GLM API key. Full stack chat and swarms.",
-    keyUrl: "https://z.ai",
+    tagline: "GLM Coding Plan",
+    blurb: "Z.AI Coding Plan or API key. Full stack chat and swarms on GLM-5.2.",
+    keyUrl: "https://z.ai/manage-apikey/apikey-list",
   },
   minimax: {
     tagline: "MiniMax models",

--- a/webapp/src/lib/pilotPickerModels.ts
+++ b/webapp/src/lib/pilotPickerModels.ts
@@ -21,12 +21,33 @@ export function filterPilotModels(models: string[], query: string): string[] {
   });
 }
 
+/** Bare model id from a `provider:model` spec (or the whole string). */
+export function modelIdOf(spec: string): string {
+  if (!spec) return "";
+  const idx = spec.indexOf(":");
+  return idx <= 0 ? spec : spec.slice(idx + 1);
+}
+
 /** Pin the current driver at the front when present; leave others in order. */
 export function pinCurrentPilot(models: string[], current: string): string[] {
   if (!current) return models.slice();
   const rest = models.filter((m) => m !== current);
   if (models.includes(current)) return [current, ...rest];
   return rest;
+}
+
+/**
+ * Keep the current spec when it is still in the picker; otherwise the first
+ * live model. A disconnected OpenRouter DeepSeek must not stay selected when
+ * the list is only Z.AI.
+ */
+export function fallbackPilot(models: string[], current: string): string {
+  if (!models.length) return current || "";
+  if (!current) return models[0];
+  if (models.includes(current)) return current;
+  const curModel = modelIdOf(current);
+  const alias = models.find((m) => m === curModel || modelIdOf(m) === curModel);
+  return alias || models[0];
 }
 
 /** Group specs by provider prefix, preserving first-seen provider order. */


### PR DESCRIPTION
## Summary
- Settings catalogs are live-first and promote family version bumps (`glm-5.2` → `glm-5.3`) without a per-provider curated edit.
- Turning a provider off reseats the composer onto a still-listed model instead of leaving a dead DeepSeek/OpenRouter pin.
- Z.AI defaults to the GLM Coding Plan host; Coding Plan rows bill as plan.

## Test plan
- [x] Local pytest (4310 passed) plus ship-scoped vitest
- [ ] CI `tests` workflow green on the merge SHA (3.9 + 3.11 + frontend-build) before tag