### PR TITLE
Explore consolidating swarm routing into worker rows

### DIFF
--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -210,12 +210,12 @@ describe("SwarmPane model badge", () => {
 
     render(<SwarmPane />);
 
-    await waitFor(() => {
-      expect(screen.getByTitle("Model: openrouter")).toHaveTextContent("openrouter");
-    });
+    const worker = await screen.findByText("Worker");
+    expect(worker.closest('[role="button"]')).toHaveTextContent("openrouter");
+    expect(screen.queryByTitle("Model: openrouter")).not.toBeInTheDocument();
   });
 
-  it("shows routing placeholder instead of bare agentic while running", async () => {
+  it("shows routing in the worker model slot instead of a separate routing card", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
         adapter: "agentic",
@@ -235,9 +235,9 @@ describe("SwarmPane model badge", () => {
 
     render(<SwarmPane />);
 
-    await waitFor(() => {
-      expect(screen.getByTitle("Model routing in progress")).toHaveTextContent("routing…");
-    });
+    const worker = await screen.findByText("implement (agentic)");
+    expect(worker.closest('[role="button"]')).toHaveTextContent("routing…");
+    expect(screen.queryByTitle("Model routing in progress")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Model: agentic")).not.toBeInTheDocument();
   });
 
@@ -281,12 +281,36 @@ describe("SwarmPane model badge", () => {
       });
 
       render(<SwarmPane />);
-      await waitFor(() => expect(screen.queryByText("(routed-model)")).not.toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText("(routing…)")).toBeInTheDocument());
+      expect(screen.queryByText("(routed-model)")).not.toBeInTheDocument();
       await vi.advanceTimersByTimeAsync(6000);
       await waitFor(() => expect(screen.getByText("(routed-model)")).toBeInTheDocument());
+      expect(screen.queryByText("(routing…)")).not.toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("does not label a terminal worker as routing when no model was recorded", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job-terminal-unrouted", "Terminal worker without model", {
+        tasks: [{
+          id: "task-terminal-unrouted",
+          status: "complete",
+          adapter: "agentic",
+          role: "completed-worker",
+          instruction: "",
+        }],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Terminal worker without model"));
+
+    const worker = await screen.findByText("completed-worker");
+    expect(worker.closest('[role="button"]')).not.toHaveTextContent("routing…");
   });
 });
 
@@ -331,7 +355,7 @@ describe("SwarmPane worker details", () => {
   });
 });
 
-describe("SwarmPane pin attribution", () => {
+describe("SwarmPane artifact presentation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
@@ -340,121 +364,6 @@ describe("SwarmPane pin attribution", () => {
     mockArtifacts.mockResolvedValue([]);
   });
 
-  it("labels explicit_pin routing as Explicit pin · not auto-routed", async () => {
-    mockSwarmLive.mockResolvedValue(
-      liveJob({
-        status: "running",
-        artifacts_complete: true,
-        artifacts: [
-          {
-            type: "ROUTING",
-            headline: "",
-            task_id: "task-1",
-            model: "agentic/meta/muse-spark-1.1",
-            adapter_model_name: "meta/muse-spark-1.1",
-            policy: "explicit_pin",
-            provider: "openrouter",
-            adapter: "agentic",
-            created_by: "router",
-            est_cost_usd: 0.01,
-          },
-        ],
-        tasks: [
-          {
-            id: "task-1",
-            status: "running",
-            role: "Worker",
-            instruction: "",
-            adapter: "agentic",
-          },
-        ],
-      }),
-    );
-
-    render(<SwarmPane />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Explicit pin · not auto-routed")).toBeInTheDocument();
-    });
-    // Collapsed summary keeps the full registry id (not stripped agentic/).
-    expect(screen.getAllByText("agentic/meta/muse-spark-1.1").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("explicit_pin").length).toBeGreaterThan(0);
-    expect(screen.getByText("openrouter · agentic")).toBeInTheDocument();
-    expect(screen.queryByText("Router pick")).not.toBeInTheDocument();
-  });
-
-  it("does not paint a missing routing estimate as $0", async () => {
-    mockSwarmLive.mockResolvedValue(
-      liveJob({
-        status: "running",
-        artifacts_complete: true,
-        artifacts: [
-          {
-            type: "ROUTING",
-            headline: "",
-            task_id: "task-1",
-            model: "agentic/meta/muse-spark-1.1",
-            policy: "explicit_pin",
-            provider: "openrouter",
-            adapter: "agentic",
-            created_by: "router",
-          },
-        ],
-        tasks: [
-          {
-            id: "task-1",
-            status: "running",
-            role: "Worker",
-            instruction: "",
-            adapter: "agentic",
-          },
-        ],
-      }),
-    );
-
-    render(<SwarmPane />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Explicit pin · not auto-routed")).toBeInTheDocument();
-    });
-    expect(screen.getByText("—")).toBeInTheDocument();
-    expect(screen.queryByText("$0")).not.toBeInTheDocument();
-  });
-
-  it("fail-closes missing policy as Pin attribution unknown (not Router pick)", async () => {
-    mockSwarmLive.mockResolvedValue(
-      liveJob({
-        status: "running",
-        artifacts_complete: true,
-        artifacts: [
-          {
-            type: "ROUTING",
-            headline: "",
-            task_id: "task-1",
-            model: "mystery-model",
-            created_by: "router",
-            est_cost_usd: 0.01,
-          },
-        ],
-        tasks: [
-          {
-            id: "task-1",
-            status: "running",
-            role: "Worker",
-            instruction: "",
-            adapter: "agentic",
-          },
-        ],
-      }),
-    );
-
-    render(<SwarmPane />);
-
-    await waitFor(() => {
-      expect(screen.getAllByText("Pin attribution unknown").length).toBeGreaterThanOrEqual(1);
-    });
-    expect(screen.queryByText("Router pick")).not.toBeInTheDocument();
-  });
 
   it("warns FINDING headlines that look like prompt echoes without rewriting them", async () => {
     const echoHeadline = "Role: auditor — find auth bypass paths";
@@ -483,62 +392,6 @@ describe("SwarmPane pin attribution", () => {
   });
 });
 
-describe("SwarmPane routing dedupe", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    localStorage.clear();
-    sessionStorage.clear();
-    clearSWRCache();
-    mockArtifacts.mockResolvedValue([]);
-  });
-
-  it("shows one routing model row per task when router and router-fallback both exist", async () => {
-    // Ground truth: a 5-worker swarm stores 10 ROUTING artifacts (router +
-    // router-fallback per task). Display must show the final choice only.
-    const artifacts = Array.from({ length: 5 }, (_, i) => [
-      {
-        type: "ROUTING",
-        headline: "",
-        task_id: `task-${i}`,
-        model: `initial-model-${i}`,
-        created_by: "router",
-        est_cost_usd: 0.01,
-      },
-      {
-        type: "ROUTING",
-        headline: "",
-        task_id: `task-${i}`,
-        model: `final-model-${i}`,
-        created_by: "router-fallback",
-        est_cost_usd: 0.02,
-      },
-    ]).flat();
-
-    mockSwarmLive.mockResolvedValue(
-      liveJob({
-        status: "running",
-        artifacts,
-        artifacts_complete: true,
-        tasks: Array.from({ length: 5 }, (_, i) => ({
-          id: `task-${i}`,
-          status: "running",
-          role: "Worker",
-          instruction: "",
-          adapter: "agentic",
-        })),
-      }),
-    );
-
-    render(<SwarmPane />);
-
-    await waitFor(() => {
-      expect(screen.getByTitle("Model: final-model-0")).toBeInTheDocument();
-    });
-    expect(screen.queryByText("initial-model-0")).not.toBeInTheDocument();
-    // One expanded routing card per task (5), not 10 router+fallback pairs.
-    expect(screen.getAllByTitle(/^final-model-\d$/)).toHaveLength(5);
-  });
-});
 
 describe("SwarmPane mid-run job-row meters", () => {
   beforeEach(() => {
@@ -751,46 +604,7 @@ describe("SwarmPane mid-run job-row meters", () => {
     expect(parts.total).toBe(0);
   });
 
-  it("renders local-job routing policy label after reload the same as live", async () => {
-    // Persisted local-* jobs carry UI-shaped ROUTING rows (with policy) inline;
-    // running jobs auto-expand so the chip is visible without a click.
-    mockSwarmLive.mockResolvedValue(
-      liveJob({
-        id: "local-1",
-        status: "running",
-        artifacts_complete: true,
-        artifacts: [
-          {
-            type: "ROUTING",
-            headline: "Routed to cheap-model",
-            created_by: "router",
-            model: "cheap-model",
-            policy: "balanced",
-            adapter: "agentic",
-            est_cost_usd: 0.02,
-            detail: "balanced pick",
-            task_id: "local-1-w0",
-          },
-        ],
-        tasks: [
-          {
-            id: "local-1-w0",
-            status: "running",
-            role: "implement (agentic)",
-            instruction: "",
-            adapter: "agentic",
-          },
-        ],
-      }),
-    );
 
-    render(<SwarmPane />);
-    await waitFor(() => {
-      expect(screen.getByText("balanced")).toBeInTheDocument();
-    });
-    expect(screen.getByText(/Right-sized: cheapest model/)).toBeInTheDocument();
-    expect(screen.queryByText("Pin attribution unknown")).not.toBeInTheDocument();
-  });
 });
 
 describe("SwarmPane truthful failed vs cancelled chrome", () => {

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -79,22 +79,6 @@ function routingPolicy(art: Artifact): string {
   return (detail.match(/policy=(\w+)/) || [])[1] || "";
 }
 
-// Turn the router's policy into one plain-language sentence. Fail closed when
-// policy is missing/unparsed: never claim "Router pick" without attestation.
-function summarizeRouting(art: Artifact): string {
-  const detail = typeof art.detail === "string" ? art.detail : "";
-  const policy = routingPolicy(art);
-  const planBilled = /plan-billed|in-subscription/i.test(detail);
-  const lead: Record<string, string> = {
-    balanced: "Right-sized: cheapest model that clears the task's need",
-    cheap: "Cheapest available model",
-    quality: "Highest-capability model for the task",
-    escalating: "Cheapest sufficient model, escalates if it stalls",
-    explicit_pin: "Explicit pin \u00b7 not auto-routed",
-  };
-  const base = lead[policy] || "Pin attribution unknown";
-  return planBilled ? `${base} \u00b7 plan-billed, no marginal cost` : base;
-}
 
 // FINDING headlines that look like the worker echoed its prompt rather than
 // reporting a finding. Warn with a chip; never rewrite the headline itself.
@@ -625,7 +609,6 @@ export default function SwarmPane() {
   const [selectedProjectRoot, setSelectedProjectRoot] = useState(lastSelectedProjectRoot);
   const projectSwitching = useProjectSwitching();
   const [expandedJobs, setExpandedJobs] = useState<Record<string, boolean>>({});
-  const [expandedAlts, setExpandedAlts] = useState<Record<string, boolean>>({});
   const [expandedTasks, setExpandedTasks] = useState<Record<string, boolean>>({});
   const [expandedFindings, setExpandedFindings] = useState<Record<string, boolean>>({});
   // Findings section open/closed per job. Default open (missing key); user toggle sticks.
@@ -998,9 +981,12 @@ export default function SwarmPane() {
       // Adapter chip stays separate; never badge bare agentic/native as model.
       adapterFallback: isEngineOnlyModelId(adapter) ? "" : adapter,
     });
+    // Once canonical task rows exist, they exclusively own worker→model truth.
+    // Keep the job-level model only for jobs that do not expose workers.
+    const headerModel = workerCount === 0 ? displayModel : "";
     const terminal = isTerminal(j);
     const savings = jobSavings(j);
-    const showRoutingPlaceholder = !displayModel && st === "in_progress";
+
 
     const toggle = () => {
       const next = !isExpanded;
@@ -1115,28 +1101,13 @@ export default function SwarmPane() {
               jobs (Cursor MCP, terminal `puppetmaster`) share the workspace
               store and are merged in on purpose; label them so they don't look
               like Marionette-dispatched swarms. */}
-          {(displayModel || showRoutingPlaceholder || workerCount > 0 || adapter || j.source === "cli" || attestedPolicy === "explicit_pin") && (
+          {(headerModel || workerCount > 0 || adapter || j.source === "cli") && (
             <div className="flex items-center gap-1.5 pl-6 pr-1 mt-1 flex-wrap">
-              {displayModel ? (
-                <span className="flex items-center gap-1 text-[9px] font-mono text-accent/90 bg-accent/10 px-1.5 py-0.5 rounded" title={`Model: ${displayModel}`}>
-                  <Cpu size={9} /> {displayModel}
-                </span>
-              ) : showRoutingPlaceholder ? (
-                <span
-                  className="flex items-center gap-1 text-[9px] font-mono text-faint bg-panel2/30 px-1.5 py-0.5 rounded"
-                  title="Model routing in progress"
-                >
-                  <Cpu size={9} /> routing…
+              {headerModel ? (
+                <span className="flex items-center gap-1 text-[9px] font-mono text-accent/90 bg-accent/10 px-1.5 py-0.5 rounded" title={`Model: ${headerModel}`}>
+                  <Cpu size={9} /> {headerModel}
                 </span>
               ) : null}
-              {attestedPolicy === "explicit_pin" && (
-                <span
-                  className="text-[9px] text-faint bg-edge/25 px-1.5 py-0.5 rounded font-mono"
-                  title="Routing policy: explicit_pin (not auto-routed)"
-                >
-                  explicit_pin
-                </span>
-              )}
               {workerCount > 0 && (
                 <span className="text-[9px] text-muted bg-panel2/40 px-1.5 py-0.5 rounded tabular-nums">
                   {workerCount} worker{workerCount > 1 ? "s" : ""}
@@ -1240,82 +1211,6 @@ export default function SwarmPane() {
         {/* Expanded details */}
         {isExpanded && (
           <div className="px-2 pb-2 pt-1 flex flex-col gap-2 bg-panel2/10">
-            {/* Routing */}
-            {routingArts.length > 0 && (
-              <div className="flex flex-col gap-1.5">
-                {routingArts.map((art: Artifact, idx: number) => {
-                  const hasRejected = art.rejected && art.rejected.length > 0;
-                  const key = `${art.id || idx}`;
-                  const altsExpanded = !!expandedAlts[key];
-                  const policyLabel = routingPolicy(art) || "Pin attribution unknown";
-                  const providerLabel = [art.provider, art.adapter]
-                    .map((v) => (typeof v === "string" ? v.trim() : ""))
-                    .filter(Boolean)
-                    .filter((v, i, arr) => arr.indexOf(v) === i)
-                    .join(" · ");
-                  return (
-                    <div key={key} className="p-2 bg-panel2/30 rounded border border-edge/50 text-[10px] flex flex-col gap-1.5">
-                      <div className="flex items-center justify-between text-muted gap-2">
-                        <span className="flex items-center gap-1.5 min-w-0 flex-wrap">
-                          <Cpu size={11} className="text-accent shrink-0" />
-                          <span className="text-txt font-mono font-medium truncate" title={art.model}>
-                            {art.model || "Unknown model"}
-                          </span>
-                          <span
-                            className="text-[8px] text-faint bg-edge/20 px-1 py-0.5 rounded shrink-0 font-mono"
-                            title="Routing policy"
-                          >
-                            {policyLabel}
-                          </span>
-                          {providerLabel && (
-                            <span
-                              className="text-[8px] text-faint bg-edge/20 px-1 py-0.5 rounded shrink-0 font-mono truncate max-w-[140px]"
-                              title={providerLabel}
-                            >
-                              {providerLabel}
-                            </span>
-                          )}
-                        </span>
-                        <span className="font-mono text-good shrink-0 font-semibold">
-                          {formatKnownCost(art.est_cost_usd, true)}
-                        </span>
-                      </div>
-                      {/* One plain-language line on why this model won. */}
-                      <div className="text-[9.5px] text-faint leading-relaxed">
-                        {summarizeRouting(art)}
-                      </div>
-                      {/* Alternatives, deliberately de-emphasized: a muted count,
-                          expanding to model-name chips (full reason on hover)
-                          instead of a red-looking wall of text. */}
-                      {hasRejected && (
-                        <div>
-                          <button
-                            onClick={(e) => { e.stopPropagation(); setExpandedAlts((prev) => ({ ...prev, [key]: !altsExpanded })); }}
-                            className="text-[9px] text-faint/80 hover:text-muted flex items-center gap-0.5 focus:outline-none"
-                          >
-                            {altsExpanded ? <ChevronDown size={9} /> : <ChevronRight size={9} />}
-                            {art.rejected?.length} alternatives considered
-                          </button>
-                          {altsExpanded && (
-                            <div className="mt-1.5 flex flex-wrap gap-1">
-                              {art.rejected?.map((rej: { model: string; reason: string }, ridx: number) => (
-                                <Tooltip
-                                  key={ridx}
-                                  label={rej.reason}
-                                  className="font-mono text-[8.5px] text-faint bg-panel2/30 border border-edge/40 px-1.5 py-0.5 rounded cursor-default"
-                                >
-                                  {rej.model}
-                                </Tooltip>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            )}
 
             {/* Single-worker / provider jobs (run_implement, run_parallel) have
                 NO routing artifact, so the per-worker cost row above never
@@ -1359,6 +1254,7 @@ export default function SwarmPane() {
                     const taskModelLabel = displayModelId(task.model || "", {});
                     const adapterLabel = (task.adapter || "").trim();
                     const secondaryLabel = taskModelLabel
+                      || (ts === "running" && isEngineOnlyModelId(adapterLabel) ? "routing…" : "")
                       || (adapterLabel && !isEngineOnlyModelId(adapterLabel) ? adapterLabel : "");
                     return (
                       <div


### PR DESCRIPTION
## Question

What user-facing purpose should the standalone Routing block serve now that each worker row can show its actual selected model and reveal execution details?

The current block contains real routing provenance, but much of its default presentation repeats information users can already see beside the corresponding worker. The policy explanation is also template-driven, so repeated cards can add visual weight without necessarily helping someone understand the swarm.

This PR proposes one possible answer: keep routing artifacts as durable source data, but consolidate the normal model-selection presentation into the existing worker rows.

## Proposed presentation

- A running worker without a resolved model shows `routing…` in its model position.
- When routing settles, that same task row shows its exact task-scoped model.
- Terminal workers without a recorded model do not continue to appear as routing.
- Jobs with worker rows no longer summarize the swarm with one potentially misleading job-level model.
- Jobs without task rows retain their existing job-level model surface.
- The standalone Routing cards, fixed policy explanation, and rejected-alternative display are removed from the default tracker presentation.

The underlying routing artifacts, task correlation, backend projection, and APIs are unchanged.

## Review focus

This is intended as a product question rather than a claim that routing provenance has no value.

- Is there a concrete user workflow served by keeping Routing as a permanent standalone block?
- If policy, provider, rejected alternatives, or fallback history should remain visible, when and where would they be most useful?
- Is the worker disclosure the right default place to understand worker-to-model selection?
- Are there unmatched or pre-task routing states that require a small exceptional surface?

The PR deliberately does not revisit the routing architecture or force heterogeneous model selection.

## Proof

- [x] RED test established that unresolved model state was shown outside the worker row.
- [x] SwarmPane focused suite: 49 passed on v0.9.239.
- [x] Production TypeScript/Vite build passed.
- [x] Live Marionette product-path swarm verified two completed worker rows with exact task models and no standalone Routing block.
- [x] No backend fields, endpoints, components, or routing behavior added.

A compact live-render screenshot is available for the PR discussion.
