### PR TITLE
Release v0.9.234: every swarm worker reveals execution details

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.233, deliberately pre-1.0. Swarm tracker sorts Newest/Oldest within Active and Finished, and filters Active/Completed/Failed/Untrustworthy/Cancelled without conflating lifecycle with artifact quality. Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.234, deliberately pre-1.0. Every swarm worker row expands to source-backed identity (task id, model, adapter, completion time, instruction when present). Rides puppetmaster-ai==1.22.5.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.233"
+__version__ = "0.9.234"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.233"
+version = "0.9.234"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.233",
+  "version": "0.9.234",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.233",
+      "version": "0.9.234",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.233",
+  "version": "0.9.234",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -199,6 +199,47 @@ describe("SwarmPane model badge", () => {
   });
 });
 
+describe("SwarmPane worker details", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    clearSWRCache();
+    mockArtifacts.mockResolvedValue([]);
+  });
+
+  it("lets a terminal worker reveal its source-backed identity", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job-terminal-worker", "Inspect completed worker", {
+        artifacts_complete: true,
+        tasks: [{
+          id: "task-terminal",
+          status: "complete",
+          adapter: "agentic",
+          role: "completed-worker",
+          instruction: "",
+          model: "agentic/gpt-5.6-luna",
+          completed_at: "2026-08-16T17:00:00+00:00",
+        }],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Inspect completed worker"));
+
+    const worker = screen.getByText("completed-worker").closest('[role="button"]');
+    expect(worker).not.toBeNull();
+    expect(worker).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(worker!);
+
+    expect(worker).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("task-terminal")).toBeInTheDocument();
+    expect(screen.getByText("2026-08-16T17:00:00+00:00")).toBeInTheDocument();
+  });
+});
+
 describe("SwarmPane pin attribution", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -1324,7 +1324,6 @@ export default function SwarmPane() {
                   {tasks.map((task) => {
                     const ts = taskState(task);
                     const tExpanded = !!expandedTasks[task.id];
-                    const hasInstruction = !!task.instruction;
                     // Prefer a real routed model over repeating the engine label
                     // already present in role ("implement (agentic) (agentic)").
                     const taskModelLabel = displayModelId(task.model || "", {});
@@ -1334,11 +1333,12 @@ export default function SwarmPane() {
                     return (
                       <div
                         key={task.id}
-                        role={hasInstruction ? "button" : undefined}
-                        tabIndex={hasInstruction ? 0 : undefined}
-                        onClick={hasInstruction ? () => toggleTask(task.id) : undefined}
-                        onKeyDown={hasInstruction ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleTask(task.id); } } : undefined}
-                        className={`p-1.5 rounded bg-panel2/20 border border-edge/40 flex items-start gap-2 text-[10px] ${hasInstruction ? "cursor-pointer hover:bg-panel2/35 focus:outline-none" : ""}`}
+                        role="button"
+                        tabIndex={0}
+                        aria-expanded={tExpanded}
+                        onClick={() => toggleTask(task.id)}
+                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleTask(task.id); } }}
+                        className="p-1.5 rounded bg-panel2/20 border border-edge/40 flex items-start gap-2 text-[10px] cursor-pointer hover:bg-panel2/35 focus:outline-none"
                       >
                         <span className="mt-0.5 shrink-0">
                           {ts === "running" ? <Loader2 size={10} className="animate-spin text-accent" />
@@ -1349,9 +1349,9 @@ export default function SwarmPane() {
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center justify-between gap-1">
                             <span className="font-semibold text-txt truncate flex items-center gap-1 min-w-0">
-                              {hasInstruction && (tExpanded
+                              {tExpanded
                                 ? <ChevronDown size={9} className="text-faint shrink-0" />
-                                : <ChevronRight size={9} className="text-faint shrink-0" />)}
+                                : <ChevronRight size={9} className="text-faint shrink-0" />}
                               <span className="truncate">
                                 {task.role || "Worker"}
                                 {secondaryLabel ? (
@@ -1383,11 +1383,18 @@ export default function SwarmPane() {
                               }`}>{task.status}</span>
                             </span>
                           </div>
-                          {hasInstruction && (tExpanded ? (
-                            <div className="text-muted text-[9.5px] mt-1 whitespace-pre-wrap break-words leading-relaxed">{task.instruction}</div>
-                          ) : (
+                          {tExpanded && (
+                            <div className="mt-1 text-[9px] font-mono text-faint grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                              <span>task</span><span className="text-muted break-all">{task.id}</span>
+                              {taskModelLabel && <><span>model</span><span className="text-muted break-all">{taskModelLabel}</span></>}
+                              {adapterLabel && <><span>adapter</span><span className="text-muted break-all">{adapterLabel}</span></>}
+                              {task.completed_at && <><span>completed</span><span className="text-muted break-all">{task.completed_at}</span></>}
+                              {task.instruction && <><span>instruction</span><span className="text-muted whitespace-pre-wrap break-words font-sans">{task.instruction}</span></>}
+                            </div>
+                          )}
+                          {!tExpanded && task.instruction && (
                             <Tooltip label={task.instruction} className="block text-muted text-[9.5px] mt-0.5 truncate">{task.instruction}</Tooltip>
-                          ))}
+                          )}
                         </div>
                       </div>
                     );


### PR DESCRIPTION
## Summary
- Fold Benton PR #37: every swarm worker row is expandable. Terminal projection omitting instructions no longer hides the affordance.
- Expanded rows show source-backed task id, model, adapter, completion time, and instruction when present. Failure explanation stays in Findings. Renderer-only.
- Pin stays `puppetmaster-ai==1.22.5`.

## Test plan
- [x] Local `pytest tests -q`: 4406 passed, 74 skipped
- [x] `vitest` SwarmPane: 53 passed
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)
- [ ] After merge: wait `tests` green on the exact `main` SHA, then tag `v0.9.234`