### PR TITLE
Ride puppetmaster-ai==1.22.4 on v0.9.224

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.2"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.4"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           # Floor matches the accounting/routing fixes this release needs.
           # Unpinned `puppetmaster-ai` + pip cache can leave CI on an older
           # wheel (e.g. 1.14.0) and fail fallback-pricing regressions.
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.2"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.4"
 
       # full_auto_safety modules already run inside this job via conftest
       # auto-tagging; a separate named job was redundant PR compute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.2"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.4"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.2` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.4` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.2` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.4` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.224, deliberately pre-1.0. Settings catalogs are live-first and promote family version bumps (glm-5.2 → glm-5.3) without a per-provider curated edit. Turning a provider off reseats the composer onto a still-listed model. Z.AI defaults to the GLM Coding Plan host. Rides puppetmaster-ai==1.22.2.
+> Status: v0.9.224, deliberately pre-1.0. Settings catalogs are live-first and promote family version bumps (glm-5.2 → glm-5.3) without a per-provider curated edit. Turning a provider off reseats the composer onto a still-listed model. Z.AI defaults to the GLM Coding Plan host. Rides puppetmaster-ai==1.22.4 (Grok 4.6 starter overlay).
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.2` (shared verified context / Frontier, plus prior Codex swarm fixes and model allowlists / Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.4` (Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.2" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.4" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.2"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.4"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.2" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.4" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.2}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.4}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.2";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.4";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/puppetmaster-runtime.test.cjs
+++ b/webapp/electron/puppetmaster-runtime.test.cjs
@@ -58,10 +58,10 @@ function ensure(opts, extra = {}) {
 }
 
 test("runtime parity: a venv already at the checkout pin is left alone", async () => {
-  const fake = fakeRun({ show: showOutput("Version: 1.22.2\nLocation: /venv/site-packages") });
-  const res = await ensure({ run: fake.run, resolvePin: pinAt("1.22.2") });
+  const fake = fakeRun({ show: showOutput("Version: 1.22.4\nLocation: /venv/site-packages") });
+  const res = await ensure({ run: fake.run, resolvePin: pinAt("1.22.4") });
   assert.equal(res.status, "current");
-  assert.equal(res.version, "1.22.2");
+  assert.equal(res.version, "1.22.4");
   assert.deepEqual(fake.installs(), []);
   assert.equal(runtime.isRuntimeStale(res), false);
 });
@@ -84,20 +84,20 @@ test("runtime parity: an unreachable index reports stale instead of claiming cur
     show: showOutput("Version: 1.20.10"),
     installFails: "Could not resolve host: pypi.org",
   });
-  const res = await ensure({ run: fake.run, resolvePin: pinAt("1.22.2") });
+  const res = await ensure({ run: fake.run, resolvePin: pinAt("1.22.4") });
   assert.equal(res.status, "stale");
   assert.equal(res.have, "1.20.10");
-  assert.equal(res.want, "1.22.2");
+  assert.equal(res.want, "1.22.4");
   assert.match(res.reason, /pypi\.org/);
   assert.equal(runtime.isRuntimeStale(res), true);
-  assert.match(runtime.describeRuntimeParity(res), /1\.22\.2/);
+  assert.match(runtime.describeRuntimeParity(res), /1\.22\.4/);
 });
 
 test("runtime parity: an editable dev checkout is never clobbered", async () => {
   const fake = fakeRun({
     show: showOutput("Version: 1.20.10\nEditable project location: /Users/dev/Puppetmaster"),
   });
-  const res = await ensure({ run: fake.run, resolvePin: pinAt("1.22.2") });
+  const res = await ensure({ run: fake.run, resolvePin: pinAt("1.22.4") });
   assert.equal(res.status, "skipped");
   assert.match(res.reason, /editable/);
   assert.deepEqual(fake.installs(), []);
@@ -107,7 +107,7 @@ test("runtime parity: a custom MARIONETTE_PUPPETMASTER_SPEC is honored", async (
   const fake = fakeRun({ show: showOutput("Version: 1.20.10") });
   const res = await ensure({
     run: fake.run,
-    resolvePin: pinAt("1.22.2"),
+    resolvePin: pinAt("1.22.4"),
     env: { MARIONETTE_PUPPETMASTER_SPEC: "/Users/dev/Puppetmaster" },
   });
   assert.equal(res.status, "skipped");
@@ -117,16 +117,16 @@ test("runtime parity: a custom MARIONETTE_PUPPETMASTER_SPEC is honored", async (
 
 test("runtime parity: without uv it falls back to the venv's own pip", async () => {
   const fake = fakeRun({ show: showOutput("Version: 1.20.10"), hasUv: false });
-  const res = await ensure({ run: fake.run, resolvePin: pinAt("1.22.2") });
+  const res = await ensure({ run: fake.run, resolvePin: pinAt("1.22.4") });
   assert.equal(res.status, "upgraded");
   assert.deepEqual(fake.installs(), [
-    `${PYTHON} -m pip install --upgrade puppetmaster-ai==1.22.2 --quiet`,
+    `${PYTHON} -m pip install --upgrade puppetmaster-ai==1.22.4 --quiet`,
   ]);
 });
 
 test("runtime parity: a missing venv interpreter is stale, not silently current", async () => {
-  const fake = fakeRun({ show: showOutput("Version: 1.22.2") });
-  const res = await ensure({ run: fake.run, resolvePin: pinAt("1.22.2"), exists: () => false });
+  const fake = fakeRun({ show: showOutput("Version: 1.22.4") });
+  const res = await ensure({ run: fake.run, resolvePin: pinAt("1.22.4"), exists: () => false });
   assert.equal(res.status, "stale");
   assert.match(res.reason, /no venv interpreter/);
   assert.deepEqual(fake.calls, []);
@@ -140,15 +140,15 @@ test("runtime parity: a source/dev run with no checkout is a no-op", async () =>
 
 test("runtimeParityFields: only a stale runtime annotates the update-check payload", async () => {
   const fake = fakeRun({ show: showOutput("Version: 1.20.10"), installFails: "offline" });
-  const stale = await ensure({ run: fake.run, resolvePin: pinAt("1.22.2") });
+  const stale = await ensure({ run: fake.run, resolvePin: pinAt("1.22.4") });
   const fields = runtime.runtimeParityFields(stale);
   assert.equal(fields.runtimeStale, true);
   assert.equal(fields.runtimeHave, "1.20.10");
-  assert.equal(fields.runtimeWant, "1.22.2");
-  assert.match(fields.runtimeNote, /1\.22\.2/);
+  assert.equal(fields.runtimeWant, "1.22.4");
+  assert.match(fields.runtimeNote, /1\.22\.4/);
 
-  const ok = fakeRun({ show: showOutput("Version: 1.22.2") });
-  const current = await ensure({ run: ok.run, resolvePin: pinAt("1.22.2") });
+  const ok = fakeRun({ show: showOutput("Version: 1.22.4") });
+  const current = await ensure({ run: ok.run, resolvePin: pinAt("1.22.4") });
   assert.deepEqual(runtime.runtimeParityFields(current), {});
 });
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.2";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.4";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 
 // True when `pip show` / `uv pip show` output describes an editable install
@@ -43,7 +43,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.2" }     -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.4" }     -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -65,7 +65,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.2).
+ * to 1.22.4).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/src/__tests__/StatusBar.test.tsx
+++ b/webapp/src/__tests__/StatusBar.test.tsx
@@ -652,7 +652,7 @@ describe("StatusBar session GOAL chip", () => {
 
 describe("StatusBar runtime stale toast", () => {
   const runtimeNote =
-    "Puppetmaster is at 1.20.10 but this Marionette needs 1.22.2 -- offline. Reconnect and update to finish.";
+    "Puppetmaster is at 1.20.10 but this Marionette needs 1.22.4 -- offline. Reconnect and update to finish.";
 
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary
- Move the desktop/CI Puppetmaster pin from `1.22.2` to `1.22.4` (Grok 4.6 starter overlay) across bootstrap, self-update, install/doctor, and workflows.
- Fold this into the untagged v0.9.224 ship so first-run and self-update get the same kernel as PyPI.

## Test plan
- [x] `node --test webapp/electron/puppetmaster-runtime.test.cjs webapp/electron/update.test.cjs`
- [x] `npx vitest run src/__tests__/StatusBar.test.tsx`
- [ ] `tests` workflow green on this PR (3.9 + 3.11 + Windows + frontend-build)
- [ ] After merge, `tests` green on the exact `main` SHA before tagging `v0.9.224`