### PR TITLE
Release v0.9.236: per-role two-tier swarm routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.235, deliberately pre-1.0. Highlight terminal output into the composer as an `@terminal` mention; jump-to-latest when you scroll up. Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.236, deliberately pre-1.0. Product swarms pick Luna vs Sol by role need on a two-tier catalog; a global pin still pins every role. Rides puppetmaster-ai==1.22.5.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.235"
+__version__ = "0.9.236"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/auto_registry.py
+++ b/harness/auto_registry.py
@@ -107,6 +107,12 @@ _KNOWN_MODEL_SPECS = {
     "z-ai/glm-5.2": (86, 1.0, 3.5, 1000000, ["quality", "code", "reasoning", "long-context"]),
     "glm-5.3": (86, 1.0, 3.5, 1000000, ["quality", "code", "reasoning", "long-context"]),
     "anthropic/claude-opus-4.8": (99, 5.0, 25.0, 1000000, ["frontier", "reasoning", "code", "vision", "long-context"]),
+    # Codex pair: Sol must outrank Luna or live price overlay leaves Sol
+    # strictly dominated at the shared balanced-85 template.
+    "gpt-5.6-luna": (76, 1.25, 5.0, 200000, ["balanced", "fast", "code", "vision"]),
+    "openai-codex/gpt-5.6-luna": (76, 1.25, 5.0, 200000, ["balanced", "fast", "code", "vision"]),
+    "gpt-5.6-sol": (85, 2.5, 10.0, 200000, ["frontier", "reasoning", "code", "vision"]),
+    "openai-codex/gpt-5.6-sol": (85, 2.5, 10.0, 200000, ["frontier", "reasoning", "code", "vision"]),
 }
 
 # Per-provider model discovery: maps provider name to a list of model descriptors.

--- a/harness/marionette_registry.py
+++ b/harness/marionette_registry.py
@@ -28,6 +28,15 @@ _LADDER: tuple[tuple[str, int, tuple[str, ...]], ...] = (
     ("agentic/cursor-grok-4.5-high-fast", 92, ("vision",)),
     ("cursor/grok-4-5", 91, ("vision",)),
     ("agentic/deepseek/deepseek-v4-pro", 85, ()),
+    # Codex OAuth pair. Live picker sync used to stamp both at 85 with the
+    # same tags; Sol is more expensive, so balanced cheapest-sufficient never
+    # selected it. Keep Sol at the analysis ceiling (85). Luna sits with
+    # composer-2.5-fast (76) so a real run_swarm brief (explore classifies
+    # ~73 after the shared analysis wrapper) still fits Luna, while
+    # conflict-auditor clips to 85 and can escalate. Sol above 85 is unused:
+    # max_capability clips every run_swarm need to 85.
+    ("agentic/openai-codex/gpt-5.6-sol", 85, ("vision",)),
+    ("agentic/openai-codex/gpt-5.6-luna", 76, ("vision",)),
     ("agentic/composer-2.5-fast", 76, ("vision",)),
     ("cursor/composer-2-5", 75, ("vision",)),
     ("agentic/composer-2.5", 74, ("vision",)),
@@ -75,6 +84,18 @@ _LADDER_ALIASES: dict[str, tuple[str, ...]] = {
         "agentic/deepseek/deepseek-v4-pro-0813",
         "deepseek/deepseek-v4-pro-0813",
         "deepseek-v4-pro-0813",
+    ),
+    "agentic/openai-codex/gpt-5.6-sol": (
+        "agentic/gpt-5.6-sol",
+        "gpt-5.6-sol",
+        "openai-codex/gpt-5.6-sol",
+        "openai/gpt-5.6-sol",
+    ),
+    "agentic/openai-codex/gpt-5.6-luna": (
+        "agentic/gpt-5.6-luna",
+        "gpt-5.6-luna",
+        "openai-codex/gpt-5.6-luna",
+        "openai/gpt-5.6-luna",
     ),
     "agentic/composer-2.5-fast": (
         "agentic/composer-2-5-fast",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.235"
+version = "0.9.236"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_auto_registry.py
+++ b/tests/test_auto_registry.py
@@ -742,6 +742,20 @@ def test_kimi_k3_static_economics_match_marketplace():
     assert "frontier" in tags
 
 
+def test_codex_luna_sol_known_specs_are_two_tier():
+    from harness.auto_registry import _KNOWN_MODEL_SPECS, _known_spec_for
+
+    luna = _known_spec_for("gpt-5.6-luna", "openai-codex/gpt-5.6-luna")
+    sol = _known_spec_for("gpt-5.6-sol", "openai-codex/gpt-5.6-sol")
+    assert luna is not None and sol is not None
+    assert luna[0] == 76
+    assert sol[0] == 85
+    assert luna[0] < sol[0]
+    assert luna[1] < sol[1]
+    assert _KNOWN_MODEL_SPECS["gpt-5.6-luna"][0] == 76
+    assert _KNOWN_MODEL_SPECS["gpt-5.6-sol"][0] == 85
+
+
 def test_openrouter_picker_does_not_union_curated_ladder(monkeypatch, tmp_path):
     models_path = tmp_path / "models.json"
     monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))

--- a/tests/test_bridge_agentic_swarm_routing.py
+++ b/tests/test_bridge_agentic_swarm_routing.py
@@ -379,3 +379,203 @@ def test_execute_intent_pins_isolated_marionette_registry_path(tmp_path, monkeyp
         )
         assert kimi is not None
         assert "vision" in (kimi.get("tags") or [])
+
+
+class _RoutingOrchestrator:
+    """Product-path fake: run the real router on bridge-built specs, no workers."""
+
+    last_decisions: list = []
+
+    def __init__(self, store: Any) -> None:
+        self.store = store
+
+    def run(self, goal: str, specs=None, worker_mode=None, label=None):
+        from puppetmaster.model_registry import default_registry_path, load_registry
+        from puppetmaster.router import route_task, signals_from_worker_spec
+
+        from pathlib import Path
+
+        env_path = os.environ.get("PUPPETMASTER_MODELS_PATH")
+        registry_path = Path(env_path) if env_path else default_registry_path()
+        registry = load_registry(registry_path)
+        decisions = []
+        for spec in specs or []:
+            payload = spec.payload or {}
+            if payload.get("auto_route") and not payload.get("pinned_model"):
+                policy = payload.get("routing_policy") or "balanced"
+                decision = route_task(
+                    signals_from_worker_spec(spec), registry, policy=policy,
+                )
+                payload["model"] = decision.model.adapter_model_name
+                payload["router_model_id"] = decision.model.id
+                decisions.append((spec.role, decision.model.id, decision.to_artifact_payload()))
+            else:
+                model_id = str(
+                    payload.get("pinned_model")
+                    or payload.get("router_model_id")
+                    or ""
+                )
+                decisions.append((spec.role, model_id, {"model_id": model_id}))
+        type(self).last_decisions = decisions
+        return _FakeResult()
+
+
+def _two_tier_codex_catalog() -> dict:
+    """Isolated catalog that mimics the flattened Luna/Sol 85/85 sync defect."""
+    shared_tags = ["balanced", "fast", "code", "tools", "agentic"]
+    return {
+        "version": 1,
+        "models": [
+            {
+                "id": "agentic/openai-codex/gpt-5.6-luna",
+                "adapter": "agentic",
+                "adapter_model_name": "gpt-5.6-luna",
+                "capability_score": 85,
+                "input_per_mtok_usd": 1.25,
+                "output_per_mtok_usd": 5.0,
+                "context_window": 200000,
+                "enabled": True,
+                "billing": "plan",
+                "tags": list(shared_tags),
+                "payload_defaults": {
+                    "provider": "openai-codex",
+                    "model": "gpt-5.6-luna",
+                },
+            },
+            {
+                "id": "agentic/openai-codex/gpt-5.6-sol",
+                "adapter": "agentic",
+                "adapter_model_name": "gpt-5.6-sol",
+                "capability_score": 85,
+                "input_per_mtok_usd": 2.5,
+                "output_per_mtok_usd": 10.0,
+                "context_window": 200000,
+                "enabled": True,
+                "billing": "plan",
+                "tags": list(shared_tags),
+                "payload_defaults": {
+                    "provider": "openai-codex",
+                    "model": "gpt-5.6-sol",
+                },
+            },
+        ],
+    }
+
+
+def _install_two_tier_product_path(monkeypatch, tmp_path):
+    """Isolated marionette-models.json + allowlist + capturing specs + real router."""
+    import json
+
+    shared = tmp_path / ".puppetmaster" / "models.json"
+    shared.parent.mkdir(parents=True)
+    shared.write_text(
+        json.dumps({"version": 1, "models": []}),
+        encoding="utf-8",
+    )
+    marionette = tmp_path / ".pmharness" / "marionette-models.json"
+    marionette.parent.mkdir(parents=True)
+    marionette.write_text(
+        json.dumps(_two_tier_codex_catalog()),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(marionette))
+    monkeypatch.delenv("HARNESS_ANALYSIS_DEEP", raising=False)
+    monkeypatch.delenv("HARNESS_ANALYSIS_MAX_CAPABILITY", raising=False)
+    monkeypatch.setattr(
+        "harness.marionette_registry.marionette_models_path",
+        lambda: marionette,
+    )
+    monkeypatch.setattr(
+        "harness.marionette_registry.shared_puppetmaster_models_path",
+        lambda: shared,
+    )
+    monkeypatch.setattr(
+        "puppetmaster.providers.available_providers",
+        lambda: {"openai-codex"},
+    )
+    _CapturingWorkerSpec._last_captured = []
+    _RoutingOrchestrator.last_decisions = []
+    monkeypatch.setenv("HARNESS_SWARM_ADAPTER", "agentic")
+    monkeypatch.setenv("HARNESS_REPO", str(tmp_path))
+    _pin_agentic_only_allowlist(monkeypatch)
+    monkeypatch.setattr("puppetmaster.workers.WorkerSpec", _CapturingWorkerSpec)
+    monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _RoutingOrchestrator)
+    monkeypatch.setattr(bridge, "_warn_if_unindexed", lambda *_a, **_k: None)
+    return marionette
+
+
+def test_run_swarm_two_tier_catalog_selects_two_models(monkeypatch, tmp_path):
+    """explore (~73) vs conflict-auditor (clips to 85) must cross Luna 76 / Sol 85."""
+    _install_two_tier_product_path(monkeypatch, tmp_path)
+    intent = DriverIntent(
+        action="run_swarm",
+        goal="Map the auth middleware",
+        roles=["explore", "conflict-auditor"],
+    )
+    result = bridge.execute_intent(intent, state_dir=str(tmp_path / "state"))
+    assert result is not None
+    by_role = {role: model_id for role, model_id, _payload in _RoutingOrchestrator.last_decisions}
+    assert by_role["explore"] == "agentic/openai-codex/gpt-5.6-luna"
+    assert by_role["conflict-auditor"] == "agentic/openai-codex/gpt-5.6-sol"
+    selected = {model_id for _role, model_id, _payload in _RoutingOrchestrator.last_decisions}
+    assert selected == {
+        "agentic/openai-codex/gpt-5.6-luna",
+        "agentic/openai-codex/gpt-5.6-sol",
+    }
+    captured = {spec.role: spec.payload for spec in _CapturingWorkerSpec._last_captured}
+    assert captured["explore"].get("router_model_id") == "agentic/openai-codex/gpt-5.6-luna"
+    assert captured["conflict-auditor"].get("router_model_id") == "agentic/openai-codex/gpt-5.6-sol"
+    for _role, _model_id, payload in _RoutingOrchestrator.last_decisions:
+        assert payload.get("model_id")
+        assert "capability_needed" in payload or "capability_score" in payload
+
+
+def test_run_swarm_equivalent_roles_stay_homogeneous(monkeypatch, tmp_path):
+    """Roles whose needs both sit under Luna still share one model."""
+    _install_two_tier_product_path(monkeypatch, tmp_path)
+    intent = DriverIntent(
+        action="run_swarm",
+        goal="Map the auth middleware",
+        roles=["explore", "test-coverage-reviewer"],
+    )
+    result = bridge.execute_intent(intent, state_dir=str(tmp_path / "state"))
+    assert result is not None
+    selected = {model_id for _role, model_id, _payload in _RoutingOrchestrator.last_decisions}
+    assert selected == {"agentic/openai-codex/gpt-5.6-luna"}
+
+
+def test_run_swarm_global_pin_applies_to_every_role(monkeypatch, tmp_path):
+    """A single intent.model pin stays intentionally homogeneous across roles."""
+    _install_two_tier_product_path(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "harness.swarm_model_pin.resolve_swarm_model_pin",
+        lambda pin, allowed_adapters=None: {
+            "pin_fields": {
+                "model": "gpt-5.6-luna",
+                "pinned_model": "agentic/openai-codex/gpt-5.6-luna",
+                "pinned_adapter_model_name": "gpt-5.6-luna",
+                "router_model_id": "agentic/openai-codex/gpt-5.6-luna",
+                "auto_route": False,
+            },
+            "auto_route": False,
+            "requested": pin,
+            "resolved": "agentic/openai-codex/gpt-5.6-luna",
+            "demoted": False,
+            "reason": "exact",
+            "adapter": "agentic",
+        },
+    )
+    intent = DriverIntent(
+        action="run_swarm",
+        goal="Map the auth middleware",
+        roles=["explore", "conflict-auditor"],
+        model="gpt-5.6-luna",
+    )
+    result = bridge.execute_intent(intent, state_dir=str(tmp_path / "state"))
+    assert result is not None
+    assert len(_CapturingWorkerSpec._last_captured) == 2
+    for spec in _CapturingWorkerSpec._last_captured:
+        assert spec.payload.get("auto_route") is False
+        assert spec.payload.get("pinned_model") == "agentic/openai-codex/gpt-5.6-luna"
+    selected = {model_id for _role, model_id, _payload in _RoutingOrchestrator.last_decisions}
+    assert selected == {"agentic/openai-codex/gpt-5.6-luna"}

--- a/tests/test_marionette_registry.py
+++ b/tests/test_marionette_registry.py
@@ -365,3 +365,58 @@ def test_ladder_stamps_deepseek_v4_pro_0813_snapshot(tmp_path, monkeypatch):
     assert row["capability_score"] == 85
     assert "vision" not in row["tags"]
     assert "detailed-vision" not in row["tags"]
+
+
+def test_ladder_splits_flattened_luna_sol_pair(tmp_path, monkeypatch):
+    """Picker sync used to stamp Luna and Sol both at 85; ladder must split them."""
+    dest = tmp_path / "marionette-models.json"
+    dest.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "models": [
+                    {
+                        "id": "agentic/openai-codex/gpt-5.6-luna",
+                        "adapter": "agentic",
+                        "adapter_model_name": "gpt-5.6-luna",
+                        "capability_score": 85,
+                        "tags": ["balanced", "fast", "code", "tools", "agentic"],
+                    },
+                    {
+                        "id": "agentic/gpt-5.6-luna",
+                        "adapter": "agentic",
+                        "adapter_model_name": "gpt-5.6-luna",
+                        "capability_score": 85,
+                        "tags": ["balanced", "fast", "code", "tools", "agentic"],
+                    },
+                    {
+                        "id": "agentic/openai-codex/gpt-5.6-sol",
+                        "adapter": "agentic",
+                        "adapter_model_name": "gpt-5.6-sol",
+                        "capability_score": 85,
+                        "tags": ["balanced", "fast", "code", "tools", "agentic"],
+                    },
+                    {
+                        "id": "agentic/gpt-5.6-sol",
+                        "adapter": "agentic",
+                        "adapter_model_name": "gpt-5.6-sol",
+                        "capability_score": 85,
+                        "tags": ["balanced", "fast", "code", "tools", "agentic"],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(dest))
+    report = apply_marionette_router_ladder(str(dest))
+    data = json.loads(dest.read_text(encoding="utf-8"))
+    by_id = {m["id"]: m for m in data["models"]}
+    assert by_id["agentic/openai-codex/gpt-5.6-luna"]["capability_score"] == 76
+    assert by_id["agentic/gpt-5.6-luna"]["capability_score"] == 76
+    assert by_id["agentic/openai-codex/gpt-5.6-sol"]["capability_score"] == 85
+    assert by_id["agentic/gpt-5.6-sol"]["capability_score"] == 85
+    assert "vision" in by_id["agentic/openai-codex/gpt-5.6-luna"]["tags"]
+    assert "vision" in by_id["agentic/openai-codex/gpt-5.6-sol"]["tags"]
+    assert "agentic/openai-codex/gpt-5.6-luna" in report["updated"]
+    assert "agentic/openai-codex/gpt-5.6-sol" in report["updated"]

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.235",
+  "version": "0.9.236",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.235",
+      "version": "0.9.236",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.235",
+  "version": "0.9.236",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Split Luna/Sol off the shared 85-score template so a normal product `run_swarm` can escalate harder roles (explore stays Luna; conflict-auditor can take Sol).
- Prove it through `pmharness.bridge.execute_intent` with a controlled two-tier catalog: two models when needs cross the split, one model for equivalent roles, and a global pin still pins every role.
- Closes #35. Pin stays `puppetmaster-ai==1.22.5`.

## Test plan
- [x] Local routing/registry tests: 61 passed
- [x] Local `pytest tests -q`: 4412 passed, 74 skipped (one unrelated v0.9.216 live-path flake, green on rerun)
- [ ] CI `tests` workflow green on this PR (Python 3.9 + 3.11 + Windows + frontend-build)
- [ ] After merge: wait `tests` green on the exact `main` SHA, then tag `v0.9.236`