### PR TITLE
Surface task-scoped failure reasons in worker details

### DIFF
--- a/harness/local_jobs.py
+++ b/harness/local_jobs.py
@@ -900,6 +900,8 @@ class LocalJobsMixin:
                 ),
                 "headline": headline[:240],
             }
+            if job.get("tasks") and job["tasks"][0].get("id"):
+                terminal_art["task_id"] = job["tasks"][0]["id"]
             # Provenance the artifact read surfaces need to attribute the work.
             terminal_art = stamp_provenance(terminal_art, {
                 "adapter": job.get("adapter"),

--- a/harness/state.py
+++ b/harness/state.py
@@ -231,6 +231,21 @@ class DurableState:
             art_type = str(getattr(a, "type", ""))
             task_id = getattr(a, "task_id", "") or None
             job_id = getattr(a, "job_id", "") or None
+            detail = payload.get("reason") or payload.get("detail")
+            result = payload.get("result")
+            failure = payload.get("failure")
+            kind = art_type.strip().lower()
+            if kind.endswith("verification") and (
+                failure or str(result or "").strip().lower() in ("failed", "blocked", "error")
+            ):
+                source_reason = (
+                    payload.get("turn_failure_message")
+                    or payload.get("message")
+                    or payload.get("stderr")
+                )
+                if source_reason:
+                    from harness.api.redaction import redact_secret_text
+                    detail = redact_secret_text(str(source_reason).strip())[:500] or None
             row = {
                 "id": getattr(a, "id", ""),
                 "type": art_type,
@@ -267,13 +282,13 @@ class DurableState:
                         or payload.get("model_chosen") or payload.get("driver")
                     ),
                 ),
-                "detail": payload.get("reason") or payload.get("detail"),
+                "detail": detail,
                 # Verification verdicts. "result" is failed/blocked/pass;
                 # "failure" is the machine class (no_model, billing_or_quota).
                 # The GUI needs these to render a swarm whose every worker
                 # fast-failed as a red failed run instead of a green "done".
-                "result": payload.get("result"),
-                "failure": payload.get("failure"),
+                "result": result,
+                "failure": failure,
                 # Only present for patch artifacts; None elsewhere so the GUI can
                 # cheaply test truthiness before rendering a diffstat row.
                 "files": files,
@@ -282,7 +297,6 @@ class DurableState:
             # Lightweight parent-execution pointer for signal rows. Prefer an
             # explicit payload stamp; otherwise synthesize from job/task ids so
             # legacy store rows still resolve without copying spend fields.
-            kind = art_type.strip().lower()
             if kind in ("finding", "risk", "decision"):
                 ref = payload.get("execution_ref")
                 if not isinstance(ref, dict):

--- a/tests/test_format_artifacts_routing.py
+++ b/tests/test_format_artifacts_routing.py
@@ -16,6 +16,17 @@ def _routing_artifact(**payload):
     )
 
 
+def _verification_artifact(**payload):
+    return SimpleNamespace(
+        id="verify-1",
+        type="verification",
+        confidence=1.0,
+        created_by="worker",
+        task_id="task-1",
+        payload=payload,
+    )
+
+
 def test_format_artifacts_forwards_policy_provider_adapter():
     ds = DurableState.__new__(DurableState)
     out = ds.format_artifacts([
@@ -49,3 +60,34 @@ def test_format_artifacts_omits_missing_pin_fields_as_none():
     assert row["provider"] is None
     assert row["adapter"] is None
     assert row["adapter_model_name"] is None
+
+
+def test_format_failed_verification_projects_bounded_redacted_source_reason():
+    ds = DurableState.__new__(DurableState)
+    out = ds.format_artifacts([
+        _verification_artifact(
+            result="failed",
+            failure="codex_turn_failed",
+            turn_failure_message="Spend cap reached token=super-secret-value " + ("x" * 600),
+            message="lower-priority message",
+            stderr="lower-priority stderr",
+        ),
+    ])
+
+    row = out[0]
+    assert row["failure"] == "codex_turn_failed"
+    assert row["detail"].startswith("Spend cap reached token=REDACTED")
+    assert "super-secret-value" not in row["detail"]
+    assert "lower-priority" not in row["detail"]
+    assert len(row["detail"]) == 500
+
+
+def test_format_failed_verification_falls_back_to_message_then_stderr():
+    ds = DurableState.__new__(DurableState)
+    message_row, stderr_row = ds.format_artifacts([
+        _verification_artifact(result="failed", failure="no_model", message="No eligible model"),
+        _verification_artifact(result="blocked", failure="auth_failure", stderr="Provider login required"),
+    ])
+
+    assert message_row["detail"] == "No eligible model"
+    assert stderr_row["detail"] == "Provider login required"

--- a/tests/test_local_job_labeling.py
+++ b/tests/test_local_job_labeling.py
@@ -83,6 +83,31 @@ def test_finish_local_job_overwrites_model_from_worker_result(monkeypatch):
     assert job["status"] == "completed"
 
 
+def test_failed_local_terminal_artifact_carries_exact_task_id(monkeypatch):
+    monkeypatch.setattr(
+        "harness.local_job_routing.preview_agentic_route",
+        lambda *a, **k: {},
+    )
+    s = _session()
+    s._register_local_job(
+        "local-fail", "audit failure", role="analysis",
+        engine="agentic", model="",
+    )
+    task_id = s._local_jobs["local-fail"]["tasks"][0]["id"]
+
+    s._finish_local_job(
+        "local-fail", ok=False, summary="Provider login required",
+        engine="agentic", model="",
+    )
+
+    terminal = next(
+        art for art in s._local_jobs["local-fail"]["artifacts"]
+        if art["id"] == "local-fail-result"
+    )
+    assert terminal["type"] == "error"
+    assert terminal["task_id"] == task_id
+
+
 def test_finish_does_not_clobber_preview_model_with_engine_only(monkeypatch):
     """Finish with engine but empty model must keep the preview ROUTING stamp."""
     monkeypatch.setattr(

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -406,6 +406,67 @@ describe("SwarmPane worker details", () => {
     expect(screen.getByText("2026-08-16T17:00:00+00:00")).toBeInTheDocument();
   });
 
+  it("reveals only the exact task-matched failure class and reason", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-failed-workers",
+        goal: "Inspect failed workers",
+        status: "failed",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "verification",
+            headline: "worker a",
+            task_id: "task-a",
+            result: "failed",
+            failure: "codex_turn_failed",
+            detail: "Workspace spend cap reached",
+          },
+          {
+            type: "verification",
+            headline: "worker b",
+            task_id: "task-b",
+            result: "failed",
+            failure: "auth_failure",
+            detail: "Provider login required",
+          },
+          {
+            type: "verification",
+            headline: "unmatched",
+            result: "failed",
+            failure: "no_model",
+            detail: "Must not be guessed onto a worker",
+          },
+        ],
+        tasks: [
+          { id: "task-a", status: "failed", adapter: "agentic", role: "worker-a", instruction: "", completed_at: "2026-08-17T19:00:00+00:00" },
+          { id: "task-b", status: "failed", adapter: "agentic", role: "worker-b", instruction: "" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Inspect failed workers"));
+
+    const workerA = screen.getByRole("button", { name: /worker-a/ });
+    fireEvent.click(workerA);
+    const detailsA = document.getElementById(workerA.getAttribute("aria-controls") || "");
+    expect(detailsA).toHaveTextContent("failurecodex_turn_failed");
+    expect(detailsA).toHaveTextContent("reasonWorkspace spend cap reached");
+    expect(detailsA).toHaveTextContent("completed2026-08-17T19:00:00+00:00");
+    expect(detailsA).not.toHaveTextContent("Provider login required");
+    expect(detailsA).not.toHaveTextContent("Must not be guessed onto a worker");
+
+    const workerB = screen.getByRole("button", { name: /worker-b/ });
+    fireEvent.click(workerB);
+    const detailsB = document.getElementById(workerB.getAttribute("aria-controls") || "");
+    expect(detailsB).toHaveTextContent("failureauth_failure");
+    expect(detailsB).toHaveTextContent("reasonProvider login required");
+    expect(detailsB).not.toHaveTextContent("Workspace spend cap reached");
+  });
+
   it("expands a worker from the keyboard and keeps nested Kill from toggling the job", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
@@ -2174,6 +2235,49 @@ describe("SwarmPane final-review blockers", () => {
       });
       expect(screen.queryByText("routing…")).not.toBeInTheDocument();
       expect(screen.queryByText("stale-preview-model")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies failure-detail poll updates when task state and headline stay fixed", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let pollCount = 0;
+      mockSwarmLive.mockImplementation(async () => {
+        pollCount += 1;
+        return liveJob({
+          status: "running",
+          artifacts_complete: true,
+          artifacts: [{
+            type: "verification",
+            headline: "worker failed",
+            task_id: "task-1",
+            result: "failed",
+            failure: "codex_turn_failed",
+            ...(pollCount > 2 ? { detail: "Workspace spend cap reached" } : {}),
+          }],
+          tasks: [{
+            id: "task-1",
+            status: "failed",
+            adapter: "agentic",
+            role: "worker",
+            instruction: "",
+          }],
+        });
+      });
+
+      render(<SwarmPane />);
+      const worker = await screen.findByRole("button", { name: /^worker, failed/i });
+      fireEvent.click(worker);
+      expect(screen.getByText("codex_turn_failed")).toBeInTheDocument();
+      expect(screen.queryByText("Workspace spend cap reached")).not.toBeInTheDocument();
+
+      await vi.advanceTimersByTimeAsync(6000);
+
+      await waitFor(() => {
+        expect(screen.getByText("Workspace spend cap reached")).toBeInTheDocument();
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -251,8 +251,10 @@ function swarmSignature(res: SwarmLive | null): string {
           `:${routingPolicy(a)}:${a.provider ?? ""}`,
         );
       } else {
+        const detail = typeof a.detail === "string" ? a.detail.slice(0, 500) : "";
         parts.push(
-          `A:${(a.type || "").slice(0, 8)}:${(a.headline || "").slice(0, 120)}:${a.result ?? ""}`,
+          `A:${(a.type || "").slice(0, 8)}:${(a.headline || "").slice(0, 120)}:${a.result ?? ""}` +
+          `:${a.failure ?? ""}:${detail}`,
         );
       }
     }
@@ -375,6 +377,36 @@ function associateRoutingToTasks(
     return !tid || !ids.has(tid);
   });
   return { routingForTask, unmatched };
+}
+
+function isFailedArtifact(art: Artifact): boolean {
+  const result = String(art.result || "").trim().toLowerCase();
+  const kind = String(art.type || "").trim().toLowerCase();
+  return !!art.failure || result === "failed" || result === "blocked" || result === "error" || kind === "error";
+}
+
+function failureArtifactsByTaskId(arts: Artifact[]): Map<string, Artifact> {
+  const byTask = new Map<string, Artifact>();
+  for (const art of arts) {
+    const taskId = String(art.task_id || "").trim();
+    if (!taskId || !isFailedArtifact(art)) continue;
+    const current = byTask.get(taskId);
+    const score = (art.detail ? 4 : 0) + (art.failure ? 2 : 0) + (art.headline ? 1 : 0);
+    const currentScore = current
+      ? (current.detail ? 4 : 0) + (current.failure ? 2 : 0) + (current.headline ? 1 : 0)
+      : -1;
+    if (score >= currentScore) byTask.set(taskId, art);
+  }
+  return byTask;
+}
+
+function failureReason(art?: Artifact): string {
+  if (!art) return "";
+  if (typeof art.detail === "string" && art.detail.trim()) return art.detail.trim();
+  if (String(art.type || "").trim().toLowerCase() === "error") {
+    return String(art.headline || "").trim();
+  }
+  return "";
 }
 
 function unmatchedAddsTruth(arts: Artifact[], headerModel: string): boolean {
@@ -1205,6 +1237,7 @@ export default function SwarmPane() {
       artifacts.filter((a: Artifact) => (a.type || "").toUpperCase() === "ROUTING"),
     );
     const streamArts = artifacts.filter((a: Artifact) => (a.type || "").toUpperCase() !== "ROUTING");
+    const failureForTask = failureArtifactsByTaskId(streamArts);
     const tasks = j.tasks || [];
     const { routingForTask, unmatched: unmatchedRouting } = associateRoutingToTasks(routingArts, tasks);
     // Prefer the deduped final routing decision (fallback/escalation wins) over
@@ -1490,6 +1523,9 @@ export default function SwarmPane() {
                     const tExpanded = !!expandedTasks[task.id];
                     const routing = routingForTask.get(task.id);
                     const view = workerModelView(task, routing);
+                    const failureArtifact = failureForTask.get(task.id);
+                    const failureClass = String(failureArtifact?.failure || "").trim();
+                    const sourceFailureReason = failureReason(failureArtifact);
                     const adapterLabel = (task.adapter || "").trim();
                     const provider = (routing?.provider || "").trim();
                     const createdBy = routing?.created_by || "";
@@ -1568,6 +1604,8 @@ export default function SwarmPane() {
                             <span>task</span><span className="text-muted break-all">{task.id}</span>
                             {view.rawModel && <><span>model</span><span className="text-muted break-all">{view.rawModel}</span></>}
                             {adapterLabel && <><span>adapter</span><span className="text-muted break-all">{adapterLabel}</span></>}
+                            {failureClass && <><span>failure</span><span className="text-risk/85 break-all">{failureClass}</span></>}
+                            {sourceFailureReason && <><span>reason</span><span className="text-muted whitespace-pre-wrap break-words font-sans">{sourceFailureReason}</span></>}
                             {view.policy ? (
                               <><span>policy</span><span className="text-muted break-all">{view.policy}{view.pinned ? " · pin" : ""}</span></>
                             ) : view.routing ? (


### PR DESCRIPTION
## Problem

A failed worker can render with truthful failed lifecycle chrome while its clickable execution details still cannot answer why it failed.

Puppetmaster verification artifacts already carry a machine failure class and often a source message such as `turn_failure_message`, but Marionette previously projected only the class. The useful reason was dropped before the worker disclosure rendered.


## Approach

- For failed or blocked verification artifacts, project one bounded source reason using:
  `turn_failure_message → message → stderr`.
- Redact likely secrets before the reason reaches the API response and cap it at 500 characters.
- Stamp the known local task ID onto newly created local terminal artifacts.
- Correlate failures to workers only by exact `task_id`.
- Show `failure` and `reason` inside the existing expanded worker details.
- Include failure class/detail in the live payload signature so later reason updates repaint the row.
<img width="310" height="387" alt="Screenshot 2026-08-17 at 2 32 24 PM" src="https://github.com/user-attachments/assets/e93a6e7a-7c69-4f11-a2d6-a93ac773de7c" />

No new pane, modal, endpoint, API type, component, receipt surface, or failure taxonomy is added. Unmatched artifacts are not guessed onto workers.

Successful worker details remain unchanged:
<img width="315" height="331" alt="Screenshot 2026-08-17 at 2 33 23 PM" src="https://github.com/user-attachments/assets/e08f1bd8-9919-47f7-a577-3ace34c7c6d8" />


## Boundaries

- Findings remains the full artifact/result surface; worker details show only the compact machine class and bounded reason.
- Existing lifecycle semantics are unchanged. **A task may still be lifecycle-complete while its canonical artifact outcome is failed/degraded.**
- Historical local artifacts without `task_id` are not retroactively attached by proximity.
- Routing presentation and rejected-alternative ordering are unchanged.

## Proof

- [x] RED: failed durable worker did not expose its task-scoped failure/reason.
- [x] RED: later failure-detail poll did not repaint when headline/state were unchanged.
- [x] RED: local terminal artifact lacked its known task ID.
- [x] Backend focused suite: 35 passed.
- [x] SwarmPane focused suite: 74 passed.
- [x] Production TypeScript/Vite build passed.
- [x] Focused lint exited 0 with existing warnings only.
- [x] Live source-runtime proof with `job_bf08eb7dd459` and routed `job_c8aff5fa4f4e`.
