### PR TITLE
Release v0.9.242: worker outcome hierarchy, stream timing, Puppetmaster 1.22.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.6"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.7"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           # Floor matches the accounting/routing fixes this release needs.
           # Unpinned `puppetmaster-ai` + pip cache can leave CI on an older
           # wheel (e.g. 1.14.0) and fail fallback-pricing regressions.
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.6"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.7"
 
       # full_auto_safety modules already run inside this job via conftest
       # auto-tagging; a separate named job was redundant PR compute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.6"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.7"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.6` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.7` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.7` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.241, deliberately pre-1.0. Swarm workers own their model-routing receipt, and opt-in residual labs compare bounded compaction representations without changing the production default. Rides puppetmaster-ai==1.22.7.
+> Status: v0.9.242, deliberately pre-1.0. Swarm Tracker separates worker lifecycle from outcome so complete-but-failed verification is not a green check, and chat turns record honest TTFT/TPS receipts. Rides puppetmaster-ai==1.22.7.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.6` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.7` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.241, deliberately pre-1.0. Swarm workers own their model-routing receipt, and opt-in residual labs compare bounded compaction representations without changing the production default. Rides puppetmaster-ai==1.22.6.
+> Status: v0.9.241, deliberately pre-1.0. Swarm workers own their model-routing receipt, and opt-in residual labs compare bounded compaction representations without changing the production default. Rides puppetmaster-ai==1.22.7.
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.6` (exact registry pins, GPT-5.6 tool reasoning, Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.7` (exact registry pins, GPT-5.6 tool reasoning, Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.241"
+__version__ = "0.9.242"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/session_performance.py
+++ b/harness/api/session_performance.py
@@ -1,0 +1,202 @@
+"""Read-only GET /api/session/performance peel.
+
+Returns durable per-provider-step TTFT/TPS receipts for a known harness
+session. Does not touch ``/api/session/state``. Auth is applied by the
+table-driven GET gate before this handler runs.
+
+Unknown session ids are 404. Sessions outside the active workspace
+visibility scope (``session_visible_for_workspace``) are 403. Blank
+``state_dir`` fails closed to an empty receipt list — never a tempfile
+fallback.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Set, Union
+
+from harness.api.session_control import SessionControlServices
+from harness.sessions import session_visible_for_workspace
+from harness.stream_performance_store import (
+    MAX_RECEIPTS_PER_SESSION,
+    StreamPerformanceReceiptStore,
+    safe_session_id,
+)
+
+JsonPayload = Union[dict, list]
+
+
+def _qs_first(qs: dict, key: str) -> str:
+    return (qs.get(key, [""])[0] or "").strip()
+
+
+def _parse_limit(raw: str, *, default: int, cap: int) -> int:
+    text = (raw or "").strip()
+    if not text:
+        return default
+    try:
+        n = int(text)
+    except (TypeError, ValueError):
+        return default
+    if n < 1:
+        return 1
+    if n > cap:
+        return cap
+    return n
+
+
+def _state_dir(svc: SessionControlServices) -> str:
+    cfg = getattr(svc, "cfg", None)
+    return str(getattr(cfg, "state_dir", None) or "").strip()
+
+
+def _workspace_root(svc: SessionControlServices) -> str:
+    cfg = getattr(svc, "cfg", None)
+    return str(
+        getattr(cfg, "repo", None) or getattr(cfg, "workspace_root", None) or ""
+    ).strip()
+
+
+def _is_current_session(svc: SessionControlServices, session_id: str) -> bool:
+    try:
+        if svc.get_sessions is not None:
+            sessions = svc.get_sessions()
+            active = str(getattr(sessions, "active", None) or "").strip()
+            if active and session_id == active:
+                return True
+    except Exception:
+        pass
+    try:
+        pilot = svc.get_pilot()
+        pid = str(getattr(pilot, "harness_session_id", None) or "").strip()
+        if pid and session_id == pid:
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _session_rows(svc: SessionControlServices) -> list:
+    rows: list = []
+    sessions = None
+    try:
+        if svc.get_sessions is not None:
+            sessions = svc.get_sessions()
+    except Exception:
+        sessions = None
+    if sessions is None:
+        return rows
+    rows_fn = getattr(sessions, "rows", None)
+    if not callable(rows_fn):
+        return rows
+    try:
+        for row in rows_fn() or []:
+            if isinstance(row, dict):
+                rows.append(row)
+    except Exception:
+        return rows
+    return rows
+
+
+def _lookup_session_row(svc: SessionControlServices, session_id: str) -> Optional[dict]:
+    for row in _session_rows(svc):
+        if str(row.get("id") or "").strip() == session_id:
+            return row
+    return None
+
+
+def _known_session_ids(svc: SessionControlServices) -> Set[str]:
+    known: Set[str] = set()
+    sessions = None
+    try:
+        if svc.get_sessions is not None:
+            sessions = svc.get_sessions()
+    except Exception:
+        sessions = None
+    if sessions is not None:
+        try:
+            active = str(getattr(sessions, "active", None) or "").strip()
+            if active:
+                known.add(active)
+        except Exception:
+            pass
+        for row in _session_rows(svc):
+            rid = str(row.get("id") or "").strip()
+            if rid:
+                known.add(rid)
+    try:
+        pilot = svc.get_pilot()
+        pid = str(getattr(pilot, "harness_session_id", None) or "").strip()
+        if pid:
+            known.add(pid)
+    except Exception:
+        pass
+    return known
+
+
+def _resolve_session_id(qs: dict, svc: SessionControlServices) -> tuple[str, Optional[tuple[int, dict]]]:
+    requested = _qs_first(qs, "session_id")
+    if not requested:
+        sessions = None
+        try:
+            if svc.get_sessions is not None:
+                sessions = svc.get_sessions()
+        except Exception:
+            sessions = None
+        if sessions is not None:
+            requested = str(getattr(sessions, "active", None) or "").strip()
+        if not requested:
+            try:
+                pilot = svc.get_pilot()
+                requested = str(getattr(pilot, "harness_session_id", None) or "").strip()
+            except Exception:
+                requested = ""
+    if not requested:
+        return "", (400, {"error": "missing session id"})
+    # Membership uses the caller-supplied id (stripped). Sanitizing first
+    # would turn ``../known`` into a known row and open a traversal alias.
+    if requested not in _known_session_ids(svc):
+        return requested, (404, {"error": "unknown session"})
+    if not safe_session_id(requested):
+        return requested, (404, {"error": "unknown session"})
+    workspace_root = _workspace_root(svc)
+    if workspace_root and not _is_current_session(svc, requested):
+        row = _lookup_session_row(svc, requested)
+        if row is not None and not session_visible_for_workspace(
+            row, workspace_root, _state_dir(svc),
+        ):
+            return requested, (403, {"error": "session not visible in active workspace"})
+    return requested, None
+
+
+def get_session_performance(
+    qs: dict, svc: SessionControlServices
+) -> tuple[int, JsonPayload]:
+    """GET /api/session/performance?session_id=&limit=."""
+    qs = qs or {}
+    session_id, err = _resolve_session_id(qs, svc)
+    if err is not None:
+        return err
+    limit = _parse_limit(
+        _qs_first(qs, "limit"),
+        default=MAX_RECEIPTS_PER_SESSION,
+        cap=MAX_RECEIPTS_PER_SESSION,
+    )
+    state_dir = _state_dir(svc)
+    if not state_dir:
+        return 200, {
+            "ok": True,
+            "session_id": session_id,
+            "receipts": [],
+            "count": 0,
+        }
+    try:
+        store = StreamPerformanceReceiptStore(state_dir)
+        receipts = store.list_receipts(session_id, limit=limit)
+    except Exception:
+        receipts = []
+    return 200, {
+        "ok": True,
+        "session_id": session_id,
+        "receipts": receipts,
+        "count": len(receipts),
+    }

--- a/harness/api/sessions.py
+++ b/harness/api/sessions.py
@@ -110,6 +110,11 @@ def remove_session_transcript(
         remove_session_from_index(state_dir, safe_sid)
     except Exception as e:
         diag("server.session_delete_fts", e, msg=f"sid={safe_sid}")
+    try:
+        from ..stream_performance_store import remove_session_performance_receipts
+        remove_session_performance_receipts(state_dir, safe_sid)
+    except Exception as e:
+        diag("server.session_delete_stream_performance", e, msg=f"sid={safe_sid}")
 
 
 def handle_session_delete(sid: str, svc: SessionServices) -> tuple[int, dict]:

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -419,6 +419,7 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
     from .api import schedules as _sched_api
     from .api import session_control as _sc_api
     from .api import session_events as _session_events_api
+    from .api import session_performance as _session_perf_api
     from .api import sessions as _sessions_api
     from .api import settings as _settings_api
     from .api import skills as _skills_api
@@ -597,6 +598,10 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         "/api/git/diff": _get_git_diff,
         "/api/session/state": get_json(
             _sc_api.get_session_state,
+            services=svc.session_control_services,
+            pass_qs=True),
+        "/api/session/performance": get_json(
+            _session_perf_api.get_session_performance,
             services=svc.session_control_services,
             pass_qs=True),
         "/api/session/events": _get_session_events,

--- a/harness/local_jobs.py
+++ b/harness/local_jobs.py
@@ -900,6 +900,8 @@ class LocalJobsMixin:
                 ),
                 "headline": headline[:240],
             }
+            if job.get("tasks") and job["tasks"][0].get("id"):
+                terminal_art["task_id"] = job["tasks"][0]["id"]
             # Provenance the artifact read surfaces need to attribute the work.
             terminal_art = stamp_provenance(terminal_art, {
                 "adapter": job.get("adapter"),

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -36,7 +36,6 @@ import os
 import re
 import subprocess
 import sys
-import threading
 import time
 from typing import Any, Iterator, Optional
 
@@ -49,15 +48,20 @@ from .send_image_prep import prepare_turn_images
 from .send_loop_actions import execute_turn_actions
 from .repeat_tool_reminder import reset_repeat_chain
 from .send_loop_phases import (
-    dispatch_sync_pilot_chat,
+    account_provider_attempt,
+    dispatch_pilot_provider_call,
     drain_idle_turn,
-    drain_stream_queue,
     finalize_assistant_turn,
-    maybe_attach_pilot_session_id,
     promote_trailing_reasoning_to_say,
-    meter_pilot_step,
+    record_provider_dispatch_error_receipt,
     run_auto_verify,
-    run_stream,
+)
+from .stream_performance import (
+    make_stream_timing_accumulator,
+    reset_provider_step_timing,
+    reset_timing_before_step,
+    timed_phase,
+    yield_timed_phase,
 )
 from .text_clean import clean_say
 from .tool_dispatch import _strip_ansi, is_safe_path
@@ -875,6 +879,7 @@ class SendLoopMixin:
             _hard_pilot_steps,
             _prewarm_worker_imports,
         )
+        timing = make_stream_timing_accumulator()
         if resume:
             # Keep-alive continuation: drain_swarm_results already appended the
             # result record + a user-role continuation. Generate off that history
@@ -885,7 +890,10 @@ class SendLoopMixin:
                 return
         else:
             # Native multimodal vs sidecar transcription; abort if images unusable.
-            image_prep = yield from prepare_turn_images(self, user_message, images)
+            image_prep = yield from yield_timed_phase(
+                timing, "image_prep",
+                prepare_turn_images(self, user_message, images),
+            )
             if image_prep is None:
                 return
             processed_message, native_image_paths = image_prep
@@ -900,7 +908,10 @@ class SendLoopMixin:
             self._stagnation_streak = 0
             self._failed_objective_resume_counts = {}
             self._keep_alive_waits = 0
-            yield from emit_turn_task_profile(self, user_message)
+            yield from yield_timed_phase(
+                timing, "task_profile",
+                emit_turn_task_profile(self, user_message),
+            )
             try:
                 from .turn_budget import turn_budget_enabled
 
@@ -911,10 +922,15 @@ class SendLoopMixin:
             except Exception:
                 pass
 
+            image_encode_error = None
+            # Exact order: user content, append-only trailer, plan suffix,
+            # then native image encode/append. user_append_ms is additive
+            # around trailer + encode/append; suffix stays outside the clock.
             if self._resolve_append_only():
-                processed_message = self._append_turn_context_trailer(
-                    processed_message, user_message
-                )
+                with timed_phase(timing, "user_append"):
+                    processed_message = self._append_turn_context_trailer(
+                        processed_message, user_message
+                    )
 
             if plan:
                 from .pilot import PLAN_SYSTEM_SUFFIX
@@ -922,33 +938,39 @@ class SendLoopMixin:
                     processed_message.rstrip() + "\n\n" + PLAN_SYSTEM_SUFFIX
                 )
 
-            if native_image_paths:
-                from .vision import native_multimodal_user_content
-                try:
-                    history_content = native_multimodal_user_content(
-                        processed_message, native_image_paths,
-                    )
-                except Exception as e:
-                    yield ConvEvent("error", {
-                        "error": f"Failed to load attached image(s): {e}",
-                    })
-                    return
-            else:
-                history_content = processed_message
+            with timed_phase(timing, "user_append"):
+                if native_image_paths:
+                    from .vision import native_multimodal_user_content
+                    try:
+                        history_content = native_multimodal_user_content(
+                            processed_message, native_image_paths,
+                        )
+                    except Exception as e:
+                        image_encode_error = e
+                        history_content = None
+                else:
+                    history_content = processed_message
 
-            # Preserve strict user/assistant alternation in _history: if the last
-            # message is already a user turn (e.g. a background job just drained a
-            # pilot-resume continuation before the user typed), merge into it rather
-            # than appending a second adjacent user message, which some chat APIs
-            # (Anthropic) reject and the concurrency stress test forbids.
-            if self._history and self._history[-1].get("role") == "user":
-                from .vision import merge_user_contents
-                self._history[-1]["content"] = merge_user_contents(
-                    self._history[-1].get("content"), history_content,
-                )
-            else:
-                self._history.append({"role": "user", "content": history_content})
-            self._display_transcript.append({"type": "message", "role": "user", "text": user_message})
+                # Preserve strict user/assistant alternation in _history: if the last
+                # message is already a user turn (e.g. a background job just drained a
+                # pilot-resume continuation before the user typed), merge into it rather
+                # than appending a second adjacent user message, which some chat APIs
+                # (Anthropic) reject and the concurrency stress test forbids.
+                if history_content is not None:
+                    if self._history and self._history[-1].get("role") == "user":
+                        from .vision import merge_user_contents
+                        self._history[-1]["content"] = merge_user_contents(
+                            self._history[-1].get("content"), history_content,
+                        )
+                    else:
+                        self._history.append({"role": "user", "content": history_content})
+                    self._display_transcript.append({"type": "message", "role": "user", "text": user_message})
+
+            if image_encode_error is not None:
+                yield ConvEvent("error", {
+                    "error": f"Failed to load attached image(s): {image_encode_error}",
+                })
+                return
 
             # Inject relevance-ranked CodeGraph context (best-effort, exception-guarded)
             # so the driver sees the most relevant code BEFORE it starts calling tools.
@@ -960,9 +982,10 @@ class SendLoopMixin:
                 and not self._resolve_append_only()
                 and not _skip_cg
             ):
-                cg_context = self._get_codegraph_context(user_message)
-                if cg_context:
-                    self._history.append({"role": "user", "content": cg_context})
+                with timed_phase(timing, "auto_codegraph"):
+                    cg_context = self._get_codegraph_context(user_message)
+                    if cg_context:
+                        self._history.append({"role": "user", "content": cg_context})
 
         swarms = 0
         synchronous_swarms = 0
@@ -1005,12 +1028,16 @@ class SendLoopMixin:
         # in history), NOT at the start of every tool-loop step. Mid-turn
         # history rewrites bust prefix cache for all providers. CONTEXT_OVERFLOW
         # still force-compacts inside the step loop as a last resort.
-        yield from self._maybe_compact_history()
+        yield from yield_timed_phase(
+            timing, "advisory_compaction",
+            self._maybe_compact_history(),
+        )
 
         for step in _step_iter:
             # Heal dangling tool pairs from a prior mid-spree abandon (steer/
             # cancel) BEFORE the cancel check so an interrupt never freezes
             # invalid history into the next request / export.
+            reset_timing_before_step(timing, step)
             self._sanitize_tool_pairs()
             if self._cancel.is_set():
                 yield from self._yield_stop_boundary_notices()
@@ -1039,57 +1066,62 @@ class SendLoopMixin:
             cg_symbol_count = 0
             append_only = self._resolve_append_only()
             _skip_cg, _skip_wiki = profile_skips_auto_inject(self)
+            cg_event = None
             if self.config.repo and not _no_deleg and not append_only and not _skip_cg:
-                # Cache the CodeGraph slice per user message: the underlying
-                # codegraph_context() is a blocking Node subprocess (~270-500ms).
-                # Recomputing it on every step of a multi-step turn (identical
-                # query) just stacks dead time in front of the model. Compute it
-                # once on the first step, reuse it for the rest of this turn.
-                if self._cg_cache_key == user_message:
-                    cg_section = self._cg_cache_section
-                    cg_symbol_count = self._cg_cache_symbols
-                else:
-                    try:
-                        from puppetmaster.codegraph import codegraph_context, codegraph_prompt_section
-                        cg_slice = codegraph_context(task=user_message, cwd=self.config.repo)
-                        if cg_slice:
-                            # Count located symbols (entry points + related symbols) so the
-                            # UI can show that CodeGraph was consulted this turn.
-                            cg_symbol_count = cg_slice.count("- **") + cg_slice.count("#### ")
-                            # Prepend an AUTHORITATIVE directive so the model leans on the
-                            # already-injected CodeGraph slice instead of redundantly raw-reading
-                            # whole files (qwen tends to dump files even with context present).
-                            authoritative = (
-                                "CODEGRAPH HAS ALREADY BEEN QUERIED FOR THIS TASK. The relevant "
-                                "symbols, definitions, and code are provided in the section below. "
-                                "USE THIS as your primary source. Do NOT re-read entire files that "
-                                "already appear here -- only read_file specific additional lines you "
-                                "still need (with start_line + limit), or call search_codegraph to "
-                                "widen the graph. Whole-file dumps when the answer is already below "
-                                "are wasteful and wrong.\n"
-                            )
-                            cg_section = authoritative + codegraph_prompt_section(cg_slice)
-                        # Cache the result (even an empty slice) so we never re-run
-                        # the subprocess for the same message this turn.
-                        self._cg_cache_key = user_message
-                        self._cg_cache_section = cg_section
-                        self._cg_cache_symbols = cg_symbol_count
-                        # Visibility: tell the UI CodeGraph was consulted -- only on
-                        # the first compute, so the chip shows once per turn.
-                        if cg_section and not _no_deleg:
-                            yield ConvEvent("codegraph_context", {
-                                "symbols": cg_symbol_count,
-                                "query": (user_message or "")[:120],
-                            })
-                    except Exception:
-                        pass
+                with timed_phase(timing, "step_codegraph"):
+                    # Cache the CodeGraph slice per user message: the underlying
+                    # codegraph_context() is a blocking Node subprocess (~270-500ms).
+                    # Recomputing it on every step of a multi-step turn (identical
+                    # query) just stacks dead time in front of the model. Compute it
+                    # once on the first step, reuse it for the rest of this turn.
+                    if self._cg_cache_key == user_message:
+                        cg_section = self._cg_cache_section
+                        cg_symbol_count = self._cg_cache_symbols
+                    else:
+                        try:
+                            from puppetmaster.codegraph import codegraph_context, codegraph_prompt_section
+                            cg_slice = codegraph_context(task=user_message, cwd=self.config.repo)
+                            if cg_slice:
+                                # Count located symbols (entry points + related symbols) so the
+                                # UI can show that CodeGraph was consulted this turn.
+                                cg_symbol_count = cg_slice.count("- **") + cg_slice.count("#### ")
+                                # Prepend an AUTHORITATIVE directive so the model leans on the
+                                # already-injected CodeGraph slice instead of redundantly raw-reading
+                                # whole files (qwen tends to dump files even with context present).
+                                authoritative = (
+                                    "CODEGRAPH HAS ALREADY BEEN QUERIED FOR THIS TASK. The relevant "
+                                    "symbols, definitions, and code are provided in the section below. "
+                                    "USE THIS as your primary source. Do NOT re-read entire files that "
+                                    "already appear here -- only read_file specific additional lines you "
+                                    "still need (with start_line + limit), or call search_codegraph to "
+                                    "widen the graph. Whole-file dumps when the answer is already below "
+                                    "are wasteful and wrong.\n"
+                                )
+                                cg_section = authoritative + codegraph_prompt_section(cg_slice)
+                            # Cache the result (even an empty slice) so we never re-run
+                            # the subprocess for the same message this turn.
+                            self._cg_cache_key = user_message
+                            self._cg_cache_section = cg_section
+                            self._cg_cache_symbols = cg_symbol_count
+                            # Visibility: tell the UI CodeGraph was consulted -- only on
+                            # the first compute, so the chip shows once per turn.
+                            if cg_section and not _no_deleg:
+                                cg_event = {
+                                    "symbols": cg_symbol_count,
+                                    "query": (user_message or "")[:120],
+                                }
+                        except Exception:
+                            pass
+            if cg_event is not None:
+                yield ConvEvent("codegraph_context", cg_event)
 
             wiki_section = ""
             if self._wiki.configured and not append_only and not _skip_wiki:
-                if self._wiki_cache_key == user_message:
-                    wiki_section = self._wiki_cache_section
-                else:
-                    wiki_section = self._build_turn_wiki_section(user_message)
+                with timed_phase(timing, "step_wiki"):
+                    if self._wiki_cache_key == user_message:
+                        wiki_section = self._wiki_cache_section
+                    else:
+                        wiki_section = self._build_turn_wiki_section(user_message)
 
             resp = None
             self._streamed_prose = ""  # reset per step; set if this step streams
@@ -1099,88 +1131,57 @@ class SendLoopMixin:
                 # interrupted spree — cancel/steer/worker-ceiling/exception —
                 # otherwise 400s the next provider request.)
                 self._sanitize_tool_pairs()
-                if append_only:
-                    sys_prompt = self._ensure_frozen_system_prompt(base_sys)
-                    prompt = self._render_history()
-                    self._record_prompt_stability(prompt)
-                else:
-                    sys_prompt = base_sys
-                    if cg_section:
-                        sys_prompt += "\n\n" + cg_section
-                    if wiki_section:
-                        sys_prompt += "\n\n" + wiki_section
-                    mcp_section = _format_mcp_tools_section(
-                        self._mcp,
-                        self._tool_catalog,
-                        no_delegation=getattr(self.config, "no_delegation", False),
-                        browser_enabled=getattr(self.config, "browser_enabled", True),
-                    )
-                    if mcp_section:
-                        sys_prompt += "\n\n" + mcp_section
-                    turn_note = self._turn_budget_system_note()
-                    if turn_note:
-                        sys_prompt += "\n\n" + turn_note
-                    identity_note = self._pilot_identity_system_note()
-                    if identity_note:
-                        sys_prompt += "\n\n" + identity_note
-                    adapter_note = self._active_adapters_system_note()
-                    if adapter_note:
-                        sys_prompt += "\n\n" + adapter_note
+                # prompt_tools_ms is additive: this render block plus
+                # dispatch_pilot_provider_call's tool-schema assembly.
+                with timed_phase(timing, "prompt_tools"):
+                    if append_only:
+                        sys_prompt = self._ensure_frozen_system_prompt(base_sys)
+                        prompt = self._render_history()
+                        self._record_prompt_stability(prompt)
+                    else:
+                        sys_prompt = base_sys
+                        if cg_section:
+                            sys_prompt += "\n\n" + cg_section
+                        if wiki_section:
+                            sys_prompt += "\n\n" + wiki_section
+                        mcp_section = _format_mcp_tools_section(
+                            self._mcp,
+                            self._tool_catalog,
+                            no_delegation=getattr(self.config, "no_delegation", False),
+                            browser_enabled=getattr(self.config, "browser_enabled", True),
+                        )
+                        if mcp_section:
+                            sys_prompt += "\n\n" + mcp_section
+                        turn_note = self._turn_budget_system_note()
+                        if turn_note:
+                            sys_prompt += "\n\n" + turn_note
+                        identity_note = self._pilot_identity_system_note()
+                        if identity_note:
+                            sys_prompt += "\n\n" + identity_note
+                        adapter_note = self._active_adapters_system_note()
+                        if adapter_note:
+                            sys_prompt += "\n\n" + adapter_note
 
-                    self._history[0]["content"] = sys_prompt
-                    prompt = self._render_history()
+                        self._history[0]["content"] = sys_prompt
+                        prompt = self._render_history()
 
                 try:
-                    # Cursor CLI/ACP: Autopilot → agent tools; Marionette Plan → ask.
-                    # Env HARNESS_CURSOR_CLI_MODE still wins inside apply_host_mode.
-                    _apply_mode = getattr(self.pilot, "apply_host_mode", None)
-                    if callable(_apply_mode):
-                        try:
-                            _apply_mode(plan=plan)
-                        except Exception:
-                            pass
-                    if hasattr(self.pilot, "chat"):
-                        tools_schema = _build_step_tools(synthesis_nudge_active, self._build_visible_tools_schema)
-
-                        is_interactive = not getattr(self.config, "no_delegation", False)
-                        # Gate on an EXPLICIT capability flag (is True) + a callable chat_stream.
-                        # Using `is True` avoids MagicMock test pilots (which fabricate any attr as a
-                        # truthy Mock) wrongly entering the streaming branch.
-                        _can_stream = (
-                            getattr(self.pilot, "supports_streaming", False) is True
-                            and callable(getattr(self.pilot, "chat_stream", None))
-                        )
-                        if is_interactive and _can_stream:
-                            import queue
-                            import threading
-                            q = queue.Queue()
-
-                            t = threading.Thread(
-                                target=run_stream,
-                                args=(self, q, tools_schema, sys_prompt),
-                                daemon=True,
-                            )
-                            t.start()
-
-                            streamed_prose, resp = yield from drain_stream_queue(q)
-                            self._streamed_prose = streamed_prose
-                            step_emitted_user_prose = bool(streamed_prose.strip())
-                        else:
-                            resp = dispatch_sync_pilot_chat(self, tools_schema, sys_prompt)
-                    else:
-                        # Same affinity helper as chat — only when complete()
-                        # declares session_id. Compaction summarizers call
-                        # complete() directly without this attach.
-                        complete_kwargs: dict = {"system": sys_prompt}
-                        maybe_attach_pilot_session_id(
-                            complete_kwargs,
-                            self.pilot.complete,
-                            getattr(self, "harness_session_id", None),
-                        )
-                        resp = self.pilot.complete(prompt, **complete_kwargs)
+                    streamed_prose, resp = yield from dispatch_pilot_provider_call(
+                        self,
+                        plan=plan,
+                        sys_prompt=sys_prompt,
+                        prompt=prompt,
+                        synthesis_nudge_active=synthesis_nudge_active,
+                        accumulator=timing,
+                    )
+                    self._streamed_prose = streamed_prose
+                    step_emitted_user_prose = bool(streamed_prose.strip())
                 except Exception as e:
                     # Humanize + redact — never stream raw exception/provider
                     # bodies (may contain URL tokens or key fragments).
+                    record_provider_dispatch_error_receipt(
+                        self, timing, provider_step=step, provider_attempt=attempt,
+                    )
                     try:
                         msg = self._humanize_pilot_error(str(e))
                     except Exception:
@@ -1191,16 +1192,24 @@ class SendLoopMixin:
                     if not append_only:
                         self._history[0]["content"] = base_sys
 
-                meter_pilot_step(self, resp, prompt)
+                account_provider_attempt(
+                    self, resp, prompt,
+                    provider_step=step, provider_attempt=attempt,
+                )
 
                 if resp and resp.error:
                     from pmharness.drivers import error_classifier
                     err_cls = error_classifier.classify(None, resp.error)
                     if err_cls == error_classifier.ErrorClass.CONTEXT_OVERFLOW:
                         if attempt == 0:
-                            # Force history compaction and try again
-                            yield from self._maybe_compact_history(
-                                force=True, emergency=True,
+                            # Reset this attempt's provider marks only —
+                            # keep closed turn-once pre-request durations.
+                            reset_provider_step_timing(timing)
+                            yield from yield_timed_phase(
+                                timing, "advisory_compaction",
+                                self._maybe_compact_history(
+                                    force=True, emergency=True,
+                                ),
                             )
                             continue
                         else:

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -29,6 +29,17 @@ from pmharness.bridge import execute_intent
 from .log_reconstruction import check_outbound_reconstruction
 from .pilot import PilotAction, StreamingSayExtractor
 from .stream_identity import StreamDeltaBatch, normalize_delta_payload
+from .stream_performance import (
+    STREAM_PERFORMANCE_KEY,
+    StreamTimingAccumulator,
+    attach_stream_performance,
+    call_timed_phase,
+)
+from .stream_performance_store import (
+    StreamPerformanceReceiptStore,
+    build_receipt,
+    copy_stream_performance,
+)
 from .tool_timeout import invoke_do, run_with_tool_deadline
 from .workspace_rules_refresh import maybe_refresh_workspace_rules
 from .url_safety import sanitize_url_for_display
@@ -357,7 +368,61 @@ def maybe_attach_pilot_session_id(
     kwargs["session_id"] = sid
 
 
-def dispatch_sync_pilot_chat(session: Any, tools_schema: Any, sys_prompt: str) -> Any:
+def _finish_and_attach_timing(acc: Any, resp: Any) -> None:
+    """Mark provider-call return and merge a snapshot. Never raises.
+
+    This is request dispatch → provider return, not drain terminal.
+    Malformed ``tokens_out`` must not drop the rest of the receipt or
+    raise into the stream/send hot path. Billing still reads ``tokens_out``
+    from the response itself.
+    """
+    if acc is None:
+        return
+    try:
+        acc.finish()
+    except Exception:
+        pass
+    try:
+        tokens_out = getattr(resp, "tokens_out", 0)
+    except Exception:
+        tokens_out = 0
+    try:
+        attach_stream_performance(resp, acc.snapshot(tokens_out=tokens_out))
+    except Exception:
+        return
+
+
+_PROVIDER_DISPATCH_INVOKED_ATTR = "_provider_dispatch_invoked"
+
+
+def _clear_provider_dispatch_invoked(session: Any) -> None:
+    try:
+        setattr(session, _PROVIDER_DISPATCH_INVOKED_ATTR, False)
+    except Exception:
+        return
+
+
+def _mark_provider_dispatch_invoked(session: Any) -> None:
+    try:
+        setattr(session, _PROVIDER_DISPATCH_INVOKED_ATTR, True)
+    except Exception:
+        return
+
+
+def _provider_dispatch_was_invoked(session: Any) -> bool:
+    try:
+        return bool(getattr(session, _PROVIDER_DISPATCH_INVOKED_ATTR, False))
+    except Exception:
+        return False
+
+
+def dispatch_sync_pilot_chat(
+    session: Any,
+    tools_schema: Any,
+    sys_prompt: str,
+    *,
+    accumulator: Any = None,
+) -> Any:
     """Non-streaming ``pilot.chat`` with the shared sanitize + honesty check."""
     chat_kwargs = {
         "tools": tools_schema,
@@ -373,7 +438,15 @@ def dispatch_sync_pilot_chat(session: Any, tools_schema: Any, sys_prompt: str) -
         check_outbound_reconstruction(session, outbound, sys_prompt)
     except Exception:
         pass
-    return session.pilot.chat(outbound, **chat_kwargs)
+    if accumulator is not None:
+        try:
+            accumulator.mark_request_start()
+        except Exception:
+            pass
+    _mark_provider_dispatch_invoked(session)
+    resp = session.pilot.chat(outbound, **chat_kwargs)
+    _finish_and_attach_timing(accumulator, resp)
+    return resp
 
 
 def run_stream(
@@ -381,14 +454,55 @@ def run_stream(
     q: Any,
     tools_schema: Any,
     sys_prompt: str,
+    *,
+    clock: Any = None,
+    accumulator: Any = None,
 ) -> None:
-    """Background target: pilot.chat_stream → queue (delta/reasoning/tool_hint/wait/done/error)."""
+    """Background target: pilot.chat_stream → queue (delta/reasoning/tool_hint/wait/done/error).
+
+    Best-effort ``stream_performance`` timing is merged onto the terminal
+    DriverResponse.meta. Queue event shapes and order are unchanged.
+    ``clock`` is a monotonic callable for deterministic tests.
+    ``accumulator`` is an optional send-thread pre-request clock; when omitted
+    this function constructs its own so standalone tests keep working.
+    Request-start is marked immediately before ``chat_stream``, after outbound
+    construction / reconstruction check.
+    """
     try:
+        acc = accumulator
+        if acc is None:
+            try:
+                acc = StreamTimingAccumulator(clock=clock)
+            except Exception:
+                acc = None
+        # Stream-thread close of send-thread thread_start (no-op if unopened).
+        if acc is not None:
+            try:
+                acc.end_phase("thread_start")
+            except Exception:
+                pass
+
+        def _on_delta(delta: Any) -> None:
+            if acc is not None:
+                try:
+                    acc.note("delta", delta)
+                except Exception:
+                    pass
+            q.put(("delta", delta))
+
+        def _on_reasoning(delta: Any) -> None:
+            if acc is not None:
+                try:
+                    acc.note("reasoning", delta)
+                except Exception:
+                    pass
+            q.put(("reasoning", delta))
+
         kwargs = {
             "tools": tools_schema,
             "system": sys_prompt,
-            "on_delta": lambda delta: q.put(("delta", delta)),
-            "on_reasoning_delta": lambda delta: q.put(("reasoning", delta)),
+            "on_delta": _on_delta,
+            "on_reasoning_delta": _on_reasoning,
             "on_tool_hint": lambda name: q.put(("tool_hint", name)),
         }
         try:
@@ -414,13 +528,111 @@ def run_stream(
             check_outbound_reconstruction(session, outbound, sys_prompt)
         except Exception:
             pass
+        if acc is not None:
+            try:
+                acc.mark_request_start()
+            except Exception:
+                pass
+        _mark_provider_dispatch_invoked(session)
         r = session.pilot.chat_stream(
             outbound,
             **kwargs,
         )
+        _finish_and_attach_timing(acc, r)
         q.put(("done", r))
     except Exception as ex:
         q.put(("error", ex))
+
+
+def dispatch_pilot_provider_call(
+    session: Any,
+    *,
+    plan: bool,
+    sys_prompt: str,
+    prompt: str,
+    synthesis_nudge_active: bool,
+    accumulator: Any = None,
+) -> Iterator[Any]:
+    """Apply host mode and dispatch chat_stream / chat / complete.
+
+    Generator return is ``(streamed_prose, resp)``. The stream path yields the
+    same ``drain_stream_queue`` ConvEvents as the former inline kernel.
+    ``thread_start`` is opened on the send thread and closed on the stream
+    thread; request-start is marked immediately before the provider call.
+    """
+    _clear_provider_dispatch_invoked(session)
+    # Cursor CLI/ACP: Autopilot → agent tools; Marionette Plan → ask.
+    # Env HARNESS_CURSOR_CLI_MODE still wins inside apply_host_mode.
+    _apply_mode = getattr(session.pilot, "apply_host_mode", None)
+    if callable(_apply_mode):
+        try:
+            _apply_mode(plan=plan)
+        except Exception:
+            pass
+    if hasattr(session.pilot, "chat"):
+        from .send_loop import _build_step_tools
+        tools_schema = call_timed_phase(
+            accumulator,
+            "prompt_tools",
+            _build_step_tools,
+            synthesis_nudge_active,
+            session._build_visible_tools_schema,
+        )
+        is_interactive = not getattr(session.config, "no_delegation", False)
+        # Gate on an EXPLICIT capability flag (is True) + a callable chat_stream.
+        # Using `is True` avoids MagicMock test pilots (which fabricate any attr as a
+        # truthy Mock) wrongly entering the streaming branch.
+        _can_stream = (
+            getattr(session.pilot, "supports_streaming", False) is True
+            and callable(getattr(session.pilot, "chat_stream", None))
+        )
+        if is_interactive and _can_stream:
+            import queue
+            import threading
+            q = queue.Queue()
+            t = threading.Thread(
+                target=run_stream,
+                args=(session, q, tools_schema, sys_prompt),
+                kwargs={"accumulator": accumulator},
+                daemon=True,
+            )
+            if accumulator is not None:
+                try:
+                    accumulator.begin_phase("thread_start")
+                except Exception:
+                    pass
+            try:
+                t.start()
+            except Exception:
+                if accumulator is not None:
+                    try:
+                        accumulator.end_phase("thread_start")
+                    except Exception:
+                        pass
+                raise
+            return (yield from drain_stream_queue(q, accumulator=accumulator))
+        resp = dispatch_sync_pilot_chat(
+            session, tools_schema, sys_prompt, accumulator=accumulator,
+        )
+        return "", resp
+
+    # Same affinity helper as chat — only when complete() declares session_id.
+    # Compaction summarizers call complete() directly without this attach.
+    complete_kwargs: dict = {"system": sys_prompt}
+    maybe_attach_pilot_session_id(
+        complete_kwargs,
+        session.pilot.complete,
+        getattr(session, "harness_session_id", None),
+    )
+    if accumulator is not None:
+        try:
+            accumulator.mark_request_start()
+        except Exception:
+            pass
+    _mark_provider_dispatch_invoked(session)
+    resp = session.pilot.complete(prompt, **complete_kwargs)
+    _finish_and_attach_timing(accumulator, resp)
+    return "", resp
 
 
 def run_prefetch(
@@ -656,7 +868,7 @@ def _emit_batched_delta(
     return ConvEvent(event_kind, data)  # type: ignore[arg-type]
 
 
-def drain_stream_queue(q: Any) -> Iterator[Any]:
+def drain_stream_queue(q: Any, accumulator: Any = None) -> Iterator[Any]:
     """Consume a ``run_stream`` queue and yield ConvEvents until done/error.
 
     On success, generator return value is ``(streamed_prose, resp)``. On
@@ -670,7 +882,16 @@ def drain_stream_queue(q: Any) -> Iterator[Any]:
 
     Same-(channel, stream_id) deltas are batched (~40ms / 80 chars) before
     becoming SSE frames so word-sized tokens cannot exhaust the replay ring.
-    Barriers (item done, tool hint, channel change, terminal) always flush first.
+    Each new contentful (channel, stream_id) answer/reasoning identity yields
+    its first frame immediately so perceived TTFT is not gated on the batch
+    timeout; later same-identity deltas still coalesce. Progress stays on
+    the batch path. Identities without stream_id stay on the immediate
+    legacy path (no batching). Barriers (item done, tool hint, channel
+    change, terminal) always flush first.
+
+    When ``accumulator`` is provided, the first cleaned-answer instant is
+    marked at the say-extractor boundary (backend event-ready, not paint)
+    and merged key-wise onto ``resp.meta`` at terminal.
     """
     from .conversation import ConvEvent
 
@@ -687,6 +908,7 @@ def drain_stream_queue(q: Any) -> Iterator[Any]:
     answer_batch = StreamDeltaBatch()
     progress_batch = StreamDeltaBatch()
     reasoning_batch = StreamDeltaBatch()
+    first_frames_emitted = set()
     last_queue_activity = time.monotonic()
     stream_idle_stage = 0
 
@@ -740,6 +962,51 @@ def drain_stream_queue(q: Any) -> Iterator[Any]:
                 if ev is not None:
                     yield ev
 
+    def _mark_visible_answer() -> None:
+        if accumulator is None:
+            return
+        try:
+            mark = getattr(accumulator, "mark_first_visible_answer", None)
+            if callable(mark):
+                mark()
+        except Exception:
+            return
+
+    def _emit_push_or_first_frame(
+        batch,
+        flushed,
+        *,
+        event_kind,
+        default_channel,
+        stream_id,
+    ):
+        """Yield a threshold/identity flush, then this identity's first frame.
+
+        First-frame is per (channel, stream_id), not once per channel for
+        the whole drain. A later stream_id (post-tool narration, dual
+        output) gets its own immediate first frame; later same-identity
+        deltas still batch.
+        """
+        if flushed:
+            data = dict(flushed)
+            data.setdefault("channel", default_channel)
+            if event_kind == "thinking":
+                data["delta"] = True
+            yield ConvEvent(event_kind, data)
+            flushed_sid = str(flushed.get("stream_id") or "").strip()
+            first_frames_emitted.add((default_channel, flushed_sid))
+        if not batch.pending:
+            return
+        identity = (default_channel, stream_id)
+        if identity in first_frames_emitted:
+            return
+        ev = _emit_batched_delta(
+            batch, event_kind=event_kind, default_channel=default_channel,
+        )
+        if ev is not None:
+            first_frames_emitted.add(identity)
+            yield ev
+
     def _handle_assistant_delta(val: Any):
         nonlocal last_content_kind
         text, meta = normalize_delta_payload(val)
@@ -770,6 +1037,7 @@ def drain_stream_queue(q: Any) -> Iterator[Any]:
         clean = say_extractor.feed(text)
         if not clean:
             return
+        _mark_visible_answer()
         streamed_prose.append(clean)
         last_content_kind = "prose"
         ans_meta = dict(meta)
@@ -785,10 +1053,14 @@ def drain_stream_queue(q: Any) -> Iterator[Any]:
             yield ConvEvent("message_delta", data)
             return
         flushed = answer_batch.push(clean, ans_meta, default_channel="answer")
-        if flushed:
-            data = dict(flushed)
-            data.setdefault("channel", "answer")
-            yield ConvEvent("message_delta", data)
+        for ev in _emit_push_or_first_frame(
+            answer_batch,
+            flushed,
+            event_kind="message_delta",
+            default_channel="answer",
+            stream_id=sid,
+        ):
+            yield ev
 
     def _handle_reasoning_delta(val: Any):
         nonlocal last_content_kind
@@ -808,11 +1080,14 @@ def drain_stream_queue(q: Any) -> Iterator[Any]:
         flushed = reasoning_batch.push(
             text, r_meta, default_channel="reasoning",
         )
-        if flushed:
-            data = dict(flushed)
-            data["delta"] = True
-            data.setdefault("channel", "reasoning")
-            yield ConvEvent("thinking", data)
+        for ev in _emit_push_or_first_frame(
+            reasoning_batch,
+            flushed,
+            event_kind="thinking",
+            default_channel="reasoning",
+            stream_id=sid,
+        ):
+            yield ev
 
     while True:
         # Prefer a short wait when a batch is open so time thresholds can fire
@@ -917,11 +1192,191 @@ def drain_stream_queue(q: Any) -> Iterator[Any]:
                     # Fill meta.reasoning when the driver omitted it (Cursor ACP/CLI).
                     if not str(meta.get("reasoning") or "").strip():
                         meta["reasoning"] = reasoning
+            if accumulator is not None:
+                try:
+                    mark_backend = getattr(accumulator, "mark_backend_ready", None)
+                    if callable(mark_backend):
+                        mark_backend()
+                except Exception:
+                    pass
+                try:
+                    tokens_out = getattr(val, "tokens_out", 0)
+                except Exception:
+                    tokens_out = 0
+                try:
+                    attach_stream_performance(
+                        val, accumulator.snapshot(tokens_out=tokens_out),
+                    )
+                except Exception:
+                    pass
             return "".join(streamed_prose), val
         elif kind == "error":
             for ev in _flush_all():
                 yield ev
             raise val
+
+
+def classify_provider_receipt_status(resp: Any) -> str:
+    """Map a driver response to a receipt terminal status. Never raises."""
+    try:
+        error = getattr(resp, "error", None) if resp is not None else None
+        if not error:
+            return "success"
+        from pmharness.drivers import error_classifier
+        err_cls = error_classifier.classify(None, error)
+        if err_cls == error_classifier.ErrorClass.CONTEXT_OVERFLOW:
+            return "context_overflow"
+        return "error"
+    except Exception:
+        return "error"
+
+
+def _receipt_model_label(session: Any, resp: Any, driver: str) -> str:
+    meta = getattr(resp, "meta", None) if resp is not None else None
+    if isinstance(meta, dict):
+        raw = meta.get("model")
+        if isinstance(raw, str):
+            text = raw.strip()
+            if text and len(text) <= 128 and "\n" not in text and "\x00" not in text:
+                return text
+    if "/" in driver:
+        return driver.rsplit("/", 1)[-1]
+    return driver
+
+
+def record_provider_stream_receipt(
+    session: Any,
+    resp: Any = None,
+    *,
+    provider_step: Any = 0,
+    provider_attempt: Any = 0,
+    status: Any = None,
+    stream_performance: Any = None,
+) -> None:
+    """Copy one terminal snapshot into the durable sidecar. Never raises.
+
+    Reads ``resp.meta['stream_performance']`` unless ``stream_performance``
+    is supplied. Does not mutate ``resp.meta``, does not store the
+    accumulator, and does not change ConvEvents, billing, prompt, retry,
+    or response flow on sink failure. Missing session id or state_dir
+    skips the write. ``resp`` may be omitted when ``status`` is given
+    (invoked-dispatch error path).
+    """
+    try:
+        sid = str(getattr(session, "harness_session_id", "") or "").strip()
+        state_dir = str(getattr(session, "state_dir", "") or "").strip()
+        if not sid or not state_dir:
+            return
+        if stream_performance is None:
+            if resp is None and status is None:
+                return
+            meta = getattr(resp, "meta", None) if resp is not None else None
+            raw_perf = None
+            if isinstance(meta, dict):
+                raw_perf = meta.get(STREAM_PERFORMANCE_KEY)
+            perf = copy_stream_performance(raw_perf)
+        else:
+            perf = copy_stream_performance(stream_performance)
+        if status is None:
+            if resp is None:
+                return
+            status = classify_provider_receipt_status(resp)
+        user_ordinal = None
+        try:
+            user_ordinal = session._current_user_ordinal()
+        except Exception:
+            user_ordinal = None
+        turn_index = 0
+        if user_ordinal is not None:
+            try:
+                turn_index = int(user_ordinal) + 1
+            except (TypeError, ValueError):
+                turn_index = 0
+        driver = ""
+        try:
+            driver = str(getattr(getattr(session, "config", None), "driver", "") or "")
+        except Exception:
+            driver = ""
+        receipt = build_receipt(
+            session_id=sid,
+            stream_performance=perf,
+            turn_index=turn_index,
+            user_ordinal=user_ordinal,
+            provider_step=provider_step,
+            provider_attempt=provider_attempt,
+            driver=driver,
+            model=_receipt_model_label(session, resp, driver),
+            status=status,
+        )
+        StreamPerformanceReceiptStore(state_dir).record(sid, receipt)
+    except Exception:
+        return
+
+
+def _snapshot_accumulator_for_receipt(accumulator: Any) -> Any:
+    """Best-effort terminal snapshot. Empty when timing evidence is unavailable."""
+    if accumulator is None:
+        return {}
+    try:
+        finish = getattr(accumulator, "finish", None)
+        if callable(finish):
+            finish()
+    except Exception:
+        pass
+    try:
+        snap = accumulator.snapshot()
+    except Exception:
+        return {}
+    return snap if isinstance(snap, dict) else {}
+
+
+def record_provider_dispatch_error_receipt(
+    session: Any,
+    accumulator: Any = None,
+    *,
+    provider_step: Any = 0,
+    provider_attempt: Any = 0,
+) -> None:
+    """One terminal status=error receipt after an invoked provider raise.
+
+    Skips when the provider method was never invoked. Empty
+    ``stream_performance`` is allowed; a safe accumulator snapshot is
+    copied when available. Never raises. Does not meter or mutate
+    prompt / history / display.
+    """
+    try:
+        if not _provider_dispatch_was_invoked(session):
+            return
+        record_provider_stream_receipt(
+            session,
+            None,
+            provider_step=provider_step,
+            provider_attempt=provider_attempt,
+            status="error",
+            stream_performance=_snapshot_accumulator_for_receipt(accumulator),
+        )
+    except Exception:
+        return
+
+
+def account_provider_attempt(
+    session: Any,
+    resp: Any,
+    prompt: str,
+    *,
+    provider_step: Any = 0,
+    provider_attempt: Any = 0,
+) -> None:
+    """Persist the sidecar receipt, then meter.
+
+    Receipt is written after dispatch has attached terminal timing and
+    before ``meter_pilot_step`` can raise, so a malformed ``tokens_out``
+    still produces exactly one receipt. Billing semantics are unchanged.
+    """
+    record_provider_stream_receipt(
+        session, resp, provider_step=provider_step, provider_attempt=provider_attempt,
+    )
+    meter_pilot_step(session, resp, prompt)
 
 
 def meter_pilot_step(
@@ -934,6 +1389,9 @@ def meter_pilot_step(
     Mechanical lift of the post-stream accounting block from
     ``_send_locked_inner`` — same counters, same provider-billed preference,
     same ``_session_cost`` fallback. Mutates ``session`` in place.
+
+    Per-step ``stream_performance`` (when present) stays on ``resp.meta``;
+    this function does not persist it onto the session.
 
     Anthropic may stamp ``meta.cache_write_ttl_basis`` as ``provider``,
     ``inferred``, or ``absent``. Aggregate ``cache_write_tokens`` are always
@@ -948,7 +1406,14 @@ def meter_pilot_step(
     # Preserve the effective total / fallback for compaction + UI meters, but
     # label whether tokens_in came from the provider or the prompt heuristic
     # so estimated input never masquerades as measured.
-    _t_out = int(getattr(resp, "tokens_out", 0) or 0)
+    try:
+        _raw_out = getattr(resp, "tokens_out", 0)
+        if isinstance(_raw_out, bool):
+            _t_out = 0
+        else:
+            _t_out = int(_raw_out or 0)
+    except (TypeError, ValueError, OverflowError):
+        _t_out = 0
     try:
         _reported_in = int(getattr(resp, "tokens_in", 0) or 0)
     except (TypeError, ValueError):

--- a/harness/state.py
+++ b/harness/state.py
@@ -231,6 +231,21 @@ class DurableState:
             art_type = str(getattr(a, "type", ""))
             task_id = getattr(a, "task_id", "") or None
             job_id = getattr(a, "job_id", "") or None
+            detail = payload.get("reason") or payload.get("detail")
+            result = payload.get("result")
+            failure = payload.get("failure")
+            kind = art_type.strip().lower()
+            if kind.endswith("verification") and (
+                failure or str(result or "").strip().lower() in ("failed", "blocked", "error")
+            ):
+                source_reason = (
+                    payload.get("turn_failure_message")
+                    or payload.get("message")
+                    or payload.get("stderr")
+                )
+                if source_reason:
+                    from harness.api.redaction import redact_secret_text
+                    detail = redact_secret_text(str(source_reason).strip())[:500] or None
             row = {
                 "id": getattr(a, "id", ""),
                 "type": art_type,
@@ -267,13 +282,13 @@ class DurableState:
                         or payload.get("model_chosen") or payload.get("driver")
                     ),
                 ),
-                "detail": payload.get("reason") or payload.get("detail"),
+                "detail": detail,
                 # Verification verdicts. "result" is failed/blocked/pass;
                 # "failure" is the machine class (no_model, billing_or_quota).
                 # The GUI needs these to render a swarm whose every worker
                 # fast-failed as a red failed run instead of a green "done".
-                "result": payload.get("result"),
-                "failure": payload.get("failure"),
+                "result": result,
+                "failure": failure,
                 # Only present for patch artifacts; None elsewhere so the GUI can
                 # cheaply test truthiness before rendering a diffstat row.
                 "files": files,
@@ -282,7 +297,6 @@ class DurableState:
             # Lightweight parent-execution pointer for signal rows. Prefer an
             # explicit payload stamp; otherwise synthesize from job/task ids so
             # legacy store rows still resolve without copying spend fields.
-            kind = art_type.strip().lower()
             if kind in ("finding", "risk", "decision"):
                 ref = payload.get("execution_ref")
                 if not isinstance(ref, dict):

--- a/harness/stream_performance.py
+++ b/harness/stream_performance.py
@@ -1,0 +1,644 @@
+"""O(1) TTFT / provider-output timing for the interactive pilot stream.
+
+Measures provider-callback time and backend event-ready time only:
+
+- ``request_to_first_content_callback_ms`` — first content-bearing provider
+  callback (reasoning or answer), including raw JSON envelope prefixes.
+- ``request_to_first_answer_callback_ms`` — first answer-classified callback
+  (still the raw provider payload, not cleaned say).
+- ``request_to_first_visible_answer_ms`` — first cleaned-answer instant at
+  the ``StreamingSayExtractor`` boundary, immediately before the first
+  answer ``message_delta``. Backend event-ready time, not browser paint.
+
+True browser first-paint and renderer paint acknowledgment are later
+frontend waves — not measured here.
+
+``provider_output_tokens_per_second`` is provider ``tokens_out`` over the
+first-content → last-content callback window, not answer-token decode TPS
+and not total-request throughput (``provider_call_total_ms`` / wall-clock
+from request start). ``tokens_out`` may include reasoning and tool output;
+the fixed ``throughput_basis`` string records that.
+
+``provider_call_total_ms`` is request dispatch → provider return.
+``backend_ready_total_ms`` is request dispatch → drain terminal (stream
+path only). Visible answer may land after provider return; that is valid
+when compared with the backend-ready boundary, not the provider-call
+total. Sync / complete attach provider-call total only.
+
+Pre-request phase keys (when a provider-step origin and named phases exist)
+are best-effort monotonic durations on the same accumulator. Existing
+request-relative keys stay relative to ``mark_request_start``, not turn start.
+
+``prompt_tools_ms`` is a composite Wave 3A key: additive sys-prompt / history
+render plus tool-schema assembly, not one contiguous block.
+``user_append_ms`` is user-message / context assembly (optional context
+trailer, native image encode, history append). Plan-mode suffix work is
+outside this key.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Iterator, Optional
+
+from .stream_identity import normalize_delta_payload
+
+STREAM_PERFORMANCE_KEY = "stream_performance"
+
+# Honest callback / visible / throughput keys (no production readers yet).
+FIRST_CONTENT_CALLBACK_MS = "request_to_first_content_callback_ms"
+FIRST_ANSWER_CALLBACK_MS = "request_to_first_answer_callback_ms"
+FIRST_VISIBLE_ANSWER_MS = "request_to_first_visible_answer_ms"
+PROVIDER_OUTPUT_TPS = "provider_output_tokens_per_second"
+PROVIDER_CALL_TOTAL_MS = "provider_call_total_ms"
+BACKEND_READY_TOTAL_MS = "backend_ready_total_ms"
+THROUGHPUT_BASIS_KEY = "throughput_basis"
+THROUGHPUT_BASIS = "provider_tokens_out/content_callback_window"
+
+# Fixed schema — snapshot never emits arbitrary caller-chosen keys.
+# prompt_tools_ms is additive (prompt render + tool-schema), not contiguous.
+PRE_REQUEST_PHASE_NAMES = (
+    "image_prep",
+    "task_profile",
+    "user_append",
+    "auto_codegraph",
+    "advisory_compaction",
+    "step_codegraph",
+    "step_wiki",
+    "prompt_tools",
+    "thread_start",
+)
+PRE_REQUEST_PHASES = frozenset(PRE_REQUEST_PHASE_NAMES)
+# prompt_tools / thread_start are per provider attempt. The rest are reusable
+# turn/step setup kept across a step-0 CONTEXT_OVERFLOW retry.
+PER_ATTEMPT_PHASES = frozenset({"prompt_tools", "thread_start"})
+REUSABLE_PRE_REQUEST_PHASES = PRE_REQUEST_PHASES - PER_ATTEMPT_PHASES
+
+# Callback / payload markers that are never content tokens.
+_NON_CONTENT_KINDS = frozenset({
+    "tool_hint", "wait", "item_done", "done", "error",
+    "usage", "header", "keepalive", "ping", "heartbeat",
+    "complete", "completion", "stop", "finish",
+    "progress", "tool", "tool_call",
+})
+_NON_CONTENT_MARKERS = frozenset({
+    "usage", "header", "headers", "keepalive", "keep-alive",
+    "ping", "heartbeat", "done", "complete", "completion",
+    "stop", "finish", "item_done", "tool_hint", "wait",
+    "progress", "tool", "tool_call",
+})
+_NON_CONTENT_CHANNELS = frozenset({
+    "progress", "tool", "tool_call",
+})
+
+
+def classify_stream_event(kind: Any, payload: Any = None) -> Optional[str]:
+    """Return ``reasoning``, ``answer``, or None if the event is not content.
+
+    Empty deltas, tool hints, headers, usage, keepalives, completion markers,
+    progress/tool kinds, and progress/tool channels do not count.
+    """
+    kind_s = str(kind or "").strip().lower()
+    if kind_s in _NON_CONTENT_KINDS:
+        return None
+    if isinstance(payload, dict):
+        marker = payload.get("type") or payload.get("event") or payload.get("kind")
+        if isinstance(marker, str) and marker.strip().lower() in _NON_CONTENT_MARKERS:
+            return None
+        # Usage-only chunks sometimes arrive with an empty text field.
+        if payload.get("usage") is not None:
+            text, _meta = normalize_delta_payload(payload)
+            if not str(text).strip():
+                return None
+    text, meta = normalize_delta_payload(payload)
+    if not str(text).strip():
+        return None
+    channel = str(meta.get("channel") or "").strip().lower()
+    if channel in _NON_CONTENT_CHANNELS:
+        return None
+    if kind_s in ("reasoning", "thinking") or channel == "reasoning":
+        return "reasoning"
+    if kind_s in ("delta", "answer") or channel in ("", "answer"):
+        return "answer"
+    return None
+
+
+def _finite_ms(seconds: Any) -> Optional[float]:
+    try:
+        ms = float(seconds) * 1000.0
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(ms):
+        return None
+    # Snap binary noise so JSON snapshots stay exact under a fake clock.
+    return round(ms, 6)
+
+
+def _nonneg_ms(seconds: Any) -> Optional[float]:
+    ms = _finite_ms(seconds)
+    if ms is None or ms < 0:
+        return None
+    return ms
+
+
+def _provider_tokens_out(tokens_out: Any) -> Optional[int]:
+    """Return a positive provider token count, or None when unusable.
+
+    ``bool`` is rejected (``True`` is a truthy ``int`` subclass). Never raises.
+    """
+    if tokens_out is None or isinstance(tokens_out, bool):
+        return None
+    try:
+        if isinstance(tokens_out, str):
+            text = tokens_out.strip()
+            if not text:
+                return None
+            n_out = int(text)
+        else:
+            n_out = int(tokens_out)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if n_out <= 0:
+        return None
+    return n_out
+
+
+class StreamTimingAccumulator:
+    """O(1) stream clock: start, first/last content, count, max inter-delta gap.
+
+    Does not retain every timestamp. ``clock`` is a monotonic callable so tests
+    can inject a deterministic timeline.
+
+    Construction is the provider-step origin. ``mark_request_start`` moves the
+    TTFT/TPS origin to the actual provider dispatch boundary. When that marker
+    is never called, snapshot semantics match Wave 1 (origin == request start).
+
+    Send thread, stream thread, and callback thread may all touch this object.
+    Mutations take a small lock and never hold it while calling the clock or
+    other external code. Timing failures never raise to the hot path.
+    """
+
+    def __init__(self, clock: Optional[Callable[[], float]] = None) -> None:
+        self._clock = clock or time.monotonic
+        self._lock = threading.Lock()
+        now = self._now()
+        self._origin = now
+        self._t0 = now
+        self._request_marked = False
+        self._first_content: Optional[float] = None
+        self._first_answer: Optional[float] = None
+        self._first_visible_answer: Optional[float] = None
+        self._last_content: Optional[float] = None
+        self._prev_content: Optional[float] = None
+        self._end: Optional[float] = None
+        self._backend_end: Optional[float] = None
+        self._count = 0
+        self._max_gap: Optional[float] = None
+        self._phase_open: Dict[str, float] = {}
+        self._phase_s: Dict[str, float] = {}
+
+    def _now(self) -> float:
+        return float(self._clock())
+
+    def mark_request_start(self) -> None:
+        """Mark the provider dispatch boundary. Never raises.
+
+        Subsequent ``request_to_first_*`` keys are relative to this instant.
+        """
+        try:
+            now = self._now()
+            with self._lock:
+                self._t0 = now
+                self._request_marked = True
+        except Exception:
+            return
+
+    def begin_phase(self, name: Any) -> None:
+        """Open a named pre-request phase. Unknown names are ignored. Never raises."""
+        try:
+            key = str(name or "").strip()
+            if key not in PRE_REQUEST_PHASES:
+                return
+            now = self._now()
+            with self._lock:
+                if key in self._phase_open:
+                    return
+                self._phase_open[key] = now
+        except Exception:
+            return
+
+    def end_phase(self, name: Any) -> None:
+        """Close a named pre-request phase. Unopened names are omitted. Never raises.
+
+        Repeated open/close of the same name adds durations (composite phases
+        such as ``prompt_tools`` and suspension-excluding generator segments).
+        """
+        try:
+            key = str(name or "").strip()
+            now = self._now()
+            with self._lock:
+                start = self._phase_open.pop(key, None)
+                if start is None:
+                    return
+                delta = now - start
+                if not math.isfinite(delta) or delta < 0:
+                    return
+                prev = self._phase_s.get(key)
+                self._phase_s[key] = delta if prev is None else prev + delta
+        except Exception:
+            return
+
+    def reset_for_next_provider_call(self) -> None:
+        """Fresh origin for the next provider call. Never raises.
+
+        Drops phase durations (including turn-once) and streaming marks so
+        later tool-loop steps do not blend receipts. Step-0 overflow retries
+        use ``reset_provider_attempt_marks`` instead, which keeps closed
+        reusable setup phases and rebases the origin.
+        """
+        try:
+            now = self._now()
+            with self._lock:
+                self._origin = now
+                self._t0 = now
+                self._request_marked = False
+                self._first_content = None
+                self._first_answer = None
+                self._first_visible_answer = None
+                self._last_content = None
+                self._prev_content = None
+                self._end = None
+                self._backend_end = None
+                self._count = 0
+                self._max_gap = None
+                self._phase_open = {}
+                self._phase_s = {}
+        except Exception:
+            return
+
+    def reset_provider_attempt_marks(self) -> None:
+        """Drop this attempt's stream marks and per-attempt phases. Never raises.
+
+        Clears request start, callbacks, visible, provider/backend ends,
+        count, and inter-delta gap. Drops ``prompt_tools`` / ``thread_start``
+        durations and every open phase so they cannot span the retry.
+        Closed reusable turn/step setup phases survive. Rebases the
+        construction origin so ``pre_request_total_ms`` is retry preparation
+        to retry dispatch, not the failed provider-call window.
+        """
+        try:
+            now = self._now()
+            with self._lock:
+                self._origin = now
+                self._t0 = now
+                self._request_marked = False
+                self._first_content = None
+                self._first_answer = None
+                self._first_visible_answer = None
+                self._last_content = None
+                self._prev_content = None
+                self._end = None
+                self._backend_end = None
+                self._count = 0
+                self._max_gap = None
+                self._phase_open = {}
+                self._phase_s = {
+                    key: value
+                    for key, value in self._phase_s.items()
+                    if key in REUSABLE_PRE_REQUEST_PHASES
+                }
+        except Exception:
+            return
+
+    def note(self, kind: Any, payload: Any = None) -> None:
+        """Record a provider callback. Never raises."""
+        try:
+            role = classify_stream_event(kind, payload)
+            if role is None:
+                return
+            now = self._now()
+            with self._lock:
+                if self._first_content is None or now < self._first_content:
+                    self._first_content = now
+                if role == "answer" and (
+                    self._first_answer is None or now < self._first_answer
+                ):
+                    self._first_answer = now
+                if self._prev_content is not None:
+                    gap = now - self._prev_content
+                    if (
+                        math.isfinite(gap)
+                        and gap >= 0
+                        and (self._max_gap is None or gap > self._max_gap)
+                    ):
+                        self._max_gap = gap
+                if self._prev_content is None or now >= self._prev_content:
+                    self._prev_content = now
+                if self._last_content is None or now > self._last_content:
+                    self._last_content = now
+                self._count += 1
+        except Exception:
+            return
+
+    def mark_first_visible_answer(self) -> None:
+        """First cleaned-answer / message_delta-ready instant. Never raises.
+
+        Backend event-ready time at the say-extractor boundary — not browser
+        paint and not the raw provider callback.
+        """
+        try:
+            now = self._now()
+            with self._lock:
+                if (
+                    self._first_visible_answer is None
+                    or now < self._first_visible_answer
+                ):
+                    self._first_visible_answer = now
+        except Exception:
+            return
+
+    def finish(self) -> None:
+        """Mark provider-call return. Never raises.
+
+        This is request dispatch → provider return, not drain terminal.
+        """
+        try:
+            now = self._now()
+            with self._lock:
+                self._end = now
+        except Exception:
+            return
+
+    def mark_backend_ready(self) -> None:
+        """Mark drain-terminal / backend event-ready. Never raises.
+
+        Stream path only. Sync / complete must not call this.
+        """
+        try:
+            now = self._now()
+            with self._lock:
+                if self._backend_end is None:
+                    self._backend_end = now
+        except Exception:
+            return
+
+    def snapshot(self, tokens_out: Any = 0) -> Dict[str, Any]:
+        """JSON-safe metrics. Omit keys that lack evidence; never emit inf.
+
+        ``provider_output_tokens_per_second`` uses provider output tokens over
+        the first-content → last-content callback window, not request-start →
+        stream-end and not answer-only decode. Callback TTFT keys stay
+        relative to request start (``mark_request_start`` or construction).
+        Malformed ``tokens_out`` omits the rate; it does not drop the receipt.
+        """
+        try:
+            with self._lock:
+                t0 = self._t0
+                origin = self._origin
+                request_marked = self._request_marked
+                first_content = self._first_content
+                first_answer = self._first_answer
+                first_visible = self._first_visible_answer
+                last_content = self._last_content
+                end = self._end
+                backend_end = self._backend_end
+                count = int(self._count)
+                max_gap = self._max_gap
+                phase_s = dict(self._phase_s)
+        except Exception:
+            return {"content_delta_count": 0}
+
+        out: Dict[str, Any] = {"content_delta_count": count}
+        try:
+            if end is not None:
+                total = _nonneg_ms(end - t0)
+                if total is not None:
+                    out[PROVIDER_CALL_TOTAL_MS] = total
+            if backend_end is not None:
+                backend_ms = _nonneg_ms(backend_end - t0)
+                if backend_ms is not None:
+                    out[BACKEND_READY_TOTAL_MS] = backend_ms
+            if first_content is not None:
+                first_event = _nonneg_ms(first_content - t0)
+                if first_event is not None:
+                    out[FIRST_CONTENT_CALLBACK_MS] = first_event
+            if first_answer is not None:
+                first_answer_ms = _nonneg_ms(first_answer - t0)
+                if first_answer_ms is not None:
+                    out[FIRST_ANSWER_CALLBACK_MS] = first_answer_ms
+            if first_visible is not None:
+                visible_ms = _nonneg_ms(first_visible - t0)
+                if visible_ms is not None:
+                    out[FIRST_VISIBLE_ANSWER_MS] = visible_ms
+            window_ms = None
+            if first_content is not None and last_content is not None:
+                window_ms = _nonneg_ms(last_content - first_content)
+                if window_ms is not None and window_ms > 0:
+                    out["decode_window_ms"] = window_ms
+            if max_gap is not None:
+                gap_ms = _nonneg_ms(max_gap)
+                if gap_ms is not None:
+                    out["max_inter_delta_ms"] = gap_ms
+            n_out = _provider_tokens_out(tokens_out)
+            if (
+                n_out is not None
+                and count >= 2
+                and window_ms is not None
+                and window_ms > 0
+            ):
+                tps = n_out / (window_ms / 1000.0)
+                if math.isfinite(tps) and tps > 0:
+                    out[PROVIDER_OUTPUT_TPS] = round(tps, 6)
+                    out[THROUGHPUT_BASIS_KEY] = THROUGHPUT_BASIS
+            if request_marked:
+                pre = _nonneg_ms(t0 - origin)
+                if pre is not None:
+                    out["pre_request_total_ms"] = pre
+            for name in PRE_REQUEST_PHASE_NAMES:
+                seconds = phase_s.get(name)
+                if seconds is None:
+                    continue
+                phase_ms = _nonneg_ms(seconds)
+                if phase_ms is not None:
+                    out[f"{name}_ms"] = phase_ms
+        except Exception:
+            return out
+        return out
+
+
+def make_stream_timing_accumulator(
+    clock: Optional[Callable[[], float]] = None,
+) -> Optional[StreamTimingAccumulator]:
+    """Construct an accumulator. Returns None if the clock fails. Never raises."""
+    try:
+        return StreamTimingAccumulator(clock=clock)
+    except Exception:
+        return None
+
+
+def reset_provider_step_timing(acc: Any) -> None:
+    """Reset provider-attempt marks; keep closed reusable phases. Never raises.
+
+    Used by step-0 CONTEXT_OVERFLOW retry. Drops per-attempt phases and
+    rebases origin. Later tool-loop steps call ``reset_timing_before_step``,
+    which drops every phase.
+    """
+    if acc is None:
+        return
+    try:
+        reset = getattr(acc, "reset_provider_attempt_marks", None)
+        if callable(reset):
+            reset()
+            return
+        acc.reset_for_next_provider_call()
+    except Exception:
+        return
+
+
+def reset_timing_before_step(acc: Any, step: Any) -> None:
+    """Loop-boundary reset: drop the prior receipt when ``step`` is past 0.
+
+    Step 0 keeps turn-once phases on the first provider snapshot. Later
+    steps start a fresh origin and drop phases. Overflow retries call
+    ``reset_provider_step_timing`` instead so closed reusable durations
+    survive and per-attempt phases are measured fresh. Never raises.
+    """
+    if acc is None:
+        return
+    try:
+        if step:
+            acc.reset_for_next_provider_call()
+    except Exception:
+        return
+
+
+def _safe_begin_phase(acc: Any, name: str) -> None:
+    if acc is None:
+        return
+    try:
+        acc.begin_phase(name)
+    except Exception:
+        return
+
+
+def _safe_end_phase(acc: Any, name: str) -> None:
+    if acc is None:
+        return
+    try:
+        acc.end_phase(name)
+    except Exception:
+        return
+
+
+@contextmanager
+def timed_phase(acc: Any, name: str) -> Iterator[None]:
+    """Time a function-phase block. Timing failures degrade to normal execution.
+
+    Do not wrap ``yield`` / ``yield from`` with this helper — consumer
+    suspension would enter ``phase_ms``. Use ``yield_timed_phase`` or split
+    the yield outside the timed block.
+    """
+    _safe_begin_phase(acc, name)
+    try:
+        yield
+    finally:
+        _safe_end_phase(acc, name)
+
+
+def call_timed_phase(acc: Any, name: str, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Time a function call and return its value exactly. Never raises from timing."""
+    with timed_phase(acc, name):
+        return fn(*args, **kwargs)
+
+
+def _delegate_inner(it: Any, sent: Any, throwing: bool) -> Any:
+    """Advance ``it`` with send/throw, matching PEP 380 for this wrapper."""
+    if throwing:
+        thrower = getattr(it, "throw", None)
+        if thrower is None:
+            raise sent
+        return thrower(type(sent), sent, sent.__traceback__)
+    sender = getattr(it, "send", None)
+    if sender is None:
+        if sent is not None:
+            raise TypeError("can't send non-None value to a non-generator iterator")
+        return next(it)
+    return sender(sent)
+
+
+def yield_timed_phase(acc: Any, name: str, iterator: Iterator[Any]) -> Iterator[Any]:
+    """Time harness work between yields; exclude consumer suspension.
+
+    True PEP 380-style delegation for this usage: ``send``, ``throw``, and
+    ``close`` / ``GeneratorExit`` are forwarded; ``StopIteration.value`` and
+    inner ``finally`` cleanup stay exact. Each resume → yield (or resume →
+    return) segment is added into the named phase. Time spent suspended at
+    ``yield`` is not. Timing failures never raise. Python 3.9 compatible.
+    """
+    it = iter(iterator)
+    sent: Any = None
+    throwing = False
+    started = False
+    while True:
+        _safe_begin_phase(acc, name)
+        try:
+            if not started:
+                value = next(it)
+            else:
+                value = _delegate_inner(it, sent, throwing)
+        except StopIteration as stop:
+            _safe_end_phase(acc, name)
+            return stop.value
+        except BaseException:
+            _safe_end_phase(acc, name)
+            raise
+        _safe_end_phase(acc, name)
+        started = True
+        throwing = False
+        try:
+            sent = yield value
+        except GeneratorExit:
+            closer = getattr(it, "close", None)
+            if closer is not None:
+                _safe_begin_phase(acc, name)
+                try:
+                    closer()
+                except BaseException:
+                    _safe_end_phase(acc, name)
+                    raise
+                _safe_end_phase(acc, name)
+            raise
+        except BaseException as exc:
+            throwing = True
+            sent = exc
+
+
+def attach_stream_performance(
+    resp: Any,
+    snapshot: Dict[str, Any],
+) -> None:
+    """Merge ``stream_performance`` into ``resp.meta`` without clobbering keys.
+
+    Key-wise fill-if-absent: keep every pre-existing nested key, add only
+    missing snapshot keys. Leaves ``latency_ms`` and unrelated meta untouched.
+    Never raises.
+    """
+    try:
+        if not isinstance(snapshot, dict):
+            return
+        meta = getattr(resp, "meta", None)
+        if not isinstance(meta, dict):
+            meta = {}
+            resp.meta = meta
+        existing = meta.get(STREAM_PERFORMANCE_KEY)
+        if not isinstance(existing, dict):
+            meta[STREAM_PERFORMANCE_KEY] = dict(snapshot)
+            return
+        for key, value in snapshot.items():
+            if key not in existing:
+                existing[key] = value
+    except Exception:
+        return

--- a/harness/stream_performance_store.py
+++ b/harness/stream_performance_store.py
@@ -1,0 +1,733 @@
+"""Durable per-session stream-performance receipts (TTFT / TPS sidecar).
+
+Atomic UTF-8 JSON under ``{state_dir}/stream_performance/{safe_sid}.json``.
+Not written into ``_history``, ``_display_transcript``, or the transcript
+file. Bounded: keep the newest ``MAX_RECEIPTS_PER_SESSION`` (200) in
+chronological order. Corrupt, deep, oversized, or missing files fail soft
+to empty; the next successful write repairs the sidecar atomically.
+
+Blank ``state_dir`` fails closed (no tempfile fallback). Symlinked
+performance directories, receipt files, and lock files are refused;
+resolved paths must stay inside ``state_dir``. Metrics persist only finite
+scalars for known keys.
+
+Stdlib only. Thread-safe and cross-process RMW-safe where the OS lock
+exists (fcntl / msvcrt) with a thread lock keyed by canonical path.
+Path traversal is refused. Sink failures never raise to the chat hot path.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import math
+import os
+import stat
+import tempfile
+import threading
+import time
+from typing import Any, Dict, Iterator, List, Optional
+
+from .paths import _resolve, path_within
+from .stream_performance import (
+    BACKEND_READY_TOTAL_MS,
+    FIRST_ANSWER_CALLBACK_MS,
+    FIRST_CONTENT_CALLBACK_MS,
+    FIRST_VISIBLE_ANSWER_MS,
+    PRE_REQUEST_PHASE_NAMES,
+    PROVIDER_CALL_TOTAL_MS,
+    PROVIDER_OUTPUT_TPS,
+    STREAM_PERFORMANCE_KEY,
+    THROUGHPUT_BASIS,
+    THROUGHPUT_BASIS_KEY,
+)
+
+RECEIPT_SCHEMA_VERSION = 1
+MAX_RECEIPTS_PER_SESSION = 200
+RECEIPT_STATUSES = frozenset({"success", "error", "context_overflow"})
+PERFORMANCE_SUBDIR = "stream_performance"
+_LOAD_MAX_BYTES = 2 * 1024 * 1024
+_MAX_LABEL_CHARS = 128
+_MAX_JSON_DEPTH = 8
+_MAX_NONNEG_INT = 1_000_000_000
+_THROUGHPUT_BASIS_ALLOWED = frozenset({THROUGHPUT_BASIS})
+
+_KNOWN_PERF_KEYS = frozenset({
+    "content_delta_count",
+    FIRST_CONTENT_CALLBACK_MS,
+    FIRST_ANSWER_CALLBACK_MS,
+    FIRST_VISIBLE_ANSWER_MS,
+    PROVIDER_OUTPUT_TPS,
+    PROVIDER_CALL_TOTAL_MS,
+    BACKEND_READY_TOTAL_MS,
+    THROUGHPUT_BASIS_KEY,
+    "decode_window_ms",
+    "max_inter_delta_ms",
+    "pre_request_total_ms",
+    *(f"{name}_ms" for name in PRE_REQUEST_PHASE_NAMES),
+})
+
+_PATH_LOCKS: Dict[str, threading.Lock] = {}
+_PATH_LOCKS_GUARD = threading.Lock()
+
+
+def safe_session_id(session_id: str) -> str:
+    return "".join(c for c in (session_id or "") if c.isalnum() or c in ("-", "_"))
+
+
+def _stripped_state_dir(state_dir: str) -> str:
+    return (state_dir or "").strip()
+
+
+def performance_dir(state_dir: str) -> str:
+    root = _stripped_state_dir(state_dir)
+    if not root:
+        return ""
+    return os.path.abspath(os.path.join(root, PERFORMANCE_SUBDIR))
+
+
+def receipt_file_path(state_dir: str, session_id: str) -> str:
+    """Absolute sidecar path, or ``""`` when the id/path is unsafe."""
+    safe = safe_session_id(session_id)
+    root = performance_dir(state_dir)
+    if not safe or not root:
+        return ""
+    path = os.path.abspath(os.path.join(root, f"{safe}.json"))
+    try:
+        if os.path.commonpath([root, path]) != root:
+            return ""
+    except ValueError:
+        return ""
+    if os.path.basename(path) != f"{safe}.json":
+        return ""
+    return path
+
+
+def _is_symlink(path: str) -> bool:
+    try:
+        return bool(path) and os.path.islink(path)
+    except OSError:
+        return False
+
+
+def _pytest_blocks_live_state(path: str) -> bool:
+    """Under pytest, refuse any I/O that would touch ``~/.pmharness``.
+
+    Lexical (abspath) comparison only — no realpath / open of the live tree.
+    """
+    if "PYTEST_CURRENT_TEST" not in os.environ:
+        return False
+    if not path:
+        return False
+    try:
+        live = os.path.normcase(os.path.abspath(os.path.expanduser("~/.pmharness")))
+        target = os.path.normcase(os.path.abspath(path))
+        if not live or not target:
+            return True
+        return os.path.commonpath([live, target]) == live
+    except (ValueError, OSError, TypeError):
+        return True
+
+
+def _confined_under_state(path: str, state_dir: str) -> bool:
+    """True when ``path`` realpath-contains beneath ``state_dir``.
+
+    The path itself must not be a symlink. Intermediate directory symlinks
+    (a lexical alias for ``state_dir``) are allowed; a symlinked
+    ``stream_performance`` directory or receipt file is refused by callers.
+    """
+    root = _stripped_state_dir(state_dir)
+    if not root or not path:
+        return False
+    if _is_symlink(path):
+        return False
+    try:
+        return path_within(path, root, allow_equal=False)
+    except (ValueError, OSError, TypeError):
+        return False
+
+
+def _lock_file_path(receipt_path: str) -> str:
+    if not receipt_path:
+        return ""
+    parent = os.path.dirname(receipt_path)
+    if not parent or _is_symlink(parent):
+        return ""
+    lock_path = receipt_path + ".lock"
+    if os.path.basename(lock_path) != os.path.basename(receipt_path) + ".lock":
+        return ""
+    try:
+        if os.path.commonpath([parent, os.path.abspath(lock_path)]) != parent:
+            return ""
+    except ValueError:
+        return ""
+    if _is_symlink(lock_path):
+        return ""
+    return lock_path
+
+
+def _canonical_lock_key(path: str) -> str:
+    parent = os.path.dirname(path)
+    name = os.path.basename(path)
+    try:
+        if parent and os.path.isdir(parent) and not _is_symlink(parent):
+            return os.path.normcase(os.path.join(_resolve(parent), name))
+    except OSError:
+        pass
+    return os.path.normcase(os.path.abspath(path))
+
+
+def _lock_for(path: str) -> threading.Lock:
+    with _PATH_LOCKS_GUARD:
+        lock = _PATH_LOCKS.get(path)
+        if lock is None:
+            lock = threading.Lock()
+            _PATH_LOCKS[path] = lock
+        return lock
+
+
+def _acquire_os_lock(fd: int) -> str:
+    try:
+        import fcntl
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        return "fcntl"
+    except (ImportError, OSError, AttributeError):
+        pass
+    try:
+        import msvcrt
+        os.lseek(fd, 0, os.SEEK_SET)
+        try:
+            os.write(fd, b"\0")
+        except OSError:
+            pass
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        return "msvcrt"
+    except (ImportError, OSError, AttributeError):
+        return ""
+
+
+def _release_os_lock(fd: int, kind: str) -> None:
+    try:
+        if kind == "fcntl":
+            import fcntl
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        elif kind == "msvcrt":
+            import msvcrt
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    except Exception:
+        return
+
+
+@contextlib.contextmanager
+def _receipt_lock(path: str) -> Iterator[None]:
+    """Canonical-path thread lock plus confined cross-process lock when available."""
+    if not path:
+        yield
+        return
+    thread_lock = _lock_for(_canonical_lock_key(path))
+    thread_lock.acquire()
+    fd: Optional[int] = None
+    kind = ""
+    try:
+        lock_path = _lock_file_path(path)
+        if lock_path and not _pytest_blocks_live_state(lock_path):
+            flags = os.O_RDWR | os.O_CREAT
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            if hasattr(os, "O_CLOEXEC"):
+                flags |= os.O_CLOEXEC
+            try:
+                fd = os.open(lock_path, flags, 0o600)
+                if _is_symlink(lock_path):
+                    os.close(fd)
+                    fd = None
+                else:
+                    kind = _acquire_os_lock(fd)
+            except OSError:
+                if fd is not None:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+                    fd = None
+        yield
+    finally:
+        if fd is not None:
+            _release_os_lock(fd, kind)
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        thread_lock.release()
+
+
+def _prepare_performance_dir(state_dir: str) -> str:
+    """Create or accept a non-symlink performance dir confined under ``state_dir``."""
+    root = _stripped_state_dir(state_dir)
+    if not root:
+        return ""
+    root_abs = os.path.abspath(root)
+    if _pytest_blocks_live_state(root_abs):
+        return ""
+    perf = os.path.abspath(os.path.join(root_abs, PERFORMANCE_SUBDIR))
+    if _is_symlink(perf):
+        return ""
+    if os.path.lexists(perf):
+        if not os.path.isdir(perf) or _is_symlink(perf):
+            return ""
+    else:
+        try:
+            os.makedirs(perf, exist_ok=True)
+        except OSError:
+            return ""
+        if _is_symlink(perf) or not os.path.isdir(perf):
+            return ""
+    if not _confined_under_state(perf, root_abs):
+        return ""
+    return perf
+
+
+def _usable_receipt_path(
+    state_dir: str,
+    session_id: str,
+    *,
+    create_dir: bool = False,
+) -> str:
+    path = receipt_file_path(state_dir, session_id)
+    if not path:
+        return ""
+    if _pytest_blocks_live_state(path):
+        return ""
+    parent = os.path.dirname(path)
+    if _is_symlink(parent) or _is_symlink(path):
+        return ""
+    if create_dir:
+        if not _prepare_performance_dir(state_dir):
+            return ""
+        if _is_symlink(parent) or _is_symlink(path):
+            return ""
+    if not _confined_under_state(path if not _is_symlink(path) else parent, state_dir):
+        return ""
+    return path
+
+
+def _finite_number(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        if math.isfinite(number):
+            return number
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            number = float(text)
+        except ValueError:
+            return None
+        if math.isfinite(number):
+            return number
+    return None
+
+
+def _finite_numeric_scalar(value: Any) -> Optional[float]:
+    """Finite int/float only — not bool, numeric strings, or containers."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        if math.isfinite(number):
+            return number
+    return None
+
+
+def _bounded_nonneg_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if 0 <= value <= _MAX_NONNEG_INT:
+        return value
+    return None
+
+
+def _safe_int(
+    value: Any,
+    *,
+    default: int = 0,
+    minimum: Optional[int] = None,
+    maximum: Optional[int] = None,
+) -> int:
+    if isinstance(value, bool) or value is None:
+        return default
+    try:
+        number = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    if minimum is not None and number < minimum:
+        return default
+    if maximum is not None and number > maximum:
+        return default
+    return number
+
+
+def _safe_label(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = value.strip()
+    if not text or "\n" in text or "\x00" in text:
+        return ""
+    if len(text) > _MAX_LABEL_CHARS:
+        return text[:_MAX_LABEL_CHARS]
+    return text
+
+
+def copy_stream_performance(raw: Any) -> Dict[str, Any]:
+    """Copy known finite scalar snapshot keys. Never mutates ``raw``.
+
+    Timing keys accept finite numeric scalars only (not numeric strings,
+    bools, or containers). Counts are bounded nonnegative ints.
+    ``throughput_basis`` is an allowlisted string.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    out: Dict[str, Any] = {}
+    for key in _KNOWN_PERF_KEYS:
+        if key not in raw:
+            continue
+        value = raw[key]
+        if isinstance(value, (dict, list, tuple, set)):
+            continue
+        if key == "content_delta_count":
+            number = _bounded_nonneg_int(value)
+            if number is None:
+                continue
+            out[key] = number
+            continue
+        if key == THROUGHPUT_BASIS_KEY:
+            if (
+                isinstance(value, str)
+                and value in _THROUGHPUT_BASIS_ALLOWED
+                and len(value) <= _MAX_LABEL_CHARS
+                and "\n" not in value
+                and "\x00" not in value
+            ):
+                out[key] = value
+            continue
+        number = _finite_numeric_scalar(value)
+        if number is None:
+            continue
+        out[key] = number
+    return out
+
+
+def _model_from_driver(driver: str) -> str:
+    text = _safe_label(driver)
+    if "/" in text:
+        return text.rsplit("/", 1)[-1]
+    return text
+
+
+def build_receipt(
+    *,
+    session_id: str,
+    stream_performance: Any = None,
+    turn_index: Any = 0,
+    user_ordinal: Any = None,
+    provider_step: Any = 0,
+    provider_attempt: Any = 0,
+    driver: Any = "",
+    model: Any = "",
+    status: Any = "success",
+    captured_at: Any = None,
+) -> Dict[str, Any]:
+    """Fixed JSON-safe receipt. Unknown / unsafe fields are dropped."""
+    sid = safe_session_id(str(session_id or ""))
+    status_s = str(status or "").strip().lower()
+    if status_s not in RECEIPT_STATUSES:
+        status_s = "error" if status_s else "success"
+    epoch = _finite_number(captured_at)
+    if epoch is None:
+        epoch = float(time.time())
+    driver_s = _safe_label(driver)
+    model_s = _safe_label(model) or _model_from_driver(driver_s)
+    receipt: Dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "session_id": sid,
+        "turn_index": _safe_int(
+            turn_index, default=0, minimum=0, maximum=_MAX_NONNEG_INT,
+        ),
+        "provider_step": _safe_int(
+            provider_step, default=0, minimum=0, maximum=_MAX_NONNEG_INT,
+        ),
+        "provider_attempt": _safe_int(
+            provider_attempt, default=0, minimum=0, maximum=_MAX_NONNEG_INT,
+        ),
+        "driver": driver_s,
+        "model": model_s,
+        "status": status_s,
+        "captured_at": epoch,
+        "stream_performance": copy_stream_performance(stream_performance),
+    }
+    if user_ordinal is not None and not isinstance(user_ordinal, bool):
+        try:
+            ordinal = int(user_ordinal)
+        except (TypeError, ValueError, OverflowError):
+            ordinal = None
+        if ordinal is not None and 0 <= ordinal <= _MAX_NONNEG_INT:
+            receipt["user_ordinal"] = ordinal
+    return receipt
+
+
+def sanitize_receipt(raw: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return None
+    sid = safe_session_id(str(raw.get("session_id") or ""))
+    if not sid:
+        return None
+    return build_receipt(
+        session_id=sid,
+        stream_performance=raw.get("stream_performance"),
+        turn_index=raw.get("turn_index", 0),
+        user_ordinal=raw.get("user_ordinal"),
+        provider_step=raw.get("provider_step", 0),
+        provider_attempt=raw.get("provider_attempt", 0),
+        driver=raw.get("driver", ""),
+        model=raw.get("model", ""),
+        status=raw.get("status", "success"),
+        captured_at=raw.get("captured_at"),
+    )
+
+
+def _exceeds_json_depth(value: Any, *, depth: int = 0) -> bool:
+    if depth > _MAX_JSON_DEPTH:
+        return True
+    if isinstance(value, dict):
+        return any(_exceeds_json_depth(item, depth=depth + 1) for item in value.values())
+    if isinstance(value, list):
+        return any(_exceeds_json_depth(item, depth=depth + 1) for item in value)
+    return False
+
+
+def _read_nofollow_capped(path: str, max_bytes: int) -> Optional[bytes]:
+    """Read at most ``max_bytes + 1`` from a non-symlink regular file."""
+    try:
+        info = os.lstat(path)
+    except OSError:
+        return None
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        return None
+    if info.st_size > max_bytes:
+        return None
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        try:
+            opened = os.fstat(fd)
+        except OSError:
+            return None
+        if stat.S_ISLNK(opened.st_mode) or not stat.S_ISREG(opened.st_mode):
+            return None
+        chunks: List[bytes] = []
+        remaining = max_bytes + 1
+        while remaining > 0:
+            chunk = os.read(fd, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+    finally:
+        os.close(fd)
+
+
+def _atomic_write_json(path: str, data: Dict[str, Any]) -> None:
+    if not path or _pytest_blocks_live_state(path):
+        return
+    parent = os.path.dirname(path)
+    if not parent or _is_symlink(parent) or _is_symlink(path):
+        return
+    os.makedirs(parent, exist_ok=True)
+    if _is_symlink(parent) or not os.path.isdir(parent):
+        return
+    fd, tmp = tempfile.mkstemp(prefix="stream-perf-", suffix=".json", dir=parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(data, handle, ensure_ascii=False, indent=2, allow_nan=False)
+        if _is_symlink(path) or _is_symlink(parent):
+            raise OSError("refusing to replace a symlinked receipt path")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            if os.path.lexists(tmp):
+                os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _load_document(path: str) -> List[Dict[str, Any]]:
+    if not path or _pytest_blocks_live_state(path):
+        return []
+    if _is_symlink(path) or _is_symlink(os.path.dirname(path)):
+        return []
+    raw = _read_nofollow_capped(path, _LOAD_MAX_BYTES)
+    if raw is None or len(raw) > _LOAD_MAX_BYTES:
+        return []
+    try:
+        text = raw.decode("utf-8")
+        data = json.loads(text)
+    except (
+        OSError,
+        UnicodeError,
+        json.JSONDecodeError,
+        ValueError,
+        TypeError,
+        RecursionError,
+        OverflowError,
+        MemoryError,
+    ):
+        return []
+    except Exception:
+        return []
+    try:
+        if _exceeds_json_depth(data):
+            return []
+    except RecursionError:
+        return []
+    if not isinstance(data, dict):
+        return []
+    rows = data.get("receipts")
+    if not isinstance(rows, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for item in rows:
+        receipt = sanitize_receipt(item)
+        if receipt is not None:
+            out.append(receipt)
+    return out
+
+
+def _unlink_regular_file(path: str) -> None:
+    if not path or _pytest_blocks_live_state(path) or _is_symlink(path):
+        return
+    try:
+        info = os.lstat(path)
+    except OSError:
+        return
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        return
+
+
+class StreamPerformanceReceiptStore:
+    """Session-scoped atomic JSON receipt log. One file per harness session."""
+
+    def __init__(
+        self,
+        state_dir: str,
+        *,
+        max_receipts: int = MAX_RECEIPTS_PER_SESSION,
+    ) -> None:
+        raw = _stripped_state_dir(state_dir)
+        self.state_dir = os.path.abspath(raw) if raw else ""
+        try:
+            cap = int(max_receipts)
+        except (TypeError, ValueError):
+            cap = MAX_RECEIPTS_PER_SESSION
+        self.max_receipts = max(1, cap)
+
+    def list_receipts(
+        self,
+        session_id: str,
+        *,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        try:
+            path = _usable_receipt_path(self.state_dir, session_id)
+            if not path:
+                return []
+            with _receipt_lock(path):
+                rows = _load_document(path)
+        except Exception:
+            return []
+        if limit is None:
+            return [dict(row) for row in rows]
+        try:
+            n = int(limit)
+        except (TypeError, ValueError):
+            n = self.max_receipts
+        if n < 1:
+            return []
+        return [dict(row) for row in rows[-n:]]
+
+    def record(self, session_id: str, receipt: Dict[str, Any]) -> None:
+        try:
+            path = _usable_receipt_path(self.state_dir, session_id, create_dir=True)
+            if not path:
+                return
+            cleaned = sanitize_receipt(receipt)
+            if cleaned is None:
+                return
+            cleaned["session_id"] = safe_session_id(session_id) or cleaned["session_id"]
+            with _receipt_lock(path):
+                if _is_symlink(path) or _is_symlink(os.path.dirname(path)):
+                    return
+                rows = _load_document(path)
+                rows.append(cleaned)
+                if len(rows) > self.max_receipts:
+                    rows = rows[-self.max_receipts:]
+                payload = {
+                    "schema_version": RECEIPT_SCHEMA_VERSION,
+                    "session_id": cleaned["session_id"],
+                    "receipts": rows,
+                }
+                _atomic_write_json(path, payload)
+        except Exception:
+            return
+
+    def delete_session(self, session_id: str) -> None:
+        try:
+            path = _usable_receipt_path(self.state_dir, session_id)
+            if not path:
+                return
+            with _receipt_lock(path):
+                _unlink_regular_file(path)
+        except Exception:
+            return
+
+
+def remove_session_performance_receipts(state_dir: str, session_id: str) -> None:
+    """Best-effort sidecar delete. Never raises."""
+    try:
+        StreamPerformanceReceiptStore(state_dir).delete_session(session_id)
+    except Exception:
+        return
+
+
+__all__ = (
+    "MAX_RECEIPTS_PER_SESSION",
+    "RECEIPT_SCHEMA_VERSION",
+    "RECEIPT_STATUSES",
+    "STREAM_PERFORMANCE_KEY",
+    "StreamPerformanceReceiptStore",
+    "build_receipt",
+    "copy_stream_performance",
+    "performance_dir",
+    "receipt_file_path",
+    "remove_session_performance_receipts",
+    "safe_session_id",
+    "sanitize_receipt",
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.241"
+version = "0.9.242"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.6" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.7" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.6"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.7"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.6" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.7" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.6}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.7}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -486,10 +486,11 @@ def test_advisory_compact_once_per_user_turn_not_per_tool_step(monkeypatch, tmp_
 
     from pmharness.drivers.openai_compat import DriverResponse
 
-    # Call-site contract: advisory compact is before the step loop; force=True
-    # overflow path stays inside the loop.
+    # Call-site contract: advisory compact is before the step loop; emergency
+    # overflow path stays inside the loop. Timing may wrap the advisory call
+    # in yield_timed_phase — do not require the obsolete bare yield-from.
     src = inspect.getsource(ConversationalSession._send_locked_inner)
-    advisory_idx = src.find("yield from self._maybe_compact_history()")
+    advisory_idx = src.find("self._maybe_compact_history()")
     force_idx = src.find("emergency=True")
     step_loop_idx = src.find("for step in _step_iter:")
     assert advisory_idx != -1, "advisory _maybe_compact_history() must remain"
@@ -499,11 +500,12 @@ def test_advisory_compact_once_per_user_turn_not_per_tool_step(monkeypatch, tmp_
         "advisory compact must run once before the tool-loop step iterator"
     )
     assert force_idx > step_loop_idx, (
-        "force=True overflow compact must stay inside the step loop"
+        "emergency=True overflow compact must stay inside the step loop"
     )
-    # No per-step advisory call after the loop starts (only force=True).
+    # No per-step no-arg advisory call after the loop starts (only emergency).
     after_loop = src[step_loop_idx:]
-    assert "yield from self._maybe_compact_history()" not in after_loop
+    assert "self._maybe_compact_history()" not in after_loop
+    assert "emergency=True" in after_loop
 
     class _TwoStepPilot:
         name = "two-step-compact-spy"

--- a/tests/test_format_artifacts_routing.py
+++ b/tests/test_format_artifacts_routing.py
@@ -16,6 +16,17 @@ def _routing_artifact(**payload):
     )
 
 
+def _verification_artifact(**payload):
+    return SimpleNamespace(
+        id="verify-1",
+        type="verification",
+        confidence=1.0,
+        created_by="worker",
+        task_id="task-1",
+        payload=payload,
+    )
+
+
 def test_format_artifacts_forwards_policy_provider_adapter():
     ds = DurableState.__new__(DurableState)
     out = ds.format_artifacts([
@@ -49,3 +60,34 @@ def test_format_artifacts_omits_missing_pin_fields_as_none():
     assert row["provider"] is None
     assert row["adapter"] is None
     assert row["adapter_model_name"] is None
+
+
+def test_format_failed_verification_projects_bounded_redacted_source_reason():
+    ds = DurableState.__new__(DurableState)
+    out = ds.format_artifacts([
+        _verification_artifact(
+            result="failed",
+            failure="codex_turn_failed",
+            turn_failure_message="Spend cap reached token=super-secret-value " + ("x" * 600),
+            message="lower-priority message",
+            stderr="lower-priority stderr",
+        ),
+    ])
+
+    row = out[0]
+    assert row["failure"] == "codex_turn_failed"
+    assert row["detail"].startswith("Spend cap reached token=REDACTED")
+    assert "super-secret-value" not in row["detail"]
+    assert "lower-priority" not in row["detail"]
+    assert len(row["detail"]) == 500
+
+
+def test_format_failed_verification_falls_back_to_message_then_stderr():
+    ds = DurableState.__new__(DurableState)
+    message_row, stderr_row = ds.format_artifacts([
+        _verification_artifact(result="failed", failure="no_model", message="No eligible model"),
+        _verification_artifact(result="blocked", failure="auth_failure", stderr="Provider login required"),
+    ])
+
+    assert message_row["detail"] == "No eligible model"
+    assert stderr_row["detail"] == "Provider login required"

--- a/tests/test_http_routes_table.py
+++ b/tests/test_http_routes_table.py
@@ -29,6 +29,7 @@ _SAMPLE_GUARDED_GET = (
     "/api/platform",
     "/api/settings",
     "/api/session/state",
+    "/api/session/performance",
     "/api/jobs",
     "/api/sessions",
     "/api/providers",

--- a/tests/test_local_job_labeling.py
+++ b/tests/test_local_job_labeling.py
@@ -83,6 +83,31 @@ def test_finish_local_job_overwrites_model_from_worker_result(monkeypatch):
     assert job["status"] == "completed"
 
 
+def test_failed_local_terminal_artifact_carries_exact_task_id(monkeypatch):
+    monkeypatch.setattr(
+        "harness.local_job_routing.preview_agentic_route",
+        lambda *a, **k: {},
+    )
+    s = _session()
+    s._register_local_job(
+        "local-fail", "audit failure", role="analysis",
+        engine="agentic", model="",
+    )
+    task_id = s._local_jobs["local-fail"]["tasks"][0]["id"]
+
+    s._finish_local_job(
+        "local-fail", ok=False, summary="Provider login required",
+        engine="agentic", model="",
+    )
+
+    terminal = next(
+        art for art in s._local_jobs["local-fail"]["artifacts"]
+        if art["id"] == "local-fail-result"
+    )
+    assert terminal["type"] == "error"
+    assert terminal["task_id"] == task_id
+
+
 def test_finish_does_not_clobber_preview_model_with_engine_only(monkeypatch):
     """Finish with engine but empty model must keep the preview ROUTING stamp."""
     monkeypatch.setattr(

--- a/tests/test_send_loop_phases.py
+++ b/tests/test_send_loop_phases.py
@@ -46,6 +46,7 @@ from harness.send_loop_phases import (
 
 PHASE_HELPERS = (
     "run_stream",
+    "dispatch_pilot_provider_call",
     "run_prefetch",
     "run_parallel_prefetch",
     "stream_swarm",
@@ -53,6 +54,9 @@ PHASE_HELPERS = (
     "action_display_goal",
     "drain_stream_queue",
     "meter_pilot_step",
+    "record_provider_stream_receipt",
+    "account_provider_attempt",
+    "record_provider_dispatch_error_receipt",
     "drain_idle_turn",
     "dispatch_readonly_action",
     "dispatch_local_action",
@@ -103,17 +107,106 @@ def test_mixin_still_owns_public_orchestration_surface():
 
 def test_mixin_calls_new_phase_helpers():
     src = Path(inspect.getsourcefile(SendLoopMixin)).read_text(encoding="utf-8")
-    assert "drain_stream_queue(" in src
-    assert "meter_pilot_step(" in src
+    assert "dispatch_pilot_provider_call(" in src
+    assert "account_provider_attempt(" in src
+    assert "record_provider_dispatch_error_receipt(" in src
     assert "drain_idle_turn(" in src
     assert "run_auto_verify(" in src
     assert "execute_turn_actions(" in src
+    assert "reset_timing_before_step(" in src
+    assert "yield_timed_phase(" in src
     # Action-spree fan-out (prefetch / readonly / local) lives in send_loop_actions.
     actions_src = Path("harness/send_loop_actions.py").read_text(encoding="utf-8")
     assert "action_display_goal(" in actions_src
     assert "run_parallel_prefetch(" in actions_src
     assert "dispatch_readonly_action(" in actions_src
     assert "dispatch_local_action(" in actions_src
+
+
+def test_send_locked_inner_excludes_yield_suspension_from_phase_timers():
+    """Advisory compaction and overflow compact must not use timed_phase around yield."""
+    src = Path(inspect.getsourcefile(SendLoopMixin)).read_text(encoding="utf-8")
+    assert 'yield from yield_timed_phase(' in src
+    assert 'timing, "advisory_compaction"' in src
+    assert "reset_timing_before_step(timing, step)" in src
+    # Plan+append-only order: timed trailer, untimed suffix, timed encode/append.
+    inner = inspect.getsource(SendLoopMixin._send_locked_inner)
+    first_user = inner.find('with timed_phase(timing, "user_append")')
+    plan_idx = inner.find("PLAN_SYSTEM_SUFFIX")
+    second_user = inner.find('with timed_phase(timing, "user_append")', first_user + 1)
+    assert first_user != -1 and plan_idx != -1 and second_user != -1
+    assert first_user < plan_idx < second_user
+    # CodeGraph visibility event is yielded after the timed compute block.
+    assert "cg_event" in src
+
+
+def test_plan_append_only_user_message_byte_order(tmp_path, monkeypatch):
+    """User content, append-only trailer, plan suffix, then native image parts."""
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+    from harness.pilot import PLAN_SYSTEM_SUFFIX
+    from pmharness.drivers.base import DriverResponse
+
+    trailer_mark = "TRAILER_UNIQUE_MARK"
+    encoded = {}
+
+    def fake_prep(session, user_message, images):
+        if False:
+            yield None
+        return user_message, ["fake.png"]
+
+    def fake_encode(text, paths):
+        encoded["text"] = text
+        encoded["paths"] = list(paths)
+        return [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,xx"}},
+        ]
+
+    monkeypatch.setattr("harness.send_loop.prepare_turn_images", fake_prep)
+    monkeypatch.setattr(
+        "harness.vision.native_multimodal_user_content", fake_encode,
+    )
+
+    cfg = HarnessConfig(
+        driver="stub-oracle-v2",
+        state_dir=str(tmp_path),
+        repo=str(tmp_path),
+    )
+    session = ConversationalSession(cfg)
+    monkeypatch.setattr(session, "_resolve_append_only", lambda: True)
+    monkeypatch.setattr(
+        session,
+        "_append_turn_context_trailer",
+        lambda message, user_message: message + "\n" + trailer_mark,
+    )
+
+    class OrderPilot:
+        name = "order-spy"
+
+        def chat(self, messages, tools=None, system=None):
+            return DriverResponse(
+                text='{"say": "ok", "actions": []}',
+                tokens_out=1,
+                latency_ms=1.0,
+            )
+
+    session.pilot = OrderPilot()
+    user = "hello order test"
+    list(session.send(user, plan=True))
+
+    body = encoded["text"]
+    assert body.index(user) < body.index(trailer_mark) < body.index(PLAN_SYSTEM_SUFFIX)
+    expected = user + "\n" + trailer_mark + "\n\n" + PLAN_SYSTEM_SUFFIX
+    assert body == expected
+    assert encoded["paths"] == ["fake.png"]
+
+    contents = [
+        m.get("content") for m in session._history if m.get("role") == "user"
+    ]
+    multimodal = next(c for c in contents if isinstance(c, list))
+    assert multimodal[0]["text"] == expected
+    assert multimodal[1]["type"] == "image_url"
 
 
 def test_send_locked_inner_no_longer_inlines_readonly_branches():

--- a/tests/test_stream_identity_batch.py
+++ b/tests/test_stream_identity_batch.py
@@ -10,6 +10,50 @@ from harness.send_loop_phases import drain_stream_queue
 from harness.stream_identity import StreamDeltaBatch, normalize_delta_payload
 
 
+class _CountingGetQueue(queue.Queue):
+    """Queue that records drain-loop ``get`` calls so hold vs first-frame is observable."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.get_calls = 0
+
+    def get(self, block=True, timeout=None):
+        self.get_calls += 1
+        return super().get(block=block, timeout=timeout)
+
+
+def _collect_drain(q):
+    events = []
+    gen = drain_stream_queue(q)
+    try:
+        while True:
+            events.append(next(gen))
+    except StopIteration as stop:
+        return events, stop.value
+
+
+def _finish_gen(gen):
+    extras = []
+    try:
+        while True:
+            extras.append(next(gen))
+    except StopIteration as stop:
+        return extras, stop.value
+
+
+def _replay_joined(events, kind):
+    ring = SseEventRing("sess-batch", 1)
+    for ev in events:
+        ring.append(ev.kind, ev.data)
+    replay = ring.since(0)
+    assert replay["gap"] is False
+    return "".join(
+        (e.get("data") or {}).get("text") or ""
+        for e in replay["events"]
+        if e.get("kind") == kind
+    )
+
+
 def test_normalize_delta_payload_accepts_str_and_dict():
     assert normalize_delta_payload("hi") == ("hi", {})
     text, meta = normalize_delta_payload({
@@ -133,6 +177,160 @@ def test_drain_batches_word_deltas_without_exhausting_sse_ring():
     assert streamed == ""  # progress bypasses say extractor / streamed_prose
 
 
+class _RaiseOnSecondGet:
+    """Queue stand-in: first get returns ``item``; a second get fails the test."""
+
+    def __init__(self, item):
+        self.calls = 0
+        self._item = item
+
+    def get(self, timeout=None):
+        self.calls += 1
+        if self.calls == 1:
+            return self._item
+        raise AssertionError("second queue get before first yield")
+
+
+def test_drain_yields_first_identity_answer_before_second_get():
+    q = _RaiseOnSecondGet(
+        ("delta", {"text": "Hello", "stream_id": "a1", "channel": "answer"}),
+    )
+    ev = next(drain_stream_queue(q))
+    assert ev.kind == "message_delta"
+    assert ev.data["text"] == "Hello"
+    assert ev.data.get("stream_id") == "a1"
+    assert ev.data.get("channel") == "answer"
+    assert q.calls == 1
+
+
+def test_drain_yields_first_identity_reasoning_before_second_get():
+    q = _RaiseOnSecondGet(
+        ("reasoning", {"text": "Think", "stream_id": "rs1", "channel": "reasoning"}),
+    )
+    ev = next(drain_stream_queue(q))
+    assert ev.kind == "thinking"
+    assert ev.data["text"] == "Think"
+    assert ev.data.get("stream_id") == "rs1"
+    assert ev.data.get("channel") == "reasoning"
+    assert ev.data.get("delta") is True
+    assert q.calls == 1
+
+
+def test_drain_first_overdue_identity_answer_still_yields_before_second_get():
+    """push() may flush on the char threshold; that is still the first frame."""
+    text = "x" * 80
+    q = _RaiseOnSecondGet(
+        ("delta", {"text": text, "stream_id": "a1", "channel": "answer"}),
+    )
+    ev = next(drain_stream_queue(q))
+    assert ev.kind == "message_delta"
+    assert ev.data["text"] == text
+    assert ev.data.get("stream_id") == "a1"
+    assert q.calls == 1
+
+
+def test_drain_still_holds_first_identity_progress_until_later_get():
+    """Progress stays on the batch timeout path — not a first-frame yield."""
+    q = _RaiseOnSecondGet(
+        ("delta", {"text": "pre", "stream_id": "p1", "channel": "progress"}),
+    )
+    try:
+        next(drain_stream_queue(q))
+    except AssertionError as exc:
+        assert "second queue get before first yield" in str(exc)
+        assert q.calls == 2
+    else:
+        raise AssertionError("progress must not yield before a second queue get")
+
+
+def test_drain_batches_second_same_identity_answer_until_done(monkeypatch):
+    """Second same-identity answer stays batched until the terminal get.
+
+    Final texts ``['Hello', ' world']`` are also what first-framing every
+    delta would produce — ``get_calls`` is what proves the hold.
+    """
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    q = _CountingGetQueue()
+    resp = type("R", (), {"meta": {}})()
+    q.put(("delta", {"text": "Hello", "stream_id": "a1", "channel": "answer"}))
+    q.put(("delta", {"text": " world", "stream_id": "a1", "channel": "answer"}))
+    q.put(("done", resp))
+
+    gen = drain_stream_queue(q)
+    first = next(gen)
+    assert first.kind == "message_delta"
+    assert first.data["text"] == "Hello"
+    assert first.data.get("stream_id") == "a1"
+    assert q.get_calls == 1
+
+    second = next(gen)
+    assert second.kind == "message_delta"
+    assert second.data["text"] == " world"
+    assert second.data.get("stream_id") == "a1"
+    # Held until the generator reads ``done`` (3rd get). First-framing the
+    # second delta would yield it on get 2.
+    assert q.get_calls == 3
+
+    extras, (streamed, got) = _finish_gen(gen)
+    assert extras == []
+    assert streamed == "Hello world"
+    assert got is resp
+    assert q.get_calls == 3
+
+
+def test_drain_batches_second_same_identity_reasoning_until_done(monkeypatch):
+    """Second same-identity reasoning stays batched until the terminal get."""
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    q = _CountingGetQueue()
+    resp = type("R", (), {"meta": {}})()
+    q.put(("reasoning", {"text": "Why ", "stream_id": "rs1", "channel": "reasoning"}))
+    q.put(("reasoning", {"text": "not", "stream_id": "rs1", "channel": "reasoning"}))
+    q.put(("done", resp))
+
+    gen = drain_stream_queue(q)
+    first = next(gen)
+    assert first.kind == "thinking"
+    assert first.data["text"] == "Why "
+    assert first.data.get("stream_id") == "rs1"
+    assert first.data.get("delta") is True
+    assert q.get_calls == 1
+
+    second = next(gen)
+    assert second.kind == "thinking"
+    assert second.data["text"] == "not"
+    assert second.data.get("stream_id") == "rs1"
+    assert second.data.get("delta") is True
+    assert q.get_calls == 3
+
+    extras, (streamed, got) = _finish_gen(gen)
+    assert extras == []
+    assert streamed == ""
+    assert got.meta["streamed_reasoning"] == "Why not"
+    assert q.get_calls == 3
+
+
+def test_drain_first_identity_answer_uses_say_extractor():
+    q: queue.Queue = queue.Queue()
+    resp = type("R", (), {"meta": {}})()
+    q.put((
+        "delta",
+        {"text": '{"say": "Hi"}', "stream_id": "a1", "channel": "answer"},
+    ))
+    q.put(("done", resp))
+
+    events = []
+    gen = drain_stream_queue(q)
+    try:
+        while True:
+            events.append(next(gen))
+    except StopIteration as stop:
+        streamed, _got = stop.value
+
+    deltas = [e for e in events if e.kind == "message_delta"]
+    assert [d.data["text"] for d in deltas] == ["Hi"]
+    assert streamed == "Hi"
+
+
 def test_drain_flushes_before_tool_hint_barrier():
     q: queue.Queue = queue.Queue()
     q.put(("delta", {"text": "pre ", "stream_id": "p1", "channel": "progress"}))
@@ -156,3 +354,262 @@ def test_drain_flushes_before_tool_hint_barrier():
         e.kind == "message_delta" and "pre" in e.data.get("text", "")
         for e in events[:tool_at]
     )
+
+
+def test_drain_batches_answer_word_deltas_without_exhausting_sse_ring(monkeypatch):
+    """520 same-identity answer words: first frame immediate, rest batched."""
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    q: queue.Queue = queue.Queue()
+    words = [f"w{i} " for i in range(520)]
+    for w in words:
+        q.put((
+            "delta",
+            {
+                "text": w,
+                "stream_id": "msg_answer",
+                "channel": "answer",
+                "output_index": 1,
+            },
+        ))
+    q.put(("done", type("R", (), {"meta": {}})()))
+
+    events, (streamed, _resp) = _collect_drain(q)
+    deltas = [e for e in events if e.kind == "message_delta"]
+    assert deltas[0].data["text"] == words[0]
+    # Immediate first frame + char-threshold batches — never one frame per word.
+    assert 2 <= len(deltas) < 80
+    assert len(deltas) < _SSE_RING_CAP // 2
+    joined = "".join(d.data["text"] for d in deltas)
+    assert joined == "".join(words)
+    assert all(d.data.get("stream_id") == "msg_answer" for d in deltas)
+    assert all(d.data.get("channel") == "answer" for d in deltas)
+    assert _replay_joined(deltas, "message_delta") == joined
+    assert streamed == joined
+
+
+def test_drain_batches_reasoning_word_deltas_without_exhausting_sse_ring(monkeypatch):
+    """520 same-identity reasoning words: first frame immediate, rest batched."""
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    q: queue.Queue = queue.Queue()
+    words = [f"w{i} " for i in range(520)]
+    for w in words:
+        q.put((
+            "reasoning",
+            {
+                "text": w,
+                "stream_id": "msg_reasoning",
+                "channel": "reasoning",
+                "output_index": 1,
+            },
+        ))
+    q.put(("done", type("R", (), {"meta": {}})()))
+
+    events, (streamed, resp) = _collect_drain(q)
+    thinking = [e for e in events if e.kind == "thinking"]
+    assert thinking[0].data["text"] == words[0]
+    assert 2 <= len(thinking) < 80
+    assert len(thinking) < _SSE_RING_CAP // 2
+    joined = "".join(t.data["text"] for t in thinking)
+    assert joined == "".join(words)
+    assert all(t.data.get("stream_id") == "msg_reasoning" for t in thinking)
+    assert all(t.data.get("channel") == "reasoning" for t in thinking)
+    assert all(t.data.get("delta") is True for t in thinking)
+    assert _replay_joined(thinking, "thinking") == joined
+    assert streamed == ""
+    assert resp.meta["streamed_reasoning"] == joined
+
+
+def test_drain_identity_change_after_first_frame_flushes_held_answer(monkeypatch):
+    """After the first-frame emit, a new stream_id flushes the held tail first."""
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    q = _CountingGetQueue()
+    resp = type("R", (), {"meta": {}})()
+    q.put(("delta", {"text": "Hello", "stream_id": "a1", "channel": "answer"}))
+    q.put(("delta", {"text": " world", "stream_id": "a1", "channel": "answer"}))
+    q.put(("delta", {"text": "Other", "stream_id": "a2", "channel": "answer"}))
+    q.put(("done", resp))
+
+    gen = drain_stream_queue(q)
+    first = next(gen)
+    assert first.kind == "message_delta"
+    assert first.data["text"] == "Hello"
+    assert first.data.get("stream_id") == "a1"
+    assert q.get_calls == 1
+
+    held = next(gen)
+    assert held.kind == "message_delta"
+    assert held.data["text"] == " world"
+    assert held.data.get("stream_id") == "a1"
+    # Identity-change get (3) flushes the held same-identity tail.
+    assert q.get_calls == 3
+
+    changed = next(gen)
+    assert changed.kind == "message_delta"
+    assert changed.data["text"] == "Other"
+    assert changed.data.get("stream_id") == "a2"
+    # New identity first-frames on the same identity-change get.
+    assert q.get_calls == 3
+
+    extras, (streamed, got) = _finish_gen(gen)
+    assert extras == []
+    assert streamed == "Hello worldOther"
+    assert got is resp
+
+
+def test_drain_answer_reasoning_interleave_preserves_order(monkeypatch):
+    """Interleaved answer/reasoning first-frames then holds with no drops."""
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    q = _CountingGetQueue()
+    resp = type("R", (), {"meta": {}})()
+    q.put(("delta", {"text": "A1", "stream_id": "a1", "channel": "answer"}))
+    q.put(("reasoning", {"text": "R1", "stream_id": "rs1", "channel": "reasoning"}))
+    q.put(("delta", {"text": "A2", "stream_id": "a1", "channel": "answer"}))
+    q.put(("reasoning", {"text": "R2", "stream_id": "rs1", "channel": "reasoning"}))
+    q.put(("done", resp))
+
+    gen = drain_stream_queue(q)
+    a1 = next(gen)
+    assert a1.kind == "message_delta"
+    assert a1.data["text"] == "A1"
+    assert q.get_calls == 1
+
+    r1 = next(gen)
+    assert r1.kind == "thinking"
+    assert r1.data["text"] == "R1"
+    assert r1.data.get("delta") is True
+    assert q.get_calls == 2
+
+    a2 = next(gen)
+    assert a2.kind == "message_delta"
+    assert a2.data["text"] == "A2"
+    # Later same-identity tails stay batched until ``done`` (5th get).
+    assert q.get_calls == 5
+
+    r2 = next(gen)
+    assert r2.kind == "thinking"
+    assert r2.data["text"] == "R2"
+    assert r2.data.get("delta") is True
+    assert q.get_calls == 5
+
+    extras, (streamed, got) = _finish_gen(gen)
+    assert extras == []
+    assert streamed == "A1A2"
+    assert got.meta["streamed_reasoning"] == "R1R2"
+    assert q.get_calls == 5
+
+
+def test_drain_first_frame_answer_then_tool_hint_keeps_answer_before_prep(monkeypatch):
+    """First-frame answer yields before the tool_hint get; prep follows it."""
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    q = _CountingGetQueue()
+    resp = type("R", (), {"meta": {}})()
+    q.put(("delta", {"text": "Hello", "stream_id": "a1", "channel": "answer"}))
+    q.put(("tool_hint", "read_file"))
+    q.put(("done", resp))
+
+    gen = drain_stream_queue(q)
+    first = next(gen)
+    assert first.kind == "message_delta"
+    assert first.data["text"] == "Hello"
+    # Yielded on the first get — not because tool_hint flushed a pending batch.
+    assert q.get_calls == 1
+
+    prep = next(gen)
+    assert prep.kind == "tool_prep"
+    assert prep.data["name"] == "read_file"
+    assert q.get_calls == 2
+
+    extras, (streamed, got) = _finish_gen(gen)
+    assert extras == []
+    assert streamed == "Hello"
+    assert got is resp
+    assert q.get_calls == 3
+
+
+def test_drain_new_stream_id_after_tool_first_frames(monkeypatch):
+    """Post-tool narration on a new stream_id gets its own immediate first frame."""
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    q = _CountingGetQueue()
+    resp = type("R", (), {"meta": {}})()
+    q.put(("delta", {"text": "Hello", "stream_id": "a1", "channel": "answer"}))
+    q.put(("tool_hint", "read_file"))
+    q.put(("delta", {"text": "After", "stream_id": "a2", "channel": "answer"}))
+    q.put(("delta", {"text": " tool", "stream_id": "a2", "channel": "answer"}))
+    q.put(("done", resp))
+
+    gen = drain_stream_queue(q)
+    first = next(gen)
+    assert first.kind == "message_delta"
+    assert first.data["text"] == "Hello"
+    assert first.data.get("stream_id") == "a1"
+    assert q.get_calls == 1
+
+    prep = next(gen)
+    assert prep.kind == "tool_prep"
+    assert q.get_calls == 2
+
+    after = next(gen)
+    assert after.kind == "message_delta"
+    assert after.data["text"] == "After"
+    assert after.data.get("stream_id") == "a2"
+    # New identity first-frames on its own get — not held until done.
+    assert q.get_calls == 3
+
+    tail = next(gen)
+    assert tail.kind == "message_delta"
+    assert tail.data["text"] == " tool"
+    assert tail.data.get("stream_id") == "a2"
+    # Later same-identity a2 stays batched until the terminal get.
+    assert q.get_calls == 5
+
+    extras, (streamed, got) = _finish_gen(gen)
+    assert extras == []
+    assert streamed == "HelloAfter tool"
+    assert got is resp
+
+
+def test_drain_dual_output_identities_each_first_frame(monkeypatch):
+    """Two answer stream_ids each get an immediate first frame."""
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    q = _CountingGetQueue()
+    resp = type("R", (), {"meta": {}})()
+    q.put((
+        "delta",
+        {"text": "One", "stream_id": "out_1", "channel": "answer", "output_index": 0},
+    ))
+    q.put((
+        "delta",
+        {"text": "Two", "stream_id": "out_2", "channel": "answer", "output_index": 1},
+    ))
+    q.put((
+        "delta",
+        {"text": " more", "stream_id": "out_1", "channel": "answer", "output_index": 0},
+    ))
+    q.put(("done", resp))
+
+    gen = drain_stream_queue(q)
+    one = next(gen)
+    assert one.kind == "message_delta"
+    assert one.data["text"] == "One"
+    assert one.data.get("stream_id") == "out_1"
+    assert one.data.get("output_index") == 0
+    assert q.get_calls == 1
+
+    two = next(gen)
+    assert two.kind == "message_delta"
+    assert two.data["text"] == "Two"
+    assert two.data.get("stream_id") == "out_2"
+    assert two.data.get("output_index") == 1
+    assert q.get_calls == 2
+
+    more = next(gen)
+    assert more.kind == "message_delta"
+    assert more.data["text"] == " more"
+    assert more.data.get("stream_id") == "out_1"
+    # Later same-identity out_1 stays batched until done.
+    assert q.get_calls == 4
+
+    extras, (streamed, got) = _finish_gen(gen)
+    assert extras == []
+    assert streamed == "OneTwo more"
+    assert got is resp

--- a/tests/test_stream_performance.py
+++ b/tests/test_stream_performance.py
@@ -1,0 +1,1524 @@
+"""Deterministic TTFT / provider-output timing for the interactive pilot stream."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from types import SimpleNamespace
+
+from harness.send_loop_phases import (
+    _finish_and_attach_timing,
+    dispatch_pilot_provider_call,
+    dispatch_sync_pilot_chat,
+    drain_stream_queue,
+    meter_pilot_step,
+    run_stream,
+)
+from harness.stream_performance import (
+    BACKEND_READY_TOTAL_MS,
+    FIRST_ANSWER_CALLBACK_MS,
+    FIRST_CONTENT_CALLBACK_MS,
+    FIRST_VISIBLE_ANSWER_MS,
+    PROVIDER_CALL_TOTAL_MS,
+    PROVIDER_OUTPUT_TPS,
+    STREAM_PERFORMANCE_KEY,
+    THROUGHPUT_BASIS,
+    THROUGHPUT_BASIS_KEY,
+    StreamTimingAccumulator,
+    attach_stream_performance,
+    call_timed_phase,
+    classify_stream_event,
+    make_stream_timing_accumulator,
+    reset_provider_step_timing,
+    reset_timing_before_step,
+    timed_phase,
+    yield_timed_phase,
+)
+from pmharness.drivers.base import DriverResponse
+
+
+class FakeClock:
+    """Monotonic clock in seconds, advanced by exact millisecond ticks."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self._ms = int(round(start * 1000.0))
+
+    def __call__(self) -> float:
+        return self._ms / 1000.0
+
+    def advance(self, seconds: float) -> None:
+        self._ms += int(round(seconds * 1000.0))
+
+
+def _stream_session(chat_stream):
+    history = [{"role": "system"}, {"role": "user", "content": "hi"}]
+    return SimpleNamespace(
+        pilot=SimpleNamespace(
+            chat_stream=chat_stream,
+            supports_streaming=True,
+        ),
+        _history=history,
+        _elide_stale_reads=lambda msgs: msgs,
+        _messages_for_provider=lambda: history[1:],
+    )
+
+
+def _meter_session():
+    meters = {}
+    return SimpleNamespace(
+        _tokens_used=0,
+        _tokens_out=0,
+        _turn_output_tokens=0,
+        _tokens_in=0,
+        _last_prompt_tokens=0,
+        _tokens_cached=0,
+        _tokens_cache_write=0,
+        _tokens_cache_write_5m=0,
+        _tokens_cache_write_1h=0,
+        _plan_billing=False,
+        _price_source="",
+        _provider_cost_usd=0.0,
+        _provider_billed_tokens_in=0,
+        _provider_billed_tokens_out=0,
+        _provider_billed_tokens_cached=0,
+        _provider_billed_tokens_cache_write=0,
+        _provider_billed_tokens_cache_write_5m=0,
+        _provider_billed_tokens_cache_write_1h=0,
+        config=SimpleNamespace(driver="openai/gpt-test"),
+        _accumulate_session_meters=lambda **kw: meters.update(kw),
+        meters=meters,
+    )
+
+
+def test_classify_stream_event_table():
+    cases = (
+        ("delta", "hello", "answer"),
+        ("delta", "  hello  ", "answer"),
+        ("delta", {"text": "hi", "channel": "answer"}, "answer"),
+        ("delta", {"delta": "hi", "stream_id": "a"}, "answer"),
+        ("reasoning", "think", "reasoning"),
+        ("thinking", {"text": "think", "channel": "reasoning"}, "reasoning"),
+        ("delta", {"text": "think", "channel": "reasoning"}, "reasoning"),
+        ("delta", "", None),
+        ("delta", "   ", None),
+        ("delta", None, None),
+        ("delta", {"text": ""}, None),
+        ("delta", {"text": "ok", "channel": "progress"}, None),
+        ("progress", "still working", None),
+        ("tool", "read_file", None),
+        ("tool_call", "read_file", None),
+        ("delta", {"text": "ok", "channel": "tool"}, None),
+        ("delta", {"text": "ok", "channel": "tool_call"}, None),
+        ("tool_hint", "read_file", None),
+        ("wait", "still working", None),
+        ("item_done", {"stream_id": "a"}, None),
+        ("delta", {"type": "usage", "usage": {"output_tokens": 3}}, None),
+        ("delta", {"type": "header"}, None),
+        ("delta", {"type": "keepalive"}, None),
+        ("delta", {"event": "ping"}, None),
+        ("delta", {"kind": "completion"}, None),
+        ("usage", {"output_tokens": 4}, None),
+        ("done", "ok", None),
+    )
+    for kind, payload, expected in cases:
+        assert classify_stream_event(kind, payload) == expected, (kind, payload)
+
+
+def test_empty_stream_omits_ttft_and_tps():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    clock.advance(0.012)
+    acc.finish()
+    snap = acc.snapshot(tokens_out=0)
+    assert snap["content_delta_count"] == 0
+    assert snap["provider_call_total_ms"] == 12.0
+    assert BACKEND_READY_TOTAL_MS not in snap
+    assert "request_to_first_content_callback_ms" not in snap
+    assert "request_to_first_answer_callback_ms" not in snap
+    assert "decode_window_ms" not in snap
+    assert "max_inter_delta_ms" not in snap
+    assert "provider_output_tokens_per_second" not in snap
+
+
+def test_one_answer_delta_has_ttft_but_no_tps():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    clock.advance(0.080)
+    acc.note("delta", "Hello")
+    clock.advance(0.020)
+    acc.finish()
+    snap = acc.snapshot(tokens_out=9)
+    assert snap["content_delta_count"] == 1
+    assert snap["request_to_first_content_callback_ms"] == 80.0
+    assert snap["request_to_first_answer_callback_ms"] == 80.0
+    assert snap["provider_call_total_ms"] == 100.0
+    assert "decode_window_ms" not in snap
+    assert "max_inter_delta_ms" not in snap
+    assert "provider_output_tokens_per_second" not in snap
+
+
+def test_multiple_deltas_exact_max_gap_and_tps():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    clock.advance(0.100)
+    acc.note("delta", "A")
+    clock.advance(0.100)
+    acc.note("delta", "B")
+    clock.advance(0.300)
+    acc.note("delta", "C")
+    clock.advance(0.100)
+    acc.finish()
+    snap = acc.snapshot(tokens_out=12)
+    assert snap["content_delta_count"] == 3
+    assert snap["request_to_first_content_callback_ms"] == 100.0
+    assert snap["request_to_first_answer_callback_ms"] == 100.0
+    assert snap["decode_window_ms"] == 400.0
+    assert snap["max_inter_delta_ms"] == 300.0
+    assert snap["provider_call_total_ms"] == 600.0
+    # 12 provider tokens / 0.400s first-content→last-content, not / 0.600s total.
+    assert snap["provider_output_tokens_per_second"] == 30.0
+    assert snap[THROUGHPUT_BASIS_KEY] == THROUGHPUT_BASIS
+
+
+def test_reasoning_before_answer_distinct_ttfts():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    clock.advance(0.050)
+    acc.note("reasoning", "thinking")
+    clock.advance(0.150)
+    acc.note("delta", "visible")
+    acc.finish()
+    snap = acc.snapshot(tokens_out=4)
+    assert snap["request_to_first_content_callback_ms"] == 50.0
+    assert snap["request_to_first_answer_callback_ms"] == 200.0
+    assert snap["content_delta_count"] == 2
+    assert snap["decode_window_ms"] == 150.0
+    assert snap["provider_output_tokens_per_second"] == 26.666667
+    assert snap[THROUGHPUT_BASIS_KEY] == THROUGHPUT_BASIS
+
+
+def test_empty_tool_header_usage_keepalive_excluded():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    clock.advance(0.010)
+    acc.note("delta", "")
+    acc.note("delta", "   ")
+    acc.note("tool_hint", "read_file")
+    acc.note("wait", "still working")
+    acc.note("item_done", {"stream_id": "a"})
+    acc.note("delta", {"type": "header"})
+    acc.note("delta", {"type": "usage", "usage": {"output_tokens": 2}})
+    acc.note("delta", {"type": "keepalive"})
+    acc.note("delta", {"text": "progress", "channel": "progress"})
+    clock.advance(0.040)
+    acc.note("delta", "token")
+    acc.finish()
+    snap = acc.snapshot(tokens_out=8)
+    assert snap["content_delta_count"] == 1
+    assert snap["request_to_first_content_callback_ms"] == 50.0
+    assert snap["request_to_first_answer_callback_ms"] == 50.0
+    assert "provider_output_tokens_per_second" not in snap
+
+
+def test_tps_omitted_without_tokens_or_window():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.note("delta", "A")
+    clock.advance(0.200)
+    acc.note("delta", "B")
+    acc.finish()
+    assert "provider_output_tokens_per_second" not in acc.snapshot(tokens_out=0)
+    assert "provider_output_tokens_per_second" not in acc.snapshot(tokens_out=None)
+
+
+def test_same_instant_content_omits_decode_window_and_tps():
+    """Two content callbacks at one fake-clock tick: no window, no TPS."""
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    clock.advance(0.080)
+    acc.note("delta", "A")
+    acc.note("delta", "B")
+    acc.finish()
+    snap = acc.snapshot(tokens_out=9)
+    assert snap["content_delta_count"] == 2
+    assert snap["request_to_first_content_callback_ms"] == 80.0
+    assert snap["request_to_first_answer_callback_ms"] == 80.0
+    assert "decode_window_ms" not in snap
+    assert "provider_output_tokens_per_second" not in snap
+
+
+def test_attach_preserves_existing_meta_and_latency():
+    resp = DriverResponse(
+        text="ok",
+        tokens_out=3,
+        latency_ms=42.5,
+        meta={"cache_read_tokens": 7, "custom": "keep"},
+    )
+    attach_stream_performance(resp, {"content_delta_count": 1, "provider_call_total_ms": 10.0})
+    assert resp.latency_ms == 42.5
+    assert resp.meta["cache_read_tokens"] == 7
+    assert resp.meta["custom"] == "keep"
+    assert resp.meta[STREAM_PERFORMANCE_KEY]["content_delta_count"] == 1
+
+
+def test_attach_does_not_overwrite_existing_stream_performance():
+    resp = SimpleNamespace(
+        latency_ms=9.0,
+        meta={STREAM_PERFORMANCE_KEY: {"content_delta_count": 99}},
+    )
+    attach_stream_performance(resp, {"content_delta_count": 1})
+    assert resp.meta[STREAM_PERFORMANCE_KEY]["content_delta_count"] == 99
+    assert resp.latency_ms == 9.0
+
+
+def test_run_stream_queue_shape_unchanged_and_attaches_performance():
+    q: queue.Queue = queue.Queue()
+    clock = FakeClock()
+    resp = DriverResponse(
+        text="ok",
+        tokens_out=6,
+        latency_ms=17.0,
+        meta={"foo": "bar"},
+    )
+
+    def chat_stream(messages, **kwargs):
+        kwargs["on_reasoning_delta"]("think")
+        kwargs["on_delta"]("")
+        kwargs["on_tool_hint"]("read_file")
+        clock.advance(0.200)
+        kwargs["on_delta"]("hello")
+        return resp
+
+    run_stream(_stream_session(chat_stream), q, [{"name": "t"}], "sys", clock=clock)
+    events = []
+    while not q.empty():
+        events.append(q.get_nowait())
+    kinds = [kind for kind, _val in events]
+    assert kinds == ["reasoning", "delta", "tool_hint", "delta", "done"]
+    assert events[1][1] == ""
+    assert events[2][1] == "read_file"
+    assert events[3][1] == "hello"
+    done = events[-1][1]
+    assert done is resp
+    assert done.latency_ms == 17.0
+    assert done.meta["foo"] == "bar"
+    perf = done.meta[STREAM_PERFORMANCE_KEY]
+    assert perf["content_delta_count"] == 2
+    assert perf["request_to_first_content_callback_ms"] == 0.0
+    assert perf["request_to_first_answer_callback_ms"] == 200.0
+    assert perf["decode_window_ms"] == 200.0
+    assert perf["provider_output_tokens_per_second"] == 30.0
+    assert perf[THROUGHPUT_BASIS_KEY] == THROUGHPUT_BASIS
+
+
+def test_run_stream_empty_stream_still_puts_done():
+    q: queue.Queue = queue.Queue()
+    clock = FakeClock()
+    resp = DriverResponse(text="", tokens_out=0, latency_ms=5.0, meta={})
+
+    def chat_stream(messages, **kwargs):
+        clock.advance(0.025)
+        return resp
+
+    run_stream(_stream_session(chat_stream), q, [], "sys", clock=clock)
+    kind, val = q.get_nowait()
+    assert kind == "done"
+    perf = val.meta[STREAM_PERFORMANCE_KEY]
+    assert perf["content_delta_count"] == 0
+    assert perf["provider_call_total_ms"] == 25.0
+    assert BACKEND_READY_TOTAL_MS not in perf
+    assert FIRST_VISIBLE_ANSWER_MS not in perf
+    assert "provider_output_tokens_per_second" not in perf
+
+
+def test_run_stream_timing_failure_does_not_break_chat():
+    q: queue.Queue = queue.Queue()
+    resp = DriverResponse(text="ok", latency_ms=1.0)
+
+    def boom_clock():
+        raise RuntimeError("clock broke")
+
+    def chat_stream(messages, **kwargs):
+        kwargs["on_delta"]("hi")
+        return resp
+
+    run_stream(_stream_session(chat_stream), q, [], "sys", clock=boom_clock)
+    kinds = []
+    while not q.empty():
+        kinds.append(q.get_nowait()[0])
+    assert kinds == ["delta", "done"]
+
+
+def test_meter_pilot_step_preserves_stream_performance_and_accounting(monkeypatch):
+    session = _meter_session()
+    perf = {
+        "content_delta_count": 3,
+        "request_to_first_content_callback_ms": 40.0,
+        "request_to_first_answer_callback_ms": 80.0,
+        "decode_window_ms": 200.0,
+        "provider_output_tokens_per_second": 50.0,
+    }
+    resp = SimpleNamespace(
+        tokens_out=10,
+        tokens_in=100,
+        latency_ms=33.0,
+        meta={
+            "cache_read_tokens": 40,
+            "cache_write_tokens": 5,
+            "provider_cost_usd": 0.0123,
+            STREAM_PERFORMANCE_KEY: perf,
+        },
+    )
+    meter_pilot_step(session, resp, prompt="x" * 400)
+    assert resp.latency_ms == 33.0
+    assert resp.meta[STREAM_PERFORMANCE_KEY] == perf
+    assert resp.meta["tokens_in_basis"] == "provider"
+    assert session._tokens_out == 10
+    assert session._tokens_in == 100
+    assert session._tokens_used == 110
+    assert session._tokens_cached == 40
+    assert session._provider_cost_usd == 0.0123
+    assert session.meters["estimated_cost_usd"] == 0.0123
+    assert session.meters["output_tokens"] == 10
+    assert not hasattr(session, STREAM_PERFORMANCE_KEY)
+    assert not hasattr(session, "_last_stream_performance")
+
+
+def test_meter_pilot_step_malformed_tokens_out_is_honest():
+    session = _meter_session()
+    resp = SimpleNamespace(
+        tokens_out="nope",
+        tokens_in=40,
+        latency_ms=5.0,
+        meta={STREAM_PERFORMANCE_KEY: {"content_delta_count": 1}},
+    )
+    meter_pilot_step(session, resp, prompt="x" * 80)
+    assert session._tokens_out == 0
+    assert session._turn_output_tokens == 0
+    assert session._tokens_in == 40
+    assert session._tokens_used == 40
+    assert resp.meta[STREAM_PERFORMANCE_KEY]["content_delta_count"] == 1
+    assert resp.latency_ms == 5.0
+
+
+def test_phase_durations_and_pre_request_total():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("image_prep")
+    clock.advance(0.050)
+    acc.end_phase("image_prep")
+    acc.begin_phase("prompt_tools")
+    clock.advance(0.030)
+    acc.end_phase("prompt_tools")
+    clock.advance(0.020)
+    acc.mark_request_start()
+    acc.finish()
+    snap = acc.snapshot()
+    assert snap["image_prep_ms"] == 50.0
+    assert snap["prompt_tools_ms"] == 30.0
+    assert snap["pre_request_total_ms"] == 100.0
+    assert "task_profile_ms" not in snap
+    assert "step_wiki_ms" not in snap
+    assert "request_to_first_content_callback_ms" not in snap
+
+
+def test_skipped_and_unknown_phases_omitted():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("not_a_real_phase")
+    clock.advance(0.040)
+    acc.end_phase("not_a_real_phase")
+    acc.begin_phase("step_codegraph")
+    clock.advance(0.010)
+    # never closed
+    acc.mark_request_start()
+    snap = acc.snapshot()
+    assert "not_a_real_phase_ms" not in snap
+    assert "step_codegraph_ms" not in snap
+    assert snap["pre_request_total_ms"] == 50.0
+
+
+def test_ttft_stays_request_relative_after_long_pre_request():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("advisory_compaction")
+    clock.advance(0.400)
+    acc.end_phase("advisory_compaction")
+    acc.mark_request_start()
+    clock.advance(0.080)
+    acc.note("delta", "Hello")
+    clock.advance(0.020)
+    acc.finish()
+    snap = acc.snapshot(tokens_out=9)
+    assert snap["advisory_compaction_ms"] == 400.0
+    assert snap["pre_request_total_ms"] == 400.0
+    assert snap["request_to_first_content_callback_ms"] == 80.0
+    assert snap["request_to_first_answer_callback_ms"] == 80.0
+    assert snap["provider_call_total_ms"] == 100.0
+    assert "provider_output_tokens_per_second" not in snap
+
+
+def test_attach_fills_missing_keys_without_overwrite():
+    resp = SimpleNamespace(
+        latency_ms=9.0,
+        meta={
+            STREAM_PERFORMANCE_KEY: {
+                "image_prep_ms": 12.0,
+                "content_delta_count": 0,
+            },
+            "custom": "keep",
+        },
+    )
+    attach_stream_performance(resp, {
+        "content_delta_count": 3,
+        "request_to_first_content_callback_ms": 40.0,
+        "image_prep_ms": 99.0,
+        "provider_call_total_ms": 25.0,
+    })
+    perf = resp.meta[STREAM_PERFORMANCE_KEY]
+    assert perf["image_prep_ms"] == 12.0
+    assert perf["content_delta_count"] == 0
+    assert perf["request_to_first_content_callback_ms"] == 40.0
+    assert perf["provider_call_total_ms"] == 25.0
+    assert resp.latency_ms == 9.0
+    assert resp.meta["custom"] == "keep"
+
+
+def test_sync_chat_attaches_pre_request_without_ttft():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("prompt_tools")
+    clock.advance(0.040)
+    acc.end_phase("prompt_tools")
+    resp = DriverResponse(text="ok", tokens_out=4, latency_ms=25.0, meta={"foo": "bar"})
+
+    def chat(messages, **kwargs):
+        clock.advance(0.025)
+        return resp
+
+    history = [{"role": "system"}, {"role": "user", "content": "hi"}]
+    session = SimpleNamespace(
+        pilot=SimpleNamespace(chat=chat),
+        _history=history,
+        _elide_stale_reads=lambda msgs: msgs,
+        _messages_for_provider=lambda: history[1:],
+        harness_session_id=None,
+    )
+    out = dispatch_sync_pilot_chat(session, [], "sys", accumulator=acc)
+    assert out is resp
+    assert resp.latency_ms == 25.0
+    assert resp.meta["foo"] == "bar"
+    perf = resp.meta[STREAM_PERFORMANCE_KEY]
+    assert perf["prompt_tools_ms"] == 40.0
+    assert perf["pre_request_total_ms"] == 40.0
+    assert perf["provider_call_total_ms"] == 25.0
+    assert BACKEND_READY_TOTAL_MS not in perf
+    assert FIRST_VISIBLE_ANSWER_MS not in perf
+    assert perf["content_delta_count"] == 0
+    assert "request_to_first_content_callback_ms" not in perf
+    assert "request_to_first_answer_callback_ms" not in perf
+    assert "decode_window_ms" not in perf
+    assert "provider_output_tokens_per_second" not in perf
+
+
+def test_empty_stream_omits_ttft_even_with_pre_request():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("user_append")
+    clock.advance(0.015)
+    acc.end_phase("user_append")
+    q: queue.Queue = queue.Queue()
+    resp = DriverResponse(text="", tokens_out=0, latency_ms=5.0, meta={})
+
+    def chat_stream(messages, **kwargs):
+        clock.advance(0.025)
+        return resp
+
+    run_stream(
+        _stream_session(chat_stream), q, [], "sys",
+        clock=clock, accumulator=acc,
+    )
+    kind, val = q.get_nowait()
+    assert kind == "done"
+    perf = val.meta[STREAM_PERFORMANCE_KEY]
+    assert perf["user_append_ms"] == 15.0
+    assert perf["pre_request_total_ms"] == 15.0
+    assert perf["provider_call_total_ms"] == 25.0
+    assert perf["content_delta_count"] == 0
+    assert "request_to_first_content_callback_ms" not in perf
+    assert "provider_output_tokens_per_second" not in perf
+
+
+def test_timed_phase_helpers_survive_boom_clock():
+    def boom_clock():
+        raise RuntimeError("clock broke")
+
+    acc = make_stream_timing_accumulator(clock=boom_clock)
+    assert acc is None
+
+    def gen():
+        yield "vision"
+        return ("ok", [])
+
+    def runner():
+        result = yield from yield_timed_phase(None, "image_prep", gen())
+        assert result == ("ok", [])
+
+    assert list(runner()) == ["vision"]
+    assert call_timed_phase(None, "prompt_tools", lambda: 7) == 7
+    with timed_phase(None, "step_wiki"):
+        seen = True
+    assert seen
+
+
+def test_yield_timed_phase_preserves_events_and_return():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+
+    def gen():
+        yield {"kind": "task_profile", "profile": "STANDARD"}
+        clock.advance(0.012)
+        return "classified"
+
+    def runner():
+        result = yield from yield_timed_phase(acc, "task_profile", gen())
+        assert result == "classified"
+
+    assert list(runner()) == [{"kind": "task_profile", "profile": "STANDARD"}]
+    snap = acc.snapshot()
+    assert snap["task_profile_ms"] == 12.0
+
+
+def test_reset_drops_turn_once_phases_and_rebases_origin():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("image_prep")
+    clock.advance(0.100)
+    acc.end_phase("image_prep")
+    acc.mark_request_start()
+    clock.advance(0.050)
+    acc.note("delta", "a")
+    acc.finish()
+    first = acc.snapshot(tokens_out=1)
+    assert first["image_prep_ms"] == 100.0
+    assert first["request_to_first_content_callback_ms"] == 50.0
+
+    acc.reset_for_next_provider_call()
+    clock.advance(0.020)
+    acc.begin_phase("step_codegraph")
+    clock.advance(0.030)
+    acc.end_phase("step_codegraph")
+    acc.mark_request_start()
+    second = acc.snapshot()
+    assert "image_prep_ms" not in second
+    assert second["step_codegraph_ms"] == 30.0
+    assert second["pre_request_total_ms"] == 50.0
+    assert second["content_delta_count"] == 0
+    assert "request_to_first_content_callback_ms" not in second
+
+
+def test_run_stream_shared_accumulator_keeps_pre_request_and_request_relative_ttft():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("image_prep")
+    clock.advance(0.050)
+    acc.end_phase("image_prep")
+    acc.begin_phase("thread_start")
+    clock.advance(0.004)
+    q: queue.Queue = queue.Queue()
+    resp = DriverResponse(text="ok", tokens_out=6, latency_ms=17.0, meta={})
+
+    def chat_stream(messages, **kwargs):
+        clock.advance(0.080)
+        kwargs["on_delta"]("hello")
+        return resp
+
+    run_stream(
+        _stream_session(chat_stream), q, [], "sys",
+        clock=clock, accumulator=acc,
+    )
+    events = []
+    while not q.empty():
+        events.append(q.get_nowait())
+    assert [kind for kind, _val in events] == ["delta", "done"]
+    perf = events[-1][1].meta[STREAM_PERFORMANCE_KEY]
+    assert perf["image_prep_ms"] == 50.0
+    assert perf["thread_start_ms"] == 4.0
+    assert perf["pre_request_total_ms"] == 54.0
+    assert perf["request_to_first_content_callback_ms"] == 80.0
+    assert perf["request_to_first_answer_callback_ms"] == 80.0
+    assert events[-1][1].latency_ms == 17.0
+
+
+def test_dispatch_complete_attaches_without_ttft():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("prompt_tools")
+    clock.advance(0.018)
+    acc.end_phase("prompt_tools")
+    resp = DriverResponse(text="done", tokens_out=2, latency_ms=11.0, meta={})
+
+    def complete(prompt, **kwargs):
+        clock.advance(0.011)
+        return resp
+
+    session = SimpleNamespace(
+        pilot=SimpleNamespace(complete=complete),
+        config=SimpleNamespace(no_delegation=False),
+        harness_session_id=None,
+    )
+
+    def run():
+        return (yield from dispatch_pilot_provider_call(
+            session,
+            plan=False,
+            sys_prompt="sys",
+            prompt="ping",
+            synthesis_nudge_active=False,
+            accumulator=acc,
+        ))
+
+    streamed, out = _exhaust_dispatch(run())
+    assert streamed == ""
+    assert out is resp
+    perf = resp.meta[STREAM_PERFORMANCE_KEY]
+    assert perf["prompt_tools_ms"] == 18.0
+    assert perf["pre_request_total_ms"] == 18.0
+    assert perf["provider_call_total_ms"] == 11.0
+    assert BACKEND_READY_TOTAL_MS not in perf
+    assert FIRST_VISIBLE_ANSWER_MS not in perf
+    assert "request_to_first_content_callback_ms" not in perf
+    assert "provider_output_tokens_per_second" not in perf
+    assert resp.latency_ms == 11.0
+
+
+def _exhaust_dispatch(gen):
+    try:
+        while True:
+            next(gen)
+    except StopIteration as stop:
+        return stop.value
+
+
+def test_yield_timed_phase_excludes_consumer_suspension():
+    """Fake-clock time while the consumer is suspended must not enter phase_ms."""
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+
+    def gen():
+        clock.advance(0.010)
+        yield {"kind": "task_profile", "profile": "STANDARD"}
+        clock.advance(0.005)
+        return "classified"
+
+    def runner():
+        result = yield from yield_timed_phase(acc, "task_profile", gen())
+        assert result == "classified"
+
+    it = runner()
+    ev = next(it)
+    assert ev["profile"] == "STANDARD"
+    clock.advance(0.200)
+    try:
+        while True:
+            next(it)
+    except StopIteration:
+        pass
+    snap = acc.snapshot()
+    assert snap["task_profile_ms"] == 15.0
+    assert "request_to_first_content_callback_ms" not in snap
+
+
+def test_yield_timed_phase_image_prep_excludes_yielded_event_wait():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+
+    def gen():
+        clock.advance(0.008)
+        yield {"kind": "vision", "status": "native"}
+        clock.advance(0.004)
+        return ("ok", [])
+
+    def runner():
+        result = yield from yield_timed_phase(acc, "image_prep", gen())
+        assert result == ("ok", [])
+
+    it = runner()
+    next(it)
+    clock.advance(0.500)
+    try:
+        while True:
+            next(it)
+    except StopIteration:
+        pass
+    assert acc.snapshot()["image_prep_ms"] == 12.0
+
+
+def test_malformed_tokens_out_does_not_drop_receipt_or_raise():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    clock.advance(0.080)
+    acc.note("delta", "Hello")
+    clock.advance(0.020)
+    acc.finish()
+    for bad in ("nope", True, object(), [], {}):
+        snap = acc.snapshot(tokens_out=bad)
+        assert snap["content_delta_count"] == 1
+        assert snap[FIRST_CONTENT_CALLBACK_MS] == 80.0
+        assert snap[FIRST_ANSWER_CALLBACK_MS] == 80.0
+        assert PROVIDER_OUTPUT_TPS not in snap
+        assert THROUGHPUT_BASIS_KEY not in snap
+
+    resp = DriverResponse(text="ok", tokens_out="nope", latency_ms=5.0, meta={"foo": "bar"})
+    _finish_and_attach_timing(acc, resp)
+    assert resp.latency_ms == 5.0
+    assert resp.meta["foo"] == "bar"
+    perf = resp.meta[STREAM_PERFORMANCE_KEY]
+    assert perf[FIRST_CONTENT_CALLBACK_MS] == 80.0
+    assert PROVIDER_OUTPUT_TPS not in perf
+
+
+def test_run_stream_malformed_tokens_out_still_attaches():
+    q: queue.Queue = queue.Queue()
+    clock = FakeClock()
+    resp = DriverResponse(text="ok", tokens_out="bad", latency_ms=9.0, meta={})
+
+    def chat_stream(messages, **kwargs):
+        kwargs["on_delta"]("hello")
+        return resp
+
+    run_stream(_stream_session(chat_stream), q, [], "sys", clock=clock)
+    events = []
+    while not q.empty():
+        events.append(q.get_nowait())
+    assert [kind for kind, _val in events] == ["delta", "done"]
+    perf = events[-1][1].meta[STREAM_PERFORMANCE_KEY]
+    assert perf["content_delta_count"] == 1
+    assert FIRST_CONTENT_CALLBACK_MS in perf
+    assert PROVIDER_OUTPUT_TPS not in perf
+
+
+def test_visible_answer_is_say_extractor_not_raw_callback():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.mark_request_start()
+    acc.note("delta", {"text": '{"say": "', "stream_id": "a1", "channel": "answer"})
+    clock.advance(0.050)
+    acc.note("delta", {"text": 'Hi"}', "stream_id": "a1", "channel": "answer"})
+    q: queue.Queue = queue.Queue()
+    resp = DriverResponse(text="ok", tokens_out=4, latency_ms=8.0, meta={})
+    q.put(("delta", {"text": '{"say": "', "stream_id": "a1", "channel": "answer"}))
+    q.put(("delta", {"text": 'Hi"}', "stream_id": "a1", "channel": "answer"}))
+    q.put(("done", resp))
+
+    events = []
+    gen = drain_stream_queue(q, accumulator=acc)
+    try:
+        while True:
+            events.append(next(gen))
+    except StopIteration as stop:
+        streamed, got = stop.value
+
+    deltas = [e for e in events if e.kind == "message_delta"]
+    assert [d.data["text"] for d in deltas] == ["Hi"]
+    assert streamed == "Hi"
+    acc.finish()
+    attach_stream_performance(got, acc.snapshot(tokens_out=4))
+    perf = got.meta[STREAM_PERFORMANCE_KEY]
+    assert perf[FIRST_CONTENT_CALLBACK_MS] == 0.0
+    assert perf[FIRST_ANSWER_CALLBACK_MS] == 0.0
+    assert perf[FIRST_VISIBLE_ANSWER_MS] == 50.0
+    assert got.latency_ms == 8.0
+
+
+def test_reset_timing_before_step_preserves_then_drops_turn_once():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("image_prep")
+    clock.advance(0.100)
+    acc.end_phase("image_prep")
+    acc.begin_phase("user_append")
+    clock.advance(0.020)
+    acc.end_phase("user_append")
+    reset_timing_before_step(acc, 0)
+    first = acc.snapshot()
+    assert first["image_prep_ms"] == 100.0
+    assert first["user_append_ms"] == 20.0
+
+    reset_timing_before_step(acc, 1)
+    second = acc.snapshot()
+    assert "image_prep_ms" not in second
+    assert "user_append_ms" not in second
+    assert second["content_delta_count"] == 0
+
+
+def test_reset_timing_before_step_past_zero_drops_prior_receipt():
+    """Later tool-loop steps still clear prior phases and stream marks."""
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("prompt_tools")
+    clock.advance(0.015)
+    acc.end_phase("prompt_tools")
+    acc.mark_request_start()
+    clock.advance(0.040)
+    acc.note("delta", "partial")
+    acc.finish()
+    prior = acc.snapshot(tokens_out=2)
+    assert prior["prompt_tools_ms"] == 15.0
+    assert prior[FIRST_CONTENT_CALLBACK_MS] == 40.0
+
+    reset_timing_before_step(acc, 1)
+    acc.begin_phase("advisory_compaction")
+    clock.advance(0.025)
+    acc.end_phase("advisory_compaction")
+    retry = acc.snapshot()
+    assert "prompt_tools_ms" not in retry
+    assert FIRST_CONTENT_CALLBACK_MS not in retry
+    assert retry["advisory_compaction_ms"] == 25.0
+
+
+def test_reset_provider_step_timing_keeps_closed_phases_clears_attempt_marks():
+    """Step-0 overflow retry keeps reusable phases; drops per-attempt clocks."""
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("image_prep")
+    clock.advance(0.100)
+    acc.end_phase("image_prep")
+    acc.begin_phase("task_profile")
+    clock.advance(0.020)
+    acc.end_phase("task_profile")
+    acc.begin_phase("user_append")
+    clock.advance(0.015)
+    acc.end_phase("user_append")
+    acc.begin_phase("auto_codegraph")
+    clock.advance(0.010)
+    acc.end_phase("auto_codegraph")
+    acc.begin_phase("advisory_compaction")
+    clock.advance(0.008)
+    acc.end_phase("advisory_compaction")
+    acc.begin_phase("step_codegraph")
+    clock.advance(0.006)
+    acc.end_phase("step_codegraph")
+    acc.begin_phase("step_wiki")
+    clock.advance(0.004)
+    acc.end_phase("step_wiki")
+    acc.begin_phase("prompt_tools")
+    clock.advance(0.012)
+    acc.end_phase("prompt_tools")
+    acc.begin_phase("thread_start")
+    clock.advance(0.003)
+    acc.end_phase("thread_start")
+    acc.mark_request_start()
+    clock.advance(0.040)
+    acc.note("delta", "partial")
+    acc.mark_first_visible_answer()
+    acc.finish()
+    acc.mark_backend_ready()
+    prior = acc.snapshot(tokens_out=2)
+    assert prior["image_prep_ms"] == 100.0
+    assert prior["prompt_tools_ms"] == 12.0
+    assert prior["thread_start_ms"] == 3.0
+    assert prior["pre_request_total_ms"] == 178.0
+    assert prior[FIRST_CONTENT_CALLBACK_MS] == 40.0
+    assert prior[FIRST_VISIBLE_ANSWER_MS] == 40.0
+    assert prior[PROVIDER_CALL_TOTAL_MS] == 40.0
+    assert prior[BACKEND_READY_TOTAL_MS] == 40.0
+
+    reset_provider_step_timing(acc)
+    cleared = acc.snapshot()
+    assert cleared["image_prep_ms"] == 100.0
+    assert cleared["task_profile_ms"] == 20.0
+    assert cleared["user_append_ms"] == 15.0
+    assert cleared["auto_codegraph_ms"] == 10.0
+    assert cleared["advisory_compaction_ms"] == 8.0
+    assert cleared["step_codegraph_ms"] == 6.0
+    assert cleared["step_wiki_ms"] == 4.0
+    assert "prompt_tools_ms" not in cleared
+    assert "thread_start_ms" not in cleared
+    assert "pre_request_total_ms" not in cleared
+    assert FIRST_CONTENT_CALLBACK_MS not in cleared
+    assert FIRST_ANSWER_CALLBACK_MS not in cleared
+    assert FIRST_VISIBLE_ANSWER_MS not in cleared
+    assert PROVIDER_CALL_TOTAL_MS not in cleared
+    assert BACKEND_READY_TOTAL_MS not in cleared
+    assert "decode_window_ms" not in cleared
+    assert "max_inter_delta_ms" not in cleared
+    assert cleared["content_delta_count"] == 0
+
+    acc.begin_phase("advisory_compaction")
+    clock.advance(0.025)
+    acc.end_phase("advisory_compaction")
+    acc.begin_phase("prompt_tools")
+    clock.advance(0.009)
+    acc.end_phase("prompt_tools")
+    acc.begin_phase("thread_start")
+    clock.advance(0.002)
+    acc.end_phase("thread_start")
+    acc.mark_request_start()
+    retry = acc.snapshot()
+    assert retry["image_prep_ms"] == 100.0
+    assert retry["task_profile_ms"] == 20.0
+    assert retry["user_append_ms"] == 15.0
+    assert retry["auto_codegraph_ms"] == 10.0
+    assert retry["step_codegraph_ms"] == 6.0
+    assert retry["step_wiki_ms"] == 4.0
+    assert retry["advisory_compaction_ms"] == 33.0
+    assert retry["prompt_tools_ms"] == 9.0
+    assert retry["thread_start_ms"] == 2.0
+    assert retry["pre_request_total_ms"] == 36.0
+    assert FIRST_CONTENT_CALLBACK_MS not in retry
+    assert FIRST_VISIBLE_ANSWER_MS not in retry
+    assert PROVIDER_CALL_TOTAL_MS not in retry
+    assert BACKEND_READY_TOTAL_MS not in retry
+
+
+def test_reset_provider_attempt_marks_drops_open_per_attempt_phase():
+    """Open prompt_tools / thread_start must not leak across the overflow reset."""
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("user_append")
+    clock.advance(0.015)
+    acc.end_phase("user_append")
+    acc.begin_phase("prompt_tools")
+    clock.advance(0.010)
+    acc.begin_phase("thread_start")
+    clock.advance(0.004)
+    acc.reset_provider_attempt_marks()
+    clock.advance(0.050)
+    acc.end_phase("prompt_tools")
+    acc.end_phase("thread_start")
+    acc.begin_phase("prompt_tools")
+    clock.advance(0.007)
+    acc.end_phase("prompt_tools")
+    acc.mark_request_start()
+    snap = acc.snapshot()
+    assert snap["user_append_ms"] == 15.0
+    assert snap["prompt_tools_ms"] == 7.0
+    assert "thread_start_ms" not in snap
+    assert snap["pre_request_total_ms"] == 57.0
+
+
+def test_reset_provider_step_timing_never_raises():
+    reset_provider_step_timing(None)
+    reset_provider_step_timing(object())
+
+    class Boom:
+        def reset_provider_attempt_marks(self):
+            raise RuntimeError("nope")
+
+    reset_provider_step_timing(Boom())
+
+
+def test_threaded_dispatch_visible_mark_and_per_identity_first_frame():
+    """Send-thread begin, stream-thread dispatch, callback, drain, attach."""
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.begin_phase("image_prep")
+    clock.advance(0.040)
+    acc.end_phase("image_prep")
+
+    resp = DriverResponse(text="ok", tokens_out=8, latency_ms=20.0, meta={"keep": 1})
+    stream_thread_name = {"name": ""}
+
+    def chat_stream(messages, **kwargs):
+        stream_thread_name["name"] = threading.current_thread().name
+        kwargs["on_delta"]({"text": "Hi", "stream_id": "a1", "channel": "answer"})
+        clock.advance(0.050)
+        kwargs["on_delta"]({"text": " there", "stream_id": "a1", "channel": "answer"})
+        kwargs["on_tool_hint"]("read_file")
+        kwargs["on_delta"]({"text": "Next", "stream_id": "a2", "channel": "answer"})
+        return resp
+
+    history = [{"role": "system"}, {"role": "user", "content": "hi"}]
+    session = SimpleNamespace(
+        pilot=SimpleNamespace(
+            chat=lambda *a, **k: resp,
+            chat_stream=chat_stream,
+            supports_streaming=True,
+        ),
+        config=SimpleNamespace(no_delegation=False),
+        _history=history,
+        _elide_stale_reads=lambda msgs: msgs,
+        _messages_for_provider=lambda: history[1:],
+        harness_session_id=None,
+        _build_visible_tools_schema=lambda: [],
+    )
+
+    send_thread_name = threading.current_thread().name
+    events = []
+
+    def run():
+        return (yield from dispatch_pilot_provider_call(
+            session,
+            plan=False,
+            sys_prompt="sys",
+            prompt="ping",
+            synthesis_nudge_active=False,
+            accumulator=acc,
+        ))
+
+    streamed, out = _exhaust_dispatch_events(run(), events)
+    assert streamed == "Hi thereNext"
+    assert out is resp
+    assert out.latency_ms == 20.0
+    assert out.meta["keep"] == 1
+    assert stream_thread_name["name"]
+    assert stream_thread_name["name"] != send_thread_name
+
+    deltas = [e for e in events if getattr(e, "kind", None) == "message_delta"]
+    assert deltas[0].data["text"] == "Hi"
+    assert deltas[0].data.get("stream_id") == "a1"
+    assert any(
+        e.data.get("stream_id") == "a2" and e.data.get("text") == "Next"
+        for e in deltas
+    )
+    assert any(getattr(e, "kind", None) == "tool_prep" for e in events)
+
+    perf = out.meta[STREAM_PERFORMANCE_KEY]
+    assert perf["image_prep_ms"] == 40.0
+    assert FIRST_CONTENT_CALLBACK_MS in perf
+    assert FIRST_ANSWER_CALLBACK_MS in perf
+    assert FIRST_VISIBLE_ANSWER_MS in perf
+    assert perf[FIRST_VISIBLE_ANSWER_MS] >= perf[FIRST_CONTENT_CALLBACK_MS]
+    assert "thread_start_ms" in perf
+    assert PROVIDER_CALL_TOTAL_MS in perf
+    assert BACKEND_READY_TOTAL_MS in perf
+    assert perf[BACKEND_READY_TOTAL_MS] >= perf[FIRST_VISIBLE_ANSWER_MS]
+
+
+def _exhaust_dispatch_events(gen, events):
+    try:
+        while True:
+            events.append(next(gen))
+    except StopIteration as stop:
+        return stop.value
+
+
+def test_yield_timed_phase_send_forwards_and_preserves_return():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+
+    def gen():
+        clock.advance(0.005)
+        got = yield "ask"
+        clock.advance(0.007)
+        return got
+
+    def runner():
+        result = yield from yield_timed_phase(acc, "task_profile", gen())
+        assert result == "pong"
+
+    it = runner()
+    assert next(it) == "ask"
+    clock.advance(0.200)
+    try:
+        it.send("pong")
+    except StopIteration:
+        pass
+    assert acc.snapshot()["task_profile_ms"] == 12.0
+
+
+def test_yield_timed_phase_throw_forwards_and_runs_inner_finally():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    seen = []
+
+    def gen():
+        try:
+            clock.advance(0.004)
+            yield "x"
+            yield "should-not-run"
+        except ValueError as exc:
+            seen.append(str(exc))
+            clock.advance(0.006)
+            yield "handled"
+        finally:
+            seen.append("finally")
+
+    def runner():
+        yield from yield_timed_phase(acc, "task_profile", gen())
+
+    it = runner()
+    assert next(it) == "x"
+    clock.advance(0.300)
+    assert it.throw(ValueError("boom")) == "handled"
+    try:
+        next(it)
+    except StopIteration:
+        pass
+    assert seen == ["boom", "finally"]
+    assert acc.snapshot()["task_profile_ms"] == 10.0
+
+
+def test_yield_timed_phase_throw_uncaught_runs_inner_finally():
+    seen = []
+
+    def gen():
+        try:
+            yield "x"
+            yield "y"
+        finally:
+            seen.append("finally")
+
+    def runner():
+        yield from yield_timed_phase(None, "task_profile", gen())
+
+    it = runner()
+    assert next(it) == "x"
+    try:
+        it.throw(ValueError("nope"))
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "nope" in str(exc)
+    assert seen == ["finally"]
+
+
+def test_yield_timed_phase_close_runs_inner_finally():
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    seen = []
+
+    def gen():
+        try:
+            clock.advance(0.004)
+            yield "x"
+            clock.advance(0.050)
+            yield "y"
+        finally:
+            clock.advance(0.006)
+            seen.append("finally")
+
+    def runner():
+        yield from yield_timed_phase(acc, "image_prep", gen())
+
+    it = runner()
+    next(it)
+    clock.advance(0.300)
+    it.close()
+    assert seen == ["finally"]
+    assert acc.snapshot()["image_prep_ms"] == 10.0
+
+
+def test_note_out_of_order_clock_uses_minima_maxima_skips_negative_gap():
+    class ReversibleClock:
+        def __init__(self) -> None:
+            self.t = 1000.0
+
+        def __call__(self) -> float:
+            return self.t
+
+    clock = ReversibleClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.mark_request_start()
+    clock.t = 1000.100
+    acc.note("delta", "late-first")
+    clock.t = 1000.020
+    acc.note("delta", "early-second")
+    clock.t = 1000.015
+    acc.mark_first_visible_answer()
+    clock.t = 1000.080
+    acc.mark_first_visible_answer()
+    clock.t = 1000.250
+    acc.note("delta", "last")
+    acc.finish()
+    snap = acc.snapshot(tokens_out=6)
+    assert snap[FIRST_CONTENT_CALLBACK_MS] == 20.0
+    assert snap[FIRST_ANSWER_CALLBACK_MS] == 20.0
+    assert snap[FIRST_VISIBLE_ANSWER_MS] == 15.0
+    assert snap["decode_window_ms"] == 230.0
+    assert snap["max_inter_delta_ms"] == 150.0
+    assert snap["max_inter_delta_ms"] >= 0
+    assert snap[PROVIDER_CALL_TOTAL_MS] == 250.0
+    assert BACKEND_READY_TOTAL_MS not in snap
+
+
+def test_concurrent_notes_minima_maxima_never_negative_gap():
+    class ThreadClock:
+        def __init__(self) -> None:
+            self.default = 1000.0
+            self.tls = threading.local()
+
+        def __call__(self) -> float:
+            return getattr(self.tls, "t", self.default)
+
+    clock = ThreadClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.mark_request_start()
+    barrier = threading.Barrier(2)
+
+    def worker(when: float, text: str) -> None:
+        clock.tls.t = when
+        barrier.wait()
+        acc.note("delta", text)
+
+    threads = [
+        threading.Thread(target=worker, args=(1000.080, "late")),
+        threading.Thread(target=worker, args=(1000.010, "early")),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    snap = acc.snapshot(tokens_out=4)
+    assert snap[FIRST_CONTENT_CALLBACK_MS] == 10.0
+    assert snap["decode_window_ms"] == 70.0
+    if "max_inter_delta_ms" in snap:
+        assert snap["max_inter_delta_ms"] >= 0
+
+
+def test_visible_after_provider_return_uses_backend_ready_boundary():
+    """Provider return before drain is valid; visible may exceed provider total."""
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    acc.mark_request_start()
+    clock.advance(0.030)
+    acc.note("delta", {"text": '{"say": "Hi"}', "stream_id": "a1", "channel": "answer"})
+    clock.advance(0.020)
+    acc.finish()
+    mid = acc.snapshot()
+    assert mid[PROVIDER_CALL_TOTAL_MS] == 50.0
+    assert FIRST_VISIBLE_ANSWER_MS not in mid
+    assert BACKEND_READY_TOTAL_MS not in mid
+
+    clock.advance(0.040)
+    q: queue.Queue = queue.Queue()
+    resp = DriverResponse(text="ok", tokens_out=2, latency_ms=8.0, meta={})
+    q.put(("delta", {"text": '{"say": "Hi"}', "stream_id": "a1", "channel": "answer"}))
+    q.put(("done", resp))
+    events = []
+    gen = drain_stream_queue(q, accumulator=acc)
+    try:
+        while True:
+            events.append(next(gen))
+    except StopIteration as stop:
+        streamed, got = stop.value
+
+    assert streamed == "Hi"
+    perf = got.meta[STREAM_PERFORMANCE_KEY]
+    assert perf[FIRST_CONTENT_CALLBACK_MS] == 30.0
+    assert perf[FIRST_VISIBLE_ANSWER_MS] == 90.0
+    assert perf[PROVIDER_CALL_TOTAL_MS] == 50.0
+    assert perf[BACKEND_READY_TOTAL_MS] == 90.0
+    assert perf[FIRST_VISIBLE_ANSWER_MS] > perf[PROVIDER_CALL_TOTAL_MS]
+    assert perf[BACKEND_READY_TOTAL_MS] >= perf[FIRST_VISIBLE_ANSWER_MS]
+    assert got.latency_ms == 8.0
+
+
+def test_step0_overflow_retry_keeps_turn_once_phases(monkeypatch, tmp_path):
+    """First-step CONTEXT_OVERFLOW keeps turn-once phases and emergency compact."""
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    orig_begin = acc.begin_phase
+    orig_end = acc.end_phase
+
+    def begin(name):
+        clock.advance(0.001)
+        return orig_begin(name)
+
+    def end(name):
+        clock.advance(0.010)
+        return orig_end(name)
+
+    acc.begin_phase = begin
+    acc.end_phase = end
+    monkeypatch.setattr(
+        "harness.send_loop.make_stream_timing_accumulator",
+        lambda clock=None: acc,
+    )
+    monkeypatch.setattr(
+        "harness.send_loop.profile_skips_auto_inject",
+        lambda session: (False, False),
+    )
+
+    snaps = []
+    orig_attach = attach_stream_performance
+
+    def spy_attach(resp, snap):
+        snaps.append(dict(snap))
+        return orig_attach(resp, snap)
+
+    monkeypatch.setattr(
+        "harness.send_loop_phases.attach_stream_performance", spy_attach,
+    )
+
+    compact_calls = []
+
+    cfg = HarnessConfig(
+        driver="stub-oracle-v2",
+        state_dir=str(tmp_path),
+        repo=str(tmp_path),
+    )
+    session = ConversationalSession(cfg)
+    monkeypatch.setattr(session, "_resolve_append_only", lambda: False)
+    session._get_codegraph_context = lambda msg: ""
+
+    def _spy_compact(force=False, emergency=False):
+        compact_calls.append({"force": force, "emergency": emergency})
+        if False:
+            yield None
+
+    monkeypatch.setattr(session, "_maybe_compact_history", _spy_compact)
+
+    class OverflowThenOk:
+        name = "overflow-then-ok"
+
+        def __init__(self):
+            self.calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            clock.advance(0.040 if self.calls == 1 else 0.020)
+            if self.calls == 1:
+                return DriverResponse(
+                    text="",
+                    error="HTTP 400: maximum context length exceeded",
+                    tokens_out=1,
+                    latency_ms=1.0,
+                )
+            return DriverResponse(
+                text='{"say": "recovered", "actions": []}',
+                tokens_out=2,
+                latency_ms=1.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session.pilot = OverflowThenOk()
+    events = list(session.send("audit the overflow retry path"))
+    assert not any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 2
+    assert any(c.get("emergency") for c in compact_calls)
+    assert len(snaps) >= 2
+    first, retry = snaps[0], snaps[-1]
+    for key in (
+        "image_prep_ms",
+        "task_profile_ms",
+        "user_append_ms",
+        "auto_codegraph_ms",
+    ):
+        assert key in first, key
+        assert key in retry, key
+        assert retry[key] == first[key]
+    if "step_codegraph_ms" in first:
+        assert retry["step_codegraph_ms"] == first["step_codegraph_ms"]
+    if "step_wiki_ms" in first:
+        assert retry["step_wiki_ms"] == first["step_wiki_ms"]
+    assert "advisory_compaction_ms" in retry
+    assert retry["advisory_compaction_ms"] > first.get("advisory_compaction_ms", 0)
+    assert "prompt_tools_ms" in first
+    assert "prompt_tools_ms" in retry
+    assert retry["prompt_tools_ms"] <= first["prompt_tools_ms"]
+    assert "thread_start_ms" not in retry
+    assert FIRST_CONTENT_CALLBACK_MS not in retry
+    assert FIRST_VISIBLE_ANSWER_MS not in retry
+    assert BACKEND_READY_TOTAL_MS not in retry
+    assert retry[PROVIDER_CALL_TOTAL_MS] == 20.0
+    assert first[PROVIDER_CALL_TOTAL_MS] == 40.0
+    assert "pre_request_total_ms" in first
+    assert "pre_request_total_ms" in retry
+    assert retry["pre_request_total_ms"] < first["pre_request_total_ms"]
+    emergency_added = (
+        retry["advisory_compaction_ms"] - first.get("advisory_compaction_ms", 0)
+    )
+    retry_prep = emergency_added + retry["prompt_tools_ms"]
+    assert retry["pre_request_total_ms"] >= retry_prep
+    # Slack is wrapper gaps only — the failed provider window is not included.
+    assert retry["pre_request_total_ms"] - retry_prep < first[PROVIDER_CALL_TOTAL_MS]
+
+
+def test_step_gt0_clears_turn_once_phases(monkeypatch, tmp_path):
+    """Normal tool-loop step > 0 still drops turn-once phases."""
+    import json
+
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    orig_begin = acc.begin_phase
+    orig_end = acc.end_phase
+
+    def begin(name):
+        clock.advance(0.001)
+        return orig_begin(name)
+
+    def end(name):
+        clock.advance(0.010)
+        return orig_end(name)
+
+    acc.begin_phase = begin
+    acc.end_phase = end
+    monkeypatch.setattr(
+        "harness.send_loop.make_stream_timing_accumulator",
+        lambda clock=None: acc,
+    )
+
+    snaps = []
+    orig_attach = attach_stream_performance
+
+    def spy_attach(resp, snap):
+        snaps.append(dict(snap))
+        return orig_attach(resp, snap)
+
+    monkeypatch.setattr(
+        "harness.send_loop_phases.attach_stream_performance", spy_attach,
+    )
+
+    (tmp_path / "spy.txt").write_text("hello", encoding="utf-8")
+    cfg = HarnessConfig(
+        driver="stub-oracle-v2",
+        state_dir=str(tmp_path),
+        repo=str(tmp_path),
+    )
+    session = ConversationalSession(cfg)
+
+    class TwoStep:
+        name = "two-step-timing"
+
+        def __init__(self):
+            self.calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            if self.calls == 1:
+                return DriverResponse(
+                    text="",
+                    tokens_out=5,
+                    latency_ms=1.0,
+                    meta={
+                        "tool_calls": [
+                            {
+                                "id": "call_spy_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "read_file",
+                                    "arguments": json.dumps({"path": "spy.txt"}),
+                                },
+                            }
+                        ],
+                        "finish_reason": "tool_calls",
+                    },
+                )
+            return DriverResponse(
+                text='{"say": "done after tool", "actions": []}',
+                tokens_out=5,
+                latency_ms=1.0,
+                meta={"tool_calls": [], "finish_reason": "stop"},
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session.pilot = TwoStep()
+    list(session.send("read spy.txt then finish"))
+    assert session.pilot.calls >= 2
+    assert len(snaps) >= 2
+    assert "image_prep_ms" in snaps[0]
+    assert "user_append_ms" in snaps[0]
+    assert "image_prep_ms" not in snaps[-1]
+    assert "user_append_ms" not in snaps[-1]
+    assert "task_profile_ms" not in snaps[-1]

--- a/tests/test_stream_performance_store.py
+++ b/tests/test_stream_performance_store.py
@@ -1,0 +1,1303 @@
+"""Durable stream-performance receipts + GET /api/session/performance."""
+
+from __future__ import annotations
+
+import json
+import math
+import multiprocessing
+import os
+import tempfile
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from harness.api.session_control import SessionControlServices
+from harness.api.session_performance import get_session_performance
+from harness.api.sessions import handle_session_delete, remove_session_transcript
+from harness.stream_performance import (
+    FIRST_CONTENT_CALLBACK_MS,
+    PROVIDER_CALL_TOTAL_MS,
+    PROVIDER_OUTPUT_TPS,
+    STREAM_PERFORMANCE_KEY,
+    THROUGHPUT_BASIS,
+    THROUGHPUT_BASIS_KEY,
+)
+from harness.stream_performance_store import (
+    MAX_RECEIPTS_PER_SESSION,
+    RECEIPT_SCHEMA_VERSION,
+    StreamPerformanceReceiptStore,
+    build_receipt,
+    copy_stream_performance,
+    receipt_file_path,
+    remove_session_performance_receipts,
+    safe_session_id,
+)
+from harness.sessions import SessionStore, save_transcript
+from pmharness.drivers.base import DriverResponse
+
+
+def _receipt(session_id: str, **kwargs):
+    kwargs.setdefault("status", "success")
+    kwargs.setdefault("stream_performance", {"content_delta_count": 1})
+    return build_receipt(session_id=session_id, **kwargs)
+
+
+def _perf_svc(*, state_dir, sessions=None, pilot=None, repo=""):
+    return SessionControlServices(
+        cfg=SimpleNamespace(
+            driver="openai/gpt-test",
+            state_dir=str(state_dir),
+            repo=repo,
+        ),
+        get_pilot=lambda: pilot or SimpleNamespace(harness_session_id=""),
+        get_runners=lambda: SimpleNamespace(get=lambda sid: None, statuses=lambda: {}, active_view_id=""),
+        gate_active_pilot_ready=lambda: None,
+        stash_put=lambda msg, imgs: "mid",
+        save_active_transcript=lambda: None,
+        upload_dir="/uploads",
+        diag=lambda *a, **k: None,
+        get_sessions=lambda: sessions or SimpleNamespace(active=None, rows=lambda: []),
+    )
+
+
+def _make_symlink(target: Path, link: Path) -> None:
+    try:
+        if target.is_dir():
+            link.symlink_to(target, target_is_directory=True)
+        else:
+            link.symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip("symlinks not supported: {0}".format(exc))
+
+
+def _mp_record_one(state_dir: str, session_id: str, step: int) -> None:
+    """Spawn-safe worker for the cross-process RMW regression."""
+    from harness.stream_performance_store import (
+        StreamPerformanceReceiptStore,
+        build_receipt,
+    )
+
+    store = StreamPerformanceReceiptStore(state_dir)
+    store.record(
+        session_id,
+        build_receipt(
+            session_id=session_id,
+            provider_step=step,
+            captured_at=float(step),
+            stream_performance={"content_delta_count": 1},
+            status="success",
+        ),
+    )
+
+
+def test_safe_session_id_strips_traversal():
+    assert safe_session_id("../etc/passwd") == "etcpasswd"
+    assert safe_session_id("sess-1_ab") == "sess-1_ab"
+    assert safe_session_id("") == ""
+
+
+def test_receipt_path_stays_inside_performance_dir(tmp_path):
+    sneaky = receipt_file_path(str(tmp_path), "../../etc/passwd")
+    root = (tmp_path / "stream_performance").resolve()
+    if sneaky:
+        resolved = Path(sneaky).resolve()
+        assert os.path.commonpath([str(root), str(resolved)]) == str(root)
+        assert resolved.name == "etcpasswd.json"
+    assert not (tmp_path / "etc").exists()
+    assert receipt_file_path(str(tmp_path), "") == ""
+
+
+def test_atomic_bounded_newest_chronological(tmp_path):
+    store = StreamPerformanceReceiptStore(str(tmp_path), max_receipts=3)
+    sid = "sess-bound"
+    for i in range(5):
+        store.record(sid, _receipt(sid, provider_step=i, captured_at=1000.0 + i))
+    rows = store.list_receipts(sid)
+    assert [r["provider_step"] for r in rows] == [2, 3, 4]
+    assert all(rows[i]["captured_at"] <= rows[i + 1]["captured_at"] for i in range(len(rows) - 1))
+    path = Path(receipt_file_path(str(tmp_path), sid))
+    assert path.is_file()
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    assert doc["schema_version"] == RECEIPT_SCHEMA_VERSION
+    assert len(doc["receipts"]) == 3
+
+
+def test_session_isolation(tmp_path):
+    store = StreamPerformanceReceiptStore(str(tmp_path))
+    store.record("alpha", _receipt("alpha", provider_step=1))
+    store.record("beta", _receipt("beta", provider_step=9))
+    assert [r["provider_step"] for r in store.list_receipts("alpha")] == [1]
+    assert [r["provider_step"] for r in store.list_receipts("beta")] == [9]
+    assert store.list_receipts("missing") == []
+
+
+def test_corrupt_file_fails_soft_and_next_write_repairs(tmp_path):
+    store = StreamPerformanceReceiptStore(str(tmp_path))
+    sid = "sess-corrupt"
+    path = Path(receipt_file_path(str(tmp_path), sid))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not-json", encoding="utf-8")
+    assert store.list_receipts(sid) == []
+    store.record(sid, _receipt(sid, provider_step=3))
+    rows = store.list_receipts(sid)
+    assert len(rows) == 1
+    assert rows[0]["provider_step"] == 3
+    json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_json_safety_omits_nonfinite_and_unknown_keys():
+    copied = copy_stream_performance({
+        "content_delta_count": 2,
+        PROVIDER_CALL_TOTAL_MS: 12.5,
+        PROVIDER_OUTPUT_TPS: float("inf"),
+        FIRST_CONTENT_CALLBACK_MS: float("nan"),
+        "decode_window_ms": -0.0,
+        "secret_prompt": "do not persist",
+        "boom": RuntimeError("nope"),
+        "nested": {"x": 1},
+    })
+    assert copied["content_delta_count"] == 2
+    assert copied[PROVIDER_CALL_TOTAL_MS] == 12.5
+    assert PROVIDER_OUTPUT_TPS not in copied
+    assert FIRST_CONTENT_CALLBACK_MS not in copied
+    assert "secret_prompt" not in copied
+    assert "boom" not in copied
+    receipt = build_receipt(
+        session_id="s1",
+        stream_performance=copied,
+        status="success",
+        driver="openai/gpt-test",
+        captured_at=float("nan"),
+    )
+    dumped = json.dumps(receipt, allow_nan=False)
+    assert "secret_prompt" not in dumped
+    assert "Infinity" not in dumped
+    assert "NaN" not in dumped
+    assert receipt["model"] == "gpt-test"
+    assert math.isfinite(receipt["captured_at"])
+
+
+def test_restart_durability_new_store_instance(tmp_path):
+    sid = "sess-restart"
+    StreamPerformanceReceiptStore(str(tmp_path)).record(
+        sid, _receipt(sid, provider_step=4, captured_at=50.0),
+    )
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts(sid)
+    assert len(rows) == 1
+    assert rows[0]["provider_step"] == 4
+    assert rows[0]["captured_at"] == 50.0
+
+
+def test_concurrent_records_are_thread_safe(tmp_path):
+    store = StreamPerformanceReceiptStore(str(tmp_path), max_receipts=50)
+    sid = "sess-threads"
+    errors = []
+
+    def _write(n):
+        try:
+            store.record(sid, _receipt(sid, provider_step=n, captured_at=float(n)))
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_write, args=(i,)) for i in range(12)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []
+    rows = store.list_receipts(sid)
+    assert len(rows) == 12
+    assert sorted(r["provider_step"] for r in rows) == list(range(12))
+
+
+def test_delete_session_removes_receipt_file(tmp_path):
+    store = StreamPerformanceReceiptStore(str(tmp_path))
+    sid = "sess-del"
+    store.record(sid, _receipt(sid))
+    path = Path(receipt_file_path(str(tmp_path), sid))
+    assert path.is_file()
+    remove_session_performance_receipts(str(tmp_path), sid)
+    assert not path.exists()
+    remove_session_performance_receipts(str(tmp_path), sid)
+
+
+def test_remove_session_transcript_clears_performance_sidecar(tmp_path):
+    state_dir = str(tmp_path)
+    sid = "sess_clear_perf"
+    StreamPerformanceReceiptStore(state_dir).record(sid, _receipt(sid))
+    path = Path(receipt_file_path(state_dir, sid))
+    assert path.is_file()
+    save_transcript(state_dir, sid, {"history": [], "display": [], "job_ids": []})
+    remove_session_transcript(sid, state_dir=state_dir)
+    assert not path.exists()
+
+
+def test_handle_session_delete_clears_performance(tmp_path):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    store = SessionStore(str(tmp_path / "harness_sessions.json"))
+    meta = store.create("Doomed", repo=str(tmp_path), workspace_root=str(tmp_path))
+    sid = meta["id"]
+    StreamPerformanceReceiptStore(str(state_dir)).record(sid, _receipt(sid))
+    path = Path(receipt_file_path(str(state_dir), sid))
+    assert path.is_file()
+    svc = SimpleNamespace(
+        sessions=store,
+        runners=SimpleNamespace(drop=lambda _sid: None),
+        sessions_state_dir=lambda: str(state_dir),
+        get_pilot=lambda: SimpleNamespace(load_history=lambda _h: None),
+        attach_view=lambda *_a, **_k: None,
+        sync_pilot_session_id=lambda: None,
+        diag=lambda *_a, **_k: None,
+    )
+    code, body = handle_session_delete(sid, svc)
+    assert code == 200 and body["ok"] is True
+    assert not path.exists()
+
+
+def test_record_helper_does_not_mutate_resp_meta(tmp_path):
+    from harness.send_loop_phases import record_provider_stream_receipt
+
+    perf = {PROVIDER_CALL_TOTAL_MS: 11.0, "content_delta_count": 0}
+    meta = {STREAM_PERFORMANCE_KEY: dict(perf), "foo": "bar"}
+    resp = DriverResponse(text="ok", tokens_out=1, latency_ms=1.0, meta=meta)
+    session = SimpleNamespace(
+        harness_session_id="sess-meta",
+        state_dir=str(tmp_path),
+        config=SimpleNamespace(driver="stub/model-x"),
+        _current_user_ordinal=lambda: 0,
+    )
+    record_provider_stream_receipt(session, resp, provider_step=0, provider_attempt=0)
+    assert resp.meta is meta
+    assert resp.meta[STREAM_PERFORMANCE_KEY] == perf
+    assert resp.meta["foo"] == "bar"
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-meta")
+    assert len(rows) == 1
+    assert rows[0]["stream_performance"][PROVIDER_CALL_TOTAL_MS] == 11.0
+    assert not hasattr(session, "_stream_timing")
+    assert not hasattr(session, "StreamTimingAccumulator")
+
+
+def test_record_helper_swallows_sink_failure(tmp_path, monkeypatch):
+    from harness.send_loop_phases import record_provider_stream_receipt
+
+    def boom(self, session_id, receipt):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(StreamPerformanceReceiptStore, "record", boom)
+    resp = DriverResponse(text="ok", tokens_out=1, latency_ms=1.0, meta={})
+    session = SimpleNamespace(
+        harness_session_id="sess-boom",
+        state_dir=str(tmp_path),
+        config=SimpleNamespace(driver="stub"),
+        _current_user_ordinal=lambda: 0,
+    )
+    record_provider_stream_receipt(session, resp, provider_step=0, provider_attempt=0)
+
+
+def _send_session(tmp_path, monkeypatch, pilot, *, sid="sess-send"):
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+
+    monkeypatch.setattr(
+        "harness.send_loop.profile_skips_auto_inject",
+        lambda session: (True, True),
+    )
+    cfg = HarnessConfig(
+        driver="stub-oracle-v2",
+        state_dir=str(tmp_path),
+        repo=str(tmp_path),
+    )
+    session = ConversationalSession(cfg)
+    session.harness_session_id = sid
+    session.pilot = pilot
+    monkeypatch.setattr(session, "_resolve_append_only", lambda: False)
+    monkeypatch.setattr(session, "_get_codegraph_context", lambda msg: "")
+    monkeypatch.setattr(session, "_maybe_compact_history", lambda **k: iter(()))
+    return session
+
+
+def test_send_records_one_receipt_per_provider_call(monkeypatch, tmp_path):
+    class Once:
+        name = "once"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            return DriverResponse(
+                text='{"say": "hi", "actions": []}',
+                tokens_out=2,
+                latency_ms=1.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    pilot = Once()
+    session = _send_session(tmp_path, monkeypatch, pilot)
+    events = list(session.send("hello there"))
+    assert not any(getattr(e, "kind", None) == "error" for e in events)
+    assert pilot.calls == 1
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-send")
+    assert len(rows) == 1
+    assert rows[0]["provider_step"] == 0
+    assert rows[0]["provider_attempt"] == 0
+    assert rows[0]["status"] == "success"
+    assert rows[0]["schema_version"] == RECEIPT_SCHEMA_VERSION
+    assert FIRST_CONTENT_CALLBACK_MS not in rows[0]["stream_performance"]
+    assert PROVIDER_OUTPUT_TPS not in rows[0]["stream_performance"]
+    assert PROVIDER_CALL_TOTAL_MS in rows[0]["stream_performance"]
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self._ms = int(round(start * 1000.0))
+
+    def __call__(self) -> float:
+        return self._ms / 1000.0
+
+    def advance(self, seconds: float) -> None:
+        self._ms += int(round(seconds * 1000.0))
+
+
+def test_overflow_failed_and_retry_are_separate_attempts(monkeypatch, tmp_path):
+    from harness.stream_performance import StreamTimingAccumulator
+
+    clock = FakeClock()
+    acc = StreamTimingAccumulator(clock=clock)
+    monkeypatch.setattr(
+        "harness.send_loop.make_stream_timing_accumulator",
+        lambda clock=None: acc,
+    )
+
+    class OverflowThenOk:
+        name = "overflow-then-ok"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            clock.advance(0.040 if self.calls == 1 else 0.020)
+            if self.calls == 1:
+                return DriverResponse(
+                    text="",
+                    error="HTTP 400: maximum context length exceeded",
+                    tokens_out=1,
+                    latency_ms=4.0,
+                )
+            return DriverResponse(
+                text='{"say": "recovered", "actions": []}',
+                tokens_out=2,
+                latency_ms=2.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    compact_calls = []
+
+    def _spy_compact(force=False, emergency=False):
+        compact_calls.append({"force": force, "emergency": emergency})
+        if False:
+            yield None
+
+    session = _send_session(tmp_path, monkeypatch, OverflowThenOk(), sid="sess-ovf")
+    monkeypatch.setattr(session, "_maybe_compact_history", _spy_compact)
+    events = list(session.send("audit overflow receipts"))
+    assert not any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 2
+    assert any(c.get("emergency") for c in compact_calls)
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-ovf")
+    assert len(rows) == 2
+    first, retry = rows
+    assert first["provider_step"] == retry["provider_step"] == 0
+    assert first["provider_attempt"] == 0
+    assert retry["provider_attempt"] == 1
+    assert first["status"] == "context_overflow"
+    assert retry["status"] == "success"
+    assert first["stream_performance"].get(PROVIDER_CALL_TOTAL_MS) == 40.0
+    assert retry["stream_performance"].get(PROVIDER_CALL_TOTAL_MS) == 20.0
+    assert FIRST_CONTENT_CALLBACK_MS not in retry["stream_performance"]
+    assert PROVIDER_OUTPUT_TPS not in first["stream_performance"]
+    assert PROVIDER_OUTPUT_TPS not in retry["stream_performance"]
+
+
+def test_multi_step_receipts_have_distinct_steps(monkeypatch, tmp_path):
+    (tmp_path / "spy.txt").write_text("hello", encoding="utf-8")
+
+    class TwoStep:
+        name = "two-step"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            if self.calls == 1:
+                return DriverResponse(
+                    text="",
+                    tokens_out=5,
+                    latency_ms=1.0,
+                    meta={
+                        "tool_calls": [
+                            {
+                                "id": "call_spy_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "read_file",
+                                    "arguments": json.dumps({"path": "spy.txt"}),
+                                },
+                            }
+                        ],
+                        "finish_reason": "tool_calls",
+                    },
+                )
+            return DriverResponse(
+                text='{"say": "done after tool", "actions": []}',
+                tokens_out=5,
+                latency_ms=1.0,
+                meta={"tool_calls": [], "finish_reason": "stop"},
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session = _send_session(tmp_path, monkeypatch, TwoStep(), sid="sess-steps")
+    list(session.send("read spy.txt then finish"))
+    assert session.pilot.calls >= 2
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-steps")
+    assert len(rows) == session.pilot.calls
+    steps = [r["provider_step"] for r in rows]
+    assert steps == list(range(len(steps)))
+    assert all(r["provider_attempt"] == 0 for r in rows)
+
+
+def test_sink_failure_does_not_change_send_hot_path(monkeypatch, tmp_path):
+    from harness.stream_performance_store import StreamPerformanceReceiptStore as Store
+
+    def boom(self, session_id, receipt):
+        raise RuntimeError("sidecar down")
+
+    monkeypatch.setattr(Store, "record", boom)
+
+    class Once:
+        name = "once-boom"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            return DriverResponse(
+                text='{"say": "still works", "actions": []}',
+                tokens_out=2,
+                latency_ms=1.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session = _send_session(tmp_path, monkeypatch, Once(), sid="sess-hot")
+    events = list(session.send("please work"))
+    kinds = [getattr(e, "kind", None) for e in events]
+    assert "error" not in kinds
+    assert any(k == "message" for k in kinds)
+    assert session.pilot.calls == 1
+
+
+def test_receipts_never_enter_history_display_or_transcript(monkeypatch, tmp_path):
+    class Once:
+        name = "once-leak"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            return DriverResponse(
+                text='{"say": "visible", "actions": []}',
+                tokens_out=2,
+                latency_ms=1.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session = _send_session(tmp_path, monkeypatch, Once(), sid="sess-leak")
+    list(session.send("do not leak receipts"))
+    history_blob = json.dumps(session._history, default=str)
+    display_blob = json.dumps(session._display_transcript, default=str)
+    outbound = json.dumps(session._messages_for_provider(), default=str)
+    assert '"provider_attempt"' not in history_blob
+    assert '"provider_step"' not in history_blob
+    assert '"captured_at"' not in history_blob
+    assert "schema_version" not in history_blob
+    assert "schema_version" not in display_blob
+    assert "provider_attempt" not in outbound
+    exported = session.export_transcript_data()
+    export_blob = json.dumps(exported, default=str)
+    assert "stream_performance" not in export_blob or STREAM_PERFORMANCE_KEY not in (
+        json.dumps(exported.get("history") or [], default=str)
+    )
+    assert "provider_attempt" not in json.dumps(exported.get("history") or [], default=str)
+    assert "provider_attempt" not in json.dumps(exported.get("display") or [], default=str)
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-leak")
+    assert len(rows) == 1
+
+
+def _assert_no_receipt_in_surfaces(session):
+    history_blob = json.dumps(session._history, default=str)
+    display_blob = json.dumps(session._display_transcript, default=str)
+    outbound = json.dumps(session._messages_for_provider(), default=str)
+    assert '"provider_attempt"' not in history_blob
+    assert '"captured_at"' not in history_blob
+    assert "schema_version" not in history_blob
+    assert "schema_version" not in display_blob
+    assert "provider_attempt" not in outbound
+    exported = session.export_transcript_data()
+    assert "provider_attempt" not in json.dumps(exported.get("history") or [], default=str)
+    assert "provider_attempt" not in json.dumps(exported.get("display") or [], default=str)
+
+
+def test_malformed_tokens_out_records_one_receipt_and_hot_path_survives(monkeypatch, tmp_path):
+    class BadTokens:
+        name = "bad-tokens"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            return DriverResponse(
+                text='{"say": "still honest", "actions": []}',
+                tokens_out="nope",
+                latency_ms=1.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session = _send_session(tmp_path, monkeypatch, BadTokens(), sid="sess-bad-tok")
+    events = list(session.send("malformed tokens_out"))
+    assert not any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 1
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-bad-tok")
+    assert len(rows) == 1
+    assert rows[0]["status"] == "success"
+    assert rows[0]["provider_step"] == 0
+    assert rows[0]["provider_attempt"] == 0
+    assert PROVIDER_CALL_TOTAL_MS in rows[0]["stream_performance"]
+    _assert_no_receipt_in_surfaces(session)
+
+
+def test_account_provider_attempt_records_before_meter_raise(tmp_path, monkeypatch):
+    from harness.send_loop_phases import account_provider_attempt
+
+    def boom(session, resp, prompt):
+        raise TypeError("tokens_out")
+
+    monkeypatch.setattr("harness.send_loop_phases.meter_pilot_step", boom)
+    resp = DriverResponse(
+        text="ok",
+        tokens_out="nope",
+        latency_ms=1.0,
+        meta={STREAM_PERFORMANCE_KEY: {PROVIDER_CALL_TOTAL_MS: 9.0}},
+    )
+    session = SimpleNamespace(
+        harness_session_id="sess-order",
+        state_dir=str(tmp_path),
+        config=SimpleNamespace(driver="stub/model-x"),
+        _current_user_ordinal=lambda: 0,
+    )
+    with pytest.raises(TypeError):
+        account_provider_attempt(session, resp, "prompt", provider_step=2, provider_attempt=1)
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-order")
+    assert len(rows) == 1
+    assert rows[0]["status"] == "success"
+    assert rows[0]["provider_step"] == 2
+    assert rows[0]["provider_attempt"] == 1
+    assert rows[0]["stream_performance"][PROVIDER_CALL_TOTAL_MS] == 9.0
+    assert resp.meta[STREAM_PERFORMANCE_KEY][PROVIDER_CALL_TOTAL_MS] == 9.0
+
+
+def test_sync_chat_raise_records_one_error_receipt(monkeypatch, tmp_path):
+    class BoomChat:
+        name = "boom-chat"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            raise RuntimeError("sync chat failed")
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session = _send_session(tmp_path, monkeypatch, BoomChat(), sid="sess-chat-raise")
+    events = list(session.send("sync raise"))
+    assert any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 1
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-chat-raise")
+    assert len(rows) == 1
+    assert rows[0]["status"] == "error"
+    assert rows[0]["provider_step"] == 0
+    assert rows[0]["provider_attempt"] == 0
+    _assert_no_receipt_in_surfaces(session)
+
+
+def test_complete_raise_records_one_error_receipt(monkeypatch, tmp_path):
+    class BoomComplete:
+        name = "boom-complete"
+        calls = 0
+
+        def complete(self, prompt, system=None):
+            self.calls += 1
+            raise RuntimeError("complete failed")
+
+    session = _send_session(tmp_path, monkeypatch, BoomComplete(), sid="sess-complete-raise")
+    events = list(session.send("complete raise"))
+    assert any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 1
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-complete-raise")
+    assert len(rows) == 1
+    assert rows[0]["status"] == "error"
+    assert rows[0]["provider_attempt"] == 0
+    _assert_no_receipt_in_surfaces(session)
+
+
+def test_chat_stream_raise_records_one_error_receipt(monkeypatch, tmp_path):
+    class BoomStream:
+        name = "boom-stream"
+        supports_streaming = True
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            raise AssertionError("chat() must not run when streaming")
+
+        def chat_stream(self, messages, **kwargs):
+            self.calls += 1
+            on_delta = kwargs.get("on_delta")
+            if callable(on_delta):
+                on_delta('{"say": "partial"}')
+            raise RuntimeError("stream producer failed")
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session = _send_session(tmp_path, monkeypatch, BoomStream(), sid="sess-stream-raise")
+    events = list(session.send("stream raise"))
+    assert any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 1
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-stream-raise")
+    assert len(rows) == 1
+    assert rows[0]["status"] == "error"
+    assert rows[0]["provider_attempt"] == 0
+    perf = rows[0]["stream_performance"]
+    assert perf.get("content_delta_count", 0) >= 0
+    _assert_no_receipt_in_surfaces(session)
+
+
+def test_returned_generic_error_does_not_double_write_receipt(monkeypatch, tmp_path):
+    class GenericErr:
+        name = "generic-err"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            return DriverResponse(
+                text="",
+                error="HTTP 500: internal server error",
+                tokens_out=1,
+                latency_ms=1.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session = _send_session(tmp_path, monkeypatch, GenericErr(), sid="sess-generic-err")
+    events = list(session.send("returned error"))
+    assert any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 1
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-generic-err")
+    assert len(rows) == 1
+    assert rows[0]["status"] == "error"
+    assert rows[0]["provider_attempt"] == 0
+    _assert_no_receipt_in_surfaces(session)
+
+
+def test_persistent_overflow_records_both_attempts(monkeypatch, tmp_path):
+    class DoubleOverflow:
+        name = "double-overflow"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            return DriverResponse(
+                text="",
+                error="HTTP 400: maximum context length exceeded",
+                tokens_out=1,
+                latency_ms=1.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    compact_calls = []
+
+    def _spy_compact(force=False, emergency=False):
+        compact_calls.append({"force": force, "emergency": emergency})
+        if False:
+            yield None
+
+    session = _send_session(tmp_path, monkeypatch, DoubleOverflow(), sid="sess-ovf-persist")
+    monkeypatch.setattr(session, "_maybe_compact_history", _spy_compact)
+    events = list(session.send("overflow twice"))
+    assert any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 2
+    assert any(c.get("emergency") for c in compact_calls)
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-ovf-persist")
+    assert len(rows) == 2
+    assert [r["provider_attempt"] for r in rows] == [0, 1]
+    assert all(r["status"] == "context_overflow" for r in rows)
+    assert all(r["provider_step"] == 0 for r in rows)
+    _assert_no_receipt_in_surfaces(session)
+
+
+def test_stream_success_records_one_receipt(monkeypatch, tmp_path):
+    class StreamOk:
+        name = "stream-ok"
+        supports_streaming = True
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            raise AssertionError("chat() must not run when streaming")
+
+        def chat_stream(self, messages, **kwargs):
+            self.calls += 1
+            on_delta = kwargs.get("on_delta")
+            if callable(on_delta):
+                on_delta('{"say": "streamed hi", "actions": []}')
+            return DriverResponse(
+                text='{"say": "streamed hi", "actions": []}',
+                tokens_out=4,
+                latency_ms=2.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session = _send_session(tmp_path, monkeypatch, StreamOk(), sid="sess-stream-ok")
+    events = list(session.send("stream success"))
+    assert not any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 1
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-stream-ok")
+    assert len(rows) == 1
+    assert rows[0]["status"] == "success"
+    assert rows[0]["provider_attempt"] == 0
+    assert PROVIDER_CALL_TOTAL_MS in rows[0]["stream_performance"]
+    _assert_no_receipt_in_surfaces(session)
+
+
+def test_complete_success_records_one_receipt(monkeypatch, tmp_path):
+    class CompleteOnly:
+        name = "complete-ok"
+        calls = 0
+
+        def complete(self, prompt, system=None):
+            self.calls += 1
+            return DriverResponse(
+                text='{"say": "from complete", "actions": []}',
+                tokens_out=2,
+                latency_ms=1.0,
+            )
+
+    session = _send_session(tmp_path, monkeypatch, CompleteOnly(), sid="sess-complete-ok")
+    events = list(session.send("complete success"))
+    assert not any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 1
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-complete-ok")
+    assert len(rows) == 1
+    assert rows[0]["status"] == "success"
+    assert FIRST_CONTENT_CALLBACK_MS not in rows[0]["stream_performance"]
+    assert PROVIDER_CALL_TOTAL_MS in rows[0]["stream_performance"]
+    _assert_no_receipt_in_surfaces(session)
+
+
+def test_receipt_turn_index_and_user_ordinal(monkeypatch, tmp_path):
+    class Once:
+        name = "ordinals"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            return DriverResponse(
+                text='{"say": "turn", "actions": []}',
+                tokens_out=2,
+                latency_ms=1.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session = _send_session(tmp_path, monkeypatch, Once(), sid="sess-ordinal")
+    list(session.send("first"))
+    list(session.send("second"))
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-ordinal")
+    assert len(rows) == 2
+    assert rows[0]["user_ordinal"] == 0
+    assert rows[0]["turn_index"] == 1
+    assert rows[1]["user_ordinal"] == 1
+    assert rows[1]["turn_index"] == 2
+    _assert_no_receipt_in_surfaces(session)
+
+
+def test_missing_session_id_skips_receipt_write(monkeypatch, tmp_path):
+    from harness.send_loop_phases import record_provider_stream_receipt
+
+    resp = DriverResponse(text="ok", tokens_out=1, latency_ms=1.0, meta={})
+    session = SimpleNamespace(
+        harness_session_id="",
+        state_dir=str(tmp_path),
+        config=SimpleNamespace(driver="stub"),
+        _current_user_ordinal=lambda: 0,
+    )
+    record_provider_stream_receipt(session, resp, provider_step=0, provider_attempt=0)
+    perf_dir = tmp_path / "stream_performance"
+    assert not perf_dir.exists() or list(perf_dir.glob("*.json")) == []
+
+    class Once:
+        name = "no-sid"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            return DriverResponse(
+                text='{"say": "ok", "actions": []}',
+                tokens_out=2,
+                latency_ms=1.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    live = _send_session(tmp_path, monkeypatch, Once(), sid="")
+    events = list(live.send("no session id"))
+    assert not any(getattr(e, "kind", None) == "error" for e in events)
+    assert live.pilot.calls == 1
+    assert StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("") == []
+    assert not perf_dir.exists() or list(perf_dir.glob("*.json")) == []
+    _assert_no_receipt_in_surfaces(live)
+
+
+def test_pre_invocation_failure_does_not_write_receipt(monkeypatch, tmp_path):
+    class NeverCalled:
+        name = "never"
+        calls = 0
+
+        def chat(self, messages, tools=None, system=None):
+            self.calls += 1
+            return DriverResponse(
+                text='{"say": "nope", "actions": []}',
+                tokens_out=1,
+                latency_ms=1.0,
+            )
+
+        def complete(self, prompt, system=None):
+            return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
+
+    session = _send_session(tmp_path, monkeypatch, NeverCalled(), sid="sess-pre")
+
+    def boom():
+        raise RuntimeError("tools schema failed")
+
+    session._build_visible_tools_schema = boom
+    events = list(session.send("before invoke"))
+    assert any(getattr(e, "kind", None) == "error" for e in events)
+    assert session.pilot.calls == 0
+    assert StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-pre") == []
+    _assert_no_receipt_in_surfaces(session)
+
+
+def test_api_unknown_and_missing_session(tmp_path):
+    sessions = SimpleNamespace(active="sess-a", rows=lambda: [{"id": "sess-a"}])
+    svc = _perf_svc(state_dir=tmp_path, sessions=sessions)
+    code, payload = get_session_performance({"session_id": [""]}, svc)
+    assert code == 200
+    assert payload["ok"] is True
+    assert payload["session_id"] == "sess-a"
+    assert payload["receipts"] == []
+    assert payload["count"] == 0
+    code, payload = get_session_performance({"session_id": ["nope"]}, svc)
+    assert code == 404
+    code, payload = get_session_performance(
+        {"session_id": ["../../etc/passwd"]}, svc,
+    )
+    assert code == 404
+    empty = _perf_svc(state_dir=tmp_path, sessions=SimpleNamespace(active=None, rows=lambda: []))
+    code, payload = get_session_performance({}, empty)
+    assert code == 400
+
+
+def test_api_limit_and_known_session_scope(tmp_path):
+    sessions = SimpleNamespace(
+        active="sess-a",
+        rows=lambda: [{"id": "sess-a"}, {"id": "sess-b"}],
+    )
+    store = StreamPerformanceReceiptStore(str(tmp_path))
+    for i in range(4):
+        store.record("sess-a", _receipt("sess-a", provider_step=i, captured_at=10.0 + i))
+    store.record("sess-b", _receipt("sess-b", provider_step=99, captured_at=1.0))
+    svc = _perf_svc(state_dir=tmp_path, sessions=sessions)
+    code, payload = get_session_performance(
+        {"session_id": ["sess-a"], "limit": ["2"]}, svc,
+    )
+    assert code == 200
+    assert payload["ok"] is True
+    assert payload["count"] == 2
+    assert [r["provider_step"] for r in payload["receipts"]] == [2, 3]
+    code, payload = get_session_performance(
+        {"session_id": ["sess-b"], "limit": ["9999"]}, svc,
+    )
+    assert code == 200
+    assert payload["count"] == 1
+    assert payload["receipts"][0]["provider_step"] == 99
+    code, payload = get_session_performance(
+        {"session_id": ["sess-a"], "limit": ["-3"]}, svc,
+    )
+    assert code == 200
+    assert payload["count"] == 1
+    code, payload = get_session_performance(
+        {"session_id": ["sess-a"], "limit": ["nope"]}, svc,
+    )
+    assert code == 200
+    assert payload["count"] == 4
+    assert payload["count"] <= MAX_RECEIPTS_PER_SESSION
+
+
+def test_api_route_is_guarded_and_state_is_not_overloaded():
+    import harness.api.static as static_api
+    import harness.server as srv
+    from harness.api.session_control import get_session_state
+
+    srv._GET_ROUTES = None
+    routes = srv._get_routes()
+    assert "/api/session/performance" in routes
+    assert "/api/session/performance" not in static_api.PUBLIC_GET_PATHS
+    sessions = SimpleNamespace(active="sess-a", rows=lambda: [{"id": "sess-a"}])
+    svc = _perf_svc(state_dir=os.path.join("unused"), sessions=sessions)
+    svc.get_pilot = lambda: SimpleNamespace(
+        state=lambda: "idle",
+        has_pending_swarms=lambda: False,
+        session_goal_dict=lambda: {},
+        harness_session_id="sess-a",
+    )
+    code, state = get_session_state({"session_id": ["sess-a"]}, svc)
+    assert code == 200
+    assert "receipts" not in state
+
+
+def test_api_http_auth_required(tmp_path):
+    import json as json_mod
+    import threading
+    import time
+    import urllib.error
+    import urllib.request
+    from http.server import ThreadingHTTPServer
+
+    import harness.server as srv
+
+    srv._GET_ROUTES = None
+    srv._POST_JSON_ROUTES = None
+    srv._cfg.state_dir = str(tmp_path)
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), srv.Handler)
+    port = httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    time.sleep(0.05)
+    url = f"http://127.0.0.1:{port}/api/session/performance?session_id=sess-a"
+    try:
+        with pytest.raises(urllib.error.HTTPError) as ei:
+            urllib.request.urlopen(url, timeout=5)
+        assert ei.value.code == 403
+        req = urllib.request.Request(
+            url, headers={"X-Harness-Token": srv._TOKEN}, method="GET",
+        )
+        # Authed: unknown session is a product 404, not an auth miss.
+        try:
+            urllib.request.urlopen(req, timeout=5)
+        except urllib.error.HTTPError as exc:
+            assert exc.code in (200, 400, 404)
+            if exc.code != 200:
+                body = json_mod.loads(exc.read())
+                assert "token" not in str(body.get("error") or "").lower()
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_never_writes_live_pmharness_under_pytest(tmp_path, monkeypatch):
+    live = Path.home() / ".pmharness" / "stream_performance"
+    store = StreamPerformanceReceiptStore(str(Path.home() / ".pmharness"))
+    store.record("pytest-must-not-write", _receipt("pytest-must-not-write"))
+    # If the live tree already had a file, we still must not create this sid.
+    target = live / "pytest-must-not-write.json"
+    assert not target.exists()
+
+
+def test_never_reads_or_deletes_live_pmharness_under_pytest():
+    live_root = Path.home() / ".pmharness"
+    live_perf = live_root / "stream_performance"
+    sid = "pytest-must-not-touch-read"
+    target = live_perf / f"{sid}.json"
+    existed_root = live_root.exists()
+    existed_perf = live_perf.exists()
+    existed_file = target.exists()
+    prior = target.read_bytes() if existed_file else None
+    store = StreamPerformanceReceiptStore(str(live_root))
+    assert store.list_receipts(sid) == []
+    store.delete_session(sid)
+    assert target.exists() == existed_file
+    if existed_file:
+        assert target.read_bytes() == prior
+    if not existed_perf:
+        assert not live_perf.exists()
+    if not existed_root:
+        assert not live_root.exists()
+
+
+def test_blank_state_dir_never_uses_tempdir(tmp_path, monkeypatch):
+    sentinel = tmp_path / "fake-tmp"
+    sentinel.mkdir()
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(sentinel))
+    for raw in ("", None, "   "):
+        store = StreamPerformanceReceiptStore(raw)
+        store.record("sess", _receipt("sess"))
+        assert store.list_receipts("sess") == []
+        store.delete_session("sess")
+    assert list(sentinel.iterdir()) == []
+    sessions = SimpleNamespace(active="sess-a", rows=lambda: [{"id": "sess-a"}])
+    svc = _perf_svc(state_dir="", sessions=sessions)
+    code, payload = get_session_performance({"session_id": ["sess-a"]}, svc)
+    assert code == 200
+    assert payload["receipts"] == []
+    assert payload["count"] == 0
+    assert list(sentinel.iterdir()) == []
+
+
+def test_symlink_dir_write_escape(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    marker = outside / "secret.txt"
+    marker.write_text("do-not-touch", encoding="utf-8")
+    state = tmp_path / "state"
+    state.mkdir()
+    _make_symlink(outside, state / "stream_performance")
+    store = StreamPerformanceReceiptStore(str(state))
+    store.record("sess", _receipt("sess", provider_step=1))
+    assert store.list_receipts("sess") == []
+    assert not (outside / "sess.json").exists()
+    assert marker.read_text(encoding="utf-8") == "do-not-touch"
+    assert list(outside.glob("stream-perf-*.json")) == []
+
+
+def test_symlink_file_read_delete_isolation(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "secrets.json"
+    target.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "session_id": "sess",
+            "receipts": [{
+                "session_id": "sess",
+                "provider_step": 9,
+                "stream_performance": {"api_key": "sk-secret"},
+            }],
+        }),
+        encoding="utf-8",
+    )
+    prior = target.read_bytes()
+    state = tmp_path / "state"
+    perf = state / "stream_performance"
+    perf.mkdir(parents=True)
+    link = perf / "sess.json"
+    _make_symlink(target, link)
+    store = StreamPerformanceReceiptStore(str(state))
+    assert store.list_receipts("sess") == []
+    store.delete_session("sess")
+    assert target.exists()
+    assert target.read_bytes() == prior
+    assert "sk-secret" not in json.dumps(store.list_receipts("sess"))
+
+
+def test_lexical_alias_multiple_stores_do_not_lose_receipts(tmp_path):
+    real = tmp_path / "real_state"
+    real.mkdir()
+    alias = tmp_path / "alias_state"
+    _make_symlink(real, alias)
+    store_a = StreamPerformanceReceiptStore(str(real))
+    store_b = StreamPerformanceReceiptStore(str(alias))
+    errors = []
+
+    def _write(store, n):
+        try:
+            store.record("sess", _receipt("sess", provider_step=n, captured_at=float(n)))
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = []
+    for i in range(12):
+        store = store_a if i % 2 == 0 else store_b
+        threads.append(threading.Thread(target=_write, args=(store, i)))
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert errors == []
+    rows = store_a.list_receipts("sess")
+    assert len(rows) == 12
+    assert sorted(r["provider_step"] for r in rows) == list(range(12))
+    assert len(store_b.list_receipts("sess")) == 12
+
+
+def test_multiprocess_rmw_preserves_all_receipts(tmp_path):
+    sid = "sess-mp"
+    state = str(tmp_path)
+    ctx = multiprocessing.get_context("spawn")
+    n = 4
+    procs = [
+        ctx.Process(target=_mp_record_one, args=(state, sid, i))
+        for i in range(n)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=20)
+        assert proc.exitcode == 0
+    rows = StreamPerformanceReceiptStore(state).list_receipts(sid)
+    assert len(rows) == n
+    assert sorted(r["provider_step"] for r in rows) == list(range(n))
+
+
+def test_deep_json_and_recursion_error_fail_soft_then_repair(tmp_path, monkeypatch):
+    store = StreamPerformanceReceiptStore(str(tmp_path))
+    sid = "sess-deep"
+    path = Path(receipt_file_path(str(tmp_path), sid))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    depth = 8000
+    path.write_text("{" + '"k":{' * depth + "}" * depth + "}", encoding="utf-8")
+    assert store.list_receipts(sid) == []
+    store.record(sid, _receipt(sid, provider_step=1))
+    assert store.list_receipts(sid)[0]["provider_step"] == 1
+
+    def _boom(*_a, **_k):
+        raise RecursionError("too deep")
+
+    monkeypatch.setattr(json, "loads", _boom)
+    assert store.list_receipts(sid) == []
+    monkeypatch.undo()
+    store.record(sid, _receipt(sid, provider_step=2))
+    assert [r["provider_step"] for r in store.list_receipts(sid)] == [1, 2]
+
+
+def test_oversized_file_byte_capped_and_next_write_repairs(tmp_path, monkeypatch):
+    store = StreamPerformanceReceiptStore(str(tmp_path))
+    sid = "sess-big"
+    path = Path(receipt_file_path(str(tmp_path), sid))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "session_id": sid,
+        "receipts": [_receipt(sid, provider_step=99)],
+    }
+    path.write_text(json.dumps(payload) + (" " * (3 * 1024 * 1024)), encoding="utf-8")
+    monkeypatch.setattr(
+        os.path,
+        "getsize",
+        lambda p: 16 if os.path.basename(str(p)) == f"{sid}.json" else os.path.getsize(p),
+    )
+    assert store.list_receipts(sid) == []
+    monkeypatch.undo()
+    store.record(sid, _receipt(sid, provider_step=7))
+    rows = store.list_receipts(sid)
+    assert len(rows) == 1
+    assert rows[0]["provider_step"] == 7
+
+
+def test_known_key_dict_secret_rejected():
+    copied = copy_stream_performance({
+        PROVIDER_CALL_TOTAL_MS: {"api_key": "sk-secret", "nested": ["leak"]},
+        "content_delta_count": {"secret": "nope"},
+        "throughput_basis": {"token": "leak"},
+        FIRST_CONTENT_CALLBACK_MS: ["sk-secret"],
+        PROVIDER_OUTPUT_TPS: {"password": "hunter2"},
+    })
+    blob = json.dumps(copied)
+    assert copied == {}
+    assert "sk-secret" not in blob
+    assert "hunter2" not in blob
+    assert "secret" not in blob
+    assert "leak" not in blob
+    assert "password" not in blob
+
+
+def test_copy_stream_performance_rejects_string_numbers_and_unlisted_basis():
+    copied = copy_stream_performance({
+        PROVIDER_CALL_TOTAL_MS: "12.5",
+        FIRST_CONTENT_CALLBACK_MS: "80",
+        PROVIDER_OUTPUT_TPS: "30.0",
+        "decode_window_ms": "400",
+        "content_delta_count": "3",
+        THROUGHPUT_BASIS_KEY: "tokens/sec",
+        "pre_request_total_ms": True,
+    })
+    assert copied == {}
+    accepted = copy_stream_performance({
+        PROVIDER_CALL_TOTAL_MS: 12.5,
+        "content_delta_count": 3,
+        THROUGHPUT_BASIS_KEY: THROUGHPUT_BASIS,
+    })
+    assert accepted[PROVIDER_CALL_TOTAL_MS] == 12.5
+    assert accepted["content_delta_count"] == 3
+    assert accepted[THROUGHPUT_BASIS_KEY] == THROUGHPUT_BASIS
+    rejected_counts = copy_stream_performance({
+        "content_delta_count": -1,
+        PROVIDER_CALL_TOTAL_MS: 1.0,
+    })
+    assert "content_delta_count" not in rejected_counts
+    huge = copy_stream_performance({"content_delta_count": 1_000_000_001})
+    assert huge == {}
+
+
+def test_default_cap_keeps_newest_200(tmp_path):
+    store = StreamPerformanceReceiptStore(str(tmp_path))
+    sid = "sess-cap"
+    assert store.max_receipts == MAX_RECEIPTS_PER_SESSION
+    for i in range(MAX_RECEIPTS_PER_SESSION + 5):
+        store.record(sid, _receipt(sid, provider_step=i, captured_at=float(i)))
+    rows = store.list_receipts(sid)
+    assert len(rows) == MAX_RECEIPTS_PER_SESSION
+    assert rows[0]["provider_step"] == 5
+    assert rows[-1]["provider_step"] == MAX_RECEIPTS_PER_SESSION + 4
+
+
+def test_api_workspace_cross_session_denied(tmp_path):
+    ws_a = tmp_path / "ws_a"
+    ws_b = tmp_path / "ws_b"
+    ws_a.mkdir()
+    ws_b.mkdir()
+    row_a = {"id": "sess-a", "workspace_root": str(ws_a)}
+    row_b = {"id": "sess-b", "workspace_root": str(ws_b)}
+    sessions = SimpleNamespace(active="sess-a", rows=lambda: [row_a, row_b])
+    store = StreamPerformanceReceiptStore(str(tmp_path))
+    store.record("sess-a", _receipt("sess-a", provider_step=1))
+    store.record("sess-b", _receipt("sess-b", provider_step=2))
+    svc = _perf_svc(state_dir=tmp_path, sessions=sessions, repo=str(ws_a))
+    code, payload = get_session_performance({"session_id": ["sess-b"]}, svc)
+    assert code == 403
+    assert payload["error"] == "session not visible in active workspace"
+    code, payload = get_session_performance({"session_id": ["sess-a"]}, svc)
+    assert code == 200
+    assert payload["count"] == 1
+    assert payload["receipts"][0]["provider_step"] == 1
+    current = _perf_svc(
+        state_dir=tmp_path,
+        sessions=sessions,
+        repo=str(ws_a),
+        pilot=SimpleNamespace(harness_session_id="sess-b"),
+    )
+    code, payload = get_session_performance({"session_id": ["sess-b"]}, current)
+    assert code == 200
+    assert payload["count"] == 1

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.6";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.7";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.6";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.7";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 
 // True when `pip show` / `uv pip show` output describes an editable install
@@ -43,7 +43,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.6" }     -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.7" }     -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -65,7 +65,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.6).
+ * to 1.22.7).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.241",
+  "version": "0.9.242",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.241",
+      "version": "0.9.242",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.241",
+  "version": "0.9.242",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import SwarmPane, { jobSavings } from "../components/SwarmPane";
+import SwarmPane, { jobSavings, workerOutcome } from "../components/SwarmPane";
 import { api, type Job, type SwarmLive } from "../lib/api";
 import { dispatchProjectSelected } from "../lib/panelTransition";
 import { clearSWRCache, writeSWRCache } from "../lib/useStaleWhileRevalidate";
@@ -1728,6 +1728,225 @@ describe("SwarmPane worker progress", () => {
       expect(screen.getByText("Workers (3)")).toBeInTheDocument();
       expect(screen.getByText("2/3 · 1 failed")).toBeInTheDocument();
     });
+  });
+});
+
+describe("SwarmPane worker outcome hierarchy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    clearSWRCache();
+    mockArtifacts.mockResolvedValue([]);
+  });
+
+  it("maps lifecycle and exact-task artifacts in workerOutcome", () => {
+    const complete = { id: "t", status: "complete", role: "w", instruction: "", adapter: "agentic" };
+    const idle = { id: "t", status: "queued", role: "w", instruction: "", adapter: "agentic" };
+    const failedArt = { type: "verification", headline: "", result: "failed" as const };
+    expect(workerOutcome(complete, failedArt)).toBe("degraded");
+    expect(workerOutcome(complete, { type: "verification", headline: "", result: "degraded" })).toBe("degraded");
+    expect(workerOutcome(complete, { type: "verification", headline: "", result: "blocked" })).toBe("degraded");
+    expect(workerOutcome(complete, { type: "finding", headline: "ok" })).toBe("ok");
+    expect(workerOutcome(complete)).toBe("ok");
+    expect(workerOutcome({ ...complete, status: "failed" })).toBe("failed");
+    expect(workerOutcome({ ...complete, status: "running" }, failedArt)).toBe("running");
+    expect(workerOutcome(idle, failedArt)).toBe("degraded");
+    expect(workerOutcome(idle)).toBe("idle");
+  });
+
+  it("paints lifecycle complete plus exact failed verification as degraded, not green success", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-complete-failed-verify",
+        goal: "Complete but failed verification",
+        status: "complete",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "verification",
+            headline: "worker a",
+            task_id: "task-a",
+            result: "failed",
+            failure: "codex_turn_failed",
+            detail: "Workspace spend cap reached",
+          },
+        ],
+        tasks: [
+          {
+            id: "task-a",
+            status: "complete",
+            adapter: "agentic",
+            role: "verify-worker",
+            instruction: "",
+            completed_at: "2026-08-17T19:00:00+00:00",
+          },
+        ],
+      }),
+    );
+
+    const { container } = render(
+      <div style={{ width: "220px", overflow: "hidden" }}>
+        <SwarmPane />
+      </div>,
+    );
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Complete but failed verification"));
+
+    const worker = screen.getByRole("button", { name: /verify-worker/ });
+    expect(worker.getAttribute("aria-label") || "").toMatch(/degraded/i);
+    expect(worker).toHaveTextContent("degraded");
+    expect(worker.querySelector(".text-good")).toBeNull();
+    expect(screen.getByText("1/1 · 1 degraded")).toBeInTheDocument();
+    expect(screen.getByLabelText(/1 of 1 workers finished, 0 failed, 1 degraded/)).toBeInTheDocument();
+    expect(container.querySelector('[style*="width: 220px"]')).toBeTruthy();
+
+    fireEvent.click(worker);
+    const details = document.getElementById(worker.getAttribute("aria-controls") || "");
+    expect(details).toHaveTextContent("failurecodex_turn_failed");
+    expect(details).toHaveTextContent("reasonWorkspace spend cap reached");
+  });
+
+  it("suppresses x/N text when every worker is ok", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-all-ok",
+        goal: "Fully successful terminal",
+        status: "complete",
+        artifacts_complete: true,
+        tasks: [
+          { id: "t1", role: "ok-a", instruction: "", status: "complete", adapter: "agentic" },
+          { id: "t2", role: "ok-b", instruction: "", status: "complete", adapter: "agentic" },
+          { id: "t3", role: "ok-c", instruction: "", status: "complete", adapter: "agentic" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Fully successful terminal"));
+
+    expect(screen.getByText("Workers (3)")).toBeInTheDocument();
+    expect(screen.queryByText("3/3")).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/3 of 3 workers finished, 0 failed, 0 degraded/)).toBeInTheDocument();
+  });
+
+  it("keeps x/N and failed count on mixed 2/3 terminal progress", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-mixed-outcome",
+        goal: "Mixed terminal outcomes",
+        status: "running",
+        tasks: [
+          { id: "t1", role: "ok-a", instruction: "", status: "complete", adapter: "agentic" },
+          { id: "t2", role: "fail-b", instruction: "", status: "failed", adapter: "agentic" },
+          { id: "t3", role: "run-c", instruction: "", status: "running", adapter: "agentic" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => {
+      expect(screen.getByText("2/3 · 1 failed")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/2 of 3 workers finished, 1 failed, 0 degraded/)).toBeInTheDocument();
+  });
+
+  it("keeps x/N during active 1/3 progress", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-active-progress",
+        goal: "Active worker progress",
+        status: "running",
+        tasks: [
+          { id: "t1", role: "done-a", instruction: "", status: "complete", adapter: "agentic" },
+          { id: "t2", role: "run-b", instruction: "", status: "running", adapter: "agentic" },
+          { id: "t3", role: "run-c", instruction: "", status: "running", adapter: "agentic" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    const progress = await screen.findByLabelText(/1 of 3 workers finished, 0 failed, 0 degraded/);
+    expect(screen.getByText("Workers (3)")).toBeInTheDocument();
+    expect(progress).toHaveTextContent("1/3");
+  });
+
+  it("does not mark any worker degraded from unmatched verification without task_id", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-unmatched-verify",
+        goal: "Unmatched verification",
+        status: "complete",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "verification",
+            headline: "unmatched",
+            result: "failed",
+            failure: "no_model",
+            detail: "Must not be guessed onto a worker",
+          },
+        ],
+        tasks: [
+          { id: "task-a", status: "complete", adapter: "agentic", role: "ok-worker-a", instruction: "" },
+          { id: "task-b", status: "complete", adapter: "agentic", role: "ok-worker-b", instruction: "" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Unmatched verification"));
+
+    const workerA = screen.getByRole("button", { name: /ok-worker-a/ });
+    const workerB = screen.getByRole("button", { name: /ok-worker-b/ });
+    expect(workerA.getAttribute("aria-label") || "").toMatch(/\bok\b/);
+    expect(workerB.getAttribute("aria-label") || "").toMatch(/\bok\b/);
+    expect(workerA).not.toHaveTextContent("degraded");
+    expect(workerB).not.toHaveTextContent("degraded");
+    expect(screen.queryByText(/degraded/)).not.toBeInTheDocument();
+    expect(screen.queryByText("2/2")).not.toBeInTheDocument();
+  });
+
+  it("does not paint workers failed or degraded from job-level degraded without task-scoped artifact", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-canonical-degraded",
+        goal: "Job-level degraded only",
+        status: "complete",
+        adapter: "agentic",
+        outcome: {
+          quality: "degraded",
+          trustworthy: false,
+          reasons: ["only verification artifacts — no findings/decisions/patches"],
+        },
+        artifacts_complete: true,
+        artifacts: [{ type: "verification", headline: "provider failed", result: "failed" }],
+        tasks: [
+          { id: "task-a", status: "complete", adapter: "agentic", role: "ok-worker-a", instruction: "" },
+          { id: "task-b", status: "complete", adapter: "agentic", role: "ok-worker-b", instruction: "" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Job-level degraded only"));
+
+    const workerA = screen.getByRole("button", { name: /ok-worker-a/ });
+    const workerB = screen.getByRole("button", { name: /ok-worker-b/ });
+    expect(workerA.getAttribute("aria-label") || "").toMatch(/\bok\b/);
+    expect(workerB.getAttribute("aria-label") || "").toMatch(/\bok\b/);
+    expect(workerA).not.toHaveTextContent("degraded");
+    expect(workerB).not.toHaveTextContent("failed");
+    expect(workerA.querySelector(".text-risk")).toBeNull();
+    expect(screen.getByText("degraded")).toBeInTheDocument();
+    expect(screen.getByText(/only verification artifacts/)).toBeInTheDocument();
   });
 });
 

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -406,6 +406,67 @@ describe("SwarmPane worker details", () => {
     expect(screen.getByText("2026-08-16T17:00:00+00:00")).toBeInTheDocument();
   });
 
+  it("reveals only the exact task-matched failure class and reason", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-failed-workers",
+        goal: "Inspect failed workers",
+        status: "failed",
+        artifacts_complete: true,
+        artifacts: [
+          {
+            type: "verification",
+            headline: "worker a",
+            task_id: "task-a",
+            result: "failed",
+            failure: "codex_turn_failed",
+            detail: "Workspace spend cap reached",
+          },
+          {
+            type: "verification",
+            headline: "worker b",
+            task_id: "task-b",
+            result: "failed",
+            failure: "auth_failure",
+            detail: "Provider login required",
+          },
+          {
+            type: "verification",
+            headline: "unmatched",
+            result: "failed",
+            failure: "no_model",
+            detail: "Must not be guessed onto a worker",
+          },
+        ],
+        tasks: [
+          { id: "task-a", status: "failed", adapter: "agentic", role: "worker-a", instruction: "", completed_at: "2026-08-17T19:00:00+00:00" },
+          { id: "task-b", status: "failed", adapter: "agentic", role: "worker-b", instruction: "" },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Inspect failed workers"));
+
+    const workerA = screen.getByRole("button", { name: /worker-a/ });
+    fireEvent.click(workerA);
+    const detailsA = document.getElementById(workerA.getAttribute("aria-controls") || "");
+    expect(detailsA).toHaveTextContent("failurecodex_turn_failed");
+    expect(detailsA).toHaveTextContent("reasonWorkspace spend cap reached");
+    expect(detailsA).toHaveTextContent("completed2026-08-17T19:00:00+00:00");
+    expect(detailsA).not.toHaveTextContent("Provider login required");
+    expect(detailsA).not.toHaveTextContent("Must not be guessed onto a worker");
+
+    const workerB = screen.getByRole("button", { name: /worker-b/ });
+    fireEvent.click(workerB);
+    const detailsB = document.getElementById(workerB.getAttribute("aria-controls") || "");
+    expect(detailsB).toHaveTextContent("failureauth_failure");
+    expect(detailsB).toHaveTextContent("reasonProvider login required");
+    expect(detailsB).not.toHaveTextContent("Workspace spend cap reached");
+  });
+
   it("expands a worker from the keyboard and keeps nested Kill from toggling the job", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
@@ -2174,6 +2235,49 @@ describe("SwarmPane final-review blockers", () => {
       });
       expect(screen.queryByText("routing…")).not.toBeInTheDocument();
       expect(screen.queryByText("stale-preview-model")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies failure-detail poll updates when task state and headline stay fixed", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let pollCount = 0;
+      mockSwarmLive.mockImplementation(async () => {
+        pollCount += 1;
+        return liveJob({
+          status: "running",
+          artifacts_complete: true,
+          artifacts: [{
+            type: "verification",
+            headline: "worker failed",
+            task_id: "task-1",
+            result: "failed",
+            failure: "codex_turn_failed",
+            ...(pollCount > 2 ? { detail: "Workspace spend cap reached" } : {}),
+          }],
+          tasks: [{
+            id: "task-1",
+            status: "failed",
+            adapter: "agentic",
+            role: "worker",
+            instruction: "",
+          }],
+        });
+      });
+
+      render(<SwarmPane />);
+      const worker = await screen.findByRole("button", { name: /^worker, failed/i });
+      fireEvent.click(worker);
+      expect(screen.getByText("codex_turn_failed")).toBeInTheDocument();
+      expect(screen.queryByText("Workspace spend cap reached")).not.toBeInTheDocument();
+
+      await vi.advanceTimersByTimeAsync(6000);
+
+      await waitFor(() => {
+        expect(screen.getByText("Workspace spend cap reached")).toBeInTheDocument();
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -248,6 +248,7 @@ import {
 import {
   cancelTypewriterWithoutFlush,
   flushTypewriterBuffer,
+  pumpTypewriterFrame,
   startTypewriterLoop,
 } from "../components/conversation/streamTypewriter";
 import type { Item } from "../components/TranscriptList";
@@ -3211,6 +3212,129 @@ describe("completionNotify / feedScroll / streamTerminal / swarmPoll", () => {
       },
     );
     expect(scheduled).toBe(1);
+  });
+});
+
+describe("streamTypewriter first reveal", () => {
+  function makeRefs(buf: string, raf: number | null = null) {
+    return {
+      typeBufRef: { current: buf },
+      typeRafRef: { current: raf },
+      typeDoneRef: { current: false },
+    };
+  }
+
+  it("idle start with buffered text appends one live chunk then schedules", () => {
+    const text = "Hello world, this is buffered prose.";
+    const refs = makeRefs(text);
+    const chunks: string[] = [];
+    let scheduled = 0;
+    startTypewriterLoop(refs, (c) => chunks.push(c), () => {
+      scheduled += 1;
+      return 42;
+    });
+    const take = text.slice(0, typewriterCharsPerFrame(text.length, false));
+    expect(chunks).toEqual([take]);
+    expect(refs.typeBufRef.current).toBe(text.slice(take.length));
+    expect(scheduled).toBe(1);
+    expect(refs.typeRafRef.current).toBe(42);
+    expect(refs.typeDoneRef.current).toBe(false);
+  });
+
+  it("active loop does not append or schedule again", () => {
+    const text = "already pumping";
+    const refs = makeRefs(text, 7);
+    const chunks: string[] = [];
+    let scheduled = 0;
+    startTypewriterLoop(refs, (c) => chunks.push(c), () => {
+      scheduled += 1;
+      return 8;
+    });
+    expect(chunks).toEqual([]);
+    expect(scheduled).toBe(0);
+    expect(refs.typeRafRef.current).toBe(7);
+    expect(refs.typeBufRef.current).toBe(text);
+    expect(refs.typeDoneRef.current).toBe(false);
+  });
+
+  it("empty idle start still schedules without appending", () => {
+    const refs = makeRefs("");
+    const chunks: string[] = [];
+    let scheduled = 0;
+    startTypewriterLoop(refs, (c) => chunks.push(c), () => {
+      scheduled += 1;
+      return 1;
+    });
+    expect(chunks).toEqual([]);
+    expect(scheduled).toBe(1);
+    expect(refs.typeRafRef.current).toBe(1);
+  });
+
+  it("flush and cancel invariants remain after first reveal", () => {
+    const text = "Hello world, this is buffered prose.";
+    const refs = makeRefs(text);
+    const chunks: string[] = [];
+    let cancelled = 0;
+    startTypewriterLoop(refs, (c) => chunks.push(c), () => 3);
+    const remaining = refs.typeBufRef.current;
+    expect(remaining.length).toBeGreaterThan(0);
+    flushTypewriterBuffer(refs, (c) => chunks.push(c), () => {
+      cancelled += 1;
+    });
+    expect(chunks.join("")).toBe(text);
+    expect(refs.typeBufRef.current).toBe("");
+    expect(refs.typeDoneRef.current).toBe(true);
+    expect(refs.typeRafRef.current).toBeNull();
+    expect(cancelled).toBe(1);
+
+    refs.typeBufRef.current = "x";
+    refs.typeRafRef.current = 9;
+    cancelTypewriterWithoutFlush(refs, () => {
+      cancelled += 1;
+    });
+    expect(refs.typeBufRef.current).toBe("");
+    expect(refs.typeDoneRef.current).toBe(false);
+    expect(refs.typeRafRef.current).toBeNull();
+    expect(cancelled).toBe(2);
+  });
+
+  it("scheduled pump continues the same live cadence on leftover buffer", () => {
+    const text = "Hello world, this is buffered prose.";
+    const refs = makeRefs(text);
+    const chunks: string[] = [];
+    let pump: (() => void) | null = null;
+    startTypewriterLoop(refs, (c) => chunks.push(c), (cb) => {
+      pump = cb;
+      return 11;
+    });
+    const first = text.slice(0, typewriterCharsPerFrame(text.length, false));
+    expect(chunks).toEqual([first]);
+    const leftover = text.slice(first.length);
+    expect(refs.typeBufRef.current).toBe(leftover);
+    expect(pump).not.toBeNull();
+    pumpTypewriterFrame(refs, (c) => chunks.push(c), () => 12);
+    const second = leftover.slice(0, typewriterCharsPerFrame(leftover.length, false));
+    expect(chunks).toEqual([first, second]);
+    expect(refs.typeBufRef.current).toBe(leftover.slice(second.length));
+  });
+
+  it("empty-buffer pump with typeDone false reschedules without appending", () => {
+    const refs = {
+      typeBufRef: { current: "" },
+      typeRafRef: { current: 5 as number | null },
+      typeDoneRef: { current: false },
+    };
+    const chunks: string[] = [];
+    let scheduled = 0;
+    pumpTypewriterFrame(refs, (c) => chunks.push(c), () => {
+      scheduled += 1;
+      return 99;
+    });
+    expect(chunks).toEqual([]);
+    expect(scheduled).toBe(1);
+    expect(refs.typeRafRef.current).toBe(99);
+    expect(refs.typeBufRef.current).toBe("");
+    expect(refs.typeDoneRef.current).toBe(false);
   });
 });
 

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Loader2, CheckCircle2, XCircle, Circle, ChevronDown, ChevronRight, Cpu, Activity, Network, X } from "lucide-react";
+import { Loader2, CheckCircle2, XCircle, Circle, ChevronDown, ChevronRight, Cpu, Activity, Network, X, AlertTriangle } from "lucide-react";
 import { api, jobArtifactList, type SwarmLive, type Job, type Artifact, type Task } from "../lib/api";
 import { displayModelId, isEngineOnlyModelId, modelIdsEqual } from "../lib/modelIdentity";
 import { lastSelectedProjectRoot, panelOpacityClass, useProjectSwitching } from "../lib/panelTransition";
@@ -382,7 +382,40 @@ function associateRoutingToTasks(
 function isFailedArtifact(art: Artifact): boolean {
   const result = String(art.result || "").trim().toLowerCase();
   const kind = String(art.type || "").trim().toLowerCase();
-  return !!art.failure || result === "failed" || result === "blocked" || result === "error" || kind === "error";
+  return !!art.failure
+    || result === "failed"
+    || result === "blocked"
+    || result === "error"
+    || result === "degraded"
+    || kind === "error";
+}
+
+export type WorkerOutcome = "running" | "idle" | "ok" | "degraded" | "failed";
+
+/** Product quality for a worker row. Lifecycle stays in taskState(); this never infers from role/model/index. */
+export function workerOutcome(task: Task, failureArt?: Artifact | null): WorkerOutcome {
+  const life = taskState(task);
+  if (life === "running") return "running";
+  if (life === "fail") return "failed";
+  const unsuccessful = !!failureArt && isFailedArtifact(failureArt);
+  if (unsuccessful && (life === "done" || life === "idle")) return "degraded";
+  if (life === "done") return "ok";
+  return "idle";
+}
+
+function WorkerOutcomeGlyph({ outcome }: { outcome: WorkerOutcome }) {
+  switch (outcome) {
+    case "running":
+      return <Loader2 size={10} className="animate-spin text-accent" />;
+    case "ok":
+      return <CheckCircle2 size={10} className="text-good" />;
+    case "degraded":
+      return <AlertTriangle size={10} className="text-warn" />;
+    case "failed":
+      return <XCircle size={10} className="text-risk" />;
+    default:
+      return <Circle size={10} className="text-muted" />;
+  }
 }
 
 function failureArtifactsByTaskId(arts: Artifact[]): Map<string, Artifact> {
@@ -782,33 +815,61 @@ function PhaseStrip({ job, phase }: { job: Job; phase?: ReturnType<typeof jobPha
   );
 }
 
-function WorkerProgress({ tasks }: { tasks: Task[] }) {
+function WorkerProgress({
+  tasks,
+  failureForTask,
+}: {
+  tasks: Task[];
+  failureForTask: Map<string, Artifact>;
+}) {
   const total = tasks.length;
   if (total === 0) return null;
-  const done = tasks.filter((t) => taskState(t) === "done").length;
-  const failed = tasks.filter((t) => taskState(t) === "fail").length;
-  const donePct = Math.round((done / total) * 100);
+  let ok = 0;
+  let degraded = 0;
+  let failed = 0;
+  for (const t of tasks) {
+    const outcome = workerOutcome(t, failureForTask.get(t.id));
+    if (outcome === "ok") ok += 1;
+    else if (outcome === "degraded") degraded += 1;
+    else if (outcome === "failed") failed += 1;
+  }
+  const finished = ok + degraded + failed;
+  const okPct = Math.round((ok / total) * 100);
+  const degradedPct = Math.round((degraded / total) * 100);
   const failedPct = Math.round((failed / total) * 100);
+  const allOk = ok === total;
+  const countText = [
+    `${finished}/${total}`,
+    failed > 0 ? `${failed} failed` : "",
+    degraded > 0 ? `${degraded} degraded` : "",
+  ].filter(Boolean).join(" · ");
   return (
     <div
       className="flex items-center gap-2"
       role="progressbar"
-      aria-label={`${done + failed} of ${total} workers finished`}
+      aria-label={`${finished} of ${total} workers finished, ${failed} failed, ${degraded} degraded`}
       aria-valuemin={0}
       aria-valuemax={total}
-      aria-valuenow={done + failed}
+      aria-valuenow={finished}
     >
       <div className="flex-1 h-px bg-edge/50 overflow-hidden flex">
-        {donePct > 0 && (
-          <div className="h-full bg-good transition-all duration-500" style={{ width: `${donePct}%` }} />
+        {okPct > 0 && (
+          <div className="h-full bg-good transition-all duration-500" style={{ width: `${okPct}%` }} />
+        )}
+        {degradedPct > 0 && (
+          <div className="h-full bg-warn transition-all duration-500" style={{ width: `${degradedPct}%` }} />
         )}
         {failedPct > 0 && (
           <div className="h-full bg-risk transition-all duration-500" style={{ width: `${failedPct}%` }} />
         )}
       </div>
-      <span className={`text-[9px] tabular-nums shrink-0 ${failed > 0 ? "text-risk/80" : "text-faint"}`}>
-        {done + failed}/{total}{failed > 0 ? ` · ${failed} failed` : ""}
-      </span>
+      {!allOk && (
+        <span className={`text-[9px] tabular-nums shrink-0 ${
+          failed > 0 ? "text-risk/80" : degraded > 0 ? "text-warn/80" : "text-faint"
+        }`}>
+          {countText}
+        </span>
+      )}
     </div>
   );
 }
@@ -1516,10 +1577,9 @@ export default function SwarmPane() {
                 <div className="flex items-center justify-between">
                   <span className="text-[8.5px] uppercase tracking-[0.14em] text-faint font-medium">Workers ({tasks.length})</span>
                 </div>
-                <WorkerProgress tasks={tasks} />
+                <WorkerProgress tasks={tasks} failureForTask={failureForTask} />
                 <div className="flex flex-col divide-y divide-edge/20 mt-0.5">
                   {tasks.map((task) => {
-                    const ts = taskState(task);
                     const tExpanded = !!expandedTasks[task.id];
                     const routing = routingForTask.get(task.id);
                     const view = workerModelView(task, routing);
@@ -1542,7 +1602,11 @@ export default function SwarmPane() {
                     const showSpend = showTokens || showCost;
                     const roleLabel = task.role || "Worker";
                     const detailsId = `swarm-worker-${task.id}`;
-                    const workerState = (task.status || ts).trim() || "idle";
+                    const outcome = workerOutcome(task, failureArtifact);
+                    const rawStatus = (task.status || "").trim();
+                    const ariaBits = [roleLabel, outcome];
+                    if (rawStatus && rawStatus.toLowerCase() !== outcome) ariaBits.push(rawStatus);
+                    if (view.slot) ariaBits.push(view.slot);
                     return (
                       <div
                         key={task.id}
@@ -1553,22 +1617,28 @@ export default function SwarmPane() {
                           tabIndex={0}
                           aria-expanded={tExpanded}
                           aria-controls={detailsId}
-                          aria-label={`${roleLabel}, ${workerState}${view.slot ? `, ${view.slot}` : ""}`}
+                          aria-label={ariaBits.join(", ")}
                           onClick={() => toggleTask(task.id)}
                           onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleTask(task.id); } }}
                           className={`group flex items-start gap-2 min-w-0 px-1 py-0.5 cursor-pointer hover:bg-panel2/25 transition-colors ${DISCLOSURE_FOCUS}`}
                         >
                           <span className="shrink-0 mt-0.5">
-                            {ts === "running" ? <Loader2 size={10} className="animate-spin text-accent" />
-                              : ts === "done" ? <CheckCircle2 size={10} className="text-good" />
-                              : ts === "fail" ? <XCircle size={10} className="text-risk" />
-                              : <Circle size={10} className="text-muted" />}
+                            <WorkerOutcomeGlyph outcome={outcome} />
                           </span>
                           <div className="min-w-0 flex-1">
                             <div className="flex items-center gap-1 min-w-0">
                               <span className="min-w-0 flex-1 truncate font-semibold text-txt">
                                 {roleLabel}
                               </span>
+                              {(outcome === "degraded" || outcome === "failed") && (
+                                <span
+                                  className={`shrink-0 text-[8.5px] font-medium ${
+                                    outcome === "failed" ? "text-risk/90" : "text-warn/90"
+                                  }`}
+                                >
+                                  {outcome}
+                                </span>
+                              )}
                               <span className="shrink-0 text-faint/60 group-hover:text-faint transition-colors">
                                 {tExpanded
                                   ? <ChevronDown size={9} />
@@ -1599,52 +1669,66 @@ export default function SwarmPane() {
                         {tExpanded && (
                           <div
                             id={detailsId}
-                            className="ml-5 mt-1 border-l border-edge/35 pl-2 text-[9px] font-mono text-faint grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5"
+                            className="ml-5 mt-1 border-l border-edge/35 pl-2 text-[9px] font-mono text-faint flex flex-col gap-1.5"
                           >
-                            <span>task</span><span className="text-muted break-all">{task.id}</span>
-                            {view.rawModel && <><span>model</span><span className="text-muted break-all">{view.rawModel}</span></>}
-                            {adapterLabel && <><span>adapter</span><span className="text-muted break-all">{adapterLabel}</span></>}
-                            {failureClass && <><span>failure</span><span className="text-risk/85 break-all">{failureClass}</span></>}
-                            {sourceFailureReason && <><span>reason</span><span className="text-muted whitespace-pre-wrap break-words font-sans">{sourceFailureReason}</span></>}
-                            {view.policy ? (
-                              <><span>policy</span><span className="text-muted break-all">{view.policy}{view.pinned ? " · pin" : ""}</span></>
-                            ) : view.routing ? (
-                              <><span>policy</span><span className="text-muted break-all">Pin attribution unknown</span></>
-                            ) : null}
-                            {provider && <><span>provider</span><span className="text-muted break-all">{provider}</span></>}
-                            {createdBy === "router-fallback" && <><span>route</span><span className="text-muted">fallback</span></>}
-                            {createdBy === "router-escalation" && <><span>route</span><span className="text-muted">escalation</span></>}
-                            {task.completed_at && <><span>completed</span><span className="text-muted break-all">{task.completed_at}</span></>}
-                            {task.instruction && <><span>instruction</span><span className="text-muted whitespace-pre-wrap break-words font-sans">{task.instruction}</span></>}
-                            {hasRejected && (
-                              <>
-                                <span>rejected</span>
-                                <span>
-                                  <button
-                                    type="button"
-                                    aria-expanded={altsExpanded}
-                                    onClick={(e) => { e.stopPropagation(); setExpandedAlts((prev) => ({ ...prev, [altKey]: !altsExpanded })); }}
-                                    onKeyDown={(e) => e.stopPropagation()}
-                                    className={`text-[9px] text-faint/80 hover:text-muted inline-flex items-center gap-0.5 ${DISCLOSURE_FOCUS}`}
-                                  >
-                                    {altsExpanded ? <ChevronDown size={9} /> : <ChevronRight size={9} />}
-                                    {routing?.rejected?.length} alternatives
-                                  </button>
-                                  {altsExpanded && (
-                                    <span className="mt-1 flex flex-wrap gap-1">
-                                      {routing?.rejected?.map((rej: { model: string; reason: string }, ridx: number) => (
-                                        <Tooltip
-                                          key={ridx}
-                                          label={rej.reason}
-                                          className="font-mono text-[8.5px] text-faint bg-panel2/30 border border-edge/40 px-1.5 py-0.5 rounded cursor-default"
-                                        >
-                                          {rej.model}
-                                        </Tooltip>
-                                      ))}
-                                    </span>
-                                  )}
-                                </span>
-                              </>
+                            {(failureClass || sourceFailureReason) && (
+                              <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                                {failureClass && <><span>failure</span><span className="text-risk/85 break-all">{failureClass}</span></>}
+                                {sourceFailureReason && <><span>reason</span><span className="text-muted whitespace-pre-wrap break-words font-sans">{sourceFailureReason}</span></>}
+                              </div>
+                            )}
+                            <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                              <span>task</span><span className="text-muted break-all">{task.id}</span>
+                              {view.rawModel && <><span>model</span><span className="text-muted break-all">{view.rawModel}</span></>}
+                              {adapterLabel && <><span>adapter</span><span className="text-muted break-all">{adapterLabel}</span></>}
+                              {view.policy ? (
+                                <><span>policy</span><span className="text-muted break-all">{view.policy}{view.pinned ? " · pin" : ""}</span></>
+                              ) : view.routing ? (
+                                <><span>policy</span><span className="text-muted break-all">Pin attribution unknown</span></>
+                              ) : null}
+                              {provider && <><span>provider</span><span className="text-muted break-all">{provider}</span></>}
+                              {createdBy === "router-fallback" && <><span>route</span><span className="text-muted">fallback</span></>}
+                              {createdBy === "router-escalation" && <><span>route</span><span className="text-muted">escalation</span></>}
+                              {hasRejected && (
+                                <>
+                                  <span>rejected</span>
+                                  <span>
+                                    <button
+                                      type="button"
+                                      aria-expanded={altsExpanded}
+                                      onClick={(e) => { e.stopPropagation(); setExpandedAlts((prev) => ({ ...prev, [altKey]: !altsExpanded })); }}
+                                      onKeyDown={(e) => e.stopPropagation()}
+                                      className={`text-[9px] text-faint/80 hover:text-muted inline-flex items-center gap-0.5 ${DISCLOSURE_FOCUS}`}
+                                    >
+                                      {altsExpanded ? <ChevronDown size={9} /> : <ChevronRight size={9} />}
+                                      {routing?.rejected?.length} alternatives
+                                    </button>
+                                    {altsExpanded && (
+                                      <span className="mt-1 flex flex-wrap gap-1">
+                                        {routing?.rejected?.map((rej: { model: string; reason: string }, ridx: number) => (
+                                          <Tooltip
+                                            key={ridx}
+                                            label={rej.reason}
+                                            className="font-mono text-[8.5px] text-faint bg-panel2/30 border border-edge/40 px-1.5 py-0.5 rounded cursor-default"
+                                          >
+                                            {rej.model}
+                                          </Tooltip>
+                                        ))}
+                                      </span>
+                                    )}
+                                  </span>
+                                </>
+                              )}
+                            </div>
+                            {task.completed_at && (
+                              <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                                <span>completed</span><span className="text-muted break-all">{task.completed_at}</span>
+                              </div>
+                            )}
+                            {task.instruction && (
+                              <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                                <span>instruction</span><span className="text-muted whitespace-pre-wrap break-words font-sans">{task.instruction}</span>
+                              </div>
                             )}
                           </div>
                         )}

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -251,8 +251,10 @@ function swarmSignature(res: SwarmLive | null): string {
           `:${routingPolicy(a)}:${a.provider ?? ""}`,
         );
       } else {
+        const detail = typeof a.detail === "string" ? a.detail.slice(0, 500) : "";
         parts.push(
-          `A:${(a.type || "").slice(0, 8)}:${(a.headline || "").slice(0, 120)}:${a.result ?? ""}`,
+          `A:${(a.type || "").slice(0, 8)}:${(a.headline || "").slice(0, 120)}:${a.result ?? ""}` +
+          `:${a.failure ?? ""}:${detail}`,
         );
       }
     }
@@ -375,6 +377,36 @@ function associateRoutingToTasks(
     return !tid || !ids.has(tid);
   });
   return { routingForTask, unmatched };
+}
+
+function isFailedArtifact(art: Artifact): boolean {
+  const result = String(art.result || "").trim().toLowerCase();
+  const kind = String(art.type || "").trim().toLowerCase();
+  return !!art.failure || result === "failed" || result === "blocked" || result === "error" || kind === "error";
+}
+
+function failureArtifactsByTaskId(arts: Artifact[]): Map<string, Artifact> {
+  const byTask = new Map<string, Artifact>();
+  for (const art of arts) {
+    const taskId = String(art.task_id || "").trim();
+    if (!taskId || !isFailedArtifact(art)) continue;
+    const current = byTask.get(taskId);
+    const score = (art.detail ? 4 : 0) + (art.failure ? 2 : 0) + (art.headline ? 1 : 0);
+    const currentScore = current
+      ? (current.detail ? 4 : 0) + (current.failure ? 2 : 0) + (current.headline ? 1 : 0)
+      : -1;
+    if (score >= currentScore) byTask.set(taskId, art);
+  }
+  return byTask;
+}
+
+function failureReason(art?: Artifact): string {
+  if (!art) return "";
+  if (typeof art.detail === "string" && art.detail.trim()) return art.detail.trim();
+  if (String(art.type || "").trim().toLowerCase() === "error") {
+    return String(art.headline || "").trim();
+  }
+  return "";
 }
 
 function unmatchedAddsTruth(arts: Artifact[], headerModel: string): boolean {
@@ -1205,6 +1237,7 @@ export default function SwarmPane() {
       artifacts.filter((a: Artifact) => (a.type || "").toUpperCase() === "ROUTING"),
     );
     const streamArts = artifacts.filter((a: Artifact) => (a.type || "").toUpperCase() !== "ROUTING");
+    const failureForTask = failureArtifactsByTaskId(streamArts);
     const tasks = j.tasks || [];
     const { routingForTask, unmatched: unmatchedRouting } = associateRoutingToTasks(routingArts, tasks);
     // Prefer the deduped final routing decision (fallback/escalation wins) over
@@ -1490,6 +1523,9 @@ export default function SwarmPane() {
                     const tExpanded = !!expandedTasks[task.id];
                     const routing = routingForTask.get(task.id);
                     const view = workerModelView(task, routing);
+                    const failureArtifact = failureForTask.get(task.id);
+                    const failureClass = String(failureArtifact?.failure || "").trim();
+                    const sourceFailureReason = failureReason(failureArtifact);
                     const adapterLabel = (task.adapter || "").trim();
                     const provider = (routing?.provider || "").trim();
                     const createdBy = routing?.created_by || "";
@@ -1568,6 +1604,8 @@ export default function SwarmPane() {
                             <span>task</span><span className="text-muted break-all">{task.id}</span>
                             {view.rawModel && <><span>model</span><span className="text-muted break-all">{view.rawModel}</span></>}
                             {adapterLabel && <><span>adapter</span><span className="text-muted break-all">{adapterLabel}</span></>}
+                            {failureClass && <><span>failure</span><span className="text-risk/85 break-all">{failureClass}</span></>}
+                            {sourceFailureReason && <><span>reason</span><span className="text-muted whitespace-pre-wrap break-words font-sans">{sourceFailureReason}</span></>}
                             {view.policy ? (
                               <><span>policy</span><span className="text-muted break-all">{view.policy}{view.pinned ? " · pin" : ""}</span></>
                             ) : view.routing ? (

--- a/webapp/src/components/conversation/streamTypewriter.ts
+++ b/webapp/src/components/conversation/streamTypewriter.ts
@@ -11,6 +11,30 @@ export type TypewriterRefs = {
   typeDoneRef: { current: boolean };
 };
 
+/** Reveal one live/done policy chunk from the buffer into React state. */
+function takeTypewriterChunk(
+  refs: TypewriterRefs,
+  appendStreamingText: (chunk: string) => void,
+): void {
+  const buf = refs.typeBufRef.current;
+  if (!buf) return;
+  const perFrame = typewriterCharsPerFrame(buf.length, refs.typeDoneRef.current);
+  if (perFrame <= 0) return;
+  const take = buf.slice(0, perFrame);
+  refs.typeBufRef.current = buf.slice(perFrame);
+  appendStreamingText(take);
+}
+
+function scheduleTypewriterPump(
+  refs: TypewriterRefs,
+  appendStreamingText: (chunk: string) => void,
+  schedule: (cb: () => void) => number,
+): void {
+  refs.typeRafRef.current = schedule(() =>
+    pumpTypewriterFrame(refs, appendStreamingText, schedule),
+  );
+}
+
 /** One animation frame: reveal backlog chars and schedule the next pump. */
 export function pumpTypewriterFrame(
   refs: TypewriterRefs,
@@ -21,20 +45,13 @@ export function pumpTypewriterFrame(
   const buf = refs.typeBufRef.current;
   if (!buf) {
     if (!refs.typeDoneRef.current) {
-      refs.typeRafRef.current = schedule(() =>
-        pumpTypewriterFrame(refs, appendStreamingText, schedule),
-      );
+      scheduleTypewriterPump(refs, appendStreamingText, schedule);
     }
     return;
   }
-  const perFrame = typewriterCharsPerFrame(buf.length, refs.typeDoneRef.current);
-  const take = buf.slice(0, perFrame);
-  refs.typeBufRef.current = buf.slice(perFrame);
-  appendStreamingText(take);
+  takeTypewriterChunk(refs, appendStreamingText);
   if (refs.typeBufRef.current || !refs.typeDoneRef.current) {
-    refs.typeRafRef.current = schedule(() =>
-      pumpTypewriterFrame(refs, appendStreamingText, schedule),
-    );
+    scheduleTypewriterPump(refs, appendStreamingText, schedule);
   }
 }
 
@@ -44,11 +61,13 @@ export function startTypewriterLoop(
   schedule: (cb: () => void) => number,
 ): void {
   refs.typeDoneRef.current = false;
-  if (refs.typeRafRef.current == null) {
-    refs.typeRafRef.current = schedule(() =>
-      pumpTypewriterFrame(refs, appendStreamingText, schedule),
-    );
+  if (refs.typeRafRef.current != null) {
+    return;
   }
+  if (refs.typeBufRef.current) {
+    takeTypewriterChunk(refs, appendStreamingText);
+  }
+  scheduleTypewriterPump(refs, appendStreamingText, schedule);
 }
 
 export function flushTypewriterBuffer(


### PR DESCRIPTION
## Summary
- Closes #51: Swarm Tracker collapsed chrome and `WorkerProgress` follow worker **outcome** (`ok` / `degraded` / `failed`) instead of treating lifecycle `complete` as a green check. Diagnosis stays expanded-only and exact-`task_id` (PR #50).
- Chat turns record honest TTFT/TPS receipts (`GET /api/session/performance`) and yield the first identity-bearing answer without an avoidable typewriter wait.
- Pins the desktop/CI runtime to `puppetmaster-ai==1.22.7`.

Compaction residual lab work from the parallel session is **not** in this PR.

## Test plan
- [x] `npx vitest run src/__tests__/SwarmPane.test.tsx` (81 passed)
- [x] Focused TTFT/version pytest (199 passed)
- [x] Full local pytest excluding residual-lab files: 4554 passed, 74 skipped
- [ ] CI `tests` workflow green on the exact `main` SHA (3.9, 3.11, Windows, frontend-build) before tagging `v0.9.242`