### PR TITLE
Release v0.9.239: compact composer and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.238, deliberately pre-1.0. Settings stays open across model toggles; the pilot keeps the turn alive with wait instead of idle-plus-resume; jump-to-latest lands on the newest feed row. Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.239, deliberately pre-1.0. Composer and footer chrome yield at narrow widths instead of overlapping. Rides puppetmaster-ai==1.22.5.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.238"
+__version__ = "0.9.239"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.238"
+version = "0.9.239"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.238",
+  "version": "0.9.239",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.238",
+      "version": "0.9.239",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.238",
+  "version": "0.9.239",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/ComposerDock.busyChrome.test.tsx
+++ b/webapp/src/__tests__/ComposerDock.busyChrome.test.tsx
@@ -125,4 +125,12 @@ describe("ComposerDock busy chrome", () => {
     expect(screen.getByRole("button", { name: /queue/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
   });
+
+  it("keeps send actions in a non-shrinking cluster so the picker can truncate", () => {
+    const { container } = renderBusyDock("");
+    expect(container.querySelector(".composer-toolbar")).toBeTruthy();
+    expect(container.querySelector(".composer-toolbar-actions")).toBeTruthy();
+    expect(container.querySelector(".composer-toolbar-send")).toBeTruthy();
+    expect(container.querySelector(".pilot-picker-slot")).toBeTruthy();
+  });
 });

--- a/webapp/src/__tests__/StatusBar.test.tsx
+++ b/webapp/src/__tests__/StatusBar.test.tsx
@@ -798,3 +798,47 @@ describe("StatusBar task profile chip", () => {
     });
   });
 });
+
+describe("StatusBar compact chrome", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWorkspaces.mockResolvedValue([]);
+    mockGetSessionState.mockResolvedValue({
+      state: "idle",
+      pending_swarms: false,
+      runners: {},
+    });
+    mockSessions.mockResolvedValue([]);
+    mockGetUsage.mockResolvedValue({
+      session: {
+        tokens_used: 1500,
+        est_cost_usd: 0.05,
+        driver: "openrouter:deepseek/deepseek-v4-pro-0813",
+        price_in: 0.4,
+        price_out: 0.8,
+      },
+      jobs: [],
+    });
+  });
+
+  it("splits the footer into overflow-safe clusters and shortens long model ids", async () => {
+    const { container } = render(
+      <StatusBar
+        {...statusBarProps}
+        config={{
+          driver: "openrouter:deepseek/deepseek-v4-pro-0813",
+          reach: "openrouter",
+          budget: 0,
+        }}
+      />,
+    );
+
+    expect(container.querySelector(".status-bar-cluster-start")).toBeTruthy();
+    expect(container.querySelector(".status-bar-cluster-end")).toBeTruthy();
+    expect(container.querySelector(".status-bar-model")).toHaveTextContent("deepseek-v4-pro-0813");
+    expect(container.querySelector(".status-bar-model")).not.toHaveTextContent("openrouter:deepseek/");
+    await waitFor(() => {
+      expect(screen.getByText("process")).toBeInTheDocument();
+    });
+  });
+});

--- a/webapp/src/components/PilotPicker.tsx
+++ b/webapp/src/components/PilotPicker.tsx
@@ -170,17 +170,17 @@ export default function PilotPicker({ config }: {
   };
 
   return (
-    <div className="relative inline-flex items-center gap-1" ref={containerRef}>
-      <div className="relative inline-block">
+    <div className="relative flex items-center gap-1 min-w-0 w-full" ref={containerRef}>
+      <div className="relative min-w-0 flex-1">
         <button
           onClick={() => {
             setReasonOpen(false);
             setModelOpen((prev) => !prev);
           }}
           title={current || "Pilot model"}
-          className="flex items-center gap-1 text-[11px] text-muted hover:text-txt rounded-md px-2 h-[22px] bg-transparent hover:bg-panel2 border border-edge/40 transition select-none"
+          className="flex items-center gap-1 min-w-0 w-full text-[11px] text-muted hover:text-txt rounded-md px-2 h-[22px] bg-transparent hover:bg-panel2 border border-edge/40 transition select-none"
         >
-          <span className="truncate max-w-[170px]">{currentLabel}</span>
+          <span className="truncate min-w-0 flex-1 text-left">{currentLabel}</span>
           <ChevronDown size={11} className="shrink-0 opacity-60" />
         </button>
 
@@ -219,7 +219,7 @@ export default function PilotPicker({ config }: {
       </div>
 
       {showReasoning && (
-        <div className="relative inline-block">
+        <div className="relative shrink-0">
           <button
             onClick={() => {
               setModelOpen(false);

--- a/webapp/src/components/StatusBar.tsx
+++ b/webapp/src/components/StatusBar.tsx
@@ -31,6 +31,7 @@ import CostBreakdown, {
   spendIsEstimated,
 } from "./CostBreakdown";
 import { sanitizeUpdateMessage } from "../lib/updateMessages";
+import { shortPilotModelLabel } from "../lib/turnProgress";
 
 type FooterRuntimeStatus = "ready" | "thinking" | "busy";
 
@@ -75,7 +76,8 @@ function truncateGoalText(text: string, max = 36): string {
 // Bottom status strip (Hermes shell/statusbar pattern): runtime health, active
 // workspace branch, pilot model, spend, and shell toggles. Job inventory lives
 // in LeftRail SESSION JOBS -- a footer total was stale across dir swaps and
-// disagreed with the scoped list, so it was removed.
+// disagreed with the scoped list, so it was removed. Narrow widths hide
+// secondary labels via container queries instead of overlapping the clusters.
 export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, onToggleRight }: {
   config: Config | null;
   leftOpen: boolean; rightOpen: boolean;
@@ -366,16 +368,21 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
   };
 
   const showUsage = usage && (usage.tokens_used > 0 || usage.est_cost_usd > 0);
+  const driverLabel = shortPilotModelLabel(config?.driver) || "pilot";
+  const driverProvider = config?.driver?.includes(":")
+    ? config.driver.split(":")[0]
+    : (config?.reach || "");
 
   return (
-    <div className="shell-inset-footer flex items-center gap-3 px-3 h-7 text-[10px] text-muted select-none">
+    <div className="shell-inset-footer status-bar px-3 h-7 text-[10px] text-muted select-none">
+      <div className="status-bar-cluster status-bar-cluster-start">
       <button onClick={onToggleLeft} title="Toggle sessions panel (Ctrl/Cmd+B)"
-        className={`p-0.5 rounded hover:bg-panel2 ${leftOpen ? "text-txt" : "text-muted"}`}><PanelLeft size={12} /></button>
+        className={`p-0.5 rounded hover:bg-panel2 shrink-0 ${leftOpen ? "text-txt" : "text-muted"}`}><PanelLeft size={12} /></button>
       <button onClick={onToggleRight} title="Toggle floating panels (Ctrl/Cmd+J)"
-        className={`p-0.5 rounded hover:bg-panel2 ${rightOpen ? "text-txt" : "text-muted"}`}><PanelRight size={12} /></button>
-      <span className="w-px h-3 bg-edge" />
+        className={`p-0.5 rounded hover:bg-panel2 shrink-0 ${rightOpen ? "text-txt" : "text-muted"}`}><PanelRight size={12} /></button>
+      <span className="w-px h-3 bg-edge shrink-0" />
       <span
-        className={`flex items-center gap-1 ${runtimeReady ? "text-good" : "text-accent"}`}
+        className={`flex items-center gap-1 shrink-0 ${runtimeReady ? "text-good" : "text-accent"}`}
         title={runtimeReady ? "Idle" : runtimeStatus === "busy" ? "Swarm or background work in progress" : "Session runner active"}
         data-runtime-status={runtimeStatus}
       >
@@ -383,24 +390,24 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
           size={7}
           className={runtimeReady ? "fill-good text-good" : "fill-accent text-accent animate-pulse"}
         />
-        {footerRuntimeStatusLabel(runtimeStatus)}
+        <span className="status-bar-optional-sm">{footerRuntimeStatusLabel(runtimeStatus)}</span>
       </span>
-      {branch && <span className="flex items-center gap-1"><GitBranch size={10} />{branch}</span>}
+      {branch && <span className="status-bar-optional-sm flex items-center gap-1"><GitBranch size={10} />{branch}</span>}
       {taskProfile && (
         <span
           data-testid="task-profile-chip"
-          className="inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-panel2 border border-edge text-txt/90"
+          className="status-bar-optional-xs inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-panel2 border border-edge text-txt/90"
           title={taskProfileTitle(taskProfile)}
         >
           <Zap size={10} className="shrink-0 text-accent" aria-hidden="true" />
-          <span className="uppercase tracking-wide text-faint shrink-0">DEPTH</span>
+          <span className="uppercase tracking-wide text-faint shrink-0 status-bar-optional-md">DEPTH</span>
           <span>{taskProfile.profile}</span>
         </span>
       )}
       {sessionGoal && (
         <span
           data-testid="session-goal-chip"
-          className="inline-flex items-center gap-1 max-w-[240px] px-1.5 py-px rounded-full bg-panel2 border border-edge text-txt/90"
+          className="status-bar-optional-xs inline-flex items-center gap-1 max-w-[240px] px-1.5 py-px rounded-full bg-panel2 border border-edge text-txt/90"
           title={`Session GOAL (${sessionGoal.status}): ${sessionGoal.text}`}
         >
           <Target size={10} className="shrink-0 text-accent" aria-hidden="true" />
@@ -462,10 +469,10 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
       )}
       {showUsage && (
         <>
-          <span className="w-px h-3 bg-edge/40" />
-          <span className="flex items-center gap-1.5 text-muted/80" title="Process-wide token usage and estimated cost since app launch (not repo session spend in Swarm pane; survives backend restart; resets on full quit)">
-            <Coins size={10} className="text-faint" />
-            <span>{formatTokens(usage.tokens_used)} tok</span>
+          <span className="w-px h-3 bg-edge/40 shrink-0" />
+          <span className="flex items-center gap-1.5 text-muted/80 min-w-0" title="Process-wide token usage and estimated cost since app launch (not repo session spend in Swarm pane; survives backend restart; resets on full quit)">
+            <Coins size={10} className="text-faint shrink-0" />
+            <span className="status-bar-optional-xs">{formatTokens(usage.tokens_used)} tok</span>
             {(() => {
               const cached = usage.tokens_cached || 0;
               const compacted = usage.tool_output_tokens_saved || 0;
@@ -528,7 +535,7 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
               ].filter(Boolean).join("  ·  ");
               return (
                 <span
-                  className="inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-good/10 border border-good/20 text-good/90"
+                  className="status-bar-optional-sm inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-good/10 border border-good/20 text-good/90"
                   title={`${hit.title} List-price value from model selection, prompt-cache, and compaction (additive, not overlapping cash refunds): ${detail}`}
                 >
                   <span className="text-good/60" aria-hidden="true">&#8595;</span>
@@ -549,7 +556,7 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
             {/* The estimated cost is now a click/hover trigger for a compact
                 routing-value breakdown (why this model / what it saved). It
                 stays a plain figure when there is nothing meaningful to expand. */}
-            <span className="relative inline-flex items-center gap-1" ref={costRef}>
+            <span className="relative inline-flex items-center gap-1 shrink-0" ref={costRef}>
               <button
                 type="button"
                 onClick={() => setCostOpen((v) => !v)}
@@ -569,7 +576,7 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
                 {spendIsEstimated(usage) ? "~" : ""}
                 {formatCost(usage.est_cost_usd)}
               </button>
-              <span className="text-faint/70 normal-case font-sans tracking-normal">process</span>
+              <span className="text-faint/70 normal-case font-sans tracking-normal status-bar-optional-lg">process</span>
               {costOpen && (
                 <div className="absolute bottom-full right-0 mb-1.5 z-50">
                   <CostBreakdown
@@ -636,7 +643,8 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
           </span>
         </>
       )}
-      <div className="flex-1" />
+      </div>
+      <div className="status-bar-cluster status-bar-cluster-end">
       {toast && (
         <span className="flex items-center gap-1.5 px-2 py-0.5 rounded bg-amber-500/10 border border-amber-500/30 text-amber-300/90">
           <span>{toast.message}</span>
@@ -654,18 +662,24 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
           ) : null}
         </span>
       )}
-      <span className="flex items-center gap-1"><Cpu size={10} />{config?.driver?.split(":").pop() || "pilot"}</span>
+      <span className="status-bar-model" title={config?.driver || "pilot"}>
+        <Cpu size={10} className="shrink-0" />
+        <span>{driverLabel}</span>
+      </span>
       {/* Show the ACTIVE model's provider (the driver spec's prefix), not the
           fallback reach. A "provider:model" driver routes through that provider;
           only a bare, unprefixed model actually falls back to reach. Showing
           reach unconditionally made e.g. anthropic:claude-opus read "openrouter". */}
-      <span>{(config?.driver?.includes(":") ? config.driver.split(":")[0] : config?.reach) || ""}</span>
+      {driverProvider ? (
+        <span className="status-bar-optional-md">{driverProvider}</span>
+      ) : null}
       {config?.edit_engine === "agentic" && (
         <span
-          className="flex items-center gap-1 text-good/80"
+          className="flex items-center gap-1 text-good/80 shrink-0"
           title="Standalone: edits and swarms route directly through your provider keys -- no external agent CLI"
         >
-          <Zap size={10} className="text-good/70" />standalone
+          <Zap size={10} className="text-good/70" />
+          <span className="status-bar-optional-md">standalone</span>
         </span>
       )}
       {apply ? (
@@ -689,7 +703,8 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
           <span>update{update.behind ? ` (${update.behind})` : ""}</span>
         </button>
       ) : null}
-      <span className="text-muted/60">{isDesktop() ? "desktop" : "web"}</span>
+      <span className="text-muted/60 status-bar-optional-lg">{isDesktop() ? "desktop" : "web"}</span>
+      </div>
     </div>
   );
 }

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -264,8 +264,8 @@ export default function ComposerDock({
   };
 
   return (
-    <div className="px-6 pb-3 pt-0.5">
-      <div className="max-w-3xl mx-auto">
+    <div className="composer-dock-shell px-6 pb-3 pt-0.5 min-w-0">
+      <div className="max-w-3xl mx-auto min-w-0">
         {wikiPrepared && wikiPrepared.pages.length > 0 && (
           <div className="mb-2 px-2.5 py-1.5 rounded-lg bg-accent/5 border border-accent/20 flex items-center gap-2 text-[11px] text-txt/85">
             <Share2 size={11} className="text-accent shrink-0" />
@@ -548,7 +548,7 @@ export default function ComposerDock({
           onDragOver={handleComposerDragOver}
           onDragLeave={handleComposerDragLeave}
           onDrop={handleComposerDrop}
-          className={`relative bg-panel2/80 border rounded-2xl focus-within:border-edge2 shadow-lg shadow-black/20 transition ${
+          className={`composer-dock relative bg-panel2/80 border rounded-2xl focus-within:border-edge2 shadow-lg shadow-black/20 transition ${
             isDragOver ? "border-accent ring-1 ring-accent" : "border-edge"
           }`}
         >
@@ -951,31 +951,35 @@ export default function ComposerDock({
             onPaste={handlePaste}
             rows={1} placeholder={auto ? "Give the pilot an objective..." : "Message the pilot..."}
             className="w-full bg-transparent px-3 pt-2.5 pb-1 text-[0.8125rem] resize-none focus:outline-none overflow-hidden placeholder:text-faint" />
-          <div className="flex items-center gap-1.5 px-3 pb-2">
-            <button onClick={() => {
+          <div className="composer-toolbar px-3 pb-2">
+            <div className="composer-toolbar-actions">
+            <button type="button" onClick={() => {
               onSetAuto((a) => {
                 const next = !a;
                 if (next) onSetPlan(false);
                 return next;
               });
             }} title="Autopilot: the pilot plans and executes autonomously (vs. you steering each step)"
-              className={`px-1.5 h-[20px] rounded-md text-[10.5px] flex items-center gap-1 transition
+              className={`px-1.5 h-[20px] rounded-md text-[10.5px] flex items-center gap-1 shrink-0 transition
                 ${auto ? "bg-warn/15 text-warn" : "text-faint hover:text-muted"}`}>
-              <Zap size={11} /> Autopilot
+              <Zap size={11} /> <span className="composer-toolbar-label">Autopilot</span>
             </button>
-            <button onClick={() => {
+            <button type="button" onClick={() => {
               onSetPlan((p) => {
                 const next = !p;
                 if (next) onSetAuto(false);
                 return next;
               });
             }} title="Plan mode -- get an actionable plan instead of execution (read-only)"
-              className={`px-1.5 h-[20px] rounded-md text-[10.5px] flex items-center gap-1 transition
+              className={`px-1.5 h-[20px] rounded-md text-[10.5px] flex items-center gap-1 shrink-0 transition
                 ${plan ? "bg-accent/15 text-accent" : "text-faint hover:text-muted"}`}>
-              <ListChecks size={11} /> Plan
+              <ListChecks size={11} /> <span className="composer-toolbar-label">Plan</span>
             </button>
-            <PilotPicker config={config} />
+            <div className="pilot-picker-slot">
+              <PilotPicker config={config} />
+            </div>
             <button
+              type="button"
               onClick={() => {
                 onSetShowContextPanel(!showContextPanel);
                 if (!showContextPanel) {
@@ -983,59 +987,68 @@ export default function ComposerDock({
                 }
               }}
               title="View context window usage breakdown"
-              className={`px-1.5 h-[20px] rounded-md text-[10.5px] font-mono flex items-center gap-1 transition
+              className={`px-1.5 h-[20px] rounded-md text-[10.5px] font-mono flex items-center gap-1 shrink-0 transition
                 ${showContextPanel ? "bg-accent/15 text-accent border border-accent/20" : "text-faint hover:text-muted bg-panel2/40 border border-edge/30 hover:bg-panel2/80"}`}
             >
               <FileText size={11} />
-              <span>
-                {contextUsage
-                  ? `${contextUsagePercent(contextUsage.total, contextUsage.limit)}%`
-                  : "Usage"}
-              </span>
+              {contextUsage ? (
+                <span>{contextUsagePercent(contextUsage.total, contextUsage.limit)}%</span>
+              ) : (
+                <span className="composer-toolbar-label">Usage</span>
+              )}
             </button>
-            <div className="flex-1" />
+            </div>
+            <div className="composer-toolbar-send">
             {input.trim() && (
               <button
+                type="button"
                 onClick={handleQueueAdd}
                 title="Queue: runs after the current turn finishes (same as Cmd/Ctrl+Enter)"
                 className="px-2 h-[20px] rounded-md bg-panel2/60 border border-edge/60 text-faint hover:text-muted hover:border-edge2 text-[10.5px] font-medium flex items-center gap-1 transition"
               >
-                <ListChecks size={9} />Queue
+                <ListChecks size={9} /><span className="composer-toolbar-send-label">Queue</span>
               </button>
             )}
             {composerBusy && input.trim() && (
               <button
+                type="button"
                 onClick={() => send("interrupt")}
                 disabled={editBusy || transcriptStale}
                 title="Stop this turn, then run this prompt next (Alt+Enter)"
+                aria-label="Interrupt"
                 className="px-2 h-[20px] rounded-md bg-panel2/60 border border-edge/60 text-faint hover:text-muted hover:border-edge2 text-[10.5px] font-medium flex items-center gap-1 transition disabled:opacity-40 disabled:cursor-default"
               >
-                Interrupt
+                <span className="composer-toolbar-send-label">Interrupt</span>
               </button>
             )}
             {composerBusy
               ? <>
                   {input.trim() ? (
                     <button
+                      type="button"
                       onClick={() => send()}
                       disabled={editBusy || transcriptStale}
                       title="Steer: redirect the current turn now (Enter). Cmd/Ctrl+Enter or Queue = run after this turn finishes. Alt+Enter or Interrupt = stop this turn, then run this prompt next."
                       className="px-2 h-[20px] rounded-md bg-panel2/60 border border-edge/60 text-faint hover:text-muted hover:border-edge2 text-[10.5px] font-medium flex items-center gap-1 transition disabled:opacity-40 disabled:cursor-default"
                     >
-                      <Send size={9} />Steer
+                      <Send size={9} /><span className="composer-toolbar-send-label">Steer</span>
                     </button>
                   ) : null}
                   <button
+                    type="button"
                     onClick={stop}
                     className="px-2.5 h-[20px] rounded-md bg-risk/15 text-risk text-[10.5px] font-semibold flex items-center gap-1 hover:brightness-110"
                     title="Stop this turn. Does not steer or queue an empty prompt."
+                    aria-label="Stop"
                   >
-                    <Square size={9} />Stop
+                    <Square size={9} /><span className="composer-toolbar-send-label">Stop</span>
                   </button>
                 </>
-              : <button onClick={() => send()} disabled={editBusy || transcriptStale || (!input.trim() && attachedImages.length === 0)}
+              : <button type="button" onClick={() => send()} disabled={editBusy || transcriptStale || (!input.trim() && attachedImages.length === 0)}
+                  aria-label={auto ? "Run" : plan ? "Plan" : "Send"}
                   className="px-2.5 h-[20px] rounded-md bg-accent text-black/90 text-[10.5px] font-semibold flex items-center gap-1 hover:brightness-110 disabled:opacity-40 disabled:cursor-default transition">
-                  <Send size={9} />{auto ? "Run" : plan ? "Plan" : "Send"}</button>}
+                  <Send size={9} /><span className="composer-toolbar-send-label">{auto ? "Run" : plan ? "Plan" : "Send"}</span></button>}
+            </div>
           </div>
         </div>
 

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -61,7 +61,7 @@ export default function ConversationChatColumn({
   onJumpToBottom?: () => void;
 }) {
   return (
-    <div className="flex flex-col flex-1 min-h-0">
+    <div className="chat-column flex flex-col flex-1 min-h-0 min-w-0">
       <div className="relative flex-1 min-h-0 flex flex-col">
         <div
           ref={feedRef}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -85,6 +85,128 @@ body {
   border: 1px solid var(--shell-panel-border);
   background: var(--shell-panel);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  container-type: inline-size;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* Footer + composer yield at narrow widths instead of overlapping. */
+.status-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.status-bar-cluster {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.status-bar-cluster-start {
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.status-bar-cluster-end {
+  flex: 0 1 auto;
+  justify-content: flex-end;
+  overflow: hidden;
+}
+
+.status-bar-model {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 0;
+  max-width: 11rem;
+  overflow: hidden;
+}
+
+.status-bar-model > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-column {
+  container-type: inline-size;
+  min-width: 0;
+}
+
+.composer-dock {
+  container-type: inline-size;
+  min-width: 0;
+}
+
+.composer-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.composer-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+  flex: 1 1 12rem;
+}
+
+.composer-toolbar-send {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+
+.pilot-picker-slot {
+  min-width: 0;
+  flex: 1 1 5rem;
+  max-width: 10.625rem;
+}
+
+@container (max-width: 1180px) {
+  .status-bar-optional-lg { display: none; }
+  .status-bar-model { max-width: 8rem; }
+}
+
+@container (max-width: 980px) {
+  .status-bar,
+  .status-bar-cluster { gap: 0.5rem; }
+  .status-bar-optional-md { display: none; }
+  .status-bar-model { max-width: 6.5rem; }
+}
+
+@container (max-width: 820px) {
+  .status-bar-optional-sm { display: none; }
+}
+
+@container (max-width: 640px) {
+  .status-bar-optional-xs { display: none; }
+  .status-bar-model { max-width: 5rem; }
+}
+
+@container (max-width: 520px) {
+  .composer-dock-shell {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}
+
+@container (max-width: 480px) {
+  .composer-toolbar-label { display: none; }
+  .pilot-picker-slot { max-width: 7.5rem; }
+}
+
+@container (max-width: 360px) {
+  .pilot-picker-slot { max-width: 5.25rem; }
 }
 
 .right-pane-board {


### PR DESCRIPTION
## Summary
- Composer toolbar yields at narrow chat-column widths: Autopilot/Plan go icon-only, the model picker truncates, and Stop/Send stay in a non-shrinking cluster that can wrap.
- Footer splits into overflow-safe start/end clusters and hides secondary labels (`desktop`, `process`, provider, `standalone`) before spend chips and the update pill can collide.
- Version bump to v0.9.239. Pin unchanged: `puppetmaster-ai==1.22.5`.

## Test plan
- [x] Local pytest green (4421 passed)
- [x] Frontend StatusBar + ComposerDock compact-chrome tests
- [ ] CI `tests` green on the merged `main` SHA (3.9, 3.11, Windows, frontend-build) before tag