### PR TITLE
Release v0.9.228: provenance reconciler and boot worktree reaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.227, deliberately pre-1.0. Swarm Tracker uses Puppetmaster's canonical run quality (amber when untrustworthy; no invented status) and queues the chat continuation before publishing terminal tracker state. Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.228, deliberately pre-1.0. Acceptance-criteria reconciler settles model-id / execution_provenance rows from stamped artifact provenance (no worker checklist required); boot reaps leftover pmedit-/pmworker- worktrees. Rides puppetmaster-ai==1.22.5.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.227"
+__version__ = "0.9.228"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/server.py
+++ b/harness/server.py
@@ -1442,6 +1442,19 @@ def _reap_stale_swarms_on_boot() -> None:
                 )
         except Exception as e:
             _diag("server.boot_reaper_sweep", e)
+    try:
+        from . import worktrees as _wt
+        repo = str(getattr(_cfg, "repo", "") or "").strip()
+        if repo:
+            result = _wt.reap_stale_managed_worktrees(repo)
+            reaped_trees = int(result.get("count") or 0)
+            if reaped_trees:
+                _diag(
+                    "server.boot_worktree_reaper",
+                    msg=f"removed {reaped_trees} stale managed worktree(s)",
+                )
+    except Exception as e:
+        _diag("server.boot_worktree_reaper", e)
 
 
 threading.Thread(target=_reap_stale_swarms_on_boot, daemon=True).start()

--- a/harness/swarm_run_facts.py
+++ b/harness/swarm_run_facts.py
@@ -55,6 +55,23 @@ _KNOWN_FILE_EXTENSIONS = frozenset({
 
 _ROUTING_TYPE = "routing"
 
+# Spend numbers belong on the job envelope. A child row that copies them is
+# fabricating a receipt (including a fake $0 / 0-token measurement).
+_SPEND_FIELDS = ("tokens", "est_cost_usd", "estimated_cost_usd")
+
+# Self-report criteria that ask about stamped identity, not a worker checklist.
+# Keep this narrow: "pyright is clean" must still require a structured citation.
+_PROVENANCE_SELF_REPORT_MARKERS = (
+    "model id",
+    "model-id",
+    "model_id",
+    "execution provenance",
+    "execution_provenance",
+    "usage_known",
+    "cost_known",
+    "no fake zero",
+)
+
 # Environment probes are bounded but not free (PATH scans, a Chrome lookup).
 # A drain pass that settles several jobs at once must not pay for each one.
 _PROBE_TTL_SECONDS = 60.0
@@ -356,18 +373,98 @@ def _verified_criterion_loci(artifact: Mapping[str, Any]) -> dict[str, str]:
     return verified
 
 
+def _is_provenance_self_report_criterion(criterion: str) -> bool:
+    """True only for model-id / execution_provenance / no-fake-zero rows."""
+    text = _normalized_text(criterion)
+    if not text:
+        return False
+    return any(marker in text for marker in _PROVENANCE_SELF_REPORT_MARKERS)
+
+
+def _honest_execution_provenance(artifact: Mapping[str, Any]) -> bool:
+    """Stamped identity plus known-flags, and no fabricated spend on the child."""
+    prov = artifact.get("execution_provenance")
+    if not isinstance(prov, Mapping):
+        return False
+    model = str(
+        prov.get("model")
+        or prov.get("adapter_model_name")
+        or prov.get("router_model_id")
+        or ""
+    ).strip()
+    if not model:
+        return False
+    if "usage_known" not in prov or "cost_known" not in prov:
+        return False
+    if not isinstance(prov.get("usage_known"), bool):
+        return False
+    if not isinstance(prov.get("cost_known"), bool):
+        return False
+    bags: tuple[Mapping[str, Any], ...] = (artifact, prov)
+    for bag in bags:
+        for field in _SPEND_FIELDS:
+            if field in bag:
+                return False
+    return True
+
+
+def _provenance_self_report_basis(
+    criterion: str,
+    artifacts: Sequence[Mapping[str, Any]],
+    job_id: str,
+) -> str:
+    """Settle a provenance criterion from stamps, not a worker-cited checklist.
+
+    Every current-job non-routing artifact must already carry honest
+    ``execution_provenance``. Zero inspected rows, a missing model id, absent
+    known-flags, or copied spend numbers leave the criterion unverified.
+    """
+    if not _is_provenance_self_report_criterion(criterion):
+        return ""
+    current = str(job_id or "").strip()
+    if not current:
+        return ""
+    inspected = 0
+    for artifact in artifacts or ():
+        if not isinstance(artifact, Mapping):
+            continue
+        if _parent_job_id(artifact) != current:
+            continue
+        if str(artifact.get("failure") or "").strip():
+            continue
+        kind = str(artifact.get("type") or "").strip().lower()
+        if kind == _ROUTING_TYPE:
+            continue
+        inspected += 1
+        if not _honest_execution_provenance(artifact):
+            return ""
+    if inspected == 0:
+        return ""
+    return (
+        f"stamped execution_provenance on {inspected} current-job "
+        "non-routing artifact(s)"
+    )
+
+
 def evaluate_acceptance_criteria(
     criteria: Sequence[str],
     artifacts: Sequence[Mapping[str, Any]],
     job_id: str,
 ) -> tuple[CriterionFact, ...]:
-    """Echo each criterion with the current-job artifact that settles it.
+    """Echo each criterion with the current-job evidence that settles it.
 
-    A criterion counts as verified only when a successful substantive artifact
-    **attributed to THIS job** explicitly maps itself to that criterion through
-    its ``acceptance_criteria`` list. Prompt/check prose is never searched: a
-    failed worker artifact often repeats the entire instruction, and treating
-    that repetition as evidence makes every criterion falsely green.
+    A code/check criterion counts as verified only when a successful
+    substantive artifact **attributed to THIS job** explicitly maps itself to
+    that criterion through its ``acceptance_criteria`` list. Prompt/check prose
+    is never searched: a failed worker artifact often repeats the entire
+    instruction, and treating that repetition as evidence makes every
+    criterion falsely green.
+
+    A narrow second path settles self-report model-id / execution_provenance
+    criteria from stamps already on current-job non-routing artifacts. That
+    path still fails closed: missing model, missing known-flags, copied spend
+    (including fake zeros), or no current-job rows leave the criterion
+    ``not_verified``.
     """
     from harness.environment_fingerprint import normalize_acceptance_criteria
 
@@ -400,6 +497,17 @@ def evaluate_acceptance_criteria(
                 break
         if basis:
             facts.append(CriterionFact(criterion, VERIFIED, basis))
+            continue
+        stamp_basis = _provenance_self_report_basis(criterion, artifacts, current)
+        if stamp_basis:
+            facts.append(CriterionFact(criterion, VERIFIED, stamp_basis))
+        elif _is_provenance_self_report_criterion(criterion):
+            facts.append(CriterionFact(
+                criterion,
+                NOT_VERIFIED,
+                "current-job non-routing artifacts do not all carry "
+                "honest execution_provenance",
+            ))
         else:
             facts.append(CriterionFact(
                 criterion,

--- a/harness/worktrees.py
+++ b/harness/worktrees.py
@@ -8,6 +8,7 @@ import logging
 import subprocess
 import tempfile
 import threading
+import time
 from typing import Optional
 
 from .paths import path_within
@@ -602,6 +603,62 @@ def cleanup_old_worktrees(repo: str, max_count: int = 25) -> None:
             remove_worktree(repo, wt["path"], force=True)
         except Exception as exc:
             logger.warning("failed to remove stale worktree %s: %s", wt["path"], exc)
+
+
+def _is_managed_worktree(wt: dict) -> bool:
+    """True for pmedit-/pmworker- scratch trees, never the main checkout."""
+    if not wt or wt.get("is_main") or wt.get("locked"):
+        return False
+    branch = (wt.get("branch") or "").strip()
+    if _is_managed_branch_name(branch):
+        return True
+    name = os.path.basename(os.path.normpath(wt.get("path") or ""))
+    return _is_managed_branch_name(name)
+
+
+def reap_stale_managed_worktrees(repo: str, max_age_seconds: float = 0) -> dict:
+    """Remove leftover managed worktrees after a crash or forgotten teardown.
+
+    Only ``pmedit-*`` / ``pmworker-*`` trees under the managed directory are
+    eligible. The main checkout, locked trees, user-named worktrees, and any
+    tree with a still-registered live pid are left alone. ``max_age_seconds=0``
+    (boot) reaps every leftover; a positive age keeps recent in-session trees.
+    """
+    if not repo or not _is_repo(repo):
+        return {"removed": [], "count": 0}
+
+    managed_dir = _get_managed_dir(repo)
+    now = time.time()
+    removed: list[str] = []
+    for wt in list_worktrees(repo):
+        path = (wt.get("path") or "").strip()
+        if not path or not _is_managed_worktree(wt):
+            continue
+        real = os.path.realpath(path)
+        if not _is_confined(real, managed_dir):
+            continue
+        if _registered_pids_for_worktree(path):
+            continue
+        if max_age_seconds > 0:
+            try:
+                age = now - os.path.getmtime(path)
+            except OSError:
+                age = max_age_seconds + 1
+            if age < max_age_seconds:
+                continue
+        try:
+            remove_worktree(repo, path, force=True)
+            removed.append(path)
+        except Exception as exc:
+            logger.warning("failed to reap stale managed worktree %s: %s", path, exc)
+
+    if removed:
+        try:
+            prune_orphan_edit_branches(repo)
+        except Exception as exc:
+            logger.warning("failed to prune orphan edit branches after reap: %s", exc)
+    return {"removed": removed, "count": len(removed)}
+
 
 _MANAGED_BRANCH_PREFIXES = ("pmedit-", "pmworker-")
 _PROTECTED_BRANCHES = frozenset({"main", "master"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.227"
+version = "0.9.228"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_swarm_run_facts.py
+++ b/tests/test_swarm_run_facts.py
@@ -573,6 +573,146 @@ class TestAcceptanceCriteria:
         assert " at harness/a.py:1" in facts[0].basis
 
 
+def _honest_provenance(**overrides):
+    stamp = {
+        "adapter": "agentic",
+        "model": "anthropic/claude-sonnet",
+        "usage_known": False,
+        "cost_known": False,
+    }
+    stamp.update(overrides)
+    return stamp
+
+
+class TestProvenanceSelfReportCriteria:
+    """Model-id / execution_provenance rows settle from stamps, not citations.
+
+    The anti-false-green citation rule still owns check criteria (pyright,
+    tsc). This class pins the narrow second path: already-stamped
+    ``execution_provenance`` on current-job non-routing artifacts.
+    """
+
+    _CRITERION = (
+        "Every non-routing artifact carries full provenance "
+        "(model id, usage_known:false, cost_known:false — no fake zeros)"
+    )
+
+    def _row(self, **overrides):
+        row = {
+            "type": "finding",
+            "headline": "something else entirely",
+            "execution_ref": {"job_id": CURRENT_JOB},
+            "execution_provenance": _honest_provenance(),
+        }
+        row.update(overrides)
+        return row
+
+    def test_stamped_provenance_verifies_without_a_worker_citation(self):
+        facts = evaluate_acceptance_criteria(
+            [self._CRITERION],
+            [self._row(), self._row(type="risk", headline="another signal")],
+            CURRENT_JOB,
+        )
+        assert [f.status for f in facts] == [VERIFIED]
+        assert "stamped execution_provenance" in facts[0].basis
+        assert "2 current-job" in facts[0].basis
+
+    def test_routing_rows_are_outside_the_denominator(self):
+        facts = evaluate_acceptance_criteria(
+            [self._CRITERION],
+            [
+                self._row(),
+                {
+                    "type": "routing",
+                    "execution_ref": {"job_id": CURRENT_JOB},
+                },
+            ],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == VERIFIED
+        assert "1 current-job" in facts[0].basis
+
+    def test_check_criteria_still_require_a_structured_citation(self):
+        facts = evaluate_acceptance_criteria(
+            ["pyright is clean"],
+            [self._row()],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == NOT_VERIFIED
+        assert "stamped execution_provenance" not in facts[0].basis
+
+    def test_prose_echo_without_stamps_does_not_verify(self):
+        facts = evaluate_acceptance_criteria(
+            [self._CRITERION],
+            [{
+                "type": "finding",
+                "headline": self._CRITERION,
+                "body": "model id usage_known cost_known no fake zeros",
+                "execution_ref": {"job_id": CURRENT_JOB},
+            }],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == NOT_VERIFIED
+
+    def test_missing_model_stays_not_verified(self):
+        facts = evaluate_acceptance_criteria(
+            [self._CRITERION],
+            [self._row(execution_provenance=_honest_provenance(model=""))],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == NOT_VERIFIED
+
+    def test_missing_known_flags_stays_not_verified(self):
+        facts = evaluate_acceptance_criteria(
+            [self._CRITERION],
+            [self._row(execution_provenance={
+                "model": "anthropic/claude-sonnet",
+            })],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == NOT_VERIFIED
+
+    def test_copied_spend_zeros_stay_not_verified(self):
+        facts = evaluate_acceptance_criteria(
+            [self._CRITERION],
+            [self._row(execution_provenance=_honest_provenance(
+                tokens=0, est_cost_usd=0.0,
+            ))],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == NOT_VERIFIED
+
+    def test_one_unstamped_sibling_blocks_the_row(self):
+        facts = evaluate_acceptance_criteria(
+            [self._CRITERION],
+            [
+                self._row(),
+                {
+                    "type": "finding",
+                    "execution_ref": {"job_id": CURRENT_JOB},
+                },
+            ],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == NOT_VERIFIED
+
+    def test_foreign_job_stamps_do_not_count(self):
+        facts = evaluate_acceptance_criteria(
+            [self._CRITERION],
+            [self._row(execution_ref={"job_id": "job-older"})],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == NOT_VERIFIED
+
+    def test_mixed_list_verifies_only_the_provenance_row(self):
+        facts = evaluate_acceptance_criteria(
+            [self._CRITERION, "pyright is clean"],
+            [self._row()],
+            CURRENT_JOB,
+        )
+        assert [f.status for f in facts] == [VERIFIED, NOT_VERIFIED]
+
+
 class TestRunFacts:
     def test_surfaces_the_current_build_and_subject(self, stub_probe):
         facts = _facts(stub_probe)

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -204,6 +204,77 @@ def test_delete_branch_refuses_current_checkout():
         shutil.rmtree(repo, ignore_errors=True)
 
 
+def test_reap_stale_managed_worktrees_removes_leftover_pmedit():
+    repo = create_temp_git_repo()
+    managed_dir = os.path.abspath(os.path.join(repo, "..", ".pmharness-worktrees"))
+    try:
+        leftover = _wt.add_worktree(repo, "pmedit-leftover1")
+        user_wt = _wt.add_worktree(repo, "feature-keep")
+        result = _wt.reap_stale_managed_worktrees(repo)
+        assert leftover["path"] in result["removed"]
+        assert result["count"] == 1
+        paths = {wt["path"] for wt in _wt.list_worktrees(repo)}
+        assert leftover["path"] not in paths
+        assert user_wt["path"] in paths
+        assert os.path.realpath(repo) in {os.path.realpath(p) for p in paths}
+        assert "pmedit-leftover1" not in _branch_list(repo)
+        assert "feature-keep" in _branch_list(repo)
+    finally:
+        shutil.rmtree(repo, ignore_errors=True)
+        shutil.rmtree(managed_dir, ignore_errors=True)
+
+
+def test_reap_stale_managed_worktrees_skips_registered_live_pid():
+    repo = create_temp_git_repo()
+    managed_dir = os.path.abspath(os.path.join(repo, "..", ".pmharness-worktrees"))
+    try:
+        live = _wt.add_worktree(repo, "pmedit-live01")
+        _wt.register_worktree_process(live["path"], 424242, kind="worker")
+        result = _wt.reap_stale_managed_worktrees(repo)
+        assert live["path"] not in result["removed"]
+        assert os.path.isdir(live["path"])
+        assert "pmedit-live01" in _branch_list(repo)
+    finally:
+        _wt.clear_managed_process_registry_for_tests()
+        shutil.rmtree(repo, ignore_errors=True)
+        shutil.rmtree(managed_dir, ignore_errors=True)
+
+
+def test_reap_stale_managed_worktrees_honors_max_age():
+    repo = create_temp_git_repo()
+    managed_dir = os.path.abspath(os.path.join(repo, "..", ".pmharness-worktrees"))
+    try:
+        recent = _wt.add_worktree(repo, "pmedit-recent1")
+        kept = _wt.reap_stale_managed_worktrees(repo, max_age_seconds=3600)
+        assert recent["path"] not in kept["removed"]
+        assert os.path.isdir(recent["path"])
+        reaped = _wt.reap_stale_managed_worktrees(repo, max_age_seconds=0)
+        assert recent["path"] in reaped["removed"]
+        assert not os.path.isdir(recent["path"])
+    finally:
+        shutil.rmtree(repo, ignore_errors=True)
+        shutil.rmtree(managed_dir, ignore_errors=True)
+
+
+def test_reap_stale_managed_worktrees_never_touches_main():
+    repo = create_temp_git_repo()
+    try:
+        result = _wt.reap_stale_managed_worktrees(repo)
+        assert result["count"] == 0
+        trees = _wt.list_worktrees(repo)
+        assert len(trees) == 1
+        assert trees[0]["is_main"] is True
+    finally:
+        shutil.rmtree(repo, ignore_errors=True)
+
+
+def test_boot_reaper_wires_managed_worktree_reap():
+    import inspect
+    import harness.server as srv
+    source = inspect.getsource(srv._reap_stale_swarms_on_boot)
+    assert "reap_stale_managed_worktrees" in source
+
+
 def test_prune_orphan_edit_branches_skips_active_and_attached_worktree():
     repo = create_temp_git_repo()
     managed_dir = os.path.abspath(os.path.join(repo, "..", ".pmharness-worktrees"))

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.227",
+  "version": "0.9.228",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.227",
+      "version": "0.9.228",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.227",
+  "version": "0.9.228",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Acceptance-criteria reconciler settles model-id / `execution_provenance` / no-fake-zeros rows from stamped artifact provenance. Check criteria still require a structured citation; prose echoes and fake zeros stay `not_verified`.
- Boot reaps leftover `pmedit-*` / `pmworker-*` worktrees under the managed dir. Main checkout, user-named trees, locked trees, and trees with a registered live pid are left alone.
- Pin stays `puppetmaster-ai==1.22.5`.

## Test plan
- [x] Local `pytest tests -q`: 4375 passed, 74 skipped
- [x] `tests/test_version_consistency.py` + reconciler + worktree tests
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)
- [ ] After merge: wait `tests` green on the exact `main` SHA, then tag `v0.9.228`