### PR TITLE
Release v0.9.226: kernel-recovery lane when Puppetmaster fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.4"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.5"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           # Floor matches the accounting/routing fixes this release needs.
           # Unpinned `puppetmaster-ai` + pip cache can leave CI on an older
           # wheel (e.g. 1.14.0) and fail fallback-pricing regressions.
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.4"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.5"
 
       # full_auto_safety modules already run inside this job via conftest
       # auto-tagging; a separate named job was redundant PR compute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.4"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.5"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.4` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.5` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.4` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.225, deliberately pre-1.0. Mid-turn vision Enter reports the action actually taken (queue vs steer). Steer enqueue/drain/drop and receipt JSONL have barrier-synced seam tests; session artifact gather is unit-tested. Rides puppetmaster-ai==1.22.4 (Grok 4.6 starter overlay).
+> Status: v0.9.226, deliberately pre-1.0. When Puppetmaster fails before start, the pilot keeps a local diagnosis lane (clipboard is not exploration; identical swarm retry stays blocked). Rides puppetmaster-ai==1.22.5 (exact registry pins + GPT-5.6 tool reasoning).
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.4` (Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.5` (exact registry pins, GPT-5.6 tool reasoning, Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.225"
+__version__ = "0.9.226"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -2585,23 +2585,29 @@ class ConversationalSession(
         # Loop-guard cache: remember successful results so identical repeats
         # within the turn can replay instead of re-executing (token bleed).
         # Skip suppress/redirect/error-shaped content even if ok was left True.
-        if ok:
-            try:
-                from .pilot_guards import record_successful_result
-                gs = getattr(self, "_turn_guard_state", None)
-                kind = getattr(act, "kind", "") or ""
-                head = (clamped_content or "")[:24]
-                if (
-                    gs is not None
-                    and kind
-                    and not is_invalid_action(act)
-                    and not head.startswith("(SUPPRESSED")
-                    and not head.startswith("(REDIRECT")
-                    and " failed:" not in (clamped_content or "")[:120]
-                ):
-                    record_successful_result(gs, kind, act, clamped_content)
-            except Exception:
-                pass
+        # Failed swarm/implement results may open kernel recovery (local
+        # diagnosis) when the kernel itself is the broken path.
+        try:
+            from .pilot_guards import (
+                note_kernel_recovery_from_result,
+                record_successful_result,
+            )
+            gs = getattr(self, "_turn_guard_state", None)
+            kind = getattr(act, "kind", "") or ""
+            if gs is not None and kind:
+                if not ok:
+                    note_kernel_recovery_from_result(gs, kind, clamped_content or "")
+                else:
+                    head = (clamped_content or "")[:24]
+                    if (
+                        not is_invalid_action(act)
+                        and not head.startswith("(SUPPRESSED")
+                        and not head.startswith("(REDIRECT")
+                        and " failed:" not in (clamped_content or "")[:120]
+                    ):
+                        record_successful_result(gs, kind, act, clamped_content)
+        except Exception:
+            pass
 
     def _read_allowed_roots(self) -> list:
         """Roots read_file may read from: the open workspace, its git toplevel

--- a/harness/pilot_guards.py
+++ b/harness/pilot_guards.py
@@ -6,12 +6,16 @@ Per-turn guards wired before native tool dispatch:
 
 1. LOOP BREAKER — suppress repeated (tool, normalized-args) calls within a turn.
 2. SWARM GATE — on broad-intent user messages, block native exploration until
-   run_swarm / run_parallel / run_implement is dispatched. After dispatch,
-   list_dir / search_files / exploration run_command stay blocked on broad
-   turns (read_file + search_codegraph remain allowed to validate concrete
-   findings); thin swarm results require re-dispatch, not an inline campaign.
+   run_swarm / run_parallel / run_implement is dispatched. After a healthy
+   dispatch, list_dir / search_files / exploration run_command stay blocked on
+   broad turns (read_file + search_codegraph remain allowed to validate
+   concrete findings); thin swarm results require re-dispatch, not an inline
+   campaign. After a kernel failure (HTTP 400 / preflight / PM unavailable)
+   the gate lifts so the pilot can diagnose locally instead of deadlocking.
 3. DELEGATE GATE — after too many native exploration calls without delegation,
    redirect the pilot to search_codegraph or Puppetmaster dispatch verbs.
+   Clipboard / local handoff commands are never exploration. Kernel recovery
+   also lifts this gate.
 4. ITERATION BUDGET — hard cap on total tool calls per pilot turn.
 
 ``TurnGuardState`` persists across model steps and keep-alive resume for the
@@ -129,6 +133,36 @@ _BARE_DIR_PROBE_RE = re.compile(
 
 _ECHO_PROBE_RE = re.compile(
     r"^echo\b",
+    re.IGNORECASE,
+)
+
+# Local clipboard / handoff sinks — not codebase exploration. ``echo hello``
+# stays an exploration probe; ``echo … | pbcopy`` is a handoff.
+_CLIPBOARD_SINK_RE = re.compile(
+    r"(?:"
+    r"\bpbcopy\b|\bpbpaste\b|"
+    r"\bclip\.exe\b|(?:^|[\s|&;])clip(?:\s|$)|"
+    r"\bwl-copy\b|\bwl-paste\b|"
+    r"\bxclip\b|\bxsel\b|"
+    r"Set-Clipboard|Get-Clipboard"
+    r")",
+    re.IGNORECASE,
+)
+
+# Failed-before-start / kernel-unavailable markers. Tight on purpose: a
+# plumbing-only swarm is not kernel recovery (that stays on the thrash path).
+_KERNEL_FAILURE_RE = re.compile(
+    r"(?:"
+    r"HTTP\s+400|"
+    r"reasoning_effort|"
+    r"Function tools with reasoning|"
+    r"Use /v1/responses|"
+    r"preflight[_ ](?:blocked|failed)|"
+    r"puppetmaster (?:is )?(?:unavailable|not (?:installed|available)|broken)|"
+    r"failed before start|"
+    r"No module named ['\"]puppetmaster|"
+    r"kernel (?:unavailable|offline)"
+    r")",
     re.IGNORECASE,
 )
 
@@ -514,6 +548,11 @@ class TurnGuardState:
     # Adaptive task depth for this turn (MICRO / STANDARD / DEEP). Separate from
     # tiny_workspace (repo scale). MICRO disables swarm-gate suppress only.
     task_profile: str = ""
+    # Set when a swarm/implement/parallel attempt failed before the kernel
+    # produced usable work (HTTP 400, preflight, PM unavailable). Lifts
+    # swarm/delegate exploration gates so the pilot can diagnose locally.
+    # Loop/thrash still block identical redispatch.
+    kernel_recovery: bool = False
 
 
 @dataclass(frozen=True)
@@ -703,9 +742,19 @@ def normalize_action_args(kind: str, act: Any) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
 
+def is_local_handoff_command(command: str) -> bool:
+    """True for clipboard copy/paste — local I/O, not codebase exploration."""
+    cmd = _norm_whitespace(command)
+    if not cmd:
+        return False
+    return bool(_CLIPBOARD_SINK_RE.search(cmd))
+
+
 def is_exploration_command(command: str) -> bool:
     cmd = _norm_whitespace(command)
     if not cmd:
+        return False
+    if is_local_handoff_command(cmd):
         return False
     if _BARE_DIR_PROBE_RE.match(cmd):
         return True
@@ -788,6 +837,11 @@ def _is_durable_recall_read(act: Any) -> bool:
 
 def is_swarm_gate_blocked_exploration(state: TurnGuardState, kind: str, act: Any) -> bool:
     if not state.broad_intent:
+        return False
+
+    # Kernel failed before producing usable work — do not deadlock the pilot
+    # on "delegate again" when the kernel is the broken path.
+    if state.kernel_recovery:
         return False
 
     # Durable recall is never swarm-gated: search_state and read_file of
@@ -1316,7 +1370,7 @@ def check_delegate_gate(state: TurnGuardState, kind: str, act: Any) -> GuardVerd
     if not is_native_exploration(kind, act):
         return GuardVerdict(False)
 
-    if state.delegation_seen:
+    if state.delegation_seen or state.kernel_recovery:
         return GuardVerdict(False)
 
     if state.exploration_count >= DELEGATE_THRESHOLD:
@@ -1349,6 +1403,29 @@ def check_iteration_budget(state: TurnGuardState, kind: str, act: Any) -> GuardV
 def plumbing_swarm_fingerprint(goal: str, model: str = "") -> tuple[str, str]:
     """Fingerprint for plumbing-only swarm thrash soft-refuse."""
     return (normalize_objective_key(goal or ""), _norm_whitespace(model or "").lower())
+
+
+def result_shows_kernel_failure(content: str) -> bool:
+    """True when a dispatch result is a failed-before-start / PM-unavailable error."""
+    text = str(content or "")
+    if not text.strip():
+        return False
+    return bool(_KERNEL_FAILURE_RE.search(text))
+
+
+def note_kernel_recovery(state: TurnGuardState) -> None:
+    """Open the local diagnosis lane after a kernel-unavailable dispatch."""
+    state.kernel_recovery = True
+
+
+def note_kernel_recovery_from_result(
+    state: TurnGuardState, kind: str, content: str,
+) -> None:
+    """Best-effort: mark recovery when a swarm/implement result is a kernel fault."""
+    if kind not in SWARM_DISPATCH_KINDS:
+        return
+    if result_shows_kernel_failure(content):
+        note_kernel_recovery(state)
 
 
 def record_plumbing_degraded_swarm(

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -741,6 +741,31 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                 )
         except Exception:
             pass
+    try:
+        from .pilot_guards import note_kernel_recovery_from_result
+        gs = getattr(session, '_turn_guard_state', None)
+        if gs is not None and not _swarm_ok:
+            _art_notes = []
+            for _art in list(getattr(result, 'artifacts', None) or []):
+                if not isinstance(_art, dict):
+                    continue
+                _art_notes.append(str(
+                    _art.get('headline') or _art.get('failure')
+                    or _art.get('summary') or _art.get('body') or ''
+                ))
+            _kernel_blob = '\n'.join(
+                str(part) for part in (
+                    _badge_summary,
+                    _badge_error,
+                    auth_failure,
+                    getattr(result, 'error', '') or '',
+                    getattr(result, 'message', '') or '',
+                    *_art_notes,
+                ) if part
+            )
+            note_kernel_recovery_from_result(gs, 'run_swarm', _kernel_blob)
+    except Exception:
+        pass
     # Only surfaced artifacts become turn findings; a refused demo contributes none.
     turn_findings.extend((a for a in _all_arts if a.get('type') != 'verification'))
     full_digest_raw = (getattr(act, 'arguments', None) or {}).get('full_digest')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.225"
+version = "0.9.226"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.4" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.5" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.4"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.5"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.4" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.5" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.4}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.5}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/tests/test_pilot_guards.py
+++ b/tests/test_pilot_guards.py
@@ -35,6 +35,7 @@ from harness.pilot_guards import (
     is_broad_intent_user_message,
     is_exploration_command,
     is_headless_chrome_file_smoke_command,
+    is_local_handoff_command,
     is_native_exploration,
     is_puppetmaster_cli_command,
     is_swarm_gate_blocked_exploration,
@@ -47,6 +48,9 @@ from harness.pilot_guards import (
     normalize_action_args,
     note_implement_exhausted_from_provenance,
     note_implement_success_from_job_result,
+    note_kernel_recovery,
+    note_kernel_recovery_from_result,
+    result_shows_kernel_failure,
     post_implement_tool_allowance,
     puppetmaster_cli_native_mapping,
     record_action_execution,
@@ -777,6 +781,81 @@ def test_echo_not_blocked_on_narrow_turn():
     assert is_swarm_gate_blocked_exploration(state, "run_command", act) is False
     verdict = check_swarm_gate(state, "run_command", act)
     assert verdict.suppress is False
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo 'handoff summary' | pbcopy",
+        "printf '%s' \"$note\" | pbcopy",
+        "pbpaste",
+        "echo hi | clip",
+        "Set-Clipboard -Value 'handoff'",
+        "xclip -selection clipboard",
+        "wl-copy",
+    ],
+)
+def test_clipboard_handoff_is_not_exploration(command):
+    assert is_local_handoff_command(command) is True
+    assert is_exploration_command(command) is False
+    assert is_native_exploration("run_command", _Act(command=command)) is False
+
+
+def test_delegate_gate_allows_clipboard_after_threshold():
+    state = new_turn_guard_state()
+    for i in range(DELEGATE_THRESHOLD):
+        record_action_execution(state, "read_file", _Act(kind="read_file", path=f"f{i}.py"))
+    act = _Act(kind="run_command", command="echo 'handoff' | pbcopy")
+    assert check_delegate_gate(state, "run_command", act).suppress is False
+    assert check_pilot_guards(state, "run_command", act).suppress is False
+
+
+def test_result_shows_kernel_failure_markers():
+    luna_400 = (
+        "HTTP 400: Function tools with reasoning_effort are not supported "
+        "for gpt-5.6-luna in /v1/chat/completions. Use /v1/responses or "
+        "set reasoning_effort to 'none'."
+    )
+    assert result_shows_kernel_failure(luna_400) is True
+    assert result_shows_kernel_failure("preflight_blocked: puppetmaster unavailable") is True
+    assert result_shows_kernel_failure("swarm produced no FINDING/RISK/DECISION artifacts") is False
+    assert result_shows_kernel_failure("") is False
+
+
+def test_kernel_recovery_lifts_swarm_and_delegate_gates():
+    state = new_turn_guard_state("Give me an audit of this directory")
+    for i in range(DELEGATE_THRESHOLD):
+        record_action_execution(state, "read_file", _Act(kind="read_file", path=f"z{i}.py"))
+    record_action_execution(state, "run_swarm", _Act(kind="run_swarm", goal="map auth"))
+    assert state.swarm_dispatched is True
+    assert state.delegation_seen is True
+
+    list_act = _Act(kind="list_dir", path=".")
+    rg_act = _Act(kind="run_command", command="rg reasoning_effort")
+    assert is_swarm_gate_blocked_exploration(state, "list_dir", list_act) is True
+    assert check_swarm_gate(state, "list_dir", list_act).suppress is True
+    assert check_swarm_gate(state, "run_command", rg_act).suppress is True
+
+    note_kernel_recovery_from_result(
+        state,
+        "run_swarm",
+        "HTTP 400: Function tools with reasoning_effort are not supported",
+    )
+    assert state.kernel_recovery is True
+    assert is_swarm_gate_blocked_exploration(state, "list_dir", list_act) is False
+    assert check_swarm_gate(state, "list_dir", list_act).suppress is False
+    assert check_swarm_gate(state, "run_command", rg_act).suppress is False
+    assert check_delegate_gate(state, "search_files", _Act(query="adapter")).suppress is False
+
+
+def test_kernel_recovery_still_loop_blocks_identical_swarm():
+    state = new_turn_guard_state("Give me an audit of this directory")
+    act = _Act(kind="run_swarm", goal="map auth")
+    record_action_execution(state, "run_swarm", act)
+    note_kernel_recovery(state)
+    verdict = check_pilot_guards(state, "run_swarm", act)
+    assert verdict.suppress is True
+    assert verdict.reason == "loop"
 
 
 @pytest.mark.parametrize(

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.4";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.5";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.4";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.5";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 
 // True when `pip show` / `uv pip show` output describes an editable install
@@ -43,7 +43,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.4" }     -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.5" }     -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -65,7 +65,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.4).
+ * to 1.22.5).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.225",
+  "version": "0.9.226",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.225",
+      "version": "0.9.226",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.225",
+  "version": "0.9.226",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Benton #24: when Puppetmaster fails before start, the pilot no longer deadlocks on its own delegate/swarm gates. Clipboard/local handoff is not exploration; a kernel-failure result lifts those gates so the pilot can diagnose locally.
- Identical swarm retry stays loop-blocked. Plumbing-only empty swarms stay on the existing thrash path.
- Rides `puppetmaster-ai==1.22.5` so the original GPT-5.6 `reasoning_effort` HTTP 400 is fixed at the kernel, not only recovered from.

## Test plan
- [x] `pytest tests/test_pilot_guards.py tests/test_send_loop_dispatch.py tests/test_send_loop_actions.py tests/test_version_consistency.py -q` (158 passed)
- [ ] CI: Python 3.9 + 3.11 + Windows + frontend-build on this SHA