### PR TITLE
Release v0.9.230: file-drop pathForFile and false overflow chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.229, deliberately pre-1.0. Provenance self-report criteria match stamp fields, honesty clauses, or artifact-scope plus a model/provenance word — not a single "model id" substring. Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.230, deliberately pre-1.0. File drops resolve via Electron pathForFile and accept documents; completion `max_tokens` 400s are not treated as context overflow. Rides puppetmaster-ai==1.22.5.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.229"
+__version__ = "0.9.230"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/files.py
+++ b/harness/api/files.py
@@ -393,18 +393,46 @@ def check_upload_request(
     return None
 
 
+_IMAGE_UPLOAD_EXTS = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
+_DOCUMENT_UPLOAD_EXTS = frozenset({
+    ".md", ".txt", ".pdf", ".json", ".py", ".ts", ".tsx", ".js",
+    ".cjs", ".mjs", ".html", ".css", ".csv", ".xml", ".yml", ".yaml",
+    ".toml", ".rst", ".tex", ".ipynb", ".rtf", ".log", ".cfg", ".ini",
+    ".svg",
+})
+_UPLOAD_EXTS = _IMAGE_UPLOAD_EXTS | _DOCUMENT_UPLOAD_EXTS
+
+
 def save_upload(body: bytes, content_type: str, upload_dir: str) -> tuple[int, dict]:
-    """POST /api/upload body — save image parts under the process upload dir."""
+    """POST /api/upload body — save image/document parts under the upload dir.
+
+    Missing extensions are not rewritten to ``.png`` (a folder drop named
+    ``authority-spoof`` used to be stored as a fake PNG). Rejected types
+    return 400 instead of an empty 200 that the UI reports as "Upload failed".
+    """
     saved = []
+    skipped = []
     for filename, data in parse_multipart_files(body, content_type):
-        ext = os.path.splitext(filename)[1].lower() or ".png"
-        if ext not in (".png", ".jpg", ".jpeg", ".webp", ".gif"):
+        ext = os.path.splitext(filename)[1].lower()
+        if ext not in _UPLOAD_EXTS:
+            skipped.append(filename or "unnamed")
             continue
         path = os.path.join(upload_dir, f"{uuid.uuid4().hex}{ext}")
         with open(path, "wb") as out:
             out.write(data)
         saved.append({"path": path, "name": filename})
-    return 200, {"saved": saved}
+    if saved:
+        return 200, {"saved": saved}
+    if skipped:
+        return 400, {
+            "error": (
+                "This file type cannot be attached. Drop an image or a "
+                "document (md, txt, pdf, json, source), or drop a file "
+                "from the open workspace to @-mention it."
+            ),
+            "saved": [],
+        }
+    return 400, {"error": "No file in upload", "saved": []}
 
 
 # ---------------------------------------------------------------------------

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -136,6 +136,41 @@ def profile_skips_auto_inject(session: Any) -> tuple[bool, bool]:
         return False, False
 
 
+# After emergency compact, a remaining "overflow" on a tiny history is almost
+# always a misclassified provider 400 (completion max_tokens), not a window blow.
+OVERFLOW_RETRY_SMALL_CONTEXT_TOKENS = 16_000
+
+
+def format_overflow_persist_error(
+    raw: str,
+    estimated_tokens: int,
+    humanize: Any,
+) -> str:
+    """Humanize a second overflow after emergency compact. Never the raw persist string."""
+    text = str(raw or "").strip() or "the provider rejected the compacted turn"
+    if int(estimated_tokens or 0) < OVERFLOW_RETRY_SMALL_CONTEXT_TOKENS:
+        try:
+            from harness.api.redaction import redact_api_secrets
+
+            tail = str(redact_api_secrets(text) or text)[:160]
+        except Exception:
+            tail = text[:160]
+        return (
+            "pilot: the provider rejected this turn after history was "
+            "compacted, and the remaining context is small -- this is "
+            "not a full context window. Try another model, or send again."
+            + (f" [provider said: {tail}]" if tail else "")
+        )
+    try:
+        return str(humanize(text) or text)
+    except Exception:
+        return (
+            "pilot: this turn still exceeded the model's context window "
+            "after compaction. Start a fresh session or pick a "
+            "longer-context model."
+        )
+
+
 class SendLoopMixin:
     """Mixin holding send-loop orchestration for ConversationalSession.
 
@@ -1168,8 +1203,17 @@ class SendLoopMixin:
                             )
                             continue
                         else:
-                            # Context overflow persists after compaction
-                            yield ConvEvent("error", {"error": "context overflow persists after compaction"})
+                            try:
+                                est = int(self._estimate_context_tokens() or 0)
+                            except Exception:
+                                est = 0
+                            yield ConvEvent("error", {
+                                "error": format_overflow_persist_error(
+                                    resp.error or "",
+                                    est,
+                                    self._humanize_pilot_error,
+                                ),
+                            })
                             return
 
                 # If there's no error or it is not context overflow, we're done

--- a/pmharness/drivers/error_classifier.py
+++ b/pmharness/drivers/error_classifier.py
@@ -29,12 +29,17 @@ class ErrorClass(str, Enum):
 
 # Phrases that mean "the prompt exceeded the model's context window" across
 # OpenAI, Anthropic, OpenRouter, z.ai, Moonshot, and most compat providers.
+# Do NOT match bare ``max_tokens`` / ``exceeds the maximum``: those fire on
+# completion-limit 400s (Kimi/GLM accept a large max_tokens; other models
+# reject the same request). Compacting history cannot fix that, and the UI
+# then lies with "overflow persists" on a 1% window.
 _CONTEXT_PATTERNS = [
     "context length", "context window", "maximum context",
-    "too many tokens", "reduce the length", "maximum_tokens",
-    "string too long", "prompt is too long", "input is too long",
-    "exceeds the maximum", "context_length_exceeded", "max_tokens",
-    "tokens > ", "request too large",
+    "too many tokens", "reduce the length of the messages",
+    "reduce the length of the prompt",
+    "prompt is too long", "input is too long",
+    "exceeds the maximum context", "exceeded the context",
+    "context_length_exceeded", "request too large",
 ]
 
 # Transient signals that appear in 5xx bodies or network exception reprs.
@@ -77,7 +82,7 @@ def classify(http_status: Optional[int] = None, message: Optional[str] = None) -
     # Context-overflow can surface as a 400 OR (rarely) a 413; the body text is
     # the reliable signal, so check it before the generic 400=fatal rule.
     if any(p in msg for p in _CONTEXT_PATTERNS):
-        # Guard: a 401 mentioning "max_tokens" in a hint is still auth.
+        # Guard: a 401 mentioning a context hint is still auth.
         if http_status not in (401, 403):
             return ErrorClass.CONTEXT_OVERFLOW
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.229"
+version = "0.9.230"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_error_classifier.py
+++ b/tests/test_error_classifier.py
@@ -22,3 +22,29 @@ def test_opencode_go_upstream_block_is_retryable_not_auth():
 def test_genuine_auth_still_fatal_for_other_providers():
     assert not is_upstream_provider_block("invalid_api_key")
     assert classify(401, "HTTP 401: incorrect api key provided") == ErrorClass.AUTH
+
+
+def test_real_context_overflow_still_classifies():
+    assert classify(
+        400, "HTTP 400: maximum context length exceeded"
+    ) == ErrorClass.CONTEXT_OVERFLOW
+    assert classify(
+        400,
+        '{"error":{"message":"prompt is too long: 250000 tokens > 200000 maximum"}}',
+    ) == ErrorClass.CONTEXT_OVERFLOW
+    assert classify(413, "request too large") == ErrorClass.CONTEXT_OVERFLOW
+
+
+def test_completion_max_tokens_reject_is_not_overflow():
+    """Kimi/GLM accept a large max_tokens; other models 400 on the same field.
+
+    That is a request-parameter error, not a prompt-window blow. Compacting
+    history cannot fix it.
+    """
+    assert classify(
+        400, 'HTTP 400: {"error":{"message":"max_tokens is too large"}}'
+    ) == ErrorClass.FATAL
+    assert classify(
+        400, "invalid max_tokens: exceeds the maximum allowed value"
+    ) == ErrorClass.FATAL
+    assert classify(None, "HTTP 400: max_tokens exceeds the maximum") == ErrorClass.FATAL

--- a/tests/test_humanize_pilot_error.py
+++ b/tests/test_humanize_pilot_error.py
@@ -79,6 +79,15 @@ def test_context_overflow_is_explained():
     assert "context window" in out.lower()
 
 
+def test_max_tokens_parameter_reject_is_not_overflow():
+    s = _s()
+    out = s._humanize_pilot_error(
+        'HTTP 400: {"error":{"message":"max_tokens is too large"}}'
+    )
+    assert "context window" not in out.lower()
+    assert "pilot:" in out
+
+
 def test_server_error_is_retryable_guidance():
     s = _s()
     out = s._humanize_pilot_error("HTTP 503: service unavailable")

--- a/tests/test_midturn_context.py
+++ b/tests/test_midturn_context.py
@@ -114,3 +114,81 @@ def test_midturn_overflow_recovery():
         # No error event because recovery handled the context overflow
         error_events = [ev for ev in events if ev.kind == "error"]
         assert len(error_events) == 0
+
+
+class MockPilotAlwaysOverflow:
+    name = "mock_always_overflow"
+
+    def chat(self, messages, tools=None, system=None):
+        return MockDriverResponse(error="HTTP 400: maximum context length exceeded")
+
+    def complete(self, prompt, system=None):
+        return MockDriverResponse(error="HTTP 400: maximum context length exceeded")
+
+
+class MockPilotMaxTokensReject:
+    name = "mock_max_tokens_reject"
+
+    def chat(self, messages, tools=None, system=None):
+        return MockDriverResponse(
+            error='HTTP 400: {"error":{"message":"max_tokens is too large"}}'
+        )
+
+    def complete(self, prompt, system=None):
+        return MockDriverResponse(
+            error='HTTP 400: {"error":{"message":"max_tokens is too large"}}'
+        )
+
+
+def test_overflow_persist_is_humanized_not_raw():
+    from harness.send_loop import format_overflow_persist_error
+
+    small = format_overflow_persist_error(
+        "HTTP 400: max_tokens is too large",
+        200,
+        lambda s: f"HUMAN {s}",
+    )
+    assert "context overflow persists" not in small
+    assert "not a full context window" in small.lower()
+    assert "max_tokens is too large" in small
+
+    large = format_overflow_persist_error(
+        "HTTP 400: maximum context length exceeded",
+        80_000,
+        lambda s: f"HUMAN:{s}",
+    )
+    assert large.startswith("HUMAN:")
+    assert "context overflow persists" not in large
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        cfg = HarnessConfig(state_dir=temp_dir, max_context_tokens=1000)
+        session = ConversationalSession(cfg)
+        session.pilot = MockPilotAlwaysOverflow()
+        for i in range(10):
+            session._history.append(
+                {"role": "user", "content": f"User msg {i}: " + ("A" * 150)}
+            )
+            session._history.append(
+                {"role": "assistant", "content": f"Assistant msg {i}: " + ("B" * 150)}
+            )
+        events = list(session.send("Solve the issue"))
+        errors = [ev for ev in events if ev.kind == "error"]
+        assert errors
+        msg = errors[0].data.get("error") or ""
+        assert "context overflow persists after compaction" not in msg
+        assert msg.startswith("pilot:")
+
+
+def test_max_tokens_reject_does_not_compact():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        cfg = HarnessConfig(state_dir=temp_dir, max_context_tokens=1000)
+        session = ConversationalSession(cfg)
+        session.pilot = MockPilotMaxTokensReject()
+        events = list(session.send("hello"))
+        compact = [ev for ev in events if ev.kind in ("compacting", "compaction")]
+        assert compact == []
+        errors = [ev for ev in events if ev.kind == "error"]
+        assert errors
+        msg = errors[0].data.get("error") or ""
+        assert "context overflow persists" not in msg
+        assert "context window" not in msg.lower()

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -239,3 +239,34 @@ def test_upload_rejects_single_quoted_boundary():
             assert e.code == 400
             data = json.loads(e.read().decode())
             assert "quoted" in data["error"].lower() or "boundary" in data["error"].lower()
+
+
+def test_save_upload_accepts_markdown(tmp_path):
+    from harness.api.files import save_upload
+
+    body, ctype = _multipart("file", "paper.md", b"# title\n", "text/markdown")
+    status, payload = save_upload(body, ctype, str(tmp_path))
+    assert status == 200
+    assert payload["saved"]
+    assert payload["saved"][0]["path"].endswith(".md")
+    assert os.path.exists(payload["saved"][0]["path"])
+
+
+def test_save_upload_rejects_exe_and_extensionless(tmp_path):
+    from harness.api.files import save_upload
+
+    body, ctype = _multipart("file", "payload.exe", b"MZ", "application/octet-stream")
+    status, payload = save_upload(body, ctype, str(tmp_path))
+    assert status == 400
+    assert payload.get("saved") == []
+    assert "cannot be attached" in (payload.get("error") or "")
+
+    body, ctype = _multipart(
+        "file", "authority-spoof", b"not an image", "application/octet-stream"
+    )
+    status, payload = save_upload(body, ctype, str(tmp_path))
+    assert status == 400
+    assert not any(
+        str(item.get("path") or "").endswith(".png")
+        for item in payload.get("saved") or []
+    )

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -1071,11 +1071,22 @@ ipcMain.handle("harness:uploadFile", async (_e, payload) => {
         let b = "";
         res.on("data", (c) => (b += c));
         res.on("end", () => {
-          try { resolve(JSON.parse(b || "{}").saved || []); }
-          catch { resolve([]); }
+          try {
+            const parsed = JSON.parse(b || "{}");
+            if (res.statusCode >= 400) {
+              resolve({
+                error: parsed.error || `Upload failed (${res.statusCode})`,
+                saved: [],
+              });
+            } else {
+              resolve({ saved: parsed.saved || [] });
+            }
+          } catch {
+            resolve({ error: "Upload failed", saved: [] });
+          }
         });
       });
-      req.on("error", () => resolve([]));
+      req.on("error", () => resolve({ error: "Upload failed", saved: [] }));
       req.write(body);
       req.end();
     });

--- a/webapp/electron/preload.cjs
+++ b/webapp/electron/preload.cjs
@@ -1,7 +1,7 @@
 // Preload: exposes window.harnessIPC implementing the renderer's transport seam
 // (lib/transport.ts checks for window.harnessIPC and routes through it). Plus
 // native fs/git bridges for the file-tree and source-control panels.
-const { contextBridge, ipcRenderer } = require("electron");
+const { contextBridge, ipcRenderer, webUtils } = require("electron");
 
 let streamSeq = 0;
 
@@ -13,6 +13,15 @@ contextBridge.exposeInMainWorld("harnessIPC", {
   // Open a URL in the OS default browser (escape hatch when in-app Google OAuth rejects).
   openExternal: (url) => ipcRenderer.invoke("browser:openExternal", url),
   uploadFile: (payload) => ipcRenderer.invoke("harness:uploadFile", payload),
+  // Electron no longer sets File.path; this is the supported drop-path API.
+  pathForFile: (file) => {
+    try {
+      if (webUtils && typeof webUtils.getPathForFile === "function") {
+        return webUtils.getPathForFile(file) || "";
+      }
+    } catch (_) {}
+    return "";
+  },
   // Fire-and-forget: persist a caught renderer error to the Electron main log so
   // a UI crash is diagnosable from ~/.pmharness/electron.log without devtools.
   logError: (payload) => { try { ipcRenderer.send("harness:rendererError", payload); } catch (_) {} },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.229",
+  "version": "0.9.230",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.229",
+      "version": "0.9.230",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.229",
+  "version": "0.9.230",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -183,6 +183,10 @@ import {
   filterMentionPaths,
   filterSlashCommands,
   mentionTokenForDroppedPath,
+  normalizeOsPath,
+  pathIsInsideRepo,
+  resolveDroppedOsPath,
+  uploadErrorMessage,
 } from "../components/conversation/composerInput";
 import {
   blankMsgQueueOnSessionSwitch,
@@ -2834,6 +2838,39 @@ describe("composerInput module", () => {
       }),
     ).toBe('@"/tmp/cool file.txt"');
     expect(appendMentionsToInput("hi", ["@a", "@b"])).toBe("hi @a @b ");
+    expect(normalizeOsPath("C:\\repo\\a.ts")).toBe("C:/repo/a.ts");
+    expect(pathIsInsideRepo("C:\\repo\\a.ts", "C:/repo")).toBe(true);
+    expect(pathIsInsideRepo("C:\\other\\a.ts", "C:/repo")).toBe(false);
+    expect(
+      mentionTokenForDroppedPath({
+        osPath: "C:\\repo\\src\\a.ts",
+        repo: "C:\\repo",
+      }),
+    ).toBe("@src/a.ts");
+    expect(
+      mentionTokenForDroppedPath({
+        osPath: "C:\\repo\\docs",
+        repo: "C:/repo",
+        isDirectory: true,
+      }),
+    ).toBe("@folder:docs");
+    expect(
+      mentionTokenForDroppedPath({
+        osPath: "/Users/me/paper.md",
+        repo: "/repo",
+      }),
+    ).toBeNull();
+    expect(uploadErrorMessage(new Error("Upload failed"), "File upload failed")).toBe(
+      "File upload failed",
+    );
+    expect(uploadErrorMessage(new Error("This file type cannot be attached."), "File upload failed")).toBe(
+      "This file type cannot be attached.",
+    );
+    const prevIpc = (window as any).harnessIPC;
+    (window as any).harnessIPC = { pathForFile: () => "/abs/dropped.md" };
+    expect(resolveDroppedOsPath({ path: "" })).toBe("/abs/dropped.md");
+    if (prevIpc === undefined) delete (window as any).harnessIPC;
+    else (window as any).harnessIPC = prevIpc;
   });
 });
 

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -112,6 +112,8 @@ import {
   filterMentionPaths,
   filterSlashCommands,
   mentionTokenForDroppedPath,
+  resolveDroppedOsPath,
+  uploadErrorMessage,
 } from "./conversation/composerInput";
 import {
   blankMsgQueueOnSessionSwitch,
@@ -1692,16 +1694,24 @@ export default function Conversation({
     setIsDragOver(false);
     const files = Array.from(e.dataTransfer.files);
     if (files.length === 0) return;
+    const items = Array.from(e.dataTransfer.items || []);
 
     setUploadError(null);
     const repo = (config?.repo || "").replace(/\/+$/, "");
     const mentions: string[] = [];
     let addedCount = attachedImages.length;
 
-    for (const file of files) {
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
       const isImage = file.type.startsWith("image/");
-      // Electron exposes the real OS path on dropped files; the browser does not.
-      const osPath: string = (file as any).path || "";
+      const osPath = resolveDroppedOsPath(file as { path?: string });
+      let isDirectory = false;
+      try {
+        const entry = items[i]?.webkitGetAsEntry?.();
+        isDirectory = !!entry && entry.isDirectory;
+      } catch {
+        isDirectory = false;
+      }
 
       if (isImage) {
         // Images attach as visual context (upload + thumbnail), as before.
@@ -1719,8 +1729,24 @@ export default function Conversation({
           addedCount++;
         } catch (err) {
           console.error("Failed to upload dropped image:", err);
-          flashUploadError("Image upload failed");
+          flashUploadError(uploadErrorMessage(err, "Image upload failed"));
         }
+        continue;
+      }
+
+      if (isDirectory) {
+        const folderToken = mentionTokenForDroppedPath({
+          osPath,
+          repo,
+          isDirectory: true,
+        });
+        if (folderToken) {
+          mentions.push(folderToken);
+          continue;
+        }
+        flashUploadError(
+          "Folders outside the open workspace cannot be attached. Open that folder as the workspace, or drop a file from it.",
+        );
         continue;
       }
 
@@ -1733,9 +1759,8 @@ export default function Conversation({
         mentions.push(insideToken);
         continue;
       }
-      // Outside repo: upload then @-mention (quoted when the path has spaces).
       try {
-        const uploaded = await api.uploadImage(file); // generic file upload endpoint
+        const uploaded = await api.uploadImage(file);
         const token = mentionTokenForDroppedPath({
           osPath: "",
           repo,
@@ -1745,7 +1770,7 @@ export default function Conversation({
         else flashUploadError("Dropped file could not be attached");
       } catch (err) {
         console.error("Failed to upload dropped file:", err);
-        flashUploadError("File upload failed");
+        flashUploadError(uploadErrorMessage(err, "File upload failed"));
       }
     }
 

--- a/webapp/src/components/conversation/composerInput.ts
+++ b/webapp/src/components/conversation/composerInput.ts
@@ -203,6 +203,42 @@ export function cycleSelectIndex(
   return (current + delta + total) % total;
 }
 
+/** Normalize OS paths so Windows `\` compares and mentions like POSIX `/`. */
+export function normalizeOsPath(path: string): string {
+  return String(path || "").replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+/** True when `osPath` is the repo root or a file/folder inside it. */
+export function pathIsInsideRepo(osPath: string, repo: string): boolean {
+  const a = normalizeOsPath(osPath);
+  const b = normalizeOsPath(repo);
+  if (!a || !b) return false;
+  const al = a.toLowerCase();
+  const bl = b.toLowerCase();
+  return al === bl || al.startsWith(bl + "/");
+}
+
+/**
+ * Electron no longer puts the OS path on `File.path`. Prefer
+ * `webUtils.getPathForFile` exposed as `harnessIPC.pathForFile`.
+ */
+export function resolveDroppedOsPath(file: { path?: string }): string {
+  const ipc =
+    typeof window !== "undefined"
+      ? (window as unknown as { harnessIPC?: { pathForFile?: (f: unknown) => string } })
+          .harnessIPC?.pathForFile
+      : undefined;
+  if (typeof ipc === "function") {
+    try {
+      const resolved = ipc(file);
+      if (resolved) return normalizeOsPath(String(resolved));
+    } catch {
+      // fall through to the legacy File.path field
+    }
+  }
+  return normalizeOsPath(String(file?.path || ""));
+}
+
 /**
  * Resolve a dropped non-image file/folder to an @-mention token.
  * Paths with spaces become quoted tokens (@"path with spaces.ts") so the
@@ -216,22 +252,31 @@ export function mentionTokenForDroppedPath(opts: {
   uploadedPath?: string;
   isDirectory?: boolean;
 }): string | null {
-  const { osPath, repo, uploadedPath, isDirectory } = opts;
-  const kind = isDirectory ? "folder" : "file";
-  const insideRepo =
-    !!osPath && !!repo && (osPath === repo || osPath.startsWith(repo + "/"));
-  if (insideRepo) {
+  const osPath = normalizeOsPath(opts.osPath);
+  const repo = normalizeOsPath(opts.repo);
+  const uploadedPath = opts.uploadedPath ? normalizeOsPath(opts.uploadedPath) : "";
+  const kind = opts.isDirectory ? "folder" : "file";
+  if (pathIsInsideRepo(osPath, repo)) {
     const rel = osPath.slice(repo.length + 1);
     if (!rel) return null;
     return formatMentionToken(rel, kind);
   }
   if (!uploadedPath) return null;
   const rel =
-    repo && uploadedPath.startsWith(repo + "/")
+    repo && pathIsInsideRepo(uploadedPath, repo)
       ? uploadedPath.slice(repo.length + 1)
       : uploadedPath;
   if (!rel) return null;
   return formatMentionToken(rel, kind);
+}
+
+/** Prefer the server/upload Error message over a generic flash. */
+export function uploadErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error) {
+    const msg = String(err.message || "").trim();
+    if (msg && msg !== "Upload failed") return msg;
+  }
+  return fallback;
 }
 
 /** Append mention tokens to the composer, adding a leading space when needed. */

--- a/webapp/src/lib/transport.ts
+++ b/webapp/src/lib/transport.ts
@@ -265,12 +265,21 @@ export async function uploadFile(file: File): Promise<{ path: string; name: stri
   const bridge = getHarnessIpc();
   if (bridge?.uploadFile) {
     const buf = await file.arrayBuffer();
-    return bridge.uploadFile({ name: file.name, type: file.type, bytes: new Uint8Array(buf) });
+    const result = await bridge.uploadFile({ name: file.name, type: file.type, bytes: new Uint8Array(buf) });
+    if (Array.isArray(result)) return result;
+    if (result && typeof result === "object") {
+      if (result.error) throw new Error(String(result.error));
+      return result.saved || [];
+    }
+    return [];
   }
   const fd = new FormData();
   fd.append("file", file);
   const r = await fetch("/api/upload", { method: "POST", body: fd, headers: { "X-Harness-Token": authToken() } });
-  const j = await r.json();
+  const j = await r.json().catch(() => ({}));
+  if (!r.ok) {
+    throw new Error((j && j.error) || `Upload failed (${r.status})`);
+  }
   return j.saved || [];
 }
 


### PR DESCRIPTION
## Summary
- File drops resolve the OS path via Electron `webUtils.getPathForFile`, @-mention workspace files, and upload documents instead of forcing the image-only endpoint (Home drops were failing).
- Completion `max_tokens` 400s are no longer classified as context overflow. After emergency compact, a tiny remaining window gets an honest provider reject instead of `context overflow persists after compaction`.
- Pin stays `puppetmaster-ai==1.22.5`.

## Test plan
- [x] Local `pytest tests -q`: 4394 passed, 74 skipped
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)
- [ ] After merge: wait `tests` green on the exact `main` SHA, then tag `v0.9.230`