### PR TITLE
Release v0.9.232: task-scoped swarm worker model attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.231, deliberately pre-1.0. Context windows resolve from the live model catalog (GLM-5.3 is 1M, not 128k); write_file fingerprints content; unborn HEAD is refused before worktree dispatch; swarm tracker keeps worker models task-scoped. Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.232, deliberately pre-1.0. Swarm tracker keeps worker models task-scoped (unknown stays unknown). Context windows resolve from the live catalog (GLM-5.3 is 1M, not 128k); write_file fingerprints content; unborn HEAD is refused before worktree dispatch. Rides puppetmaster-ai==1.22.5.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.231"
+__version__ = "0.9.232"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.231"
+version = "0.9.232"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.231",
+  "version": "0.9.232",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.231",
+      "version": "0.9.232",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.231",
+  "version": "0.9.232",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Ships [PR #34](https://github.com/professorpalmer/marionette/pull/34) (`kbentonferguson`) as a new patch: v0.9.231 is already tagged and published on `01f0638` without this change. Do not move that tag.
- Worker models resolve from task-scoped ROUTING artifacts; unknown stays unknown; live fingerprint includes `task.model`.

## Test plan
- [x] `tests/test_session_job_scoping.py` + `tests/test_swarm_live_slim.py` — 29 passed
- [x] `webapp` SwarmPane vitest — 46 passed
- [x] `tests/test_version_consistency.py` — 2 passed
- [ ] CI `tests` workflow green on this PR, then on the merge SHA
- [ ] Tag `v0.9.232` on that `main` SHA only after green CI