### PR TITLE
Release v0.9.238: Settings latch, pilot wait, jump-to-latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.237, deliberately pre-1.0. SESSION COST locks cumulative spend per pilot model across swaps; product swarms pick Luna vs Sol by role need on a two-tier catalog. Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.238, deliberately pre-1.0. Settings stays open across model toggles; the pilot keeps the turn alive with wait instead of idle-plus-resume; jump-to-latest lands on the newest feed row. Rides puppetmaster-ai==1.22.5.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.237"
+__version__ = "0.9.238"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -854,6 +854,7 @@ class ConversationalSession(
         self._stagnation_last_actions = None
         self._stagnation_streak = 0
         self._failed_objective_resume_counts: dict[str, int] = {}
+        self._keep_alive_waits = 0
         # Adaptive task depth for the current originating user turn.
         self._task_profile: str = ""
         self._task_profile_source: str = ""

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -1310,7 +1310,11 @@ class ConversationJobsMixin:
             pass
         return True
 
-    def drain_swarm_results(self) -> Iterator[ConvEvent]:
+    def drain_swarm_results(
+        self,
+        emit_resume: bool = True,
+        already_holding_busy: bool = False,
+    ) -> Iterator[ConvEvent]:
         # Drain finished background-swarm results, appending follow-up messages to
         # history under the single-writer _busy lock. CRITICAL: acquire NON-blocking.
         # This is called from an HTTP handler (the 2.5s frontend poll). If a chat
@@ -1331,11 +1335,14 @@ class ConversationJobsMixin:
         from .conversation import ConvEvent
 
         self._reap_stuck_turn()
-        if not self._busy.acquire(blocking=False):
-            if not self._try_recover_busy_for_swarm_drain():
-                return
+        acquired_here = False
+        if not already_holding_busy:
             if not self._busy.acquire(blocking=False):
-                return
+                if not self._try_recover_busy_for_swarm_drain():
+                    return
+                if not self._busy.acquire(blocking=False):
+                    return
+            acquired_here = True
         try:
             import queue
             # (job_id, objective, failed, error, degraded)
@@ -1690,11 +1697,12 @@ class ConversationJobsMixin:
                     else:
                         self._history.append({"role": "user", "content": resume_text})
 
-                    yield ConvEvent("pilot_resume", {
-                        "job_id": finished_jobs[0][0],
-                        "job_ids": [jid for jid, _obj, _f, _e, _d in finished_jobs],
-                        "objective": finished_jobs[0][1],
-                    })
+                    if emit_resume:
+                        yield ConvEvent("pilot_resume", {
+                            "job_id": finished_jobs[0][0],
+                            "job_ids": [jid for jid, _obj, _f, _e, _d in finished_jobs],
+                            "objective": finished_jobs[0][1],
+                        })
                 except Exception:
                     # Degrade: emit one resume per job (previous behavior) so the
                     # keep-alive contract is preserved even if merge fails.
@@ -1738,11 +1746,13 @@ class ConversationJobsMixin:
                                 )
                             else:
                                 self._history.append({"role": "user", "content": resume_text})
-                            yield ConvEvent("pilot_resume", {
-                                "job_id": job_id,
-                                "objective": objective,
-                            })
+                            if emit_resume:
+                                yield ConvEvent("pilot_resume", {
+                                    "job_id": job_id,
+                                    "objective": objective,
+                                })
                         except Exception:
                             pass
         finally:
-            self._busy.release()
+            if acquired_here:
+                self._busy.release()

--- a/harness/pilot.py
+++ b/harness/pilot.py
@@ -53,6 +53,7 @@ ActionKind = Literal[
     "run_command",
     "run_command_batch",
     "run_ipython",
+    "wait",
     "list_dir",
     "web_search",
     "web_fetch",
@@ -309,6 +310,19 @@ class PilotAction:
                     "peek_artifact requires artifact:// uri (or path) "
                     "or both job_id and artifact_id"
                 )
+        if self.kind == "wait":
+            raw_seconds = None
+            if isinstance(self.arguments, dict):
+                raw_seconds = self.arguments.get("seconds")
+            if raw_seconds is None and self.limit is not None:
+                raw_seconds = self.limit
+            if raw_seconds is not None:
+                try:
+                    seconds = float(raw_seconds)
+                except (TypeError, ValueError):
+                    raise PilotError("wait seconds must be a number")
+                if seconds != seconds or seconds <= 0:
+                    raise PilotError("wait seconds must be a positive number")
         if self.kind == "run_swarm" and not (self.goal or "").strip():
             raise PilotError("run_swarm action requires a non-empty goal")
         if self.kind == "run_implement" and not (self.goal or "").strip():
@@ -1087,6 +1101,37 @@ def build_tools_schema(
                     },
                 },
                 "required": ["code"],
+            },
+        },
+    })
+
+    # 3d. wait — keep this turn alive while background jobs run
+    schema.append({
+        "type": "function",
+        "function": {
+            "name": "wait",
+            "description": (
+                "Stay on this turn while background jobs run (Cursor-style Await). "
+                "Sleeps up to `seconds` (default 2, max 30), emits keep-alive "
+                "notices, and returns whether jobs settled. After run_implement / "
+                "run_parallel / a background dispatch, call wait instead of ending "
+                "the turn. Call again if jobs are still running."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "seconds": {
+                        "type": "number",
+                        "description": (
+                            "How long to wait before returning status. Default 2, "
+                            "maximum 30."
+                        ),
+                    },
+                    "job_id": {
+                        "type": "string",
+                        "description": "Optional job id to watch; omit to watch all pending jobs.",
+                    },
+                },
             },
         },
     })
@@ -2181,6 +2226,7 @@ You have direct access to a local CodeGraph-indexed workspace and can explore/ed
 - `write_file`: write/create a file atomically. Requires `path` and `content`. Use ONLY to create brand-new files.
 - `run_command`: run a terminal shell command. Requires `command`.
 - `run_ipython`: execute Python in a session-scoped persistent REPL (variables survive across turns). Prefer read_file/hash_edit/run_command/swarms for normal coding; use this for stateful probes. Requires `code`.
+- `wait`: stay on this turn while background jobs run (Cursor-style Await). Sleeps up to `seconds` (default 2, max 30) and returns whether jobs settled. After run_implement / run_parallel, call wait instead of ending the turn.
 - `list_dir`: list the files and folders inside a directory. `path` is optional.
 - `run_swarm`: dispatch a parallel agent swarm for complex/broad investigations. Requires `goal`. One worker runs per role -- for a broad ask (audit, "review the platform", "find ways to improve quality/robustness/scale") pass SEVERAL `roles` (explore, pipeline-mapper, decision-explainer, conflict-auditor, test-coverage-reviewer) so it fans out into real parallel coverage; pass all five for a full audit. Omit roles only for a single narrow question. Prefer omitting `model` so the harness auto-routes among currently keyed agentic worker providers (ChatGPT Codex OAuth, OpenCode Go, OpenRouter, …). Pass `model` only when the user names a worker from the live agentic catalog in the tool schema; session pilot ids (openai-codex:…, cursor/…, codex/…) remap to matching worker rows when present. Unknown pins demote to auto-route; they do not fail the swarm. Prompt text alone does not pin a model. To audit a DIFFERENT checkout than the open workspace, pass `repo`=<absolute git path>: the workers read that subject, while your own writes/edits/commands stay in the open session workspace.
 - `run_implement`: dispatch an edit-capable worker that edits the repo in an isolated worktree and produces a reviewable patch. Requires `goal`. Default engine is standalone `agentic` (routes directly through your provider keys, no external CLI); pass `adapter` only to force a specific engine. Optional `mode` (`implement` default, or `analysis`/`review` for read-only reports).
@@ -2227,8 +2273,8 @@ You are not just an investigator -- you can GET WORK DONE. Prefer fan-out:
 - `run_implement` ONLY for one tightly-coupled change that must land as a single coherent PATCH (shared types, interlocking modules, one atomic feature). Do NOT use a single implement worker for work that cleanly splits.
 Use route_task to preview model/cost before a big dispatch.
 
-DISPATCH IS A PAUSE-POINT (mandatory):
-When you dispatch background work (run_implement, run_parallel, or a backgrounded run_swarm), that dispatch is a PAUSE-POINT, not a completion. Emit AT MOST ONE background dispatch verb per turn (never two run_implement calls for the same objective). Do not treat the job as done at dispatch time. The worker finishes later and its result arrives as a "[swarm result ...]" record followed by a "[background job ... finished]" continuation. When you see that, you MUST first report the outcome to the user in plain language -- what the worker did, whether it passed or applied, and the key findings -- and THEN take the next step yourself. For a finished read-only analysis swarm whose findings are shallow or empty: diagnose why (too broad, wrong roles, missing repo focus) and re-dispatch a narrowed run_swarm / run_parallel analysis wave -- do NOT "validate with native tools" or grind an inline exploration campaign yourself. For implement/patch jobs: validate, run tests, fix, apply, or run a narrowed follow-up. It is not the user's job to prompt you to interpret the result or continue; do it on your own.
+DISPATCH THEN WAIT (mandatory):
+When you dispatch background work (run_implement, run_parallel, or a backgrounded run_swarm), that dispatch is not a completion. Emit AT MOST ONE background dispatch verb per turn (never two run_implement calls for the same objective). Do not treat the job as done at dispatch time. Stay on this turn: call `wait` (default 2s, repeat as needed) until the job settles, the same way an IDE agent uses Await. Do not end the turn and wait for a later resume. When wait reports the job finished — or you see a "[swarm result ...]" / "[background job ... finished]" record — first report the outcome to the user in plain language -- what the worker did, whether it passed or applied, and the key findings -- and THEN take the next step yourself. For a finished read-only analysis swarm whose findings are shallow or empty: diagnose why (too broad, wrong roles, missing repo focus) and re-dispatch a narrowed run_swarm / run_parallel analysis wave -- do NOT "validate with native tools" or grind an inline exploration campaign yourself. For implement/patch jobs: validate, run tests, fix, apply, or run a narrowed follow-up. It is not the user's job to prompt you to interpret the result or continue; do it on your own.
 
 TINY / STATIC WORKSPACE AFTER IMPLEMENT (mandatory): After a successful implement on a tiny or static workspace (few source files, HTML/CSS/JS demos, small sites), perform AT MOST ONE cheap verification (read the changed file, `node --check`, or a focused grep) and then STOP. Report the outcome. Do NOT launch headless Chrome/Chromium `--dump-dom` / `file://` smoke probes, do NOT open browsers, and do NOT re-investigate or re-read the same files in a validation campaign unless the user explicitly requests browser QA or visual validation. Native `browser_*` tools remain available only for that explicit ask.
 

--- a/harness/pilot_wait.py
+++ b/harness/pilot_wait.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+"""In-turn wait / keep-alive for background jobs.
+
+Cursor-style Await: the send loop stays on the live turn, sleeps in short
+slices, emits wait notices so SSE/chrome stay alive, and folds finished
+worker results into the same turn. The FE keep-alive resume path remains
+the fallback when this turn already closed.
+"""
+
+import time
+from typing import Any, Callable, Iterator
+
+WAIT_DEFAULT_SEC = 2.0
+WAIT_MAX_SEC = 30.0
+WAIT_SLICE_SEC = 0.25
+WAIT_KEEPALIVE_SEC = 2.0
+WAIT_KEEPALIVE_CAP = 90
+
+
+def parse_wait_seconds(raw: Any, default: float = WAIT_DEFAULT_SEC) -> float:
+    """Clamp a wait duration. Invalid values fall back to ``default``."""
+    try:
+        seconds = float(raw)
+    except (TypeError, ValueError):
+        seconds = float(default)
+    if seconds != seconds:  # NaN
+        seconds = float(default)
+    return max(0.1, min(WAIT_MAX_SEC, seconds))
+
+
+def _cancel_requested(session: Any) -> bool:
+    cancel = getattr(session, "_cancel", None)
+    if cancel is None:
+        return False
+    is_set = getattr(cancel, "is_set", None)
+    if not callable(is_set):
+        return False
+    try:
+        return bool(is_set())
+    except Exception:
+        return False
+
+
+def pending_jobs_keep_alive(session: Any) -> bool:
+    """True when a background worker future is still in flight.
+
+    Queued distill/wiki leftovers must not keep the turn open — those drain
+    after finalize. Only in-flight ``_swarm_futures`` mean the pilot should
+    Await instead of ending the turn.
+    """
+    if _cancel_requested(session):
+        return False
+    has_pending = getattr(session, "has_pending_swarms", None)
+    if not callable(has_pending):
+        return False
+    try:
+        return bool(has_pending())
+    except Exception:
+        return False
+
+
+def format_wait_status(session: Any, seconds: float, settled: bool) -> str:
+    """Compact tool-result text the pilot can act on."""
+    pending_n = 0
+    has_pending = getattr(session, "has_pending_swarms", None)
+    if callable(has_pending):
+        try:
+            pending_n = 1 if bool(has_pending()) else 0
+        except Exception:
+            pending_n = 0
+    if settled and pending_n == 0:
+        return (
+            f"(wait {seconds:g}s) Background jobs settled. "
+            "Report the outcome and continue — do not wait for the user."
+        )
+    if pending_n:
+        return (
+            f"(wait {seconds:g}s) Jobs still running. Call wait again to "
+            "stay on this turn; do not end the turn."
+        )
+    return f"(wait {seconds:g}s) No pending background jobs."
+
+
+def apply_ready_swarm_results(session: Any) -> Iterator[Any]:
+    """Fold queued worker results into this turn (no FE pilot_resume)."""
+    drain = getattr(session, "drain_swarm_results", None)
+    if not callable(drain):
+        return
+    try:
+        yielded = drain(emit_resume=False, already_holding_busy=True)
+    except TypeError:
+        # Older drain signature — skip in-turn apply rather than explode.
+        return
+    if yielded is None:
+        return
+    for ev in yielded:
+        yield ev
+
+
+def keep_alive_wait_slice(
+    session: Any,
+    seconds: float = WAIT_KEEPALIVE_SEC,
+    *,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> Iterator[Any]:
+    """Sleep up to ``seconds``, emit wait chrome, apply any finished jobs."""
+    from .conversation import ConvEvent
+
+    seconds = parse_wait_seconds(seconds, default=WAIT_KEEPALIVE_SEC)
+    deadline = monotonic() + seconds
+    last_notice = 0.0
+    yield ConvEvent("notice", {
+        "kind": "wait",
+        "message": "Waiting for background jobs…",
+    })
+    while monotonic() < deadline:
+        if _cancel_requested(session):
+            yield ConvEvent("notice", {
+                "kind": "wait",
+                "message": "Wait interrupted.",
+            })
+            return
+        for ev in apply_ready_swarm_results(session):
+            yield ev
+        if not pending_jobs_keep_alive(session):
+            yield ConvEvent("notice", {
+                "kind": "wait",
+                "message": "Background jobs finished.",
+            })
+            return
+        now = monotonic()
+        if now - last_notice >= 1.0:
+            last_notice = now
+            remain = max(0.0, deadline - now)
+            yield ConvEvent("notice", {
+                "kind": "wait",
+                "message": f"Waiting for background jobs… {remain:.0f}s left",
+            })
+        sleep(min(WAIT_SLICE_SEC, max(0.0, deadline - monotonic())))
+    for ev in apply_ready_swarm_results(session):
+        yield ev
+
+
+def dispatch_wait_action(
+    session: Any,
+    act: Any,
+    aid: str,
+    is_native: bool,
+    *,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> Iterator[Any]:
+    """Pilot ``wait`` tool: timed keep-alive, then a status action_result."""
+    from .conversation import ConvEvent
+
+    args = getattr(act, "arguments", None) or {}
+    raw_seconds = args.get("seconds")
+    if raw_seconds is None:
+        raw_seconds = getattr(act, "limit", None)
+    seconds = parse_wait_seconds(raw_seconds, default=WAIT_DEFAULT_SEC)
+    deadline = monotonic() + seconds
+    last_notice = 0.0
+    while monotonic() < deadline:
+        if _cancel_requested(session):
+            body = "(wait interrupted)"
+            yield ConvEvent("action_result", {
+                "id": aid, "error": body,
+            })
+            session._append_action_result(act, aid, body, is_native, ok=False)
+            return
+        for ev in apply_ready_swarm_results(session):
+            yield ev
+        if not pending_jobs_keep_alive(session):
+            break
+        now = monotonic()
+        if now - last_notice >= 1.0:
+            last_notice = now
+            remain = max(0.0, deadline - now)
+            yield ConvEvent("notice", {
+                "kind": "wait",
+                "message": f"Waiting… {remain:.0f}s left",
+            })
+        sleep(min(WAIT_SLICE_SEC, max(0.0, deadline - monotonic())))
+    for ev in apply_ready_swarm_results(session):
+        yield ev
+    settled = not pending_jobs_keep_alive(session)
+    body = format_wait_status(session, seconds, settled)
+    yield ConvEvent("action_result", {
+        "id": aid,
+        "status": "ok",
+        "message": body,
+        "settled": settled,
+    })
+    session._append_action_result(act, aid, body, is_native, ok=True)
+
+
+def note_keep_alive_wait(session: Any) -> bool:
+    """Count harness-injected waits; False once the per-turn cap is hit."""
+    n = int(getattr(session, "_keep_alive_waits", 0) or 0) + 1
+    session._keep_alive_waits = n
+    return n <= WAIT_KEEPALIVE_CAP

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -899,6 +899,7 @@ class SendLoopMixin:
             self._stagnation_last_actions = None
             self._stagnation_streak = 0
             self._failed_objective_resume_counts = {}
+            self._keep_alive_waits = 0
             yield from emit_turn_task_profile(self, user_message)
             try:
                 from .turn_budget import turn_budget_enabled
@@ -1450,15 +1451,10 @@ class SendLoopMixin:
             except Exception:
                 pass
 
-            # 3. No actions => the pilot is done talking. Before yielding back to
-            # the user, drain any pending steer. A steer that arrives while the
-            # model is finalizing has a safe assistant->user boundary (the last
-            # history message is this assistant turn). drain_idle_turn delivers
-            # it as a first-class user message and re-asks the model instead of
-            # terminating. Mid-spree / step-start inject in
-            # _check_and_inject_steer is the other delivery point; together they
-            # guarantee any enqueued steer is eventually delivered and never
-            # stranded.
+            # 3. No actions => the pilot is done talking unless a wait tool
+            # kept the step productive. drain_idle_turn delivers pending
+            # steers or finalizes. Mid-spree / step-start inject in
+            # _check_and_inject_steer is the other steer delivery point.
             if not turn.has_actions:
                 synthesis_decision = post_swarm_synthesis_decision(
                     synchronous_swarms=synchronous_swarms,

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -515,7 +515,21 @@ Yields the same ConvEvent stream. Generator return value is ``None``
     result = None
     swarm_error = None
     while True:
-        msg_kind, msg_val = _delta_q.get()
+        if getattr(session, "_cancel", None) is not None:
+            try:
+                if session._cancel.is_set():
+                    swarm_error = "interrupted"
+                    break
+            except Exception:
+                pass
+        try:
+            msg_kind, msg_val = _delta_q.get(timeout=2.0)
+        except _queue.Empty:
+            yield ConvEvent("notice", {
+                "kind": "wait",
+                "message": "Waiting for swarm workers…",
+            })
+            continue
         if msg_kind == 'delta':
             wid, dkind, dtext = msg_val
             yield ConvEvent('worker_delta', {'id': aid, 'worker_id': wid, 'kind': dkind, 'text': dtext})

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -61,7 +61,7 @@ STREAM_IDLE_STUCK_MESSAGE = (
 LOCAL_ACTION_KINDS: frozenset[str] = frozenset({
     "open_project", "relocate_session", "session_bank",
     "write_file", "edit_file", "hash_edit", "run_command",
-    "run_command_batch", "run_ipython",
+    "run_command_batch", "run_ipython", "wait",
     "search_tools", "search_state",
     "store_scratch", "load_scratch", "list_scratch", "clear_scratch",
     "browser_navigate", "browser_snapshot", "browser_click",
@@ -1665,6 +1665,11 @@ def dispatch_local_action(
 
     if act_goal is None:
         act_goal = action_display_goal(act)
+
+    if act.kind == "wait":
+        from .pilot_wait import dispatch_wait_action
+        yield from dispatch_wait_action(session, act, aid, is_native)
+        return
 
     if plan and (
         act.kind in PLAN_SKIP_KINDS or act.kind.startswith("browser_")

--- a/harness/task_profile.py
+++ b/harness/task_profile.py
@@ -69,6 +69,7 @@ _MICRO_VISIBLE: FrozenSet[str] = frozenset(
         "hash_edit",
         "run_command",
         "run_ipython",
+        "wait",
         "list_dir",
         "search_tools",
         "search_files",

--- a/harness/tool_discovery.py
+++ b/harness/tool_discovery.py
@@ -34,6 +34,7 @@ CORE_ALWAYS: Set[str] = {
     "edit_file",
     "run_command",
     "run_ipython",
+    "wait",
     "list_dir",
     "search_tools",
 }
@@ -74,6 +75,7 @@ _PILOT_EXTRAS: Set[str] = {
     "run_swarm",
     "run_implement",
     "run_parallel",
+    "wait",
     "query_wiki",
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.237"
+version = "0.9.238"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_conversation_jobs_mixin.py
+++ b/tests/test_conversation_jobs_mixin.py
@@ -154,6 +154,31 @@ def test_drain_swarm_results_characterization():
     )
 
 
+def test_drain_swarm_results_in_turn_skips_pilot_resume():
+    """In-turn keep-alive applies results without starting a FE resume turn."""
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
+    session = ConversationalSession(cfg)
+    session._swarm_results.put({
+        "job_id": "job_in_turn",
+        "objective": "in-turn drain",
+        "result": {
+            "applied": True,
+            "files": ["a.py"],
+            "summary": "ok",
+        },
+    })
+    events = list(session.drain_swarm_results(
+        emit_resume=False, already_holding_busy=True,
+    ))
+    kinds = [e.kind for e in events]
+    assert "swarm_result" in kinds
+    assert "pilot_resume" not in kinds
+    assert any(
+        m["role"] == "user" and "[background job job_in_turn finished]" in m["content"]
+        for m in session._history
+    )
+
+
 def test_run_provider_worker_background_finishes_local_job():
     """Provider-worker background path still finishes the local job + queues result."""
     from harness.worker import WorkerResult

--- a/tests/test_native_tools.py
+++ b/tests/test_native_tools.py
@@ -31,6 +31,7 @@ def test_build_tools_schema():
     assert "web_fetch" in names
     assert "read_pdf" in names
     assert "run_swarm" in names
+    assert "wait" in names
     assert "search_codegraph" in names
     assert "query_wiki" in names
 

--- a/tests/test_pilot_wait.py
+++ b/tests/test_pilot_wait.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from harness.pilot import PilotAction, PilotError, from_wire
+from harness.pilot_wait import (
+    dispatch_wait_action,
+    format_wait_status,
+    keep_alive_wait_slice,
+    note_keep_alive_wait,
+    parse_wait_seconds,
+    pending_jobs_keep_alive,
+)
+
+
+def test_parse_wait_seconds_clamps_and_falls_back():
+    assert parse_wait_seconds(2) == 2.0
+    assert parse_wait_seconds(0) == 0.1
+    assert parse_wait_seconds(99) == 30.0
+    assert parse_wait_seconds("nope") == 2.0
+    assert parse_wait_seconds(None) == 2.0
+
+
+def test_from_wire_wait_and_validate():
+    act = from_wire("wait", {"seconds": 3})
+    assert act.kind == "wait"
+    assert act.arguments.get("seconds") == 3
+    try:
+        PilotAction(kind="wait", arguments={"seconds": "nope"}).validate()
+    except PilotError:
+        pass
+    else:
+        raise AssertionError("invalid wait seconds must raise")
+
+
+def test_pending_jobs_keep_alive():
+    assert pending_jobs_keep_alive(SimpleNamespace()) is False
+    assert pending_jobs_keep_alive(
+        SimpleNamespace(has_pending_swarms=lambda: True)
+    ) is True
+    q = SimpleNamespace(empty=lambda: False)
+    assert pending_jobs_keep_alive(SimpleNamespace(_swarm_results=q)) is False
+    cancel = SimpleNamespace(is_set=lambda: True)
+    assert pending_jobs_keep_alive(
+        SimpleNamespace(has_pending_swarms=lambda: True, _cancel=cancel)
+    ) is False
+
+
+def test_keep_alive_wait_slice_is_instant_with_fake_clock():
+    times = [0.0]
+
+    def mono():
+        return times[0]
+
+    def sleep(dt):
+        times[0] += dt
+
+    session = SimpleNamespace(
+        has_pending_swarms=lambda: times[0] < 1.5,
+        drain_swarm_results=lambda **_k: iter(()),
+        _cancel=SimpleNamespace(is_set=lambda: False),
+    )
+    events = list(keep_alive_wait_slice(
+        session, seconds=2.0, sleep=sleep, monotonic=mono,
+    ))
+    kinds = [ev.kind for ev in events]
+    assert "notice" in kinds
+    assert any(ev.data.get("kind") == "wait" for ev in events)
+
+
+def test_dispatch_wait_action_returns_status():
+    times = [0.0]
+
+    def mono():
+        return times[0]
+
+    def sleep(dt):
+        times[0] += max(dt, 0.1)
+
+    appended = []
+    session = SimpleNamespace(
+        has_pending_swarms=lambda: False,
+        drain_swarm_results=lambda **_k: iter(()),
+        _cancel=SimpleNamespace(is_set=lambda: False),
+        _append_action_result=lambda *a, **k: appended.append((a, k)),
+    )
+    act = from_wire("wait", {"seconds": 1})
+    events = list(dispatch_wait_action(
+        session, act, "w1", True, sleep=sleep, monotonic=mono,
+    ))
+    assert events[-1].kind == "action_result"
+    assert events[-1].data.get("settled") is True
+    assert appended
+
+
+def test_format_wait_status_settled():
+    session = SimpleNamespace(has_pending_swarms=lambda: False)
+    text = format_wait_status(session, 2.0, True)
+    assert "settled" in text.lower()
+
+
+def test_note_keep_alive_wait_caps():
+    session = SimpleNamespace()
+    assert note_keep_alive_wait(session) is True
+    session._keep_alive_waits = 90
+    assert note_keep_alive_wait(session) is False
+

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.237",
+  "version": "0.9.238",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.237",
+      "version": "0.9.238",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.237",
+  "version": "0.9.238",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/RightPane.collapse.test.tsx
+++ b/webapp/src/__tests__/RightPane.collapse.test.tsx
@@ -6,6 +6,7 @@ import { api } from "../lib/api";
 import { dispatchProjectSelected } from "../lib/panelTransition";
 import { usePolling } from "../lib/usePolling";
 import { clearSWRCache, readSWRCache } from "../lib/useStaleWhileRevalidate";
+import { resetSettingsOverlay, setSettingsOverlayOpen } from "../lib/settingsOverlay";
 
 vi.mock("../lib/api", () => ({
   api: {
@@ -23,7 +24,13 @@ vi.mock("../components/BrowserPane", () => ({ default: () => <div /> }));
 vi.mock("../components/FileTree", () => ({ default: () => <div /> }));
 vi.mock("../components/SourceControl", () => ({ default: () => <div /> }));
 vi.mock("../components/WorktreesPane", () => ({ default: () => <div /> }));
-vi.mock("../components/SettingsShell", () => ({ default: () => <div /> }));
+vi.mock("../components/SettingsShell", () => ({
+  default: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="settings-shell">
+      <button type="button" onClick={onClose}>close-settings</button>
+    </div>
+  ),
+}));
 vi.mock("../components/TerminalPane", () => ({
   default: () => <div data-testid="terminal-pane" />,
 }));
@@ -71,6 +78,7 @@ describe("RightPane collapse placement", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    resetSettingsOverlay();
     Element.prototype.scrollIntoView = vi.fn();
     seedBoardTabOrder();
   });
@@ -145,6 +153,27 @@ describe("RightPane collapse placement", () => {
     expect(screen.getByRole("separator", { name: "Resize stacked panel height" })).toBeInTheDocument();
     const stack = screen.getByRole("region", { name: "State panel" }).closest(".right-pane-card-stack") as HTMLElement;
     expect(stack.style.gridTemplateRows).toBe("minmax(0, 50fr) minmax(0, 50fr)");
+  });
+
+  it("does not close the rail while Settings is open on an empty board", () => {
+    localStorage.setItem("pmharness.board.openCards", JSON.stringify([]));
+    const onEmpty = vi.fn();
+
+    render(<RightPane {...baseProps} onEmpty={onEmpty} initialTab="settings" />);
+
+    expect(screen.getByTestId("settings-shell")).toBeInTheDocument();
+    expect(onEmpty).not.toHaveBeenCalled();
+  });
+
+  it("keeps Settings open across a remount when the overlay latch is set", () => {
+    setSettingsOverlayOpen(true);
+    const onEmpty = vi.fn();
+    const { unmount } = render(<RightPane {...baseProps} onEmpty={onEmpty} />);
+    expect(screen.getByTestId("settings-shell")).toBeInTheDocument();
+    unmount();
+    render(<RightPane {...baseProps} onEmpty={onEmpty} />);
+    expect(screen.getByTestId("settings-shell")).toBeInTheDocument();
+    expect(onEmpty).not.toHaveBeenCalled();
   });
 
   it("does not render an empty board and asks the shell to close it", () => {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -1043,6 +1043,8 @@ export default function Conversation({
   // tracks real geometry so keyboard/scrollbar unpin is not swallowed.
   const scrollSettlingRef = useRef(false);
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
+  const [feedSettleEpoch, setFeedSettleEpoch] = useState(0);
+  const scrollFeedToEndRef = useRef<(() => void) | null>(null);
   const publishJumpVisibilityRef = useRef(() => {});
   publishJumpVisibilityRef.current = () => {
     const next = shouldShowJumpToBottom({
@@ -1052,13 +1054,13 @@ export default function Conversation({
     setShowJumpToBottom((prev) => (prev === next ? prev : next));
   };
   const jumpToLatest = () => {
-    const el = feedRef.current;
-    if (!el) return;
     pinnedToBottomRef.current = true;
     scrollReleasedByGestureRef.current = false;
-    scrollSettlingRef.current = false;
-    el.scrollTop = el.scrollHeight;
     setShowJumpToBottom(false);
+    const scrollToEnd = scrollFeedToEndRef.current;
+    if (scrollToEnd) scrollToEnd();
+    else if (feedRef.current) feedRef.current.scrollTop = feedRef.current.scrollHeight;
+    setFeedSettleEpoch((n) => n + 1);
   };
   useEffect(() => {
     const el = feedRef.current;
@@ -1131,7 +1133,9 @@ export default function Conversation({
     const el = feedRef.current;
     if (!el) return;
     if (pinnedToBottomRef.current || scrollSettlingRef.current) {
-      el.scrollTo(0, el.scrollHeight);
+      const scrollToEnd = scrollFeedToEndRef.current;
+      if (scrollToEnd) scrollToEnd();
+      else el.scrollTo(0, el.scrollHeight);
     }
   }, [items]);
 
@@ -1145,7 +1149,9 @@ export default function Conversation({
     prevFeedScrollTopRef.current = null;
     scrollSettlingRef.current = true;
     setShowJumpToBottom(false);
-    el.scrollTop = el.scrollHeight;
+    const scrollToEnd = scrollFeedToEndRef.current;
+    if (scrollToEnd) scrollToEnd();
+    else el.scrollTop = el.scrollHeight;
     let frame = 0;
     let stableFrames = 0;
     let lastHeight = el.scrollHeight;
@@ -1169,7 +1175,9 @@ export default function Conversation({
       stableFrames = step.stableFrames;
       frame = step.frame;
       lastHeight = height;
-      node.scrollTop = height;
+      const scrollToEnd = scrollFeedToEndRef.current;
+      if (scrollToEnd) scrollToEnd();
+      else node.scrollTop = height;
       pinnedToBottomRef.current = true;
       if (step.done) {
         scrollSettlingRef.current = false;
@@ -1183,7 +1191,7 @@ export default function Conversation({
       cancelAnimationFrame(rafId);
       scrollSettlingRef.current = false;
     };
-  }, [activeSessionId]);
+  }, [activeSessionId, feedSettleEpoch]);
 
   // Alt-tab / blur can zero the feed height and reset scrollTop. Restore the
   // last offset (or re-stick to bottom if still pinned) after focus paints.
@@ -3073,6 +3081,7 @@ export default function Conversation({
           busyElapsedMs={busyElapsedMs}
           turnOpen={turnOpen}
           holdSwarmAwait={holdSwarmAwait}
+          scrollToEndRef={scrollFeedToEndRef}
           onEditMessage={stableEditMessage}
           onExecuteSend={stableExecuteSend}
           onImageClick={handleTranscriptImageClick}

--- a/webapp/src/components/ModelsSettingsPage.tsx
+++ b/webapp/src/components/ModelsSettingsPage.tsx
@@ -208,8 +208,13 @@ export default function ModelsSettingsPage() {
                   <div className="flex flex-col rounded-lg border border-edge/40 overflow-hidden">
                     {g.items.map((entry, i) => (
                       <button
+                        type="button"
                         key={entry.spec}
-                        onClick={() => toggle(entry)}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          void toggle(entry);
+                        }}
                         disabled={busy === entry.spec}
                         className={`flex items-center justify-between px-3 py-2 text-left transition
                           ${i > 0 ? "border-t border-edge/30" : ""}

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -16,6 +16,10 @@ import { lastSelectedProjectRoot } from "../lib/panelTransition";
 import { usePolling } from "../lib/usePolling";
 import { writeSWRCache } from "../lib/useStaleWhileRevalidate";
 import {
+  isSettingsOverlayOpen,
+  setSettingsOverlayOpen,
+} from "../lib/settingsOverlay";
+import {
   loadRightPaneTabVisibility,
   saveRightPaneTabVisibility,
   type RightPaneTabVisibility,
@@ -258,7 +262,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
   const boardRef = useRef<HTMLDivElement | null>(null);
   const preferredResizeGroupRef = useRef(-1);
   const [draggedTab, setDraggedTab] = useState<Tab | null>(null);
-  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(isSettingsOverlayOpen);
   const handledInitialTab = useRef<string | null>(null);
   const [tabOrder, setTabOrder] = useState<Tab[]>(() => {
     const validTabs = CANONICAL_ORDER.filter(tab => tab !== PINNED_LAST);
@@ -294,12 +298,23 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     localStorage.setItem("pmharness.tabOrder", JSON.stringify(nextOrder));
     localStorage.setItem("pmharness.board.openCards", JSON.stringify(flat));
     localStorage.setItem(BOARD_COLUMNS_STORAGE_KEY, JSON.stringify(cols));
-    if (flat.length === 0) onEmpty?.();
+    if (flat.length === 0 && !isSettingsOverlayOpen()) onEmpty?.();
   }, [onEmpty]);
+
+  const openSettings = useCallback(() => {
+    setSettingsOverlayOpen(true);
+    setSettingsOpen(true);
+  }, []);
+
+  const closeSettings = useCallback(() => {
+    setSettingsOverlayOpen(false);
+    setSettingsOpen(false);
+    if (openCards.length === 0) onEmpty?.();
+  }, [onEmpty, openCards.length]);
 
   const addCard = useCallback((tabName: Tab) => {
     if (tabName === PINNED_LAST) {
-      setSettingsOpen(true);
+      openSettings();
       return;
     }
     if (!tabVisibilityRef.current[tabName]) {
@@ -309,7 +324,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     }
     persistBoard(tabOrder, openCards.includes(tabName) ? openCards : [...openCards, tabName]);
     requestAnimationFrame(() => document.getElementById(`right-pane-card-${tabName}`)?.focus());
-  }, [openCards, persistBoard, tabOrder]);
+  }, [openCards, openSettings, persistBoard, tabOrder]);
 
   const removeCard = (tabName: Tab) => {
     const nextOpenCards = openCards.filter(card => card !== tabName);
@@ -467,17 +482,17 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
 
   useEffect(() => {
     if (!initialTab || initialTab === PINNED_LAST) {
-      if (initialTab === PINNED_LAST) setSettingsOpen(true);
+      if (initialTab === PINNED_LAST) openSettings();
       return;
     }
     if (handledInitialTab.current === initialTab) return;
     handledInitialTab.current = initialTab;
     addCard(initialTab as Tab);
-  }, [initialTab, addCard]);
+  }, [initialTab, addCard, openSettings]);
 
   useEffect(() => {
-    if (visible && openCards.length === 0 && !initialTab) onEmpty?.();
-  }, [initialTab, onEmpty, openCards.length, visible]);
+    if (visible && openCards.length === 0 && !initialTab && !settingsOpen) onEmpty?.();
+  }, [initialTab, onEmpty, openCards.length, settingsOpen, visible]);
 
   const [reviews, setReviews] = useState<PendingReview[]>([]);
   /** Sticky when getReviews fails — DiffReviewPane must not claim an empty queue. */
@@ -558,7 +573,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
         const validTabs: Tab[] = ["state", "files", "git", "worktrees", "terminal", "browser", "settings", "swarm", "checkpoints", "review"];
         if (validTabs.includes(targetTab)) {
           if (targetTab === "settings") {
-            setSettingsOpen(true);
+            openSettings();
             return;
           }
           addCard(targetTab);
@@ -567,7 +582,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     };
     window.addEventListener("harness-focus-tab", onFocusTab as EventListener);
     return () => window.removeEventListener("harness-focus-tab", onFocusTab as EventListener);
-  }, [addCard]);
+  }, [addCard, openSettings]);
 
   const renderCardBody = (tabName: Tab) => (
     <ErrorBoundary label={TAB_CONFIG[tabName]?.label || tabName} inline>
@@ -782,13 +797,10 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
           </div>
         )}
       </div>
-      {visible && settingsOpen && (
+      {settingsOpen && (
         <SettingsShell
           onOpenWizard={onOpenWizard}
-          onClose={() => {
-            setSettingsOpen(false);
-            if (openCards.length === 0) onEmpty?.();
-          }}
+          onClose={closeSettings}
         />
       )}
     </>

--- a/webapp/src/components/SettingsShell.tsx
+++ b/webapp/src/components/SettingsShell.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { X, Cpu, SlidersHorizontal, ShieldCheck, Zap, Bell, Wrench, Info, Puzzle } from "lucide-react";
 import ModelsSettingsPage from "./ModelsSettingsPage";
 import SettingsPane, { type SettingsSection } from "./SettingsPane";
@@ -76,8 +77,8 @@ export default function SettingsShell({
     return () => window.removeEventListener("harness-settings-page", onPage as EventListener);
   }, []);
 
-  return (
-    <div className="fixed inset-0 z-50 bg-bg flex flex-col">
+  return createPortal(
+    <div className="fixed inset-0 z-[80] bg-bg flex flex-col" data-testid="settings-shell">
       {/* top bar -- fixed px pad clears macOS traffic lights (not rem) */}
       <div
         data-testid="settings-shell-titlebar"
@@ -86,6 +87,7 @@ export default function SettingsShell({
       >
         <span className="text-[13px] font-semibold text-txt">Settings</span>
         <button
+          type="button"
           onClick={onClose}
           title="Close settings"
           className="p-1.5 rounded-md text-muted hover:text-txt hover:bg-panel2 transition"
@@ -134,6 +136,7 @@ export default function SettingsShell({
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -806,6 +806,8 @@ export type TranscriptListProps = {
    */
   holdSwarmAwait?: boolean;
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  /** Conversation jump-to-latest / stick-to-bottom: virtualizer-aware end scroll. */
+  scrollToEndRef?: React.MutableRefObject<(() => void) | null>;
   onEditMessage: (idx: number, originalText: string) => void;
   onExecuteSend: (msg: string, useAuto: boolean, usePlan?: boolean) => void;
   onImageClick: (url: string) => void;
@@ -825,6 +827,7 @@ export const TranscriptList = memo(function TranscriptList({
   turnOpen = false,
   holdSwarmAwait = false,
   scrollContainerRef,
+  scrollToEndRef,
   onEditMessage,
   onExecuteSend,
   onImageClick,
@@ -904,6 +907,23 @@ export const TranscriptList = memo(function TranscriptList({
         ? (element) => element.getBoundingClientRect().height
         : undefined,
   });
+  const scrollToEnd = useCallback(() => {
+    const last = grouped.length - 1;
+    if (last >= 0) {
+      rowVirtualizer.scrollToIndex(last, { align: "end" });
+    }
+    const el = scrollContainerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [grouped.length, rowVirtualizer, scrollContainerRef]);
+  useLayoutEffect(() => {
+    if (!scrollToEndRef) return;
+    scrollToEndRef.current = scrollToEnd;
+    return () => {
+      if (scrollToEndRef.current === scrollToEnd) {
+        scrollToEndRef.current = null;
+      }
+    };
+  }, [scrollToEnd, scrollToEndRef]);
   void scrollEpoch;
 
   // Find the last assistant message inside the original items array

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -3,7 +3,7 @@
  * Conversation owns all state; this is a presentational peel.
  */
 
-import type { ReactNode, RefObject } from "react";
+import type { MutableRefObject, ReactNode, RefObject } from "react";
 import { ChevronDown } from "lucide-react";
 import { panelOpacityClass } from "../../lib/panelTransition";
 import {
@@ -26,6 +26,7 @@ export default function ConversationChatColumn({
   busyElapsedMs,
   turnOpen,
   holdSwarmAwait = false,
+  scrollToEndRef,
   onEditMessage,
   onExecuteSend,
   onImageClick,
@@ -48,6 +49,7 @@ export default function ConversationChatColumn({
   turnOpen: boolean;
   /** Same hold as Conversation — pending jobs keep transcript latch through idle flaps. */
   holdSwarmAwait?: boolean;
+  scrollToEndRef?: MutableRefObject<(() => void) | null>;
   onEditMessage: (idx: number, text: string) => void;
   onExecuteSend: (msg: string, useAuto: boolean, usePlan?: boolean) => void;
   onImageClick: (url: string) => void;
@@ -94,6 +96,7 @@ export default function ConversationChatColumn({
             turnOpen={turnOpen}
             holdSwarmAwait={holdSwarmAwait}
             scrollContainerRef={feedRef}
+            scrollToEndRef={scrollToEndRef}
             onEditMessage={onEditMessage}
             onExecuteSend={onExecuteSend}
             onImageClick={onImageClick}

--- a/webapp/src/lib/settingsOverlay.ts
+++ b/webapp/src/lib/settingsOverlay.ts
@@ -1,0 +1,15 @@
+/** Latch so Settings survives RightPane remounts and right-rail collapse. */
+
+let settingsOverlayOpen = false;
+
+export function isSettingsOverlayOpen(): boolean {
+  return settingsOverlayOpen;
+}
+
+export function setSettingsOverlayOpen(open: boolean): void {
+  settingsOverlayOpen = open;
+}
+
+export function resetSettingsOverlay(): void {
+  settingsOverlayOpen = false;
+}


### PR DESCRIPTION
## Summary
- Keep Settings open while toggling models: portal + overlay latch so a catalog remount does not dismiss the overlay.
- Add a first-class `wait` tool so the pilot stays on the turn after background dispatch instead of idle-plus-`pilot_resume`.
- Jump-to-latest uses the virtualizer end index so an open Investigating/Explored bar is not a two-step landing pad.
- Pin stays `puppetmaster-ai==1.22.5`.

## Test plan
- [x] `pytest tests/test_pilot_wait.py tests/test_native_tools.py tests/test_conversation_jobs_mixin.py tests/test_append_only_context.py tests/test_version_consistency.py`
- [x] `vitest` RightPane collapse / Settings / Models / feed scroll
- [ ] CI `tests` workflow green on this PR
- [ ] After merge: wait `tests` green on exact `main` SHA, then tag `v0.9.238`