### PR TITLE
Release v0.9.235: terminal add-to-chat and jump-to-latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.234, deliberately pre-1.0. Every swarm worker row expands to source-backed identity (task id, model, adapter, completion time, instruction when present). Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.235, deliberately pre-1.0. Highlight terminal output into the composer as an `@terminal` mention; jump-to-latest when you scroll up. Rides puppetmaster-ai==1.22.5.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.234"
+__version__ = "0.9.235"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.234"
+version = "0.9.235"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.234",
+  "version": "0.9.235",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.234",
+      "version": "0.9.235",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.234",
+  "version": "0.9.235",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -322,6 +322,8 @@ export default function App() {
         case "b": e.preventDefault(); setLeftOpen((v) => !v); break;        // toggle sessions panel
         case "j": e.preventDefault(); setRightOpen((v) => !v); break;       // toggle right pane
         case "i":                                                          // focus chat input (Cursor: toggle sidepanel)
+        // Cmd/Ctrl+L focuses the composer. TerminalPane capture steals this
+        // when the live xterm has a selection (Add to chat).
         case "l": e.preventDefault(); window.dispatchEvent(new Event("harness-focus-input")); break;
         case "n":                                                          // new session (Cursor: new chat)
         case "r": e.preventDefault(); window.dispatchEvent(new Event("harness-new-session")); break;

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -2753,6 +2753,8 @@ describe("composerInput module", () => {
     expect(detectComposerTrigger("@folder:src/lib ", 16).kind).toBe("none");
     expect(detectComposerTrigger('@folder:"my docs" ', 18).kind).toBe("none");
     expect(detectComposerTrigger("@codebase ", 10).kind).toBe("none");
+    expect(detectComposerTrigger("@terminal:term:12", 17).kind).toBe("none");
+    expect(detectComposerTrigger("@terminal:term:12 ", 18).kind).toBe("none");
   });
 
   it("builds inserts, cycles selection, and resolves drop mentions", () => {

--- a/webapp/src/__tests__/feedScroll.test.ts
+++ b/webapp/src/__tests__/feedScroll.test.ts
@@ -3,6 +3,7 @@ import {
   FEED_REPIN_THRESHOLD_PX,
   nextFeedPinState,
   settleFrameResult,
+  shouldShowJumpToBottom,
   shouldUnpinOnWheel,
 } from "../components/conversation/feedScroll";
 
@@ -52,5 +53,11 @@ describe("feedScroll hysteresis", () => {
       frame: 4,
     });
     expect(settle.done).toBe(true);
+  });
+
+  it("shows jump-to-latest only when unpinned and not settling", () => {
+    expect(shouldShowJumpToBottom({ pinned: true, settling: false })).toBe(false);
+    expect(shouldShowJumpToBottom({ pinned: false, settling: true })).toBe(false);
+    expect(shouldShowJumpToBottom({ pinned: false, settling: false })).toBe(true);
   });
 });

--- a/webapp/src/__tests__/terminalSelection.test.ts
+++ b/webapp/src/__tests__/terminalSelection.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  addToChatShortcutHint,
+  appendTerminalMention,
+  applyTerminalSelectionsToMessage,
+  formatTerminalMention,
+  isAddSelectionShortcut,
+  isMacNavigator,
+  terminalLabelsFromDraft,
+  terminalSelectionAnchor,
+  terminalSelectionLabel,
+} from "../lib/terminalSelection";
+import {
+  clearTerminalSelectionCache,
+  dropTerminalLabels,
+  peekTerminalSelections,
+  putTerminalSelection,
+} from "../components/conversation/terminalSelectionCache";
+
+describe("terminalSelection", () => {
+  it("detects Cmd+L on Mac and Ctrl+L elsewhere", () => {
+    expect(isMacNavigator({ platform: "MacIntel" })).toBe(true);
+    expect(isMacNavigator({ platform: "Win32" })).toBe(false);
+    expect(
+      isAddSelectionShortcut({ key: "l", metaKey: true, ctrlKey: false, shiftKey: false }, true),
+    ).toBe(true);
+    expect(
+      isAddSelectionShortcut({ key: "l", metaKey: false, ctrlKey: true, shiftKey: false }, false),
+    ).toBe(true);
+    expect(
+      isAddSelectionShortcut({ key: "l", metaKey: true, ctrlKey: false, shiftKey: true }, true),
+    ).toBe(false);
+    expect(
+      isAddSelectionShortcut({ key: "l", metaKey: false, ctrlKey: true, shiftKey: false }, true),
+    ).toBe(false);
+    expect(addToChatShortcutHint(true)).toBe("Cmd+L");
+    expect(addToChatShortcutHint(false)).toBe("Ctrl+L");
+  });
+
+  it("labels a selection from buffer coords or line count", () => {
+    expect(
+      terminalSelectionLabel("ls", "term", { start: { y: 12 }, end: { y: 12 } }),
+    ).toBe("term:12");
+    expect(
+      terminalSelectionLabel("a\nb\n", "term", { start: { y: 3 }, end: { y: 8 } }),
+    ).toBe("term:3-8");
+    expect(terminalSelectionLabel("one line", "term")).toBe("term:1");
+    expect(terminalSelectionLabel("a\nb\nc\n", "agent")).toBe("agent:1-3");
+  });
+
+  it("anchors the add button to the last painted selection rect", () => {
+    const hostRect = { left: 100, top: 40, width: 400, height: 300 };
+    const selRect = { left: 140, top: 80, width: 80, height: 16, bottom: 96 };
+    const host = {
+      clientWidth: 400,
+      clientHeight: 300,
+      getBoundingClientRect: () => hostRect,
+      querySelectorAll: () =>
+        [{
+          getBoundingClientRect: () => selRect,
+        }] as unknown as NodeListOf<HTMLElement>,
+    };
+    expect(terminalSelectionAnchor(host)).toEqual({ left: 40, top: 60 });
+    expect(terminalSelectionAnchor({
+      ...host,
+      querySelectorAll: () => [] as unknown as NodeListOf<HTMLElement>,
+    })).toBeNull();
+  });
+
+  it("appends a mention once and expands it on send", () => {
+    expect(formatTerminalMention("term:12")).toBe("@terminal:term:12");
+    expect(formatTerminalMention("my shell")).toBe('@terminal:"my shell"');
+    expect(appendTerminalMention("", "term:12")).toBe("@terminal:term:12 ");
+    expect(appendTerminalMention("look at", "term:12")).toBe("look at @terminal:term:12 ");
+    expect(appendTerminalMention("look at @terminal:term:12 ", "term:12")).toBe(
+      "look at @terminal:term:12 ",
+    );
+    expect(terminalLabelsFromDraft('see @terminal:term:12 and @terminal:"my shell"')).toEqual([
+      "term:12",
+      "my shell",
+    ]);
+    expect(
+      applyTerminalSelectionsToMessage("see @terminal:term:12 please", {
+        "term:12": "npm test\n",
+      }),
+    ).toBe("see ```terminal\nnpm test\n``` please");
+    expect(
+      applyTerminalSelectionsToMessage("see @terminal:missing", { "term:12": "x" }),
+    ).toBe("see @terminal:missing");
+  });
+});
+
+describe("terminalSelectionCache", () => {
+  afterEach(() => {
+    clearTerminalSelectionCache();
+  });
+
+  it("stores per-session bodies and drops consumed labels", () => {
+    putTerminalSelection("s1", "term:12", "ls -la");
+    putTerminalSelection("s2", "term:12", "other");
+    expect(peekTerminalSelections("s1")).toEqual({ "term:12": "ls -la" });
+    dropTerminalLabels("s1", ["term:12"]);
+    expect(peekTerminalSelections("s1")).toEqual({});
+    expect(peekTerminalSelections("s2")).toEqual({ "term:12": "other" });
+  });
+});

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -85,11 +85,23 @@ import {
   FEED_REPIN_THRESHOLD_PX,
   nextFeedPinState,
   settleFrameResult,
+  shouldShowJumpToBottom,
   shouldUnpinOnTouchMove,
   FEED_UNPIN_BUBBLE_EVENT,
   feedWheelUnpinListenerOptions,
   shouldUnpinOnWheel,
 } from "./conversation/feedScroll";
+import {
+  ADD_TERMINAL_SELECTION_EVENT,
+  appendTerminalMention,
+  applyTerminalSelectionsToMessage,
+  terminalLabelsFromDraft,
+} from "../lib/terminalSelection";
+import {
+  dropTerminalLabels,
+  peekTerminalSelections,
+  putTerminalSelection,
+} from "./conversation/terminalSelectionCache";
 import { restoreFeedScrollAfterFocus } from "./conversation/transcriptVirtualWindow";
 import {
   STREAM_ABORT_MESSAGE,
@@ -909,7 +921,9 @@ export default function Conversation({
   };
 
   const handleQueueAdd = () => {
-    const text = input.trim();
+    const raw = input.trim();
+    const sessionKey = activeSessionIdRef.current || "_draft";
+    const text = applyTerminalSelectionsToMessage(raw, peekTerminalSelections(sessionKey));
     if (!text) return;
     // Snapshot the attached image paths BEFORE clearing input/attachments, so a
     // queued prompt carries its images just like a normal turn. The backend
@@ -917,6 +931,7 @@ export default function Conversation({
     const sid = activeSessionIdRef.current;
     const queueImages = attachedImages.map((img) => img.path).filter(Boolean);
     setInput("");
+    dropTerminalLabels(sessionKey, terminalLabelsFromDraft(raw));
     setAttachedImages([]);
     api.queueAdd(text, queueImages)
       .then(() => {
@@ -1027,6 +1042,24 @@ export default function Conversation({
   // to bottom until height stabilizes (or wall-clock timeout). onScroll still
   // tracks real geometry so keyboard/scrollbar unpin is not swallowed.
   const scrollSettlingRef = useRef(false);
+  const [showJumpToBottom, setShowJumpToBottom] = useState(false);
+  const publishJumpVisibilityRef = useRef(() => {});
+  publishJumpVisibilityRef.current = () => {
+    const next = shouldShowJumpToBottom({
+      pinned: pinnedToBottomRef.current,
+      settling: scrollSettlingRef.current,
+    });
+    setShowJumpToBottom((prev) => (prev === next ? prev : next));
+  };
+  const jumpToLatest = () => {
+    const el = feedRef.current;
+    if (!el) return;
+    pinnedToBottomRef.current = true;
+    scrollReleasedByGestureRef.current = false;
+    scrollSettlingRef.current = false;
+    el.scrollTop = el.scrollHeight;
+    setShowJumpToBottom(false);
+  };
   useEffect(() => {
     const el = feedRef.current;
     if (!el) return;
@@ -1044,6 +1077,7 @@ export default function Conversation({
       pinnedToBottomRef.current = next.pinned;
       scrollReleasedByGestureRef.current = next.releasedByGesture;
       prevFeedScrollTopRef.current = el.scrollTop;
+      publishJumpVisibilityRef.current();
     };
     const onScroll = () => {
       applyPinState();
@@ -1055,12 +1089,14 @@ export default function Conversation({
       if (shouldUnpinOnWheel(e.deltaY, scrollSettlingRef.current)) {
         scrollReleasedByGestureRef.current = true;
         pinnedToBottomRef.current = false;
+        publishJumpVisibilityRef.current();
       }
     };
     const onNestedFeedUnpin = () => {
       if (!scrollSettlingRef.current) {
         scrollReleasedByGestureRef.current = true;
         pinnedToBottomRef.current = false;
+        publishJumpVisibilityRef.current();
       }
     };
     let touchY: number | null = null;
@@ -1072,6 +1108,7 @@ export default function Conversation({
       if (shouldUnpinOnTouchMove(touchY, y ?? null, scrollSettlingRef.current)) {
         scrollReleasedByGestureRef.current = true;
         pinnedToBottomRef.current = false;
+        publishJumpVisibilityRef.current();
       }
       touchY = y ?? touchY;
     };
@@ -1107,6 +1144,7 @@ export default function Conversation({
     scrollReleasedByGestureRef.current = false;
     prevFeedScrollTopRef.current = null;
     scrollSettlingRef.current = true;
+    setShowJumpToBottom(false);
     el.scrollTop = el.scrollHeight;
     let frame = 0;
     let stableFrames = 0;
@@ -1135,6 +1173,7 @@ export default function Conversation({
       pinnedToBottomRef.current = true;
       if (step.done) {
         scrollSettlingRef.current = false;
+        publishJumpVisibilityRef.current();
         return;
       }
       rafId = requestAnimationFrame(settle);
@@ -1358,6 +1397,21 @@ export default function Conversation({
     const onFocus = () => { taRef.current?.focus(); };
     window.addEventListener("harness-focus-input", onFocus);
     return () => window.removeEventListener("harness-focus-input", onFocus);
+  }, []);
+
+  useEffect(() => {
+    const onAdd = (e: Event) => {
+      const detail = (e as CustomEvent<{ text?: string; label?: string }>).detail || {};
+      const text = String(detail.text || "").trim();
+      const label = String(detail.label || "").trim();
+      if (!text || !label) return;
+      const sid = activeSessionIdRef.current || "_draft";
+      putTerminalSelection(sid, label, text);
+      setInput((prev) => appendTerminalMention(prev, label));
+      taRef.current?.focus();
+    };
+    window.addEventListener(ADD_TERMINAL_SELECTION_EVENT, onAdd as EventListener);
+    return () => window.removeEventListener(ADD_TERMINAL_SELECTION_EVENT, onAdd as EventListener);
   }, []);
 
   // Command palette (and other chrome) can clear/compact without going through
@@ -2613,7 +2667,9 @@ export default function Conversation({
 
   const send = (mode?: "interrupt") => {
     if (editBusy) return;
-    const msg = input.trim();
+    const raw = input.trim();
+    const sid = activeSessionIdRef.current || "_draft";
+    const msg = applyTerminalSelectionsToMessage(raw, peekTerminalSelections(sid));
     // Allow a send/steer that is only attached image(s) with no text -- the
     // backend accepts text OR images.
     if (shouldBlockEmptySend({
@@ -2779,6 +2835,7 @@ export default function Conversation({
         .then((res) => {
           if (shouldClearSteerDraftOnResult(true)) {
             setInput("");
+            dropTerminalLabels(sid, terminalLabelsFromDraft(raw));
             setAttachedImages([]);
           }
           const chrome = steerResultChrome({
@@ -2819,6 +2876,7 @@ export default function Conversation({
 
     const kickSend = () => {
       setInput("");
+      dropTerminalLabels(sid, terminalLabelsFromDraft(raw));
       executeSend(msg, auto, plan);
     };
 
@@ -3021,6 +3079,8 @@ export default function Conversation({
           onSetCard={stableSetCard}
           onExecutePlan={handleTranscriptExecutePlan}
           onCommandApproval={handleCommandApproval}
+          showJumpToBottom={showJumpToBottom}
+          onJumpToBottom={jumpToLatest}
           composerDock={(
       <ComposerDock
         config={config}

--- a/webapp/src/components/TerminalPane.tsx
+++ b/webapp/src/components/TerminalPane.tsx
@@ -12,6 +12,16 @@ import {
   syncAgentTerminalSnapshot,
 } from "../lib/agentTerminalStream";
 import { registerTerminalPathLinks } from "../lib/terminalPathLinks";
+import {
+  addToChatShortcutHint,
+  dispatchAddTerminalSelection,
+  isAddSelectionShortcut,
+  isMacNavigator,
+  readLiveTerminalSelection,
+  readTerminalSelectionPosition,
+  terminalSelectionAnchor,
+  terminalSelectionLabel,
+} from "../lib/terminalSelection";
 import { hostHasLayout, safePtyDims } from "./terminalDims";
 import { terminalBareOnDoneAction } from "./terminalStreamPolicy";
 
@@ -52,6 +62,30 @@ export default function TerminalPane() {
   const [restartNonce, setRestartNonce] = useState(0);
   const [exited, setExited] = useState(false);
   const [agentView, setAgentView] = useState<AgentView | null>(null);
+  const [selection, setSelection] = useState("");
+  const [selectionStyle, setSelectionStyle] = useState<{ left: number; top: number } | null>(null);
+  const agentViewRef = useRef<AgentView | null>(null);
+  agentViewRef.current = agentView;
+
+  const clearSelectionUi = () => {
+    setSelection("");
+    setSelectionStyle(null);
+  };
+
+  const addSelectionToChat = (term: Terminal | null, shellName: string) => {
+    const text = readLiveTerminalSelection(term);
+    if (!text.trim() || !term) return;
+    const label = terminalSelectionLabel(
+      text,
+      shellName,
+      readTerminalSelectionPosition(term),
+    );
+    dispatchAddTerminalSelection(text, label);
+    try {
+      term.clearSelection();
+    } catch { /* ignore */ }
+    clearSelectionUi();
+  };
 
   const restart = () => {
     setExited(false);
@@ -119,6 +153,7 @@ export default function TerminalPane() {
       agentUnregisterRef.current = null;
       return;
     }
+    clearSelectionUi();
     const host = agentHostRef.current;
     if (!host) return;
 
@@ -162,6 +197,13 @@ export default function TerminalPane() {
       } catch { /* ignore */ }
     });
 
+    const syncSelection = () => {
+      const text = readLiveTerminalSelection(term);
+      setSelection(text);
+      setSelectionStyle(text.trim() ? terminalSelectionAnchor(host) : null);
+    };
+    const selectionSub = term.onSelectionChange(syncSelection);
+
     const ro = new ResizeObserver(() => {
       try {
         fit?.fit();
@@ -170,9 +212,11 @@ export default function TerminalPane() {
     ro.observe(host);
 
     return () => {
+      try { selectionSub.dispose(); } catch { /* ignore */ }
       ro.disconnect();
       agentUnregisterRef.current?.();
       agentUnregisterRef.current = null;
+      clearSelectionUi();
     };
   }, [agentView]);
 
@@ -214,6 +258,12 @@ export default function TerminalPane() {
     attachTerminalLinkHandlers(term);
     term.open(host);
     termRef.current = term;
+    const selectionSub = term.onSelectionChange(() => {
+      if (agentViewRef.current) return;
+      const text = readLiveTerminalSelection(term);
+      setSelection(text);
+      setSelectionStyle(text.trim() ? terminalSelectionAnchor(host) : null);
+    });
 
     let disposed = false;
     let layoutWaitRo: ResizeObserver | null = null;
@@ -359,9 +409,27 @@ export default function TerminalPane() {
       if (cancelRef.current) cancelRef.current();
       if (idRef.current) postJSON("/api/terminal/kill", { id: idRef.current });
       idRef.current = "";
+      try { selectionSub.dispose(); } catch { /* ignore */ }
       term.dispose();
+      clearSelectionUi();
     };
   }, [restartNonce]);
+
+  // Cmd/Ctrl+L adds the live xterm selection to the composer. Only swallow
+  // the key when there is text -- otherwise App.tsx still focuses the input.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!isAddSelectionShortcut(e, isMacNavigator())) return;
+      const agent = agentViewRef.current;
+      const term = agent ? agentTermRef.current : termRef.current;
+      if (!readLiveTerminalSelection(term).trim()) return;
+      e.preventDefault();
+      e.stopPropagation();
+      addSelectionToChat(term, agent ? "agent" : "term");
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, []);
 
   const agentLabel = agentView
     ? (agentView.command.length > 64
@@ -408,7 +476,7 @@ export default function TerminalPane() {
           </>
         )}
       </div>
-      <div className="relative flex-1 min-h-0">
+      <div className="relative flex-1 min-h-0" data-terminal="">
         <div
           ref={hostRef}
           className={`absolute inset-0 p-1.5 overflow-hidden ${agentView ? "invisible pointer-events-none" : ""}`}
@@ -420,6 +488,28 @@ export default function TerminalPane() {
           aria-hidden={!agentView}
           data-testid="agent-terminal-mirror"
         />
+        {selection.trim() ? (
+          <button
+            type="button"
+            data-testid="terminal-add-to-chat"
+            title={`Add selection to chat (${addToChatShortcutHint(isMacNavigator())})`}
+            className="absolute z-10 text-[10px] px-1.5 py-0.5 rounded border text-faint border-edge2 bg-[#0f1113] hover:text-muted hover:bg-panel2/80 transition-colors"
+            style={selectionStyle ?? { right: 12, top: 8 }}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              addSelectionToChat(
+                agentView ? agentTermRef.current : termRef.current,
+                agentView ? "agent" : "term",
+              );
+            }}
+          >
+            Add to chat
+            <span className="ml-1 opacity-60">
+              {addToChatShortcutHint(isMacNavigator())}
+            </span>
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { ReactNode, RefObject } from "react";
+import { ChevronDown } from "lucide-react";
 import { panelOpacityClass } from "../../lib/panelTransition";
 import {
   TranscriptList,
@@ -32,6 +33,8 @@ export default function ConversationChatColumn({
   onExecutePlan,
   onCommandApproval,
   composerDock,
+  showJumpToBottom = false,
+  onJumpToBottom,
 }: {
   feedRef: RefObject<HTMLDivElement | null>;
   transcriptStale: boolean;
@@ -52,13 +55,16 @@ export default function ConversationChatColumn({
   onExecutePlan: (planText: string) => void;
   onCommandApproval: (item: CommandApprovalItem, approve: boolean) => void;
   composerDock: ReactNode;
+  showJumpToBottom?: boolean;
+  onJumpToBottom?: () => void;
 }) {
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <div
-        ref={feedRef}
-        className={`flex-1 overflow-y-auto overscroll-contain [overflow-anchor:none] [scrollbar-gutter:stable] ${panelOpacityClass(transcriptStale)}`}
-      >
+      <div className="relative flex-1 min-h-0 flex flex-col">
+        <div
+          ref={feedRef}
+          className={`flex-1 min-h-0 overflow-y-auto overscroll-contain [overflow-anchor:none] [scrollbar-gutter:stable] ${panelOpacityClass(transcriptStale)}`}
+        >
         {/* overflow-anchor:none — the virtualizer unmounts off-screen rows, so
             auto-anchor would snap to the first remaining node (top of history)
             on alt-tab / compositor restore. feedScroll pin/unpin owns stick.
@@ -96,6 +102,20 @@ export default function ConversationChatColumn({
             onCommandApproval={onCommandApproval}
           />
         </div>
+      </div>
+      {showJumpToBottom ? (
+        <button
+          type="button"
+          data-testid="jump-to-latest"
+          title="Jump to latest"
+          aria-label="Jump to latest"
+          onClick={onJumpToBottom}
+          className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full border border-edge2 text-muted hover:text-txt hover:bg-panel2/80 transition-colors"
+          style={{ backgroundColor: "#0f1113" }}
+        >
+          <ChevronDown size={16} />
+        </button>
+      ) : null}
       </div>
       {composerDock}
     </div>

--- a/webapp/src/components/conversation/composerInput.ts
+++ b/webapp/src/components/conversation/composerInput.ts
@@ -17,9 +17,13 @@ export type ComposerTrigger =
 function isActiveMentionQuery(textAfterAt: string): boolean {
   if (textAfterAt.includes("\n")) return false;
 
-  const kindMatch = /^(folder:|symbol:|codebase:)/i.exec(textAfterAt);
+  const kindMatch = /^(folder:|symbol:|codebase:|terminal:)/i.exec(textAfterAt);
   const kind = kindMatch ? kindMatch[1].toLowerCase() : "";
   const body = kindMatch ? textAfterAt.slice(kindMatch[0].length) : textAfterAt;
+
+  // Terminal refs are inserted complete (`@terminal:term:12`). Never open
+  // the file picker on that prefix.
+  if (kind === "terminal:") return false;
 
   // Quoted path/filter: stay open only until the closing quote appears.
   if (body.startsWith('"')) {

--- a/webapp/src/components/conversation/feedScroll.ts
+++ b/webapp/src/components/conversation/feedScroll.ts
@@ -92,6 +92,14 @@ export function nextFeedPinState(opts: {
   return { pinned: false, releasedByGesture: false };
 }
 
+/** Show the jump-to-latest control only while the user has read away. */
+export function shouldShowJumpToBottom(opts: {
+  pinned: boolean;
+  settling: boolean;
+}): boolean {
+  return !opts.pinned && !opts.settling;
+}
+
 /** Upward wheel should unpin (unless settle glue is active). */
 export function shouldUnpinOnWheel(deltaY: number, settling: boolean): boolean {
   if (settling) return false;

--- a/webapp/src/components/conversation/terminalSelectionCache.ts
+++ b/webapp/src/components/conversation/terminalSelectionCache.ts
@@ -1,0 +1,40 @@
+/**
+ * Per-session bodies for `@terminal:` composer mentions.
+ * Mentions live in the draft; this map is the payload expanded on send.
+ */
+
+const terminalSelectionsBySessionId = new Map<string, Record<string, string>>();
+
+function cacheKey(sessionId: string): string {
+  return sessionId || "_draft";
+}
+
+/** Test helper: drop every cached selection. */
+export function clearTerminalSelectionCache(): void {
+  terminalSelectionsBySessionId.clear();
+}
+
+export function peekTerminalSelections(sessionId: string): Record<string, string> {
+  return { ...(terminalSelectionsBySessionId.get(cacheKey(sessionId)) || {}) };
+}
+
+export function putTerminalSelection(sessionId: string, label: string, text: string): void {
+  const key = cacheKey(sessionId);
+  const tag = String(label || "").trim();
+  const body = String(text || "").trim();
+  if (!tag || !body) return;
+  const prev = terminalSelectionsBySessionId.get(key) || {};
+  terminalSelectionsBySessionId.set(key, { ...prev, [tag]: body });
+}
+
+export function dropTerminalLabels(sessionId: string, labels: string[]): void {
+  const key = cacheKey(sessionId);
+  const prev = terminalSelectionsBySessionId.get(key);
+  if (!prev) return;
+  const next = { ...prev };
+  for (const label of labels) {
+    delete next[label];
+  }
+  if (Object.keys(next).length === 0) terminalSelectionsBySessionId.delete(key);
+  else terminalSelectionsBySessionId.set(key, next);
+}

--- a/webapp/src/lib/terminalSelection.ts
+++ b/webapp/src/lib/terminalSelection.ts
@@ -1,0 +1,160 @@
+/**
+ * Hermes-style "Add to chat" helpers for the built-in xterm pane.
+ * Steal the behavior (selection mention + Cmd/Ctrl+L), not the chrome.
+ */
+
+export const ADD_TERMINAL_SELECTION_EVENT = "harness-add-terminal-selection";
+
+export type TerminalSelectionDetail = {
+  text: string;
+  label: string;
+};
+
+export type TerminalSelectionPosition = {
+  start: { y: number };
+  end: { y: number };
+};
+
+/** `@terminal:zsh:12` or `@terminal:"spaced label"`. */
+export const TERMINAL_REF_RE = /@terminal:(?:"([^"]+)"|(\S+))/g;
+
+export function isMacNavigator(
+  nav: { platform?: string; userAgent?: string } = typeof navigator !== "undefined"
+    ? navigator
+    : {},
+): boolean {
+  const platform = String(nav.platform || "");
+  if (platform) return /mac/i.test(platform);
+  return /mac/i.test(String(nav.userAgent || ""));
+}
+
+export function isAddSelectionShortcut(
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "shiftKey">,
+  isMac: boolean,
+): boolean {
+  const mod = isMac ? event.metaKey : event.ctrlKey;
+  return Boolean(mod && !event.shiftKey && event.key.toLowerCase() === "l");
+}
+
+export function addToChatShortcutHint(isMac: boolean): string {
+  return isMac ? "Cmd+L" : "Ctrl+L";
+}
+
+export function terminalSelectionLabel(
+  text: string,
+  shellName: string,
+  position?: TerminalSelectionPosition | null,
+): string {
+  const name = String(shellName || "term").trim() || "term";
+  if (position) {
+    return position.start.y === position.end.y
+      ? `${name}:${position.start.y}`
+      : `${name}:${position.start.y}-${position.end.y}`;
+  }
+  const lines = Math.max(1, text.replace(/\s+$/g, "").split(/\r?\n/).length);
+  return lines === 1 ? `${name}:1` : `${name}:1-${lines}`;
+}
+
+type SelectionHost = {
+  clientWidth: number;
+  clientHeight: number;
+  getBoundingClientRect: () => { left: number; top: number };
+  querySelectorAll: (selector: string) => ArrayLike<{ getBoundingClientRect: () => { width: number; height: number; left: number; top: number; bottom: number } }>;
+};
+
+export function terminalSelectionAnchor(
+  host: SelectionHost | null,
+  buttonWidth = 120,
+): { left: number; top: number } | null {
+  if (!host) return null;
+  const rects = Array.from(host.querySelectorAll(".xterm-selection div"))
+    .map((node) => node.getBoundingClientRect())
+    .filter((r) => r.width > 0 && r.height > 0);
+  const rect = rects[rects.length - 1];
+  if (!rect) return null;
+  const hostRect = host.getBoundingClientRect();
+  const left = Math.min(
+    Math.max(rect.left - hostRect.left, 8),
+    Math.max(8, host.clientWidth - buttonWidth - 8),
+  );
+  const top = Math.min(
+    Math.max(rect.bottom - hostRect.top + 4, 8),
+    Math.max(8, host.clientHeight - 34),
+  );
+  return { left, top };
+}
+
+export function formatTerminalMention(label: string): string {
+  const trimmed = String(label || "").trim();
+  if (!trimmed) return "";
+  if (/\s/.test(trimmed)) {
+    return `@terminal:"${trimmed.replace(/"/g, "")}"`;
+  }
+  return `@terminal:${trimmed}`;
+}
+
+export function appendTerminalMention(draft: string, label: string): string {
+  const token = formatTerminalMention(label);
+  if (!token) return draft;
+  if (draft.includes(token)) return draft;
+  const trimmed = draft.replace(/\s+$/g, "");
+  if (!trimmed) return `${token} `;
+  return `${trimmed} ${token} `;
+}
+
+export function terminalLabelsFromDraft(draft: string): string[] {
+  const labels: string[] = [];
+  const re = new RegExp(TERMINAL_REF_RE.source, "g");
+  let match: RegExpExecArray | null = re.exec(draft);
+  while (match) {
+    const label = match[1] || match[2] || "";
+    if (label) labels.push(label);
+    match = re.exec(draft);
+  }
+  return labels;
+}
+
+export function applyTerminalSelectionsToMessage(
+  message: string,
+  selections: Record<string, string>,
+): string {
+  return message.replace(TERMINAL_REF_RE, (full, quoted: string, bare: string) => {
+    const label = quoted || bare || "";
+    const body = selections[label];
+    if (!body) return full;
+    return "```terminal\n" + body.replace(/\s+$/g, "") + "\n```";
+  });
+}
+
+export function dispatchAddTerminalSelection(text: string, label: string): void {
+  const trimmed = String(text || "").trim();
+  const tag = String(label || "").trim();
+  if (!trimmed || !tag) return;
+  window.dispatchEvent(
+    new CustomEvent<TerminalSelectionDetail>(ADD_TERMINAL_SELECTION_EVENT, {
+      detail: { text: trimmed, label: tag },
+    }),
+  );
+}
+
+export function readLiveTerminalSelection(term: { getSelection?: () => string } | null): string {
+  if (!term || typeof term.getSelection !== "function") return "";
+  try {
+    return String(term.getSelection() || "");
+  } catch {
+    return "";
+  }
+}
+
+export function readTerminalSelectionPosition(
+  term: { getSelectionPosition?: () => TerminalSelectionPosition | undefined | null } | null,
+): TerminalSelectionPosition | null {
+  if (!term || typeof term.getSelectionPosition !== "function") return null;
+  try {
+    const pos = term.getSelectionPosition();
+    if (!pos) return null;
+    return { start: { y: pos.start.y }, end: { y: pos.end.y } };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Highlight in the Terminal pane (Add to chat / Cmd+L) inserts an `@terminal` mention that expands to a fenced block on send.
- Scrolling up in a session shows a jump-to-latest arrow so you do not have to scroll the whole feed.
- Pin stays `puppetmaster-ai==1.22.5`.

## Test plan
- [x] Local `pytest tests -q`: 4406 passed, 74 skipped
- [x] `vitest` terminalSelection + feedScroll + conversation.helpers
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)
- [ ] After merge: wait `tests` green on the exact `main` SHA, then tag `v0.9.235`