### PR TITLE
Make swarm tracker ordering intelligible and filterable

### DIFF
--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -47,6 +47,97 @@ function finishedJob(
   return liveJob({ id, goal, status: "complete", adapter: "agentic", ...overrides });
 }
 
+function expectBefore(first: HTMLElement, second: HTMLElement) {
+  expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+}
+
+describe("SwarmPane sort and filter controls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    clearSWRCache();
+    mockArtifacts.mockResolvedValue([]);
+    mockSwarmLive.mockResolvedValue({
+      session: { tokens_used: 0, est_cost_usd: 0 },
+      jobs: [
+        { id: "job-z", goal: "Older active audit", status: "running", created_at: "2026-01-01T00:00:00Z", model: "model-old" },
+        { id: "job-a", goal: "Newest active build", status: "running", created_at: "2026-03-01T00:00:00Z", model: "model-new" },
+        { id: "job-no-time", goal: "Active job without timestamp", status: "running" },
+        { id: "job-y", goal: "Older completed review", status: "complete", created_at: "2026-01-15T00:00:00Z" },
+        { id: "job-b", goal: "Newest failed review", status: "failed", created_at: "2026-02-15T00:00:00Z" },
+        { id: "job-c", goal: "Degraded architecture review", status: "complete", created_at: "2026-02-01T00:00:00Z", outcome: { quality: "degraded", trustworthy: false, reasons: ["only verification artifacts"] } },
+      ],
+    });
+  });
+
+  it("distributes filter and sort controls evenly across the toolbar", async () => {
+    render(<SwarmPane />);
+    const filter = await screen.findByLabelText("Filter swarms");
+    const sort = screen.getByLabelText("Sort swarms");
+
+    expect(filter.parentElement).toHaveClass("grid", "grid-cols-2");
+    expect(filter).toHaveClass("w-full");
+    expect(sort).toHaveClass("w-full");
+  });
+
+  it("sorts active and finished jobs newest-first by creation time", async () => {
+    render(<SwarmPane />);
+
+    const newestActive = await screen.findByText("Newest active build");
+    expectBefore(newestActive, screen.getByText("Older active audit"));
+
+    fireEvent.click(screen.getByText("Finished"));
+    expectBefore(
+      await screen.findByText("Newest failed review"),
+      screen.getByText("Degraded architecture review"),
+    );
+    expectBefore(
+      screen.getByText("Degraded architecture review"),
+      screen.getByText("Older completed review"),
+    );
+  });
+
+  it("reverses both lifecycle groups when Oldest is selected", async () => {
+    render(<SwarmPane />);
+    await screen.findByText("Newest active build");
+
+    fireEvent.change(screen.getByLabelText("Sort swarms"), { target: { value: "oldest" } });
+    expectBefore(screen.getByText("Older active audit"), screen.getByText("Newest active build"));
+    expectBefore(screen.getByText("Newest active build"), screen.getByText("Active job without timestamp"));
+
+    fireEvent.click(screen.getByText("Finished"));
+    expectBefore(
+      await screen.findByText("Older completed review"),
+      screen.getByText("Degraded architecture review"),
+    );
+  });
+
+  it("filters by lifecycle without conflating failed and untrustworthy jobs", async () => {
+    render(<SwarmPane />);
+    await screen.findByText("Newest active build");
+
+    fireEvent.change(screen.getByLabelText("Filter swarms"), { target: { value: "failed" } });
+    expect(await screen.findByText("Newest failed review")).toBeInTheDocument();
+    expect(screen.queryByText("Degraded architecture review")).not.toBeInTheDocument();
+    expect(screen.queryByText("Newest active build")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter swarms"), { target: { value: "untrustworthy" } });
+    expect(await screen.findByText("Degraded architecture review")).toBeInTheDocument();
+    expect(screen.queryByText("Newest failed review")).not.toBeInTheDocument();
+  });
+
+  it("clears a filter with no matching jobs", async () => {
+    render(<SwarmPane />);
+    await screen.findByText("Newest active build");
+
+    fireEvent.change(screen.getByLabelText("Filter swarms"), { target: { value: "cancelled" } });
+    expect(await screen.findByText("No swarm jobs match this filter")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Clear filter" }));
+    expect(await screen.findByText("Newest active build")).toBeInTheDocument();
+  });
+});
+
 describe("SwarmPane SWR cache first-open", () => {
   const REPO = "C:\\Users\\pwall\\Projects\\warm-swarm";
 
@@ -1437,6 +1528,26 @@ describe("SwarmPane harness-open-swarm-job deep-link", () => {
     await waitFor(() => {
       expect(mockArtifacts).toHaveBeenCalledWith("job_abcdef012345");
     });
+  });
+
+  it("clears filters that hide a deep-link target", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job_abcdef012345", "Deep-link target behind filter"),
+    );
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText("Filter swarms"), { target: { value: "active" } });
+    expect(await screen.findByText("No swarm jobs match this filter")).toBeInTheDocument();
+
+    window.dispatchEvent(
+      new CustomEvent("harness-open-swarm-job", {
+        detail: { jobId: "job_abcdef012345" },
+      }),
+    );
+
+    expect(await screen.findByText("Deep-link target behind filter")).toBeInTheDocument();
+    expect(screen.getByLabelText("Filter swarms")).toHaveValue("all");
   });
 
   it("consumes a pending open-job queued before mount", async () => {

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -44,19 +44,23 @@ function Tooltip({ label, children, className }: { label: string; children: Reac
 }
 
 type Status = "pending" | "in_progress" | "completed" | "failed" | "cancelled";
+type SortOrder = "newest" | "oldest";
+type JobFilter = "all" | "active" | "completed" | "failed" | "untrustworthy" | "cancelled";
+
+function timestampMs(ts: unknown): number | null {
+  if (typeof ts === "number" && isFinite(ts)) return ts > 1e12 ? ts : ts * 1000;
+  if (typeof ts === "string" && ts) {
+    const parsed = Date.parse(ts);
+    if (!isNaN(parsed)) return parsed;
+  }
+  return null;
+}
 
 // Compact "how long ago" label for a job's last activity. Accepts epoch seconds
 // or an ISO string (the backend sends created_at/updated_at as either). Returns
 // "" when we can't parse a timestamp so the caller can omit the affordance.
 function relativeSince(ts: unknown, nowMs: number): string {
-  let t: number | null = null;
-  if (typeof ts === "number" && isFinite(ts)) {
-    // Heuristic: seconds vs milliseconds.
-    t = ts > 1e12 ? ts : ts * 1000;
-  } else if (typeof ts === "string" && ts) {
-    const parsed = Date.parse(ts);
-    if (!isNaN(parsed)) t = parsed;
-  }
+  const t = timestampMs(ts);
   if (t === null) return "";
   const secs = Math.max(0, Math.round((nowMs - t) / 1000));
   if (secs < 60) return `${secs}s ago`;
@@ -632,6 +636,8 @@ export default function SwarmPane() {
 
   const [dismissed, setDismissed] = useState<Set<string>>(() => loadDismissed(scopedRepo));
   const [finishedOpen, setFinishedOpen] = useState(false);
+  const [jobFilter, setJobFilter] = useState<JobFilter>("all");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
   // Job ids we have asked the backend to cancel. Held in local view state so the
   // row can show a subtle 'cancelling...' affordance immediately, before the next
   // poll reflects the terminal 'cancelled' status from /api/swarm/live.
@@ -732,6 +738,7 @@ export default function SwarmPane() {
     });
     setExpandedJobs((prev) => ({ ...prev, [id]: true }));
     setFinishedOpen(true);
+    setJobFilter("all");
     const job = dataRef.current?.jobs?.find((j) => j.id === id);
     if (job) ensureFullArtifacts(job);
     const scrollToJob = () => {
@@ -903,7 +910,28 @@ export default function SwarmPane() {
     });
   }, [allJobs]);
 
-  const visibleJobs = allJobs.filter((j) => !isTerminal(j) || !dismissed.has(j.id));
+  const undismissedJobs = allJobs.filter((j) => !isTerminal(j) || !dismissed.has(j.id));
+  const matchesJobFilter = (j: Job) => {
+    const status = jobStatus(j);
+    if (jobFilter === "active") return status === "pending" || status === "in_progress";
+    if (jobFilter === "completed") return status === "completed" && j.outcome?.trustworthy !== false;
+    if (jobFilter === "failed") return status === "failed";
+    if (jobFilter === "untrustworthy") return status === "completed" && j.outcome?.trustworthy === false;
+    if (jobFilter === "cancelled") return status === "cancelled";
+    return true;
+  };
+  const compareJobs = (a: Job, b: Job) => {
+    const aTime = timestampMs(a.created_at) ?? timestampMs(a.updated_at);
+    const bTime = timestampMs(b.created_at) ?? timestampMs(b.updated_at);
+    if (aTime === null || bTime === null) {
+      if (aTime !== bTime) return aTime === null ? 1 : -1;
+      return a.id.localeCompare(b.id);
+    }
+    const byTime = aTime - bTime;
+    if (byTime !== 0) return sortOrder === "oldest" ? byTime : -byTime;
+    return a.id.localeCompare(b.id);
+  };
+  const visibleJobs = undismissedJobs.filter(matchesJobFilter).sort(compareJobs);
   const running = visibleJobs.filter((j) => !isTerminal(j));
   const finished = visibleJobs.filter((j) => isTerminal(j));
   const failedCount = finished.filter((j) => jobStatus(j) === "failed").length;
@@ -926,7 +954,9 @@ export default function SwarmPane() {
   const clearFinished = () =>
     setDismissed((prev) => {
       const next = new Set(prev);
-      for (const j of finished) next.add(j.id);
+      for (const j of undismissedJobs) {
+        if (isTerminal(j)) next.add(j.id);
+      }
       return next;
     });
   const restoreDismissed = () => setDismissed(new Set());
@@ -1536,6 +1566,35 @@ export default function SwarmPane() {
         </div>
       </div>
 
+      <div className="shrink-0 grid grid-cols-2 gap-1.5 px-2 py-1.5 border-b border-[var(--shell-panel-border)] bg-panel2/10">
+        <select
+          aria-label="Filter swarms"
+          value={jobFilter}
+          onChange={(e) => {
+            const next = e.target.value as JobFilter;
+            setJobFilter(next);
+            if (next !== "all" && next !== "active") setFinishedOpen(true);
+          }}
+          className="w-full h-6 rounded border border-edge bg-panel2/40 px-1.5 text-[10px] text-muted focus:outline-none focus:border-accent/60"
+        >
+          <option value="all">All statuses</option>
+          <option value="active">Active</option>
+          <option value="completed">Completed</option>
+          <option value="failed">Failed</option>
+          <option value="untrustworthy">Untrustworthy</option>
+          <option value="cancelled">Cancelled</option>
+        </select>
+        <select
+          aria-label="Sort swarms"
+          value={sortOrder}
+          onChange={(e) => setSortOrder(e.target.value as SortOrder)}
+          className="w-full h-6 rounded border border-edge bg-panel2/40 px-1.5 text-[10px] text-muted focus:outline-none focus:border-accent/60"
+        >
+          <option value="newest">Newest first</option>
+          <option value="oldest">Oldest first</option>
+        </select>
+      </div>
+
       {/* Scrollable Jobs list. min-h-0 is load-bearing: without it a flex-1 item
           in a flex-col defaults to min-height:auto, refuses to shrink below its
           content, grows past the panel, and the root's overflow-hidden clips it
@@ -1547,9 +1606,18 @@ export default function SwarmPane() {
             <span className="text-[12px] text-muted font-medium">
               {isValidating && !data
                 ? "Loading swarm jobs..."
-                : hiddenCount > 0 ? "All swarm jobs cleared" : "No swarm jobs yet"}
+                : undismissedJobs.length > 0
+                  ? "No swarm jobs match this filter"
+                  : hiddenCount > 0 ? "All swarm jobs cleared" : "No swarm jobs yet"}
             </span>
-            {hiddenCount > 0 ? (
+            {undismissedJobs.length > 0 ? (
+              <button
+                onClick={() => setJobFilter("all")}
+                className="text-[10.5px] text-accent hover:underline focus:outline-none"
+              >
+                Clear filter
+              </button>
+            ) : hiddenCount > 0 ? (
               // "Clear" hid every job. Without this affordance the pane read as
               // "No swarm jobs yet" even though the backend had a full history --
               // indistinguishable from a broken tracker.
@@ -1569,8 +1637,8 @@ export default function SwarmPane() {
           </div>
         ) : (
           <>
-            {/* Active runs pinned on top, newest first. */}
-            {running.slice().reverse().map(renderJob)}
+            {/* Active runs stay pinned above terminal history; sort applies within each group. */}
+            {running.map(renderJob)}
 
             {/* Finished runs folded into a collapsible section so a long session
                 stays a short list. Non-destructive: "Clear" only hides. */}
@@ -1602,7 +1670,7 @@ export default function SwarmPane() {
                     Clear
                   </button>
                 </div>
-                {finishedOpen && finished.slice().reverse().map(renderJob)}
+                {finishedOpen && finished.map(renderJob)}
               </div>
             )}
           </>


### PR DESCRIPTION
## Summary
- Replace the tracker’s implicit reverse backend-list order with deterministic `Newest first` / `Oldest first` sorting inside the existing Active and Finished lifecycle groups.
- Sort from each job’s creation timestamp with updated-time fallback, stable job-ID tie-breaking, and missing timestamps last in either direction.
- Add status filtering for Active, Completed, Failed, Untrustworthy, and Cancelled without conflating terminal lifecycle with Puppetmaster’s artifact-quality outcome.
- Automatically reveal Finished results for terminal filters, and clear an incompatible filter when a transcript deep-link opens a specific job.
- Keep the change renderer-only: no `/api/swarm/live`, routing presentation, dismissal, accounting, or persistence behavior changes.

## Test plan
- [x] `cd webapp && NODE_ENV=test npm test` — 995 passed across 85 files
- [x] `cd webapp && NODE_ENV=test npm test -- --run src/__tests__/SwarmPane.test.tsx` — 52 passed
- [x] `cd webapp && npm run build`
- [x] `cd webapp && npm run lint -- src/components/SwarmPane.tsx src/__tests__/SwarmPane.test.tsx` — exit 0; existing warnings only
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)
