### PR TITLE
Release v0.9.246

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.7` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.245, deliberately pre-1.0. Compact residual factory default is catalog (extractive handle index plus a selected story, with vault retrieve). After compact, the transcript shows last-wins kept/dropped plus handle chips; overlapping asks cite vault hits as from compacted history. Summary and hybrid stay Settings opt-ins. Rides puppetmaster-ai==1.22.7.
+> Status: v0.9.246, deliberately pre-1.0. Update availability now has one authoritative renderer owner, visible background workers keep truthful activity motion, and source relaunches fall back from a dead Vite URL to the built renderer. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins. Rides puppetmaster-ai==1.22.7.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Start here, then follow the map:
 | [DEMO.md](DEMO.md) | A guided walkthrough of the harness in action. |
 | [FINDINGS.md](FINDINGS.md) | Research-rig findings: which models can drive the harness. |
 | [NOTICE.md](NOTICE.md) | Third-party attributions. |
-| [Catalog, Not Summary](https://professorpalmer.github.io/catalog-residual/) | Compaction residual lab and paper (separate repo). |
+| [Extractive Residuals After Compaction](https://professorpalmer.github.io/catalog-residual/) | Compaction residual lab and paper (separate repo). |
 | [docs/discord-mcp.md](docs/discord-mcp.md) | Optional recipe: wire a MIT Discord MCP (Docker + `manage_mcp`), not a first-party Discord product. |
 | [docs/LEGACY_FRONTEND.md](docs/LEGACY_FRONTEND.md) | Historical frontend notes (not the shipping Electron UI). |
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.245"
+__version__ = "0.9.246"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.245"
+version = "0.9.246"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -34,12 +34,18 @@ const {
   decideBackendReuse,
   buildBackendMarkerPayload,
 } = require("./backend-identity.cjs");
+const {
+  createDevServerFallbackLatch,
+  shouldRetryFailedRendererLoad,
+  resolveClassicDevRendererSource,
+} = require("./renderer-fallback.cjs");
 
 // Must run before any git/npm/uv child spawns: on Windows the portable tools
 // installed by first-run bootstrap are only on PATH in-memory, per process.
 reinjectPortableTools();
 
 const isDev = !!process.env.PMHARNESS_DEV_SERVER;
+const configuredDevServerLatch = createDevServerFallbackLatch();
 const isPackaged = app.isPackaged;
 
 // Keep the renderer at full speed while the window is blurred or occluded
@@ -558,9 +564,21 @@ function cleanupVite() {
 
 // Point the window at the right renderer source: the classic dev server, the
 // self-dev Vite HMR server (live React), or the prebuilt dist/ bundle.
+// After a matching classic-dev fail-load, the process-local latch stays on
+// dist for this process (including later restartBackend reloads).
 async function loadRenderer() {
   if (!win) return;
-  if (isDev) { win.loadURL(process.env.PMHARNESS_DEV_SERVER); return; }
+  if (isDev) {
+    if (resolveClassicDevRendererSource({
+      configuredDevServerUrl: process.env.PMHARNESS_DEV_SERVER,
+      abandoned: configuredDevServerLatch.isAbandoned(),
+    }) === "dev") {
+      win.loadURL(process.env.PMHARNESS_DEV_SERVER);
+      return;
+    }
+    win.loadFile(resolveDistIndex());
+    return;
+  }
   if (shouldUseViteDev(resolveRepoRoot())) {
     const url = await ensureViteDevServer(resolveRepoRoot());
     if (url) { win.loadURL(url); return; }
@@ -1473,11 +1491,28 @@ function createWindow() {
   // Drop the reference when the window is closed so a reopen builds a clean one
   // (and a failed renderer load doesn't leave a half-dead window bound to `win`).
   win.on("closed", () => { win = null; });
-  // If the renderer fails to load (white screen / error), reload it once so a
-  // transient failure on reopen self-heals instead of stranding the user.
+  // If the renderer fails to load (white screen / error), reload it so a
+  // transient failure on reopen self-heals. A matching classic-dev origin
+  // failure latches onto dist instead of retrying the dead Vite URL forever.
   win.webContents.on("did-fail-load", (_e, errorCode, errorDesc, validatedURL, isMainFrame) => {
     if (isMainFrame && errorCode !== -3) {  // -3 = aborted (navigation), ignore
       _dbg2(`renderer did-fail-load ${errorCode} ${errorDesc} ${validatedURL}`);
+    }
+    const details = {
+      isMainFrame,
+      errorCode,
+      validatedURL,
+      configuredDevServerUrl: process.env.PMHARNESS_DEV_SERVER,
+    };
+    if (configuredDevServerLatch.noteFailure(details)) {
+      _dbg2(`renderer abandoning dead dev server; falling back to dist`);
+      try { if (win) loadRenderer(); } catch {}
+      return;
+    }
+    if (shouldRetryFailedRendererLoad({
+      ...details,
+      abandoned: configuredDevServerLatch.isAbandoned(),
+    })) {
       setTimeout(() => {
         try { if (win) loadRenderer(); } catch {}
       }, 500);

--- a/webapp/electron/renderer-fallback.cjs
+++ b/webapp/electron/renderer-fallback.cjs
@@ -1,0 +1,121 @@
+"use strict";
+
+/**
+ * Pure helpers for classic electron:dev renderer-load fallback.
+ *
+ * Classic `electron:dev` sets PMHARNESS_DEV_SERVER. Update & Relaunch re-execs
+ * Electron after the old Vite owner exits, but the new process still has that
+ * URL. A process-local latch abandons the configured origin after the first
+ * non-aborted main-frame failure matching it; loadRenderer then uses dist and
+ * never returns to the dead URL (including later restartBackend reloads).
+ *
+ * Does not flip isDev, delete env, start Vite, or change relaunch.
+ */
+
+/** Chromium ERR_ABORTED — navigation superseded; never treat as a dead origin. */
+const ERR_ABORTED = -3;
+
+/**
+ * Scheme + host + port for comparison. Trailing slashes and paths collapse to
+ * the same origin; another port or scheme does not. Invalid/empty → null.
+ */
+function normalizeRendererOrigin(url) {
+  if (typeof url !== "string") return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return null;
+  }
+}
+
+function configuredDevOriginMatches(configuredUrl, validatedUrl) {
+  const configured = normalizeRendererOrigin(configuredUrl);
+  const validated = normalizeRendererOrigin(validatedUrl);
+  if (!configured || !validated) return false;
+  return configured === validated;
+}
+
+/**
+ * True when this did-fail-load should abandon the configured classic-dev URL.
+ * Subframes, aborted navigations (-3), empty/invalid configured URLs, and
+ * mismatched origins (other port/scheme/host) must not latch.
+ */
+function shouldAbandonConfiguredDevServer({
+  isMainFrame,
+  errorCode,
+  validatedURL,
+  configuredDevServerUrl,
+} = {}) {
+  if (isMainFrame !== true) return false;
+  if (errorCode === ERR_ABORTED) return false;
+  return configuredDevOriginMatches(configuredDevServerUrl, validatedURL);
+}
+
+/**
+ * Existing 500 ms retry applies only to non-aborted main-frame failures while
+ * the latch is unset. After abandonment, do not start a dist retry loop. A
+ * matching configured-origin failure also must not retry the dead URL.
+ */
+function shouldRetryFailedRendererLoad({
+  isMainFrame,
+  errorCode,
+  abandoned,
+  validatedURL,
+  configuredDevServerUrl,
+} = {}) {
+  if (isMainFrame !== true) return false;
+  if (errorCode === ERR_ABORTED) return false;
+  if (abandoned === true) return false;
+  if (shouldAbandonConfiguredDevServer({
+    isMainFrame,
+    errorCode,
+    validatedURL,
+    configuredDevServerUrl,
+  })) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Classic-dev source selection. Before the latch, use the configured Vite URL;
+ * after it (or when no URL is configured), use resolveDistIndex().
+ */
+function resolveClassicDevRendererSource({
+  configuredDevServerUrl,
+  abandoned,
+} = {}) {
+  if (abandoned) return "dist";
+  if (typeof configuredDevServerUrl === "string" && configuredDevServerUrl.trim()) {
+    return "dev";
+  }
+  return "dist";
+}
+
+/** Process-local latch: first matching abandon sticks for the life of this process. */
+function createDevServerFallbackLatch() {
+  let abandoned = false;
+  return {
+    isAbandoned() {
+      return abandoned;
+    },
+    noteFailure(details) {
+      if (abandoned) return false;
+      if (!shouldAbandonConfiguredDevServer(details)) return false;
+      abandoned = true;
+      return true;
+    },
+  };
+}
+
+module.exports = {
+  ERR_ABORTED,
+  normalizeRendererOrigin,
+  configuredDevOriginMatches,
+  shouldAbandonConfiguredDevServer,
+  shouldRetryFailedRendererLoad,
+  resolveClassicDevRendererSource,
+  createDevServerFallbackLatch,
+};

--- a/webapp/electron/renderer-fallback.test.cjs
+++ b/webapp/electron/renderer-fallback.test.cjs
@@ -1,0 +1,142 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  normalizeRendererOrigin,
+  configuredDevOriginMatches,
+  shouldAbandonConfiguredDevServer,
+  shouldRetryFailedRendererLoad,
+  resolveClassicDevRendererSource,
+  createDevServerFallbackLatch,
+} = require("./renderer-fallback.cjs");
+
+const DEV = "http://127.0.0.1:5273";
+
+function fail(overrides) {
+  return {
+    isMainFrame: true,
+    errorCode: -102,
+    validatedURL: "http://127.0.0.1:5273/",
+    configuredDevServerUrl: DEV,
+    ...overrides,
+  };
+}
+
+test("matching -102 main frame abandons", () => {
+  assert.equal(shouldAbandonConfiguredDevServer(fail()), true);
+  assert.equal(
+    shouldRetryFailedRendererLoad({ ...fail(), abandoned: false }),
+    false,
+  );
+});
+
+test("trailing slash and path normalize to the configured origin", () => {
+  assert.equal(normalizeRendererOrigin(DEV), "http://127.0.0.1:5273");
+  assert.equal(normalizeRendererOrigin("http://127.0.0.1:5273/"), "http://127.0.0.1:5273");
+  assert.equal(configuredDevOriginMatches(DEV, "http://127.0.0.1:5273/"), true);
+  assert.equal(configuredDevOriginMatches(DEV, "http://127.0.0.1:5273/index.html"), true);
+  assert.equal(configuredDevOriginMatches(`${DEV}/`, "http://127.0.0.1:5273/foo/bar"), true);
+  assert.equal(
+    shouldAbandonConfiguredDevServer(fail({ validatedURL: "http://127.0.0.1:5273/app/" })),
+    true,
+  );
+});
+
+test("subframe and aborted -3 failures are ignored", () => {
+  assert.equal(shouldAbandonConfiguredDevServer(fail({ isMainFrame: false })), false);
+  assert.equal(shouldAbandonConfiguredDevServer(fail({ errorCode: -3 })), false);
+  assert.equal(
+    shouldRetryFailedRendererLoad({ ...fail({ isMainFrame: false }), abandoned: false }),
+    false,
+  );
+  assert.equal(
+    shouldRetryFailedRendererLoad({ ...fail({ errorCode: -3 }), abandoned: false }),
+    false,
+  );
+});
+
+test("other port, scheme, unrelated, or invalid URL does not abandon", () => {
+  assert.equal(
+    shouldAbandonConfiguredDevServer(fail({ validatedURL: "http://127.0.0.1:5274/" })),
+    false,
+  );
+  assert.equal(
+    shouldAbandonConfiguredDevServer(fail({ validatedURL: "https://127.0.0.1:5273/" })),
+    false,
+  );
+  assert.equal(
+    shouldAbandonConfiguredDevServer(fail({ validatedURL: "http://example.com/" })),
+    false,
+  );
+  assert.equal(
+    shouldAbandonConfiguredDevServer(fail({ validatedURL: "not a url" })),
+    false,
+  );
+  assert.equal(configuredDevOriginMatches(DEV, "http://127.0.0.1:5274"), false);
+  assert.equal(configuredDevOriginMatches(DEV, "https://127.0.0.1:5273"), false);
+});
+
+test("empty configured URL is not abandoned", () => {
+  assert.equal(shouldAbandonConfiguredDevServer(fail({ configuredDevServerUrl: "" })), false);
+  assert.equal(shouldAbandonConfiguredDevServer(fail({ configuredDevServerUrl: "   " })), false);
+  assert.equal(shouldAbandonConfiguredDevServer(fail({ configuredDevServerUrl: undefined })), false);
+  assert.equal(normalizeRendererOrigin(""), null);
+});
+
+test("renderer source chooses dev before latch and dist after latch", () => {
+  assert.equal(
+    resolveClassicDevRendererSource({ configuredDevServerUrl: DEV, abandoned: false }),
+    "dev",
+  );
+  assert.equal(
+    resolveClassicDevRendererSource({ configuredDevServerUrl: DEV, abandoned: true }),
+    "dist",
+  );
+  assert.equal(
+    resolveClassicDevRendererSource({ configuredDevServerUrl: "", abandoned: false }),
+    "dist",
+  );
+});
+
+test("unrelated main-frame failures still retry while the latch is unset", () => {
+  assert.equal(
+    shouldRetryFailedRendererLoad({
+      ...fail({ validatedURL: "http://127.0.0.1:9/" }),
+      abandoned: false,
+    }),
+    true,
+  );
+});
+
+test("latch remains sticky and does not retry dist after abandonment", () => {
+  const latch = createDevServerFallbackLatch();
+  assert.equal(latch.isAbandoned(), false);
+  assert.equal(latch.noteFailure(fail()), true);
+  assert.equal(latch.isAbandoned(), true);
+  assert.equal(
+    latch.noteFailure(fail({
+      errorCode: -6,
+      validatedURL: "file:///tmp/webapp/dist/index.html",
+    })),
+    false,
+  );
+  assert.equal(latch.isAbandoned(), true);
+  assert.equal(
+    resolveClassicDevRendererSource({
+      configuredDevServerUrl: DEV,
+      abandoned: latch.isAbandoned(),
+    }),
+    "dist",
+  );
+  assert.equal(
+    shouldRetryFailedRendererLoad({
+      isMainFrame: true,
+      errorCode: -6,
+      abandoned: true,
+      validatedURL: "file:///tmp/webapp/dist/index.html",
+      configuredDevServerUrl: DEV,
+    }),
+    false,
+  );
+});

--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -638,6 +638,18 @@ async function applyUpdate({ repoRoot, branch = DEFAULT_BRANCH, strategy = "ff",
   }
 }
 
+/** Result when apply has nothing to run: authoritative idle vs failed check. */
+function emptyApplyPlanResult({ gitResult = {}, packagedResult = null } = {}) {
+  const checkError =
+    (gitResult && gitResult.error) ||
+    (packagedResult && packagedResult.error) ||
+    "";
+  if (checkError) {
+    return { ok: false, code: "check_failed", error: checkError };
+  }
+  return { ok: false, code: "no_update", error: "no update available" };
+}
+
 // Register IPC. `opts.getRepoRoot()` returns the checkout path; `opts.relaunch()`
 // tears down the backend and re-execs the app. Packaged installs also get
 // `opts.packagedUpdater` (electron-updater) so shell skew is resolved via a
@@ -876,7 +888,7 @@ function registerUpdateBridge(ipcMain, app, shell, opts = {}) {
         return sourceResult;
       }
 
-      return { ok: false, error: "no update available" };
+      return emptyApplyPlanResult({ gitResult: gitRes, packagedResult: packagedRes });
     } finally {
       applying = false;
     }
@@ -908,5 +920,6 @@ module.exports = {
   isElectronMainProcessFile,
   updateChangesElectronMain,
   describeMainProcessUpdate,
+  emptyApplyPlanResult,
   resolvePuppetmasterPin,
 };

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -420,3 +420,30 @@ test("describeMainProcessUpdate: no shell change means nothing extra to require"
   assert.equal(verdict.installerUpdateRequired, false);
   assert.equal(verdict.note, undefined);
 });
+
+test("emptyApplyPlanResult: authoritative no-update is a no_update code", () => {
+  const result = bridge.emptyApplyPlanResult({
+    gitResult: { available: false, behind: 0 },
+    packagedResult: { available: false },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "no_update");
+  assert.equal(result.error, "no update available");
+});
+
+test("emptyApplyPlanResult: a failed apply-time check is check_failed", () => {
+  const gitFail = bridge.emptyApplyPlanResult({
+    gitResult: { available: false, error: "git fetch failed" },
+    packagedResult: { available: false },
+  });
+  assert.equal(gitFail.ok, false);
+  assert.equal(gitFail.code, "check_failed");
+  assert.equal(gitFail.error, "git fetch failed");
+
+  const packagedFail = bridge.emptyApplyPlanResult({
+    gitResult: { available: false, behind: 0 },
+    packagedResult: { available: false, error: "electron-updater unavailable" },
+  });
+  assert.equal(packagedFail.code, "check_failed");
+  assert.equal(packagedFail.error, "electron-updater unavailable");
+});

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.245",
+  "version": "0.9.246",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.245",
+      "version": "0.9.246",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.245",
+  "version": "0.9.246",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -232,17 +232,14 @@ export default function App() {
     checkSetupStatus();
   }, []);
 
-  // PERF: pause CSS animations when the app is backgrounded or the OS window is
-  // not focused. Toggles html.app-idle (see index.css) so the shared macOS GPU
-  // compositor goes idle instead of driving dozens of spinners/pulses at 60fps
-  // while you are in another window -- the cause of alt-tab/window-switch stutter
-  // during a long session with live swarms. blur/focus covers alt-tab (the window
-  // can stay "visible" but unfocused); visibilitychange covers minimize/hide.
+  // PERF: pause nonessential CSS motion while the app is backgrounded. Keep
+  // separate idle/hidden classes so visible worker activity can remain truthful
+  // when the window is merely unfocused, while hidden windows fully pause.
   useEffect(() => {
     const root = document.documentElement;
     const setIdle = () => {
-      const idle = document.hidden || !document.hasFocus();
-      root.classList.toggle("app-idle", idle);
+      root.classList.toggle("app-idle", document.hidden || !document.hasFocus());
+      root.classList.toggle("app-hidden", document.hidden);
     };
     setIdle();
     window.addEventListener("blur", setIdle);

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api, type Config } from "./lib/api";
+import { subscribeDocumentMotionPolicy } from "./lib/motionPolicy";
 import LeftRail from "./components/LeftRail";
 import Conversation from "./components/Conversation";
 import RightPane from "./components/RightPane";
@@ -235,22 +236,8 @@ export default function App() {
   // PERF: pause nonessential CSS motion while the app is backgrounded. Keep
   // separate idle/hidden classes so visible worker activity can remain truthful
   // when the window is merely unfocused, while hidden windows fully pause.
-  useEffect(() => {
-    const root = document.documentElement;
-    const setIdle = () => {
-      root.classList.toggle("app-idle", document.hidden || !document.hasFocus());
-      root.classList.toggle("app-hidden", document.hidden);
-    };
-    setIdle();
-    window.addEventListener("blur", setIdle);
-    window.addEventListener("focus", setIdle);
-    document.addEventListener("visibilitychange", setIdle);
-    return () => {
-      window.removeEventListener("blur", setIdle);
-      window.removeEventListener("focus", setIdle);
-      document.removeEventListener("visibilitychange", setIdle);
-    };
-  }, []);
+  // Unsubscribe clears both classes so App unmount cannot leave them on <html>.
+  useEffect(() => subscribeDocumentMotionPolicy(), []);
 
   // persist layout
   useEffect(() => { localStorage.setItem(LS.left, String(leftW)); }, [leftW]);

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -5,7 +5,7 @@ import Conversation from "./components/Conversation";
 import RightPane from "./components/RightPane";
 import RightDock from "./components/RightDock";
 import StatusBar from "./components/StatusBar";
-import UpdateBanner from "./components/UpdateBanner";
+import UpdateBanner, { type UpdateAvailability } from "./components/UpdateBanner";
 import ProviderKeyBanner from "./components/ProviderKeyBanner";
 import Resizer from "./components/Resizer";
 import RegistryWizard from "./components/RegistryWizard";
@@ -117,6 +117,7 @@ function hasStoredRightPaneCards(): boolean {
 
 export default function App() {
   const [config, setConfig] = useState<Config | null>(null);
+  const [availableUpdate, setAvailableUpdate] = useState<UpdateAvailability | null>(null);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [artifacts, setArtifacts] = useState<{ type: string; headline: string; confidence?: number }[]>([]);
   const [jobsRefresh, setJobsRefresh] = useState(0);
@@ -336,7 +337,7 @@ export default function App() {
 
   return (
     <div className="h-full flex flex-col bg-[var(--shell-chrome)]">
-      <UpdateBanner />
+      <UpdateBanner onAvailabilityChange={setAvailableUpdate} />
       {/* Keyless nudge: agentic is the shipped default, so instead of a demo run
           we tell the user to plug in a key. Suppressed while the first-run wizard
           is up (it already covers key setup) to avoid stacking two prompts. */}
@@ -441,7 +442,7 @@ export default function App() {
         </div>
       </div>
       <div className="shrink-0 px-px py-px">
-        <StatusBar config={config}
+        <StatusBar config={config} update={availableUpdate}
           leftOpen={leftOpen} rightOpen={rightOpen}
           onToggleLeft={() => setLeftOpen((v) => !v)} onToggleRight={() => setRightOpen((v) => !v)} />
       </div>

--- a/webapp/src/__tests__/StatusBar.test.tsx
+++ b/webapp/src/__tests__/StatusBar.test.tsx
@@ -1,10 +1,12 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import StatusBar, {
   deriveFooterRuntimeStatus,
   footerRuntimeStatusLabel,
   sessionGoalForChip,
 } from "../components/StatusBar";
+import UpdateBanner, { type UpdateAvailability } from "../components/UpdateBanner";
 import { api } from "../lib/api";
 import { publishTaskProfile } from "../lib/taskProfileChrome";
 
@@ -37,11 +39,22 @@ const mockClearSessionGoal = vi.mocked(api.clearSessionGoal);
 
 const statusBarProps = {
   config: null,
+  update: null,
   leftOpen: true,
   rightOpen: false,
   onToggleLeft: vi.fn(),
   onToggleRight: vi.fn(),
 };
+
+function AppUpdateChromeHarness() {
+  const [update, setUpdate] = useState<UpdateAvailability | null>(null);
+  return (
+    <>
+      <UpdateBanner onAvailabilityChange={setUpdate} />
+      <StatusBar {...statusBarProps} update={update} />
+    </>
+  );
+}
 
 describe("sessionGoalForChip", () => {
   it("returns null when goal is absent, cleared, or empty", () => {
@@ -650,58 +663,6 @@ describe("StatusBar session GOAL chip", () => {
   });
 });
 
-describe("StatusBar runtime stale toast", () => {
-  const runtimeNote =
-    "Puppetmaster is at 1.20.10 but this Marionette needs 1.22.4 -- offline. Reconnect and update to finish.";
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockWorkspaces.mockResolvedValue([]);
-    mockGetUsage.mockResolvedValue({ session: emptyUsageSession, jobs: [] });
-    mockGetSessionState.mockResolvedValue({
-      state: "idle",
-      pending_swarms: false,
-      runners: {},
-    });
-    mockSessions.mockResolvedValue([]);
-  });
-
-  afterEach(() => {
-    delete (window as any).harnessIPC;
-  });
-
-  it("surfaces runtimeNote once as a toast without showing the update pill", async () => {
-    const check = vi
-      .fn()
-      .mockResolvedValue({ runtimeStale: true, runtimeNote, available: false });
-    (window as any).harnessIPC = {
-      updates: { check, onAvailable: null, onProgress: vi.fn(() => () => {}) },
-    };
-
-    render(<StatusBar {...statusBarProps} />);
-
-    await waitFor(() => expect(check).toHaveBeenCalled());
-    await waitFor(() => {
-      expect(screen.getByText(runtimeNote)).toBeInTheDocument();
-    });
-    expect(screen.queryByText(/^update/)).not.toBeInTheDocument();
-  });
-
-  it("does not toast when runtimeStale is absent", async () => {
-    const check = vi.fn().mockResolvedValue({ available: false });
-    (window as any).harnessIPC = {
-      updates: { check, onAvailable: null, onProgress: vi.fn(() => () => {}) },
-    };
-
-    render(<StatusBar {...statusBarProps} />);
-
-    await waitFor(() => {
-      expect(check).toHaveBeenCalled();
-    });
-    expect(screen.queryByText(/Puppetmaster is at/i)).not.toBeInTheDocument();
-  });
-});
-
 describe("StatusBar update progress mirror", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -717,6 +678,70 @@ describe("StatusBar update progress mirror", () => {
 
   afterEach(() => {
     delete (window as any).harnessIPC;
+  });
+
+  it("renders the projected compact update and delegates its click", async () => {
+    const applyRequest = vi.fn();
+    window.addEventListener("harness-update-apply", applyRequest);
+    (window as any).harnessIPC = {
+      updates: {
+        onProgress: vi.fn(() => () => {}),
+      },
+    };
+
+    const { rerender } = render(
+      <StatusBar
+        {...statusBarProps}
+        update={{ behind: 2, branch: "main", version: "0.9.245" }}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "update (2)" }));
+    expect(applyRequest).toHaveBeenCalledTimes(1);
+
+    rerender(<StatusBar {...statusBarProps} update={null} />);
+    expect(screen.queryByRole("button", { name: "update (2)" })).not.toBeInTheDocument();
+    window.removeEventListener("harness-update-apply", applyRequest);
+  });
+
+  it("shares App-projected availability and banner-owned apply progress", async () => {
+    let availableListener: ((payload: any) => void) | null = null;
+    const progressListeners: Array<(payload: any) => void> = [];
+    const apply = vi.fn(() => new Promise(() => {}));
+    (window as any).harnessIPC = {
+      updates: {
+        check: vi.fn(() => new Promise(() => {})),
+        apply,
+        onAvailable: vi.fn((listener) => {
+          availableListener = listener;
+          return () => {};
+        }),
+        onProgress: vi.fn((listener) => {
+          progressListeners.push(listener);
+          return () => {};
+        }),
+      },
+    };
+
+    render(<AppUpdateChromeHarness />);
+    act(() => availableListener?.({
+      available: true,
+      downloaded: false,
+      behind: 2,
+      branch: "main",
+      current: "0.9.245",
+    }));
+
+    expect(await screen.findByTestId("update-banner")).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("button", { name: "update (2)" }));
+    await waitFor(() => expect(apply).toHaveBeenCalledTimes(1));
+
+    act(() => progressListeners.forEach((listener) => listener({
+      stage: "install",
+      message: "Installing update",
+      percent: 50,
+    })));
+    await waitFor(() => expect(screen.getAllByText("Installing update 50%")).toHaveLength(2));
   });
 
   it("clears apply chrome when a terminal idle progress event arrives", async () => {

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -200,7 +200,7 @@ describe("SwarmPane model badge", () => {
     });
   });
 
-  it("keeps active worker motion semantic while the window is visibly unfocused", async () => {
+  it("marks only worker, job, and aggregate running indicators as semantic", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
         status: "running",
@@ -209,9 +209,38 @@ describe("SwarmPane model badge", () => {
     );
 
     const { container } = render(<SwarmPane />);
+    const worker = await screen.findByRole("button", { name: /Worker/ });
+    const job = screen.getByRole("button", { name: /Audit auth flow/ });
+    const aggregate = screen.getByText("1 running");
+
+    expect(worker.querySelector(".semantic-activity-spinner")).toBeTruthy();
+    expect(job.querySelector(".semantic-activity-spinner")).toBeTruthy();
+    expect(aggregate.querySelector(".semantic-activity-spinner")).toBeTruthy();
+    expect(container.querySelectorAll(".semantic-activity-spinner")).toHaveLength(3);
+
+    const headerPulse = screen.getByTitle("1 running");
+    expect(headerPulse).toHaveClass("animate-pulse");
+    expect(headerPulse).not.toHaveClass("semantic-activity-spinner");
+    for (const pulse of container.querySelectorAll(".animate-pulse")) {
+      expect(pulse).not.toHaveClass("semantic-activity-spinner");
+    }
+  });
+
+  it("does not mark finished-job chrome as semantic activity", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "complete",
+        tasks: [{ id: "task-1", status: "complete", adapter: "agentic", role: "Worker", instruction: "" }],
+      }),
+    );
+
+    const { container } = render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Audit auth flow"));
     await screen.findByRole("button", { name: /Worker/ });
 
-    expect(container.querySelectorAll(".semantic-activity-spinner").length).toBeGreaterThanOrEqual(3);
+    expect(container.querySelectorAll(".semantic-activity-spinner")).toHaveLength(0);
   });
 
   it("falls back to the adapter on the worker row when no routed model is present", async () => {

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -200,6 +200,20 @@ describe("SwarmPane model badge", () => {
     });
   });
 
+  it("keeps active worker motion semantic while the window is visibly unfocused", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        tasks: [{ id: "task-1", status: "running", adapter: "agentic", role: "Worker", instruction: "" }],
+      }),
+    );
+
+    const { container } = render(<SwarmPane />);
+    await screen.findByRole("button", { name: /Worker/ });
+
+    expect(container.querySelectorAll(".semantic-activity-spinner").length).toBeGreaterThanOrEqual(3);
+  });
+
   it("falls back to the adapter on the worker row when no routed model is present", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({

--- a/webapp/src/__tests__/UpdateBanner.test.tsx
+++ b/webapp/src/__tests__/UpdateBanner.test.tsx
@@ -6,6 +6,7 @@ type CheckResult = {
   available: boolean;
   downloaded: boolean;
   busy?: boolean;
+  error?: string;
   behind?: number;
   branch?: string;
   current?: string;
@@ -123,6 +124,46 @@ describe("UpdateBanner update checks", () => {
     expect(onAvailabilityChange).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves a latched update when check resolves a live IPC error", async () => {
+    let now = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const onAvailabilityChange = vi.fn();
+    const check = vi
+      .fn()
+      .mockResolvedValueOnce({
+        available: true,
+        downloaded: false,
+        behind: 2,
+        branch: "main",
+        current: "0.9.245",
+      })
+      .mockResolvedValueOnce({
+        available: false,
+        downloaded: false,
+        error: "fatal: unable to access 'https://github.com/professorpalmer/marionette.git/': Could not resolve host",
+      });
+    (window as any).harnessIPC.updates.check = check;
+
+    render(<UpdateBanner onAvailabilityChange={onAvailabilityChange} />);
+    expect(await screen.findByTestId("update-banner")).toBeInTheDocument();
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith({
+      behind: 2,
+      branch: "main",
+      version: "0.9.245",
+    });
+
+    now += 5 * 60 * 1000;
+    act(() => window.dispatchEvent(new Event("focus")));
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId("update-banner")).toBeInTheDocument();
+    expect(onAvailabilityChange).toHaveBeenCalledTimes(1);
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith({
+      behind: 2,
+      branch: "main",
+      version: "0.9.245",
+    });
+  });
+
   it("surfaces a runtime-stale note from the owner check", async () => {
     const note = "Puppetmaster must be updated before workers are ready.";
     const toast = vi.fn();
@@ -198,6 +239,33 @@ describe("UpdateBanner update checks", () => {
 
     act(() => {
       rejectCheck?.(new Error("network unavailable"));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("update-banner")).not.toBeInTheDocument();
+    });
+    expect(idleListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears checking progress when a resolved check carries an error", async () => {
+    render(<UpdateBanner />);
+
+    await waitFor(() => expect(progressListener).not.toBeNull());
+    act(() => {
+      progressListener?.({
+        stage: "check",
+        message: "Checking for app shell update",
+        percent: 0,
+      });
+    });
+    expect(screen.queryByTestId("update-banner")).not.toBeInTheDocument();
+
+    act(() => {
+      resolveCheck?.({
+        available: false,
+        downloaded: false,
+        error: "git fetch failed",
+      });
     });
 
     await waitFor(() => {
@@ -289,7 +357,7 @@ describe("UpdateBanner update checks", () => {
 
   it("revokes stale availability when apply confirms there is no update", async () => {
     const onAvailabilityChange = vi.fn();
-    const apply = vi.fn(async () => ({ ok: false, error: "no update available" }));
+    const apply = vi.fn(async () => ({ ok: false, code: "no_update", error: "no update available" }));
     (window as any).harnessIPC.updates.apply = apply;
     (window as any).harnessIPC.updates.onAvailable = vi.fn((listener: (res: CheckResult) => void) => {
       listener({
@@ -308,5 +376,44 @@ describe("UpdateBanner update checks", () => {
     await waitFor(() => expect(apply).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.queryByTestId("update-banner")).not.toBeInTheDocument());
     expect(onAvailabilityChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("preserves availability when apply-time check fails", async () => {
+    const onAvailabilityChange = vi.fn();
+    const toast = vi.fn();
+    window.addEventListener("harness-toast", toast);
+    const apply = vi.fn(async () => ({
+      ok: false,
+      code: "check_failed",
+      error: "fatal: unable to access 'https://github.com/professorpalmer/marionette.git/': Could not resolve host",
+    }));
+    (window as any).harnessIPC.updates.apply = apply;
+    (window as any).harnessIPC.updates.onAvailable = vi.fn((listener: (res: CheckResult) => void) => {
+      listener({
+        available: true,
+        downloaded: false,
+        behind: 1,
+        branch: "main",
+        current: "0.9.245",
+      });
+      return () => {};
+    });
+
+    render(<UpdateBanner onAvailabilityChange={onAvailabilityChange} />);
+    expect(await screen.findByTestId("update-banner")).toBeInTheDocument();
+    await act(async () => screen.getByRole("button", { name: /restart now/i }).click());
+
+    await waitFor(() => expect(apply).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("update-banner")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /restart now/i })).toBeInTheDocument();
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith({
+      behind: 1,
+      branch: "main",
+      version: "0.9.245",
+    });
+    expect(onAvailabilityChange).not.toHaveBeenCalledWith(null);
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    expect((toast.mock.calls[0][0] as CustomEvent).detail).toMatch(/Could not resolve host/);
+    window.removeEventListener("harness-toast", toast);
   });
 });

--- a/webapp/src/__tests__/UpdateBanner.test.tsx
+++ b/webapp/src/__tests__/UpdateBanner.test.tsx
@@ -6,6 +6,11 @@ type CheckResult = {
   available: boolean;
   downloaded: boolean;
   busy?: boolean;
+  behind?: number;
+  branch?: string;
+  current?: string;
+  runtimeStale?: boolean;
+  runtimeNote?: string;
 };
 
 type ProgressPayload = {
@@ -50,6 +55,90 @@ describe("UpdateBanner update checks", () => {
   afterEach(() => {
     window.removeEventListener("harness-update-idle", idleListener);
     delete (window as any).harnessIPC;
+    vi.restoreAllMocks();
+  });
+
+  it("revokes a latched update only after a definitive unavailable check", async () => {
+    let now = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const onAvailabilityChange = vi.fn();
+    const check = vi
+      .fn()
+      .mockResolvedValueOnce({
+        available: true,
+        downloaded: false,
+        behind: 2,
+        branch: "main",
+        current: "0.9.245",
+      })
+      .mockResolvedValueOnce({ available: false, downloaded: false });
+    (window as any).harnessIPC.updates.check = check;
+
+    render(<UpdateBanner onAvailabilityChange={onAvailabilityChange} />);
+
+    expect(await screen.findByTestId("update-banner")).toBeInTheDocument();
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith({
+      behind: 2,
+      branch: "main",
+      version: "0.9.245",
+    });
+
+    now += 5 * 60 * 1000;
+    act(() => window.dispatchEvent(new Event("focus")));
+
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByTestId("update-banner")).not.toBeInTheDocument());
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("preserves a latched update across busy and failed checks", async () => {
+    let now = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const onAvailabilityChange = vi.fn();
+    const check = vi
+      .fn()
+      .mockResolvedValueOnce({
+        available: true,
+        downloaded: false,
+        behind: 1,
+        branch: "main",
+        current: "0.9.245",
+      })
+      .mockResolvedValueOnce({ available: false, downloaded: false, busy: true })
+      .mockRejectedValueOnce(new Error("network unavailable"));
+    (window as any).harnessIPC.updates.check = check;
+
+    render(<UpdateBanner onAvailabilityChange={onAvailabilityChange} />);
+    expect(await screen.findByTestId("update-banner")).toBeInTheDocument();
+
+    now += 5 * 60 * 1000;
+    act(() => window.dispatchEvent(new Event("focus")));
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId("update-banner")).toBeInTheDocument();
+
+    now += 5 * 60 * 1000;
+    act(() => window.dispatchEvent(new Event("focus")));
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(3));
+    expect(screen.getByTestId("update-banner")).toBeInTheDocument();
+    expect(onAvailabilityChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a runtime-stale note from the owner check", async () => {
+    const note = "Puppetmaster must be updated before workers are ready.";
+    const toast = vi.fn();
+    window.addEventListener("harness-toast", toast);
+    (window as any).harnessIPC.updates.check = vi.fn().mockResolvedValue({
+      available: false,
+      downloaded: false,
+      runtimeStale: true,
+      runtimeNote: note,
+    });
+
+    render(<UpdateBanner />);
+
+    await waitFor(() => expect(toast).toHaveBeenCalledTimes(1));
+    expect((toast.mock.calls[0][0] as CustomEvent).detail).toBe(note);
+    window.removeEventListener("harness-toast", toast);
   });
 
   it("keeps checking progress invisible when no packaged update is available", async () => {
@@ -196,5 +285,28 @@ describe("UpdateBanner update checks", () => {
     });
     // Must not recover to a second Restart click while quitAndInstall runs.
     expect(screen.queryByRole("button", { name: /restart now/i })).not.toBeInTheDocument();
+  });
+
+  it("revokes stale availability when apply confirms there is no update", async () => {
+    const onAvailabilityChange = vi.fn();
+    const apply = vi.fn(async () => ({ ok: false, error: "no update available" }));
+    (window as any).harnessIPC.updates.apply = apply;
+    (window as any).harnessIPC.updates.onAvailable = vi.fn((listener: (res: CheckResult) => void) => {
+      listener({
+        available: true,
+        downloaded: false,
+        behind: 1,
+        branch: "main",
+        current: "0.9.245",
+      });
+      return () => {};
+    });
+
+    render(<UpdateBanner onAvailabilityChange={onAvailabilityChange} />);
+    await act(async () => screen.getByRole("button", { name: /restart now/i }).click());
+
+    await waitFor(() => expect(apply).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByTestId("update-banner")).not.toBeInTheDocument());
+    expect(onAvailabilityChange).toHaveBeenLastCalledWith(null);
   });
 });

--- a/webapp/src/__tests__/motionPolicy.test.ts
+++ b/webapp/src/__tests__/motionPolicy.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import motionCss from "../index.css?raw";
+import {
+  APP_HIDDEN_CLASS,
+  APP_IDLE_CLASS,
+  applyMotionRootClasses,
+  clearMotionRootClasses,
+  motionRootClasses,
+  subscribeDocumentMotionPolicy,
+} from "../lib/motionPolicy";
+
+function mediaBlock(css: string, query: string): string {
+  const start = css.indexOf(`@media (${query})`);
+  expect(start).toBeGreaterThan(-1);
+  const open = css.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === "{") depth += 1;
+    else if (css[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return css.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unclosed @media (${query})`);
+}
+
+describe("motionRootClasses", () => {
+  it("leaves the root unmarked when the window is focused and visible", () => {
+    expect(motionRootClasses({ hidden: false, focused: true })).toEqual({
+      idle: false,
+      hidden: false,
+    });
+  });
+
+  it("marks idle-only when visible but unfocused so decorative motion can pause", () => {
+    expect(motionRootClasses({ hidden: false, focused: false })).toEqual({
+      idle: true,
+      hidden: false,
+    });
+  });
+
+  it("marks idle and hidden when minimized, even if the document still reports focus", () => {
+    expect(motionRootClasses({ hidden: true, focused: true })).toEqual({
+      idle: true,
+      hidden: true,
+    });
+    expect(motionRootClasses({ hidden: true, focused: false })).toEqual({
+      idle: true,
+      hidden: true,
+    });
+  });
+});
+
+describe("applyMotionRootClasses / clearMotionRootClasses", () => {
+  it("toggles and clears html classes without leaving residue", () => {
+    const root = document.createElement("div");
+    applyMotionRootClasses(root, { hidden: false, focused: false });
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(true);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+
+    applyMotionRootClasses(root, { hidden: true, focused: false });
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(true);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(true);
+
+    applyMotionRootClasses(root, { hidden: false, focused: true });
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(false);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+
+    applyMotionRootClasses(root, { hidden: true, focused: true });
+    clearMotionRootClasses(root);
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(false);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+  });
+});
+
+describe("subscribeDocumentMotionPolicy", () => {
+  const viewport = { hidden: false, focused: true };
+  let stop: (() => void) | undefined;
+
+  afterEach(() => {
+    stop?.();
+    stop = undefined;
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(document, "hidden");
+    document.documentElement.classList.remove(APP_IDLE_CLASS, APP_HIDDEN_CLASS);
+  });
+
+  function installViewport() {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      enumerable: true,
+      get: () => viewport.hidden,
+    });
+    vi.spyOn(document, "hasFocus").mockImplementation(() => viewport.focused);
+  }
+
+  it("applies blur vs hidden class policy and clears both on unsubscribe", () => {
+    viewport.hidden = false;
+    viewport.focused = true;
+    installViewport();
+    stop = subscribeDocumentMotionPolicy();
+    const root = document.documentElement;
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(false);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+
+    viewport.focused = false;
+    window.dispatchEvent(new Event("blur"));
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(true);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+
+    viewport.hidden = true;
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(true);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(true);
+
+    const unsub = stop;
+    stop = undefined;
+    unsub();
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(false);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+
+    window.dispatchEvent(new Event("blur"));
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(root.classList.contains(APP_IDLE_CLASS)).toBe(false);
+    expect(root.classList.contains(APP_HIDDEN_CLASS)).toBe(false);
+  });
+
+  it("adds and removes the same blur, focus, and visibility listeners", () => {
+    viewport.hidden = false;
+    viewport.focused = true;
+    installViewport();
+    const addWin = vi.spyOn(window, "addEventListener");
+    const remWin = vi.spyOn(window, "removeEventListener");
+    const addDoc = vi.spyOn(document, "addEventListener");
+    const remDoc = vi.spyOn(document, "removeEventListener");
+
+    stop = subscribeDocumentMotionPolicy();
+    const blur = addWin.mock.calls.find((call) => call[0] === "blur")?.[1];
+    const focus = addWin.mock.calls.find((call) => call[0] === "focus")?.[1];
+    const visibility = addDoc.mock.calls.find((call) => call[0] === "visibilitychange")?.[1];
+    expect(blur).toEqual(expect.any(Function));
+    expect(focus).toBe(blur);
+    expect(visibility).toBe(blur);
+
+    const unsub = stop;
+    stop = undefined;
+    unsub();
+    expect(remWin.mock.calls.some((call) => call[0] === "blur" && call[1] === blur)).toBe(true);
+    expect(remWin.mock.calls.some((call) => call[0] === "focus" && call[1] === focus)).toBe(true);
+    expect(remDoc.mock.calls.some((call) => call[0] === "visibilitychange" && call[1] === visibility)).toBe(true);
+  });
+});
+
+describe("index.css motion selector contract", () => {
+  it("pauses idle descendants, resumes only marked semantic spinners while visible, and keeps reduced-motion authoritative", () => {
+    const reduceAt = motionCss.indexOf("@media (prefers-reduced-motion: reduce)");
+    expect(reduceAt).toBeGreaterThan(-1);
+    const beforeReduce = motionCss.slice(0, reduceAt);
+
+    expect(beforeReduce).toMatch(
+      /html\.app-idle \*,\s*html\.app-idle \*::before,\s*html\.app-idle \*::after\s*\{[^}]*animation-play-state:\s*paused\s*!important/,
+    );
+    expect(beforeReduce).toMatch(
+      /html\.app-idle:not\(\.app-hidden\) \.semantic-activity-spinner\s*\{[^}]*animation-play-state:\s*running\s*!important/,
+    );
+    expect(beforeReduce.indexOf("html.app-idle *")).toBeLessThan(
+      beforeReduce.indexOf("html.app-idle:not(.app-hidden) .semantic-activity-spinner"),
+    );
+
+    const runningRules = [...beforeReduce.matchAll(/([^{]+)\{[^}]*animation-play-state:\s*running/g)];
+    expect(runningRules).toHaveLength(1);
+    expect(runningRules[0][1]).toContain(".semantic-activity-spinner");
+    expect(runningRules[0][1]).toContain(":not(.app-hidden)");
+    expect(runningRules[0][1]).not.toContain(".animate-pulse");
+    expect(runningRules[0][1]).not.toContain(".animate-spin");
+
+    const reduce = mediaBlock(motionCss, "prefers-reduced-motion: reduce");
+    expect(reduce).not.toContain("semantic-activity-spinner");
+    expect(reduce).not.toContain("animation-play-state");
+    expect(reduce).toMatch(/animation-duration:\s*0\.001ms\s*!important/);
+    expect(reduce).toMatch(/animation-iteration-count:\s*1\s*!important/);
+  });
+});

--- a/webapp/src/components/StatusBar.tsx
+++ b/webapp/src/components/StatusBar.tsx
@@ -32,6 +32,7 @@ import CostBreakdown, {
 } from "./CostBreakdown";
 import { sanitizeUpdateMessage } from "../lib/updateMessages";
 import { shortPilotModelLabel } from "../lib/turnProgress";
+import type { UpdateAvailability } from "./UpdateBanner";
 
 type FooterRuntimeStatus = "ready" | "thinking" | "busy";
 
@@ -78,8 +79,9 @@ function truncateGoalText(text: string, max = 36): string {
 // in LeftRail SESSION JOBS -- a footer total was stale across dir swaps and
 // disagreed with the scoped list, so it was removed. Narrow widths hide
 // secondary labels via container queries instead of overlapping the clusters.
-export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, onToggleRight }: {
+export default function StatusBar({ config, update, leftOpen, rightOpen, onToggleLeft, onToggleRight }: {
   config: Config | null;
+  update: UpdateAvailability | null;
   leftOpen: boolean; rightOpen: boolean;
   onToggleLeft: () => void; onToggleRight: () => void;
 }) {
@@ -87,7 +89,6 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
   const [usage, setUsage] = useState<UsageData["session"] | null>(null);
   const [costOpen, setCostOpen] = useState(false);
   const costRef = useRef<HTMLDivElement | null>(null);
-  const [update, setUpdate] = useState<{ behind: number; branch: string; version: string } | null>(null);
   const [apply, setApply] = useState<{ stage: string; message: string; percent: number | null } | null>(null);
   const [toast, setToast] = useState<{
     message: string;
@@ -97,8 +98,6 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
   const [sessionState, setSessionState] = useState<SessionState | null>(null);
   const [taskProfile, setTaskProfile] = useState<TaskProfileChip | null>(null);
   const [goalBusy, setGoalBusy] = useState(false);
-  // Dedup runtime-stale notes across the 5-minute focus throttle and 30-minute polls.
-  const lastRuntimeNoteRef = useRef<string | null>(null);
 
   const refreshSessionState = () =>
     api.getSessionState()
@@ -155,57 +154,6 @@ export default function StatusBar({ config, leftOpen, rightOpen, onToggleLeft, o
 
   useEffect(() => subscribeTaskProfile(setTaskProfile), []);
 
-  // Self-update check: how far behind the tracked branch we are (desktop only).
-  // Silent on failure -- an update nudge must never get in the way. Re-checks
-  // every 30 minutes and on window focus (throttled) so a release that lands
-  // mid-session surfaces without a relaunch -- previously the pill only ever
-  // checked once on mount.
-  useEffect(() => {
-    const ipc = (window as any).harnessIPC;
-    if (!ipc || !ipc.updates) return;
-    let cancelled = false;
-    let lastCheck = 0;
-    const MIN_GAP_MS = 5 * 60 * 1000;
-    const check = (force = false) => {
-      const now = Date.now();
-      if (!force && now - lastCheck < MIN_GAP_MS) return;
-      lastCheck = now;
-      ipc.updates.check()
-        .then((res: any) => {
-          if (cancelled || !res) return;
-          // Informational only: a stale Puppetmaster runtime is not an actionable
-          // app update, but users deserve an honest one-line explanation once.
-          if (res.runtimeStale && res.runtimeNote && res.runtimeNote !== lastRuntimeNoteRef.current) {
-            lastRuntimeNoteRef.current = res.runtimeNote;
-            window.dispatchEvent(new CustomEvent("harness-toast", { detail: res.runtimeNote }));
-          }
-          if (res.available || res.downloaded) {
-            setUpdate({ behind: res.behind || 0, branch: res.branch || "main", version: res.current || "" });
-          }
-        })
-        .catch(() => {});
-    };
-    check(true);
-    const interval = window.setInterval(() => check(true), 30 * 60 * 1000);
-    const onFocus = () => check();
-    window.addEventListener("focus", onFocus);
-    // PUSH path: the main-process update watcher notifies the moment its
-    // background fetch sees new commits, so the pill appears without waiting
-    // for the next renderer poll tick.
-    const offAvailable = ipc.updates.onAvailable
-      ? ipc.updates.onAvailable((res: any) => {
-          if (!cancelled && res && (res.available || res.downloaded)) {
-            setUpdate({ behind: res.behind || 0, branch: res.branch || "main", version: res.current || "" });
-          }
-        })
-      : null;
-    return () => {
-      cancelled = true;
-      window.clearInterval(interval);
-      window.removeEventListener("focus", onFocus);
-      if (offAvailable) offAvailable();
-    };
-  }, []);
 
   // The UpdateBanner owns the single, robust apply() path (latching, error
   // recovery, watchdog, idempotent install). The pill just asks it to start and

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -406,7 +406,7 @@ export function workerOutcome(task: Task, failureArt?: Artifact | null): WorkerO
 function WorkerOutcomeGlyph({ outcome }: { outcome: WorkerOutcome }) {
   switch (outcome) {
     case "running":
-      return <Loader2 size={10} className="animate-spin text-accent" />;
+      return <Loader2 size={10} className="animate-spin semantic-activity-spinner text-accent" />;
     case "ok":
       return <CheckCircle2 size={10} className="text-good" />;
     case "degraded":
@@ -1375,7 +1375,7 @@ export default function SwarmPane() {
               </span>
               <span className="shrink-0">
                 {st === "in_progress" ? (
-                  <Loader2 size={12} className="animate-spin text-accent" />
+                  <Loader2 size={12} className="animate-spin semantic-activity-spinner text-accent" />
                 ) : st === "failed" ? (
                   <XCircle size={12} className="text-risk" />
                 ) : outcomeWarning ? (
@@ -1876,7 +1876,7 @@ export default function SwarmPane() {
         <div className="flex items-center gap-2.5 text-[10px]">
           {anyRunning && (
             <span className="flex items-center gap-1 text-accent">
-              <Loader2 size={10} className="animate-spin" /> {runningCount} running
+              <Loader2 size={10} className="animate-spin semantic-activity-spinner" /> {runningCount} running
             </span>
           )}
           {completedCount > 0 && (

--- a/webapp/src/components/UpdateBanner.tsx
+++ b/webapp/src/components/UpdateBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowUpCircle, RefreshCw, X } from "lucide-react";
 import { sanitizeUpdateMessage } from "../lib/updateMessages";
 import { TITLEBAR_TRAFFIC_PAD_PX } from "../lib/titlebarSafe";
@@ -14,7 +14,17 @@ import { TITLEBAR_TRAFFIC_PAD_PX } from "../lib/titlebarSafe";
 //
 // The pill stays as the always-present compact indicator; this banner is the
 // occasional "your update is ready, one click to finish" nudge.
-export default function UpdateBanner() {
+export type UpdateAvailability = {
+  behind: number;
+  branch: string;
+  version: string;
+};
+
+export default function UpdateBanner({
+  onAvailabilityChange,
+}: {
+  onAvailabilityChange?: (update: UpdateAvailability | null) => void;
+} = {}) {
   const [latest, setLatest] = useState<string>("");
   const [ready, setReady] = useState(false);
   const [applying, setApplying] = useState(false);
@@ -27,6 +37,20 @@ export default function UpdateBanner() {
   // Restart, so genuine post-commit install/relaunch stages still show progress.
   const readyRef = useRef(false);
   const committedRef = useRef(false);
+  const lastRuntimeNoteRef = useRef<string | null>(null);
+  const publishAvailability = useCallback((res: any) => {
+    onAvailabilityChange?.({
+      behind: res.behind || 0,
+      branch: res.branch || "main",
+      version: res.current || "",
+    });
+  }, [onAvailabilityChange]);
+  const revokeAvailability = useCallback(() => {
+    readyRef.current = false;
+    setReady(false);
+    setLatest("");
+    onAvailabilityChange?.(null);
+  }, [onAvailabilityChange]);
 
   useEffect(() => {
     const ipc = (window as any).harnessIPC;
@@ -69,6 +93,14 @@ export default function UpdateBanner() {
         .check()
         .then((res: any) => {
           if (cancelled || committedRef.current || res?.busy) return;
+          if (
+            res.runtimeStale &&
+            res.runtimeNote &&
+            res.runtimeNote !== lastRuntimeNoteRef.current
+          ) {
+            lastRuntimeNoteRef.current = res.runtimeNote;
+            window.dispatchEvent(new CustomEvent("harness-toast", { detail: res.runtimeNote }));
+          }
           if (res.available || res.downloaded) {
             // Only a real version string labels the banner. Source-run updates
             // track a branch tip, and falling back to the branch name rendered
@@ -76,10 +108,12 @@ export default function UpdateBanner() {
             setLatest(res.latest || "");
             readyRef.current = true;
             setReady(true);
+            publishAvailability(res);
           } else {
             // Packaged shell checks emit transient "Checking for app shell update"
             // progress; when the poll finishes with nothing to install, drop that
             // spinner so the banner (and StatusBar pill mirror) cannot stick at 0%.
+            revokeAvailability();
             clearCheckProgress();
           }
         })
@@ -102,6 +136,7 @@ export default function UpdateBanner() {
           setLatest(res.latest || "");
           readyRef.current = true;
           setReady(true);
+          publishAvailability(res);
         })
       : null;
 
@@ -164,7 +199,7 @@ export default function UpdateBanner() {
       if (off) off();
       if (offAvailable) offAvailable();
     };
-  }, []);
+  }, [publishAvailability, revokeAvailability]);
 
   const restart = (strategy?: "ff" | "stash") => {
     const ipc = (window as any).harnessIPC;
@@ -178,10 +213,13 @@ export default function UpdateBanner() {
     window.dispatchEvent(new Event("harness-update-committing"));
 
     // Recover the banner to an actionable state instead of stranding the user.
-    const recover = (msg: string) => {
+    const settleApply = () => {
       committedRef.current = false;
       setApplying(false);
       window.dispatchEvent(new Event("harness-update-idle")); // release the pill mirror too
+    };
+    const recover = (msg: string) => {
+      settleApply();
       window.dispatchEvent(new CustomEvent("harness-toast", { detail: msg }));
     };
 
@@ -196,10 +234,15 @@ export default function UpdateBanner() {
     ipc.updates
       .apply(strategy ? { strategy } : undefined)
       .then((r: any) => {
-        // apply() resolves { ok:false, error } when there's nothing to install
-        // (e.g. a stale banner) -- surface it instead of spinning.
+        // A stale positive can race the authoritative apply-time check. Clear
+        // both update surfaces silently when that check says nothing remains.
         if (r && r.ok === false) {
           window.clearTimeout(watchdog);
+          if (r.error === "no update available") {
+            revokeAvailability();
+            settleApply();
+            return;
+          }
           // A self-edited checkout collides with fast-forward. Offer the sane
           // recovery for each case instead of a dead-end error (Marionette
           // edits its own source, so this is a normal path, not an edge case).

--- a/webapp/src/components/UpdateBanner.tsx
+++ b/webapp/src/components/UpdateBanner.tsx
@@ -109,6 +109,12 @@ export default function UpdateBanner({
             readyRef.current = true;
             setReady(true);
             publishAvailability(res);
+          } else if (res.error) {
+            // Live updates.check() resolves git/network/remote failures as
+            // {available:false,error:...} instead of rejecting. A transient
+            // miss must not revoke a latched update; only an authoritative
+            // available:false without error does that.
+            clearCheckProgress();
           } else {
             // Packaged shell checks emit transient "Checking for app shell update"
             // progress; when the poll finishes with nothing to install, drop that
@@ -238,7 +244,7 @@ export default function UpdateBanner({
         // both update surfaces silently when that check says nothing remains.
         if (r && r.ok === false) {
           window.clearTimeout(watchdog);
-          if (r.error === "no update available") {
+          if (r.code === "no_update") {
             revokeAvailability();
             settleApply();
             return;

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -10,7 +10,8 @@ html, body, #root { height: 100%; margin: 0; }
    composer) keep the compositor pinned even after you alt-tab away -- which is
    exactly what makes window-switching stutter during a long session with live
    swarms. Semantic worker indicators are the narrow exception while the window
-   remains visible; a hidden/minimized window still pauses everything. */
+   remains visible; a hidden/minimized window still pauses everything.
+   prefers-reduced-motion below stays authoritative and has no semantic exception. */
 html.app-idle *,
 html.app-idle *::before,
 html.app-idle *::after {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -9,13 +9,16 @@ html, body, #root { height: 100%; margin: 0; }
    windows, so dozens of always-running spinners/pulses (swarm rows, status bar,
    composer) keep the compositor pinned even after you alt-tab away -- which is
    exactly what makes window-switching stutter during a long session with live
-   swarms. When hidden or blurred we set animation-play-state: paused so the
-   compositor goes idle and the window server gets its frames back. Visible/
-   focused restores everything with zero code changes at the call sites. */
+   swarms. Semantic worker indicators are the narrow exception while the window
+   remains visible; a hidden/minimized window still pauses everything. */
 html.app-idle *,
 html.app-idle *::before,
 html.app-idle *::after {
   animation-play-state: paused !important;
+}
+
+html.app-idle:not(.app-hidden) .semantic-activity-spinner {
+  animation-play-state: running !important;
 }
 
 /* Respect users who ask for less motion: kill the continuous spinners/pulses. */

--- a/webapp/src/lib/motionPolicy.ts
+++ b/webapp/src/lib/motionPolicy.ts
@@ -1,0 +1,55 @@
+/** Root classes that pause decorative CSS motion when the window is idle. */
+export const APP_IDLE_CLASS = "app-idle";
+export const APP_HIDDEN_CLASS = "app-hidden";
+
+export type MotionViewport = {
+  hidden: boolean;
+  focused: boolean;
+};
+
+export type MotionRootState = {
+  idle: boolean;
+  hidden: boolean;
+};
+
+/** Decorative motion pauses on blur; everything pauses when hidden/minimized. */
+export function motionRootClasses(viewport: MotionViewport): MotionRootState {
+  return {
+    idle: viewport.hidden || !viewport.focused,
+    hidden: viewport.hidden,
+  };
+}
+
+export function applyMotionRootClasses(
+  root: Pick<Element, "classList">,
+  viewport: MotionViewport,
+): void {
+  const next = motionRootClasses(viewport);
+  root.classList.toggle(APP_IDLE_CLASS, next.idle);
+  root.classList.toggle(APP_HIDDEN_CLASS, next.hidden);
+}
+
+export function clearMotionRootClasses(root: Pick<Element, "classList">): void {
+  root.classList.remove(APP_IDLE_CLASS, APP_HIDDEN_CLASS);
+}
+
+/** Bind html.app-idle / html.app-hidden; unsubscribe always clears both classes. */
+export function subscribeDocumentMotionPolicy(): () => void {
+  const root = document.documentElement;
+  const sync = () => {
+    applyMotionRootClasses(root, {
+      hidden: document.hidden,
+      focused: document.hasFocus(),
+    });
+  };
+  sync();
+  window.addEventListener("blur", sync);
+  window.addEventListener("focus", sync);
+  document.addEventListener("visibilitychange", sync);
+  return () => {
+    window.removeEventListener("blur", sync);
+    window.removeEventListener("focus", sync);
+    document.removeEventListener("visibilitychange", sync);
+    clearMotionRootClasses(root);
+  };
+}


### PR DESCRIPTION
## Summary
- centralize update availability and preserve it through transient updater failures
- keep visible background worker activity animated while pausing hidden/decorative motion
- fall back to the built renderer when Update & Relaunch inherits a dead Vite URL
- synchronize Marionette version stamps at v0.9.246

## Test plan
- [x] full Python suite: 4592 passed, 74 skipped
- [x] full renderer suite: 1063 passed
- [x] full Electron suite: 158 passed
- [x] production frontend build
- [x] version consistency tests
- [ ] GitHub `tests` workflow green on the merged main SHA before tagging