### PR TITLE
Make swarm outcomes honest without inventing status

### DIFF
--- a/harness/api/jobs.py
+++ b/harness/api/jobs.py
@@ -36,7 +36,6 @@ class JobServices:
     routing_saved_usd: Callable[..., float]
     cache_saved_usd_swarm: Callable[..., float]
     tokens_cached_swarm: Callable[..., int]
-    job_dead_run_failure: Callable[..., Any]
     job_savings_fields: Callable[[str], dict]
     repo_session_stamped_meters: Callable[[str], dict]
     session_cost_split: Callable[..., float]
@@ -76,7 +75,6 @@ def make_job_services(**overrides: Any) -> JobServices:
         "routing_saved_usd": lambda *_a, **_k: 0.0,
         "cache_saved_usd_swarm": lambda *_a, **_k: 0.0,
         "tokens_cached_swarm": lambda *_a, **_k: 0,
-        "job_dead_run_failure": lambda *_a, **_k: None,
         "job_savings_fields": lambda *_a, **_k: {},
         "repo_session_stamped_meters": lambda *_a, **_k: {},
         "session_cost_split": lambda *_a, **_k: 0.0,
@@ -89,6 +87,13 @@ def make_job_services(**overrides: Any) -> JobServices:
     }
     defaults.update(overrides)
     return JobServices(**defaults)
+
+
+def canonical_job_outcome(raw_artifacts: list[Any]) -> dict[str, Any]:
+    """Return Puppetmaster's canonical artifact-quality verdict unchanged."""
+    from puppetmaster.quality import assess_run_quality
+
+    return assess_run_quality(raw_artifacts)
 
 
 def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
@@ -449,7 +454,7 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
                 (tasks_by_job.get(jid, []) if tasks_by_job is not None else []),
                 j.get("adapter", ""),
             )
-            dead_run = svc.job_dead_run_failure(raw_arts, str(job_status))
+            outcome = canonical_job_outcome(raw_arts)
 
             tasks_list = []
             try:
@@ -523,6 +528,7 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
                 "swarm_cache_unpriced_tokens": job_cache_unpriced_tokens,
                 "artifacts": artifacts_list,
                 "artifacts_complete": artifacts_complete,
+                "outcome": outcome,
                 "tasks": tasks_list,
                 "source": j.get("source", "harness"),
                 "label": j.get("label"),
@@ -542,8 +548,6 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
             ):
                 if j.get(_rk) not in (None, "", [], {}):
                     row[_rk] = j.get(_rk)
-            if dead_run:
-                row["dead_run_failure"] = dead_run
             res_jobs.append(apply_job_economics_policy(row))
     except Exception as e:
         svc.diag("server.jobs_list_aggregate", e)

--- a/harness/server.py
+++ b/harness/server.py
@@ -203,43 +203,6 @@ def _slim_swarm_list_artifacts(raw_arts, state_obj) -> list:
         return []
 
 
-def _job_dead_run_failure(raw_arts, status: str):
-    """Mirror SwarmPane dead-run detection against raw store artifacts.
-
-    Computed server-side before the live payload is slimmed -- otherwise a
-    finished job that still has FINDING rows would look like an all-failed
-    dead run once those findings are stripped from the poll response.
-
-    Returns the failure class string, or None when the job is not a dead run.
-    """
-    s = (status or "").lower()
-    if "complete" not in s and "done" not in s:
-        return None
-    if not raw_arts:
-        return None
-    failed = []
-    for art in raw_arts:
-        payload = getattr(art, "payload", None)
-        if not isinstance(payload, dict):
-            # Already-formatted dict rows (local jobs) carry result on the art.
-            if isinstance(art, dict):
-                payload = art
-            else:
-                return None
-        result = str(payload.get("result") or "").lower()
-        if result in ("failed", "blocked"):
-            failed.append(payload)
-        else:
-            return None
-    if not failed:
-        return None
-    for payload in failed:
-        failure = payload.get("failure")
-        if failure:
-            return str(failure)
-    return "workers failed"
-
-
 def _get_platform_json_path() -> str:
     """Canonical platform.json — same file Puppetmaster's lock reads."""
     from .platform_config import platform_json_path
@@ -1579,7 +1542,6 @@ def _job_services():
         cache_saved_usd_swarm=_cache_saved_usd_swarm,
         cache_saved_usd_swarm_detail=_cache_saved_usd_swarm_detail,
         tokens_cached_swarm=_tokens_cached_swarm,
-        job_dead_run_failure=_job_dead_run_failure,
         job_savings_fields=_job_savings_fields,
         repo_session_stamped_meters=_repo_session_stamped_meters,
         session_cost_split=_session_cost_split,

--- a/tests/test_cost_accounting.py
+++ b/tests/test_cost_accounting.py
@@ -350,7 +350,6 @@ def test_get_swarm_live_logs_on_price_resolve_exception(monkeypatch, caplog):
         routing_saved_usd=lambda *_a, **_k: 0.0,
         cache_saved_usd_swarm=lambda *_a, **_k: 0.0,
         tokens_cached_swarm=lambda *_a, **_k: 0,
-        job_dead_run_failure=lambda *_a, **_k: None,
         job_savings_fields=lambda *_a, **_k: {},
         repo_session_stamped_meters=lambda *_a, **_k: {},
         session_cost_split=lambda *_a, **_k: 0.0,

--- a/tests/test_session_fts_hybrid.py
+++ b/tests/test_session_fts_hybrid.py
@@ -443,7 +443,6 @@ def test_get_artifacts_hook_indexes_headlines():
             routing_saved_usd=lambda *_a, **_k: 0.0,
             cache_saved_usd_swarm=lambda *_a, **_k: 0.0,
             tokens_cached_swarm=lambda *_a, **_k: 0,
-            job_dead_run_failure=lambda *_a, **_k: None,
             job_savings_fields=lambda _jid: {},
             repo_session_stamped_meters=lambda _repo: {},
             session_cost_split=lambda *_a, **_k: 0.0,

--- a/tests/test_swarm_live_session_scope.py
+++ b/tests/test_swarm_live_session_scope.py
@@ -152,6 +152,12 @@ def test_swarm_live_repo_scope_excludes_active_pilot_meters(monkeypatch):
             assert live["session"]["swarm_cache_savings_basis"] == "unknown"
             assert live["session"]["swarm_cache_unpriced_tokens"] == 400
             assert live["jobs"][0]["swarm_cache_unpriced_tokens"] == 400
+            assert live["jobs"][0]["outcome"] == {
+                "quality": "empty",
+                "reasons": ["no artifacts were produced"],
+                "trustworthy": False,
+                "blocking_failures": [],
+            }
 
             # Unscoped still includes the active pilot meters + active-repo jobs.
             unscoped = json.loads(

--- a/tests/test_swarm_live_slim.py
+++ b/tests/test_swarm_live_slim.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from harness.api.jobs import canonical_job_outcome
 from harness.server import (
-    _job_dead_run_failure,
     _job_status_is_terminal,
     _slim_swarm_list_artifacts,
 )
@@ -83,28 +83,34 @@ def test_slim_keeps_routing_and_verdicts_drops_findings():
     assert len(slim) == 2
 
 
-def test_dead_run_from_raw_before_slim():
-    dead = [
+def test_canonical_outcome_uses_full_raw_artifacts_before_slim():
+    failed_before_execution = [
         _art(
-            art_type=ArtifactType.VERIFICATION,
-            payload={"result": "failed", "failure": "no_model"},
+            art_type=ArtifactType.ROUTING,
+            created_by="router",
+            payload={"model_id": "gpt-5.6-luna"},
         ),
         _art(
             art_type=ArtifactType.VERIFICATION,
-            payload={"result": "failed", "failure": "no_model"},
+            payload={"result": "failed", "failure": "provider_error"},
         ),
     ]
-    assert _job_dead_run_failure(dead, "completed") == "no_model"
+    outcome = canonical_job_outcome(failed_before_execution)
+    assert outcome["quality"] == "degraded"
+    assert outcome["trustworthy"] is False
+    assert outcome["reasons"] == [
+        "only verification artifacts — no findings/decisions/patches"
+    ]
 
-    alive = dead + [
+    substantive = failed_before_execution + [
         _art(art_type=ArtifactType.FINDING, payload={"claim": "real work"}),
     ]
-    assert _job_dead_run_failure(alive, "completed") is None
+    outcome = canonical_job_outcome(substantive)
+    assert outcome["quality"] == "ok"
+    assert outcome["trustworthy"] is True
 
-    # Slim list of only failed verdicts must not be used client-side alone;
-    # server stamp is computed on the full raw list above.
-    slim_only = _slim_swarm_list_artifacts(alive, _Fmt())
-    # After slim, findings are gone -- client would mis-detect without stamp.
+    # Canonical quality is computed before the poll payload drops findings.
+    slim_only = _slim_swarm_list_artifacts(substantive, _Fmt())
     assert all(
         (a.get("result") or "").lower() in ("failed", "blocked", "")
         for a in slim_only

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -659,14 +659,18 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
     expect(screen.getByText("Interrupted command")).toBeInTheDocument();
   });
 
-  it("keeps dead_run_failure authoritative as failed chrome", async () => {
+  it("renders Puppetmaster's canonical degraded outcome as amber, never green", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
-        id: "job-dead",
-        goal: "Dead run",
+        id: "job-degraded",
+        goal: "Provider failed before analysis",
         status: "complete",
         adapter: "agentic",
-        dead_run_failure: "no_model",
+        outcome: {
+          quality: "degraded",
+          trustworthy: false,
+          reasons: ["only verification artifacts — no findings/decisions/patches"],
+        },
         artifacts_complete: false,
         artifacts: [],
       }),
@@ -674,13 +678,13 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
 
     render(<SwarmPane />);
     await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
-    expect(screen.getByText(/1 failed/)).toBeInTheDocument();
-    expect(screen.queryByText(/cancelled/)).not.toBeInTheDocument();
+    expect(screen.getByText(/1 degraded/)).toBeInTheDocument();
     fireEvent.click(screen.getByText("Finished"));
     await waitFor(() => {
-      expect(screen.getByText(/all workers failed: no model/)).toBeInTheDocument();
-      expect(screen.getByText("failed")).toBeInTheDocument();
+      expect(screen.getByText("degraded")).toBeInTheDocument();
+      expect(screen.getByText(/only verification artifacts/)).toBeInTheDocument();
     });
+    expect(screen.queryByText("done")).not.toBeInTheDocument();
   });
 
   it("paints true user cancel as cancelled and does not tally it as failed", async () => {
@@ -803,7 +807,7 @@ describe("SwarmPane cancel Kill contract", () => {
   });
 });
 
-describe("SwarmPane dead-run detection", () => {
+describe("SwarmPane canonical outcome", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
@@ -812,58 +816,12 @@ describe("SwarmPane dead-run detection", () => {
     mockArtifacts.mockResolvedValue([]);
   });
 
-  it("renders a complete job whose every artifact failed as a failed run with the reason", async () => {
+  it("keeps a trustworthy complete job rendered as done", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
         status: "complete",
         adapter: "agentic",
-        artifacts: [
-          { type: "verification", headline: "audit", result: "failed", failure: "no_model" },
-          { type: "verification", headline: "audit", result: "failed", failure: "no_model" },
-        ],
-      }),
-    );
-
-    render(<SwarmPane />);
-
-    // Terminal jobs fold into the collapsed Finished accordion; open it.
-    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
-    fireEvent.click(screen.getByText("Finished"));
-
-    await waitFor(() => {
-      expect(screen.getByText(/all workers failed: no model/)).toBeInTheDocument();
-      expect(screen.getByText("failed")).toBeInTheDocument();
-      expect(screen.queryByText("done")).not.toBeInTheDocument();
-    });
-  });
-
-  it("uses server dead_run_failure when the live payload is slim", async () => {
-    mockSwarmLive.mockResolvedValue(
-      liveJob({
-        status: "complete",
-        adapter: "agentic",
-        artifacts_complete: false,
-        dead_run_failure: "no_model",
-        artifacts: [
-          { type: "verification", headline: "audit", result: "failed", failure: "no_model" },
-        ],
-      }),
-    );
-
-    render(<SwarmPane />);
-    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
-    fireEvent.click(screen.getByText("Finished"));
-
-    await waitFor(() => {
-      expect(screen.getByText(/all workers failed: no model/)).toBeInTheDocument();
-    });
-  });
-
-  it("keeps a complete job with real findings rendered as done", async () => {
-    mockSwarmLive.mockResolvedValue(
-      liveJob({
-        status: "complete",
-        adapter: "agentic",
+        outcome: { quality: "ok", trustworthy: true, reasons: [] },
         artifacts: [
           { type: "finding", headline: "found a bug" },
           { type: "verification", headline: "audit", result: "failed", failure: "no_model" },
@@ -878,7 +836,7 @@ describe("SwarmPane dead-run detection", () => {
 
     await waitFor(() => {
       expect(screen.getByText("done")).toBeInTheDocument();
-      expect(screen.queryByText(/all workers failed/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/only verification artifacts/)).not.toBeInTheDocument();
     });
   });
 });

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -437,6 +437,53 @@ describe("SwarmPane mid-run job-row meters", () => {
     }
   });
 
+  it("drops hydrated success artifacts when the same job becomes degraded", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let pollCount = 0;
+      mockSwarmLive.mockImplementation(async () => {
+        pollCount += 1;
+        if (pollCount <= 2) {
+          return liveJob({
+            id: "job-outcome-flip",
+            goal: "Outcome flips",
+            status: "complete",
+            outcome: { quality: "ok", trustworthy: true, reasons: [] },
+            artifacts_complete: true,
+            artifacts: [{ type: "finding", headline: "stale success finding" }],
+          });
+        }
+        return liveJob({
+          id: "job-outcome-flip",
+          goal: "Outcome flips",
+          status: "complete",
+          outcome: {
+            quality: "degraded",
+            trustworthy: false,
+            reasons: ["only verification artifacts — no findings/decisions/patches"],
+          },
+          artifacts_complete: false,
+          artifacts: [{ type: "verification", headline: "provider failed", result: "failed" }],
+        });
+      });
+
+      render(<SwarmPane />);
+      await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+      fireEvent.click(screen.getByText("Finished"));
+      fireEvent.click(await screen.findByText("Outcome flips"));
+      expect(await screen.findByText("stale success finding")).toBeInTheDocument();
+
+      await vi.advanceTimersByTimeAsync(6000);
+
+      await waitFor(() => {
+        expect(screen.getByText("degraded")).toBeInTheDocument();
+        expect(screen.queryByText("stale success finding")).not.toBeInTheDocument();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("refuses visibility-only jobs in jobSavings totals", () => {
     const parts = jobSavings({
       id: "j-ext",
@@ -678,7 +725,6 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
 
     render(<SwarmPane />);
     await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
-    expect(screen.getByText(/1 degraded/)).toBeInTheDocument();
     fireEvent.click(screen.getByText("Finished"));
     await waitFor(() => {
       expect(screen.getByText("degraded")).toBeInTheDocument();

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -43,7 +43,7 @@ function Tooltip({ label, children, className }: { label: string; children: Reac
   );
 }
 
-type Status = "pending" | "in_progress" | "completed" | "failed" | "cancelled";
+type Status = "pending" | "in_progress" | "completed" | "degraded" | "failed" | "cancelled";
 
 // Compact "how long ago" label for a job's last activity. Accepts epoch seconds
 // or an ISO string (the backend sends created_at/updated_at as either). Returns
@@ -116,7 +116,6 @@ function isFailedTerminalStatus(status: string): boolean {
 
 function jobStatus(j: Job): Status {
   const s = (j.status || "").toLowerCase();
-  if (s.includes("complete") || s.includes("done")) return "completed";
   // User cancel / abort — distinct from ordinary worker failure chrome.
   if (
     s.includes("cancel")
@@ -129,6 +128,14 @@ function jobStatus(j: Job): Status {
     return "failed";
   }
   if (s.includes("run") || s.includes("progress") || s.includes("active")) return "in_progress";
+  if (s.includes("complete") || s.includes("done")) {
+    const quality = String(j.outcome?.quality || "").toLowerCase();
+    if (quality === "blocked") return "failed";
+    if (quality === "degraded" || quality === "empty" || j.outcome?.trustworthy === false) {
+      return "degraded";
+    }
+    return "completed";
+  }
   return "pending";
 }
 
@@ -137,7 +144,7 @@ function jobStatus(j: Job): Status {
 // into a wall.
 function isTerminal(j: Job): boolean {
   const st = jobStatus(j);
-  return st === "completed" || st === "failed" || st === "cancelled";
+  return st === "completed" || st === "degraded" || st === "failed" || st === "cancelled";
 }
 
 function taskState(t: Task): "running" | "done" | "fail" | "idle" {
@@ -242,7 +249,8 @@ function swarmSignature(res: SwarmLive | null): string {
       `:${j.swarm_cache_savings_basis ?? ""}:${j.swarm_cache_unpriced_tokens ?? 0}` +
       `:${(j.tool_output_savings_usd ?? 0).toFixed(4)}` +
       `:${j.source ?? "harness"}` +
-      `:${j.dead_run_failure ?? ""}:${j.updated_at ?? ""}`,
+      `:${j.outcome?.quality ?? ""}:${j.outcome?.trustworthy ?? ""}` +
+      `:${(j.outcome?.reasons || []).join("|")}:${j.updated_at ?? ""}`,
     );
     for (const t of tasks) {
       parts.push(
@@ -320,28 +328,6 @@ function dedupeRouting(arts: Artifact[]): Artifact[] {
     }
   }
   return [...groups.values()];
-}
-
-// A "dead run": the job reads complete, but every artifact it produced is a
-// failed verdict -- e.g. all workers fast-failed with no_model before doing any
-// work. Older Puppetmaster versions stitched these into COMPLETE, so the
-// tracker painted a fully dead swarm as a healthy green "done" at $0 (the
-// worst failure mode: it looks like success). Prefer the server stamp
-// (computed before the live payload is slimmed); fall back to client scan
-// when the full artifact list is still present.
-function jobDeadRunFailure(j: Job): string | null {
-  if (typeof j.dead_run_failure === "string" && j.dead_run_failure) {
-    return j.dead_run_failure;
-  }
-  if (j.dead_run_failure === null) return null;
-  if (jobStatus(j) !== "completed") return null;
-  // Slim live payloads omit FINDING rows; never infer dead-run from a partial list.
-  if (j.artifacts_complete === false) return null;
-  const arts = jobArtifactList(j);
-  if (arts.length === 0) return null;
-  const failed = arts.filter((a) => (a.result || "").toLowerCase() === "failed" || (a.result || "").toLowerCase() === "blocked");
-  if (failed.length !== arts.length) return null;
-  return failed.find((a) => a.failure)?.failure || "workers failed";
 }
 
 /** Merge a fresh /swarm/live poll into cached state without wiping expanded full artifacts. */
@@ -565,6 +551,7 @@ function jobPhase(j: Job): { key: string; label: string; index: number; failed: 
     const label = st === "cancelled" ? "cancelled" : "failed";
     return { key: label, label, index: reached, failed: true };
   }
+  if (st === "degraded") return { key: "degraded", label: "degraded", index: 3, failed: false };
   if (st === "completed") return { key: "done", label: "done", index: 3, failed: false };
   if (total > 0 && running > 0) return { key: "workers", label: `running ${doneCount}/${total}`, index: 2, failed: false };
   if (total > 0) return { key: "workers", label: `${total} worker${total > 1 ? "s" : ""}`, index: 2, failed: false };
@@ -574,7 +561,7 @@ function jobPhase(j: Job): { key: string; label: string; index: number; failed: 
 
 function PhaseStrip({ job, phase }: { job: Job; phase?: ReturnType<typeof jobPhase> }) {
   const { index, failed, key } = phase ?? jobPhase(job);
-  const active = key !== "done" && !failed;
+  const active = key !== "done" && key !== "degraded" && !failed;
   return (
     <div className="flex items-center gap-1 mt-1.5" title={PHASES.join(" -> ")}>
       {PHASES.map((_, i) => {
@@ -583,7 +570,7 @@ function PhaseStrip({ job, phase }: { job: Job; phase?: ReturnType<typeof jobPha
         const color = failed && i === index
           ? (key === "cancelled" ? "bg-muted" : "bg-risk")
           : reached
-          ? (key === "done" ? "bg-good" : "bg-accent")
+          ? (key === "done" ? "bg-good" : key === "degraded" ? "bg-warn" : "bg-accent")
           : "bg-edge/60";
         return (
           <div
@@ -911,14 +898,10 @@ export default function SwarmPane() {
   const visibleJobs = allJobs.filter((j) => !isTerminal(j) || !dismissed.has(j.id));
   const running = visibleJobs.filter((j) => !isTerminal(j));
   const finished = visibleJobs.filter((j) => isTerminal(j));
-  // Ordinary failures + dead-run stamps count as failed; true user cancels do not.
-  const failedCount = finished.filter((j) =>
-    jobDeadRunFailure(j) !== null || jobStatus(j) === "failed",
-  ).length;
-  const cancelledCount = finished.filter((j) =>
-    jobDeadRunFailure(j) === null && jobStatus(j) === "cancelled",
-  ).length;
-  const completedCount = finished.length - failedCount - cancelledCount;
+  const failedCount = finished.filter((j) => jobStatus(j) === "failed").length;
+  const degradedCount = finished.filter((j) => jobStatus(j) === "degraded").length;
+  const cancelledCount = finished.filter((j) => jobStatus(j) === "cancelled").length;
+  const completedCount = finished.length - failedCount - degradedCount - cancelledCount;
   const runningCount = running.filter((j) => jobStatus(j) === "in_progress").length;
   const anyRunning = runningCount > 0;
 
@@ -942,14 +925,10 @@ export default function SwarmPane() {
   // accordion. Defined in-scope so it closes over the expand/dismiss state
   // instead of threading a dozen props.
   const renderJob = (j: Job) => {
-    const deadRunFailure = jobDeadRunFailure(j);
-    // dead_run_failure is authoritative: paint as failed, never as a user cancel.
-    const st: Status = deadRunFailure ? "failed" : jobStatus(j);
+    const st = jobStatus(j);
     const manualExpanded = expandedJobs[j.id];
     const isExpanded = manualExpanded !== undefined ? manualExpanded : (st === "in_progress");
-    const phase = deadRunFailure
-      ? { key: "failed", label: "failed", index: 2, failed: true }
-      : jobPhase(j);
+    const phase = jobPhase(j);
 
     const artifacts = jobArtifactList(j);
     const routingArts = dedupeRouting(
@@ -1000,6 +979,8 @@ export default function SwarmPane() {
             ? "border-accent/30"
             : st === "completed"
             ? "border-good/25"
+            : st === "degraded"
+            ? "border-warn/35"
             : st === "failed"
             ? "border-risk/25"
             : st === "cancelled"
@@ -1026,6 +1007,8 @@ export default function SwarmPane() {
                   <Loader2 size={12} className="animate-spin text-accent" />
                 ) : st === "completed" ? (
                   <CheckCircle2 size={12} className="text-good" />
+                ) : st === "degraded" ? (
+                  <Circle size={12} className="text-warn" />
                 ) : st === "failed" ? (
                   <XCircle size={12} className="text-risk" />
                 ) : st === "cancelled" ? (
@@ -1165,13 +1148,11 @@ export default function SwarmPane() {
             </div>
           )}
 
-          {/* Dead run: every worker fast-failed before doing work. Say so and
-              why, instead of letting the card read as a normal finished swarm. */}
-          {deadRunFailure && (
-            <div className="pl-6 pr-1 mt-1 text-[9.5px] text-risk/90">
-              all workers failed: {deadRunFailure.replace(/_/g, " ")} -- no work ran, nothing was spent
+          {st === "degraded" && j.outcome?.reasons?.length ? (
+            <div className="pl-6 pr-1 mt-1 text-[9.5px] text-warn/90">
+              {j.outcome.reasons[0]}
             </div>
-          )}
+          ) : null}
 
           {/* Phase strip + label -- the at-a-glance "where is this swarm". */}
           <div className="flex items-center gap-2 pl-6 pr-1 mt-1">
@@ -1181,6 +1162,8 @@ export default function SwarmPane() {
                 ? "text-muted"
                 : phase.failed
                 ? "text-risk/80"
+                : phase.key === "degraded"
+                ? "text-warn/80"
                 : phase.key === "done"
                 ? "text-good/80"
                 : "text-accent/80"
@@ -1590,6 +1573,9 @@ export default function SwarmPane() {
                     <span className="text-faint/60 normal-case tracking-normal">({finished.length})</span>
                     {failedCount > 0 && (
                       <span className="text-risk/70 normal-case tracking-normal">{"\u00b7"} {failedCount} failed</span>
+                    )}
+                    {degradedCount > 0 && (
+                      <span className="text-warn/80 normal-case tracking-normal">{"\u00b7"} {degradedCount} degraded</span>
                     )}
                     {cancelledCount > 0 && (
                       <span className="text-muted normal-case tracking-normal">{"\u00b7"} {cancelledCount} cancelled</span>

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -43,7 +43,7 @@ function Tooltip({ label, children, className }: { label: string; children: Reac
   );
 }
 
-type Status = "pending" | "in_progress" | "completed" | "degraded" | "failed" | "cancelled";
+type Status = "pending" | "in_progress" | "completed" | "failed" | "cancelled";
 
 // Compact "how long ago" label for a job's last activity. Accepts epoch seconds
 // or an ISO string (the backend sends created_at/updated_at as either). Returns
@@ -128,14 +128,7 @@ function jobStatus(j: Job): Status {
     return "failed";
   }
   if (s.includes("run") || s.includes("progress") || s.includes("active")) return "in_progress";
-  if (s.includes("complete") || s.includes("done")) {
-    const quality = String(j.outcome?.quality || "").toLowerCase();
-    if (quality === "blocked") return "failed";
-    if (quality === "degraded" || quality === "empty" || j.outcome?.trustworthy === false) {
-      return "degraded";
-    }
-    return "completed";
-  }
+  if (s.includes("complete") || s.includes("done")) return "completed";
   return "pending";
 }
 
@@ -144,7 +137,7 @@ function jobStatus(j: Job): Status {
 // into a wall.
 function isTerminal(j: Job): boolean {
   const st = jobStatus(j);
-  return st === "completed" || st === "degraded" || st === "failed" || st === "cancelled";
+  return st === "completed" || st === "failed" || st === "cancelled";
 }
 
 function taskState(t: Task): "running" | "done" | "fail" | "idle" {
@@ -339,8 +332,18 @@ function mergeSwarmLive(prev: SwarmLive | null | undefined, next: SwarmLive): Sw
     jobs: (next.jobs || []).map((j) => {
       const old = prevById.get(j.id);
       if (!old) return j;
-      // Keep a previously hydrated full artifact list when the poll is slim.
-      if (j.artifacts_complete === false && old.artifacts_complete === true) {
+      // Keep hydrated artifacts only while the fresh row remains healthy. A
+      // failed or non-trustworthy terminal poll is authoritative and must not
+      // retain stale success evidence from an earlier expansion of the same job.
+      const freshStatus = jobStatus(j);
+      const mayKeepHydrated = freshStatus !== "failed"
+        && freshStatus !== "cancelled"
+        && j.outcome?.trustworthy !== false;
+      if (
+        mayKeepHydrated
+        && j.artifacts_complete === false
+        && old.artifacts_complete === true
+      ) {
         return {
           ...j,
           artifacts: old.artifacts,
@@ -551,8 +554,10 @@ function jobPhase(j: Job): { key: string; label: string; index: number; failed: 
     const label = st === "cancelled" ? "cancelled" : "failed";
     return { key: label, label, index: reached, failed: true };
   }
-  if (st === "degraded") return { key: "degraded", label: "degraded", index: 3, failed: false };
-  if (st === "completed") return { key: "done", label: "done", index: 3, failed: false };
+  if (st === "completed") {
+    const label = j.outcome?.trustworthy === false ? j.outcome.quality : "done";
+    return { key: "done", label, index: 3, failed: false };
+  }
   if (total > 0 && running > 0) return { key: "workers", label: `running ${doneCount}/${total}`, index: 2, failed: false };
   if (total > 0) return { key: "workers", label: `${total} worker${total > 1 ? "s" : ""}`, index: 2, failed: false };
   if (hasRouting) return { key: "routing", label: "routing", index: 1, failed: false };
@@ -561,7 +566,8 @@ function jobPhase(j: Job): { key: string; label: string; index: number; failed: 
 
 function PhaseStrip({ job, phase }: { job: Job; phase?: ReturnType<typeof jobPhase> }) {
   const { index, failed, key } = phase ?? jobPhase(job);
-  const active = key !== "done" && key !== "degraded" && !failed;
+  const warning = jobStatus(job) === "completed" && job.outcome?.trustworthy === false;
+  const active = key !== "done" && !failed;
   return (
     <div className="flex items-center gap-1 mt-1.5" title={PHASES.join(" -> ")}>
       {PHASES.map((_, i) => {
@@ -569,8 +575,10 @@ function PhaseStrip({ job, phase }: { job: Job; phase?: ReturnType<typeof jobPha
         const isActiveSeg = i === index && active;
         const color = failed && i === index
           ? (key === "cancelled" ? "bg-muted" : "bg-risk")
+          : warning && reached
+          ? "bg-warn"
           : reached
-          ? (key === "done" ? "bg-good" : key === "degraded" ? "bg-warn" : "bg-accent")
+          ? (key === "done" ? "bg-good" : "bg-accent")
           : "bg-edge/60";
         return (
           <div
@@ -899,9 +907,10 @@ export default function SwarmPane() {
   const running = visibleJobs.filter((j) => !isTerminal(j));
   const finished = visibleJobs.filter((j) => isTerminal(j));
   const failedCount = finished.filter((j) => jobStatus(j) === "failed").length;
-  const degradedCount = finished.filter((j) => jobStatus(j) === "degraded").length;
   const cancelledCount = finished.filter((j) => jobStatus(j) === "cancelled").length;
-  const completedCount = finished.length - failedCount - degradedCount - cancelledCount;
+  const completedCount = finished.filter(
+    (j) => jobStatus(j) === "completed" && j.outcome?.trustworthy !== false,
+  ).length;
   const runningCount = running.filter((j) => jobStatus(j) === "in_progress").length;
   const anyRunning = runningCount > 0;
 
@@ -926,6 +935,7 @@ export default function SwarmPane() {
   // instead of threading a dozen props.
   const renderJob = (j: Job) => {
     const st = jobStatus(j);
+    const outcomeWarning = st === "completed" && j.outcome?.trustworthy === false;
     const manualExpanded = expandedJobs[j.id];
     const isExpanded = manualExpanded !== undefined ? manualExpanded : (st === "in_progress");
     const phase = jobPhase(j);
@@ -977,12 +987,12 @@ export default function SwarmPane() {
         className={`shrink-0 rounded-md border bg-panel2/20 flex flex-col overflow-hidden transition-colors ${
           st === "in_progress"
             ? "border-accent/30"
-            : st === "completed"
-            ? "border-good/25"
-            : st === "degraded"
-            ? "border-warn/35"
             : st === "failed"
             ? "border-risk/25"
+            : outcomeWarning
+            ? "border-warn/35"
+            : st === "completed"
+            ? "border-good/25"
             : st === "cancelled"
             ? "border-muted/40"
             : "border-edge"
@@ -1005,12 +1015,12 @@ export default function SwarmPane() {
               <span className="shrink-0">
                 {st === "in_progress" ? (
                   <Loader2 size={12} className="animate-spin text-accent" />
-                ) : st === "completed" ? (
-                  <CheckCircle2 size={12} className="text-good" />
-                ) : st === "degraded" ? (
-                  <Circle size={12} className="text-warn" />
                 ) : st === "failed" ? (
                   <XCircle size={12} className="text-risk" />
+                ) : outcomeWarning ? (
+                  <Circle size={12} className="text-warn" />
+                ) : st === "completed" ? (
+                  <CheckCircle2 size={12} className="text-good" />
                 ) : st === "cancelled" ? (
                   <XCircle size={12} className="text-muted" />
                 ) : (
@@ -1148,7 +1158,7 @@ export default function SwarmPane() {
             </div>
           )}
 
-          {st === "degraded" && j.outcome?.reasons?.length ? (
+          {outcomeWarning && j.outcome?.reasons?.length ? (
             <div className="pl-6 pr-1 mt-1 text-[9.5px] text-warn/90">
               {j.outcome.reasons[0]}
             </div>
@@ -1162,7 +1172,7 @@ export default function SwarmPane() {
                 ? "text-muted"
                 : phase.failed
                 ? "text-risk/80"
-                : phase.key === "degraded"
+                : outcomeWarning
                 ? "text-warn/80"
                 : phase.key === "done"
                 ? "text-good/80"
@@ -1573,9 +1583,6 @@ export default function SwarmPane() {
                     <span className="text-faint/60 normal-case tracking-normal">({finished.length})</span>
                     {failedCount > 0 && (
                       <span className="text-risk/70 normal-case tracking-normal">{"\u00b7"} {failedCount} failed</span>
-                    )}
-                    {degradedCount > 0 && (
-                      <span className="text-warn/80 normal-case tracking-normal">{"\u00b7"} {degradedCount} degraded</span>
                     )}
                     {cancelledCount > 0 && (
                       <span className="text-muted normal-case tracking-normal">{"\u00b7"} {cancelledCount} cancelled</span>

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -246,8 +246,13 @@ export type Job = {
   // False on /api/swarm/live (slim routing+verdicts for in-progress and terminal).
   // Expand fetches /api/artifacts and flips this true.
   artifacts_complete?: boolean;
-  // Server-computed before slim: all workers failed/blocked with no real work.
-  dead_run_failure?: string | null;
+  // Puppetmaster's canonical artifact-quality verdict, computed from full raw artifacts.
+  outcome?: {
+    quality: "ok" | "degraded" | "empty" | "blocked" | string;
+    trustworthy: boolean;
+    reasons: string[];
+    blocking_failures?: string[];
+  };
   /** Validation reuse: fresh | reused | partial | invalidated (optional/backcompat). */
   reuse_status?: "fresh" | "reused" | "partial" | "invalidated" | string;
   /** Prior job whose findings were reused or partially reverified. */


### PR DESCRIPTION
## Summary
- A Puppetmaster job can reach lifecycle `complete` while its canonical outcome is untrustworthy; the Swarm Tracker previously painted that green and could retain hydrated success artifacts through a later slim poll.
- Replace Marionette's duplicate dead-run inference with Puppetmaster's existing `assess_run_quality` outcome. Lifecycle stays in `job.status`; canonical quality controls amber chrome and the displayed reason.
- Stop carrying cached full artifacts when a fresh poll reports `outcome.trustworthy=false`; healthy slim polls still preserve expanded detail.

## Test plan
- [x] `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q -p no:cacheprovider tests/test_swarm_live_slim.py tests/test_swarm_live_session_scope.py tests/test_cost_accounting.py tests/test_session_fts_hybrid.py` (53 passed)
- [x] `cd webapp && NODE_ENV=test npm test -- --run src/__tests__/SwarmPane.test.tsx` (44 passed)
- [x] `cd webapp && npm run build`
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)
