### PR TITLE
Release v0.9.241: worker-owned routing and residual lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.6` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.240, deliberately pre-1.0. Compacted history remains durably retrievable through bounded session archives. Rides puppetmaster-ai==1.22.6.
+> Status: v0.9.241, deliberately pre-1.0. Swarm workers own their model-routing receipt, and opt-in residual labs compare bounded compaction representations without changing the production default. Rides puppetmaster-ai==1.22.6.
 
 ## Documentation
 

--- a/docs/COMPACTION_RESIDUAL_LAB.md
+++ b/docs/COMPACTION_RESIDUAL_LAB.md
@@ -1,0 +1,183 @@
+# Compaction Residual Lab
+
+Whitepaper extension for the completed Layer-0 compaction-residual experiment.
+This note records what shipped as an opt-in lab, what the hermetic battery
+measured, and what is still required before any production-default change.
+
+## Status and question
+
+This is an opt-in Layer-0 lab, not a production-default recommendation. The
+shipping residual remains the existing causal summary. Catalog, hybrid, and
+`off` exist so a fixture-level comparison can be run without changing default
+behavior.
+
+Research question: can a bounded deterministic handle catalog preserve buried
+facts at lower residual cost than the existing causal summary, with
+archive-backed `peek_history` as a fallback?
+
+## Implemented seams
+
+`HARNESS_COMPACTION_RESIDUAL` selects how `_maybe_compact_history` rewrites the
+compacted middle (`harness/compaction_residual.py`):
+
+| Value | Role |
+| --- | --- |
+| `summary` | Default. Empty, missing, or unknown values also fall back here — never to `off`. |
+| `catalog` | Deterministic unique-handle index extracted from the pruned middle. |
+| `hybrid` | Existing extractive four-heading body plus a capped handle index. |
+| `off` | Explicit no-compaction test ceiling. Must be set; it is never inferred. |
+
+Catalog and hybrid are extractive and bounded. They collect unique files, tool
+names, durable URIs (`spill://`, `artifact://`, `job://`), and
+error/decision/constraint stems. Hybrid keeps the four causal headings
+(`## Historical Task Snapshot`, `## Resolved`, `## Pending / Open Questions`,
+`## Key Facts / Decisions / Files`) and appends `## Unique handles`. Neither
+path invents turn IDs or peek offsets. Copied residual text is redacted for
+likely secrets.
+
+Wave 1 archive sidecar (`harness/compaction_archive.py`):
+
+- Path: `{state_dir}/transcripts/{session}.archive.json` (session-scoped;
+  same containment as `save_transcript`).
+- Writes are atomic UTF-8 JSON. Residual transcript persist does not replace
+  this file.
+- `peek_history` composes archive + residual. When an archive exists, the
+  residual is the live post-compact tail first so a stale pre-compact
+  transcript is not concatenated on top of elided rows. Callers may pass
+  `expected_generation`; a mismatch returns `stale_generation`.
+- Corrupt, foreign-version, or oversized sidecars fail closed (empty archive,
+  no raise). Load refuses files above 512 KiB.
+- Retention keeps oldest + newest rows under 400 messages / 256 KiB
+  serialized bytes. When rows must drop, a single truncation marker is
+  inserted; prior markers are stripped so repeated Compact Now cannot grow
+  the sidecar without limit.
+- Session deletion (`remove_session_transcript`) removes the archive beside
+  the transcript.
+
+## Method
+
+The labeled battery lives in `pmharness/compaction_residual_battery.py`. Seven
+deterministic cases bury a fact in a long-session middle, then probe whether
+the residual (and, for arm C, archive-backed peek) still carries it:
+
+1. **Early constraint** — write-path constraint (`never write to production.db`;
+   `scratch.sqlite`) placed before filler turns.
+2. **Mid-session file path** — `src/billing/ledger_v3.py` read via a tool call
+   with `_read_path`.
+3. **Reversed decision** — later `Decision: use SQLite instead of Redis`
+   must survive the earlier Redis candidate.
+4. **Error-tail fact** — `ERROR: ... secret-policy.yaml ... E-7721` in a
+   tool result.
+5. **Spill / artifact handles** — `spill://`, `artifact://`, and `job://`
+   URIs retained as durable handles.
+6. **Distractor twin** — active `auth_current_v2.py` versus retired
+   `auth_legacy_v1.py`. The retired name is a false-recall guard, not a
+   fabrication token.
+7. **Catalog-miss plain fact** — measurement tokens
+   (`omega-cache-token-9f3a`, `shard-omega-p95`) with no path or URI shape.
+   The catalog is designed to miss this case so arm C can measure peek lift
+   separately from residual recall.
+
+Arms:
+
+| Arm | Residual | Compaction | Peek |
+| --- | --- | --- | --- |
+| A | `summary` | yes | no — scripted-summary omission control |
+| B | `catalog` | yes | no |
+| C | `catalog` | yes | yes — real archive-backed `peek_history` |
+| D | `off` | no | no — no-compaction ceiling |
+
+The runner (`pmharness/compaction_residual_bench.py`) drives
+`ConversationalSession._maybe_compact_history(force=True)`. It does not use
+the single-shot episode rig (`pmharness.run_episode` does not compact
+conversations) or `CassetteDriver` (its request hash includes the residual).
+
+Scoring is stdlib substring oracles: `must_contain` is all-of, not any-of;
+`must_not_contain` is a false-recall guard. Arm C splits residual vs peek so
+a peek-only recovery is credited without blending the two channels into one
+blob. Receipts record residual tokens, peek calls, and peek tokens. Default
+execution uses no API keys.
+
+## Results
+
+Full battery, this workspace: 28 receipts, 19 successful end-task receipts.
+
+| Arm | End-task success | Residual recall | Notes | Avg residual tokens | Peek |
+| --- | --- | --- | --- | --- | --- |
+| A | 0/7 | 0/7 | Intentional scripted omission control | 169.0 | 0 calls |
+| B | 6/7 | 6/7 | Misses the plain-fact case | 195.0 | 0 calls |
+| C | 7/7 | 6/7 | One peek-only recovery | 195.0 | 2.0 avg calls, 808.3 avg peek tokens |
+| D | 6/7 | 7/7 raw | 1/7 false recall | 837.9 | 0 calls |
+
+The one C lift is `catalog_miss_plain_fact`: the catalog residual does not
+carry the measurement tokens; archive-backed peek recovers them. D's false
+recall is `distractor_twin` — the no-compaction ceiling still contains the
+deliberately retained retired filename `auth_legacy_v1.py`. Catalog/hybrid
+arms that extract unique handles can keep the active file without treating
+the retired twin as a required residual fact.
+
+Catalog residual cost (195.0) is far below the uncompacted ceiling (837.9)
+and only modestly above the scripted four-heading control (169.0). That
+comparison is valid only against this fixture, not against a production
+summarizer.
+
+## Interpretation and gate
+
+The catalog is a credible candidate for a bounded hybrid experiment. It
+preserved handle-shaped buried facts at a residual much smaller than the
+raw transcript, and archive-backed peek recovered the one designed catalog
+miss.
+
+This fixture-level result does not justify changing the production default.
+Keep `summary` as the default.
+
+Before a go decision, require:
+
+- provider-backed replay with real summarizer outputs (not the scripted
+  omission control);
+- larger and adversarial batteries;
+- task-level probes that decide *when* to call peek, rather than scripting
+  the calls;
+- cost and latency accounting at the pilot-turn level.
+
+Provisional gate: do not ship catalog-only. Continue hybrid/peek research if
+the next battery preserves recall while keeping residual and retrieval
+overhead within a predeclared budget.
+
+## Limitations
+
+- Arm A is not a production summarizer benchmark. The mock summary is a
+  valid four-heading seed that omits buried tokens on purpose.
+- Arm C directly scripts `peek_history` windows. It measures archive
+  recoverability, not pilot tool-choice quality.
+- The battery is small (seven pattern-based cases) and uses substring
+  oracles, not an LLM-as-judge.
+- The catalog intentionally does not resolve arbitrary prose and does not
+  fabricate turn IDs. Plain facts without a handle shape are expected misses.
+- Bounded archive truncation is surfaced with an explicit marker. The
+  sidecar does not silently pretend full recall after repeated Compact Now.
+- The distractor oracle measures retention more than ranking. For bare
+  filenames, keeping both twins in an uncompacted history is a false-recall
+  against the retired name, not a claim about which file a model would cite.
+
+## Reproduction
+
+Hermetic battery (no API keys):
+
+```
+./.venv/bin/python -m pmharness.compaction_residual_bench
+```
+
+Focused compaction / residual / archive / peek suite:
+
+```
+./.venv/bin/python -m pytest -q tests/test_compaction_residual.py tests/test_compaction_residual_bench.py tests/test_compaction_archive.py tests/test_peek_tools.py tests/test_compaction.py tests/test_compaction_quality_guards.py tests/test_compaction_mixin.py tests/test_compaction_timeout.py
+```
+
+Full local suite used for this note:
+
+```
+./.venv/bin/python -m pytest -q
+```
+
+That full run reported 4450 passed, 74 skipped locally.

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.240"
+__version__ = "0.9.241"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/compaction_mixin.py
+++ b/harness/compaction_mixin.py
@@ -67,6 +67,7 @@ REASON_BELOW_MIN_FLOOR = "below_min_compactable"
 REASON_SUMMARY_REJECTED = "summary_rejected"
 REASON_THRASH_COOLDOWN = "thrash_cooldown"
 REASON_CACHE_DEFERRED = "cache_deferred"
+REASON_RESIDUAL_OFF = "residual_off"
 
 
 def neutralize_compaction_control_tokens(text: str) -> str:
@@ -691,10 +692,63 @@ class CompactionContextMixin:
                 summary = self._clip_text(summary, char_budget)
         return summary
 
+    def _residual_char_budget(
+        self,
+        middle_block: list[dict],
+        char_budget: Optional[int],
+    ) -> int:
+        if char_budget is None:
+            middle_tokens = self._estimate_context_tokens_for_list(middle_block)
+            char_budget = summary_token_budget_for_middle(middle_tokens) * 4
+        return max(int(char_budget), MIN_SUMMARY_SEED_CHARS + 160)
+
+    def _make_catalog_residual(
+        self,
+        middle_block: list[dict],
+        *,
+        char_budget: Optional[int] = None,
+    ) -> str:
+        """Deterministic unique-handle catalog. ConvEvent mode stays extractive."""
+        from .compaction_residual import build_catalog_residual
+
+        return build_catalog_residual(
+            middle_block,
+            char_budget=self._residual_char_budget(middle_block, char_budget),
+        )
+
+    def _make_hybrid_residual(
+        self,
+        middle_block: list[dict],
+        *,
+        char_budget: Optional[int] = None,
+    ) -> str:
+        """Extractive four-heading snapshot plus a capped unique-handle index."""
+        from harness.api.redaction import redact_secret_text
+
+        from .compaction_residual import append_handle_index
+
+        budget = self._residual_char_budget(middle_block, char_budget)
+        body = redact_secret_text(
+            self._make_fallback_summary(middle_block, char_budget=budget)
+        )
+        return append_handle_index(body, middle_block, char_budget=budget)
+
     def _maybe_compact_history(
         self, force: bool = False, emergency: bool = False,
     ) -> Iterator["ConvEvent"]:
         from .conversation import ConvEvent
+        from .compaction_residual import (
+            RESIDUAL_CATALOG,
+            RESIDUAL_HYBRID,
+            RESIDUAL_OFF,
+            compaction_residual_mode,
+        )
+
+        residual_mode = compaction_residual_mode()
+        # Explicit off only — empty/invalid env values stay on the summary path.
+        if residual_mode == RESIDUAL_OFF:
+            self._set_compaction_attempt(REASON_RESIDUAL_OFF)
+            return
 
         self._set_compaction_attempt(REASON_BELOW_TRIGGER)
 
@@ -944,6 +998,14 @@ class CompactionContextMixin:
 
         def _fallback() -> str:
             # Same prune discipline as the LLM path — raw middle_block can flood.
+            if residual_mode == RESIDUAL_CATALOG:
+                return self._make_catalog_residual(
+                    pruned_middle, char_budget=summary_char_budget
+                )
+            if residual_mode == RESIDUAL_HYBRID:
+                return self._make_hybrid_residual(
+                    pruned_middle, char_budget=summary_char_budget
+                )
             return self._make_fallback_summary(
                 pruned_middle, char_budget=summary_char_budget
             )
@@ -957,7 +1019,10 @@ class CompactionContextMixin:
         # Manual force bypasses summarizer-fail cooldown (same as anti-thrash)
         # so Compact Now actually calls the pilot instead of only falling back.
         _fail_until = float(getattr(self, "_compaction_fail_until", 0.0) or 0.0)
-        if (not force) and now < _fail_until:
+        if residual_mode in (RESIDUAL_CATALOG, RESIDUAL_HYBRID):
+            # Deterministic extractive residuals — never call the summarizer.
+            summary = _fallback()
+        elif (not force) and now < _fail_until:
             summary = _fallback()
         else:
             try:

--- a/harness/compaction_residual.py
+++ b/harness/compaction_residual.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+"""Experimental compaction residual representations (Wave 2 lab seam).
+
+``HARNESS_COMPACTION_RESIDUAL`` selects how the compacted middle is rewritten:
+
+- ``summary`` (default): existing LLM / extractive four-heading snapshot
+- ``catalog``: deterministic unique-handle index from the pruned middle
+- ``hybrid``: existing extractive four-heading body plus a capped handle index
+- ``off``: test-only no-compaction ceiling (must be an explicit value)
+
+Empty, missing, or unknown values resolve to ``summary`` — never to ``off``.
+Catalog / hybrid paths are extractive and do not invent turn IDs or peek
+offsets. Text copied into a residual is redacted for likely secrets.
+"""
+
+import os
+import re
+from typing import Any, Iterable
+
+from harness.api.redaction import redact_secret_text
+
+_SPILL_URI_RE = re.compile(r"spill://[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")
+
+
+def _min_summary_seed_chars() -> int:
+    """Lazy read so this module cannot import-cycle the mixin."""
+    try:
+        from harness.compaction_mixin import MIN_SUMMARY_SEED_CHARS
+        return int(MIN_SUMMARY_SEED_CHARS)
+    except Exception:
+        return 200
+
+RESIDUAL_SUMMARY = "summary"
+RESIDUAL_CATALOG = "catalog"
+RESIDUAL_HYBRID = "hybrid"
+RESIDUAL_OFF = "off"
+
+VALID_RESIDUAL_MODES = frozenset({
+    RESIDUAL_SUMMARY,
+    RESIDUAL_CATALOG,
+    RESIDUAL_HYBRID,
+    RESIDUAL_OFF,
+})
+
+CATALOG_HEADING = "## Handle catalog"
+HYBRID_INDEX_HEADING = "## Unique handles"
+
+_PATH_RE = re.compile(
+    r"(?:[A-Za-z]:)?(?:[\w.-]+/)+\w[\w.-]*\.[A-Za-z0-9]+"
+)
+_ARTIFACT_URI_RE = re.compile(r"artifact://[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")
+_JOB_URI_RE = re.compile(r"job://[A-Za-z0-9._-]+")
+_ERROR_RE = re.compile(
+    r"(?im)^(?:\s*(?:error|exception|failed|traceback|fatal)[:\s].+)$"
+)
+_STEM_RE = re.compile(
+    r"(?im)^(?:\s*(?:decision|decided|constraint|must not|never|require[sd]?)[:\s].+)$"
+)
+
+_MAX_FILES = 24
+_MAX_TOOLS = 16
+_MAX_HANDLES = 16
+_MAX_STEMS = 10
+_STEM_CHARS = 160
+_LAST_ASK_CHARS = 240
+_HYBRID_INDEX_FILES = 8
+_HYBRID_INDEX_HANDLES = 8
+_HYBRID_INDEX_TOOLS = 8
+_HYBRID_INDEX_CHARS = 400
+
+
+def compaction_residual_mode() -> str:
+    """Return the residual representation. Empty / invalid -> ``summary``."""
+    try:
+        raw = (os.environ.get("HARNESS_COMPACTION_RESIDUAL") or "").strip().lower()
+    except Exception:
+        return RESIDUAL_SUMMARY
+    if not raw:
+        return RESIDUAL_SUMMARY
+    if raw in VALID_RESIDUAL_MODES:
+        return raw
+    return RESIDUAL_SUMMARY
+
+
+def _unique_append(dst: list[str], seen: set[str], value: str, cap: int) -> None:
+    text = redact_secret_text((value or "").strip())
+    if not text or text in seen or len(dst) >= cap:
+        return
+    seen.add(text)
+    dst.append(text)
+
+
+def _iter_message_text(message: dict) -> Iterable[str]:
+    content = message.get("content")
+    if isinstance(content, str):
+        yield content
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, str):
+                yield block
+            elif isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    yield text
+    read_path = message.get("_read_path")
+    if isinstance(read_path, str) and read_path.strip():
+        yield read_path
+    for tc in message.get("tool_calls") or []:
+        if not isinstance(tc, dict):
+            continue
+        func = tc.get("function") or {}
+        name = func.get("name")
+        if isinstance(name, str):
+            yield name
+        args = func.get("arguments")
+        if isinstance(args, str):
+            yield args
+
+
+def extract_handle_index(middle_block: list[dict]) -> dict[str, Any]:
+    """Collect unique files / tools / handles / stems from a pruned middle.
+
+    O(unique handles), not one row per message. Does not invent turn IDs.
+    """
+    files: list[str] = []
+    tools: list[str] = []
+    handles: list[str] = []
+    stems: list[str] = []
+    seen_files: set[str] = set()
+    seen_tools: set[str] = set()
+    seen_handles: set[str] = set()
+    seen_stems: set[str] = set()
+    last_ask = ""
+
+    if not isinstance(middle_block, list):
+        middle_block = []
+
+    for message in middle_block:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "")
+        if role == "user" and not message.get("_compressed_summary"):
+            raw_ask = str(message.get("content") or "").strip().split("\n", 1)[0]
+            last_ask = redact_secret_text(raw_ask[:_LAST_ASK_CHARS])
+        read_path = message.get("_read_path")
+        if isinstance(read_path, str):
+            _unique_append(files, seen_files, read_path, _MAX_FILES)
+        for tc in message.get("tool_calls") or []:
+            if not isinstance(tc, dict):
+                continue
+            func = tc.get("function") or {}
+            name = func.get("name")
+            if isinstance(name, str) and name.strip():
+                _unique_append(tools, seen_tools, name.strip(), _MAX_TOOLS)
+        for text in _iter_message_text(message):
+            if not text:
+                continue
+            for match in _PATH_RE.findall(text):
+                _unique_append(files, seen_files, match, _MAX_FILES)
+            for match in _SPILL_URI_RE.findall(text):
+                _unique_append(handles, seen_handles, match, _MAX_HANDLES)
+            for match in _ARTIFACT_URI_RE.findall(text):
+                _unique_append(handles, seen_handles, match, _MAX_HANDLES)
+            for match in _JOB_URI_RE.findall(text):
+                _unique_append(handles, seen_handles, match, _MAX_HANDLES)
+            for match in _ERROR_RE.findall(text):
+                _unique_append(
+                    stems, seen_stems, "error: " + match.strip()[:_STEM_CHARS], _MAX_STEMS
+                )
+            for match in _STEM_RE.findall(text):
+                _unique_append(
+                    stems, seen_stems, match.strip()[:_STEM_CHARS], _MAX_STEMS
+                )
+
+    return {
+        "files": files,
+        "tools": tools,
+        "handles": handles,
+        "stems": stems,
+        "last_ask": last_ask,
+        "middle_messages": len(middle_block),
+    }
+
+
+def _bullet_block(title: str, items: list[str], empty: str) -> str:
+    if not items:
+        return f"{title}\n- {empty}\n"
+    lines = "\n".join(f"- {item}" for item in items)
+    return f"{title}\n{lines}\n"
+
+
+def _clip(text: str, limit: int) -> str:
+    if limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    if limit <= 40:
+        return text[:limit]
+    return text[: max(0, limit - 40)].rstrip() + "\n... [truncated to fit budget]"
+
+
+def _pad_catalog(summary: str, index: dict[str, Any], char_budget: int) -> str:
+    if len(summary.strip()) >= _min_summary_seed_chars():
+        return summary
+    pad = (
+        f"[Handle catalog: {len(index['files'])} files, "
+        f"{len(index['tools'])} tools, {len(index['handles'])} handles "
+        f"from {index['middle_messages']} middle messages. "
+        "Unique-handle index, not a turn log. "
+        "peek_history offsets are not implied by this catalog.]"
+    )
+    if index.get("last_ask"):
+        pad += f" Last ask retained: {index['last_ask']}"
+    combined = summary.rstrip() + "\n" + pad
+    if len(combined) > char_budget:
+        combined = _clip(combined, char_budget)
+    return combined
+
+
+def build_catalog_residual(
+    middle_block: list[dict],
+    *,
+    char_budget: int,
+) -> str:
+    """Deterministic unique-handle catalog bounded by ``char_budget``."""
+    char_budget = max(int(char_budget), _min_summary_seed_chars() + 160)
+    index = extract_handle_index(middle_block)
+    last_ask = index["last_ask"] or "(no open user ask captured)"
+    summary = (
+        f"{CATALOG_HEADING}\n"
+        "Unique files, tools, and durable handles from the compacted middle. "
+        "Not a per-message log.\n"
+        + _bullet_block("### Files", index["files"], "(no file pointers found)")
+        + _bullet_block("### Tools", index["tools"], "(no tool names found)")
+        + _bullet_block("### Handles", index["handles"], "(no durable handles found)")
+        + _bullet_block("### Stems", index["stems"], "(no error/decision/constraint stems)")
+        + f"### Last ask\n- {last_ask}\n"
+    )
+    if len(summary) > char_budget:
+        summary = _clip(summary, char_budget)
+    return _pad_catalog(summary, index, char_budget)
+
+
+def build_hybrid_index(
+    middle_block: list[dict],
+    *,
+    max_chars: int = _HYBRID_INDEX_CHARS,
+) -> str:
+    """Small capped unique-handle appendix for the hybrid residual."""
+    index = extract_handle_index(middle_block)
+    files = index["files"][:_HYBRID_INDEX_FILES]
+    tools = index["tools"][:_HYBRID_INDEX_TOOLS]
+    handles = index["handles"][:_HYBRID_INDEX_HANDLES]
+    file_part = "; ".join(files) if files else "(none)"
+    tool_part = ", ".join(tools) if tools else "(none)"
+    handle_part = "; ".join(handles) if handles else "(none)"
+    text = (
+        f"{HYBRID_INDEX_HEADING}\n"
+        f"- files ({len(index['files'])}): {file_part}\n"
+        f"- tools: {tool_part}\n"
+        f"- uris: {handle_part}\n"
+    )
+    if len(text) > max_chars:
+        text = _clip(text, max_chars)
+    return text
+
+
+def append_handle_index(
+    body: str,
+    middle_block: list[dict],
+    *,
+    char_budget: int,
+) -> str:
+    """Append a capped handle index to an existing extractive snapshot."""
+    char_budget = max(int(char_budget), _min_summary_seed_chars() + 160)
+    index_budget = min(_HYBRID_INDEX_CHARS, max(80, char_budget // 4))
+    index = build_hybrid_index(middle_block, max_chars=index_budget)
+    body = (body or "").rstrip()
+    if HYBRID_INDEX_HEADING in body:
+        combined = body
+    else:
+        room = char_budget - len(index) - 1
+        if room < _min_summary_seed_chars():
+            index = _clip(index, max(40, char_budget - len(body) - 1))
+            combined = body + "\n" + index
+        else:
+            if len(body) > room:
+                body = _clip(body, room)
+            combined = body + "\n" + index
+    if len(combined) > char_budget:
+        combined = _clip(combined, char_budget)
+    return combined

--- a/pmharness/compaction_residual_battery.py
+++ b/pmharness/compaction_residual_battery.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+"""Deterministic compaction-residual battery (research lab, not product GUI).
+
+Labeled templates bury a fact in a long-session middle, then probe whether
+the residual (and, for arm C, archive-backed peek) still carries it. Scoring is
+stdlib substring oracles — no LLM-as-judge, no API keys.
+
+Arm A is a scripted omission control (the mock summary deliberately drops
+buried tokens). It is not a measure of production summarizer quality.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ResidualCase:
+    id: str
+    template: str
+    transcript: tuple
+    probe_prompt: str
+    must_contain: tuple
+    must_not_contain: tuple = ()
+    expected_arms: dict = field(default_factory=dict)
+    # False when the catalog residual is designed to miss the buried fact so
+    # arm C can measure archive-peek lift separately from residual recall.
+    catalog_recalls_fact: bool = True
+
+
+def _msg(role: str, content: str, **extra: Any) -> dict:
+    row = {"role": role, "content": content}
+    row.update(extra)
+    return row
+
+
+def _filler_pairs(n: int, prefix: str) -> list[dict]:
+    rows: list[dict] = []
+    for i in range(n):
+        rows.append(_msg("user", f"{prefix} user {i}: refactor comments and docs only. " + ("pad " * 20)))
+        rows.append(_msg("assistant", f"{prefix} assistant {i}: acknowledged docs pass. " + ("ack " * 20)))
+    return rows
+
+
+def _tail() -> list[dict]:
+    return [
+        _msg("user", "Please continue the current docs pass."),
+        _msg("assistant", "Continuing the docs pass without restating earlier facts."),
+    ]
+
+
+def _base_system() -> list[dict]:
+    return [_msg("system", "You are a coding assistant in a long session.")]
+
+
+def _arm_meta() -> dict:
+    return {
+        "A": {"peek": False, "compact": True, "residual": "summary"},
+        "B": {"peek": False, "compact": True, "residual": "catalog"},
+        "C": {"peek": True, "compact": True, "residual": "catalog"},
+        "D": {"peek": False, "compact": False, "residual": "off"},
+    }
+
+
+def _early_constraint() -> ResidualCase:
+    buried = (
+        "CONSTRAINT: never write to production.db; use scratch.sqlite only."
+    )
+    history = (
+        _base_system()
+        + [_msg("user", buried), _msg("assistant", "Constraint recorded.")]
+        + _filler_pairs(8, "early")
+        + _tail()
+    )
+    return ResidualCase(
+        id="early_constraint",
+        template="early_constraint",
+        transcript=tuple(history),
+        probe_prompt="What early write constraint was set for the database files?",
+        must_contain=("never write to production.db", "scratch.sqlite"),
+        must_not_contain=("write to production.db is required",),
+        expected_arms=_arm_meta(),
+    )
+
+
+def _mid_session_file_path() -> ResidualCase:
+    path = "src/billing/ledger_v3.py"
+    history = (
+        _base_system()
+        + _filler_pairs(3, "pre")
+        + [
+            _msg("user", f"Please read {path} and report the public entry points."),
+            _msg(
+                "assistant",
+                "reading the ledger module",
+                tool_calls=[{
+                    "id": "call_read_ledger",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": f'{{"path": "{path}"}}',
+                    },
+                }],
+            ),
+            _msg(
+                "tool",
+                f"def post_invoice():\n    return {path}\n",
+                tool_call_id="call_read_ledger",
+                _read_path=path,
+            ),
+            _msg("assistant", f"Read {path}; post_invoice is the public entry."),
+        ]
+        + _filler_pairs(5, "post")
+        + _tail()
+    )
+    return ResidualCase(
+        id="mid_session_file_path",
+        template="mid_session_file_path",
+        transcript=tuple(history),
+        probe_prompt="Which billing ledger file was read mid-session?",
+        must_contain=("src/billing/ledger_v3.py",),
+        must_not_contain=("src/billing/ledger_v2.py",),
+        expected_arms=_arm_meta(),
+    )
+
+
+def _reversed_decision() -> ResidualCase:
+    history = (
+        _base_system()
+        + [
+            _msg("user", "Let's use Redis for the session store."),
+            _msg("assistant", "Redis is a candidate."),
+        ]
+        + _filler_pairs(4, "mid")
+        + [
+            _msg("user", "Decision: use SQLite instead of Redis for the session store."),
+            _msg("assistant", "Switched the store decision to SQLite."),
+        ]
+        + _filler_pairs(4, "after")
+        + _tail()
+    )
+    return ResidualCase(
+        id="reversed_decision",
+        template="reversed_decision",
+        transcript=tuple(history),
+        probe_prompt="What is the current session-store decision?",
+        must_contain=("sqlite instead of redis",),
+        must_not_contain=("keep redis", "postgres"),
+        expected_arms=_arm_meta(),
+    )
+
+
+def _error_tail_fact() -> ResidualCase:
+    err = "ERROR: ConfigMissing: /etc/marionette/secret-policy.yaml not found (code E-7721)"
+    history = (
+        _base_system()
+        + _filler_pairs(6, "pre-err")
+        + [
+            _msg("user", "Load the policy file."),
+            _msg(
+                "assistant",
+                "loading policy",
+                tool_calls=[{
+                    "id": "call_policy",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": '{"path": "policy.yaml"}'},
+                }],
+            ),
+            _msg("tool", err, tool_call_id="call_policy"),
+            _msg("assistant", "Policy load failed with the error above."),
+        ]
+        + _filler_pairs(2, "post-err")
+        + _tail()
+    )
+    return ResidualCase(
+        id="error_tail_fact",
+        template="error_tail_fact",
+        transcript=tuple(history),
+        probe_prompt="What error code was returned when the policy file was missing?",
+        must_contain=("E-7721", "secret-policy.yaml"),
+        must_not_contain=("E-7700",),
+        expected_arms=_arm_meta(),
+    )
+
+
+def _spill_artifact_handle() -> ResidualCase:
+    spill = "spill://sess-lab/result-omega"
+    artifact = "artifact://job-omega/finding-0"
+    job = "job://job-omega"
+    history = (
+        _base_system()
+        + _filler_pairs(4, "pre-spill")
+        + [
+            _msg("user", "Run the audit swarm and keep the handles."),
+            _msg(
+                "assistant",
+                "swarm running",
+                tool_calls=[{
+                    "id": "call_swarm",
+                    "type": "function",
+                    "function": {"name": "run_swarm", "arguments": '{"goal": "audit"}'},
+                }],
+            ),
+            _msg(
+                "tool",
+                f"full output at {spill} and {artifact}; also {job}",
+                tool_call_id="call_swarm",
+            ),
+            _msg("assistant", f"Audit handles retained: {spill} {artifact} {job}"),
+        ]
+        + _filler_pairs(4, "post-spill")
+        + _tail()
+    )
+    return ResidualCase(
+        id="spill_artifact_handle",
+        template="spill_artifact_handle",
+        transcript=tuple(history),
+        probe_prompt="What durable spill and artifact handles were produced?",
+        must_contain=(spill, artifact),
+        must_not_contain=("spill://sess-lab/result-alpha",),
+        expected_arms=_arm_meta(),
+    )
+
+
+def _distractor_twin() -> ResidualCase:
+    current = "auth_current_v2.py"
+    legacy = "auth_legacy_v1.py"
+    history = (
+        _base_system()
+        + [
+            _msg("user", f"Ignore {legacy}; it is the retired twin."),
+            _msg("assistant", f"{legacy} is not the active module."),
+            _msg("user", f"Read {current} — that is the active auth module."),
+            _msg(
+                "assistant",
+                "reading current auth",
+                tool_calls=[{
+                    "id": "call_auth",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": f'{{"path": "{current}"}}',
+                    },
+                }],
+            ),
+            _msg(
+                "tool",
+                f"active auth lives in {current}",
+                tool_call_id="call_auth",
+                _read_path=current,
+            ),
+            _msg("assistant", f"Confirmed active file is {current}."),
+        ]
+        + _filler_pairs(6, "twin")
+        + _tail()
+    )
+    return ResidualCase(
+        id="distractor_twin",
+        template="distractor_twin",
+        transcript=tuple(history),
+        probe_prompt="Which auth module is the active current file?",
+        must_contain=(current,),
+        # Retired twin is actually in the buried transcript — a vacuous
+        # fabrication token would never fire the false-recall guard.
+        must_not_contain=(legacy,),
+        expected_arms=_arm_meta(),
+    )
+
+
+def _catalog_miss_plain_fact() -> ResidualCase:
+    """Catalog-miss / peek-hit: a plain tool-result fact with no handle shape.
+
+    extract_handle_index collects paths, URIs, error/decision stems, and tool
+    names — not arbitrary measurement tokens. Arm B must fail recall; arm C
+    recovers the tokens from the Wave 1 archive via peek_history.
+    """
+    token_a = "omega-cache-token-9f3a"
+    token_b = "shard-omega-p95"
+    history = (
+        _base_system()
+        + _filler_pairs(6, "pre-plain")
+        + [
+            _msg("user", "Run the cache probe and report the raw measurement only."),
+            _msg(
+                "assistant",
+                "probing cache",
+                tool_calls=[{
+                    "id": "call_cache_probe",
+                    "type": "function",
+                    "function": {
+                        "name": "run_command",
+                        "arguments": '{"command": "probe-cache"}',
+                    },
+                }],
+            ),
+            _msg(
+                "tool",
+                f"Plain measurement only: {token_a} observed on {token_b}. "
+                "No file path and no durable URI in this result.",
+                tool_call_id="call_cache_probe",
+            ),
+            _msg("assistant", "Cache probe finished; continuing the docs pass."),
+        ]
+        + _filler_pairs(4, "post-plain")
+        + _tail()
+    )
+    return ResidualCase(
+        id="catalog_miss_plain_fact",
+        template="catalog_miss_plain_fact",
+        transcript=tuple(history),
+        probe_prompt="What cache-shard measurement tokens were returned by the probe?",
+        must_contain=(token_a, token_b),
+        must_not_contain=("omega-cache-token-0000",),
+        expected_arms=_arm_meta(),
+        catalog_recalls_fact=False,
+    )
+
+
+RESIDUAL_CASES: tuple[ResidualCase, ...] = (
+    _early_constraint(),
+    _mid_session_file_path(),
+    _reversed_decision(),
+    _error_tail_fact(),
+    _spill_artifact_handle(),
+    _distractor_twin(),
+    _catalog_miss_plain_fact(),
+)
+
+
+def cases_by_id() -> dict[str, ResidualCase]:
+    return {case.id: case for case in RESIDUAL_CASES}

--- a/pmharness/compaction_residual_bench.py
+++ b/pmharness/compaction_residual_bench.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+"""Hermetic compaction-residual laboratory.
+
+Drives the real ConversationalSession / ``_maybe_compact_history(force=True)``
+seam — not ``pmharness.run_episode`` (that path does not compact conversations)
+and not CassetteDriver (its request hash includes the residual).
+
+Arms:
+    A  scripted omission control (not production summarizer quality)
+    B  catalog residual
+    C  catalog + Wave 1 archive-backed peek_history
+    D  no-compaction ceiling (explicit residual=off)
+
+Default execution is stdlib-only, no API keys, and fast enough for unit tests.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import tempfile
+from typing import Any, Callable, Iterable, Optional
+
+from pmharness.compaction_residual_battery import (
+    RESIDUAL_CASES,
+    ResidualCase,
+    cases_by_id,
+)
+
+ARM_A = "A"
+ARM_B = "B"
+ARM_C = "C"
+ARM_D = "D"
+ALL_ARMS = (ARM_A, ARM_B, ARM_C, ARM_D)
+
+_ARM_RESIDUAL = {
+    ARM_A: "summary",
+    ARM_B: "catalog",
+    ARM_C: "catalog",
+    ARM_D: "off",
+}
+
+# Arm A control: valid four-heading seed that omits buried facts on purpose.
+# This is a scripted omission, not a claim about production summarizer quality.
+SCRIPTED_SUMMARY = (
+    "## Historical Task Snapshot\n"
+    "Long-session docs pass. Earlier turns were compacted for residual comparison.\n"
+    "## Resolved\n"
+    "Acknowledged the docs-only refactor requests in the filler turns.\n"
+    "## Pending / Open Questions\n"
+    "Continue the current docs pass.\n"
+    "## Key Facts / Decisions / Files\n"
+    "No buried handles retained in this scripted summary.\n"
+)
+
+
+class ScriptedPilot:
+    """Mock pilot used only by arm A. Catalog/hybrid/off must not need it."""
+
+    name = "scripted-residual"
+
+    def __init__(self, return_text: str = SCRIPTED_SUMMARY) -> None:
+        self.return_text = return_text
+        self.chat_calls: list[tuple] = []
+        self.complete_calls: list[tuple] = []
+
+    def chat(self, messages, tools=None, system=None):
+        self.chat_calls.append((messages, system))
+        return type("Resp", (), {"text": self.return_text, "error": None, "tokens_out": 8})()
+
+    def complete(self, prompt, system=None):
+        self.complete_calls.append((prompt, system))
+        return type("Resp", (), {"text": self.return_text, "error": None, "tokens_out": 8})()
+
+
+class RaisingPilot:
+    """Fails if the summarizer path is entered — catalog/off must stay extractive."""
+
+    name = "raising-residual"
+
+    def chat(self, messages, tools=None, system=None):
+        raise RuntimeError("catalog/off residual must not call the summarizer")
+
+    def complete(self, prompt, system=None):
+        raise RuntimeError("catalog/off residual must not call the summarizer")
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(0, len(text or "") // 4)
+
+
+def score_residual_text(case: ResidualCase, text: str) -> dict[str, Any]:
+    """Deterministic substring oracles. ``must_contain`` is all-of, not any-of."""
+    blob = (text or "").lower()
+    tokens = tuple(str(token).lower() for token in case.must_contain)
+    hit = bool(tokens) and all(token in blob for token in tokens)
+    fab = any(str(token).lower() in blob for token in case.must_not_contain) if case.must_not_contain else False
+    return {
+        "buried_fact_recall": bool(hit),
+        "false_recall": bool(fab),
+        "end_task_success": bool(hit and not fab),
+    }
+
+
+def _env_scope(updates: dict[str, str]) -> Callable[[], None]:
+    previous: dict[str, Optional[str]] = {}
+    for key, value in updates.items():
+        previous[key] = os.environ.get(key)
+        os.environ[key] = value
+
+    def restore() -> None:
+        for key, old in previous.items():
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+    return restore
+
+
+def _residual_text(session: Any) -> str:
+    parts: list[str] = []
+    for message in getattr(session, "_history", []) or []:
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "system":
+            continue
+        parts.append(str(message.get("content") or ""))
+    return "\n".join(parts)
+
+
+def _peek_windows(session: Any, *, max_calls: int = 3) -> tuple[str, int, int]:
+    from harness.pilot import PilotAction
+
+    chunks: list[str] = []
+    calls = 0
+    tokens = 0
+    offset = 0
+    total = 0
+    while calls < max_calls:
+        ok, status, text = session._do_peek_history(
+            PilotAction(kind="peek_history", arguments={"offset": offset, "limit": 20})
+        )
+        calls += 1
+        text = text or ""
+        tokens += _estimate_tokens(text)
+        chunks.append(text)
+        if not ok or status != "success":
+            break
+        parsed_total = 0
+        for line in text.splitlines():
+            if line.startswith("offset="):
+                for part in line.split():
+                    if part.startswith("total="):
+                        try:
+                            parsed_total = int(part.split("=", 1)[1])
+                        except ValueError:
+                            parsed_total = 0
+        if parsed_total:
+            total = parsed_total
+        offset += 20
+        if total and offset >= total:
+            break
+        if not parsed_total:
+            break
+    return "\n".join(chunks), calls, tokens
+
+
+def run_residual_arm(
+    case: ResidualCase,
+    arm: str,
+    *,
+    state_dir: str = "",
+) -> dict[str, Any]:
+    """Run one case/arm through the live compaction seam."""
+    if arm not in _ARM_RESIDUAL:
+        raise ValueError(f"unknown arm {arm!r}")
+
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+    from harness.sessions import save_transcript
+
+    owned_tmp = None
+    if not state_dir:
+        owned_tmp = tempfile.mkdtemp(prefix="residual-lab-")
+        state_dir = owned_tmp
+
+    restore = _env_scope({
+        "HARNESS_COMPACTION_RESIDUAL": _ARM_RESIDUAL[arm],
+        "HARNESS_MIN_COMPACTABLE_TOKENS": "0",
+        "HARNESS_COMPACTION_TAIL_TOKENS": "80",
+    })
+    compacted = False
+    peek_calls = 0
+    peek_tokens = 0
+    peek_text = ""
+    mode = ""
+    try:
+        session = ConversationalSession(
+            HarnessConfig(driver="stub-oracle-v2", state_dir=state_dir, max_context_tokens=8000)
+        )
+        session.harness_session_id = f"residual-{case.id}-{arm}"
+        session._history = [dict(row) for row in case.transcript]
+        if arm == ARM_A:
+            session.pilot = ScriptedPilot()
+        else:
+            session.pilot = RaisingPilot()
+
+        events = []
+        if arm != ARM_D:
+            events = list(session._maybe_compact_history(force=True))
+            done = [e for e in events if getattr(e, "kind", "") == "compaction"]
+            compacted = bool(done) and not done[-1].data.get("aborted")
+            if done:
+                mode = str(done[-1].data.get("mode") or "")
+        else:
+            # Explicit off: force=True must still be a no-op ceiling.
+            events = list(session._maybe_compact_history(force=True))
+            compacted = False
+            mode = "off"
+
+        if arm == ARM_C and compacted:
+            save_transcript(
+                state_dir,
+                session.harness_session_id,
+                session.export_transcript_data(),
+            )
+            peek_text, peek_calls, peek_tokens = _peek_windows(session)
+
+        residual = _residual_text(session)
+        residual_scored = score_residual_text(case, residual)
+        peek_scored = score_residual_text(case, peek_text)
+        # Combined success is at least one clean channel so arm C can credit
+        # archive-peek lift without scoring residual+peek as one blob.
+        if arm == ARM_C:
+            buried = bool(
+                residual_scored["buried_fact_recall"] or peek_scored["buried_fact_recall"]
+            )
+            success = bool(
+                residual_scored["end_task_success"] or peek_scored["end_task_success"]
+            )
+            false_recall = bool(residual_scored["false_recall"])
+        else:
+            buried = bool(residual_scored["buried_fact_recall"])
+            success = bool(residual_scored["end_task_success"])
+            false_recall = bool(residual_scored["false_recall"])
+        residual_tokens = 0
+        try:
+            residual_tokens = int(session._estimate_context_tokens() or 0)
+        except Exception:
+            residual_tokens = _estimate_tokens(residual)
+
+        receipt = {
+            "arm": arm,
+            "case_id": case.id,
+            "template": case.template,
+            "probe_prompt": case.probe_prompt,
+            "residual_mode": _ARM_RESIDUAL[arm],
+            "compacted": compacted,
+            "mode": mode,
+            "buried_fact_recall": buried,
+            "false_recall": false_recall,
+            "residual_buried_fact_recall": residual_scored["buried_fact_recall"],
+            "peek_buried_fact_recall": peek_scored["buried_fact_recall"],
+            "peek_false_recall": peek_scored["false_recall"],
+            "peek_task_success": peek_scored["end_task_success"],
+            "residual_tokens": residual_tokens,
+            "peek_calls": peek_calls,
+            "peek_tokens": peek_tokens,
+            "end_task_success": success,
+            "expected_arms": case.expected_arms,
+            "event_kinds": [getattr(e, "kind", "") for e in events],
+        }
+        return receipt
+    finally:
+        restore()
+        if owned_tmp:
+            shutil.rmtree(owned_tmp, ignore_errors=True)
+
+
+def run_compaction_residual_bench(
+    *,
+    arms: Optional[Iterable[str]] = None,
+    case_ids: Optional[Iterable[str]] = None,
+    state_dir: str = "",
+) -> dict[str, Any]:
+    """Run the labeled battery. Default path is hermetic and fast."""
+    wanted_arms = tuple(arms) if arms else ALL_ARMS
+    catalog = cases_by_id()
+    if case_ids:
+        cases = [catalog[cid] for cid in case_ids]
+    else:
+        cases = list(RESIDUAL_CASES)
+    rows = []
+    for case in cases:
+        for arm in wanted_arms:
+            rows.append(run_residual_arm(case, arm, state_dir=state_dir))
+    successes = sum(1 for row in rows if row["end_task_success"])
+    return {
+        "n": len(rows),
+        "successes": successes,
+        "rows": rows,
+    }
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Hermetic compaction-residual laboratory (no API keys).",
+    )
+    parser.add_argument("--arm", action="append", choices=list(ALL_ARMS), dest="arms")
+    parser.add_argument("--case", action="append", dest="cases")
+    parser.add_argument("--state-dir", default="")
+    args = parser.parse_args(argv)
+    result = run_compaction_residual_bench(
+        arms=args.arms,
+        case_ids=args.cases,
+        state_dir=args.state_dir,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.240"
+version = "0.9.241"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_compaction_residual.py
+++ b/tests/test_compaction_residual.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+"""Focused harness tests for the experimental compaction residual switch."""
+
+from harness.compaction_mixin import (
+    REASON_RESIDUAL_OFF,
+    MIN_SUMMARY_SEED_CHARS,
+)
+from harness.compaction_residual import (
+    CATALOG_HEADING,
+    HYBRID_INDEX_HEADING,
+    RESIDUAL_CATALOG,
+    RESIDUAL_HYBRID,
+    RESIDUAL_OFF,
+    RESIDUAL_SUMMARY,
+    build_catalog_residual,
+    compaction_residual_mode,
+    extract_handle_index,
+)
+from harness.config import HarnessConfig
+from harness.conversation import ConversationalSession
+
+
+_GOOD_SUMMARY = (
+    "## Historical Task Snapshot\n"
+    "Compaction fixture summary with enough seed characters to pass guards.\n"
+    "## Resolved\nPrior turns were compacted for the unit test.\n"
+    "## Pending / Open Questions\nNone.\n"
+    "## Key Facts / Decisions / Files\ntests/test_compaction_residual.py\n"
+)
+
+
+class MockPilot:
+    name = "mock"
+
+    def __init__(self, return_text=_GOOD_SUMMARY):
+        self.return_text = return_text
+        self.chat_calls = []
+        self.complete_calls = []
+
+    def chat(self, messages, tools=None, system=None):
+        self.chat_calls.append((messages, system))
+        return type("Resp", (), {"text": self.return_text, "error": None, "tokens_out": 10})()
+
+    def complete(self, prompt, system=None):
+        self.complete_calls.append((prompt, system))
+        return type("Resp", (), {"text": self.return_text, "error": None, "tokens_out": 10})()
+
+
+def _fat_history(session: ConversationalSession, *, secret: str = "") -> None:
+    session._history = [{"role": "system", "content": "sys"}]
+    session._history.append({
+        "role": "user",
+        "content": "CONSTRAINT: keep src/billing/ledger_v3.py as the source of truth.",
+    })
+    session._history.append({
+        "role": "assistant",
+        "content": "reading",
+        "tool_calls": [{
+            "id": "call_r",
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "arguments": '{"path": "src/billing/ledger_v3.py"}',
+            },
+        }],
+    })
+    tool_body = (
+        "src/billing/ledger_v3.py contents. "
+        "full: spill://sess-lab/result-omega artifact://job-omega/finding-0 "
+        "job://job-omega"
+    )
+    if secret:
+        tool_body += (
+            f"\nERROR: failed with api_key={secret} token sk-abcdefghijklmnopqrstuvwx"
+        )
+    session._history.append({
+        "role": "tool",
+        "tool_call_id": "call_r",
+        "content": tool_body,
+        "_read_path": "src/billing/ledger_v3.py",
+    })
+    for i in range(8):
+        session._history.append({
+            "role": "user",
+            "content": f"User message number {i}: " + ("A" * 150),
+        })
+        session._history.append({
+            "role": "assistant",
+            "content": f"Assistant response number {i}: " + ("B" * 150),
+        })
+    session._history.append({"role": "user", "content": "please continue"})
+    session._history.append({"role": "assistant", "content": "continuing"})
+
+
+def _session(tmp_path, monkeypatch, budget: int = 4000) -> ConversationalSession:
+    monkeypatch.setattr("harness.compaction_mixin.MIN_COMPACTABLE_TOKENS", 0)
+    cfg = HarnessConfig(max_context_tokens=budget, state_dir=str(tmp_path))
+    session = ConversationalSession(cfg)
+    session.harness_session_id = "sess-residual"
+    session.pilot = MockPilot()
+    return session
+
+
+def test_residual_mode_default_and_empty_never_off(monkeypatch):
+    monkeypatch.delenv("HARNESS_COMPACTION_RESIDUAL", raising=False)
+    assert compaction_residual_mode() == RESIDUAL_SUMMARY
+    monkeypatch.setenv("HARNESS_COMPACTION_RESIDUAL", "")
+    assert compaction_residual_mode() == RESIDUAL_SUMMARY
+    monkeypatch.setenv("HARNESS_COMPACTION_RESIDUAL", "   ")
+    assert compaction_residual_mode() == RESIDUAL_SUMMARY
+    monkeypatch.setenv("HARNESS_COMPACTION_RESIDUAL", "nope")
+    assert compaction_residual_mode() == RESIDUAL_SUMMARY
+    monkeypatch.setenv("HARNESS_COMPACTION_RESIDUAL", "off")
+    assert compaction_residual_mode() == RESIDUAL_OFF
+    monkeypatch.setenv("HARNESS_COMPACTION_RESIDUAL", "CATALOG")
+    assert compaction_residual_mode() == RESIDUAL_CATALOG
+
+
+def test_default_summary_mode_unchanged(tmp_path, monkeypatch):
+    """Unset residual switch keeps the existing LLM summary path (mode=llm)."""
+    monkeypatch.delenv("HARNESS_COMPACTION_RESIDUAL", raising=False)
+    session = _session(tmp_path, monkeypatch)
+    _fat_history(session)
+    events = list(session._maybe_compact_history(force=True))
+    assert [e.kind for e in events] == ["compacting", "compaction"]
+    assert events[-1].data.get("mode") == "llm"
+    assert session.pilot.chat_calls
+    assert session._history[1].get("_compressed_summary") is True
+    assert "[Earlier conversation summarized to fit context]" in session._history[1]["content"]
+    assert "Compaction fixture summary" in session._history[1]["content"]
+    assert session._history[-1]["content"] == "continuing"
+
+
+def test_off_is_no_compaction_ceiling(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_COMPACTION_RESIDUAL", "off")
+    session = _session(tmp_path, monkeypatch)
+    _fat_history(session)
+    original = list(session._history)
+    events = list(session._maybe_compact_history(force=True))
+    assert events == []
+    assert session._history == original
+    assert session._last_compaction_attempt.get("reason") == REASON_RESIDUAL_OFF
+    assert not session.pilot.chat_calls
+
+
+def test_catalog_extractive_no_llm_and_redacts(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_COMPACTION_RESIDUAL", "catalog")
+    session = _session(tmp_path, monkeypatch)
+    secret = "supersecret-residual-key"
+    _fat_history(session, secret=secret)
+    events = list(session._maybe_compact_history(force=True))
+    assert [e.kind for e in events] == ["compacting", "compaction"]
+    # Deterministic catalog/hybrid paths emit mode=extractive (not llm).
+    assert events[-1].data.get("mode") == "extractive"
+    assert not session.pilot.chat_calls
+    injected = session._history[1]["content"]
+    assert CATALOG_HEADING in injected
+    assert "src/billing/ledger_v3.py" in injected
+    assert "read_file" in injected
+    assert "spill://sess-lab/result-omega" in injected
+    assert "artifact://job-omega/finding-0" in injected
+    assert "job://job-omega" in injected
+    assert "never invent turn" not in injected.lower()
+    assert secret not in injected
+    assert "sk-abcdefghijklmnopqrstuvwx" not in injected
+    assert "REDACTED" in injected
+    assert session._history[-1]["content"] == "continuing"
+
+
+def test_hybrid_keeps_four_headings_and_handle_index(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_COMPACTION_RESIDUAL", "hybrid")
+    session = _session(tmp_path, monkeypatch)
+    _fat_history(session)
+    events = list(session._maybe_compact_history(force=True))
+    assert events[-1].data.get("mode") == "extractive"
+    assert not session.pilot.chat_calls
+    injected = session._history[1]["content"]
+    assert "## Historical Task Snapshot" in injected
+    assert "## Resolved" in injected
+    assert "## Pending / Open Questions" in injected
+    assert "## Key Facts / Decisions / Files" in injected
+    assert HYBRID_INDEX_HEADING in injected
+    assert "src/billing/ledger_v3.py" in injected
+    assert "spill://sess-lab/result-omega" in injected
+
+
+def test_hybrid_redacts_secrets_in_body_and_index(tmp_path, monkeypatch):
+    """Hybrid body and handle index must redact secrets like catalog mode."""
+    monkeypatch.setenv("HARNESS_COMPACTION_RESIDUAL", "hybrid")
+    session = _session(tmp_path, monkeypatch)
+    secret = "supersecret-hybrid-residual-key"
+    _fat_history(session, secret=secret)
+    session._history[-2]["content"] = (
+        f"please continue with api_key={secret} token sk-zyxwvutsrqponmlkjihgfedcba"
+    )
+    events = list(session._maybe_compact_history(force=True))
+    assert events[-1].data.get("mode") == "extractive"
+    assert not session.pilot.chat_calls
+    injected = session._history[1]["content"]
+    assert "## Historical Task Snapshot" in injected
+    assert HYBRID_INDEX_HEADING in injected
+    assert "src/billing/ledger_v3.py" in injected
+    assert secret not in injected
+    assert "sk-abcdefghijklmnopqrstuvwx" not in injected
+    assert "sk-zyxwvutsrqponmlkjihgfedcba" not in injected
+    assert "REDACTED" in injected
+
+
+def test_catalog_extraction_is_unique_handle_not_per_message():
+    middle = []
+    for i in range(12):
+        middle.append({
+            "role": "user",
+            "content": f"again src/billing/ledger_v3.py mention {i}",
+        })
+        middle.append({
+            "role": "assistant",
+            "content": "read_file again spill://sess-lab/result-omega",
+            "tool_calls": [{
+                "id": f"c{i}",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }],
+        })
+    index = extract_handle_index(middle)
+    assert index["files"] == ["src/billing/ledger_v3.py"]
+    assert index["tools"] == ["read_file"]
+    assert index["handles"] == ["spill://sess-lab/result-omega"]
+    catalog = build_catalog_residual(middle, char_budget=2000)
+    assert catalog.count("src/billing/ledger_v3.py") <= 3
+    assert len(catalog) >= MIN_SUMMARY_SEED_CHARS
+
+
+def test_repeated_catalog_compaction_stays_bounded(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_COMPACTION_RESIDUAL", "catalog")
+    session = _session(tmp_path, monkeypatch, budget=8000)
+    _fat_history(session)
+    list(session._maybe_compact_history(force=True))
+    first = session._history[1]["content"]
+    first_len = len(first)
+    for wave in range(3):
+        for i in range(6):
+            session._history.append({
+                "role": "user",
+                "content": f"wave-{wave} again src/billing/ledger_v3.py " + ("Z" * 120),
+            })
+            session._history.append({
+                "role": "assistant",
+                "content": "still spill://sess-lab/result-omega " + ("Y" * 120),
+            })
+        list(session._maybe_compact_history(force=True))
+    later = session._history[1]["content"]
+    assert CATALOG_HEADING in later
+    # Unique-handle residual must not grow with message count / re-compaction.
+    assert later.count("src/billing/ledger_v3.py") <= 4
+    assert later.count("spill://sess-lab/result-omega") <= 4
+    assert len(later) < first_len * 3

--- a/tests/test_compaction_residual_bench.py
+++ b/tests/test_compaction_residual_bench.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+"""Hermetic compaction-residual laboratory tests.
+
+Runs through the real ConversationalSession compaction seam and the Wave 1
+archive-backed peek_history path. No API keys. No fake string-only runner.
+"""
+
+from harness.compaction_archive import load_compaction_archive_messages
+from harness.compaction_residual import RESIDUAL_SUMMARY, compaction_residual_mode
+from pmharness.compaction_residual_battery import RESIDUAL_CASES, ResidualCase
+from pmharness.compaction_residual_bench import (
+    ARM_A,
+    ARM_B,
+    ARM_C,
+    ARM_D,
+    SCRIPTED_SUMMARY,
+    run_compaction_residual_bench,
+    run_residual_arm,
+    score_residual_text,
+)
+
+
+REQUIRED_TEMPLATES = {
+    "early_constraint",
+    "mid_session_file_path",
+    "reversed_decision",
+    "error_tail_fact",
+    "spill_artifact_handle",
+    "distractor_twin",
+    "catalog_miss_plain_fact",
+}
+
+
+def test_battery_schema_covers_six_templates():
+    templates = {case.template for case in RESIDUAL_CASES}
+    assert REQUIRED_TEMPLATES <= templates
+    assert len(RESIDUAL_CASES) >= 6
+    for case in RESIDUAL_CASES:
+        assert isinstance(case, ResidualCase)
+        assert case.id
+        assert case.transcript
+        assert case.transcript[0]["role"] == "system"
+        assert case.probe_prompt
+        assert case.must_contain
+        assert isinstance(case.must_not_contain, tuple)
+        assert set(case.expected_arms) >= {"A", "B", "C", "D"}
+        assert case.expected_arms["A"]["residual"] == "summary"
+        assert case.expected_arms["B"]["residual"] == "catalog"
+        assert case.expected_arms["C"]["peek"] is True
+        assert case.expected_arms["D"]["compact"] is False
+    distractor = next(c for c in RESIDUAL_CASES if c.id == "distractor_twin")
+    assert distractor.must_not_contain == ("auth_legacy_v1.py",)
+    peek_only = next(c for c in RESIDUAL_CASES if c.id == "catalog_miss_plain_fact")
+    assert peek_only.catalog_recalls_fact is False
+    assert len(peek_only.must_contain) >= 2
+
+
+def test_scoring_is_deterministic_substring_oracle():
+    case = ResidualCase(
+        id="unit",
+        template="early_constraint",
+        transcript=({"role": "system", "content": "s"},),
+        probe_prompt="p",
+        must_contain=("alpha-fact", "gamma-fact"),
+        must_not_contain=("beta-fab",),
+    )
+    # must_contain is all-of: one token is not enough.
+    partial = score_residual_text(case, "the ALPHA-FACT is present")
+    assert partial["buried_fact_recall"] is False
+    assert partial["false_recall"] is False
+    assert partial["end_task_success"] is False
+    hit = score_residual_text(case, "the ALPHA-FACT and GAMMA-FACT are present")
+    assert hit["buried_fact_recall"] is True
+    assert hit["false_recall"] is False
+    assert hit["end_task_success"] is True
+    fab = score_residual_text(case, "beta-fab only")
+    assert fab["buried_fact_recall"] is False
+    assert fab["false_recall"] is True
+    assert fab["end_task_success"] is False
+    silent = score_residual_text(case, "nothing relevant")
+    assert silent["buried_fact_recall"] is False
+    assert silent["false_recall"] is False
+    assert silent["end_task_success"] is False
+
+
+def test_default_summary_mode_untouched_by_import(monkeypatch):
+    monkeypatch.delenv("HARNESS_COMPACTION_RESIDUAL", raising=False)
+    assert compaction_residual_mode() == RESIDUAL_SUMMARY
+
+
+def test_all_four_arms_on_representative_cases(tmp_path, monkeypatch):
+    monkeypatch.delenv("HARNESS_COMPACTION_RESIDUAL", raising=False)
+    representative = ("early_constraint", "spill_artifact_handle", "distractor_twin")
+    result = run_compaction_residual_bench(
+        case_ids=representative,
+        state_dir=str(tmp_path),
+    )
+    assert result["n"] == 12
+    by_key = {(row["case_id"], row["arm"]): row for row in result["rows"]}
+
+    for case_id in representative:
+        arm_a = by_key[(case_id, ARM_A)]
+        arm_b = by_key[(case_id, ARM_B)]
+        arm_c = by_key[(case_id, ARM_C)]
+        arm_d = by_key[(case_id, ARM_D)]
+
+        assert arm_a["compacted"] is True
+        assert arm_a["mode"] == "llm"
+        assert arm_a["residual_mode"] == "summary"
+        assert arm_a["peek_calls"] == 0
+        # Arm A is a scripted omission control, not production summarizer quality.
+        assert arm_a["buried_fact_recall"] is False
+        assert arm_a["residual_buried_fact_recall"] is False
+        assert arm_a["peek_buried_fact_recall"] is False
+
+        assert arm_b["compacted"] is True
+        assert arm_b["mode"] == "extractive"
+        assert arm_b["residual_mode"] == "catalog"
+        assert arm_b["buried_fact_recall"] is True
+        assert arm_b["residual_buried_fact_recall"] is True
+        assert arm_b["peek_buried_fact_recall"] is False
+        assert arm_b["false_recall"] is False
+        assert arm_b["end_task_success"] is True
+        assert arm_b["peek_calls"] == 0
+
+        assert arm_c["compacted"] is True
+        assert arm_c["mode"] == "extractive"
+        assert arm_c["peek_calls"] >= 1
+        assert arm_c["peek_tokens"] > 0
+        assert arm_c["buried_fact_recall"] is True
+        assert arm_c["residual_buried_fact_recall"] is True
+        assert arm_c["peek_buried_fact_recall"] is True
+        assert arm_c["end_task_success"] is True
+        archive = load_compaction_archive_messages(
+            str(tmp_path),
+            f"residual-{case_id}-C",
+        )
+        assert archive, "arm C must use the Wave 1 archive, not fake recall"
+
+        assert arm_d["compacted"] is False
+        assert arm_d["residual_mode"] == "off"
+        assert arm_d["event_kinds"] == []
+        assert arm_d["buried_fact_recall"] is True
+        assert arm_d["residual_tokens"] > arm_b["residual_tokens"]
+
+
+def test_full_battery_no_keys_and_tail_integrity(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("HARNESS_COMPACTION_RESIDUAL", raising=False)
+    result = run_compaction_residual_bench(state_dir=str(tmp_path))
+    assert result["n"] == len(RESIDUAL_CASES) * 4
+    by_id = {case.id: case for case in RESIDUAL_CASES}
+    for row in result["rows"]:
+        assert row["arm"] in (ARM_A, ARM_B, ARM_C, ARM_D)
+        assert row["case_id"]
+        assert "buried_fact_recall" in row
+        assert "false_recall" in row
+        assert "residual_buried_fact_recall" in row
+        assert "peek_buried_fact_recall" in row
+        assert "peek_false_recall" in row
+        assert "peek_task_success" in row
+        assert "residual_tokens" in row
+        assert "peek_calls" in row
+        assert "peek_tokens" in row
+        assert "end_task_success" in row
+        case = by_id[row["case_id"]]
+        if row["arm"] == ARM_B:
+            if case.catalog_recalls_fact:
+                assert row["end_task_success"] is True
+                assert row["residual_buried_fact_recall"] is True
+            else:
+                assert row["residual_buried_fact_recall"] is False
+                assert row["end_task_success"] is False
+        if row["arm"] == ARM_C:
+            assert row["end_task_success"] is True
+            if not case.catalog_recalls_fact:
+                assert row["residual_buried_fact_recall"] is False
+                assert row["peek_buried_fact_recall"] is True
+                assert row["peek_task_success"] is True
+        if row["arm"] == ARM_D:
+            assert row["compacted"] is False
+            assert row["buried_fact_recall"] is True
+
+
+def test_arm_c_peek_reads_elided_middle(tmp_path, monkeypatch):
+    monkeypatch.delenv("HARNESS_COMPACTION_RESIDUAL", raising=False)
+    case = next(c for c in RESIDUAL_CASES if c.id == "early_constraint")
+    receipt = run_residual_arm(case, ARM_C, state_dir=str(tmp_path))
+    assert receipt["peek_calls"] >= 1
+    archive = load_compaction_archive_messages(
+        str(tmp_path),
+        f"residual-{case.id}-C",
+    )
+    archive_text = " ".join(str(m.get("content") or "") for m in archive)
+    assert "never write to production.db" in archive_text
+    assert receipt["buried_fact_recall"] is True
+    assert receipt["peek_buried_fact_recall"] is True
+
+
+def test_catalog_miss_plain_fact_is_peek_only_lift(tmp_path, monkeypatch):
+    monkeypatch.delenv("HARNESS_COMPACTION_RESIDUAL", raising=False)
+    case = next(c for c in RESIDUAL_CASES if c.id == "catalog_miss_plain_fact")
+    assert case.catalog_recalls_fact is False
+    arm_b = run_residual_arm(case, ARM_B, state_dir=str(tmp_path))
+    arm_c = run_residual_arm(case, ARM_C, state_dir=str(tmp_path))
+    assert arm_b["residual_buried_fact_recall"] is False
+    assert arm_b["buried_fact_recall"] is False
+    assert arm_b["end_task_success"] is False
+    assert arm_b["peek_calls"] == 0
+    assert arm_c["residual_buried_fact_recall"] is False
+    assert arm_c["peek_buried_fact_recall"] is True
+    assert arm_c["peek_false_recall"] is False
+    assert arm_c["peek_task_success"] is True
+    assert arm_c["buried_fact_recall"] is True
+    assert arm_c["end_task_success"] is True
+    archive = load_compaction_archive_messages(
+        str(tmp_path),
+        f"residual-{case.id}-C",
+    )
+    archive_text = " ".join(str(m.get("content") or "") for m in archive)
+    assert "omega-cache-token-9f3a" in archive_text
+    assert "shard-omega-p95" in archive_text
+
+
+def test_scripted_summary_omits_buried_tokens():
+    blob = SCRIPTED_SUMMARY.lower()
+    for case in RESIDUAL_CASES:
+        assert not any(token.lower() in blob for token in case.must_contain)

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.240",
+  "version": "0.9.241",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.240",
+      "version": "0.9.241",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.240",
+  "version": "0.9.241",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -200,7 +200,7 @@ describe("SwarmPane model badge", () => {
     });
   });
 
-  it("falls back to the adapter when no routed model is present", async () => {
+  it("falls back to the adapter on the worker row when no routed model is present", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
         adapter: "openrouter",
@@ -210,12 +210,16 @@ describe("SwarmPane model badge", () => {
 
     render(<SwarmPane />);
 
-    await waitFor(() => {
-      expect(screen.getByTitle("Model: openrouter")).toHaveTextContent("openrouter");
-    });
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    expect(worker).toHaveTextContent("openrouter");
+    expect(screen.getByLabelText("Model: openrouter")).toBeInTheDocument();
+    // Job-level model badge stays off once canonical task rows exist.
+    const job = screen.getByRole("button", { name: /Audit auth flow/ });
+    expect(job).not.toHaveTextContent("openrouter");
+    expect(job.getAttribute("aria-label") || "").toMatch(/running|worker|dispatched|routing/i);
   });
 
-  it("shows routing placeholder instead of bare agentic while running", async () => {
+  it("shows routing in the worker model slot instead of a job-level badge", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
         adapter: "agentic",
@@ -235,10 +239,12 @@ describe("SwarmPane model badge", () => {
 
     render(<SwarmPane />);
 
-    await waitFor(() => {
-      expect(screen.getByTitle("Model routing in progress")).toHaveTextContent("routing…");
-    });
+    const worker = await screen.findByRole("button", { name: /implement \(agentic\)/ });
+    expect(worker).toHaveTextContent("routing…");
+    expect(screen.getByLabelText("Model routing in progress")).toHaveTextContent("routing…");
     expect(screen.queryByTitle("Model: agentic")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Model: agentic")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Audit auth flow/ })).not.toHaveTextContent("routing…");
   });
 
   it("shows each worker's own model without inheriting the job model", async () => {
@@ -257,10 +263,12 @@ describe("SwarmPane model badge", () => {
     render(<SwarmPane />);
 
     await waitFor(() => {
-      expect(screen.getByText("(model-a)")).toBeInTheDocument();
-      expect(screen.getByText("(model-b)")).toBeInTheDocument();
+      expect(screen.getByLabelText("Model: model-a")).toBeInTheDocument();
+      expect(screen.getByLabelText("Model: model-b")).toBeInTheDocument();
     });
-    expect(screen.queryByText("(job-default)")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Model: job-default")).not.toBeInTheDocument();
+    expect(screen.queryByText("(model-a)")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /worker-unknown/ })).toHaveTextContent("routing…");
   });
 
   it("updates a worker model when routing settles on a later poll", async () => {
@@ -281,12 +289,80 @@ describe("SwarmPane model badge", () => {
       });
 
       render(<SwarmPane />);
-      await waitFor(() => expect(screen.queryByText("(routed-model)")).not.toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText("routing…")).toBeInTheDocument());
+      expect(screen.queryByLabelText("Model: routed-model")).not.toBeInTheDocument();
       await vi.advanceTimersByTimeAsync(6000);
-      await waitFor(() => expect(screen.getByText("(routed-model)")).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByLabelText("Model: routed-model")).toBeInTheDocument());
+      expect(screen.queryByText("routing…")).not.toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("does not label a terminal worker as routing when no model was recorded", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job-terminal-unrouted", "Terminal worker without model", {
+        tasks: [{
+          id: "task-terminal-unrouted",
+          status: "complete",
+          adapter: "agentic",
+          role: "completed-worker",
+          instruction: "",
+        }],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Terminal worker without model"));
+
+    const worker = await screen.findByRole("button", { name: /completed-worker/ });
+    expect(worker).not.toHaveTextContent("routing…");
+    expect(worker).toHaveTextContent("no-model");
+    expect(screen.getByLabelText("No model recorded")).toBeInTheDocument();
+  });
+
+  it("shows routing… for queued and pending workers without a model", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        adapter: "agentic",
+        status: "running",
+        tasks: [
+          { id: "task-queued", status: "queued", adapter: "agentic", role: "queued-worker", instruction: "" },
+          { id: "task-pending", status: "pending", adapter: "agentic", role: "pending-worker", instruction: "" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    const queued = await screen.findByRole("button", { name: /queued-worker/ });
+    const pending = screen.getByRole("button", { name: /pending-worker/ });
+    expect(queued).toHaveTextContent("routing…");
+    expect(pending).toHaveTextContent("routing…");
+    expect(queued).not.toHaveTextContent("no-model");
+    expect(pending).not.toHaveTextContent("no-model");
+    expect(queued.getAttribute("aria-label") || "").toMatch(/queued/i);
+    expect(pending.getAttribute("aria-label") || "").toMatch(/pending/i);
+  });
+
+  it("keeps job-level routing… only when there are zero task rows", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        adapter: "agentic",
+        model: "agentic",
+        status: "running",
+        tasks: [],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Model routing in progress")).toHaveTextContent("routing…");
+    });
+    expect(screen.queryByText("Workers")).not.toBeInTheDocument();
   });
 });
 
@@ -329,6 +405,58 @@ describe("SwarmPane worker details", () => {
     expect(screen.getByText("task-terminal")).toBeInTheDocument();
     expect(screen.getByText("2026-08-16T17:00:00+00:00")).toBeInTheDocument();
   });
+
+  it("expands a worker from the keyboard and keeps nested Kill from toggling the job", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-keys",
+        goal: "Keyboard disclosure",
+        status: "running",
+        tasks: [
+          {
+            id: "task-keys",
+            status: "running",
+            adapter: "agentic",
+            role: "key-worker",
+            instruction: "do the secret thing",
+            model: "routed-model",
+          },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    mockSwarmCancel.mockResolvedValue({ ok: true, job_id: "job-keys" });
+    const job = await screen.findByRole("button", { name: /Keyboard disclosure/ });
+    expect(job).toHaveAttribute("aria-expanded", "true");
+    expect(job.className).toMatch(/focus-visible:outline/);
+    expect(job.getAttribute("aria-label") || "").toMatch(/Keyboard disclosure/);
+    expect(screen.queryByText("do the secret thing")).not.toBeInTheDocument();
+
+    const worker = screen.getByRole("button", { name: /key-worker/ });
+    expect(worker).toHaveAttribute("aria-expanded", "false");
+    expect(worker).toHaveAttribute("aria-controls");
+    expect(worker.className).toMatch(/focus-visible:outline/);
+    expect(worker.getAttribute("aria-label") || "").toMatch(/running/i);
+    worker.focus();
+    fireEvent.keyDown(worker, { key: " " });
+    expect(worker).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("do the secret thing")).toBeInTheDocument();
+    const details = document.getElementById(worker.getAttribute("aria-controls") || "");
+    expect(details).toBeTruthy();
+    expect(worker.contains(details)).toBe(false);
+
+    const kill = screen.getByRole("button", { name: "Cancel this job" });
+    kill.focus();
+    fireEvent.keyDown(kill, { key: " " });
+    fireEvent.keyDown(kill, { key: "Enter" });
+    expect(job).toHaveAttribute("aria-expanded", "true");
+    expect(mockSwarmCancel).not.toHaveBeenCalled();
+    fireEvent.click(kill);
+    await waitFor(() => {
+      expect(mockSwarmCancel).toHaveBeenCalledWith("job-keys");
+    });
+  });
 });
 
 describe("SwarmPane pin attribution", () => {
@@ -340,7 +468,7 @@ describe("SwarmPane pin attribution", () => {
     mockArtifacts.mockResolvedValue([]);
   });
 
-  it("labels explicit_pin routing as Explicit pin · not auto-routed", async () => {
+  it("keeps explicit_pin full registry id and a pin marker on the worker", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
         status: "running",
@@ -373,14 +501,20 @@ describe("SwarmPane pin attribution", () => {
 
     render(<SwarmPane />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Explicit pin · not auto-routed")).toBeInTheDocument();
-    });
-    // Collapsed summary keeps the full registry id (not stripped agentic/).
-    expect(screen.getAllByText("agentic/meta/muse-spark-1.1").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("explicit_pin").length).toBeGreaterThan(0);
-    expect(screen.getByText("openrouter · agentic")).toBeInTheDocument();
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    expect(worker).toHaveTextContent("agentic/meta/muse-spark-1.1");
+    expect(screen.getByTitle("explicit_pin · not auto-routed")).toHaveTextContent("pin");
     expect(screen.queryByText("Router pick")).not.toBeInTheDocument();
+    expect(screen.queryByText("Explicit pin · not auto-routed")).not.toBeInTheDocument();
+
+    fireEvent.click(worker);
+    expect(worker).toHaveAttribute("aria-expanded", "true");
+    expect(worker).toHaveAttribute("aria-controls");
+    expect(screen.getByText("explicit_pin · pin")).toBeInTheDocument();
+    expect(screen.getByText("openrouter")).toBeInTheDocument();
+    const details = document.getElementById(worker.getAttribute("aria-controls") || "");
+    expect(details).toHaveTextContent("agentic");
+    expect(worker.contains(details)).toBe(false);
   });
 
   it("does not paint a missing routing estimate as $0", async () => {
@@ -414,10 +548,8 @@ describe("SwarmPane pin attribution", () => {
 
     render(<SwarmPane />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Explicit pin · not auto-routed")).toBeInTheDocument();
-    });
-    expect(screen.getByText("—")).toBeInTheDocument();
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    expect(worker).not.toHaveTextContent("—");
     expect(screen.queryByText("$0")).not.toBeInTheDocument();
   });
 
@@ -450,6 +582,8 @@ describe("SwarmPane pin attribution", () => {
 
     render(<SwarmPane />);
 
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    fireEvent.click(worker);
     await waitFor(() => {
       expect(screen.getAllByText("Pin attribution unknown").length).toBeGreaterThanOrEqual(1);
     });
@@ -492,7 +626,7 @@ describe("SwarmPane routing dedupe", () => {
     mockArtifacts.mockResolvedValue([]);
   });
 
-  it("shows one routing model row per task when router and router-fallback both exist", async () => {
+  it("shows one final model per worker when router and router-fallback both exist", async () => {
     // Ground truth: a 5-worker swarm stores 10 ROUTING artifacts (router +
     // router-fallback per task). Display must show the final choice only.
     const artifacts = Array.from({ length: 5 }, (_, i) => [
@@ -522,7 +656,7 @@ describe("SwarmPane routing dedupe", () => {
         tasks: Array.from({ length: 5 }, (_, i) => ({
           id: `task-${i}`,
           status: "running",
-          role: "Worker",
+          role: `worker-${i}`,
           instruction: "",
           adapter: "agentic",
         })),
@@ -532,11 +666,40 @@ describe("SwarmPane routing dedupe", () => {
     render(<SwarmPane />);
 
     await waitFor(() => {
-      expect(screen.getByTitle("Model: final-model-0")).toBeInTheDocument();
+      expect(screen.getByLabelText("Model: final-model-0")).toBeInTheDocument();
     });
     expect(screen.queryByText("initial-model-0")).not.toBeInTheDocument();
-    // One expanded routing card per task (5), not 10 router+fallback pairs.
-    expect(screen.getAllByTitle(/^final-model-\d$/)).toHaveLength(5);
+    expect(screen.getAllByLabelText(/^Model: final-model-\d$/)).toHaveLength(5);
+    expect(screen.queryByText("Right-sized: cheapest model that clears the task's need")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /worker-0/ }));
+    expect(screen.getByText("fallback")).toBeInTheDocument();
+  });
+
+  it("prefers router-escalation over fallback for the worker model", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        artifacts_complete: true,
+        artifacts: [
+          { type: "ROUTING", headline: "", task_id: "task-1", model: "initial-model", created_by: "router" },
+          { type: "ROUTING", headline: "", task_id: "task-1", model: "fallback-model", created_by: "router-fallback" },
+          { type: "ROUTING", headline: "", task_id: "task-1", model: "escalated-model", created_by: "router-escalation" },
+        ],
+        tasks: [
+          { id: "task-1", status: "running", role: "Worker", instruction: "", adapter: "agentic" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Model: escalated-model")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Model: fallback-model")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Model: initial-model")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Worker/ }));
+    expect(screen.getByText("escalation")).toBeInTheDocument();
   });
 });
 
@@ -751,9 +914,10 @@ describe("SwarmPane mid-run job-row meters", () => {
     expect(parts.total).toBe(0);
   });
 
-  it("renders local-job routing policy label after reload the same as live", async () => {
-    // Persisted local-* jobs carry UI-shaped ROUTING rows (with policy) inline;
-    // running jobs auto-expand so the chip is visible without a click.
+  it("renders local-job routing policy on worker expansion without template prose", async () => {
+    // Production local-* preview ROUTING rows have no task_id; the sole
+    // worker is `${job_id}-w0`. Associate the final unscoped route (fallback
+    // over router) so the worker owns model/policy and no unmatched note.
     mockSwarmLive.mockResolvedValue(
       liveJob({
         id: "local-1",
@@ -762,14 +926,23 @@ describe("SwarmPane mid-run job-row meters", () => {
         artifacts: [
           {
             type: "ROUTING",
-            headline: "Routed to cheap-model",
+            headline: "Routed to initial-cheap",
             created_by: "router",
+            model: "initial-cheap",
+            policy: "balanced",
+            adapter: "agentic",
+            est_cost_usd: 0.01,
+            detail: "balanced pick",
+          },
+          {
+            type: "ROUTING",
+            headline: "Routed to cheap-model",
+            created_by: "router-fallback",
             model: "cheap-model",
             policy: "balanced",
             adapter: "agentic",
             est_cost_usd: 0.02,
             detail: "balanced pick",
-            task_id: "local-1-w0",
           },
         ],
         tasks: [
@@ -785,11 +958,21 @@ describe("SwarmPane mid-run job-row meters", () => {
     );
 
     render(<SwarmPane />);
-    await waitFor(() => {
-      expect(screen.getByText("balanced")).toBeInTheDocument();
-    });
-    expect(screen.getByText(/Right-sized: cheapest model/)).toBeInTheDocument();
+    const worker = await screen.findByRole("button", { name: /implement \(agentic\)/ });
+    expect(worker).toHaveTextContent("cheap-model");
+    expect(screen.queryByText("initial-cheap")).not.toBeInTheDocument();
+    expect(screen.queryByText("balanced")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Right-sized: cheapest model/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Unmatched routing/)).not.toBeInTheDocument();
+
+    fireEvent.click(worker);
+    expect(screen.getByText("balanced")).toBeInTheDocument();
+    expect(screen.getByText("fallback")).toBeInTheDocument();
+    expect(screen.queryByText(/Right-sized: cheapest model/)).not.toBeInTheDocument();
     expect(screen.queryByText("Pin attribution unknown")).not.toBeInTheDocument();
+    expect(screen.queryByText("Router pick")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Unmatched routing/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/no matching worker/)).not.toBeInTheDocument();
   });
 });
 
@@ -1147,6 +1330,257 @@ describe("SwarmPane findings section collapse", () => {
   });
 });
 
+describe("SwarmPane worker-owned routing surface", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    clearSWRCache();
+    mockArtifacts.mockResolvedValue([]);
+  });
+
+  it("keeps the model slot distinct from a long role and hides collapsed instructions", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "ROUTING",
+            headline: "",
+            task_id: "task-1",
+            model: "agentic/meta/muse-spark-1.1",
+            policy: "explicit_pin",
+            created_by: "router",
+          },
+        ],
+        tasks: [
+          {
+            id: "task-1",
+            status: "running",
+            role: "test-coverage-reviewer",
+            instruction: "review every uncovered branch in the swarm tracker",
+            adapter: "agentic",
+          },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    const worker = await screen.findByRole("button", { name: /test-coverage-reviewer/ });
+    expect(worker).toHaveTextContent("test-coverage-reviewer");
+    expect(worker.textContent || "").not.toMatch(/test-coverage-reviewer \(/);
+    const modelSlot = screen.getByLabelText("Model: agentic/meta/muse-spark-1.1");
+    expect(modelSlot).toBeInTheDocument();
+    expect(modelSlot.className).toMatch(/truncate/);
+    expect(modelSlot.className).toMatch(/min-w-0/);
+    expect(modelSlot).not.toHaveAttribute("title");
+    expect(screen.queryByText("running")).not.toBeInTheDocument();
+    expect(worker).not.toHaveTextContent("—");
+    expect(screen.queryByText("review every uncovered branch in the swarm tracker")).not.toBeInTheDocument();
+    expect(screen.queryByText("Routing")).not.toBeInTheDocument();
+  });
+
+  it("shows one unmatched routing residual after workers, never a card stack", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "ROUTING",
+            headline: "",
+            task_id: "orphan-a",
+            model: "orphan-model-a",
+            created_by: "router",
+            provider: "openrouter",
+          },
+        ],
+        tasks: [
+          {
+            id: "task-1",
+            status: "running",
+            role: "matched-worker",
+            instruction: "",
+            adapter: "agentic",
+            model: "worker-model",
+          },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Workers (1)")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Model: worker-model")).toBeInTheDocument();
+    expect(screen.getByText(/Unmatched routing · orphan-model-a · no matching worker/)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Model: orphan-model-a")).not.toBeInTheDocument();
+    expect(screen.queryByText("Right-sized: cheapest model that clears the task's need")).not.toBeInTheDocument();
+    const workers = screen.getByText("Workers (1)");
+    const unmatched = screen.getByText(/Unmatched routing · orphan-model-a/);
+    expectBefore(workers, unmatched);
+  });
+
+  it("does not repeat unmatched routing when the job header already owns the model", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        model: "glm-5.2",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "ROUTING",
+            headline: "",
+            model: "glm-5.2",
+            created_by: "router",
+            policy: "balanced",
+            provider: "openrouter",
+          },
+        ],
+        tasks: [],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Model: glm-5.2")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Unmatched routing/)).not.toBeInTheDocument();
+  });
+
+  it("exposes rejected alternatives on worker expansion only", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "ROUTING",
+            headline: "",
+            task_id: "task-1",
+            model: "final-model",
+            created_by: "router-fallback",
+            rejected: [
+              { model: "alt-a", reason: "too expensive" },
+              { model: "alt-b", reason: "unavailable" },
+            ],
+          },
+        ],
+        tasks: [
+          { id: "task-1", status: "running", role: "Worker", instruction: "", adapter: "agentic" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    expect(screen.queryByText("2 alternatives")).not.toBeInTheDocument();
+    fireEvent.click(worker);
+    const alts = screen.getByRole("button", { name: /2 alternatives/ });
+    expect(alts).toHaveAttribute("aria-expanded", "false");
+    expect(worker.contains(alts)).toBe(false);
+    fireEvent.click(alts);
+    expect(alts).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("alt-a")).toBeInTheDocument();
+    expect(screen.getByText("alt-b")).toBeInTheDocument();
+  });
+
+  it("does not paint plan-billed zero as measured provider $0", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "ROUTING",
+            headline: "",
+            task_id: "task-1",
+            model: "cursor/gpt-5-4",
+            created_by: "router",
+            est_cost_usd: 0,
+            detail: "plan-billed in-subscription",
+          },
+        ],
+        tasks: [
+          { id: "task-1", status: "running", role: "Worker", instruction: "", adapter: "agentic" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    expect(worker).not.toHaveTextContent("—");
+    expect(screen.queryByText("$0")).not.toBeInTheDocument();
+  });
+
+  it("keeps provider-attested exact zero as $0 even when routing is plan-billed", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "ROUTING",
+            headline: "",
+            task_id: "task-1",
+            model: "free-model",
+            created_by: "router",
+            est_cost_usd: 0,
+            detail: "plan-billed in-subscription",
+          },
+        ],
+        tasks: [
+          {
+            id: "task-1",
+            status: "running",
+            role: "Worker",
+            instruction: "",
+            adapter: "openrouter",
+            model: "free-model",
+            est_cost_usd: 0,
+            estimated: false,
+            cost_provenance: "provider",
+          },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    expect(worker).toHaveTextContent("$0");
+    expect(worker).not.toHaveTextContent("—");
+  });
+
+  it("keeps provider-attested exact zero as $0", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        tasks: [
+          {
+            id: "task-1",
+            status: "running",
+            role: "Worker",
+            instruction: "",
+            adapter: "openrouter",
+            model: "free-model",
+            est_cost_usd: 0,
+            estimated: false,
+            cost_provenance: "provider",
+          },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    expect(worker).toHaveTextContent("$0");
+  });
+});
+
 describe("SwarmPane worker tokens and cost", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1197,6 +1631,10 @@ describe("SwarmPane worker tokens and cost", () => {
     expect(screen.getByText("~$0.1400")).toBeInTheDocument();
     expect(screen.getByText("60,000t")).toBeInTheDocument();
     expect(screen.getByText("~$0.0700")).toBeInTheDocument();
+    expect(screen.queryByText("build it")).not.toBeInTheDocument();
+    expect(screen.queryByText("check it")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /implement/ }));
+    expect(screen.getByText("build it")).toBeInTheDocument();
   });
 });
 
@@ -1621,5 +2059,253 @@ describe("SwarmPane harness-open-swarm-job deep-link", () => {
     await waitFor(() => {
       expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
     });
+  });
+});
+
+describe("SwarmPane final-review blockers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    clearSWRCache();
+    mockArtifacts.mockResolvedValue([]);
+  });
+
+  it("prefers final associated ROUTING over a stale task.model preview", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "ROUTING",
+            headline: "",
+            task_id: "task-1",
+            model: "final-routed-model",
+            created_by: "router-fallback",
+            policy: "balanced",
+          },
+        ],
+        tasks: [
+          {
+            id: "task-1",
+            status: "running",
+            role: "Worker",
+            instruction: "",
+            adapter: "agentic",
+            model: "stale-preview-model",
+          },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    expect(worker).toHaveTextContent("final-routed-model");
+    expect(worker).not.toHaveTextContent("stale-preview-model");
+    expect(screen.getByLabelText("Model: final-routed-model")).toBeInTheDocument();
+  });
+
+  it("chooses escalation over fallback for zero-task job header model", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        model: "stale-job-model",
+        artifacts_complete: true,
+        artifacts: [
+          { type: "ROUTING", headline: "", model: "initial-model", created_by: "router", policy: "balanced" },
+          { type: "ROUTING", headline: "", model: "fallback-model", created_by: "router-fallback", policy: "balanced" },
+          { type: "ROUTING", headline: "", model: "escalated-model", created_by: "router-escalation", policy: "balanced" },
+        ],
+        tasks: [],
+      }),
+    );
+
+    render(<SwarmPane />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Model: escalated-model")).toBeInTheDocument();
+    });
+    expect(screen.queryByTitle("Model: fallback-model")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Model: initial-model")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Model: stale-job-model")).not.toBeInTheDocument();
+  });
+
+  it("applies routing-only poll updates when task.model and counts stay fixed", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let pollCount = 0;
+      mockSwarmLive.mockImplementation(async () => {
+        pollCount += 1;
+        const artifacts = pollCount > 2
+          ? [{
+              type: "ROUTING" as const,
+              headline: "",
+              task_id: "task-1",
+              model: "poll-settled-model",
+              created_by: "router-fallback",
+              policy: "balanced",
+              provider: "openrouter",
+            }]
+          : [];
+        return liveJob({
+          status: "running",
+          artifacts_complete: true,
+          artifacts,
+          tasks: [{
+            id: "task-1",
+            status: "running",
+            adapter: "agentic",
+            role: "worker",
+            instruction: "",
+            ...(pollCount > 2 ? { model: "stale-preview-model" } : {}),
+          }],
+        });
+      });
+
+      render(<SwarmPane />);
+      await waitFor(() => expect(screen.getByText("routing…")).toBeInTheDocument());
+
+      await vi.advanceTimersByTimeAsync(6000);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Model: poll-settled-model")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("routing…")).not.toBeInTheDocument();
+      expect(screen.queryByText("stale-preview-model")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not render orphan receipt divider or green em dash on empty terminal jobs", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job-empty-receipt", "Terminal without meters", {
+        adapter: "agentic",
+        est_cost_usd: undefined,
+        tokens: 0,
+        tool_output_tokens_saved: 0,
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+
+    const job = await screen.findByRole("button", { name: /Terminal without meters/ });
+    expect(job).not.toHaveTextContent("—");
+    expect(job.textContent || "").not.toMatch(/\$0/);
+    expect(job.querySelector('[aria-hidden="true"].bg-edge\\/70, [aria-hidden="true"][class*="bg-edge"]')).toBeNull();
+  });
+
+  it("still renders provider-attested $0 on terminal jobs when cost is known", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job-zero-cost", "Terminal with attested zero", {
+        adapter: "openrouter",
+        est_cost_usd: 0,
+        estimated: false,
+        cost_provenance: "provider",
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+
+    const job = await screen.findByRole("button", { name: /Terminal with attested zero/ });
+    expect(job).toHaveTextContent("$0");
+    expect(job).not.toHaveTextContent("—");
+  });
+
+  function renderInCompactRail(widthPx: number) {
+    const { container } = render(
+      <div style={{ width: `${widthPx}px`, overflow: "hidden" }}>
+        <SwarmPane />
+      </div>,
+    );
+    return container;
+  }
+
+  it("keeps role and model slot distinct at 320px rail width", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "ROUTING",
+            headline: "",
+            task_id: "task-1",
+            model: "agentic/meta/muse-spark-1.1",
+            policy: "explicit_pin",
+            created_by: "router",
+          },
+        ],
+        tasks: [
+          {
+            id: "task-1",
+            status: "running",
+            role: "test-coverage-reviewer",
+            instruction: "",
+            adapter: "agentic",
+          },
+        ],
+      }),
+    );
+
+    renderInCompactRail(320);
+
+    const worker = await screen.findByRole("button", { name: /test-coverage-reviewer/ });
+    expect(worker).toHaveTextContent("test-coverage-reviewer");
+    expect(worker.textContent || "").not.toMatch(/test-coverage-reviewer \(/);
+    const modelSlot = screen.getByLabelText("Model: agentic/meta/muse-spark-1.1");
+    expect(modelSlot).toBeInTheDocument();
+    expect(modelSlot.className).toMatch(/truncate/);
+    expect(modelSlot.className).toMatch(/min-w-0/);
+    expect(modelSlot.closest(".inline-flex")).toHaveClass("min-w-0");
+  });
+
+  it("wraps worker model slot safely at 220px rail width", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "ROUTING",
+            headline: "",
+            task_id: "task-1",
+            model: "agentic/meta/muse-spark-1.1",
+            policy: "explicit_pin",
+            created_by: "router",
+          },
+        ],
+        tasks: [
+          {
+            id: "task-1",
+            status: "running",
+            role: "test-coverage-reviewer",
+            instruction: "",
+            adapter: "agentic",
+            tokens: 12_000,
+            est_cost_usd: 0.05,
+          },
+        ],
+      }),
+    );
+
+    const container = renderInCompactRail(220);
+
+    const worker = await screen.findByRole("button", { name: /test-coverage-reviewer/ });
+    expect(worker).toHaveTextContent("test-coverage-reviewer");
+    const modelSlot = screen.getByLabelText("Model: agentic/meta/muse-spark-1.1");
+    expect(modelSlot).toBeInTheDocument();
+    expect(modelSlot.className).toMatch(/truncate/);
+    expect(modelSlot.className).toMatch(/min-w-0/);
+    const modelWrap = modelSlot.closest(".inline-flex");
+    expect(modelWrap).toHaveClass("min-w-0");
+    expect(modelWrap).toHaveClass("flex-wrap");
+    expect(container.querySelector('[style*="width: 220px"]')).toBeTruthy();
   });
 });

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Loader2, CheckCircle2, XCircle, Circle, ChevronDown, ChevronRight, Cpu, Activity, Network, X } from "lucide-react";
 import { api, jobArtifactList, type SwarmLive, type Job, type Artifact, type Task } from "../lib/api";
-import { displayModelId, isEngineOnlyModelId } from "../lib/modelIdentity";
+import { displayModelId, isEngineOnlyModelId, modelIdsEqual } from "../lib/modelIdentity";
 import { lastSelectedProjectRoot, panelOpacityClass, useProjectSwitching } from "../lib/panelTransition";
 import {
   peekPendingSwarmOpenJob,
@@ -79,21 +79,10 @@ function routingPolicy(art: Artifact): string {
   return (detail.match(/policy=(\w+)/) || [])[1] || "";
 }
 
-// Turn the router's policy into one plain-language sentence. Fail closed when
-// policy is missing/unparsed: never claim "Router pick" without attestation.
-function summarizeRouting(art: Artifact): string {
+function isPlanBilledRouting(art?: Artifact): boolean {
+  if (!art) return false;
   const detail = typeof art.detail === "string" ? art.detail : "";
-  const policy = routingPolicy(art);
-  const planBilled = /plan-billed|in-subscription/i.test(detail);
-  const lead: Record<string, string> = {
-    balanced: "Right-sized: cheapest model that clears the task's need",
-    cheap: "Cheapest available model",
-    quality: "Highest-capability model for the task",
-    escalating: "Cheapest sufficient model, escalates if it stalls",
-    explicit_pin: "Explicit pin \u00b7 not auto-routed",
-  };
-  const base = lead[policy] || "Pin attribution unknown";
-  return planBilled ? `${base} \u00b7 plan-billed, no marginal cost` : base;
+  return /plan-billed|in-subscription/i.test(detail);
 }
 
 // FINDING headlines that look like the worker echoed its prompt rather than
@@ -255,9 +244,17 @@ function swarmSignature(res: SwarmLive | null): string {
       );
     }
     for (const a of arts) {
-      parts.push(
-        `A:${(a.type || "").slice(0, 8)}:${(a.headline || "").slice(0, 120)}:${a.result ?? ""}`,
-      );
+      const type = (a.type || "").toUpperCase();
+      if (type === "ROUTING") {
+        parts.push(
+          `R:${a.task_id ?? ""}:${a.model ?? ""}:${a.created_by ?? ""}` +
+          `:${routingPolicy(a)}:${a.provider ?? ""}`,
+        );
+      } else {
+        parts.push(
+          `A:${(a.type || "").slice(0, 8)}:${(a.headline || "").slice(0, 120)}:${a.result ?? ""}`,
+        );
+      }
     }
   }
   const s = res.session;
@@ -327,6 +324,132 @@ function dedupeRouting(arts: Artifact[]): Artifact[] {
   return [...groups.values()];
 }
 
+function routingByTaskId(arts: Artifact[]): Map<string, Artifact> {
+  const map = new Map<string, Artifact>();
+  for (const art of arts) {
+    const id = (art.task_id || "").trim();
+    if (id) map.set(id, art);
+  }
+  return map;
+}
+
+function isUnscopedRouting(art: Artifact): boolean {
+  return !(art.task_id || "").trim();
+}
+
+function bestUnscopedRouting(arts: Artifact[]): Artifact | undefined {
+  let best: Artifact | undefined;
+  for (const art of arts) {
+    if (!isUnscopedRouting(art)) continue;
+    if (!best || routingCreatedByRank(art.created_by) > routingCreatedByRank(best.created_by)) {
+      best = art;
+    }
+  }
+  return best;
+}
+
+/** Local single-worker jobs use `${job_id}-w0` but the ROUTING preview has no task_id. */
+function associateRoutingToTasks(
+  arts: Artifact[],
+  tasks: Task[],
+): { routingForTask: Map<string, Artifact>; unmatched: Artifact[] } {
+  const routingForTask = routingByTaskId(arts);
+  const consumedUnscoped = new Set<Artifact>();
+  if (tasks.length === 1 && !routingForTask.has(tasks[0].id)) {
+    const taskId = tasks[0].id;
+    const isLocalWorkerSlot = /-w\d+$/.test(taskId);
+    if (isLocalWorkerSlot) {
+      const best = bestUnscopedRouting(arts);
+      if (best) {
+        routingForTask.set(tasks[0].id, best);
+        for (const art of arts) {
+          if (isUnscopedRouting(art)) consumedUnscoped.add(art);
+        }
+      }
+    }
+  }
+  const ids = new Set(tasks.map((t) => t.id));
+  const unmatched = arts.filter((a) => {
+    if (consumedUnscoped.has(a)) return false;
+    const tid = (a.task_id || "").trim();
+    return !tid || !ids.has(tid);
+  });
+  return { routingForTask, unmatched };
+}
+
+function unmatchedAddsTruth(arts: Artifact[], headerModel: string): boolean {
+  return arts.some((a) => {
+    const policy = routingPolicy(a);
+    if (policy === "explicit_pin") return true;
+    const created = a.created_by || "";
+    if (created === "router-fallback" || created === "router-escalation") return true;
+    if (a.rejected && a.rejected.length > 0) return true;
+    const model = (a.model || "").trim();
+    // Header already owns this model — a provider stamp is not extra truth.
+    if (model && headerModel && modelIdsEqual(model, headerModel)) return false;
+    if ((a.provider || "").trim()) return true;
+    return !!(model && headerModel && !modelIdsEqual(model, headerModel));
+  });
+}
+
+type WorkerModelView = {
+  rawModel: string;
+  display: string;
+  slot: string;
+  pending: boolean;
+  residual: boolean;
+  pinned: boolean;
+  policy: string;
+  routing?: Artifact;
+};
+
+function isInFlightWorker(task: Task): boolean {
+  const ts = taskState(task);
+  if (ts === "running") return true;
+  if (ts === "done" || ts === "fail") return false;
+  const s = (task.status || "").toLowerCase();
+  return (
+    s.includes("queued")
+    || s.includes("pending")
+    || s.includes("registered")
+    || s.includes("started")
+  );
+}
+
+function workerModelView(task: Task, routing?: Artifact): WorkerModelView {
+  const adapterLabel = (task.adapter || "").trim();
+  // Associated final ROUTING wins over a stale task.model preview from an earlier poll.
+  const rawModel = (routing?.model || task.model || "").trim();
+  const policy = routing ? routingPolicy(routing) : "";
+  const display = displayModelId(rawModel, {
+    policy,
+    adapterFallback: isEngineOnlyModelId(adapterLabel) ? "" : adapterLabel,
+  });
+  const ts = taskState(task);
+  const pinned = policy === "explicit_pin";
+  if (display) {
+    return { rawModel, display, slot: display, pending: false, residual: false, pinned, policy, routing };
+  }
+  if (isInFlightWorker(task)) {
+    return { rawModel, display, slot: "routing…", pending: true, residual: false, pinned: false, policy, routing };
+  }
+  const meaningfulResidual =
+    ts === "fail" || isEngineOnlyModelId(adapterLabel) || isEngineOnlyModelId(rawModel);
+  return {
+    rawModel,
+    display,
+    slot: meaningfulResidual ? "no-model" : "",
+    pending: false,
+    residual: meaningfulResidual,
+    pinned: false,
+    policy,
+    routing,
+  };
+}
+
+const DISCLOSURE_FOCUS =
+  "focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-accent";
+
 /** Merge a fresh /swarm/live poll into cached state without wiping expanded full artifacts. */
 function mergeSwarmLive(prev: SwarmLive | null | undefined, next: SwarmLive): SwarmLive {
   if (!prev?.jobs?.length) return next;
@@ -366,10 +489,6 @@ function mergeSwarmLive(prev: SwarmLive | null | undefined, next: SwarmLive): Sw
   };
 }
 
-function jobCost(j: Job): number {
-  return Number(j.est_cost_usd || 0);
-}
-
 function jobTokens(j: Job): number {
   return Number(j.tokens || 0);
 }
@@ -387,7 +506,36 @@ function formatCost(cost: number, estimated?: boolean): string {
 /** Missing/unpriceable estimates must not paint as measured $0. */
 function formatKnownCost(cost: unknown, estimated?: boolean): string {
   if (typeof cost !== "number" || !isFinite(cost)) return "—";
+  if (!(cost > 0) && estimated) return "—";
   return formatCost(cost, estimated);
+}
+
+function isKnownPositiveCost(cost: unknown): boolean {
+  return typeof cost === "number" && isFinite(cost) && cost > 0;
+}
+
+function isProviderAttestedExactZero(cost: unknown, estimated?: boolean): cost is number {
+  return typeof cost === "number" && isFinite(cost) && !(cost > 0) && estimated === false;
+}
+
+function hasMeaningfulJobCost(j: Job): boolean {
+  const estimated = j.estimated !== false && j.cost_provenance !== "provider";
+  if (isKnownPositiveCost(j.est_cost_usd)) return true;
+  return isProviderAttestedExactZero(j.est_cost_usd, estimated);
+}
+
+function formatWorkerCost(
+  cost: unknown,
+  estimated?: boolean,
+  planBilled?: boolean,
+): string {
+  if (isProviderAttestedExactZero(cost, estimated)) {
+    return formatCost(cost, false);
+  }
+  if (planBilled && !isKnownPositiveCost(cost)) {
+    return "—";
+  }
+  return formatKnownCost(cost, estimated);
 }
 
 function positiveUsd(n?: number): number {
@@ -531,10 +679,10 @@ export function SavingsChip({ parts, className }: { parts: SavingsParts; classNa
   if (parts.total <= 0) return null;
   return (
     <span
-      className={`inline-flex items-center gap-0.5 px-1 py-px rounded-full bg-good/10 border border-good/20 text-good/80 tabular-nums ${className ?? ""}`}
+      className={`inline-flex items-center gap-1 text-good/80 tabular-nums ${className ?? ""}`}
       title={`List-price value from model selection, prompt-cache, and compaction (additive, not billed): ${savingsDetail(parts)}`}
     >
-      <span className="text-good/60" aria-hidden="true">{"\u2193"}</span>
+      <span className="text-good/45" aria-hidden="true">{"\u2193"}</span>
       {formatCost(parts.total, parts.modelSelectionEstimated || parts.cachePartial)} saved
     </span>
   );
@@ -573,7 +721,14 @@ function PhaseStrip({ job, phase }: { job: Job; phase?: ReturnType<typeof jobPha
   const warning = jobStatus(job) === "completed" && job.outcome?.trustworthy === false;
   const active = key !== "done" && !failed;
   return (
-    <div className="flex items-center gap-1 mt-1.5" title={PHASES.join(" -> ")}>
+    <div
+      className="flex items-center gap-0.5"
+      role="progressbar"
+      aria-label={`Swarm phase: ${key}`}
+      aria-valuemin={0}
+      aria-valuemax={PHASES.length - 1}
+      aria-valuenow={index}
+    >
       {PHASES.map((_, i) => {
         const reached = i <= index;
         const isActiveSeg = i === index && active;
@@ -587,7 +742,7 @@ function PhaseStrip({ job, phase }: { job: Job; phase?: ReturnType<typeof jobPha
         return (
           <div
             key={i}
-            className={`h-1 flex-1 rounded-full transition-all ${color} ${isActiveSeg ? "animate-pulse" : ""}`}
+            className={`h-px flex-1 transition-all ${color} ${isActiveSeg ? "animate-pulse" : ""}`}
           />
         );
       })}
@@ -603,8 +758,15 @@ function WorkerProgress({ tasks }: { tasks: Task[] }) {
   const donePct = Math.round((done / total) * 100);
   const failedPct = Math.round((failed / total) * 100);
   return (
-    <div className="flex items-center gap-2">
-      <div className="flex-1 h-1.5 bg-panel2/40 border border-edge/50 rounded-full overflow-hidden flex">
+    <div
+      className="flex items-center gap-2"
+      role="progressbar"
+      aria-label={`${done + failed} of ${total} workers finished`}
+      aria-valuemin={0}
+      aria-valuemax={total}
+      aria-valuenow={done + failed}
+    >
+      <div className="flex-1 h-px bg-edge/50 overflow-hidden flex">
         {donePct > 0 && (
           <div className="h-full bg-good transition-all duration-500" style={{ width: `${donePct}%` }} />
         )}
@@ -615,6 +777,71 @@ function WorkerProgress({ tasks }: { tasks: Task[] }) {
       <span className={`text-[9px] tabular-nums shrink-0 ${failed > 0 ? "text-risk/80" : "text-faint"}`}>
         {done + failed}/{total}{failed > 0 ? ` · ${failed} failed` : ""}
       </span>
+    </div>
+  );
+}
+
+function WorkerModelSlot({
+  view,
+}: {
+  view: WorkerModelView;
+}) {
+  if (!view.slot) return null;
+  const title = view.pending
+    ? "Model routing in progress"
+    : view.residual
+      ? "No model recorded"
+      : `Model: ${view.display || view.rawModel || view.slot}`;
+  return (
+    <span className="inline-flex items-center gap-1 min-w-0 max-w-full flex-wrap">
+      <Cpu size={9} className={`shrink-0 ${view.pending || view.residual ? "text-faint/60" : "text-accent/65"}`} />
+      <Tooltip label={title} className="min-w-0 max-w-full">
+        <span
+          className={`font-mono text-[9px] truncate min-w-0 max-w-full ${
+            view.pending
+              ? "text-faint italic"
+              : view.residual
+                ? "text-faint"
+                : "text-accent/85"
+          }`}
+          aria-label={title}
+        >
+          {view.slot}
+        </span>
+      </Tooltip>
+      {view.pinned && (
+        <span
+          className="text-[7.5px] text-faint uppercase tracking-[0.12em] shrink-0"
+          title="explicit_pin · not auto-routed"
+        >
+          pinned
+        </span>
+      )}
+    </span>
+  );
+}
+
+function UnmatchedRoutingNote({
+  arts,
+  hasTasks,
+  headerModel,
+}: {
+  arts: Artifact[];
+  hasTasks: boolean;
+  headerModel: string;
+}) {
+  if (arts.length === 0) return null;
+  if (!hasTasks && !unmatchedAddsTruth(arts, headerModel)) return null;
+  const firstModel = (arts[0].model || "").trim() || "unresolved";
+  const label = arts.length === 1
+    ? `Unmatched routing · ${firstModel} · no matching worker`
+    : `Unmatched routing · ${arts.length} routes · no matching worker`;
+  return (
+    <div
+      className="text-[9px] text-faint leading-relaxed px-0.5 py-0.5"
+      title="ROUTING artifact with no matching worker task_id"
+    >
+      {label}
     </div>
   );
 }
@@ -979,28 +1206,33 @@ export default function SwarmPane() {
     );
     const streamArts = artifacts.filter((a: Artifact) => (a.type || "").toUpperCase() !== "ROUTING");
     const tasks = j.tasks || [];
-    // Prefer the deduped final routing card (fallback/escalation wins) over the
-    // job.model field so a stale initial router pick never badges the header.
-    // Local agentic jobs stamp model as "agentic/<id>"; strip the engine prefix
-    // so the badge shows the real model next to the separate adapter chip.
-    const primaryRouting =
-      routingArts.find((a: Artifact) => a.model) || routingArts[0];
+    const { routingForTask, unmatched: unmatchedRouting } = associateRoutingToTasks(routingArts, tasks);
+    // Prefer the deduped final routing decision (fallback/escalation wins) over
+    // the job.model field so a stale initial router pick never badges the header.
+    const primaryRouting = tasks.length === 0
+      ? bestUnscopedRouting(routingArts) || routingArts.find((a: Artifact) => a.model) || routingArts[0]
+      : routingArts.find((a: Artifact) => a.model) || routingArts[0];
     const routerModel = primaryRouting?.model || j.model || "";
     const attestedPolicy = primaryRouting ? routingPolicy(primaryRouting) : "";
     const workerCount = tasks.length;
     const adapter = j.adapter || tasks[0]?.adapter || "";
-    // Explicit pins keep the full registry id (agentic/meta/...) on the
-    // collapsed summary so Sol-style attribution is visible without expanding.
-    // Auto-routed rows strip every engine prefix (idempotent) for scannability
-    // so agentic/agentic/... never badges as agentic/<provider>/...
     const displayModel = displayModelId(routerModel || "", {
       policy: attestedPolicy,
-      // Adapter chip stays separate; never badge bare agentic/native as model.
       adapterFallback: isEngineOnlyModelId(adapter) ? "" : adapter,
     });
+    // Canonical task rows own worker→model truth. Job-level model / routing…
+    // stays only when there are zero task rows (including pre-task in-flight).
+    const headerModel = workerCount === 0 ? displayModel : "";
+    const showJobRoutingPlaceholder = workerCount === 0 && !headerModel && st === "in_progress";
+    const showUnmatched = unmatchedRouting.length > 0
+      && (workerCount > 0 || unmatchedAddsTruth(unmatchedRouting, headerModel));
     const terminal = isTerminal(j);
     const savings = jobSavings(j);
-    const showRoutingPlaceholder = !displayModel && st === "in_progress";
+    const showJobTokens = jobTokens(j) > 0;
+    const showJobCompactTokens = jobCompactTokens(j) > 0;
+    const showJobCost = hasMeaningfulJobCost(j);
+    const showJobSavings = savings.total > 0;
+    const hasHeaderMeters = showJobTokens || showJobCompactTokens || showJobCost || showJobSavings;
 
     const toggle = () => {
       const next = !isExpanded;
@@ -1036,11 +1268,13 @@ export default function SwarmPane() {
         <div
           role="button"
           tabIndex={0}
+          aria-expanded={isExpanded}
+          aria-label={`${j.goal || "Swarm job"}, ${phase.label}`}
           onClick={toggle}
           onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); } }}
-          className="w-full flex flex-col gap-0 p-2 hover:bg-panel2/35 text-left transition-colors select-none cursor-pointer focus:outline-none"
+          className={`w-full flex flex-col gap-0 p-2 hover:bg-panel2/35 text-left transition-colors select-none cursor-pointer ${DISCLOSURE_FOCUS}`}
         >
-          <div className="flex items-center justify-between w-full">
+          <div className="flex items-center justify-between w-full gap-2">
             <div className="flex items-center gap-2 min-w-0 flex-1">
               <span className="shrink-0 text-faint">
                 {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
@@ -1064,22 +1298,7 @@ export default function SwarmPane() {
                 {j.goal}
               </Tooltip>
             </div>
-            <div className="flex items-center gap-3 shrink-0 text-[10px] pl-2">
-              {(terminal || jobCost(j) > 0 || jobTokens(j) > 0 || jobCompactTokens(j) > 0 || savings.total > 0) && (
-                <span className="text-muted font-mono flex items-center gap-1.5">
-                  {jobTokens(j) > 0 && <span>{jobTokens(j).toLocaleString()}t</span>}
-                  {jobCompactTokens(j) > 0 && (
-                    <span className="text-accent/90">{jobCompactTokens(j).toLocaleString()} compact</span>
-                  )}
-                  <span className="text-good/90">
-                    {formatKnownCost(
-                      j.est_cost_usd,
-                      j.estimated !== false && j.cost_provenance !== "provider",
-                    )}
-                  </span>
-                  <SavingsChip parts={savings} className="text-[9px] font-sans" />
-                </span>
-              )}
+            <div className="flex items-center gap-2 shrink-0 text-[10px]">
               {/* Kill: running jobs only. Best-effort cooperative cancel on the
                   backend. Shows 'cancelling...' until the next poll flips the job
                   to a terminal state. */}
@@ -1088,9 +1307,12 @@ export default function SwarmPane() {
                   <span className="text-[9px] text-risk/70 italic tabular-nums">cancelling...</span>
                 ) : (
                   <button
+                    type="button"
                     onClick={(e) => { e.stopPropagation(); void cancelJob(j.id); }}
+                    onKeyDown={(e) => e.stopPropagation()}
                     title="Cancel this job"
-                    className="text-faint/50 hover:text-risk transition-colors focus:outline-none"
+                    aria-label="Cancel this job"
+                    className={`text-faint/50 hover:text-risk transition-colors ${DISCLOSURE_FOCUS}`}
                   >
                     <X size={12} />
                   </button>
@@ -1100,9 +1322,12 @@ export default function SwarmPane() {
                   confusing. Non-destructive; the run stays in PM history. */}
               {terminal && (
                 <button
+                  type="button"
                   onClick={(e) => { e.stopPropagation(); dismissJob(j.id); }}
+                  onKeyDown={(e) => e.stopPropagation()}
                   title="Dismiss from tracker (stays in Puppetmaster history)"
-                  className="text-faint/50 hover:text-risk transition-colors focus:outline-none"
+                  aria-label="Dismiss from tracker (stays in Puppetmaster history)"
+                  className={`text-faint/50 hover:text-risk transition-colors ${DISCLOSURE_FOCUS}`}
                 >
                   <X size={12} />
                 </button>
@@ -1110,44 +1335,63 @@ export default function SwarmPane() {
             </div>
           </div>
 
-          {/* Model + worker count + adapter -- the "who's doing this and on what"
-              line, so the swarm's shape reads without expanding. CLI/external
-              jobs (Cursor MCP, terminal `puppetmaster`) share the workspace
-              store and are merged in on purpose; label them so they don't look
-              like Marionette-dispatched swarms. */}
-          {(displayModel || showRoutingPlaceholder || workerCount > 0 || adapter || j.source === "cli" || attestedPolicy === "explicit_pin") && (
-            <div className="flex items-center gap-1.5 pl-6 pr-1 mt-1 flex-wrap">
-              {displayModel ? (
-                <span className="flex items-center gap-1 text-[9px] font-mono text-accent/90 bg-accent/10 px-1.5 py-0.5 rounded" title={`Model: ${displayModel}`}>
-                  <Cpu size={9} /> {displayModel}
+          {/* One quiet receipt line: spend first, then execution identity.
+              Rare provenance remains textual so the header never becomes a
+              dashboard of pills. */}
+          {(hasHeaderMeters || headerModel || showJobRoutingPlaceholder || workerCount > 0 || adapter || j.source === "cli" || (workerCount === 0 && attestedPolicy === "explicit_pin")) && (
+            <div className="flex items-center gap-x-2 gap-y-1 pl-6 pr-1 mt-1.5 flex-wrap text-[9px]">
+              {hasHeaderMeters && (
+                <span className="inline-flex items-center gap-1.5 min-w-0 flex-wrap font-mono text-muted tabular-nums">
+                  {showJobTokens && <span>{jobTokens(j).toLocaleString()}t</span>}
+                  {showJobCompactTokens && (
+                    <span className="text-accent/80">{jobCompactTokens(j).toLocaleString()} compact</span>
+                  )}
+                  {showJobCost && (
+                    <span className="text-good/85">
+                      {formatKnownCost(
+                        j.est_cost_usd,
+                        j.estimated !== false && j.cost_provenance !== "provider",
+                      )}
+                    </span>
+                  )}
+                  {showJobSavings && <SavingsChip parts={savings} className="font-sans" />}
                 </span>
-              ) : showRoutingPlaceholder ? (
+              )}
+              {hasHeaderMeters && (headerModel || showJobRoutingPlaceholder || workerCount > 0 || adapter) && (
+                <span className="h-2.5 w-px bg-edge/70" aria-hidden="true" />
+              )}
+              {headerModel ? (
+                <span className="inline-flex items-center gap-1 min-w-0 max-w-full font-mono text-accent/85" title={`Model: ${headerModel}`}>
+                  <Cpu size={9} className="shrink-0" />
+                  <span className="truncate min-w-0">{headerModel}</span>
+                </span>
+              ) : showJobRoutingPlaceholder ? (
                 <span
-                  className="flex items-center gap-1 text-[9px] font-mono text-faint bg-panel2/30 px-1.5 py-0.5 rounded"
+                  className="flex items-center gap-1 font-mono text-faint italic"
                   title="Model routing in progress"
                 >
                   <Cpu size={9} /> routing…
                 </span>
               ) : null}
-              {attestedPolicy === "explicit_pin" && (
+              {workerCount === 0 && attestedPolicy === "explicit_pin" && (
                 <span
-                  className="text-[9px] text-faint bg-edge/25 px-1.5 py-0.5 rounded font-mono"
-                  title="Routing policy: explicit_pin (not auto-routed)"
+                  className="text-[8px] text-faint uppercase tracking-wide"
+                  title="explicit_pin · not auto-routed"
                 >
-                  explicit_pin
+                  pin
                 </span>
               )}
               {workerCount > 0 && (
-                <span className="text-[9px] text-muted bg-panel2/40 px-1.5 py-0.5 rounded tabular-nums">
+                <span className="text-muted tabular-nums">
                   {workerCount} worker{workerCount > 1 ? "s" : ""}
                 </span>
               )}
               {adapter && adapter.toLowerCase() !== displayModel.toLowerCase() && (
-                <span className="text-[9px] text-faint bg-panel2/30 px-1.5 py-0.5 rounded lowercase">{adapter}</span>
+                <span className="text-faint lowercase">{adapter}</span>
               )}
               {j.source === "cli" && (
                 <span
-                  className="text-[9px] text-muted bg-panel2/40 border border-edge/50 px-1.5 py-0.5 rounded"
+                  className="text-muted uppercase tracking-[0.1em]"
                   title="Started outside Marionette (Cursor MCP or terminal Puppetmaster) for this workspace"
                 >
                   external
@@ -1198,7 +1442,7 @@ export default function SwarmPane() {
           ) : null}
 
           {/* Phase strip + label -- the at-a-glance "where is this swarm". */}
-          <div className="flex items-center gap-2 pl-6 pr-1 mt-1">
+          <div className="flex items-center gap-2 pl-6 pr-1 mt-2">
             <div className="flex-1"><PhaseStrip job={j} phase={phase} /></div>
             <span className={`text-[9px] font-medium tabular-nums shrink-0 ${
               phase.key === "cancelled"
@@ -1215,23 +1459,16 @@ export default function SwarmPane() {
             </span>
           </div>
 
-          {/* Live-progress line for a running job: a "last activity" relative time
-              plus a compact token readout that updates on each poll, so the row
-              visibly moves instead of sitting on a static spinner. Cost is
-              deliberately omitted here (shown once in the bottom status bar). */}
+          {/* Last activity supplies motion without repeating the receipt. */}
           {st === "in_progress" && (() => {
             const since = relativeSince(j.updated_at ?? j.created_at, nowTick);
-            const showTokens = j.tokens !== undefined && j.tokens > 0;
-            if (!since && !showTokens) return null;
+            if (!since) return null;
             return (
               <div className="flex items-center gap-2 pl-6 pr-1 mt-1 text-[9px] text-faint tabular-nums">
-                {since && (
-                  <span className="flex items-center gap-1">
-                    <Activity size={9} className="text-accent/70 animate-pulse" />
-                    {since}
-                  </span>
-                )}
-                {showTokens && <span className="font-mono text-muted">{j.tokens!.toLocaleString()}t</span>}
+                <span className="flex items-center gap-1">
+                  <Activity size={9} className="text-accent/60 animate-pulse" />
+                  {since}
+                </span>
               </div>
             );
           })()}
@@ -1240,197 +1477,152 @@ export default function SwarmPane() {
         {/* Expanded details */}
         {isExpanded && (
           <div className="px-2 pb-2 pt-1 flex flex-col gap-2 bg-panel2/10">
-            {/* Routing */}
-            {routingArts.length > 0 && (
-              <div className="flex flex-col gap-1.5">
-                {routingArts.map((art: Artifact, idx: number) => {
-                  const hasRejected = art.rejected && art.rejected.length > 0;
-                  const key = `${art.id || idx}`;
-                  const altsExpanded = !!expandedAlts[key];
-                  const policyLabel = routingPolicy(art) || "Pin attribution unknown";
-                  const providerLabel = [art.provider, art.adapter]
-                    .map((v) => (typeof v === "string" ? v.trim() : ""))
-                    .filter(Boolean)
-                    .filter((v, i, arr) => arr.indexOf(v) === i)
-                    .join(" · ");
-                  return (
-                    <div key={key} className="p-2 bg-panel2/30 rounded border border-edge/50 text-[10px] flex flex-col gap-1.5">
-                      <div className="flex items-center justify-between text-muted gap-2">
-                        <span className="flex items-center gap-1.5 min-w-0 flex-wrap">
-                          <Cpu size={11} className="text-accent shrink-0" />
-                          <span className="text-txt font-mono font-medium truncate" title={art.model}>
-                            {art.model || "Unknown model"}
-                          </span>
-                          <span
-                            className="text-[8px] text-faint bg-edge/20 px-1 py-0.5 rounded shrink-0 font-mono"
-                            title="Routing policy"
-                          >
-                            {policyLabel}
-                          </span>
-                          {providerLabel && (
-                            <span
-                              className="text-[8px] text-faint bg-edge/20 px-1 py-0.5 rounded shrink-0 font-mono truncate max-w-[140px]"
-                              title={providerLabel}
-                            >
-                              {providerLabel}
-                            </span>
-                          )}
-                        </span>
-                        <span className="font-mono text-good shrink-0 font-semibold">
-                          {formatKnownCost(art.est_cost_usd, true)}
-                        </span>
-                      </div>
-                      {/* One plain-language line on why this model won. */}
-                      <div className="text-[9.5px] text-faint leading-relaxed">
-                        {summarizeRouting(art)}
-                      </div>
-                      {/* Alternatives, deliberately de-emphasized: a muted count,
-                          expanding to model-name chips (full reason on hover)
-                          instead of a red-looking wall of text. */}
-                      {hasRejected && (
-                        <div>
-                          <button
-                            onClick={(e) => { e.stopPropagation(); setExpandedAlts((prev) => ({ ...prev, [key]: !altsExpanded })); }}
-                            className="text-[9px] text-faint/80 hover:text-muted flex items-center gap-0.5 focus:outline-none"
-                          >
-                            {altsExpanded ? <ChevronDown size={9} /> : <ChevronRight size={9} />}
-                            {art.rejected?.length} alternatives considered
-                          </button>
-                          {altsExpanded && (
-                            <div className="mt-1.5 flex flex-wrap gap-1">
-                              {art.rejected?.map((rej: { model: string; reason: string }, ridx: number) => (
-                                <Tooltip
-                                  key={ridx}
-                                  label={rej.reason}
-                                  className="font-mono text-[8.5px] text-faint bg-panel2/30 border border-edge/40 px-1.5 py-0.5 rounded cursor-default"
-                                >
-                                  {rej.model}
-                                </Tooltip>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-
-            {/* Single-worker / provider jobs (run_implement, run_parallel) have
-                NO routing artifact, so the per-worker cost row above never
-                rendered for them -- the dash showed a single-worker swarm with no
-                price. Synthesize a cost/model line from the job fields so every
-                job surfaces its spend, matching multi-worker swarms. */}
-            {routingArts.length === 0 && ((j.est_cost_usd ?? 0) > 0 || (j.tokens ?? 0) > 0) && (
-              <div className="p-2 bg-panel2/30 rounded border border-edge/50 text-[10px] flex items-center justify-between text-muted">
-                <span className="flex items-center gap-1.5 truncate max-w-[72%]">
-                  <Cpu size={11} className="text-accent shrink-0" />
-                  <span className="text-txt font-mono font-medium truncate" title={displayModel}>
-                    {displayModel || "worker"}
-                  </span>
-                </span>
-                <span className="flex items-center gap-2 shrink-0 font-mono">
-                  {(j.tokens ?? 0) > 0 && <span className="text-faint">{j.tokens!.toLocaleString()}t</span>}
-                  <span className="text-good font-semibold">
-                    {formatCost(
-                      Number(j.est_cost_usd || 0),
-                      j.estimated !== false && j.cost_provenance !== "provider",
-                    )}
-                  </span>
-                </span>
-              </div>
-            )}
-
-            {/* Workers -- with a completion progress bar so a wave of parallel
-                workers reads as a single advancing unit. */}
+            {/* Workers first -- never a standalone Routing card stack. */}
             {tasks.length > 0 && (
-              <div className="border-t border-edge/20 pt-1.5 flex flex-col gap-1.5">
+              <div className="border-t border-edge/25 pt-2 flex flex-col gap-1.5">
                 <div className="flex items-center justify-between">
-                  <span className="text-[9px] uppercase tracking-wider text-faint font-medium">Workers ({tasks.length})</span>
+                  <span className="text-[8.5px] uppercase tracking-[0.14em] text-faint font-medium">Workers ({tasks.length})</span>
                 </div>
                 <WorkerProgress tasks={tasks} />
-                <div className="flex flex-col gap-1 mt-0.5">
+                <div className="flex flex-col divide-y divide-edge/20 mt-0.5">
                   {tasks.map((task) => {
                     const ts = taskState(task);
                     const tExpanded = !!expandedTasks[task.id];
-                    // Prefer a real routed model over repeating the engine label
-                    // already present in role ("implement (agentic) (agentic)").
-                    const taskModelLabel = displayModelId(task.model || "", {});
+                    const routing = routingForTask.get(task.id);
+                    const view = workerModelView(task, routing);
                     const adapterLabel = (task.adapter || "").trim();
-                    const secondaryLabel = taskModelLabel
-                      || (adapterLabel && !isEngineOnlyModelId(adapterLabel) ? adapterLabel : "");
+                    const provider = (routing?.provider || "").trim();
+                    const createdBy = routing?.created_by || "";
+                    const hasRejected = !!(routing?.rejected && routing.rejected.length > 0);
+                    const altKey = `${j.id}:${task.id}`;
+                    const altsExpanded = !!expandedAlts[altKey];
+                    const costValue = task.est_cost_usd ?? routing?.est_cost_usd;
+                    const costEstimated = task.est_cost_usd != null
+                      ? task.estimated !== false && task.cost_provenance !== "provider"
+                      : true;
+                    const showTokens = (task.tokens ?? 0) > 0;
+                    const showCost = isKnownPositiveCost(costValue)
+                      || isProviderAttestedExactZero(costValue, costEstimated);
+                    const showSpend = showTokens || showCost;
+                    const roleLabel = task.role || "Worker";
+                    const detailsId = `swarm-worker-${task.id}`;
+                    const workerState = (task.status || ts).trim() || "idle";
                     return (
                       <div
                         key={task.id}
-                        role="button"
-                        tabIndex={0}
-                        aria-expanded={tExpanded}
-                        onClick={() => toggleTask(task.id)}
-                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleTask(task.id); } }}
-                        className="p-1.5 rounded bg-panel2/20 border border-edge/40 flex items-start gap-2 text-[10px] cursor-pointer hover:bg-panel2/35 focus:outline-none"
+                        className="py-1.5 flex flex-col text-[10px]"
                       >
-                        <span className="mt-0.5 shrink-0">
-                          {ts === "running" ? <Loader2 size={10} className="animate-spin text-accent" />
-                            : ts === "done" ? <CheckCircle2 size={10} className="text-good" />
-                            : ts === "fail" ? <XCircle size={10} className="text-risk" />
-                            : <Circle size={10} className="text-muted" />}
-                        </span>
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center justify-between gap-1">
-                            <span className="font-semibold text-txt truncate flex items-center gap-1 min-w-0">
-                              {tExpanded
-                                ? <ChevronDown size={9} className="text-faint shrink-0" />
-                                : <ChevronRight size={9} className="text-faint shrink-0" />}
-                              <span className="truncate">
-                                {task.role || "Worker"}
-                                {secondaryLabel ? (
-                                  <span className="text-faint font-normal"> ({secondaryLabel})</span>
-                                ) : !task.role ? (
-                                  <span className="text-faint font-normal"> (no-adapter)</span>
-                                ) : null}
+                        <div
+                          role="button"
+                          tabIndex={0}
+                          aria-expanded={tExpanded}
+                          aria-controls={detailsId}
+                          aria-label={`${roleLabel}, ${workerState}${view.slot ? `, ${view.slot}` : ""}`}
+                          onClick={() => toggleTask(task.id)}
+                          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleTask(task.id); } }}
+                          className={`group flex items-start gap-2 min-w-0 px-1 py-0.5 cursor-pointer hover:bg-panel2/25 transition-colors ${DISCLOSURE_FOCUS}`}
+                        >
+                          <span className="shrink-0 mt-0.5">
+                            {ts === "running" ? <Loader2 size={10} className="animate-spin text-accent" />
+                              : ts === "done" ? <CheckCircle2 size={10} className="text-good" />
+                              : ts === "fail" ? <XCircle size={10} className="text-risk" />
+                              : <Circle size={10} className="text-muted" />}
+                          </span>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-1 min-w-0">
+                              <span className="min-w-0 flex-1 truncate font-semibold text-txt">
+                                {roleLabel}
                               </span>
-                            </span>
-                            <span className="flex items-center gap-1.5 shrink-0">
-                              {((task.tokens ?? 0) > 0 || (task.est_cost_usd ?? 0) > 0) && (
-                                <span className="text-muted font-mono text-[9px] flex items-center gap-1 tabular-nums">
-                                  {(task.tokens ?? 0) > 0 && (
+                              <span className="shrink-0 text-faint/60 group-hover:text-faint transition-colors">
+                                {tExpanded
+                                  ? <ChevronDown size={9} />
+                                  : <ChevronRight size={9} />}
+                              </span>
+                            </div>
+                            <div className="mt-0.5 flex items-center gap-x-2 gap-y-0.5 min-w-0 flex-wrap">
+                              <WorkerModelSlot view={view} />
+                              {showSpend && (
+                                <span className="text-muted font-mono text-[8.5px] flex items-center gap-1 tabular-nums">
+                                  {showTokens && (
                                     <span>{Number(task.tokens).toLocaleString()}t</span>
                                   )}
-                                  <span className="text-good/90">
-                                    {formatCost(
-                                      Number(task.est_cost_usd || 0),
-                                      task.estimated !== false && task.cost_provenance !== "provider",
-                                    )}
-                                  </span>
+                                  {showCost && (
+                                    <span className="text-good/85">
+                                      {formatWorkerCost(
+                                        costValue,
+                                        costEstimated,
+                                        isPlanBilledRouting(routing),
+                                      )}
+                                    </span>
+                                  )}
                                 </span>
                               )}
-                              <span className={`text-[8px] uppercase font-bold px-1 rounded ${
-                                ts === "running" ? "text-accent bg-accent/10"
-                                  : ts === "done" ? "text-good bg-good/10"
-                                  : ts === "fail" ? "text-risk bg-risk/10"
-                                  : "text-muted bg-panel2/30"
-                              }`}>{task.status}</span>
-                            </span>
-                          </div>
-                          {tExpanded && (
-                            <div className="mt-1 text-[9px] font-mono text-faint grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
-                              <span>task</span><span className="text-muted break-all">{task.id}</span>
-                              {taskModelLabel && <><span>model</span><span className="text-muted break-all">{taskModelLabel}</span></>}
-                              {adapterLabel && <><span>adapter</span><span className="text-muted break-all">{adapterLabel}</span></>}
-                              {task.completed_at && <><span>completed</span><span className="text-muted break-all">{task.completed_at}</span></>}
-                              {task.instruction && <><span>instruction</span><span className="text-muted whitespace-pre-wrap break-words font-sans">{task.instruction}</span></>}
                             </div>
-                          )}
-                          {!tExpanded && task.instruction && (
-                            <Tooltip label={task.instruction} className="block text-muted text-[9.5px] mt-0.5 truncate">{task.instruction}</Tooltip>
-                          )}
+                          </div>
                         </div>
+                        {tExpanded && (
+                          <div
+                            id={detailsId}
+                            className="ml-5 mt-1 border-l border-edge/35 pl-2 text-[9px] font-mono text-faint grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5"
+                          >
+                            <span>task</span><span className="text-muted break-all">{task.id}</span>
+                            {view.rawModel && <><span>model</span><span className="text-muted break-all">{view.rawModel}</span></>}
+                            {adapterLabel && <><span>adapter</span><span className="text-muted break-all">{adapterLabel}</span></>}
+                            {view.policy ? (
+                              <><span>policy</span><span className="text-muted break-all">{view.policy}{view.pinned ? " · pin" : ""}</span></>
+                            ) : view.routing ? (
+                              <><span>policy</span><span className="text-muted break-all">Pin attribution unknown</span></>
+                            ) : null}
+                            {provider && <><span>provider</span><span className="text-muted break-all">{provider}</span></>}
+                            {createdBy === "router-fallback" && <><span>route</span><span className="text-muted">fallback</span></>}
+                            {createdBy === "router-escalation" && <><span>route</span><span className="text-muted">escalation</span></>}
+                            {task.completed_at && <><span>completed</span><span className="text-muted break-all">{task.completed_at}</span></>}
+                            {task.instruction && <><span>instruction</span><span className="text-muted whitespace-pre-wrap break-words font-sans">{task.instruction}</span></>}
+                            {hasRejected && (
+                              <>
+                                <span>rejected</span>
+                                <span>
+                                  <button
+                                    type="button"
+                                    aria-expanded={altsExpanded}
+                                    onClick={(e) => { e.stopPropagation(); setExpandedAlts((prev) => ({ ...prev, [altKey]: !altsExpanded })); }}
+                                    onKeyDown={(e) => e.stopPropagation()}
+                                    className={`text-[9px] text-faint/80 hover:text-muted inline-flex items-center gap-0.5 ${DISCLOSURE_FOCUS}`}
+                                  >
+                                    {altsExpanded ? <ChevronDown size={9} /> : <ChevronRight size={9} />}
+                                    {routing?.rejected?.length} alternatives
+                                  </button>
+                                  {altsExpanded && (
+                                    <span className="mt-1 flex flex-wrap gap-1">
+                                      {routing?.rejected?.map((rej: { model: string; reason: string }, ridx: number) => (
+                                        <Tooltip
+                                          key={ridx}
+                                          label={rej.reason}
+                                          className="font-mono text-[8.5px] text-faint bg-panel2/30 border border-edge/40 px-1.5 py-0.5 rounded cursor-default"
+                                        >
+                                          {rej.model}
+                                        </Tooltip>
+                                      ))}
+                                    </span>
+                                  )}
+                                </span>
+                              </>
+                            )}
+                          </div>
+                        )}
                       </div>
                     );
                   })}
                 </div>
               </div>
+            )}
+
+            {showUnmatched && (
+              <UnmatchedRoutingNote
+                arts={unmatchedRouting}
+                hasTasks={workerCount > 0}
+                headerModel={headerModel}
+              />
             )}
 
             {/* Findings / artifacts stream -- the substance of an audit, made
@@ -1517,7 +1709,7 @@ export default function SwarmPane() {
               );
             })()}
 
-            {tasks.length === 0 && streamArts.length === 0 && routingArts.length === 0 && (
+            {tasks.length === 0 && streamArts.length === 0 && !showUnmatched && (
               <div className="text-[9.5px] text-faint italic px-1 py-0.5">
                 {loadingArts.has(j.id) || (j.artifacts_complete === false)
                   ? "Loading artifacts..."


### PR DESCRIPTION
## Summary
- replace the standalone routing wall with compact, accessible worker-owned model receipts and exceptional provenance disclosure
- add an opt-in deterministic compaction residual laboratory while keeping causal summary as the production default
- harden routing/cost truth, narrow-rail layout, and hybrid residual secret redaction after adversarial review

## Test plan
- [x] `.venv/bin/python -m pytest -q` (4,450 passed, 74 skipped)
- [x] `npm test` (1,027 passed)
- [x] `npm run test:electron` (148 passed)
- [x] `npm run build`
- [x] version consistency and `git diff --check`
- [x] live Electron swarm tracker preview

Resolves the product direction raised in #47; that contribution is superseded rather than merged because this implementation also preserves routing provenance, accessibility, cost truth, and compact-rail behavior.