### PR TITLE
Clear stale update availability across banner and status bar

### DIFF
--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -638,6 +638,18 @@ async function applyUpdate({ repoRoot, branch = DEFAULT_BRANCH, strategy = "ff",
   }
 }
 
+/** Result when apply has nothing to run: authoritative idle vs failed check. */
+function emptyApplyPlanResult({ gitResult = {}, packagedResult = null } = {}) {
+  const checkError =
+    (gitResult && gitResult.error) ||
+    (packagedResult && packagedResult.error) ||
+    "";
+  if (checkError) {
+    return { ok: false, code: "check_failed", error: checkError };
+  }
+  return { ok: false, code: "no_update", error: "no update available" };
+}
+
 // Register IPC. `opts.getRepoRoot()` returns the checkout path; `opts.relaunch()`
 // tears down the backend and re-execs the app. Packaged installs also get
 // `opts.packagedUpdater` (electron-updater) so shell skew is resolved via a
@@ -876,7 +888,7 @@ function registerUpdateBridge(ipcMain, app, shell, opts = {}) {
         return sourceResult;
       }
 
-      return { ok: false, error: "no update available" };
+      return emptyApplyPlanResult({ gitResult: gitRes, packagedResult: packagedRes });
     } finally {
       applying = false;
     }
@@ -908,5 +920,6 @@ module.exports = {
   isElectronMainProcessFile,
   updateChangesElectronMain,
   describeMainProcessUpdate,
+  emptyApplyPlanResult,
   resolvePuppetmasterPin,
 };

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -420,3 +420,30 @@ test("describeMainProcessUpdate: no shell change means nothing extra to require"
   assert.equal(verdict.installerUpdateRequired, false);
   assert.equal(verdict.note, undefined);
 });
+
+test("emptyApplyPlanResult: authoritative no-update is a no_update code", () => {
+  const result = bridge.emptyApplyPlanResult({
+    gitResult: { available: false, behind: 0 },
+    packagedResult: { available: false },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "no_update");
+  assert.equal(result.error, "no update available");
+});
+
+test("emptyApplyPlanResult: a failed apply-time check is check_failed", () => {
+  const gitFail = bridge.emptyApplyPlanResult({
+    gitResult: { available: false, error: "git fetch failed" },
+    packagedResult: { available: false },
+  });
+  assert.equal(gitFail.ok, false);
+  assert.equal(gitFail.code, "check_failed");
+  assert.equal(gitFail.error, "git fetch failed");
+
+  const packagedFail = bridge.emptyApplyPlanResult({
+    gitResult: { available: false, behind: 0 },
+    packagedResult: { available: false, error: "electron-updater unavailable" },
+  });
+  assert.equal(packagedFail.code, "check_failed");
+  assert.equal(packagedFail.error, "electron-updater unavailable");
+});

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -5,7 +5,7 @@ import Conversation from "./components/Conversation";
 import RightPane from "./components/RightPane";
 import RightDock from "./components/RightDock";
 import StatusBar from "./components/StatusBar";
-import UpdateBanner from "./components/UpdateBanner";
+import UpdateBanner, { type UpdateAvailability } from "./components/UpdateBanner";
 import ProviderKeyBanner from "./components/ProviderKeyBanner";
 import Resizer from "./components/Resizer";
 import RegistryWizard from "./components/RegistryWizard";
@@ -117,6 +117,7 @@ function hasStoredRightPaneCards(): boolean {
 
 export default function App() {
   const [config, setConfig] = useState<Config | null>(null);
+  const [availableUpdate, setAvailableUpdate] = useState<UpdateAvailability | null>(null);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [artifacts, setArtifacts] = useState<{ type: string; headline: string; confidence?: number }[]>([]);
   const [jobsRefresh, setJobsRefresh] = useState(0);
@@ -336,7 +337,7 @@ export default function App() {
 
   return (
     <div className="h-full flex flex-col bg-[var(--shell-chrome)]">
-      <UpdateBanner />
+      <UpdateBanner onAvailabilityChange={setAvailableUpdate} />
       {/* Keyless nudge: agentic is the shipped default, so instead of a demo run
           we tell the user to plug in a key. Suppressed while the first-run wizard
           is up (it already covers key setup) to avoid stacking two prompts. */}
@@ -441,7 +442,7 @@ export default function App() {
         </div>
       </div>
       <div className="shrink-0 px-px py-px">
-        <StatusBar config={config}
+        <StatusBar config={config} update={availableUpdate}
           leftOpen={leftOpen} rightOpen={rightOpen}
           onToggleLeft={() => setLeftOpen((v) => !v)} onToggleRight={() => setRightOpen((v) => !v)} />
       </div>

--- a/webapp/src/__tests__/StatusBar.test.tsx
+++ b/webapp/src/__tests__/StatusBar.test.tsx
@@ -1,10 +1,12 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import StatusBar, {
   deriveFooterRuntimeStatus,
   footerRuntimeStatusLabel,
   sessionGoalForChip,
 } from "../components/StatusBar";
+import UpdateBanner, { type UpdateAvailability } from "../components/UpdateBanner";
 import { api } from "../lib/api";
 import { publishTaskProfile } from "../lib/taskProfileChrome";
 
@@ -37,11 +39,22 @@ const mockClearSessionGoal = vi.mocked(api.clearSessionGoal);
 
 const statusBarProps = {
   config: null,
+  update: null,
   leftOpen: true,
   rightOpen: false,
   onToggleLeft: vi.fn(),
   onToggleRight: vi.fn(),
 };
+
+function AppUpdateChromeHarness() {
+  const [update, setUpdate] = useState<UpdateAvailability | null>(null);
+  return (
+    <>
+      <UpdateBanner onAvailabilityChange={setUpdate} />
+      <StatusBar {...statusBarProps} update={update} />
+    </>
+  );
+}
 
 describe("sessionGoalForChip", () => {
   it("returns null when goal is absent, cleared, or empty", () => {
@@ -650,58 +663,6 @@ describe("StatusBar session GOAL chip", () => {
   });
 });
 
-describe("StatusBar runtime stale toast", () => {
-  const runtimeNote =
-    "Puppetmaster is at 1.20.10 but this Marionette needs 1.22.4 -- offline. Reconnect and update to finish.";
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockWorkspaces.mockResolvedValue([]);
-    mockGetUsage.mockResolvedValue({ session: emptyUsageSession, jobs: [] });
-    mockGetSessionState.mockResolvedValue({
-      state: "idle",
-      pending_swarms: false,
-      runners: {},
-    });
-    mockSessions.mockResolvedValue([]);
-  });
-
-  afterEach(() => {
-    delete (window as any).harnessIPC;
-  });
-
-  it("surfaces runtimeNote once as a toast without showing the update pill", async () => {
-    const check = vi
-      .fn()
-      .mockResolvedValue({ runtimeStale: true, runtimeNote, available: false });
-    (window as any).harnessIPC = {
-      updates: { check, onAvailable: null, onProgress: vi.fn(() => () => {}) },
-    };
-
-    render(<StatusBar {...statusBarProps} />);
-
-    await waitFor(() => expect(check).toHaveBeenCalled());
-    await waitFor(() => {
-      expect(screen.getByText(runtimeNote)).toBeInTheDocument();
-    });
-    expect(screen.queryByText(/^update/)).not.toBeInTheDocument();
-  });
-
-  it("does not toast when runtimeStale is absent", async () => {
-    const check = vi.fn().mockResolvedValue({ available: false });
-    (window as any).harnessIPC = {
-      updates: { check, onAvailable: null, onProgress: vi.fn(() => () => {}) },
-    };
-
-    render(<StatusBar {...statusBarProps} />);
-
-    await waitFor(() => {
-      expect(check).toHaveBeenCalled();
-    });
-    expect(screen.queryByText(/Puppetmaster is at/i)).not.toBeInTheDocument();
-  });
-});
-
 describe("StatusBar update progress mirror", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -717,6 +678,70 @@ describe("StatusBar update progress mirror", () => {
 
   afterEach(() => {
     delete (window as any).harnessIPC;
+  });
+
+  it("renders the projected compact update and delegates its click", async () => {
+    const applyRequest = vi.fn();
+    window.addEventListener("harness-update-apply", applyRequest);
+    (window as any).harnessIPC = {
+      updates: {
+        onProgress: vi.fn(() => () => {}),
+      },
+    };
+
+    const { rerender } = render(
+      <StatusBar
+        {...statusBarProps}
+        update={{ behind: 2, branch: "main", version: "0.9.245" }}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "update (2)" }));
+    expect(applyRequest).toHaveBeenCalledTimes(1);
+
+    rerender(<StatusBar {...statusBarProps} update={null} />);
+    expect(screen.queryByRole("button", { name: "update (2)" })).not.toBeInTheDocument();
+    window.removeEventListener("harness-update-apply", applyRequest);
+  });
+
+  it("shares App-projected availability and banner-owned apply progress", async () => {
+    let availableListener: ((payload: any) => void) | null = null;
+    const progressListeners: Array<(payload: any) => void> = [];
+    const apply = vi.fn(() => new Promise(() => {}));
+    (window as any).harnessIPC = {
+      updates: {
+        check: vi.fn(() => new Promise(() => {})),
+        apply,
+        onAvailable: vi.fn((listener) => {
+          availableListener = listener;
+          return () => {};
+        }),
+        onProgress: vi.fn((listener) => {
+          progressListeners.push(listener);
+          return () => {};
+        }),
+      },
+    };
+
+    render(<AppUpdateChromeHarness />);
+    act(() => availableListener?.({
+      available: true,
+      downloaded: false,
+      behind: 2,
+      branch: "main",
+      current: "0.9.245",
+    }));
+
+    expect(await screen.findByTestId("update-banner")).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("button", { name: "update (2)" }));
+    await waitFor(() => expect(apply).toHaveBeenCalledTimes(1));
+
+    act(() => progressListeners.forEach((listener) => listener({
+      stage: "install",
+      message: "Installing update",
+      percent: 50,
+    })));
+    await waitFor(() => expect(screen.getAllByText("Installing update 50%")).toHaveLength(2));
   });
 
   it("clears apply chrome when a terminal idle progress event arrives", async () => {

--- a/webapp/src/__tests__/UpdateBanner.test.tsx
+++ b/webapp/src/__tests__/UpdateBanner.test.tsx
@@ -6,6 +6,7 @@ type CheckResult = {
   available: boolean;
   downloaded: boolean;
   busy?: boolean;
+  error?: string;
   behind?: number;
   branch?: string;
   current?: string;
@@ -123,6 +124,46 @@ describe("UpdateBanner update checks", () => {
     expect(onAvailabilityChange).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves a latched update when check resolves a live IPC error", async () => {
+    let now = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const onAvailabilityChange = vi.fn();
+    const check = vi
+      .fn()
+      .mockResolvedValueOnce({
+        available: true,
+        downloaded: false,
+        behind: 2,
+        branch: "main",
+        current: "0.9.245",
+      })
+      .mockResolvedValueOnce({
+        available: false,
+        downloaded: false,
+        error: "fatal: unable to access 'https://github.com/professorpalmer/marionette.git/': Could not resolve host",
+      });
+    (window as any).harnessIPC.updates.check = check;
+
+    render(<UpdateBanner onAvailabilityChange={onAvailabilityChange} />);
+    expect(await screen.findByTestId("update-banner")).toBeInTheDocument();
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith({
+      behind: 2,
+      branch: "main",
+      version: "0.9.245",
+    });
+
+    now += 5 * 60 * 1000;
+    act(() => window.dispatchEvent(new Event("focus")));
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId("update-banner")).toBeInTheDocument();
+    expect(onAvailabilityChange).toHaveBeenCalledTimes(1);
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith({
+      behind: 2,
+      branch: "main",
+      version: "0.9.245",
+    });
+  });
+
   it("surfaces a runtime-stale note from the owner check", async () => {
     const note = "Puppetmaster must be updated before workers are ready.";
     const toast = vi.fn();
@@ -198,6 +239,33 @@ describe("UpdateBanner update checks", () => {
 
     act(() => {
       rejectCheck?.(new Error("network unavailable"));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("update-banner")).not.toBeInTheDocument();
+    });
+    expect(idleListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears checking progress when a resolved check carries an error", async () => {
+    render(<UpdateBanner />);
+
+    await waitFor(() => expect(progressListener).not.toBeNull());
+    act(() => {
+      progressListener?.({
+        stage: "check",
+        message: "Checking for app shell update",
+        percent: 0,
+      });
+    });
+    expect(screen.queryByTestId("update-banner")).not.toBeInTheDocument();
+
+    act(() => {
+      resolveCheck?.({
+        available: false,
+        downloaded: false,
+        error: "git fetch failed",
+      });
     });
 
     await waitFor(() => {
@@ -289,7 +357,7 @@ describe("UpdateBanner update checks", () => {
 
   it("revokes stale availability when apply confirms there is no update", async () => {
     const onAvailabilityChange = vi.fn();
-    const apply = vi.fn(async () => ({ ok: false, error: "no update available" }));
+    const apply = vi.fn(async () => ({ ok: false, code: "no_update", error: "no update available" }));
     (window as any).harnessIPC.updates.apply = apply;
     (window as any).harnessIPC.updates.onAvailable = vi.fn((listener: (res: CheckResult) => void) => {
       listener({
@@ -308,5 +376,44 @@ describe("UpdateBanner update checks", () => {
     await waitFor(() => expect(apply).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.queryByTestId("update-banner")).not.toBeInTheDocument());
     expect(onAvailabilityChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("preserves availability when apply-time check fails", async () => {
+    const onAvailabilityChange = vi.fn();
+    const toast = vi.fn();
+    window.addEventListener("harness-toast", toast);
+    const apply = vi.fn(async () => ({
+      ok: false,
+      code: "check_failed",
+      error: "fatal: unable to access 'https://github.com/professorpalmer/marionette.git/': Could not resolve host",
+    }));
+    (window as any).harnessIPC.updates.apply = apply;
+    (window as any).harnessIPC.updates.onAvailable = vi.fn((listener: (res: CheckResult) => void) => {
+      listener({
+        available: true,
+        downloaded: false,
+        behind: 1,
+        branch: "main",
+        current: "0.9.245",
+      });
+      return () => {};
+    });
+
+    render(<UpdateBanner onAvailabilityChange={onAvailabilityChange} />);
+    expect(await screen.findByTestId("update-banner")).toBeInTheDocument();
+    await act(async () => screen.getByRole("button", { name: /restart now/i }).click());
+
+    await waitFor(() => expect(apply).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("update-banner")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /restart now/i })).toBeInTheDocument();
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith({
+      behind: 1,
+      branch: "main",
+      version: "0.9.245",
+    });
+    expect(onAvailabilityChange).not.toHaveBeenCalledWith(null);
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    expect((toast.mock.calls[0][0] as CustomEvent).detail).toMatch(/Could not resolve host/);
+    window.removeEventListener("harness-toast", toast);
   });
 });

--- a/webapp/src/__tests__/UpdateBanner.test.tsx
+++ b/webapp/src/__tests__/UpdateBanner.test.tsx
@@ -6,6 +6,11 @@ type CheckResult = {
   available: boolean;
   downloaded: boolean;
   busy?: boolean;
+  behind?: number;
+  branch?: string;
+  current?: string;
+  runtimeStale?: boolean;
+  runtimeNote?: string;
 };
 
 type ProgressPayload = {
@@ -50,6 +55,90 @@ describe("UpdateBanner update checks", () => {
   afterEach(() => {
     window.removeEventListener("harness-update-idle", idleListener);
     delete (window as any).harnessIPC;
+    vi.restoreAllMocks();
+  });
+
+  it("revokes a latched update only after a definitive unavailable check", async () => {
+    let now = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const onAvailabilityChange = vi.fn();
+    const check = vi
+      .fn()
+      .mockResolvedValueOnce({
+        available: true,
+        downloaded: false,
+        behind: 2,
+        branch: "main",
+        current: "0.9.245",
+      })
+      .mockResolvedValueOnce({ available: false, downloaded: false });
+    (window as any).harnessIPC.updates.check = check;
+
+    render(<UpdateBanner onAvailabilityChange={onAvailabilityChange} />);
+
+    expect(await screen.findByTestId("update-banner")).toBeInTheDocument();
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith({
+      behind: 2,
+      branch: "main",
+      version: "0.9.245",
+    });
+
+    now += 5 * 60 * 1000;
+    act(() => window.dispatchEvent(new Event("focus")));
+
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByTestId("update-banner")).not.toBeInTheDocument());
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("preserves a latched update across busy and failed checks", async () => {
+    let now = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const onAvailabilityChange = vi.fn();
+    const check = vi
+      .fn()
+      .mockResolvedValueOnce({
+        available: true,
+        downloaded: false,
+        behind: 1,
+        branch: "main",
+        current: "0.9.245",
+      })
+      .mockResolvedValueOnce({ available: false, downloaded: false, busy: true })
+      .mockRejectedValueOnce(new Error("network unavailable"));
+    (window as any).harnessIPC.updates.check = check;
+
+    render(<UpdateBanner onAvailabilityChange={onAvailabilityChange} />);
+    expect(await screen.findByTestId("update-banner")).toBeInTheDocument();
+
+    now += 5 * 60 * 1000;
+    act(() => window.dispatchEvent(new Event("focus")));
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId("update-banner")).toBeInTheDocument();
+
+    now += 5 * 60 * 1000;
+    act(() => window.dispatchEvent(new Event("focus")));
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(3));
+    expect(screen.getByTestId("update-banner")).toBeInTheDocument();
+    expect(onAvailabilityChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a runtime-stale note from the owner check", async () => {
+    const note = "Puppetmaster must be updated before workers are ready.";
+    const toast = vi.fn();
+    window.addEventListener("harness-toast", toast);
+    (window as any).harnessIPC.updates.check = vi.fn().mockResolvedValue({
+      available: false,
+      downloaded: false,
+      runtimeStale: true,
+      runtimeNote: note,
+    });
+
+    render(<UpdateBanner />);
+
+    await waitFor(() => expect(toast).toHaveBeenCalledTimes(1));
+    expect((toast.mock.calls[0][0] as CustomEvent).detail).toBe(note);
+    window.removeEventListener("harness-toast", toast);
   });
 
   it("keeps checking progress invisible when no packaged update is available", async () => {
@@ -196,5 +285,28 @@ describe("UpdateBanner update checks", () => {
     });
     // Must not recover to a second Restart click while quitAndInstall runs.
     expect(screen.queryByRole("button", { name: /restart now/i })).not.toBeInTheDocument();
+  });
+
+  it("revokes stale availability when apply confirms there is no update", async () => {
+    const onAvailabilityChange = vi.fn();
+    const apply = vi.fn(async () => ({ ok: false, error: "no update available" }));
+    (window as any).harnessIPC.updates.apply = apply;
+    (window as any).harnessIPC.updates.onAvailable = vi.fn((listener: (res: CheckResult) => void) => {
+      listener({
+        available: true,
+        downloaded: false,
+        behind: 1,
+        branch: "main",
+        current: "0.9.245",
+      });
+      return () => {};
+    });
+
+    render(<UpdateBanner onAvailabilityChange={onAvailabilityChange} />);
+    await act(async () => screen.getByRole("button", { name: /restart now/i }).click());
+
+    await waitFor(() => expect(apply).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByTestId("update-banner")).not.toBeInTheDocument());
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith(null);
   });
 });

--- a/webapp/src/components/StatusBar.tsx
+++ b/webapp/src/components/StatusBar.tsx
@@ -32,6 +32,7 @@ import CostBreakdown, {
 } from "./CostBreakdown";
 import { sanitizeUpdateMessage } from "../lib/updateMessages";
 import { shortPilotModelLabel } from "../lib/turnProgress";
+import type { UpdateAvailability } from "./UpdateBanner";
 
 type FooterRuntimeStatus = "ready" | "thinking" | "busy";
 
@@ -78,8 +79,9 @@ function truncateGoalText(text: string, max = 36): string {
 // in LeftRail SESSION JOBS -- a footer total was stale across dir swaps and
 // disagreed with the scoped list, so it was removed. Narrow widths hide
 // secondary labels via container queries instead of overlapping the clusters.
-export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, onToggleRight }: {
+export default function StatusBar({ config, update, leftOpen, rightOpen, onToggleLeft, onToggleRight }: {
   config: Config | null;
+  update: UpdateAvailability | null;
   leftOpen: boolean; rightOpen: boolean;
   onToggleLeft: () => void; onToggleRight: () => void;
 }) {
@@ -87,7 +89,6 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
   const [usage, setUsage] = useState<UsageData["session"] | null>(null);
   const [costOpen, setCostOpen] = useState(false);
   const costRef = useRef<HTMLDivElement | null>(null);
-  const [update, setUpdate] = useState<{ behind: number; branch: string; version: string } | null>(null);
   const [apply, setApply] = useState<{ stage: string; message: string; percent: number | null } | null>(null);
   const [toast, setToast] = useState<{
     message: string;
@@ -97,8 +98,6 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
   const [sessionState, setSessionState] = useState<SessionState | null>(null);
   const [taskProfile, setTaskProfile] = useState<TaskProfileChip | null>(null);
   const [goalBusy, setGoalBusy] = useState(false);
-  // Dedup runtime-stale notes across the 5-minute focus throttle and 30-minute polls.
-  const lastRuntimeNoteRef = useRef<string | null>(null);
 
   const refreshSessionState = () =>
     api.getSessionState()
@@ -155,57 +154,6 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
 
   useEffect(() => subscribeTaskProfile(setTaskProfile), []);
 
-  // Self-update check: how far behind the tracked branch we are (desktop only).
-  // Silent on failure -- an update nudge must never get in the way. Re-checks
-  // every 30 minutes and on window focus (throttled) so a release that lands
-  // mid-session surfaces without a relaunch -- previously the pill only ever
-  // checked once on mount.
-  useEffect(() => {
-    const ipc = (window as any).harnessIPC;
-    if (!ipc || !ipc.updates) return;
-    let cancelled = false;
-    let lastCheck = 0;
-    const MIN_GAP_MS = 5 * 60 * 1000;
-    const check = (force = false) => {
-      const now = Date.now();
-      if (!force && now - lastCheck < MIN_GAP_MS) return;
-      lastCheck = now;
-      ipc.updates.check()
-        .then((res: any) => {
-          if (cancelled || !res) return;
-          // Informational only: a stale Puppetmaster runtime is not an actionable
-          // app update, but users deserve an honest one-line explanation once.
-          if (res.runtimeStale && res.runtimeNote && res.runtimeNote !== lastRuntimeNoteRef.current) {
-            lastRuntimeNoteRef.current = res.runtimeNote;
-            window.dispatchEvent(new CustomEvent("harness-toast", { detail: res.runtimeNote }));
-          }
-          if (res.available || res.downloaded) {
-            setUpdate({ behind: res.behind || 0, branch: res.branch || "main", version: res.current || "" });
-          }
-        })
-        .catch(() => {});
-    };
-    check(true);
-    const interval = window.setInterval(() => check(true), 30 * 60 * 1000);
-    const onFocus = () => check();
-    window.addEventListener("focus", onFocus);
-    // PUSH path: the main-process update watcher notifies the moment its
-    // background fetch sees new commits, so the pill appears without waiting
-    // for the next renderer poll tick.
-    const offAvailable = ipc.updates.onAvailable
-      ? ipc.updates.onAvailable((res: any) => {
-          if (!cancelled && res && (res.available || res.downloaded)) {
-            setUpdate({ behind: res.behind || 0, branch: res.branch || "main", version: res.current || "" });
-          }
-        })
-      : null;
-    return () => {
-      cancelled = true;
-      window.clearInterval(interval);
-      window.removeEventListener("focus", onFocus);
-      if (offAvailable) offAvailable();
-    };
-  }, []);
 
   // The UpdateBanner owns the single, robust apply() path (latching, error
   // recovery, watchdog, idempotent install). The pill just asks it to start and

--- a/webapp/src/components/UpdateBanner.tsx
+++ b/webapp/src/components/UpdateBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowUpCircle, RefreshCw, X } from "lucide-react";
 import { sanitizeUpdateMessage } from "../lib/updateMessages";
 import { TITLEBAR_TRAFFIC_PAD_PX } from "../lib/titlebarSafe";
@@ -14,7 +14,17 @@ import { TITLEBAR_TRAFFIC_PAD_PX } from "../lib/titlebarSafe";
 //
 // The pill stays as the always-present compact indicator; this banner is the
 // occasional "your update is ready, one click to finish" nudge.
-export default function UpdateBanner() {
+export type UpdateAvailability = {
+  behind: number;
+  branch: string;
+  version: string;
+};
+
+export default function UpdateBanner({
+  onAvailabilityChange,
+}: {
+  onAvailabilityChange?: (update: UpdateAvailability | null) => void;
+} = {}) {
   const [latest, setLatest] = useState<string>("");
   const [ready, setReady] = useState(false);
   const [applying, setApplying] = useState(false);
@@ -27,6 +37,20 @@ export default function UpdateBanner() {
   // Restart, so genuine post-commit install/relaunch stages still show progress.
   const readyRef = useRef(false);
   const committedRef = useRef(false);
+  const lastRuntimeNoteRef = useRef<string | null>(null);
+  const publishAvailability = useCallback((res: any) => {
+    onAvailabilityChange?.({
+      behind: res.behind || 0,
+      branch: res.branch || "main",
+      version: res.current || "",
+    });
+  }, [onAvailabilityChange]);
+  const revokeAvailability = useCallback(() => {
+    readyRef.current = false;
+    setReady(false);
+    setLatest("");
+    onAvailabilityChange?.(null);
+  }, [onAvailabilityChange]);
 
   useEffect(() => {
     const ipc = (window as any).harnessIPC;
@@ -69,6 +93,14 @@ export default function UpdateBanner() {
         .check()
         .then((res: any) => {
           if (cancelled || committedRef.current || res?.busy) return;
+          if (
+            res.runtimeStale &&
+            res.runtimeNote &&
+            res.runtimeNote !== lastRuntimeNoteRef.current
+          ) {
+            lastRuntimeNoteRef.current = res.runtimeNote;
+            window.dispatchEvent(new CustomEvent("harness-toast", { detail: res.runtimeNote }));
+          }
           if (res.available || res.downloaded) {
             // Only a real version string labels the banner. Source-run updates
             // track a branch tip, and falling back to the branch name rendered
@@ -76,10 +108,12 @@ export default function UpdateBanner() {
             setLatest(res.latest || "");
             readyRef.current = true;
             setReady(true);
+            publishAvailability(res);
           } else {
             // Packaged shell checks emit transient "Checking for app shell update"
             // progress; when the poll finishes with nothing to install, drop that
             // spinner so the banner (and StatusBar pill mirror) cannot stick at 0%.
+            revokeAvailability();
             clearCheckProgress();
           }
         })
@@ -102,6 +136,7 @@ export default function UpdateBanner() {
           setLatest(res.latest || "");
           readyRef.current = true;
           setReady(true);
+          publishAvailability(res);
         })
       : null;
 
@@ -164,7 +199,7 @@ export default function UpdateBanner() {
       if (off) off();
       if (offAvailable) offAvailable();
     };
-  }, []);
+  }, [publishAvailability, revokeAvailability]);
 
   const restart = (strategy?: "ff" | "stash") => {
     const ipc = (window as any).harnessIPC;
@@ -178,10 +213,13 @@ export default function UpdateBanner() {
     window.dispatchEvent(new Event("harness-update-committing"));
 
     // Recover the banner to an actionable state instead of stranding the user.
-    const recover = (msg: string) => {
+    const settleApply = () => {
       committedRef.current = false;
       setApplying(false);
       window.dispatchEvent(new Event("harness-update-idle")); // release the pill mirror too
+    };
+    const recover = (msg: string) => {
+      settleApply();
       window.dispatchEvent(new CustomEvent("harness-toast", { detail: msg }));
     };
 
@@ -196,10 +234,15 @@ export default function UpdateBanner() {
     ipc.updates
       .apply(strategy ? { strategy } : undefined)
       .then((r: any) => {
-        // apply() resolves { ok:false, error } when there's nothing to install
-        // (e.g. a stale banner) -- surface it instead of spinning.
+        // A stale positive can race the authoritative apply-time check. Clear
+        // both update surfaces silently when that check says nothing remains.
         if (r && r.ok === false) {
           window.clearTimeout(watchdog);
+          if (r.error === "no update available") {
+            revokeAvailability();
+            settleApply();
+            return;
+          }
           // A self-edited checkout collides with fast-forward. Offer the sane
           // recovery for each case instead of a dead-end error (Marionette
           // edits its own source, so this is a normal path, not an edge case).

--- a/webapp/src/components/UpdateBanner.tsx
+++ b/webapp/src/components/UpdateBanner.tsx
@@ -109,6 +109,12 @@ export default function UpdateBanner({
             readyRef.current = true;
             setReady(true);
             publishAvailability(res);
+          } else if (res.error) {
+            // Live updates.check() resolves git/network/remote failures as
+            // {available:false,error:...} instead of rejecting. A transient
+            // miss must not revoke a latched update; only an authoritative
+            // available:false without error does that.
+            clearCheckProgress();
           } else {
             // Packaged shell checks emit transient "Checking for app shell update"
             // progress; when the poll finishes with nothing to install, drop that
@@ -238,7 +244,7 @@ export default function UpdateBanner({
         // both update surfaces silently when that check says nothing remains.
         if (r && r.ok === false) {
           window.clearTimeout(watchdog);
-          if (r.error === "no update available") {
+          if (r.code === "no_update") {
             revokeAvailability();
             settleApply();
             return;


### PR DESCRIPTION
## Problem

Update availability is independently latched by both `UpdateBanner` and `StatusBar`. After the checkout becomes current, those surfaces can remain actionable; clicking them reaches the authoritative updater check and reports `Update failed: no update available` instead of clearing stale chrome.

## Change

- Make `UpdateBanner` the sole update-availability lifecycle owner.
- Project one `UpdateAvailability | null` value through `App` into `StatusBar`.
- Remove StatusBar's duplicate check, timer, focus listener, `onAvailable` subscription, and update state.
- Clear both banner and compact pill only after a successful authoritative `available: false` response.
- Preserve known availability during busy or failed/network checks.
- Silently clear stale availability when apply confirms `no update available`.
- Preserve compact-pill apply delegation and progress mirroring.

No backend or Electron behavior changes.

## Proof

- RED tests reproduced missing revoke/projection behavior before implementation.
- `NODE_ENV=test npx vitest run src/__tests__/UpdateBanner.test.tsx src/__tests__/StatusBar.test.tsx`
  - 45 passed
- `NODE_ENV=development npm run build`
  - passed
- Focused oxlint introduced no new warnings.
- Live mounted Electron round trip in a fully isolated physical checkout:
  - before: banner visible, `update (1)` pill visible, Restart button mounted
  - clicked real mounted Restart button
  - updater fast-forwarded and relaunched
  - after: banner absent, update pill absent, Restart button absent
  - fixture work HEAD equaled remote HEAD and worktree was clean

## Scope

Five existing renderer/test files; no new files. Production code deletes StatusBar's competing availability authority while retaining its compact presentation and apply-progress mirror.
