### PR TITLE
Surface terminal swarm failures without stale chat chrome

### DIFF
--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -1149,20 +1149,7 @@ class ConversationJobsMixin:
                 if isinstance(row, dict)
                 and str(row.get("type") or "") in ("finding", "risk", "decision")
             ]
-            self._finish_local_job(
-                job_id,
-                ok=not res_dict.get("error"),
-                summary=res_dict.get("summary", ""),
-                files=res_dict.get("files") or [],
-                tokens=res_dict.get("tokens_out", 0) + res_dict.get("tokens_in", 0),
-                est_cost_usd=float(getattr(res, "est_cost_usd", 0.0) or 0.0),
-                engine=wr_engine,
-                model=wr_model,
-                findings=_signal_rows,
-                diff=(getattr(res, "patch", "") or ""),
-                worker_provenance=provenance,
-            )
-            # Copy reuse provenance from the stamped local job onto the queued
+            # Copy reuse provenance from the registered local job onto the queued
             # result so drain/SSE hydrate stay honest after reload.
             try:
                 stamped = (getattr(self, "_local_jobs", {}) or {}).get(job_id) or {}
@@ -1185,6 +1172,22 @@ class ConversationJobsMixin:
                 "result": res_dict,
                 "state_dir": None
             })
+            # Queue the chat continuation before publishing terminal tracker
+            # status. Otherwise swarm/live can prune the final pending id and
+            # disable the only drain poll while this result is not yet visible.
+            self._finish_local_job(
+                job_id,
+                ok=not res_dict.get("error"),
+                summary=res_dict.get("summary", ""),
+                files=res_dict.get("files") or [],
+                tokens=res_dict.get("tokens_out", 0) + res_dict.get("tokens_in", 0),
+                est_cost_usd=float(getattr(res, "est_cost_usd", 0.0) or 0.0),
+                engine=wr_engine,
+                model=wr_model,
+                findings=_signal_rows,
+                diff=(getattr(res, "patch", "") or ""),
+                worker_provenance=provenance,
+            )
 
         except Exception as e:
             try:
@@ -1209,10 +1212,6 @@ class ConversationJobsMixin:
                 return
             failure_text = _worker_provenance_text(failure_provenance)
             failure_summary = f"{failure_text}\nFailed background worker: {e}".strip()
-            self._finish_local_job(
-                job_id, ok=False, summary=failure_summary,
-                worker_provenance=failure_provenance,
-            )
             self._swarm_results.put({
                 "job_id": job_id,
                 "objective": objective,
@@ -1234,6 +1233,12 @@ class ConversationJobsMixin:
                 },
                 "state_dir": None
             })
+            # The result queue owns the durable/visible terminal continuation;
+            # publish failed tracker state only after that continuation exists.
+            self._finish_local_job(
+                job_id, ok=False, summary=failure_summary,
+                worker_provenance=failure_provenance,
+            )
         finally:
             # Free the objective for legitimate future dispatch regardless of
             # how this worker settled (applied, failed, or crashed).

--- a/tests/test_send_loop_dispatch.py
+++ b/tests/test_send_loop_dispatch.py
@@ -10,8 +10,10 @@ import ast
 import inspect
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from harness.config import HarnessConfig
+from harness.conversation import ConversationalSession
 from harness.pilot import PilotAction
 from harness.send_loop import SendLoopMixin
 from harness.send_loop_dispatch import (
@@ -31,6 +33,41 @@ DISPATCH_HELPERS = (
     "dispatch_route_task_action",
     "dispatch_memory_action",
 )
+
+
+def test_background_failure_queues_result_before_tracker_turns_terminal(tmp_path):
+    """A terminal live row must never outrun its drainable chat continuation."""
+    session = ConversationalSession(
+        HarnessConfig(driver="stub-oracle-v2", state_dir=str(tmp_path))
+    )
+    job_id = "local-terminal-order"
+    session._register_local_job(
+        job_id,
+        goal="prove terminal ordering",
+        role="implement",
+        engine="native",
+    )
+    queue_ready_when_finished: list[bool] = []
+    finish = session._finish_local_job
+
+    def finish_after_queue(*args, **kwargs):
+        queue_ready_when_finished.append(not session._swarm_results.empty())
+        return finish(*args, **kwargs)
+
+    with (
+        patch.object(
+            session,
+            "_run_edit_worker_bounded",
+            side_effect=RuntimeError("worker died"),
+        ),
+        patch.object(session, "_finish_local_job", side_effect=finish_after_queue),
+    ):
+        session._run_provider_worker_background(job_id, "prove terminal ordering")
+
+    assert queue_ready_when_finished == [True]
+    queued = session._swarm_results.get_nowait()
+    assert queued["job_id"] == job_id
+    assert queued["result"]["error"] == "worker died"
 
 
 def _inner_source() -> str:

--- a/webapp/src/__tests__/swarmAwaitChrome.test.ts
+++ b/webapp/src/__tests__/swarmAwaitChrome.test.ts
@@ -13,6 +13,7 @@ import {
   SWARM_AWAIT_HINT,
   swarmResultsAwaitChromeClear,
   terminalJobIdsFromSwarmLive,
+  terminalJobIdsNeedingResultRecovery,
   triggerResumeGate,
   waitHintForAssistantDone,
 } from "../components/conversation/swarmPoll";
@@ -490,6 +491,42 @@ describe("swarm await chrome", () => {
     ).toEqual(["job_alive"]);
     expect(pruneTerminalJobIds(["job_alive"], [])).toEqual(["job_alive"]);
     expect(pruneTerminalJobIds([], ["job_done"])).toEqual([]);
+  });
+
+  it("recovers a missed terminal result through the durable drain exactly once", () => {
+    const pending = [{
+      kind: "swarm_pending",
+      job_ids: ["job_failed"],
+      objective: "repair terminal continuation",
+      status: "running",
+      resolved: false,
+    }] as Item[];
+
+    expect(terminalJobIdsNeedingResultRecovery(
+      ["job_failed"],
+      ["job_failed", "job_other_session"],
+      pending,
+    )).toEqual(["job_failed"]);
+
+    const delivered = [...pending, {
+      kind: "swarm_result",
+      job_id: "job_failed",
+      objective: "repair terminal continuation",
+      applied: false,
+      files: [],
+      summary: "Background work failed.",
+      error: "worker died",
+    }] as Item[];
+    expect(terminalJobIdsNeedingResultRecovery(
+      ["job_failed"],
+      ["job_failed"],
+      delivered,
+    )).toEqual([]);
+    expect(terminalJobIdsNeedingResultRecovery(
+      ["job_failed"],
+      ["job_other_session"],
+      pending,
+    )).toEqual([]);
   });
 
   it("fences trailing getSessionState apply so late session-A poll cannot mutate B", () => {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -152,6 +152,7 @@ import {
   SWARM_AWAIT_HINT,
   swarmResultsAwaitChromeClear,
   terminalJobIdsFromSwarmLive,
+  terminalJobIdsNeedingResultRecovery,
   triggerResumeGate,
 } from "./conversation/swarmPoll";
 import { armResumeKick } from "./conversation/sessionResumeLatch";
@@ -1959,6 +1960,7 @@ export default function Conversation({
     () => {
       const pollSid = activeSessionId;
       const pollGen = transcriptLoadGenRef.current;
+      let pollResumeFired = false;
       return api.getSwarmResults()
         .then((res) => {
           // Same session+gen fence as swarmLive: do not apply pilot_resume /
@@ -1975,7 +1977,6 @@ export default function Conversation({
           if (res && res.results && res.results.length > 0) {
             // At most one triggerResume per poll tick (first pilot_resume wins;
             // extras only set resumeQueuedRef). Mid-stream path already coalesces.
-            let pollResumeFired = false;
             res.results.forEach((evt) => {
               if (!shouldApplySwarmLiveMerge({
                 pollGen,
@@ -2049,6 +2050,11 @@ export default function Conversation({
             );
             const terminalIds = terminalJobIdsFromSwarmLive(jobs);
             const hasTerminal = terminalIds.length > 0;
+            const recoveryIds = terminalJobIdsNeedingResultRecovery(
+              pendingJobIdsRef.current,
+              terminalIds,
+              itemsRef.current,
+            );
             // Live terminal status must prune await trackers even when drain
             // never delivered swarm_result (busy-held starve / missed poll).
             if (hasTerminal) {
@@ -2074,6 +2080,44 @@ export default function Conversation({
                   return prev;
                 }
                 return mergeJobActionsIntoItems(prev, jobs);
+              });
+            }
+            if (recoveryIds.length > 0) {
+              const recoverySet = new Set(recoveryIds);
+              return api.getSwarmResults().then((recovered) => {
+                if (!shouldApplySwarmLiveMerge({
+                  pollGen,
+                  currentGen: transcriptLoadGenRef.current,
+                  pollSessionId: pollSid,
+                  cachedSessionId: cachedSessionIdRef.current,
+                  activeSessionId: cachedSessionIdRef.current,
+                })) {
+                  return null;
+                }
+                for (const evt of recovered?.results || []) {
+                  const action = classifySwarmPollEvent(evt);
+                  if (
+                    action.kind === "swarm_result"
+                    && recoverySet.has(String(action.data?.job_id || ""))
+                  ) {
+                    handleSwarmResult(action.data);
+                  } else if (action.kind === "pilot_resume") {
+                    const resumeAct = pilotResumePollAction({
+                      userStopped: userStoppedRef.current,
+                      alreadyFired: pollResumeFired,
+                    });
+                    if (resumeAct === "suppress_clear_hint") {
+                      setWaitHint((prev) => clearSwarmAwaitWaitHint(prev));
+                    } else if (resumeAct === "fire_looking") {
+                      pollResumeFired = true;
+                      setWaitHint(PILOT_LOOKING_HINT);
+                      resumeTriggerRef.current();
+                    } else {
+                      resumeQueuedRef.current = true;
+                    }
+                  }
+                }
+                return api.getSessionState();
               });
             }
             return api.getSessionState();

--- a/webapp/src/components/conversation/swarmPoll.ts
+++ b/webapp/src/components/conversation/swarmPoll.ts
@@ -128,6 +128,34 @@ export function pruneTerminalJobIds(
   return pending.filter((id) => !terminal.has(id));
 }
 
+/**
+ * Terminal ids owned by this conversation that still lack a visible result.
+ * These need one final durable drain before pending ids are allowed to vanish.
+ */
+export function terminalJobIdsNeedingResultRecovery(
+  pendingJobIds: readonly string[],
+  terminalJobIds: readonly string[],
+  items: readonly Item[],
+): string[] {
+  if (!pendingJobIds.length || !terminalJobIds.length) return [];
+  const pending = new Set(pendingJobIds.map((id) => String(id || "").trim()).filter(Boolean));
+  const delivered = new Set(
+    items
+      .filter((item) => item.kind === "swarm_result")
+      .map((item) => String(item.job_id || "").trim())
+      .filter(Boolean),
+  );
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of terminalJobIds) {
+    const id = String(raw || "").trim();
+    if (!id || seen.has(id) || !pending.has(id) || delivered.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
 /** Job ids from swarm/live rows whose status is already terminal. */
 export function terminalJobIdsFromSwarmLive(
   jobs: readonly SwarmLiveJobRow[],


### PR DESCRIPTION
## Summary
- A background swarm could publish terminal tracker state before its `swarm_result` entered the chat drain queue. The renderer then removed the final pending job ID, stopped polling, and left stale Investigating chrome without the failed continuation.
- Queue the terminal continuation before publishing terminal local-job status, so tracker completion cannot outrun the durable transcript result.
- When `/api/swarm/live` still exposes a terminal job without a visible result, perform one final session-fenced drain. Normal delivery remains idempotent; late jobs from another session or repository cannot mutate the active conversation.

## Test plan
- [x] RED: backend regression failed with an empty result queue at terminal publication (`[False] != [True]`)
- [x] RED: renderer regression failed because terminal-result recovery was absent
- [x] `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q -p no:cacheprovider tests/test_send_loop_dispatch.py tests/test_swarm_surfaced_honesty.py tests/test_session_control_deferred_refetch.py` (52 passed)
- [x] `cd webapp && NODE_ENV=test npm test -- --run src/__tests__/Conversation.resume.test.ts src/__tests__/swarmAwaitChrome.test.ts src/__tests__/chatLoopResilience.wave5.test.ts` (48 passed)
- [x] `cd webapp && npm run build`
- [ ] Live installed-runtime verification after approval to update/restart `/Users/bferguson/.marionette/marionette`
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)
