### PR TITLE
Release v0.9.231: live context windows, write_file fingerprint, unborn HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.230, deliberately pre-1.0. File drops resolve via Electron pathForFile and accept documents; completion `max_tokens` 400s are not treated as context overflow. Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.231, deliberately pre-1.0. Context windows resolve from the live model catalog (GLM-5.3 is 1M, not 128k); write_file fingerprints content; unborn HEAD is refused before worktree dispatch. Rides puppetmaster-ai==1.22.5.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.230"
+__version__ = "0.9.231"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/usage_meters.py
+++ b/harness/api/usage_meters.py
@@ -648,7 +648,11 @@ def _tool_output_savings_fields(price_in: float, *, process_wide: bool = False) 
     try:
         from ..compaction_advisor import advice_payload, apply_manual_compaction_ack
 
-        budget = getattr(getattr(_pilot(), "config", None), "max_context_tokens", 96000)
+        pilot = _pilot()
+        try:
+            budget = int(pilot.active_context_limit())
+        except Exception:
+            budget = getattr(getattr(pilot, "config", None), "max_context_tokens", 96000)
         advice = advice_payload(
             _pilot().state_dir,
             getattr(_pilot(), "harness_session_id", "") or "default",

--- a/harness/api/workspace.py
+++ b/harness/api/workspace.py
@@ -430,6 +430,7 @@ def get_workspace(svc: WorkspaceServices) -> tuple[int, JsonPayload]:
     repo = svc.cfg.repo
     is_git = False
     branch = ""
+    head_unborn = False
     if repo and os.path.isdir(repo):
         try:
             proc = subprocess.run(
@@ -444,6 +445,12 @@ def get_workspace(svc: WorkspaceServices) -> tuple[int, JsonPayload]:
                 )
                 if proc_branch.returncode == 0:
                     branch = proc_branch.stdout.strip()
+                try:
+                    from ..validation_reuse import _git_head_unborn
+
+                    head_unborn = bool(_git_head_unborn(repo))
+                except Exception:
+                    head_unborn = False
         except Exception:
             pass
     cg_status = svc.get_codegraph_status(repo) if repo else "none"
@@ -474,6 +481,7 @@ def get_workspace(svc: WorkspaceServices) -> tuple[int, JsonPayload]:
         "repo": repo,
         "branch": branch,
         "is_git": is_git,
+        "head_unborn": head_unborn,
         "codegraph_status": cg_status,
         "recents": recents,
         "home": svc.home_workspace_path(),

--- a/harness/compaction_mixin.py
+++ b/harness/compaction_mixin.py
@@ -728,7 +728,10 @@ class CompactionContextMixin:
             })
             return
 
-        budget = getattr(self.config, "max_context_tokens", 96000)
+        try:
+            budget = int(self.active_context_limit())
+        except Exception:
+            budget = getattr(self.config, "max_context_tokens", 96000)
         trigger = int(budget * 0.75)
         # Advisor-driven auto compaction fires only at level "now". "soon" is a
         # warning / Needs-attention signal and must not bypass the 75% trigger

--- a/harness/config.py
+++ b/harness/config.py
@@ -21,6 +21,11 @@ class HarnessConfig:
     wiki_url: str = ""               # portable-llm-wiki base url (HARNESS_WIKI_URL)
     wiki_auto: bool = False          # auto-ingest findings to the wiki (HARNESS_WIKI_AUTO)
     max_context_tokens: int = 96000
+    # True when the caller (test fixture, HARNESS_MAX_CONTEXT_TOKENS, or
+    # ~/.harness.json) pinned a cap. False when from_env resolved the window
+    # from the live/catalog model — get_context_usage must re-resolve so a
+    # stale 128k family fallback cannot stick after a model swap.
+    max_context_tokens_pinned: bool = True
     no_delegation: bool = False
     verify_cmd: str = ""
     # Host quality GATE (interactive turn finish): optional shell command(s)
@@ -129,8 +134,10 @@ class HarnessConfig:
             except (ValueError, TypeError):
                 pass
 
+        max_ctx_pinned = False
         if max_ctx_val is not None:
             max_ctx = max_ctx_val
+            max_ctx_pinned = True
         else:
             try:
                 from pmharness.registry import context_window
@@ -175,6 +182,7 @@ class HarnessConfig:
             wiki_url=pick("HARNESS_WIKI_URL", "wiki_url", ""),
             wiki_auto=str(pick("HARNESS_WIKI_AUTO", "wiki_auto", "")).strip() in ("1","true","yes","True"),
             max_context_tokens=max_ctx,
+            max_context_tokens_pinned=max_ctx_pinned,
             no_delegation=str(pick("HARNESS_NO_DELEGATION", "no_delegation", "")).strip() in ("1","true","yes","True"),
             verify_cmd=pick("HARNESS_VERIFY_CMD", "verify_cmd", ""),
             quality_gate_cmds=pick("HARNESS_QUALITY_GATE_CMDS", "quality_gate_cmds", ""),

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -1902,8 +1902,35 @@ class ConversationalSession(
         except Exception:
             return {}
 
+    def active_context_limit(self) -> int:
+        """Live context window for the current driver.
+
+        Explicit pins (HARNESS_MAX_CONTEXT_TOKENS / harness.json / test
+        fixtures) win. Otherwise resolve from the live catalog every call so
+        a stale 128k family fallback cannot stick after a model swap.
+        """
+        cfg = self.config
+        if getattr(cfg, "max_context_tokens_pinned", False):
+            return int(getattr(cfg, "max_context_tokens", 200000) or 200000)
+        try:
+            from pmharness.registry import context_window
+
+            window = context_window(getattr(cfg, "driver", "") or "", default=200000)
+            if window > 0:
+                cfg.max_context_tokens = window
+                try:
+                    from harness.context_budget import budget_for_context_window
+
+                    self.context_budget_config = budget_for_context_window(window)
+                except Exception:
+                    pass
+                return window
+        except Exception:
+            pass
+        return int(getattr(cfg, "max_context_tokens", 200000) or 200000)
+
     def get_context_usage(self) -> dict:
-        budget = getattr(self.config, "max_context_tokens", 96000)
+        budget = self.active_context_limit()
 
         prefix = self._context_usage_prefix_tokens()
         system_prompt_tokens = prefix["system_prompt_tokens"]

--- a/harness/implement_guards.py
+++ b/harness/implement_guards.py
@@ -287,6 +287,18 @@ def check_implement_workspace(repo: str, *, goal: str = "") -> Optional[str]:
             f"Project on that path, or use run_command / run_swarm with a "
             f"git cwd."
         )
+    try:
+        from harness.validation_reuse import _git_head_unborn
+
+        if _git_head_unborn(repo):
+            return (
+                f"REFUSED: {repo} is a git repository with no commits yet "
+                f"(unborn HEAD), so run_implement cannot create a worktree. "
+                f"Make an initial commit first, then retry; or use "
+                f"write_file / edit_file / run_command on the live tree."
+            )
+    except Exception:
+        pass
     return None
 
 
@@ -299,6 +311,8 @@ def is_preflight_worker_error(error: str) -> bool:
         "not a git repo",
         "not a valid git repository",
         "no git repository",
+        "unborn head",
+        "no commits yet",
         "refused:",
         "no workspace directory",
         "could not select a model",

--- a/harness/pilot_guards.py
+++ b/harness/pilot_guards.py
@@ -118,21 +118,30 @@ NATIVE_EXPLORATION_KINDS = frozenset({
     "list_dir",
 })
 
-_EXPLORATION_CMD_RE = re.compile(
-    r"(?:^|[\s;&|])(?:"
-    r"rg|ripgrep|grep|find|fd|tree|ls|dir|ack|ag|locate|where|which|"
-    r"Get-ChildItem|Select-String|gci|git\s+grep"
-    r")\b",
-    re.IGNORECASE,
-)
+# First-argv exploration only. Searching the whole command string falsely
+# classified `cat <<EOF` / `python …` writes as exploration whenever the
+# body mentioned find/which/where/ls.
+_EXPLORATION_COMMANDS = frozenset({
+    "rg",
+    "ripgrep",
+    "grep",
+    "find",
+    "fd",
+    "tree",
+    "ls",
+    "dir",
+    "ack",
+    "ag",
+    "locate",
+    "get-childitem",
+    "select-string",
+    "gci",
+})
+_LEADING_SEGMENT_RE = re.compile(r"[;&|\n]")
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 _BARE_DIR_PROBE_RE = re.compile(
     r"^(?:ls(?:\s+-1)?|dir)\s*$",
-    re.IGNORECASE,
-)
-
-_ECHO_PROBE_RE = re.compile(
-    r"^echo\b",
     re.IGNORECASE,
 )
 
@@ -668,6 +677,15 @@ def normalize_action_args(kind: str, act: Any) -> str:
         if kind == "read_file":
             payload["start_line"] = _norm_optional_int(getattr(act, "start_line", None))
             payload["limit"] = _norm_optional_int(getattr(act, "limit", None))
+        if kind == "write_file":
+            import hashlib
+            content = getattr(act, "content", None)
+            if content is None or content == "":
+                content = args.get("content") or args.get("text") or ""
+            text = str(content or "")
+            payload["content_fingerprint"] = (
+                hashlib.sha256(text.encode("utf-8")).hexdigest()[:16] if text else ""
+            )
         if kind == "edit_file":
             payload["old_str"] = _norm_whitespace(getattr(act, "old_str", "") or "")
             payload["new_str"] = _norm_whitespace(getattr(act, "new_str", "") or "")
@@ -750,6 +768,25 @@ def is_local_handoff_command(command: str) -> bool:
     return bool(_CLIPBOARD_SINK_RE.search(cmd))
 
 
+def _leading_command_tokens(command: str) -> list[str]:
+    """First argv tokens of the first pipeline/simple command (ignore env assigns)."""
+    cmd = _norm_whitespace(command)
+    if not cmd:
+        return []
+    segment = _LEADING_SEGMENT_RE.split(cmd, 1)[0].strip()
+    tokens: list[str] = []
+    for raw in segment.split():
+        if _ENV_ASSIGN_RE.match(raw):
+            continue
+        name = raw.rsplit("/", 1)[-1].rsplit("\\", 1)[-1].lower()
+        if name.endswith(".exe"):
+            name = name[:-4]
+        tokens.append(name)
+        if len(tokens) >= 2:
+            break
+    return tokens
+
+
 def is_exploration_command(command: str) -> bool:
     cmd = _norm_whitespace(command)
     if not cmd:
@@ -758,9 +795,15 @@ def is_exploration_command(command: str) -> bool:
         return False
     if _BARE_DIR_PROBE_RE.match(cmd):
         return True
-    if _ECHO_PROBE_RE.match(cmd):
+    tokens = _leading_command_tokens(cmd)
+    if not tokens:
+        return False
+    lead = tokens[0]
+    if lead == "echo":
         return True
-    return bool(_EXPLORATION_CMD_RE.search(cmd))
+    if lead == "git" and len(tokens) > 1 and tokens[1] == "grep":
+        return True
+    return lead in _EXPLORATION_COMMANDS
 
 
 def is_puppetmaster_cli_command(command: str) -> bool:

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -46,9 +46,17 @@ READ_ONLY_KINDS: frozenset[str] = frozenset({
 })
 
 # Honest composer wait-hint when the provider stream goes quiet mid-turn.
+# Stage 1 is a one-shot at 9s; later stages escalate so a 15-minute stall
+# is not a single stale "still working" line.
 STREAM_IDLE_NOTICE_SEC = 9.0
+STREAM_IDLE_ESCALATE_SEC = 60.0
+STREAM_IDLE_STUCK_SEC = 300.0
 STREAM_IDLE_POLL_SEC = 1.0
 STREAM_IDLE_NOTICE_MESSAGE = "Provider still working — stream idle"
+STREAM_IDLE_ESCALATE_MESSAGE = "Provider still idle after 1m — stream has not advanced"
+STREAM_IDLE_STUCK_MESSAGE = (
+    "Provider still idle after 5m — consider Stop if the stream is stuck"
+)
 
 LOCAL_ACTION_KINDS: frozenset[str] = frozenset({
     "open_project", "relocate_session", "session_bank",
@@ -680,25 +688,35 @@ def drain_stream_queue(q: Any) -> Iterator[Any]:
     progress_batch = StreamDeltaBatch()
     reasoning_batch = StreamDeltaBatch()
     last_queue_activity = time.monotonic()
-    stream_idle_notice_sent = False
+    stream_idle_stage = 0
 
     def _note_queue_activity():
-        nonlocal last_queue_activity, stream_idle_notice_sent
+        nonlocal last_queue_activity, stream_idle_stage
         last_queue_activity = time.monotonic()
-        stream_idle_notice_sent = False
+        stream_idle_stage = 0
 
     def _maybe_emit_stream_idle_notice():
-        nonlocal stream_idle_notice_sent
-        if stream_idle_notice_sent:
-            return None
-        now = time.monotonic()
-        if (now - last_queue_activity) < STREAM_IDLE_NOTICE_SEC:
-            return None
-        stream_idle_notice_sent = True
-        return ConvEvent("notice", {
-            "message": STREAM_IDLE_NOTICE_MESSAGE,
-            "kind": "wait",
-        })
+        nonlocal stream_idle_stage
+        idle_for = time.monotonic() - last_queue_activity
+        if idle_for >= STREAM_IDLE_STUCK_SEC and stream_idle_stage < 3:
+            stream_idle_stage = 3
+            return ConvEvent("notice", {
+                "message": STREAM_IDLE_STUCK_MESSAGE,
+                "kind": "wait",
+            })
+        if idle_for >= STREAM_IDLE_ESCALATE_SEC and stream_idle_stage < 2:
+            stream_idle_stage = 2
+            return ConvEvent("notice", {
+                "message": STREAM_IDLE_ESCALATE_MESSAGE,
+                "kind": "wait",
+            })
+        if idle_for >= STREAM_IDLE_NOTICE_SEC and stream_idle_stage < 1:
+            stream_idle_stage = 1
+            return ConvEvent("notice", {
+                "message": STREAM_IDLE_NOTICE_MESSAGE,
+                "kind": "wait",
+            })
+        return None
 
     def _flush_all():
         for bat, ek, ch in (

--- a/harness/server.py
+++ b/harness/server.py
@@ -915,6 +915,7 @@ if "HARNESS_DRIVER" not in os.environ:
                 try:
                     from pmharness.registry import context_window as _boot_ctx_window
                     _cfg.max_context_tokens = _boot_ctx_window(_cfg.driver, default=200000)
+                    _cfg.max_context_tokens_pinned = False
                 except Exception as e:
                     _diag("server.boot_driver_context_window", e)
     except Exception as e:
@@ -1041,6 +1042,7 @@ def _resolve_available_driver():
                     try:
                         from pmharness.registry import context_window
                         _cfg.max_context_tokens = context_window(_cfg.driver, default=200000)
+                        _cfg.max_context_tokens_pinned = False
                     except Exception as e:
                         _diag("server.resolve_driver_context_window", e)
                 return
@@ -1912,9 +1914,11 @@ def _apply_model_context_window():
     after a model swap. An explicit HARNESS_MAX_CONTEXT_TOKENS env override
     always wins (so a deliberate cap is never silently widened)."""
     if "HARNESS_MAX_CONTEXT_TOKENS" in os.environ:
+        _cfg.max_context_tokens_pinned = True
         return
     from pmharness.registry import apply_context_window
     _cfg.max_context_tokens = apply_context_window(_cfg.driver, default=200000)
+    _cfg.max_context_tokens_pinned = False
 
 
 def _attach_services():

--- a/pmharness/registry.py
+++ b/pmharness/registry.py
@@ -641,7 +641,11 @@ _STATIC_WINDOWS = {
     "gemini25flash": 1000000,
     "gemini": 1000000,
     # Open-weights frontier families.
+    # GLM-5.3 / 5.2 are 1M input (128k is max *output*, not the window).
+    # Longest-prefix match: glm53/glm52 beat the legacy "glm" 128k family.
+    "glm53": 1000000,
     "glm52": 1000000,
+    "glm51": 200000,
     "glm47": 128000,
     "glm": 128000,
     "qwen3coder": 262144,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.230"
+version = "0.9.231"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_workspace_peel.py
+++ b/tests/test_api_workspace_peel.py
@@ -79,6 +79,21 @@ def test_workspace_forget_clears_active(tmp_path):
     assert cleared["n"] == 1
 
 
+def test_get_workspace_reports_unborn_head(tmp_path):
+    import subprocess
+
+    repo = tmp_path / "unborn"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, capture_output=True)
+    cfg = SimpleNamespace(repo=str(repo))
+    svc, _, ws_json, _ = _svc(cfg, tmp_path)
+    ws_json.write_text(json.dumps({"recents": []}), encoding="utf-8")
+    code, payload = get_workspace(svc)
+    assert code == 200
+    assert payload["is_git"] is True
+    assert payload["head_unborn"] is True
+
+
 def test_get_workspace_reports_home_without_rerecording(tmp_path):
     cfg = SimpleNamespace(repo="")
     svc, _, ws_json, home = _svc(cfg, tmp_path)

--- a/tests/test_context_usage.py
+++ b/tests/test_context_usage.py
@@ -157,6 +157,19 @@ def test_context_usage_prefers_real_total():
     assert usage_real["total"] > heuristic_total
 
 
+def test_context_usage_limit_follows_live_driver_when_unpinned(monkeypatch):
+    monkeypatch.setenv("PMHARNESS_OR_LIVE_WINDOWS", "0")
+    import pmharness.registry as reg
+    monkeypatch.setattr(reg, "_CW_MEM", None, raising=False)
+    cfg = HarnessConfig(driver="glm-5.3", max_context_tokens=128000)
+    cfg.max_context_tokens_pinned = False
+    s = ConversationalSession(cfg)
+    s._history[0]["content"] = "sys"
+    usage = s.get_context_usage()
+    assert usage["limit"] == 1000000
+    assert cfg.max_context_tokens == 1000000
+
+
 def test_context_usage_falls_back_offline():
     """No real usage -> total is the heuristic category sum (unchanged behavior)."""
     s = _session(budget=5000)

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -30,6 +30,12 @@ def test_unknown_model_falls_back_to_floor():
     assert context_window("not-a-real-model", default=120000) == 120000
 
 
+def test_glm_5_3_static_window_is_1m_not_128k():
+    """128k is GLM-5.3 max output. Input window is 1M (same base as 5.2)."""
+    assert context_window("glm-5.3") == 1000000
+    assert context_window("zai:glm-5.3") == 1000000
+
+
 def test_config_resolves_window_from_driver(monkeypatch):
     monkeypatch.delenv("HARNESS_MAX_CONTEXT_TOKENS", raising=False)
     monkeypatch.setenv("HARNESS_DRIVER", "claude-frontier")

--- a/tests/test_context_window_live.py
+++ b/tests/test_context_window_live.py
@@ -42,6 +42,15 @@ def test_live_map_wins_when_present(monkeypatch):
     assert reg.context_window("glm-5.2") == 1048576
 
 
+def test_glm_5_3_live_map_wins_over_static(monkeypatch):
+    import pmharness.registry as reg
+    monkeypatch.setenv("PMHARNESS_OR_LIVE_WINDOWS", "1")
+    monkeypatch.setattr(reg, "_CW_MEM", None, raising=False)
+    monkeypatch.setattr(reg, "_live_windows", lambda: {"z-ai/glm-5.3": 1048576})
+    assert reg.context_window("glm-5.3") == 1048576
+    assert reg.context_window("zai:glm-5.3") == 1048576
+
+
 def test_native_name_fuzzy_matches_openrouter_twin(monkeypatch):
     import pmharness.registry as reg
     monkeypatch.setenv("PMHARNESS_OR_LIVE_WINDOWS", "1")

--- a/tests/test_implement_fanout_and_metrics.py
+++ b/tests/test_implement_fanout_and_metrics.py
@@ -90,7 +90,34 @@ def test_check_implement_workspace_allows_git(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@example.com"],
+        cwd=repo, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=repo, check=True, capture_output=True,
+    )
+    (repo / "README.md").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-qm", "initial"],
+        cwd=repo, check=True, capture_output=True,
+    )
     assert check_implement_workspace(str(repo), goal="edit foo.py") is None
+
+
+def test_check_implement_workspace_refuses_unborn_head(tmp_path, monkeypatch):
+    import subprocess
+
+    monkeypatch.setenv("HARNESS_IMPLEMENT_GIT_GUARD", "1")
+    repo = tmp_path / "unborn"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    msg = check_implement_workspace(str(repo), goal="edit foo.py")
+    assert msg is not None
+    assert "REFUSED" in msg
+    assert "unborn" in msg.lower() or "no commits" in msg.lower()
 
 
 def test_check_implement_workspace_refuses_home(tmp_path, monkeypatch):

--- a/tests/test_pilot_guards.py
+++ b/tests/test_pilot_guards.py
@@ -66,6 +66,7 @@ from harness.pilot_guards import (
 class _Act:
     kind: str = ""
     path: str = ""
+    content: str = ""
     command: str = ""
     query: str = ""
     goal: str = ""
@@ -515,6 +516,42 @@ def test_delegate_gate_trips_after_threshold():
     assert verdict.reason == "delegate"
     assert "search_codegraph" in verdict.message
     assert "run_swarm" in verdict.message
+
+
+def test_write_file_fingerprint_includes_content():
+    a = _Act(kind="write_file", path="wiki/README.md", content="first draft")
+    b = _Act(kind="write_file", path="wiki/README.md", content="rewritten body")
+    assert normalize_action_args("write_file", a) != normalize_action_args("write_file", b)
+    same = _Act(kind="write_file", path="wiki/README.md", content="first draft")
+    assert normalize_action_args("write_file", a) == normalize_action_args("write_file", same)
+
+
+def test_write_file_loop_guard_allows_changed_content():
+    from harness.pilot_guards import record_successful_result
+
+    state = new_turn_guard_state()
+    first = _Act(kind="write_file", path="canaries/BANK.md", content="mangled")
+    record_action_execution(state, "write_file", first)
+    record_successful_result(state, "write_file", first, "wrote 3064 bytes")
+    retry = _Act(kind="write_file", path="canaries/BANK.md", content="clean table")
+    verdict = check_loop_guard(state, "write_file", retry)
+    assert verdict.suppress is False
+
+
+def test_heredoc_write_is_not_exploration():
+    command = (
+        "cat > harness/build_canaries.py <<'EOF'\n"
+        "def find_all():\n"
+        "    which = 'not a probe'\n"
+        "EOF"
+    )
+    assert is_exploration_command(command) is False
+    assert is_native_exploration("run_command", _Act(command=command)) is False
+
+
+def test_which_and_where_are_not_exploration():
+    assert is_exploration_command("which ollama") is False
+    assert is_exploration_command("where python") is False
 
 
 def test_delegate_gate_counts_exploration_run_command():

--- a/tests/test_send_loop_phases.py
+++ b/tests/test_send_loop_phases.py
@@ -36,8 +36,12 @@ from harness.send_loop_phases import (
     run_prefetch,
     run_stream,
     stream_swarm,
+    STREAM_IDLE_ESCALATE_MESSAGE,
+    STREAM_IDLE_ESCALATE_SEC,
     STREAM_IDLE_NOTICE_MESSAGE,
     STREAM_IDLE_NOTICE_SEC,
+    STREAM_IDLE_STUCK_MESSAGE,
+    STREAM_IDLE_STUCK_SEC,
 )
 
 PHASE_HELPERS = (
@@ -604,6 +608,39 @@ def test_drain_stream_queue_stream_idle_notice_is_one_shot_until_progress(monkey
         and e.data.get("message") == STREAM_IDLE_NOTICE_MESSAGE
     ]
     assert len(idle) == 2
+    assert got is resp
+
+
+def test_drain_stream_queue_escalates_stream_idle_notice(monkeypatch):
+    clock = {"t": 0.0}
+    monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr("harness.send_loop_phases.STREAM_IDLE_POLL_SEC", 0)
+
+    resp = SimpleNamespace(text="ok")
+    script = [
+        ("reasoning", "partial thought"),
+        ("advance", STREAM_IDLE_NOTICE_SEC + 1),
+        queue.Empty,
+        ("advance", STREAM_IDLE_ESCALATE_SEC - STREAM_IDLE_NOTICE_SEC),
+        queue.Empty,
+        ("advance", STREAM_IDLE_STUCK_SEC - STREAM_IDLE_ESCALATE_SEC),
+        queue.Empty,
+        ("done", resp),
+    ]
+    q = MagicMock()
+    q.get = _mock_stream_queue_get(clock, script)
+
+    events, (_prose, got) = _collect_drain_events(drain_stream_queue(q))
+    idle = [
+        e.data.get("message")
+        for e in events
+        if e.kind == "notice" and e.data.get("kind") == "wait"
+    ]
+    assert idle == [
+        STREAM_IDLE_NOTICE_MESSAGE,
+        STREAM_IDLE_ESCALATE_MESSAGE,
+        STREAM_IDLE_STUCK_MESSAGE,
+    ]
     assert got is resp
 
 

--- a/tests/test_workspaces_unit.py
+++ b/tests/test_workspaces_unit.py
@@ -40,6 +40,13 @@ def test_list_workspaces_empty_without_repo():
     assert list_workspaces("/no/such/path") == []
 
 
+def test_list_workspaces_empty_on_unborn_head(tmp_path):
+    repo = tmp_path / "unborn"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, capture_output=True)
+    assert list_workspaces(str(repo)) == []
+
+
 def test_list_workspaces_marks_active_and_dirty(tmp_path):
     repo = _init_repo(tmp_path)
     _git(repo, "branch", "feature")

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.230",
+  "version": "0.9.231",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.230",
+      "version": "0.9.231",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.230",
+  "version": "0.9.231",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -1734,7 +1734,9 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
             </div>
           }
         >
-          {workspaces.length === 0 && <Empty>No branches</Empty>}
+          {workspaces.length === 0 && (
+            <Empty>{workspaceInfo?.head_unborn ? "No commits yet" : "No branches"}</Empty>
+          )}
           <div className="space-y-0.5 overflow-y-auto" style={{ height: branchesHeight }}>
             {workspaces.map((w) => {
               const linked = !!w.worktree_path;

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -440,6 +440,8 @@ export type WorkspaceInfo = {
   repo: string;
   branch: string;
   is_git: boolean;
+  /** True when `.git` exists but HEAD has no commits yet. */
+  head_unborn?: boolean;
   codegraph_status: string;
   recents?: string[];
   home?: string;


### PR DESCRIPTION
## Summary
- Resolve context windows from the live catalog on each usage read so GLM-5.3 is 1M tokens, not a sticky 128k family default.
- Fingerprint `write_file` content so a rewritten body is not treated as a cached repeat; classify exploration on the first argv only so heredoc writes and `which`/`where` are not suppressed.
- Refuse `run_implement` on unborn HEAD, escalate idle-stream notices at 1m/5m, and show "No commits yet" in Branches.

## Test plan
- [x] Local `.venv/bin/python -m pytest -q` — 4405 passed, 74 skipped
- [ ] CI `tests` workflow green on the merge SHA: Python 3.9, 3.11, Windows, frontend-build
- [ ] After green CI, tag `v0.9.231` on `main` (do not tag `dev`; do not tag untagged v0.9.230)