### PR TITLE
Release v0.9.225: honest steer action and seam tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.4` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.224, deliberately pre-1.0. Settings catalogs are live-first and promote family version bumps (glm-5.2 → glm-5.3) without a per-provider curated edit. Turning a provider off reseats the composer onto a still-listed model. Z.AI defaults to the GLM Coding Plan host. Rides puppetmaster-ai==1.22.4 (Grok 4.6 starter overlay).
+> Status: v0.9.225, deliberately pre-1.0. Mid-turn vision Enter reports the action actually taken (queue vs steer). Steer enqueue/drain/drop and receipt JSONL have barrier-synced seam tests; session artifact gather is unit-tested. Rides puppetmaster-ai==1.22.4 (Grok 4.6 starter overlay).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.224"
+__version__ = "0.9.225"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/session_control.py
+++ b/harness/api/session_control.py
@@ -562,10 +562,12 @@ def post_session_steer(body: dict, svc: SessionControlServices) -> tuple[int, Js
         code = 200 if result.get("ok") else 400
         return code, result
     if valid_imgs and hasattr(pilot, "steer_with_images"):
-        pilot.steer_with_images(text, valid_imgs)
-    else:
-        pilot.enqueue_steer(text)
-    return 200, {"ok": True}
+        from ..delivery_mode import realized_steer_action
+
+        actual = realized_steer_action(pilot.steer_with_images(text, valid_imgs))
+        return 200, {"ok": True, "action": actual}
+    pilot.enqueue_steer(text)
+    return 200, {"ok": True, "action": "enqueue_steer"}
 
 
 def post_session_queue(body: dict, svc: SessionControlServices) -> tuple[int, JsonPayload]:

--- a/harness/delivery_mode.py
+++ b/harness/delivery_mode.py
@@ -54,6 +54,17 @@ def _try_interrupt_session(session: Any) -> bool:
     return False
 
 
+def realized_steer_action(result: Any) -> str:
+    """Map ``steer_with_images`` return (or None) to the action taken.
+
+    Vision busy-Enter queues a follow-up (``enqueue_prompt``). Everything
+    else, including a missing/legacy ``None`` return, is a mid-turn steer.
+    """
+    if result == DeliveryAction.ENQUEUE_PROMPT.value:
+        return DeliveryAction.ENQUEUE_PROMPT.value
+    return DeliveryAction.ENQUEUE_STEER.value
+
+
 def resolve_delivery(session_busy: bool, requested: Optional[str]) -> str:
     """Map (busy, mode) → action for run_auto / enqueue_steer / enqueue_prompt / interrupt_then_queue.
 
@@ -90,7 +101,11 @@ def apply_delivery(
         if not cleaned and not imgs:
             return {"ok": False, "error": "missing text", "action": action}
         if imgs and hasattr(session, "steer_with_images"):
-            session.steer_with_images(cleaned, imgs)
+            actual = realized_steer_action(session.steer_with_images(cleaned, imgs))
+            result = {"ok": True, "action": actual}
+            if actual != action:
+                result["requested_action"] = action
+            return result
         elif hasattr(session, "enqueue_steer"):
             session.enqueue_steer(cleaned)
         else:

--- a/harness/steer_mixin.py
+++ b/harness/steer_mixin.py
@@ -104,7 +104,7 @@ class SteerMixin:
         from .conversation import ConvEvent
         yield ConvEvent("notice", dict(pending))
 
-    def steer_with_images(self, text: str, images: Optional[list] = None) -> None:
+    def steer_with_images(self, text: str, images: Optional[list] = None) -> str:
         """Enqueue a steer with attached images.
 
         Mid-turn steers are text-only user messages at a safe boundary, so they
@@ -117,7 +117,13 @@ class SteerMixin:
           chrome row (``steer:`` plus QUEUED TO SEND) for one Enter.
         - Text-only pilots: transcribe via sidecar into the steer text (same
           path as view_image for non-vision models).
+
+        Returns the action actually taken (``enqueue_prompt`` or
+        ``enqueue_steer``) so HTTP/UI chrome can match. Empty string if
+        nothing was enqueued.
         """
+        from .delivery_mode import DeliveryAction
+
         cleaned = text.strip() if text and text.strip() else ""
         paths = [p for p in (images or []) if p]
         if paths:
@@ -132,7 +138,7 @@ class SteerMixin:
                             cleaned or "(see attached image)",
                             images=paths,
                         )
-                        return
+                        return DeliveryAction.ENQUEUE_PROMPT.value
                     notice = (
                         cleaned + "\n\n" if cleaned else ""
                     ) + (
@@ -141,7 +147,7 @@ class SteerMixin:
                         "pixels — send as a follow-up turn]"
                     )
                     self.enqueue_steer(notice)
-                    return
+                    return DeliveryAction.ENQUEUE_STEER.value
                 from .vision import transcribe_images
                 parts = [cleaned] if cleaned else []
                 for r in transcribe_images(paths):
@@ -152,16 +158,18 @@ class SteerMixin:
                 combined = "\n\n".join(p for p in parts if p)
                 if combined:
                     self.enqueue_steer(combined)
-                return
+                return DeliveryAction.ENQUEUE_STEER.value
             except Exception as e:
                 parts = [cleaned] if cleaned else []
                 parts.append(f"[attached image transcription failed: {e}]")
                 combined = "\n\n".join(p for p in parts if p)
                 if combined:
                     self.enqueue_steer(combined)
-                return
+                return DeliveryAction.ENQUEUE_STEER.value
         if cleaned:
             self.enqueue_steer(cleaned)
+            return DeliveryAction.ENQUEUE_STEER.value
+        return ""
 
     def _abandoned_turn_blocks_steer_enqueue(self) -> bool:
         """True only while a Stop-abandoned generator may still own the turn.

--- a/harness/task_receipt.py
+++ b/harness/task_receipt.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 import subprocess
+import threading
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, List, Optional
@@ -16,6 +17,10 @@ from typing import Any, List, Optional
 JSONL_FILENAME = "task_receipts.jsonl"
 PROMPT_HASH_LEN = 16
 GIT_TIMEOUT_S = 5
+
+# Windows concurrent ``open(..., "a")`` writers can drop whole lines (CI
+# Windows 3.11 lost 2/8 oversized receipts). Serialize same-process appends.
+_APPEND_LOCK = threading.Lock()
 
 
 @dataclass
@@ -134,8 +139,9 @@ def append_receipt(state_dir: str, receipt: Any) -> None:
         os.makedirs(root, exist_ok=True)
         path = os.path.join(root, JSONL_FILENAME)
         line = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
-        with open(path, "a", encoding="utf-8", newline="\n") as fh:
-            fh.write(line + "\n")
+        with _APPEND_LOCK:
+            with open(path, "a", encoding="utf-8", newline="\n") as fh:
+                fh.write(line + "\n")
     except Exception:
         return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.224"
+version = "0.9.225"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_session_control_peel.py
+++ b/tests/test_api_session_control_peel.py
@@ -129,7 +129,10 @@ def test_steer_and_queue(tmp_path):
     p = _P()
     svc = _svc(pilot=p, upload_dir=str(tmp_path))
     assert post_session_steer({}, svc)[0] == 400
-    assert post_session_steer({"text": "go"}, svc)[0] == 200
+    code_steer, payload_steer = post_session_steer({"text": "go"}, svc)
+    assert code_steer == 200
+    assert payload_steer["ok"] is True
+    assert payload_steer["action"] == "enqueue_steer"
     assert p.steers == ["go"]
     code, enq = post_session_queue({"text": "next"}, svc)
     assert code == 200 and enq["item"]["id"] == "q1"
@@ -137,6 +140,40 @@ def test_steer_and_queue(tmp_path):
     assert post_session_queue({"clear": True}, svc)[1]["cleared"] == 1
     code2, reo = post_session_queue_reorder({"ids": ["a", "b"]}, svc)
     assert code2 == 200 and [i["id"] for i in reo["items"]] == ["a", "b"]
+
+
+def test_steer_vision_images_reports_enqueue_prompt(tmp_path):
+    """Busy-Enter with pixels must tell the UI it queued, not steered."""
+    img = tmp_path / "shot.png"
+    img.write_bytes(b"x")
+
+    class _P:
+        def __init__(self):
+            self.steers = []
+            self.prompts = []
+
+        def enqueue_steer(self, text):
+            self.steers.append(text)
+
+        def enqueue_prompt(self, text, images=None, model=None):
+            item = {"id": "q1", "text": text, "images": list(images or [])}
+            self.prompts.append(item)
+            return item
+
+        def steer_with_images(self, text, images=None):
+            self.enqueue_prompt(text or "(see attached image)", images=images)
+            return "enqueue_prompt"
+
+    p = _P()
+    svc = _svc(pilot=p, upload_dir=str(tmp_path))
+    code, payload = post_session_steer(
+        {"text": "look", "images": [str(img)]}, svc,
+    )
+    assert code == 200
+    assert payload["ok"] is True
+    assert payload["action"] == "enqueue_prompt"
+    assert p.steers == []
+    assert p.prompts[0]["text"] == "look"
 
 
 def test_rewind_requires_target():

--- a/tests/test_delivery_mode.py
+++ b/tests/test_delivery_mode.py
@@ -7,6 +7,7 @@ from harness.delivery_mode import (
     apply_delivery,
     deliver_schedule_to_session,
     normalize_delivery_mode,
+    realized_steer_action,
     resolve_delivery,
     schedule_should_inject,
 )
@@ -53,6 +54,36 @@ def test_delivery_mode_steer_when_busy():
     assert result["ok"] is True
     assert result["action"] == "enqueue_steer"
     assert session.steers == ["nudge left"]
+
+
+def test_realized_steer_action_maps_vision_queue():
+    assert realized_steer_action("enqueue_prompt") == "enqueue_prompt"
+    assert realized_steer_action("enqueue_steer") == "enqueue_steer"
+    assert realized_steer_action(None) == "enqueue_steer"
+    assert realized_steer_action("") == "enqueue_steer"
+
+
+def test_delivery_mode_steer_vision_images_reports_queue():
+    """Requested steer + native-vision images must report enqueue_prompt."""
+
+    class _VisionSession(_FakeSession):
+        def steer_with_images(self, text, images=None):
+            self.enqueue_prompt(text or "(see attached image)", images=images)
+            return "enqueue_prompt"
+
+    session = _VisionSession()
+    result = apply_delivery(
+        session,
+        "look at this",
+        session_busy=True,
+        requested="steer",
+        images=["/tmp/shot.png"],
+    )
+    assert result["ok"] is True
+    assert result["action"] == "enqueue_prompt"
+    assert result["requested_action"] == "enqueue_steer"
+    assert session.steers == []
+    assert session.prompts[0]["text"] == "look at this"
 
 
 def test_delivery_mode_follow_up_queues():

--- a/tests/test_session_control_deferred_refetch.py
+++ b/tests/test_session_control_deferred_refetch.py
@@ -101,6 +101,7 @@ def test_steer_refetches_pilot_after_deferred_gate_swap():
     code, payload = post_session_steer({"text": "nudge"}, svc)
 
     assert code == 200 and payload["ok"] is True
+    assert payload["action"] == "enqueue_steer"
     assert real.steers == ["nudge"]
     assert box["gate_calls"] == 1
     assert any(p is placeholder for p in box["get_snapshots"])

--- a/tests/test_steer_concurrency.py
+++ b/tests/test_steer_concurrency.py
@@ -1,0 +1,210 @@
+"""Concurrency-seam tests for mid-turn steer enqueue / drain / drop.
+
+Wiki rule Concurrency Seam Testing (v0.9.105): contend the lock with a
+barrier, then assert the post-join partition. No wall-clock latency checks.
+
+Production seam (harness/steer_mixin.py):
+- drop_queued_steers:50 takes ``_steer_lock`` and returns stripped items
+- _abandoned_turn_blocks_steer_enqueue:174 is True only when
+  ``_stop_holds_idle`` coincides with ``_busy.locked()``
+- enqueue_steer:194 strips blanks, refuses abandon, then appends under lock
+- drain_steer:211 pops the whole queue under the same lock
+"""
+from __future__ import annotations
+
+import collections
+import threading
+
+from harness.steer_mixin import SteerMixin
+
+
+class _SteerHost(SteerMixin):
+    """Minimal host: mixin methods plus the fields they read and write."""
+
+    def __init__(self) -> None:
+        self._steer_lock = threading.Lock()
+        self._steer_queue = collections.deque()
+        self._steer_pending = False
+        self._stop_holds_idle = False
+        self._busy = threading.Lock()
+        self._pending_steer_drop_notice = None
+        self._display_transcript = []
+
+
+def _join_threads(threads):
+    for thread in threads:
+        thread.join(timeout=5)
+    still_running = [thread.name for thread in threads if thread.is_alive()]
+    assert still_running == [], still_running
+
+
+def test_concurrent_enqueue_and_drain_preserves_every_text_exactly_once():
+    """N producers barrier-sync then enqueue; drainers run in the same window."""
+    host = _SteerHost()
+    producer_count = 16
+    drainer_count = 3
+    texts = ["steer-%02d" % i for i in range(producer_count)]
+    barrier = threading.Barrier(producer_count + drainer_count)
+    producers_done = threading.Event()
+    drained = []
+    drain_lock = threading.Lock()
+    errors = []
+
+    def produce(text):
+        try:
+            barrier.wait(timeout=5)
+            host.enqueue_steer(text)
+        except Exception as exc:  # pragma: no cover - failure surfaces below
+            errors.append(exc)
+
+    def drain():
+        try:
+            barrier.wait(timeout=5)
+            while True:
+                items = host.drain_steer()
+                if items:
+                    with drain_lock:
+                        drained.extend(items)
+                if producers_done.is_set():
+                    leftover = host.drain_steer()
+                    if leftover:
+                        with drain_lock:
+                            drained.extend(leftover)
+                    break
+        except Exception as exc:  # pragma: no cover - failure surfaces below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=produce, args=(text,)) for text in texts]
+    threads.extend(threading.Thread(target=drain) for _ in range(drainer_count))
+    for thread in threads:
+        thread.start()
+    _join_threads(threads[:producer_count])
+    producers_done.set()
+    _join_threads(threads[producer_count:])
+
+    leftover = host.drain_steer()
+    drained.extend(leftover)
+
+    assert errors == []
+    assert leftover == []
+    assert "" not in drained
+    assert all(item.strip() for item in drained)
+    assert sorted(drained) == texts
+    assert len(drained) == len(set(drained)) == producer_count
+    assert list(host._steer_queue) == []
+
+
+def test_concurrent_drop_and_enqueue_partition_without_loss_or_double_count():
+    """Queue remainder plus dropped items equal the enqueued set."""
+    host = _SteerHost()
+    enqueue_count = 16
+    dropper_count = 4
+    texts = ["drop-steer-%02d" % i for i in range(enqueue_count)]
+    barrier = threading.Barrier(enqueue_count + dropper_count)
+    producers_done = threading.Event()
+    dropped = []
+    drop_lock = threading.Lock()
+    errors = []
+
+    def produce(text):
+        try:
+            barrier.wait(timeout=5)
+            host.enqueue_steer(text)
+        except Exception as exc:  # pragma: no cover - failure surfaces below
+            errors.append(exc)
+
+    def drop():
+        try:
+            barrier.wait(timeout=5)
+            while True:
+                items = host.drop_queued_steers()
+                if items:
+                    with drop_lock:
+                        dropped.extend(items)
+                if producers_done.is_set():
+                    leftover = host.drop_queued_steers()
+                    if leftover:
+                        with drop_lock:
+                            dropped.extend(leftover)
+                    break
+        except Exception as exc:  # pragma: no cover - failure surfaces below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=produce, args=(text,)) for text in texts]
+    threads.extend(threading.Thread(target=drop) for _ in range(dropper_count))
+    for thread in threads:
+        thread.start()
+    _join_threads(threads[:enqueue_count])
+    producers_done.set()
+    _join_threads(threads[enqueue_count:])
+
+    remaining = host.drain_steer()
+
+    assert errors == []
+    combined = remaining + dropped
+    assert "" not in combined
+    assert len(combined) == enqueue_count
+    assert sorted(combined) == texts
+    assert set(remaining) | set(dropped) == set(texts)
+    assert set(remaining) & set(dropped) == set()
+    assert len(remaining) == len(set(remaining))
+    assert len(dropped) == len(set(dropped))
+
+
+def test_abandoned_turn_blocks_enqueue_only_while_busy_is_held():
+    """Stop hold + locked busy refuses enqueue and records a drop notice.
+
+    Idle sessions still accept steers when ``_stop_holds_idle`` is sticky.
+    """
+    host = _SteerHost()
+    host._stop_holds_idle = True
+    assert host._busy.acquire(blocking=False)
+    try:
+        assert host._abandoned_turn_blocks_steer_enqueue() is True
+        host.enqueue_steer("late steer after stop")
+        assert list(host._steer_queue) == []
+        assert host.drain_steer() == []
+        notice = host._pending_steer_drop_notice
+        assert notice is not None
+        assert notice["reason"] == "steer_dropped"
+        assert notice["count"] == 1
+        assert "Dropped 1 queued steer" in notice["message"]
+        assert host._display_transcript
+        assert host._display_transcript[0]["role"] == "assistant"
+        assert host._display_transcript[0]["text"] == notice["message"]
+    finally:
+        host._busy.release()
+
+    # Sticky idle hold on a ready session must not refuse enqueue.
+    host._pending_steer_drop_notice = None
+    host._display_transcript = []
+    assert host._busy.locked() is False
+    assert host._abandoned_turn_blocks_steer_enqueue() is False
+    host.enqueue_steer("valid after idle hold")
+    assert host.drain_steer() == ["valid after idle hold"]
+    assert host._pending_steer_drop_notice is None
+
+    # Busy without the Stop hold is a live turn: enqueue stays open.
+    assert host._busy.acquire(blocking=False)
+    try:
+        host._stop_holds_idle = False
+        assert host._abandoned_turn_blocks_steer_enqueue() is False
+        host.enqueue_steer("live-turn steer")
+        assert host.drain_steer() == ["live-turn steer"]
+    finally:
+        host._busy.release()
+
+
+def test_enqueue_steer_ignores_blank_and_whitespace():
+    """Blank composer text never enters the queue (existing contract)."""
+    host = _SteerHost()
+    host.enqueue_steer("")
+    host.enqueue_steer("   ")
+    host.enqueue_steer("\n\t ")
+    host.enqueue_steer(None)  # type: ignore[arg-type]
+    assert host.drain_steer() == []
+    assert list(host._steer_queue) == []
+    assert host._pending_steer_drop_notice is None
+
+    host.enqueue_steer("  keep me  ")
+    assert host.drain_steer() == ["keep me"]

--- a/tests/test_steer_images.py
+++ b/tests/test_steer_images.py
@@ -46,7 +46,7 @@ def test_steer_image_error_is_surfaced_not_dropped(monkeypatch):
 
 def test_text_only_steer_still_works(monkeypatch):
     s = _session()
-    s.steer_with_images("just text", [])
+    assert s.steer_with_images("just text", []) == "enqueue_steer"
     assert s.drain_steer() == ["just text"]
 
 
@@ -72,7 +72,8 @@ def test_steer_native_vision_queues_prompt_skips_sidecar(monkeypatch):
     monkeypatch.setattr("harness.vision.transcribe_images", _boom)
     s.enqueue_prompt = _queue
     s.enqueue_steer = _steer
-    s.steer_with_images("look at this", ["/tmp/shot.png"])
+    action = s.steer_with_images("look at this", ["/tmp/shot.png"])
+    assert action == "enqueue_prompt"
     assert called["transcribe"] == 0
     assert called["steer"] == 0
     assert queued == [{"text": "look at this", "images": ["/tmp/shot.png"]}]
@@ -90,6 +91,7 @@ def test_steer_native_vision_images_only_is_queue_only(monkeypatch):
 
     monkeypatch.setattr("harness.vision.session_supports_native_images", lambda _s: True)
     s.enqueue_prompt = _queue
-    s.steer_with_images("", ["/tmp/shot.png"])
+    action = s.steer_with_images("", ["/tmp/shot.png"])
+    assert action == "enqueue_prompt"
     assert queued == [{"text": "(see attached image)", "images": ["/tmp/shot.png"]}]
     assert s.drain_steer() == []

--- a/tests/test_task_receipt.py
+++ b/tests/test_task_receipt.py
@@ -109,8 +109,8 @@ def test_append_receipt_never_raises(tmp_path: Path):
 def test_concurrent_append_receipts_are_intact_jsonl(tmp_path: Path):
     """Barrier-synced threads must each land as one intact JSON object.
 
-    POSIX writes under PIPE_BUF are often atomic; this test does not assume
-    that. Each line is larger than a typical 8KiB stdio buffer so a torn
+    Unlocked Windows ``open(..., "a")`` can drop whole lines (CI 3.11 lost
+    2/8). Each line is larger than a typical 8KiB stdio buffer so a torn
     write would fail json.loads or drop a task_id. load_receipts skips
     malformed lines, so the raw JSONL is checked as well.
     """

--- a/tests/test_task_receipt.py
+++ b/tests/test_task_receipt.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+import threading
 from pathlib import Path
 
 from harness.task_receipt import (
+    JSONL_FILENAME,
     TaskReceipt,
     append_receipt,
     build_receipt,
@@ -101,6 +104,64 @@ def test_append_receipt_never_raises(tmp_path: Path):
     bad.write_text("x", encoding="utf-8")
     append_receipt(str(bad), {"task_id": "x"})
     assert load_receipts(str(tmp_path / "missing"), limit=5) == []
+
+
+def test_concurrent_append_receipts_are_intact_jsonl(tmp_path: Path):
+    """Barrier-synced threads must each land as one intact JSON object.
+
+    POSIX writes under PIPE_BUF are often atomic; this test does not assume
+    that. Each line is larger than a typical 8KiB stdio buffer so a torn
+    write would fail json.loads or drop a task_id. load_receipts skips
+    malformed lines, so the raw JSONL is checked as well.
+    """
+    n = 8
+    # Optional field only — receipt schema is unchanged.
+    oversized_repo = "R" * 9000
+    state = tmp_path / "state"
+    barrier = threading.Barrier(n)
+    errors = []
+
+    def worker(index: int) -> None:
+        try:
+            barrier.wait(timeout=5)
+            append_receipt(
+                str(state),
+                {
+                    "task_id": "concurrent-{0}".format(index),
+                    "profile": "MICRO",
+                    "repo": oversized_repo,
+                    "created_at": "2026-08-15T00:00:00+00:00",
+                },
+            )
+        except Exception as exc:  # pragma: no cover - failure surfaces below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert errors == []
+    loaded = load_receipts(str(state), limit=n)
+    expected_ids = {"concurrent-{0}".format(i) for i in range(n)}
+    assert {row["task_id"] for row in loaded} == expected_ids
+    assert len(loaded) == n
+    for row in loaded:
+        assert isinstance(row, dict)
+        assert row["repo"] == oversized_repo
+
+    raw_path = state / JSONL_FILENAME
+    raw_lines = [
+        line for line in raw_path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    assert len(raw_lines) == n
+    parsed_ids = []
+    for line in raw_lines:
+        rec = json.loads(line)
+        assert isinstance(rec, dict)
+        parsed_ids.append(rec["task_id"])
+    assert set(parsed_ids) == expected_ids
 
 
 def test_compute_patch_hash_empty_and_stable(tmp_path: Path):

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.224",
+  "version": "0.9.225",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.224",
+      "version": "0.9.225",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.224",
+  "version": "0.9.225",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/agentLinks.test.ts
+++ b/webapp/src/__tests__/agentLinks.test.ts
@@ -88,6 +88,30 @@ describe("agentLinks detection", () => {
     expect(looksLikePathInlineCode("/Users/me/My Projects/app.ts:12")).toBe(true);
   });
 
+  it("does not treat package specs as file editor links", () => {
+    const packages = [
+      "@anysphere/ui",
+      "@anysphere/agent-store-sync",
+      "@cursor/july@0.1.40",
+      "@base-ui/react@1.6.0",
+      "@stylexjs/stylex@0.18.3",
+      "@tanstack/react-virtual@3.13.23",
+      "tar@6.2.1",
+      "lodash@4.17.21",
+      "@/lib/utils",
+    ];
+    for (const spec of packages) {
+      expect(looksLikeFilePath(spec)).toBe(false);
+      expect(looksLikePathInlineCode(spec)).toBe(false);
+    }
+    expect(looksLikeFilePath("anysphere/ui")).toBe(false);
+    expect(looksLikePathInlineCode("anysphere/ui")).toBe(false);
+    expect(looksLikeFilePath("package.json")).toBe(true);
+    expect(looksLikeFilePath("~/Downloads/security-assessment-report.md")).toBe(true);
+    expect(looksLikePathInlineCode("~/Downloads/security-assessment-report.md")).toBe(true);
+    expect(looksLikeFilePath("/tmp/@scope/pkg/index.ts")).toBe(true);
+  });
+
   it("classifies action goals by kind", () => {
     expect(classifyActionGoal("read_file", "a/b.ts")).toEqual({
       linkKind: "file",
@@ -201,6 +225,14 @@ describe("autolinkAgentText", () => {
   it("wraps bare spill:// URIs outside fences", () => {
     const out = autolinkAgentText("Full output at spill://sess1/call_a for recall.");
     expect(out).toContain("[spill://sess1/call_a](spill://sess1/call_a)");
+  });
+
+  it("does not autolink package specs in prose", () => {
+    const src = "The critical tar@6.2.1 finding and @anysphere/ui stay plain.";
+    const out = autolinkAgentText(src);
+    expect(out).toBe(src);
+    expect(out).not.toContain("](@anysphere");
+    expect(out).not.toContain("](tar@");
   });
 
   it("skips fenced code and existing links", () => {

--- a/webapp/src/__tests__/clickableOutput.test.ts
+++ b/webapp/src/__tests__/clickableOutput.test.ts
@@ -39,6 +39,13 @@ describe("tokenizeClickableOutput", () => {
     expect(segs.every((s) => s.kind === "text")).toBe(true);
   });
 
+  it("does not treat npm package specs as file paths", () => {
+    const segs = tokenizeClickableOutput(
+      "critical tar@6.2.1 and @anysphere/ui plus @cursor/july@0.1.40\n",
+    );
+    expect(segs.every((s) => s.kind === "text")).toBe(true);
+  });
+
   it("tokenizes quoted and unquoted spaced paths without prose spam", () => {
     const spaced = tokenizeClickableOutput(
       "boom /Users/me/My Projects/app.ts:3\n",

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -159,6 +159,8 @@ import {
   shouldBlockEmptySend,
   shouldSteerWhileBusy,
   shouldClearSteerDraftOnResult,
+  steerResultChrome,
+  steerTranscriptItem,
   showStandaloneEditNoticeDismiss,
   userOrdinalBeforeIndex,
 } from "../components/conversation/composerSend";
@@ -2220,6 +2222,24 @@ describe("composerSend module", () => {
     expect(shouldSteerWhileBusy({ text: "" })).toBe(false);
     expect(shouldSteerWhileBusy({ text: "   " })).toBe(false);
     expect(shouldSteerWhileBusy({ text: "pivot" })).toBe(true);
+    // Vision busy-Enter reports enqueue_prompt — queue chip only, no steer row.
+    expect(steerResultChrome({ action: "enqueue_prompt" })).toBe("queue");
+    expect(steerTranscriptItem({ text: "look", chrome: "queue" })).toBeNull();
+    expect(steerResultChrome({ action: "enqueue_steer" })).toBe("steer");
+    expect(steerTranscriptItem({ text: "nudge", chrome: "steer" })).toEqual({
+      kind: "steer",
+      text: "nudge",
+    });
+    expect(steerResultChrome({ action: undefined })).toBe("steer");
+    expect(
+      steerResultChrome({ action: "enqueue_prompt", composerMode: "interrupt" }),
+    ).toBe("interrupt");
+    expect(steerResultChrome({ action: "interrupt_then_queue" })).toBe("interrupt");
+    expect(steerTranscriptItem({ text: "stop", chrome: "interrupt" })).toEqual({
+      kind: "steer",
+      text: "stop",
+      mode: "interrupt",
+    });
     expect(
       executeSendGate({ transcriptStale: true, resume: false, userStopped: false }),
     ).toBe("stale");

--- a/webapp/src/__tests__/sessionArtifacts.test.ts
+++ b/webapp/src/__tests__/sessionArtifacts.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "../lib/api";
+import { gatherSessionArtifacts } from "../components/conversation/sessionArtifacts";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    artifacts: vi.fn(),
+  },
+}));
+
+const mockArtifacts = vi.mocked(api.artifacts);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function displayCards(
+  artifacts: Array<{ type: string; headline: string }>,
+) {
+  return [
+    {
+      type: "card",
+      result: { artifacts },
+    },
+  ];
+}
+
+describe("gatherSessionArtifacts", () => {
+  it("returns a sync unique merge when jobIds is missing", () => {
+    const result = gatherSessionArtifacts({
+      display: displayCards([
+        { type: "diff", headline: "a" },
+        { type: "diff", headline: "a" },
+        { type: "note", headline: "b" },
+      ]),
+      jobIds: undefined,
+      stillCurrent: () => true,
+    });
+
+    expect(result).not.toBeInstanceOf(Promise);
+    expect(result).toEqual([
+      { type: "diff", headline: "a" },
+      { type: "note", headline: "b" },
+    ]);
+    expect(mockArtifacts).not.toHaveBeenCalled();
+  });
+
+  it("returns a sync unique merge when jobIds is empty", () => {
+    const result = gatherSessionArtifacts({
+      display: displayCards([
+        { type: "diff", headline: "a" },
+        { type: "note", headline: "b" },
+        { type: "note", headline: "b" },
+      ]),
+      jobIds: [],
+      stillCurrent: () => true,
+    });
+
+    expect(result).not.toBeInstanceOf(Promise);
+    expect(result).toEqual([
+      { type: "diff", headline: "a" },
+      { type: "note", headline: "b" },
+    ]);
+    expect(mockArtifacts).not.toHaveBeenCalled();
+  });
+
+  it("merges display artifacts with fetched job artifacts", async () => {
+    mockArtifacts.mockImplementation(async (jobId: string) => {
+      if (jobId === "job-1") return [{ type: "patch", headline: "c" }];
+      if (jobId === "job-2") return [{ type: "note", headline: "d" }];
+      return [];
+    });
+
+    const pending = gatherSessionArtifacts({
+      display: displayCards([{ type: "diff", headline: "a" }]),
+      jobIds: ["job-1", "job-2"],
+      stillCurrent: () => true,
+    });
+
+    expect(pending).toBeInstanceOf(Promise);
+    await expect(pending).resolves.toEqual([
+      { type: "diff", headline: "a" },
+      { type: "patch", headline: "c" },
+      { type: "note", headline: "d" },
+    ]);
+    expect(mockArtifacts).toHaveBeenCalledWith("job-1");
+    expect(mockArtifacts).toHaveBeenCalledWith("job-2");
+  });
+
+  it("returns [] when stillCurrent is false after fetches", async () => {
+    mockArtifacts.mockResolvedValue([{ type: "patch", headline: "c" }]);
+
+    const result = await gatherSessionArtifacts({
+      display: displayCards([{ type: "diff", headline: "a" }]),
+      jobIds: ["job-1"],
+      stillCurrent: () => false,
+    });
+
+    expect(result).toEqual([]);
+    expect(mockArtifacts).toHaveBeenCalledWith("job-1");
+  });
+
+  it("treats a rejected job fetch as [] and still merges the rest", async () => {
+    mockArtifacts.mockImplementation(async (jobId: string) => {
+      if (jobId === "job-bad") throw new Error("network");
+      return [{ type: "patch", headline: "c" }];
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      gatherSessionArtifacts({
+        display: displayCards([{ type: "diff", headline: "a" }]),
+        jobIds: ["job-bad", "job-ok"],
+        stillCurrent: () => true,
+      }),
+    ).resolves.toEqual([
+      { type: "diff", headline: "a" },
+      { type: "patch", headline: "c" },
+    ]);
+
+    expect(mockArtifacts).toHaveBeenCalledWith("job-bad");
+    expect(mockArtifacts).toHaveBeenCalledWith("job-ok");
+    errorSpy.mockRestore();
+  });
+});

--- a/webapp/src/__tests__/transcriptVirtualWindow.test.ts
+++ b/webapp/src/__tests__/transcriptVirtualWindow.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOccludedScrollParentSize,
+  restoreFeedScrollAfterFocus,
+  shouldUseVirtualTranscriptWindow,
+} from "../components/conversation/transcriptVirtualWindow";
+
+describe("transcriptVirtualWindow", () => {
+  it("treats a 0x0 scroll parent as occluded, not unsized-forever", () => {
+    expect(isOccludedScrollParentSize(0, 0)).toBe(true);
+    expect(isOccludedScrollParentSize(360, 0)).toBe(false);
+    expect(isOccludedScrollParentSize(0, 360)).toBe(false);
+  });
+
+  it("latches virtualization after the feed has been sized once", () => {
+    expect(
+      shouldUseVirtualTranscriptWindow({
+        scrollParentSized: false,
+        alreadyVirtualized: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseVirtualTranscriptWindow({
+        scrollParentSized: true,
+        alreadyVirtualized: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseVirtualTranscriptWindow({
+        scrollParentSized: false,
+        alreadyVirtualized: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("restores saved offset when unpinned, bottom when pinned", () => {
+    expect(
+      restoreFeedScrollAfterFocus({
+        savedScrollTop: 1400,
+        pinned: false,
+        settling: false,
+        scrollHeight: 8000,
+      }),
+    ).toBe(1400);
+    expect(
+      restoreFeedScrollAfterFocus({
+        savedScrollTop: 1400,
+        pinned: true,
+        settling: false,
+        scrollHeight: 8000,
+      }),
+    ).toBe(8000);
+    expect(
+      restoreFeedScrollAfterFocus({
+        savedScrollTop: 1400,
+        pinned: false,
+        settling: true,
+        scrollHeight: 8000,
+      }),
+    ).toBe(8000);
+  });
+});

--- a/webapp/src/__tests__/transcriptVirtualizer.test.tsx
+++ b/webapp/src/__tests__/transcriptVirtualizer.test.tsx
@@ -180,4 +180,26 @@ describe("transcript feed virtualizer", () => {
     expect(screen.queryByRole("button", { name: /Show earlier messages/i })).toBeNull();
     expect(screen.getByTestId("transcript-virtual-list")).toBeTruthy();
   });
+
+  it("keeps the virtual window after the scroll parent reports 0 height", async () => {
+    vi.stubGlobal("ResizeObserver", SizedResizeObserver);
+    const items = longTranscript(60);
+    const { rerender } = render(<VirtualFeedHarness items={items} />);
+
+    await waitFor(() => {
+      const rows = screen.getAllByTestId("transcript-virtual-row");
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows.length).toBeLessThan(80);
+    });
+
+    const feed = screen.getByTestId("virtual-feed") as HTMLDivElement;
+    Object.defineProperty(feed, "clientHeight", { configurable: true, get: () => 0 });
+    Object.defineProperty(feed, "offsetHeight", { configurable: true, get: () => 0 });
+    rerender(<VirtualFeedHarness items={items} />);
+
+    const list = screen.getByTestId("transcript-virtual-list");
+    expect(list.className).toContain("relative");
+    expect(list.className).not.toContain("flex-col");
+    expect(screen.queryAllByTestId("transcript-virtual-row").length).toBeLessThan(80);
+  });
 });

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -75,6 +75,8 @@ import {
   shouldBlockEmptySend,
   shouldClearSteerDraftOnResult,
   shouldSteerWhileBusy,
+  steerResultChrome,
+  steerTranscriptItem,
   userOrdinalBeforeIndex,
 } from "./conversation/composerSend";
 import { runCommandPaletteAction } from "../lib/commandPalette";
@@ -88,6 +90,7 @@ import {
   feedWheelUnpinListenerOptions,
   shouldUnpinOnWheel,
 } from "./conversation/feedScroll";
+import { restoreFeedScrollAfterFocus } from "./conversation/transcriptVirtualWindow";
 import {
   STREAM_ABORT_MESSAGE,
   streamErrorText,
@@ -1139,6 +1142,48 @@ export default function Conversation({
       scrollSettlingRef.current = false;
     };
   }, [activeSessionId]);
+
+  // Alt-tab / blur can zero the feed height and reset scrollTop. Restore the
+  // last offset (or re-stick to bottom if still pinned) after focus paints.
+  useEffect(() => {
+    let saved = 0;
+    let raf1 = 0;
+    let raf2 = 0;
+    const remember = () => {
+      const node = feedRef.current;
+      if (node) saved = node.scrollTop;
+    };
+    const restore = () => {
+      window.cancelAnimationFrame(raf1);
+      window.cancelAnimationFrame(raf2);
+      raf1 = window.requestAnimationFrame(() => {
+        raf2 = window.requestAnimationFrame(() => {
+          const node = feedRef.current;
+          if (!node) return;
+          node.scrollTop = restoreFeedScrollAfterFocus({
+            savedScrollTop: saved,
+            pinned: pinnedToBottomRef.current,
+            settling: scrollSettlingRef.current,
+            scrollHeight: node.scrollHeight,
+          });
+        });
+      });
+    };
+    const onVisibility = () => {
+      if (document.hidden) remember();
+      else restore();
+    };
+    window.addEventListener("blur", remember);
+    window.addEventListener("focus", restore);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.cancelAnimationFrame(raf1);
+      window.cancelAnimationFrame(raf2);
+      window.removeEventListener("blur", remember);
+      window.removeEventListener("focus", restore);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
 
   const contextUsageFetchGenRef = useRef(0);
   const fetchContextUsage = () => {
@@ -2643,19 +2688,22 @@ export default function Conversation({
       const steerImages = attachedImages.map((img) => img.path).filter(Boolean);
       const deliveryMode = mode === "interrupt" ? "interrupt" as const : undefined;
       api.steerSession(msg, steerImages, deliveryMode)
-        .then(() => {
+        .then((res) => {
           if (shouldClearSteerDraftOnResult(true)) {
             setInput("");
             setAttachedImages([]);
           }
-          setItems((prev) => [
-            ...prev,
-            {
-              kind: "steer",
-              text: msg,
-              ...(mode === "interrupt" ? { mode: "interrupt" as const } : {}),
-            },
-          ]);
+          const chrome = steerResultChrome({
+            action: res?.action,
+            composerMode: mode,
+          });
+          if (chrome === "queue") {
+            refreshQueue();
+            return;
+          }
+          const row = steerTranscriptItem({ text: msg, chrome });
+          if (!row) return;
+          setItems((prev) => [...prev, row]);
         })
         .catch((err) => {
           console.error(

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -63,6 +63,10 @@ import {
   shouldUnpinInnerOnWheel,
   THINKING_INNER_PIN_THRESHOLD_PX,
 } from "./conversation/feedScroll";
+import {
+  isOccludedScrollParentSize,
+  shouldUseVirtualTranscriptWindow,
+} from "./conversation/transcriptVirtualWindow";
 import { focusReviewTabAndRefresh } from "./conversation/streamApply";
 
 export type Msg = {
@@ -850,13 +854,21 @@ export const TranscriptList = memo(function TranscriptList({
   // scrollEpoch re-renders once feedRef attaches / resizes so getScrollElement
   // is observed (refs alone do not trigger React updates).
   const listAnchorRef = useRef<HTMLDivElement>(null);
+  const virtualizedOnceRef = useRef(false);
   const [scrollMargin, setScrollMargin] = useState(0);
   const [scrollEpoch, setScrollEpoch] = useState(0);
   useLayoutEffect(() => {
     const scrollEl = scrollContainerRef.current;
     if (!scrollEl) return;
     setScrollEpoch((n) => n + 1);
-    const onResize = () => setScrollEpoch((n) => n + 1);
+    const onResize = () => {
+      // Alt-tab / occlusion often reports 0x0. Bumping epoch then would
+      // remount the unvirtualized list and snap the feed to the top.
+      if (isOccludedScrollParentSize(scrollEl.clientHeight, scrollEl.offsetHeight)) {
+        return;
+      }
+      setScrollEpoch((n) => n + 1);
+    };
     const ro = typeof ResizeObserver !== "undefined" ? new ResizeObserver(onResize) : null;
     ro?.observe(scrollEl);
     return () => ro?.disconnect();
@@ -1263,12 +1275,20 @@ export const TranscriptList = memo(function TranscriptList({
   const virtualItems = rowVirtualizer.getVirtualItems();
   // jsdom / pre-layout: scroll parent missing or unsized → mount full flow so
   // presentation tests keep working without faking a 40-row window.
-  const scrollReady = Boolean(
+  // Once sized, stay virtual even if alt-tab reports a 0-height parent —
+  // flipping back remounts every bubble and snaps the feed to the top.
+  const scrollParentSized = Boolean(
     scrollContainerRef.current &&
-      (scrollContainerRef.current.clientHeight > 0 ||
-        scrollContainerRef.current.offsetHeight > 0),
+      !isOccludedScrollParentSize(
+        scrollContainerRef.current.clientHeight,
+        scrollContainerRef.current.offsetHeight,
+      ),
   );
-  const useVirtualWindow = scrollReady && virtualItems.length > 0;
+  if (scrollParentSized) virtualizedOnceRef.current = true;
+  const useVirtualWindow = shouldUseVirtualTranscriptWindow({
+    scrollParentSized,
+    alreadyVirtualized: virtualizedOnceRef.current,
+  });
   const list = useVirtualWindow ? (
     <div
       ref={listAnchorRef}

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -57,15 +57,14 @@ export default function ConversationChatColumn({
     <div className="flex flex-col flex-1 min-h-0">
       <div
         ref={feedRef}
-        className={`flex-1 overflow-y-auto overscroll-contain [overflow-anchor:auto] [scrollbar-gutter:stable] ${panelOpacityClass(transcriptStale)}`}
+        className={`flex-1 overflow-y-auto overscroll-contain [overflow-anchor:none] [scrollbar-gutter:stable] ${panelOpacityClass(transcriptStale)}`}
       >
-        {/* overflow-anchor keeps the row you are reading still when height
-            lands above it. scrollbar-gutter avoids a 15px jump when the bar
-            appears. overscroll-contain stops rubber-band from yanking the window.
-            Composer sits outside this scrollport, so scroll-padding-bottom is
-            not the last-bubble fix here — feedScroll pin/unpin still owns that.
-            TranscriptList virtualizes rows (measureElement) against this feedRef
-            scroll parent; do not move the composer inside the scrollport. */}
+        {/* overflow-anchor:none — the virtualizer unmounts off-screen rows, so
+            auto-anchor would snap to the first remaining node (top of history)
+            on alt-tab / compositor restore. feedScroll pin/unpin owns stick.
+            scrollbar-gutter avoids a 15px jump when the bar appears.
+            overscroll-contain stops rubber-band from yanking the window.
+            Composer sits outside this scrollport; do not move it inside. */}
         <div className="max-w-3xl mx-auto px-6 py-6 flex flex-col gap-1">
           <TranscriptEmptyState transcriptStale={transcriptStale} itemCount={items.length} />
           {/*

--- a/webapp/src/components/conversation/composerSend.ts
+++ b/webapp/src/components/conversation/composerSend.ts
@@ -142,6 +142,33 @@ export function shouldClearSteerDraftOnResult(ok: boolean): boolean {
   return ok;
 }
 
+/**
+ * Chrome after POST /api/session/steer. Match the action the harness took —
+ * a vision busy-Enter queues a follow-up and must not also paint `steer:`.
+ */
+export function steerResultChrome(opts: {
+  action?: string;
+  composerMode?: "send" | "queue" | "interrupt" | "noop";
+}): "steer" | "queue" | "interrupt" {
+  if (opts.composerMode === "interrupt" || opts.action === "interrupt_then_queue") {
+    return "interrupt";
+  }
+  if (opts.action === "enqueue_prompt") return "queue";
+  return "steer";
+}
+
+/** Transcript `steer:` / `interrupt:` row — never for a queued follow-up. */
+export function steerTranscriptItem(opts: {
+  text: string;
+  chrome: "steer" | "queue" | "interrupt";
+}): { kind: "steer"; text: string; mode?: "steer" | "interrupt" } | null {
+  if (opts.chrome === "queue") return null;
+  if (opts.chrome === "interrupt") {
+    return { kind: "steer", text: opts.text, mode: "interrupt" };
+  }
+  return { kind: "steer", text: opts.text };
+}
+
 export type StopHonestyNotice = {
   message?: string;
   reason?: string;

--- a/webapp/src/components/conversation/reexports.ts
+++ b/webapp/src/components/conversation/reexports.ts
@@ -177,6 +177,8 @@ export {
   formatSteerErrorMessage,
   formatInterruptErrorMessage,
   shouldClearSteerDraftOnResult,
+  steerResultChrome,
+  steerTranscriptItem,
   formatRenderCommandErrorMessage,
   editNoticeAfterSend,
   EDIT_BUSY_PROGRESS_NOTICE,

--- a/webapp/src/components/conversation/transcriptVirtualWindow.ts
+++ b/webapp/src/components/conversation/transcriptVirtualWindow.ts
@@ -1,0 +1,33 @@
+/**
+ * Virtual transcript window vs full-list fallback.
+ *
+ * Chromium/Electron often reports clientHeight=0 while the window is
+ * blurred or occluded (alt-tab). Falling back to the unvirtualized list
+ * remounts every bubble and snaps the feed to the top. Latch virtualization
+ * once the scroll parent has been sized, and ignore zero-size resizes.
+ */
+
+export function isOccludedScrollParentSize(
+  clientHeight: number,
+  offsetHeight: number,
+): boolean {
+  return clientHeight <= 0 && offsetHeight <= 0;
+}
+
+export function shouldUseVirtualTranscriptWindow(opts: {
+  scrollParentSized: boolean;
+  alreadyVirtualized: boolean;
+}): boolean {
+  return opts.alreadyVirtualized || opts.scrollParentSized;
+}
+
+/** Scroll offset to apply after the window is focused again. */
+export function restoreFeedScrollAfterFocus(opts: {
+  savedScrollTop: number;
+  pinned: boolean;
+  settling: boolean;
+  scrollHeight: number;
+}): number {
+  if (opts.pinned || opts.settling) return Math.max(0, opts.scrollHeight);
+  return Math.max(0, opts.savedScrollTop);
+}

--- a/webapp/src/lib/agentLinks.ts
+++ b/webapp/src/lib/agentLinks.ts
@@ -96,6 +96,37 @@ export function stableCommandId(value: string): string {
 }
 
 /**
+ * Hermes `looksLikePath` / Prime `isLocalPathSpecifier`: a real filesystem
+ * prefix, not merely a slash. `@scope/pkg` has a slash and is not a path.
+ */
+function hasFilesystemPrefix(clean: string): boolean {
+  return (
+    /^[A-Za-z]:[\\/]/.test(clean)
+    || clean.startsWith("/")
+    || clean.startsWith("~/")
+    || /^\.{1,2}[\\/]/.test(clean)
+  );
+}
+
+/**
+ * Last segment looks like a filename (`App.tsx`, `foo.py:12`, `archive.7z`).
+ * Letter-start extensions reject version tails (`.1` in `tar@6.2.1`).
+ */
+function hasFilenameExtension(clean: string): boolean {
+  const withoutLine = clean.replace(/(?::\d+){0,2}$/, "");
+  const base = withoutLine.split(/[\\/]/).pop() || "";
+  return /\.([A-Za-z][\w]{0,7}|7z)$/.test(base);
+}
+
+/**
+ * npm/pip-style package specs and import aliases, not local files.
+ * `@` without a filesystem prefix is `@scope/pkg`, `tar@6.2.1`, `@/alias`.
+ */
+function looksLikePackageSpec(clean: string): boolean {
+  return clean.includes("@") && !hasFilesystemPrefix(clean);
+}
+
+/**
  * Conservative spaced filesystem path (macOS "My Projects/app.ts", etc.).
  * Requires a directory separator and a dotted filename so prose / shell
  * lines with spaces stay non-paths.
@@ -103,13 +134,12 @@ export function stableCommandId(value: string): string {
 function looksLikeSpacedFilePath(text: string): boolean {
   const clean = text
     .replace(/^file:\/\//i, "")
-    .replace(/^["']|["']$/g, "")
-    .replace(/(?::\d+){0,2}$/, "");
+    .replace(/^["']|["']$/g, "");
   if (!clean || !/\s/.test(clean)) return false;
   if (/&&|\|\||[|<>;&]/.test(clean)) return false;
   if (!/[\\/]/.test(clean)) return false;
-  const base = clean.split(/[\\/]/).pop() || "";
-  return /\.\w{1,8}$/.test(base);
+  if (looksLikePackageSpec(clean)) return false;
+  return hasFilenameExtension(clean);
 }
 
 /**
@@ -139,8 +169,9 @@ export function isExternalUrl(href: string): boolean {
 
 /**
  * Heuristic: does this look like a filesystem path (not a URL/scheme)?
- * Accepts Windows abs, POSIX abs/rel, and dotted filenames with optional :line[:col].
- * Rejects shell command lines and bare launcher executables (npm.cmd, etc.).
+ * Accepts Windows abs, POSIX abs/home/rel, and dotted filenames with optional
+ * :line[:col]. Rejects shell lines, launchers, and package specs
+ * (`@scope/pkg`, `tar@6.2.1`) the way Hermes/Prime require a path prefix.
  */
 export function looksLikeFilePath(href: string): boolean {
   if (!href) return false;
@@ -156,14 +187,13 @@ export function looksLikeFilePath(href: string): boolean {
   const clean = h
     .replace(/^file:\/\//i, "")
     .replace(/^["']|["']$/g, "");
+  if (looksLikePackageSpec(clean)) return false;
   // Bare executables without a directory separator are shell launchers, not files.
   if (!/[\\/]/.test(clean) && BARE_EXEC_EXT.test(clean)) return false;
-  // Drive letter, absolute, relative with slash, or name.ext[:line[:col]]
-  if (/^[A-Za-z]:[\\/]/.test(clean)) return true;
-  if (/[\\/]/.test(clean)) return true;
-  if (/^\.\.?[\\/]/.test(clean)) return true;
-  if (/\.\w{1,8}(:\d+){0,2}$/.test(clean)) return true;
-  return false;
+  if (hasFilesystemPrefix(clean)) return true;
+  // Repo-relative `dir/file.ext` or bare `name.ext` — never a slash-only token
+  // (`anysphere/ui`) or a numeric version tail (`6.2.1`).
+  return hasFilenameExtension(clean);
 }
 
 /** Strip file:// and optional :line[:col] suffix. */
@@ -194,7 +224,7 @@ export function parseFileHref(href: string): ParsedFileHref | null {
   return { path: raw, line, col };
 }
 
-/** Inline `` `path` `` that should open as a file. */
+/** Inline `` `path` `` that should open as a file — not a package or command. */
 export function looksLikePathInlineCode(text: string): boolean {
   const t = (text || "").trim();
   if (!t || t.includes("\n") || t.length > 260) return false;


### PR DESCRIPTION
## Summary
- Mid-turn vision Enter now reports the action actually taken (`enqueue_prompt` vs `enqueue_steer`) so chrome cannot label a queued follow-up as a steer.
- Barrier-synced steer enqueue/drain/drop and receipt JSONL tests close the remaining concurrency yellows; `gatherSessionArtifacts` has Vitest coverage.
- Also lands the unpushed file-link / alt-tab scroll fix from `19d1564`.

## Test plan
- [x] Local pytest: 4346 passed, 74 skipped
- [x] Focused peel / concurrency / receipt / MIMO / version tests
- [x] Vitest: `sessionArtifacts.test.ts` + `conversation.helpers.test.ts` (142)
- [ ] CI `tests` workflow green on the merge SHA (3.9 floor, 3.11, Windows, frontend-build) before tag