### PR TITLE
Keep swarm worker model attribution task-scoped

### DIFF
--- a/harness/api/jobs.py
+++ b/harness/api/jobs.py
@@ -486,6 +486,12 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
                         "adapter": getattr(t, "adapter", ""),
                         "completed_at": getattr(t, "completed_at", None),
                     }
+                    task_model = resolve_job_model(
+                        [a for a in raw_arts if getattr(a, "task_id", "") == tid],
+                        [t],
+                    ) if tid else ""
+                    if task_model:
+                        entry["model"] = task_model
                     acct = task_accounting.get(tid) if tid else None
                     if acct:
                         t_tokens = int(acct.get("tokens") or 0)

--- a/tests/test_swarm_live_slim.py
+++ b/tests/test_swarm_live_slim.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from harness.api.jobs import canonical_job_outcome
+from harness.api.jobs import (
+    canonical_job_outcome,
+    get_swarm_live,
+    make_job_services,
+)
 from harness.server import (
     _job_status_is_terminal,
     _slim_swarm_list_artifacts,
 )
-from puppetmaster.models import Artifact, ArtifactType
+from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
 
 
 def _art(
@@ -81,6 +85,65 @@ def test_slim_keeps_routing_and_verdicts_drops_findings():
     assert "finding" not in types
     assert "risk" not in types
     assert len(slim) == 2
+
+
+def test_swarm_live_projects_each_tasks_final_routed_model():
+    tasks = [
+        Task(job_id="job-1", id="t1", role="one", instruction="", status=TaskStatus.COMPLETE, adapter="agentic"),
+        Task(job_id="job-1", id="t2", role="two", instruction="", status=TaskStatus.COMPLETE, adapter="agentic"),
+    ]
+    artifacts = [
+        Artifact(
+            job_id="job-1", task_id="t1", type=ArtifactType.ROUTING,
+            created_by="router", payload={"model_id": "model-a"},
+            confidence=1.0, evidence=["route"],
+        ),
+        Artifact(
+            job_id="job-1", task_id="t2", type=ArtifactType.ROUTING,
+            created_by="router", payload={"model_id": "model-b"},
+            confidence=1.0, evidence=["route"],
+        ),
+    ]
+
+    class Store:
+        def list_artifacts_for_jobs(self, _job_ids):
+            return artifacts
+
+        def list_tasks_for_jobs(self, _job_ids):
+            return tasks
+
+    store = Store()
+    state = SimpleNamespace(store=store, format_artifacts=_Fmt().format_artifacts)
+    pilot = SimpleNamespace(
+        harness_session_id="", live_local_jobs=lambda: [],
+        _tokens_used=0, _tokens_cached=0, _worker_tokens_in=0,
+        _worker_tokens_out=0, _provider_cost_usd=0.0,
+    )
+    errors = []
+    svc = make_job_services(
+        cfg=SimpleNamespace(driver="agentic", repo="/repo", state_dir="/tmp"),
+        sessions=SimpleNamespace(active=""),
+        get_pilot=lambda: pilot,
+        get_session=lambda: SimpleNamespace(state=lambda: state),
+        diag=lambda *args, **_kwargs: errors.append(args),
+        scoped_jobs_with_stores=lambda **_k: ([{
+            "id": "job-1", "status": "complete", "goal": "two models",
+            "adapter": "agentic", "source": "harness",
+            "accounting_owned": True, "accounting_scope": "marionette",
+        }], store, None),
+        job_status_is_terminal=lambda _status: True,
+        slim_swarm_list_artifacts=_slim_swarm_list_artifacts,
+        job_swarm_accounting=lambda *_a, **_k: (0, 0.0),
+    )
+
+    code, payload = get_swarm_live("/repo", svc)
+
+    assert code == 200
+    assert payload["jobs"], errors
+    assert {task["id"]: task.get("model") for task in payload["jobs"][0]["tasks"]} == {
+        "t1": "model-a",
+        "t2": "model-b",
+    }
 
 
 def test_canonical_outcome_uses_full_raw_artifacts_before_slim():

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -149,6 +149,54 @@ describe("SwarmPane model badge", () => {
     });
     expect(screen.queryByTitle("Model: agentic")).not.toBeInTheDocument();
   });
+
+  it("shows each worker's own model without inheriting the job model", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        model: "job-default",
+        adapter: "agentic",
+        tasks: [
+          { id: "task-a", status: "running", adapter: "agentic", role: "worker-a", instruction: "", model: "model-a" },
+          { id: "task-b", status: "running", adapter: "agentic", role: "worker-b", instruction: "", model: "model-b" },
+          { id: "task-unknown", status: "running", adapter: "agentic", role: "worker-unknown", instruction: "" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    await waitFor(() => {
+      expect(screen.getByText("(model-a)")).toBeInTheDocument();
+      expect(screen.getByText("(model-b)")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("(job-default)")).not.toBeInTheDocument();
+  });
+
+  it("updates a worker model when routing settles on a later poll", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let pollCount = 0;
+      mockSwarmLive.mockImplementation(async () => {
+        pollCount += 1;
+        return liveJob({
+          model: "job-default",
+          adapter: "agentic",
+          tasks: [{
+            id: "task-1", status: "running", adapter: "agentic",
+            role: "worker", instruction: "",
+            ...(pollCount > 2 ? { model: "routed-model" } : {}),
+          }],
+        });
+      });
+
+      render(<SwarmPane />);
+      await waitFor(() => expect(screen.queryByText("(routed-model)")).not.toBeInTheDocument());
+      await vi.advanceTimersByTimeAsync(6000);
+      await waitFor(() => expect(screen.getByText("(routed-model)")).toBeInTheDocument());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("SwarmPane pin attribution", () => {

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -247,7 +247,7 @@ function swarmSignature(res: SwarmLive | null): string {
     );
     for (const t of tasks) {
       parts.push(
-        `${t.id}=${t.status}:${t.tokens ?? 0}:${(t.est_cost_usd ?? 0).toFixed(4)}`,
+        `${t.id}=${t.status}:${t.model ?? ""}:${t.tokens ?? 0}:${(t.est_cost_usd ?? 0).toFixed(4)}`,
       );
     }
     for (const a of arts) {
@@ -1327,7 +1327,7 @@ export default function SwarmPane() {
                     const hasInstruction = !!task.instruction;
                     // Prefer a real routed model over repeating the engine label
                     // already present in role ("implement (agentic) (agentic)").
-                    const taskModelLabel = displayModelId(task.model || "", {}) || displayModel;
+                    const taskModelLabel = displayModelId(task.model || "", {});
                     const adapterLabel = (task.adapter || "").trim();
                     const secondaryLabel = taskModelLabel
                       || (adapterLabel && !isEngineOnlyModelId(adapterLabel) ? adapterLabel : "");


### PR DESCRIPTION
## Summary
- `/api/swarm/live` now resolves each worker model from routing artifacts stamped with that worker's `task_id`, with the existing task-payload fallback.
- Stop copying one job-level model onto worker rows whose model is unknown; unknown stays unknown instead of presenting false attribution.
- Include `task.model` in the live-payload fingerprint so a routing decision that settles on a later poll repaints the worker row.
- This does not enable heterogeneous dispatch; it keeps the tracker read model honest for task-scoped routes produced by Puppetmaster.

## Test plan
- [x] `.venv/bin/python -m pytest -q -p no:cacheprovider tests/test_session_job_scoping.py tests/test_swarm_live_slim.py` — 29 passed
- [x] `cd webapp && NODE_ENV=test npm test -- --run src/__tests__/SwarmPane.test.tsx` — 46 passed
- [x] `cd webapp && NODE_ENV=production npm run build`
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)