### PR TITLE
Let every swarm worker reveal execution details

### DIFF
--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -199,6 +199,47 @@ describe("SwarmPane model badge", () => {
   });
 });
 
+describe("SwarmPane worker details", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    clearSWRCache();
+    mockArtifacts.mockResolvedValue([]);
+  });
+
+  it("lets a terminal worker reveal its source-backed identity", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job-terminal-worker", "Inspect completed worker", {
+        artifacts_complete: true,
+        tasks: [{
+          id: "task-terminal",
+          status: "complete",
+          adapter: "agentic",
+          role: "completed-worker",
+          instruction: "",
+          model: "agentic/gpt-5.6-luna",
+          completed_at: "2026-08-16T17:00:00+00:00",
+        }],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Inspect completed worker"));
+
+    const worker = screen.getByText("completed-worker").closest('[role="button"]');
+    expect(worker).not.toBeNull();
+    expect(worker).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(worker!);
+
+    expect(worker).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("task-terminal")).toBeInTheDocument();
+    expect(screen.getByText("2026-08-16T17:00:00+00:00")).toBeInTheDocument();
+  });
+});
+
 describe("SwarmPane pin attribution", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -1324,7 +1324,6 @@ export default function SwarmPane() {
                   {tasks.map((task) => {
                     const ts = taskState(task);
                     const tExpanded = !!expandedTasks[task.id];
-                    const hasInstruction = !!task.instruction;
                     // Prefer a real routed model over repeating the engine label
                     // already present in role ("implement (agentic) (agentic)").
                     const taskModelLabel = displayModelId(task.model || "", {});
@@ -1334,11 +1333,12 @@ export default function SwarmPane() {
                     return (
                       <div
                         key={task.id}
-                        role={hasInstruction ? "button" : undefined}
-                        tabIndex={hasInstruction ? 0 : undefined}
-                        onClick={hasInstruction ? () => toggleTask(task.id) : undefined}
-                        onKeyDown={hasInstruction ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleTask(task.id); } } : undefined}
-                        className={`p-1.5 rounded bg-panel2/20 border border-edge/40 flex items-start gap-2 text-[10px] ${hasInstruction ? "cursor-pointer hover:bg-panel2/35 focus:outline-none" : ""}`}
+                        role="button"
+                        tabIndex={0}
+                        aria-expanded={tExpanded}
+                        onClick={() => toggleTask(task.id)}
+                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleTask(task.id); } }}
+                        className="p-1.5 rounded bg-panel2/20 border border-edge/40 flex items-start gap-2 text-[10px] cursor-pointer hover:bg-panel2/35 focus:outline-none"
                       >
                         <span className="mt-0.5 shrink-0">
                           {ts === "running" ? <Loader2 size={10} className="animate-spin text-accent" />
@@ -1349,9 +1349,9 @@ export default function SwarmPane() {
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center justify-between gap-1">
                             <span className="font-semibold text-txt truncate flex items-center gap-1 min-w-0">
-                              {hasInstruction && (tExpanded
+                              {tExpanded
                                 ? <ChevronDown size={9} className="text-faint shrink-0" />
-                                : <ChevronRight size={9} className="text-faint shrink-0" />)}
+                                : <ChevronRight size={9} className="text-faint shrink-0" />}
                               <span className="truncate">
                                 {task.role || "Worker"}
                                 {secondaryLabel ? (
@@ -1383,11 +1383,18 @@ export default function SwarmPane() {
                               }`}>{task.status}</span>
                             </span>
                           </div>
-                          {hasInstruction && (tExpanded ? (
-                            <div className="text-muted text-[9.5px] mt-1 whitespace-pre-wrap break-words leading-relaxed">{task.instruction}</div>
-                          ) : (
+                          {tExpanded && (
+                            <div className="mt-1 text-[9px] font-mono text-faint grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                              <span>task</span><span className="text-muted break-all">{task.id}</span>
+                              {taskModelLabel && <><span>model</span><span className="text-muted break-all">{taskModelLabel}</span></>}
+                              {adapterLabel && <><span>adapter</span><span className="text-muted break-all">{adapterLabel}</span></>}
+                              {task.completed_at && <><span>completed</span><span className="text-muted break-all">{task.completed_at}</span></>}
+                              {task.instruction && <><span>instruction</span><span className="text-muted whitespace-pre-wrap break-words font-sans">{task.instruction}</span></>}
+                            </div>
+                          )}
+                          {!tExpanded && task.instruction && (
                             <Tooltip label={task.instruction} className="block text-muted text-[9.5px] mt-0.5 truncate">{task.instruction}</Tooltip>
-                          ))}
+                          )}
                         </div>
                       </div>
                     );


### PR DESCRIPTION
## Summary
- `hasInstruction` came from the original expandable-details change (`ad666b6`), when the full instruction was the only hidden worker content; suppressing the affordance avoided opening an empty row.
- Terminal task projection now intentionally omits instructions, so that content gate accidentally made completed and failed workers non-interactive. Delete the gate now that every valid task has source-backed identity to inspect.
- Reuse the existing inline expansion and `expandedTasks` state to show task ID plus available model, adapter, completion time, and instruction. Running, completed, failed, cancelled, and external task rows all use the same contract.
- Preserve the collapsed layout and keep failure explanation in Findings. No backend fields, endpoint, modal, component, receipt/log surface, or inferred metadata is added.

## Test plan
- [x] RED: a terminal worker with no instruction had no clickable ancestor
- [x] `cd webapp && NODE_ENV=test npm test -- --run src/__tests__/SwarmPane.test.tsx` — 47 passed
- [x] `cd webapp && NODE_ENV=production npm run build`
- [x] Real completed BI worker payload confirmed task ID, model, adapter, status, and completion timestamp are available to the live branch UI
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)