### PR TITLE
Keep visible worker spinners active when unfocused

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -232,17 +232,14 @@ export default function App() {
     checkSetupStatus();
   }, []);
 
-  // PERF: pause CSS animations when the app is backgrounded or the OS window is
-  // not focused. Toggles html.app-idle (see index.css) so the shared macOS GPU
-  // compositor goes idle instead of driving dozens of spinners/pulses at 60fps
-  // while you are in another window -- the cause of alt-tab/window-switch stutter
-  // during a long session with live swarms. blur/focus covers alt-tab (the window
-  // can stay "visible" but unfocused); visibilitychange covers minimize/hide.
+  // PERF: pause nonessential CSS motion while the app is backgrounded. Keep
+  // separate idle/hidden classes so visible worker activity can remain truthful
+  // when the window is merely unfocused, while hidden windows fully pause.
   useEffect(() => {
     const root = document.documentElement;
     const setIdle = () => {
-      const idle = document.hidden || !document.hasFocus();
-      root.classList.toggle("app-idle", idle);
+      root.classList.toggle("app-idle", document.hidden || !document.hasFocus());
+      root.classList.toggle("app-hidden", document.hidden);
     };
     setIdle();
     window.addEventListener("blur", setIdle);

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api, type Config } from "./lib/api";
+import { subscribeDocumentMotionPolicy } from "./lib/motionPolicy";
 import LeftRail from "./components/LeftRail";
 import Conversation from "./components/Conversation";
 import RightPane from "./components/RightPane";
@@ -235,22 +236,8 @@ export default function App() {
   // PERF: pause nonessential CSS motion while the app is backgrounded. Keep
   // separate idle/hidden classes so visible worker activity can remain truthful
   // when the window is merely unfocused, while hidden windows fully pause.
-  useEffect(() => {
-    const root = document.documentElement;
-    const setIdle = () => {
-      root.classList.toggle("app-idle", document.hidden || !document.hasFocus());
-      root.classList.toggle("app-hidden", document.hidden);
-    };
-    setIdle();
-    window.addEventListener("blur", setIdle);
-    window.addEventListener("focus", setIdle);
-    document.addEventListener("visibilitychange", setIdle);
-    return () => {
-      window.removeEventListener("blur", setIdle);
-      window.removeEventListener("focus", setIdle);
-      document.removeEventListener("visibilitychange", setIdle);
-    };
-  }, []);
+  // Unsubscribe clears both classes so App unmount cannot leave them on <html>.
+  useEffect(() => subscribeDocumentMotionPolicy(), []);
 
   // persist layout
   useEffect(() => { localStorage.setItem(LS.left, String(leftW)); }, [leftW]);

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -200,7 +200,7 @@ describe("SwarmPane model badge", () => {
     });
   });
 
-  it("keeps active worker motion semantic while the window is visibly unfocused", async () => {
+  it("marks only worker, job, and aggregate running indicators as semantic", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
         status: "running",
@@ -209,9 +209,38 @@ describe("SwarmPane model badge", () => {
     );
 
     const { container } = render(<SwarmPane />);
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    const job = screen.getByRole("button", { name: /Audit auth flow/ });
+    const aggregate = screen.getByText("1 running");
+
+    expect(worker.querySelector(".semantic-activity-spinner")).toBeTruthy();
+    expect(job.querySelector(".semantic-activity-spinner")).toBeTruthy();
+    expect(aggregate.querySelector(".semantic-activity-spinner")).toBeTruthy();
+    expect(container.querySelectorAll(".semantic-activity-spinner")).toHaveLength(3);
+
+    const headerPulse = screen.getByTitle("1 running");
+    expect(headerPulse).toHaveClass("animate-pulse");
+    expect(headerPulse).not.toHaveClass("semantic-activity-spinner");
+    for (const pulse of container.querySelectorAll(".animate-pulse")) {
+      expect(pulse).not.toHaveClass("semantic-activity-spinner");
+    }
+  });
+
+  it("does not mark finished-job chrome as semantic activity", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "complete",
+        tasks: [{ id: "task-1", status: "complete", adapter: "agentic", role: "Worker", instruction: "" }],
+      }),
+    );
+
+    const { container } = render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Audit auth flow"));
     await screen.findByRole("button", { name: /Worker/ });
 
-    expect(container.querySelectorAll(".semantic-activity-spinner").length).toBeGreaterThanOrEqual(3);
+    expect(container.querySelectorAll(".semantic-activity-spinner")).toHaveLength(0);
   });
 
   it("falls back to the adapter on the worker row when no routed model is present", async () => {

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -200,6 +200,20 @@ describe("SwarmPane model badge", () => {
     });
   });
 
+  it("keeps active worker motion semantic while the window is visibly unfocused", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        tasks: [{ id: "task-1", status: "running", adapter: "agentic", role: "Worker", instruction: "" }],
+      }),
+    );
+
+    const { container } = render(<SwarmPane />);
+    await screen.findByRole("button", { name: /Worker/ });
+
+    expect(container.querySelectorAll(".semantic-activity-spinner").length).toBeGreaterThanOrEqual(3);
+  });
+
   it("falls back to the adapter on the worker row when no routed model is present", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({

--- a/webapp/src/__tests__/motionPolicy.test.ts
+++ b/webapp/src/__tests__/motionPolicy.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import motionCss from "../index.css?raw";
+import {
+  APP_HIDDEN_CLASS,
+  APP_IDLE_CLASS,
+  applyMotionRootClasses,
+  clearMotionRootClasses,
+  motionRootClasses,
+  subscribeDocumentMotionPolicy,
+} from "../lib/motionPolicy";
+
+function mediaBlock(css: string, query: string): string {
+  const start = css.indexOf(`@media (${query})`);
+  expect(start).toBeGreaterThan(-1);
+  const open = css.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === "{") depth += 1;
+    else if (css[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return css.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unclosed @media (${query})`);
+}
+
+describe("motionRootClasses", () => {
+  it("leaves the root unmarked when the window is focused and visible", () => {
+    expect(motionRootClasses({ hidden: false, focused: true })).toEqual({
+      idle: false,
+      hidden: false,
+    });
+  });
+
+  it("marks idle-only when visible but unfocused so decorative motion can pause", () => {
+    expect(motionRootClasses({ hidden: false, focused: false })).toEqual({
+      idle: true,
+      hidden: false,
+    });
+  });
+
+  it("marks idle and hidden when minimized, even if the document still reports focus", () => {
+    expect(motionRootClasses({ hidden: true, focused: true })).toEqual({
+      idle: true,
+      hidden: true,
+    });
+    expect(motionRootClasses({ hidden: true, focused: false })).toEqual({
+      idle: true,
+      hidden: true,
+    });
+  });
+});
+
+describe("applyMotionRootClasses / clearMotionRootClasses", () => {
+  it("toggles and clears html classes without leaving residue", () => {
+    const root = document.createElement("div");
+    applyMotionRootClasses(root, { hidden: false, focused: false });
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(true);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+
+    applyMotionRootClasses(root, { hidden: true, focused: false });
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(true);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(true);
+
+    applyMotionRootClasses(root, { hidden: false, focused: true });
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(false);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+
+    applyMotionRootClasses(root, { hidden: true, focused: true });
+    clearMotionRootClasses(root);
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(false);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+  });
+});
+
+describe("subscribeDocumentMotionPolicy", () => {
+  const viewport = { hidden: false, focused: true };
+  let stop: (() => void) | undefined;
+
+  afterEach(() => {
+    stop?.();
+    stop = undefined;
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(document, "hidden");
+    document.documentElement.classList.remove(APP_IDLE_CLASS, APP_HIDDEN_CLASS);
+  });
+
+  function installViewport() {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      enumerable: true,
+      get: () => viewport.hidden,
+    });
+    vi.spyOn(document, "hasFocus").mockImplementation(() => viewport.focused);
+  }
+
+  it("applies blur vs hidden class policy and clears both on unsubscribe", () => {
+    viewport.hidden = false;
+    viewport.focused = true;
+    installViewport();
+    stop = subscribeDocumentMotionPolicy();
+    const root = document.documentElement;
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(false);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+
+    viewport.focused = false;
+    window.dispatchEvent(new Event("blur"));
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(true);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+
+    viewport.hidden = true;
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(true);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(true);
+
+    const unsub = stop;
+    stop = undefined;
+    unsub();
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(false);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+
+    window.dispatchEvent(new Event("blur"));
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(false);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+  });
+
+  it("adds and removes the same blur, focus, and visibility listeners", () => {
+    viewport.hidden = false;
+    viewport.focused = true;
+    installViewport();
+    const addWin = vi.spyOn(window, "addEventListener");
+    const remWin = vi.spyOn(window, "removeEventListener");
+    const addDoc = vi.spyOn(document, "addEventListener");
+    const remDoc = vi.spyOn(document, "removeEventListener");
+
+    stop = subscribeDocumentMotionPolicy();
+    const blur = addWin.mock.calls.find((call) => call[0] === "blur")?.[1];
+    const focus = addWin.mock.calls.find((call) => call[0] === "focus")?.[1];
+    const visibility = addDoc.mock.calls.find((call) => call[0] === "visibilitychange")?.[1];
+    expect(blur).toEqual(expect.any(Function));
+    expect(focus).toBe(blur);
+    expect(visibility).toBe(blur);
+
+    const unsub = stop;
+    stop = undefined;
+    unsub();
+    expect(remWin.mock.calls.some((call) => call[0] === "blur" && call[1] === blur)).toBe(true);
+    expect(remWin.mock.calls.some((call) => call[0] === "focus" && call[1] === focus)).toBe(true);
+    expect(remDoc.mock.calls.some((call) => call[0] === "visibilitychange" && call[1] === visibility)).toBe(true);
+  });
+});
+
+describe("index.css motion selector contract", () => {
+  it("pauses idle descendants, resumes only marked semantic spinners while visible, and keeps reduced-motion authoritative", () => {
+    const reduceAt = motionCss.indexOf("@media (prefers-reduced-motion: reduce)");
+    expect(reduceAt).toBeGreaterThan(-1);
+    const beforeReduce = motionCss.slice(0, reduceAt);
+
+    expect(beforeReduce).toMatch(
+      /html\.app-idle \*,\s*html\.app-idle \*::before,\s*html\.app-idle \*::after\s*\{[^}]*animation-play-state:\s*paused\s*!important/,
+    );
+    expect(beforeReduce).toMatch(
+      /html\.app-idle:not\(\.app-hidden\) \.semantic-activity-spinner\s*\{[^}]*animation-play-state:\s*running\s*!important/,
+    );
+    expect(beforeReduce.indexOf("html.app-idle *")).toBeLessThan(
+      beforeReduce.indexOf("html.app-idle:not(.app-hidden) .semantic-activity-spinner"),
+    );
+
+    const runningRules = [...beforeReduce.matchAll(/([^{]+)\{[^}]*animation-play-state:\s*running/g)];
+    expect(runningRules).toHaveLength(1);
+    expect(runningRules[0][1]).toContain(".semantic-activity-spinner");
+    expect(runningRules[0][1]).toContain(":not(.app-hidden)");
+    expect(runningRules[0][1]).not.toContain(".animate-pulse");
+    expect(runningRules[0][1]).not.toContain(".animate-spin");
+
+    const reduce = mediaBlock(motionCss, "prefers-reduced-motion: reduce");
+    expect(reduce).not.toContain("semantic-activity-spinner");
+    expect(reduce).not.toContain("animation-play-state");
+    expect(reduce).toMatch(/animation-duration:\s*0\.001ms\s*!important/);
+    expect(reduce).toMatch(/animation-iteration-count:\s*1\s*!important/);
+  });
+});

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -406,7 +406,7 @@ export function workerOutcome(task: Task, failureArt?: Artifact | null): WorkerO
 function WorkerOutcomeGlyph({ outcome }: { outcome: WorkerOutcome }) {
   switch (outcome) {
     case "running":
-      return <Loader2 size={10} className="animate-spin text-accent" />;
+      return <Loader2 size={10} className="animate-spin semantic-activity-spinner text-accent" />;
     case "ok":
       return <CheckCircle2 size={10} className="text-good" />;
     case "degraded":
@@ -1375,7 +1375,7 @@ export default function SwarmPane() {
               </span>
               <span className="shrink-0">
                 {st === "in_progress" ? (
-                  <Loader2 size={12} className="animate-spin text-accent" />
+                  <Loader2 size={12} className="animate-spin semantic-activity-spinner text-accent" />
                 ) : st === "failed" ? (
                   <XCircle size={12} className="text-risk" />
                 ) : outcomeWarning ? (
@@ -1876,7 +1876,7 @@ export default function SwarmPane() {
         <div className="flex items-center gap-2.5 text-[10px]">
           {anyRunning && (
             <span className="flex items-center gap-1 text-accent">
-              <Loader2 size={10} className="animate-spin" /> {runningCount} running
+              <Loader2 size={10} className="animate-spin semantic-activity-spinner" /> {runningCount} running
             </span>
           )}
           {completedCount > 0 && (

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -10,7 +10,8 @@ html, body, #root { height: 100%; margin: 0; }
    composer) keep the compositor pinned even after you alt-tab away -- which is
    exactly what makes window-switching stutter during a long session with live
    swarms. Semantic worker indicators are the narrow exception while the window
-   remains visible; a hidden/minimized window still pauses everything. */
+   remains visible; a hidden/minimized window still pauses everything.
+   prefers-reduced-motion below stays authoritative and has no semantic exception. */
 html.app-idle *,
 html.app-idle *::before,
 html.app-idle *::after {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -9,13 +9,16 @@ html, body, #root { height: 100%; margin: 0; }
    windows, so dozens of always-running spinners/pulses (swarm rows, status bar,
    composer) keep the compositor pinned even after you alt-tab away -- which is
    exactly what makes window-switching stutter during a long session with live
-   swarms. When hidden or blurred we set animation-play-state: paused so the
-   compositor goes idle and the window server gets its frames back. Visible/
-   focused restores everything with zero code changes at the call sites. */
+   swarms. Semantic worker indicators are the narrow exception while the window
+   remains visible; a hidden/minimized window still pauses everything. */
 html.app-idle *,
 html.app-idle *::before,
 html.app-idle *::after {
   animation-play-state: paused !important;
+}
+
+html.app-idle:not(.app-hidden) .semantic-activity-spinner {
+  animation-play-state: running !important;
 }
 
 /* Respect users who ask for less motion: kill the continuous spinners/pulses. */

--- a/webapp/src/lib/motionPolicy.ts
+++ b/webapp/src/lib/motionPolicy.ts
@@ -1,0 +1,55 @@
+/** Root classes that pause decorative CSS motion when the window is idle. */
+export const APP_IDLE_CLASS = "app-idle";
+export const APP_HIDDEN_CLASS = "app-hidden";
+
+export type MotionViewport = {
+  hidden: boolean;
+  focused: boolean;
+};
+
+export type MotionRootState = {
+  idle: boolean;
+  hidden: boolean;
+};
+
+/** Decorative motion pauses on blur; everything pauses when hidden/minimized. */
+export function motionRootClasses(viewport: MotionViewport): MotionRootState {
+  return {
+    idle: viewport.hidden || !viewport.focused,
+    hidden: viewport.hidden,
+  };
+}
+
+export function applyMotionRootClasses(
+  root: Pick<Element, "classList">,
+  viewport: MotionViewport,
+): void {
+  const next = motionRootClasses(viewport);
+  root.classList.toggle(APP_IDLE_CLASS, next.idle);
+  root.classList.toggle(APP_HIDDEN_CLASS, next.hidden);
+}
+
+export function clearMotionRootClasses(root: Pick<Element, "classList">): void {
+  root.classList.remove(APP_IDLE_CLASS, APP_HIDDEN_CLASS);
+}
+
+/** Bind html.app-idle / html.app-hidden; unsubscribe always clears both classes. */
+export function subscribeDocumentMotionPolicy(): () => void {
+  const root = document.documentElement;
+  const sync = () => {
+    applyMotionRootClasses(root, {
+      hidden: document.hidden,
+      focused: document.hasFocus(),
+    });
+  };
+  sync();
+  window.addEventListener("blur", sync);
+  window.addEventListener("focus", sync);
+  document.addEventListener("visibilitychange", sync);
+  return () => {
+    window.removeEventListener("blur", sync);
+    window.removeEventListener("focus", sync);
+    document.removeEventListener("visibilitychange", sync);
+    clearMotionRootClasses(root);
+  };
+}


### PR DESCRIPTION
## Problem

Marionette pauses every CSS animation whenever its window loses focus to reduce macOS compositor load. That also freezes semantic Swarm Tracker activity indicators while timers and real worker execution continue, making visible background workers look stuck.

## Change

- Preserve the broad `app-idle` motion pause for nonessential animation.
- Track hidden/minimized state separately from visible blur.
- Mark only active worker, active job, and aggregate-running spinners as semantic activity.
- Allow those indicators to continue while Marionette remains visible but unfocused.
- Fully pause them when the window is hidden or minimized.

No backend, worker lifecycle, polling, or timer behavior changes.

## Proof

- `NODE_ENV=test npx vitest run src/__tests__/SwarmPane.test.tsx`
  - 82 passed
- `NODE_ENV=development npm run build`
  - passed
- Focused oxlint introduced no new warnings.
- Mounted Electron computed-style proof:

```json
{
  "visibleBlurred": "running",
  "hidden": "paused",
  "focused": "running"
}
```

- Manual source-run verification confirmed worker spinners remain active when clicking into another app.

## Scope

Four existing files, zero new files. Decorative motion remains paused; only three truthful worker-activity surfaces are exempt while visible.
