### PR TITLE
Fall back to built renderer after dev-server relaunch

### DIFF
--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -34,12 +34,18 @@ const {
   decideBackendReuse,
   buildBackendMarkerPayload,
 } = require("./backend-identity.cjs");
+const {
+  createDevServerFallbackLatch,
+  shouldRetryFailedRendererLoad,
+  resolveClassicDevRendererSource,
+} = require("./renderer-fallback.cjs");
 
 // Must run before any git/npm/uv child spawns: on Windows the portable tools
 // installed by first-run bootstrap are only on PATH in-memory, per process.
 reinjectPortableTools();
 
 const isDev = !!process.env.PMHARNESS_DEV_SERVER;
+const configuredDevServerLatch = createDevServerFallbackLatch();
 const isPackaged = app.isPackaged;
 
 // Keep the renderer at full speed while the window is blurred or occluded
@@ -558,9 +564,21 @@ function cleanupVite() {
 
 // Point the window at the right renderer source: the classic dev server, the
 // self-dev Vite HMR server (live React), or the prebuilt dist/ bundle.
+// After a matching classic-dev fail-load, the process-local latch stays on
+// dist for this process (including later restartBackend reloads).
 async function loadRenderer() {
   if (!win) return;
-  if (isDev) { win.loadURL(process.env.PMHARNESS_DEV_SERVER); return; }
+  if (isDev) {
+    if (resolveClassicDevRendererSource({
+      configuredDevServerUrl: process.env.PMHARNESS_DEV_SERVER,
+      abandoned: configuredDevServerLatch.isAbandoned(),
+    }) === "dev") {
+      win.loadURL(process.env.PMHARNESS_DEV_SERVER);
+      return;
+    }
+    win.loadFile(resolveDistIndex());
+    return;
+  }
   if (shouldUseViteDev(resolveRepoRoot())) {
     const url = await ensureViteDevServer(resolveRepoRoot());
     if (url) { win.loadURL(url); return; }
@@ -1473,11 +1491,28 @@ function createWindow() {
   // Drop the reference when the window is closed so a reopen builds a clean one
   // (and a failed renderer load doesn't leave a half-dead window bound to `win`).
   win.on("closed", () => { win = null; });
-  // If the renderer fails to load (white screen / error), reload it once so a
-  // transient failure on reopen self-heals instead of stranding the user.
+  // If the renderer fails to load (white screen / error), reload it so a
+  // transient failure on reopen self-heals. A matching classic-dev origin
+  // failure latches onto dist instead of retrying the dead Vite URL forever.
   win.webContents.on("did-fail-load", (_e, errorCode, errorDesc, validatedURL, isMainFrame) => {
     if (isMainFrame && errorCode !== -3) {  // -3 = aborted (navigation), ignore
       _dbg2(`renderer did-fail-load ${errorCode} ${errorDesc} ${validatedURL}`);
+    }
+    const details = {
+      isMainFrame,
+      errorCode,
+      validatedURL,
+      configuredDevServerUrl: process.env.PMHARNESS_DEV_SERVER,
+    };
+    if (configuredDevServerLatch.noteFailure(details)) {
+      _dbg2(`renderer abandoning dead dev server; falling back to dist`);
+      try { if (win) loadRenderer(); } catch {}
+      return;
+    }
+    if (shouldRetryFailedRendererLoad({
+      ...details,
+      abandoned: configuredDevServerLatch.isAbandoned(),
+    })) {
       setTimeout(() => {
         try { if (win) loadRenderer(); } catch {}
       }, 500);

--- a/webapp/electron/renderer-fallback.cjs
+++ b/webapp/electron/renderer-fallback.cjs
@@ -1,0 +1,121 @@
+"use strict";
+
+/**
+ * Pure helpers for classic electron:dev renderer-load fallback.
+ *
+ * Classic `electron:dev` sets PMHARNESS_DEV_SERVER. Update & Relaunch re-execs
+ * Electron after the old Vite owner exits, but the new process still has that
+ * URL. A process-local latch abandons the configured origin after the first
+ * non-aborted main-frame failure matching it; loadRenderer then uses dist and
+ * never returns to the dead URL (including later restartBackend reloads).
+ *
+ * Does not flip isDev, delete env, start Vite, or change relaunch.
+ */
+
+/** Chromium ERR_ABORTED — navigation superseded; never treat as a dead origin. */
+const ERR_ABORTED = -3;
+
+/**
+ * Scheme + host + port for comparison. Trailing slashes and paths collapse to
+ * the same origin; another port or scheme does not. Invalid/empty → null.
+ */
+function normalizeRendererOrigin(url) {
+  if (typeof url !== "string") return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return null;
+  }
+}
+
+function configuredDevOriginMatches(configuredUrl, validatedUrl) {
+  const configured = normalizeRendererOrigin(configuredUrl);
+  const validated = normalizeRendererOrigin(validatedUrl);
+  if (!configured || !validated) return false;
+  return configured === validated;
+}
+
+/**
+ * True when this did-fail-load should abandon the configured classic-dev URL.
+ * Subframes, aborted navigations (-3), empty/invalid configured URLs, and
+ * mismatched origins (other port/scheme/host) must not latch.
+ */
+function shouldAbandonConfiguredDevServer({
+  isMainFrame,
+  errorCode,
+  validatedURL,
+  configuredDevServerUrl,
+} = {}) {
+  if (isMainFrame !== true) return false;
+  if (errorCode === ERR_ABORTED) return false;
+  return configuredDevOriginMatches(configuredDevServerUrl, validatedURL);
+}
+
+/**
+ * Existing 500 ms retry applies only to non-aborted main-frame failures while
+ * the latch is unset. After abandonment, do not start a dist retry loop. A
+ * matching configured-origin failure also must not retry the dead URL.
+ */
+function shouldRetryFailedRendererLoad({
+  isMainFrame,
+  errorCode,
+  abandoned,
+  validatedURL,
+  configuredDevServerUrl,
+} = {}) {
+  if (isMainFrame !== true) return false;
+  if (errorCode === ERR_ABORTED) return false;
+  if (abandoned === true) return false;
+  if (shouldAbandonConfiguredDevServer({
+    isMainFrame,
+    errorCode,
+    validatedURL,
+    configuredDevServerUrl,
+  })) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Classic-dev source selection. Before the latch, use the configured Vite URL;
+ * after it (or when no URL is configured), use resolveDistIndex().
+ */
+function resolveClassicDevRendererSource({
+  configuredDevServerUrl,
+  abandoned,
+} = {}) {
+  if (abandoned) return "dist";
+  if (typeof configuredDevServerUrl === "string" && configuredDevServerUrl.trim()) {
+    return "dev";
+  }
+  return "dist";
+}
+
+/** Process-local latch: first matching abandon sticks for the life of this process. */
+function createDevServerFallbackLatch() {
+  let abandoned = false;
+  return {
+    isAbandoned() {
+      return abandoned;
+    },
+    noteFailure(details) {
+      if (abandoned) return false;
+      if (!shouldAbandonConfiguredDevServer(details)) return false;
+      abandoned = true;
+      return true;
+    },
+  };
+}
+
+module.exports = {
+  ERR_ABORTED,
+  normalizeRendererOrigin,
+  configuredDevOriginMatches,
+  shouldAbandonConfiguredDevServer,
+  shouldRetryFailedRendererLoad,
+  resolveClassicDevRendererSource,
+  createDevServerFallbackLatch,
+};

--- a/webapp/electron/renderer-fallback.test.cjs
+++ b/webapp/electron/renderer-fallback.test.cjs
@@ -1,0 +1,142 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  normalizeRendererOrigin,
+  configuredDevOriginMatches,
+  shouldAbandonConfiguredDevServer,
+  shouldRetryFailedRendererLoad,
+  resolveClassicDevRendererSource,
+  createDevServerFallbackLatch,
+} = require("./renderer-fallback.cjs");
+
+const DEV = "http://127.0.0.1:5273";
+
+function fail(overrides) {
+  return {
+    isMainFrame: true,
+    errorCode: -102,
+    validatedURL: "http://127.0.0.1:5273/",
+    configuredDevServerUrl: DEV,
+    ...overrides,
+  };
+}
+
+test("matching -102 main frame abandons", () => {
+  assert.equal(shouldAbandonConfiguredDevServer(fail()), true);
+  assert.equal(
+    shouldRetryFailedRendererLoad({ ...fail(), abandoned: false }),
+    false,
+  );
+});
+
+test("trailing slash and path normalize to the configured origin", () => {
+  assert.equal(normalizeRendererOrigin(DEV), "http://127.0.0.1:5273");
+  assert.equal(normalizeRendererOrigin("http://127.0.0.1:5273/"), "http://127.0.0.1:5273");
+  assert.equal(configuredDevOriginMatches(DEV, "http://127.0.0.1:5273/"), true);
+  assert.equal(configuredDevOriginMatches(DEV, "http://127.0.0.1:5273/index.html"), true);
+  assert.equal(configuredDevOriginMatches(`${DEV}/`, "http://127.0.0.1:5273/foo/bar"), true);
+  assert.equal(
+    shouldAbandonConfiguredDevServer(fail({ validatedURL: "http://127.0.0.1:5273/app/" })),
+    true,
+  );
+});
+
+test("subframe and aborted -3 failures are ignored", () => {
+  assert.equal(shouldAbandonConfiguredDevServer(fail({ isMainFrame: false })), false);
+  assert.equal(shouldAbandonConfiguredDevServer(fail({ errorCode: -3 })), false);
+  assert.equal(
+    shouldRetryFailedRendererLoad({ ...fail({ isMainFrame: false }), abandoned: false }),
+    false,
+  );
+  assert.equal(
+    shouldRetryFailedRendererLoad({ ...fail({ errorCode: -3 }), abandoned: false }),
+    false,
+  );
+});
+
+test("other port, scheme, unrelated, or invalid URL does not abandon", () => {
+  assert.equal(
+    shouldAbandonConfiguredDevServer(fail({ validatedURL: "http://127.0.0.1:5274/" })),
+    false,
+  );
+  assert.equal(
+    shouldAbandonConfiguredDevServer(fail({ validatedURL: "https://127.0.0.1:5273/" })),
+    false,
+  );
+  assert.equal(
+    shouldAbandonConfiguredDevServer(fail({ validatedURL: "http://example.com/" })),
+    false,
+  );
+  assert.equal(
+    shouldAbandonConfiguredDevServer(fail({ validatedURL: "not a url" })),
+    false,
+  );
+  assert.equal(configuredDevOriginMatches(DEV, "http://127.0.0.1:5274"), false);
+  assert.equal(configuredDevOriginMatches(DEV, "https://127.0.0.1:5273"), false);
+});
+
+test("empty configured URL is not abandoned", () => {
+  assert.equal(shouldAbandonConfiguredDevServer(fail({ configuredDevServerUrl: "" })), false);
+  assert.equal(shouldAbandonConfiguredDevServer(fail({ configuredDevServerUrl: "   " })), false);
+  assert.equal(shouldAbandonConfiguredDevServer(fail({ configuredDevServerUrl: undefined })), false);
+  assert.equal(normalizeRendererOrigin(""), null);
+});
+
+test("renderer source chooses dev before latch and dist after latch", () => {
+  assert.equal(
+    resolveClassicDevRendererSource({ configuredDevServerUrl: DEV, abandoned: false }),
+    "dev",
+  );
+  assert.equal(
+    resolveClassicDevRendererSource({ configuredDevServerUrl: DEV, abandoned: true }),
+    "dist",
+  );
+  assert.equal(
+    resolveClassicDevRendererSource({ configuredDevServerUrl: "", abandoned: false }),
+    "dist",
+  );
+});
+
+test("unrelated main-frame failures still retry while the latch is unset", () => {
+  assert.equal(
+    shouldRetryFailedRendererLoad({
+      ...fail({ validatedURL: "http://127.0.0.1:9/" }),
+      abandoned: false,
+    }),
+    true,
+  );
+});
+
+test("latch remains sticky and does not retry dist after abandonment", () => {
+  const latch = createDevServerFallbackLatch();
+  assert.equal(latch.isAbandoned(), false);
+  assert.equal(latch.noteFailure(fail()), true);
+  assert.equal(latch.isAbandoned(), true);
+  assert.equal(
+    latch.noteFailure(fail({
+      errorCode: -6,
+      validatedURL: "file:///tmp/webapp/dist/index.html",
+    })),
+    false,
+  );
+  assert.equal(latch.isAbandoned(), true);
+  assert.equal(
+    resolveClassicDevRendererSource({
+      configuredDevServerUrl: DEV,
+      abandoned: latch.isAbandoned(),
+    }),
+    "dist",
+  );
+  assert.equal(
+    shouldRetryFailedRendererLoad({
+      isMainFrame: true,
+      errorCode: -6,
+      abandoned: true,
+      validatedURL: "file:///tmp/webapp/dist/index.html",
+      configuredDevServerUrl: DEV,
+    }),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- latch a failed classic-dev renderer origin after Update & Relaunch
- fall back to the freshly built `dist` renderer without changing dev/relaunch ownership
- cover origin matching, abort/subframe exclusions, sticky fallback, and retry policy

Closes #56.

## Test plan
- [x] `node --test electron/renderer-fallback.test.cjs electron/packaged-updater.test.cjs electron/update.test.cjs`
- [x] `NODE_ENV=development npm run build`
- [ ] full repository suite after collective integration