### PR TITLE
Release v0.9.229: harden provenance self-report matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.228, deliberately pre-1.0. Acceptance-criteria reconciler settles model-id / execution_provenance rows from stamped artifact provenance (no worker checklist required); boot reaps leftover pmedit-/pmworker- worktrees. Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.229, deliberately pre-1.0. Provenance self-report criteria match stamp fields, honesty clauses, or artifact-scope plus a model/provenance word — not a single "model id" substring. Rides puppetmaster-ai==1.22.5.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.228"
+__version__ = "0.9.229"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/swarm_run_facts.py
+++ b/harness/swarm_run_facts.py
@@ -60,16 +60,51 @@ _ROUTING_TYPE = "routing"
 _SPEND_FIELDS = ("tokens", "est_cost_usd", "estimated_cost_usd")
 
 # Self-report criteria that ask about stamped identity, not a worker checklist.
-# Keep this narrow: "pyright is clean" must still require a structured citation.
-_PROVENANCE_SELF_REPORT_MARKERS = (
-    "model id",
-    "model-id",
-    "model_id",
+# Field names and honesty clauses are enough on their own. Identity phrases
+# cover "state your model" without requiring the exact "model id" spelling.
+# A scope phrase plus a stamp/model word catches "every artifact carries
+# provenance" without letting "document the provenance of the cache bug"
+# or "fix the model registry" through. Check criteria stay citation-only.
+_PROVENANCE_FIELD_PHRASES = (
     "execution provenance",
     "execution_provenance",
     "usage_known",
     "cost_known",
+    "usage known",
+    "cost known",
+)
+_PROVENANCE_HONESTY_PHRASES = (
     "no fake zero",
+    "no invented zero",
+    "no fabricated zero",
+    "no fabricated spend",
+)
+_PROVENANCE_IDENTITY_PHRASES = (
+    "model id",
+    "model-id",
+    "model_id",
+    "model identifier",
+    "adapter_model_name",
+    "adapter model name",
+    "router_model_id",
+    "router model id",
+    "state your model",
+    "state the model",
+    "name your model",
+    "name the model",
+)
+_PROVENANCE_SCOPE_PHRASES = (
+    "non-routing",
+    "non routing",
+    "every artifact",
+    "all artifacts",
+    "each artifact",
+    "every finding",
+    "all findings",
+    "each finding",
+    "every row",
+    "all rows",
+    "each row",
 )
 
 # Environment probes are bounded but not free (PATH scans, a Chrome lookup).
@@ -373,12 +408,36 @@ def _verified_criterion_loci(artifact: Mapping[str, Any]) -> dict[str, str]:
     return verified
 
 
+def _phrase_in(text: str, phrase: str) -> bool:
+    return bool(phrase) and phrase in text
+
+
+def _word_in(text: str, word: str) -> bool:
+    """Whole-word match so ``stamp`` does not hit ``timestamp``."""
+    if not word or not text:
+        return False
+    return f" {word} " in f" {text} "
+
+
 def _is_provenance_self_report_criterion(criterion: str) -> bool:
-    """True only for model-id / execution_provenance / no-fake-zero rows."""
+    """True for stamp/model-id self-report rows, not check criteria."""
     text = _normalized_text(criterion)
     if not text:
         return False
-    return any(marker in text for marker in _PROVENANCE_SELF_REPORT_MARKERS)
+    if any(_phrase_in(text, phrase) for phrase in _PROVENANCE_FIELD_PHRASES):
+        return True
+    if any(_phrase_in(text, phrase) for phrase in _PROVENANCE_HONESTY_PHRASES):
+        return True
+    if any(_phrase_in(text, phrase) for phrase in _PROVENANCE_IDENTITY_PHRASES):
+        return True
+    if not any(_phrase_in(text, phrase) for phrase in _PROVENANCE_SCOPE_PHRASES):
+        return False
+    return (
+        _word_in(text, "provenance")
+        or _word_in(text, "stamped")
+        or _word_in(text, "stamp")
+        or _word_in(text, "model")
+    )
 
 
 def _honest_execution_provenance(artifact: Mapping[str, Any]) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.228"
+version = "0.9.229"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_swarm_run_facts.py
+++ b/tests/test_swarm_run_facts.py
@@ -712,6 +712,62 @@ class TestProvenanceSelfReportCriteria:
         )
         assert [f.status for f in facts] == [VERIFIED, NOT_VERIFIED]
 
+    @pytest.mark.parametrize(
+        "criterion",
+        [
+            "state your model",
+            "state the model identifier on each finding",
+            "every artifact carries full provenance",
+            "all artifacts report their model",
+            "each finding is stamped with provenance",
+            "no invented zeros on child artifacts",
+            "usage known and cost known on every row",
+        ],
+        ids=[
+            "state_your_model",
+            "model_identifier",
+            "every_artifact_provenance",
+            "all_artifacts_model",
+            "each_finding_stamped",
+            "no_invented_zeros",
+            "usage_known_words",
+        ],
+    )
+    def test_alternate_wordings_still_settle_from_stamps(self, criterion):
+        facts = evaluate_acceptance_criteria(
+            [criterion],
+            [self._row()],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == VERIFIED
+        assert "stamped execution_provenance" in facts[0].basis
+
+    @pytest.mark.parametrize(
+        "criterion",
+        [
+            "document the provenance of the cache bug",
+            "the model router chose composer",
+            "fix the model registry",
+            "every artifact has a timestamp",
+            "tsc passes",
+        ],
+        ids=[
+            "bug_provenance",
+            "router_chose",
+            "model_registry",
+            "timestamp",
+            "tsc",
+        ],
+    )
+    def test_unrelated_wordings_stay_citation_only(self, criterion):
+        facts = evaluate_acceptance_criteria(
+            [criterion],
+            [self._row()],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == NOT_VERIFIED
+        assert "stamped execution_provenance" not in facts[0].basis
+
 
 class TestRunFacts:
     def test_surfaces_the_current_build_and_subject(self, stub_probe):

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.228",
+  "version": "0.9.229",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.228",
+      "version": "0.9.229",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.228",
+  "version": "0.9.229",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Provenance self-report criteria match stamp field names, honesty clauses (`no invented zeros`), identity phrases (`state your model`), or artifact-scope plus a model/provenance word.
- Check criteria stay citation-only. `timestamp` does not match `stamp`. Pin stays `puppetmaster-ai==1.22.5`.

## Test plan
- [x] Local `pytest tests -q`: 4387 passed, 74 skipped
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)
- [ ] After merge: wait `tests` green on the exact `main` SHA, then tag `v0.9.229`