### PR TITLE
Release v0.9.240: durable compacted-history retrieval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.5"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.6"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           # Floor matches the accounting/routing fixes this release needs.
           # Unpinned `puppetmaster-ai` + pip cache can leave CI on an older
           # wheel (e.g. 1.14.0) and fail fallback-pricing regressions.
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.5"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.6"
 
       # full_auto_safety modules already run inside this job via conftest
       # auto-tagging; a separate named job was redundant PR compute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.5"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.6"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.5` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.6` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.5` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.6` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.239, deliberately pre-1.0. Composer and footer chrome yield at narrow widths instead of overlapping. Rides puppetmaster-ai==1.22.5.
+> Status: v0.9.239, deliberately pre-1.0. Composer and footer chrome yield at narrow widths instead of overlapping. Rides puppetmaster-ai==1.22.6.
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.5` (exact registry pins, GPT-5.6 tool reasoning, Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.6` (exact registry pins, GPT-5.6 tool reasoning, Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.6` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.239, deliberately pre-1.0. Composer and footer chrome yield at narrow widths instead of overlapping. Rides puppetmaster-ai==1.22.6.
+> Status: v0.9.240, deliberately pre-1.0. Compacted history remains durably retrievable through bounded session archives. Rides puppetmaster-ai==1.22.6.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.239"
+__version__ = "0.9.240"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/sessions.py
+++ b/harness/api/sessions.py
@@ -101,6 +101,11 @@ def remove_session_transcript(
         except Exception as e:
             diag("server.session_delete_transcript", e, msg=f"sid={safe_sid}")
     try:
+        from ..compaction_archive import remove_compaction_archive
+        remove_compaction_archive(state_dir, safe_sid)
+    except Exception as e:
+        diag("server.session_delete_compaction_archive", e, msg=f"sid={safe_sid}")
+    try:
         from ..session_fts import remove_session_from_index
         remove_session_from_index(state_dir, safe_sid)
     except Exception as e:

--- a/harness/compaction_archive.py
+++ b/harness/compaction_archive.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+"""Session-scoped durable archive of history elided by compaction.
+
+``_maybe_compact_history`` rewrites live history to ``[system, summary] + tail``
+and the subsequent transcript persist writes only that residual. This sidecar
+keeps the elided middle retrievable for ``peek_history`` without changing the
+normal transcript display file.
+
+Layout (same containment as ``save_transcript``):
+    ``{state_dir}/transcripts/{safe_session_id}.archive.json``
+
+Writes are atomic UTF-8 JSON. Residual transcript persist must not touch this
+file. Load/append/remove never raise — corrupt, foreign, or oversized files
+fail closed. Repeated Compact Now must not grow the sidecar without limit:
+append and load both apply oldest/newest retention under explicit message and
+serialized-byte caps.
+"""
+
+import json
+import os
+from typing import Any, Optional
+
+
+ARCHIVE_VERSION = 1
+_ARCHIVE_SUFFIX = ".archive.json"
+
+# Conservative retention: a normal first compaction of a few dozen turns
+# stays under both caps. Repeated Compact Now drops the middle, not the
+# oldest or newest retained rows, and records a synthetic truncation marker.
+ARCHIVE_MAX_MESSAGES = 400
+ARCHIVE_MAX_SERIALIZED_BYTES = 256 * 1024
+# File-level fail-closed cap (indented envelope is larger than compact
+# message JSON). Never json.load an unbounded sidecar.
+ARCHIVE_LOAD_MAX_BYTES = 512 * 1024
+
+ARCHIVE_TRUNCATION_FLAG = "_archive_truncated"
+ARCHIVE_TRUNCATION_PREFIX = "[compaction-archive truncated:"
+
+
+def safe_session_id(session_id: str) -> str:
+    return "".join(c for c in (session_id or "") if c.isalnum() or c in ("-", "_"))
+
+
+def compaction_archive_path(state_dir: str, session_id: str) -> str:
+    safe_sid = safe_session_id(session_id)
+    if not state_dir or not safe_sid:
+        return ""
+    return os.path.join(state_dir, "transcripts", f"{safe_sid}{_ARCHIVE_SUFFIX}")
+
+
+def _copy_messages(messages: Any) -> list[dict]:
+    copied: list[dict] = []
+    if not isinstance(messages, list):
+        return copied
+    for raw in messages:
+        if not isinstance(raw, dict):
+            continue
+        try:
+            item = json.loads(json.dumps(raw, default=str))
+        except Exception:
+            item = {
+                "role": str(raw.get("role") or ""),
+                "content": raw.get("content") if isinstance(raw.get("content"), (str, list)) else str(raw.get("content") or ""),
+            }
+        if isinstance(item, dict):
+            copied.append(item)
+    return copied
+
+
+def _serialized_message_bytes(messages: list[dict]) -> int:
+    try:
+        return len(json.dumps(messages, default=str).encode("utf-8"))
+    except Exception:
+        return ARCHIVE_MAX_SERIALIZED_BYTES + 1
+
+
+def _fits_retention(messages: list[dict]) -> bool:
+    return (
+        len(messages) <= ARCHIVE_MAX_MESSAGES
+        and _serialized_message_bytes(messages) <= ARCHIVE_MAX_SERIALIZED_BYTES
+    )
+
+
+def _truncation_marker(omitted: int) -> dict:
+    omitted = max(0, int(omitted))
+    return {
+        "role": "system",
+        "content": (
+            f"{ARCHIVE_TRUNCATION_PREFIX} omitted {omitted} messages "
+            f"to stay within {ARCHIVE_MAX_MESSAGES} messages / "
+            f"{ARCHIVE_MAX_SERIALIZED_BYTES} serialized bytes]"
+        ),
+        ARCHIVE_TRUNCATION_FLAG: True,
+    }
+
+
+def retain_archive_messages(messages: Any) -> list[dict]:
+    """Keep oldest + newest rows under both caps. No-op for small archives.
+
+    When rows must be dropped, a single synthetic marker is inserted between
+    the retained prefix and suffix. Prior markers are stripped so repeated
+    appends do not accumulate truncation rows.
+    """
+    cleaned = [
+        item for item in _copy_messages(messages)
+        if not item.get(ARCHIVE_TRUNCATION_FLAG)
+    ]
+    if _fits_retention(cleaned):
+        return cleaned
+    n = len(cleaned)
+    if n == 0:
+        return []
+
+    # Leave one slot for the marker. Prefer keeping more real rows, then
+    # shrink until the serialized-byte cap also fits.
+    max_keep = max(0, min(n - 1, ARCHIVE_MAX_MESSAGES - 1))
+    for keep in range(max_keep, -1, -1):
+        oldest_n = keep // 2
+        newest_n = keep - oldest_n
+        omitted = n - oldest_n - newest_n
+        head = cleaned[:oldest_n]
+        tail = cleaned[n - newest_n:] if newest_n else []
+        result = head + [_truncation_marker(omitted)] + tail
+        if _fits_retention(result):
+            return result
+
+    marker = [_truncation_marker(n)]
+    return marker if _fits_retention(marker) else []
+
+
+def _atomic_write_json(path: str, data: dict) -> None:
+    parent = os.path.dirname(path)
+    os.makedirs(parent, exist_ok=True)
+    tmp = path + ".tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(data, handle, indent=2)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _load_archive_document(state_dir: str, session_id: str) -> Optional[dict]:
+    path = compaction_archive_path(state_dir, session_id)
+    if not path or not os.path.isfile(path):
+        return None
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return None
+    if size > ARCHIVE_LOAD_MAX_BYTES:
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("version") != ARCHIVE_VERSION:
+        return None
+    messages = data.get("messages")
+    if messages is not None and not isinstance(messages, list):
+        return None
+    return data
+
+
+def load_compaction_archive_messages(state_dir: str, session_id: str) -> list[dict]:
+    """Return archived elided rows. Missing, corrupt, or oversized files yield ``[]``."""
+    try:
+        data = _load_archive_document(state_dir, session_id)
+        if data is None:
+            return []
+        messages = _copy_messages(data.get("messages") or [])
+        # Already-bounded documents keep their truncation marker. Re-retain
+        # only when a pre-cap sidecar still exceeds the live limits.
+        if _fits_retention(messages):
+            return messages
+        return retain_archive_messages(messages)
+    except Exception:
+        return []
+
+
+def append_compaction_archive(
+    state_dir: str,
+    session_id: str,
+    messages: Any,
+) -> bool:
+    """Append elided rows before a history rewrite. Never raises.
+
+    Subsequent residual transcript writes use a different filename and must
+    not replace this sidecar. A later compaction appends; it does not replace
+    earlier elided rows, but both append and load apply retention so the
+    sidecar cannot grow without limit.
+    """
+    try:
+        safe_sid = safe_session_id(session_id)
+        if not state_dir or not safe_sid:
+            return False
+        incoming = _copy_messages(messages)
+        if not incoming:
+            return False
+        existing = _load_archive_document(state_dir, session_id)
+        prior = _copy_messages((existing or {}).get("messages") or [])
+        retained = retain_archive_messages(prior + incoming)
+        if not retained:
+            return False
+        payload = {
+            "version": ARCHIVE_VERSION,
+            "session_id": safe_sid,
+            "messages": retained,
+            "truncated": any(item.get(ARCHIVE_TRUNCATION_FLAG) for item in retained),
+        }
+        _atomic_write_json(compaction_archive_path(state_dir, safe_sid), payload)
+        return True
+    except Exception:
+        return False
+
+
+def remove_compaction_archive(state_dir: str, session_id: str) -> None:
+    """Delete the session archive (and a leftover tmp). Never raises."""
+    try:
+        path = compaction_archive_path(state_dir, session_id)
+        if not path:
+            return
+        trans_dir = os.path.abspath(os.path.join(state_dir, "transcripts"))
+        for candidate in (path, path + ".tmp"):
+            abs_path = os.path.abspath(candidate)
+            if not abs_path.startswith(trans_dir):
+                continue
+            if os.path.exists(abs_path):
+                try:
+                    os.remove(abs_path)
+                except OSError:
+                    pass
+    except Exception:
+        return

--- a/harness/compaction_mixin.py
+++ b/harness/compaction_mixin.py
@@ -1152,6 +1152,20 @@ class CompactionContextMixin:
         chars_before = sum(len(str(m.get("content") or "")) for m in middle_block)
         chars_after = len(summary_msg["content"])
 
+        # Persist the elided middle before the rewrite so peek_history can
+        # still address those rows after residual transcript persist. Fail
+        # closed: archive I/O must not block or crash Compact Now.
+        try:
+            from .compaction_archive import append_compaction_archive
+
+            append_compaction_archive(
+                getattr(self, "state_dir", "") or "",
+                getattr(self, "harness_session_id", None) or "default",
+                middle_block,
+            )
+        except Exception:
+            pass
+
         self._history[:] = [self._history[0], summary_msg] + recent_block
         # Compaction replaces the middle with a summary; new length usually
         # differs but not guaranteed (a tiny middle replaced by a summary_msg

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -921,29 +921,45 @@ class ToolDispatchMixin:
         sid = (getattr(self, "harness_session_id", None) or "").strip() or "default"
         state_dir = getattr(self, "state_dir", None) or getattr(self.config, "state_dir", "") or ""
         messages: list = []
+        archive: list = []
+        try:
+            from .compaction_archive import load_compaction_archive_messages
+
+            archive = load_compaction_archive_messages(state_dir, sid)
+        except Exception:
+            archive = []
+        disk_messages: list = []
         try:
             data = load_transcript(state_dir, sid)
             if isinstance(data, dict):
-                messages = list(data.get("history") or [])
+                disk_messages = list(data.get("history") or [])
             elif isinstance(data, list):
-                messages = list(data)
+                disk_messages = list(data)
         except Exception:
-            messages = []
-        if not messages:
-            try:
-                export = getattr(self, "export_transcript_data", None)
-                if callable(export):
-                    data = export()
-                    if isinstance(data, dict):
-                        messages = list(data.get("history") or [])
-                if not messages:
-                    history = list(getattr(self, "_history", []) or [])
-                    messages = [
-                        m for m in history
-                        if isinstance(m, dict) and m.get("role") != "system"
-                    ]
-            except Exception:
-                messages = []
+            disk_messages = []
+        live_messages: list = []
+        try:
+            export = getattr(self, "export_transcript_data", None)
+            if callable(export):
+                data = export()
+                if isinstance(data, dict):
+                    live_messages = list(data.get("history") or [])
+            if not live_messages:
+                history = list(getattr(self, "_history", []) or [])
+                live_messages = [
+                    m for m in history
+                    if isinstance(m, dict) and m.get("role") != "system"
+                ]
+        except Exception:
+            live_messages = []
+        # When an archive exists, residual must be the post-compact tail
+        # (live first) so a stale pre-compact transcript is not concatenated
+        # on top of the elided rows. Without an archive, keep preferring disk.
+        if archive:
+            residual = live_messages or disk_messages
+            messages = list(archive) + residual
+        else:
+            messages = disk_messages or live_messages
 
         if role_filter:
             messages = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.239"
+version = "0.9.240"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.5" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.6" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.5"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.6"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.5" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.6" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.5}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.6}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/tests/test_compaction_archive.py
+++ b/tests/test_compaction_archive.py
@@ -1,0 +1,210 @@
+"""Session-scoped compaction archive sidecar."""
+from __future__ import annotations
+
+import json
+
+from harness.api.sessions import remove_session_transcript
+from harness.compaction_archive import (
+    ARCHIVE_LOAD_MAX_BYTES,
+    ARCHIVE_MAX_MESSAGES,
+    ARCHIVE_MAX_SERIALIZED_BYTES,
+    ARCHIVE_TRUNCATION_FLAG,
+    ARCHIVE_TRUNCATION_PREFIX,
+    append_compaction_archive,
+    compaction_archive_path,
+    load_compaction_archive_messages,
+    remove_compaction_archive,
+    retain_archive_messages,
+)
+from harness.sessions import save_transcript
+
+
+def test_append_survives_residual_transcript_persist(tmp_path):
+    state_dir = str(tmp_path)
+    sid = "sess_archive"
+    assert append_compaction_archive(
+        state_dir,
+        sid,
+        [{"role": "user", "content": "elided-middle"}],
+    )
+    save_transcript(
+        state_dir,
+        sid,
+        {
+            "history": [{"role": "user", "content": "residual-tail"}],
+            "display": [],
+            "job_ids": [],
+        },
+    )
+    rows = load_compaction_archive_messages(state_dir, sid)
+    assert [m.get("content") for m in rows] == ["elided-middle"]
+
+
+def test_append_does_not_replace_prior_elided_rows(tmp_path):
+    state_dir = str(tmp_path)
+    sid = "sess_archive_gen"
+    append_compaction_archive(state_dir, sid, [{"role": "user", "content": "gen-1"}])
+    append_compaction_archive(state_dir, sid, [{"role": "user", "content": "gen-2"}])
+    rows = load_compaction_archive_messages(state_dir, sid)
+    assert [m.get("content") for m in rows] == ["gen-1", "gen-2"]
+
+
+def test_corrupt_archive_fails_closed(tmp_path):
+    state_dir = str(tmp_path)
+    sid = "sess_bad"
+    path = compaction_archive_path(state_dir, sid)
+    from pathlib import Path
+
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("{nope", encoding="utf-8")
+    assert load_compaction_archive_messages(state_dir, sid) == []
+    # A later append replaces the unreadable sidecar with valid rows.
+    assert append_compaction_archive(state_dir, sid, [{"role": "user", "content": "recovered"}])
+    assert [m.get("content") for m in load_compaction_archive_messages(state_dir, sid)] == [
+        "recovered"
+    ]
+
+
+def test_session_isolation_and_traversal(tmp_path):
+    state_dir = str(tmp_path)
+    append_compaction_archive(state_dir, "alpha", [{"role": "user", "content": "secret-a"}])
+    append_compaction_archive(state_dir, "beta", [{"role": "user", "content": "secret-b"}])
+    assert [m.get("content") for m in load_compaction_archive_messages(state_dir, "alpha")] == [
+        "secret-a"
+    ]
+    assert [m.get("content") for m in load_compaction_archive_messages(state_dir, "beta")] == [
+        "secret-b"
+    ]
+    # Same sanitizer as save_transcript: "../alpha" collapses to "alpha".
+    assert [m.get("content") for m in load_compaction_archive_messages(state_dir, "../alpha")] == [
+        "secret-a"
+    ]
+    assert append_compaction_archive(state_dir, "../etc/passwd", [{"role": "user", "content": "x"}])
+    from pathlib import Path
+
+    trans = Path(state_dir) / "transcripts"
+    written = list(trans.glob("*.archive.json"))
+    assert written
+    for path in written:
+        assert path.parent == trans
+        assert ".." not in path.name
+    assert not (Path(state_dir) / "etc").exists()
+
+
+def test_remove_session_transcript_clears_archive(tmp_path):
+    state_dir = str(tmp_path)
+    sid = "sess_clear"
+    append_compaction_archive(state_dir, sid, [{"role": "user", "content": "gone"}])
+    save_transcript(state_dir, sid, {"history": [], "display": [], "job_ids": []})
+    archive = compaction_archive_path(state_dir, sid)
+    from pathlib import Path
+
+    assert Path(archive).is_file()
+    remove_session_transcript(sid, state_dir=state_dir)
+    assert not Path(archive).exists()
+    assert load_compaction_archive_messages(state_dir, sid) == []
+    remove_compaction_archive(state_dir, sid)  # idempotent
+
+
+def test_small_session_is_not_truncated(tmp_path):
+    state_dir = str(tmp_path)
+    sid = "sess_small"
+    rows = [{"role": "user", "content": f"keep-{i}"} for i in range(6)]
+    assert append_compaction_archive(state_dir, sid, rows)
+    loaded = load_compaction_archive_messages(state_dir, sid)
+    assert [m.get("content") for m in loaded] == [f"keep-{i}" for i in range(6)]
+    assert not any(m.get(ARCHIVE_TRUNCATION_FLAG) for m in loaded)
+
+
+def test_message_cap_keeps_oldest_and_newest_with_marker(tmp_path, monkeypatch):
+    import harness.compaction_archive as archive_mod
+
+    monkeypatch.setattr(archive_mod, "ARCHIVE_MAX_MESSAGES", 8)
+    monkeypatch.setattr(archive_mod, "ARCHIVE_MAX_SERIALIZED_BYTES", 64 * 1024)
+    monkeypatch.setattr(archive_mod, "ARCHIVE_LOAD_MAX_BYTES", 128 * 1024)
+    state_dir = str(tmp_path)
+    sid = "sess_msg_cap"
+    incoming = [{"role": "user", "content": f"row-{i}"} for i in range(20)]
+    assert append_compaction_archive(state_dir, sid, incoming)
+    loaded = load_compaction_archive_messages(state_dir, sid)
+    assert len(loaded) <= 8
+    assert any(m.get(ARCHIVE_TRUNCATION_FLAG) for m in loaded)
+    assert any(
+        isinstance(m.get("content"), str) and m["content"].startswith(ARCHIVE_TRUNCATION_PREFIX)
+        for m in loaded
+    )
+    contents = [m.get("content") for m in loaded if not m.get(ARCHIVE_TRUNCATION_FLAG)]
+    assert contents[0] == "row-0"
+    assert contents[-1] == "row-19"
+    assert "row-10" not in contents
+
+
+def test_byte_cap_bounds_sidecar_and_signals_truncation(tmp_path, monkeypatch):
+    import harness.compaction_archive as archive_mod
+
+    monkeypatch.setattr(archive_mod, "ARCHIVE_MAX_MESSAGES", 400)
+    monkeypatch.setattr(archive_mod, "ARCHIVE_MAX_SERIALIZED_BYTES", 800)
+    monkeypatch.setattr(archive_mod, "ARCHIVE_LOAD_MAX_BYTES", 8 * 1024)
+    state_dir = str(tmp_path)
+    sid = "sess_byte_cap"
+    incoming = [{"role": "user", "content": f"blob-{i}-" + ("x" * 120)} for i in range(20)]
+    assert append_compaction_archive(state_dir, sid, incoming)
+    loaded = load_compaction_archive_messages(state_dir, sid)
+    assert any(m.get(ARCHIVE_TRUNCATION_FLAG) for m in loaded)
+    serialized = json.dumps(loaded, default=str).encode("utf-8")
+    assert len(serialized) <= 800
+    assert len(loaded) < 20
+    from pathlib import Path
+
+    path = Path(compaction_archive_path(state_dir, sid))
+    assert path.stat().st_size <= 8 * 1024
+    contents = [m.get("content") for m in loaded if not m.get(ARCHIVE_TRUNCATION_FLAG)]
+    assert contents[0].startswith("blob-0-")
+    assert contents[-1].startswith("blob-19-")
+
+
+def test_oversized_sidecar_fails_closed_on_load(tmp_path, monkeypatch):
+    import harness.compaction_archive as archive_mod
+
+    monkeypatch.setattr(archive_mod, "ARCHIVE_LOAD_MAX_BYTES", 300)
+    state_dir = str(tmp_path)
+    sid = "sess_huge"
+    path = compaction_archive_path(state_dir, sid)
+    from pathlib import Path
+
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(
+        '{"version": 1, "session_id": "sess_huge", "messages": ['
+        + f'{{"role":"user","content":"{"pad" * 200}"}}'
+        + "]}",
+        encoding="utf-8",
+    )
+    assert Path(path).stat().st_size > 300
+    assert load_compaction_archive_messages(state_dir, sid) == []
+    # A later append replaces the oversized sidecar with a bounded document.
+    assert append_compaction_archive(state_dir, sid, [{"role": "user", "content": "recovered"}])
+    assert [m.get("content") for m in load_compaction_archive_messages(state_dir, sid)] == [
+        "recovered"
+    ]
+
+
+def test_real_caps_bound_repeated_appends(tmp_path):
+    state_dir = str(tmp_path)
+    sid = "sess_real_cap"
+    for wave in range(0, ARCHIVE_MAX_MESSAGES + 40, 40):
+        batch = [{"role": "user", "content": f"w{wave}-{i}"} for i in range(40)]
+        assert append_compaction_archive(state_dir, sid, batch)
+    loaded = load_compaction_archive_messages(state_dir, sid)
+    assert len(loaded) <= ARCHIVE_MAX_MESSAGES
+    assert any(m.get(ARCHIVE_TRUNCATION_FLAG) for m in loaded)
+    contents = [m.get("content") for m in loaded if not m.get(ARCHIVE_TRUNCATION_FLAG)]
+    assert contents[0] == "w0-0"
+    assert contents[-1].startswith("w")
+
+
+def test_retain_helper_is_noop_under_caps():
+    rows = [{"role": "user", "content": "a"}, {"role": "assistant", "content": "b"}]
+    assert retain_archive_messages(rows) == rows
+    assert ARCHIVE_MAX_MESSAGES >= 8
+    assert ARCHIVE_MAX_SERIALIZED_BYTES >= 1024
+    assert ARCHIVE_LOAD_MAX_BYTES >= ARCHIVE_MAX_SERIALIZED_BYTES

--- a/tests/test_peek_tools.py
+++ b/tests/test_peek_tools.py
@@ -3,9 +3,31 @@ from __future__ import annotations
 
 import tempfile
 
+from harness.compaction_archive import compaction_archive_path
 from harness.config import HarnessConfig
 from harness.pilot import PilotAction, from_wire
-from harness.sessions import save_transcript
+from harness.sessions import load_transcript, save_transcript
+
+_GOOD_SUMMARY = (
+    "## Historical Task Snapshot\n"
+    "Compaction fixture summary with enough seed characters to pass guards.\n"
+    "## Resolved\nPrior turns were compacted for the unit test.\n"
+    "## Pending / Open Questions\nNone.\n"
+    "## Key Facts / Decisions / Files\ntests/test_peek_tools.py\n"
+)
+
+
+class _CompactPilot:
+    name = "mock"
+
+    def __init__(self, return_text=_GOOD_SUMMARY):
+        self.return_text = return_text
+
+    def chat(self, messages, tools=None, system=None):
+        return type("Resp", (), {"text": self.return_text, "error": None, "tokens_out": 10})()
+
+    def complete(self, prompt, system=None):
+        return type("Resp", (), {"text": self.return_text, "error": None, "tokens_out": 10})()
 
 
 def _session(tmp_path, monkeypatch, state_dir: str | None = None):
@@ -23,17 +45,122 @@ def _session(tmp_path, monkeypatch, state_dir: str | None = None):
     return session, sd
 
 
-def test_peek_history_reads_durable_transcript_after_compact(tmp_path, monkeypatch):
+def _compactable_history(session):
+    session._history = [{"role": "system", "content": "sys"}]
+    session._history.append({
+        "role": "user",
+        "content": "UNIQUE-ELIDED-MARKER early topic alpha",
+    })
+    session._history.append({
+        "role": "assistant",
+        "content": "UNIQUE-ELIDED-REPLY acknowledged alpha",
+    })
+    for i in range(10):
+        session._history.append({
+            "role": "user",
+            "content": f"User message number {i}: " + ("A" * 150),
+        })
+        session._history.append({
+            "role": "assistant",
+            "content": f"Assistant response number {i}: " + ("B" * 150),
+        })
+    session._history.append({
+        "role": "user",
+        "content": "UNIQUE-TAIL-MARKER latest ask",
+    })
+    session._history.append({
+        "role": "assistant",
+        "content": "UNIQUE-TAIL-REPLY latest answer",
+    })
+
+
+def test_peek_history_reads_elided_rows_after_real_compact_and_persist(tmp_path, monkeypatch):
+    """Exercise the real compact + residual persist path, not an in-memory fixture."""
+    monkeypatch.setattr("harness.compaction_mixin.MIN_COMPACTABLE_TOKENS", 0)
+    session, state_dir = _session(tmp_path, monkeypatch)
+    session.harness_session_id = "sess_peek_real"
+    session.pilot = _CompactPilot()
+    _compactable_history(session)
+
+    events = list(session._maybe_compact_history(force=True))
+    assert [e.kind for e in events] == ["compacting", "compaction"]
+    assert events[-1].data.get("aborted") is not True
+
+    save_transcript(state_dir, session.harness_session_id, session.export_transcript_data())
+    persisted = load_transcript(state_dir, session.harness_session_id)
+    residual = list((persisted or {}).get("history") or [])
+    residual_text = " ".join(str(m.get("content") or "") for m in residual)
+    assert "UNIQUE-ELIDED-MARKER" not in residual_text
+    assert "UNIQUE-TAIL-MARKER" in residual_text or "UNIQUE-TAIL-REPLY" in residual_text
+
+    ok, status, head = session._do_peek_history(
+        PilotAction(kind="peek_history", arguments={"offset": 0, "limit": 5})
+    )
+    assert ok and status == "success"
+    assert "compaction_generation=" in head
+    assert "UNIQUE-ELIDED-MARKER" in head
+
+    total = 0
+    for line in head.splitlines():
+        if line.startswith("offset="):
+            for part in line.split():
+                if part.startswith("total="):
+                    total = int(part.split("=", 1)[1])
+    assert total > 5
+    ok_tail, status_tail, tail = session._do_peek_history(
+        PilotAction(
+            kind="peek_history",
+            arguments={"offset": max(0, total - 5), "limit": 5},
+        )
+    )
+    assert ok_tail and status_tail == "success"
+    assert "UNIQUE-TAIL-MARKER" in tail or "UNIQUE-TAIL-REPLY" in tail
+
+    generation = session._compaction_generation()
+    assert generation >= 1
+    ok_stale, status_stale, err = session._do_peek_history(
+        PilotAction(kind="peek_history", arguments={"expected_generation": generation + 7})
+    )
+    assert not ok_stale
+    assert status_stale == "stale_generation"
+    assert "stale" in err
+
+
+def test_peek_history_corrupt_archive_fails_closed(tmp_path, monkeypatch):
+    session, state_dir = _session(tmp_path, monkeypatch)
+    session.harness_session_id = "sess_peek_corrupt"
+    sid = session.harness_session_id
+    save_transcript(
+        state_dir,
+        sid,
+        {
+            "history": [{"role": "user", "content": "live-residual-ok"}],
+            "display": [],
+            "job_ids": [],
+        },
+    )
+    archive_path = compaction_archive_path(state_dir, sid)
+    from pathlib import Path
+
+    Path(archive_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(archive_path).write_text("{this is not json", encoding="utf-8")
+
+    ok, status, text = session._do_peek_history(
+        PilotAction(kind="peek_history", arguments={"offset": 0, "limit": 5})
+    )
+    assert ok and status == "success"
+    assert "live-residual-ok" in text
+
+
+def test_peek_history_reads_durable_transcript_without_archive(tmp_path, monkeypatch):
     session, state_dir = _session(tmp_path, monkeypatch)
     session.harness_session_id = "sess_peek"
     sid = session.harness_session_id
-    # Persist a durable transcript larger than the live residual.
     history = [
         {"role": "user", "content": f"turn-{i} detail about topic {i}"}
         for i in range(12)
     ]
     save_transcript(state_dir, sid, {"history": history, "display": [], "job_ids": []})
-    # Live residual looks compacted / short.
     session._history = [
         {"role": "system", "content": "sys"},
         {"role": "user", "content": "summary only"},

--- a/tests/test_state_scoping_invariants.py
+++ b/tests/test_state_scoping_invariants.py
@@ -310,8 +310,14 @@ def test_session_delete_removes_metadata_and_transcript(tmp_path):
     meta = store.create("Doomed", repo=str(tmp_path), workspace_root=str(tmp_path))
     sid = meta["id"]
     save_transcript(str(state_dir), sid, {"display": [{"role": "user", "text": "hi"}]})
+    from harness.compaction_archive import append_compaction_archive, compaction_archive_path
+
+    append_compaction_archive(str(state_dir), sid, [{"role": "user", "content": "elided"}])
     transcript = state_dir / "transcripts" / f"{sid}.json"
+    archive = state_dir / "transcripts" / f"{sid}.archive.json"
     assert transcript.is_file()
+    assert archive.is_file()
+    assert compaction_archive_path(str(state_dir), sid) == str(archive)
 
     class _Runners:
         def drop(self, _sid):
@@ -331,6 +337,7 @@ def test_session_delete_removes_metadata_and_transcript(tmp_path):
     assert body["ok"] is True
     assert sid not in {s["id"] for s in store.rows()}
     assert not transcript.exists()
+    assert not archive.exists()
 
 
 def test_remove_session_transcript_is_idempotent(tmp_path):

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.5";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.6";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.5";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.6";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 
 // True when `pip show` / `uv pip show` output describes an editable install
@@ -43,7 +43,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.5" }     -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.6" }     -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -65,7 +65,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.5).
+ * to 1.22.6).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.239",
+  "version": "0.9.240",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.239",
+      "version": "0.9.240",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.239",
+  "version": "0.9.240",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- preserve elided conversation rows in bounded, session-scoped archives so `peek_history` remains truthful after compaction persistence
- clean archives with session deletion and fail closed on corrupt or oversized sidecars
- align CI, installers, doctors, and Electron defaults on `puppetmaster-ai==1.22.6`
- bump Marionette to v0.9.240

The residual catalog/hybrid experiment and benchmark are intentionally excluded from this release.

## Test plan
- [x] `./.venv/bin/python -m pytest -q` — 4434 passed, 74 skipped
- [x] `npm test` — 1008 passed
- [x] `npm run test:electron` — 148 passed
- [x] `npm run build`
- [ ] GitHub `tests` workflow green on the exact merged `main` SHA before tagging