### PR TITLE
Fix send-loop fence for v0.9.245 vault cite

### DIFF
--- a/harness/compaction_mixin.py
+++ b/harness/compaction_mixin.py
@@ -804,6 +804,29 @@ class CompactionContextMixin:
         except Exception:
             return {"section": "", "route": "empty", "snippets": []}
 
+    def _turn_vault_context(self, user_message: str, append_only: bool):
+        """Return inject section plus optional transcript cite payload.
+
+        Lives here so ``_send_locked_inner`` does not grow past its fence.
+        Empty FTS stays empty (no cite). Never raises.
+        """
+        if append_only:
+            return "", None
+        try:
+            cite = self._build_turn_vault_cite(user_message)
+            section = cite.get("section") or ""
+            snippets = list(cite.get("snippets") or [])
+            route = str(cite.get("route") or "empty")
+            if snippets and route != "empty":
+                return section, {
+                    "route": route,
+                    "snippets": snippets,
+                    "query": (user_message or "")[:120],
+                }
+            return section, None
+        except Exception:
+            return "", None
+
     def _build_turn_vault_section(self, user_message: str) -> str:
         """Query-conditioned recall of elided history. Never raises."""
         return str(self._build_turn_vault_cite(user_message).get("section") or "")

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -1122,22 +1122,9 @@ class SendLoopMixin:
                         wiki_section = self._wiki_cache_section
                     else:
                         wiki_section = self._build_turn_wiki_section(user_message)
-            vault_section = ""
-            vault_cite = None
-            if not append_only:
-                try:
-                    cite = self._build_turn_vault_cite(user_message)
-                    vault_section = cite.get("section") or ""
-                    snippets = list(cite.get("snippets") or [])
-                    route = str(cite.get("route") or "empty")
-                    if snippets and route != "empty":
-                        vault_cite = {
-                            "route": route,
-                            "snippets": snippets,
-                            "query": (user_message or "")[:120],
-                        }
-                except Exception:
-                    vault_section = ""
+            vault_section, vault_cite = self._turn_vault_context(
+                user_message, append_only
+            )
             if vault_cite is not None:
                 yield ConvEvent("vault_cite", vault_cite)
 


### PR DESCRIPTION
## Summary
- Ubuntu 3.11 on #54 failed `test_send_locked_inner_within_growth_fence`: `_send_locked_inner` grew to 710 lines (max 700).
- Peel vault-cite payload construction onto CompactionMixin so the residual send body stays under the fence. No residual-algorithm change.

## Test plan
- [ ] `tests/test_send_loop_residual.py` plus vault/SSE tests green
- [ ] `tests` workflow green on the exact `main` merge SHA (3.9 + 3.11 + frontend-build)
- [ ] Tag `v0.9.245` only after that SHA is green