### PR TITLE
release: v0.9.247

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.7"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.8"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           # Floor matches the accounting/routing fixes this release needs.
           # Unpinned `puppetmaster-ai` + pip cache can leave CI on an older
           # wheel (e.g. 1.14.0) and fail fallback-pricing regressions.
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.7"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.8"
 
       # full_auto_safety modules already run inside this job via conftest
       # auto-tagging; a separate named job was redundant PR compute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.7"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.8"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.7` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.8` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.7` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.8` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.246, deliberately pre-1.0. Update availability now has one authoritative renderer owner, visible background workers keep truthful activity motion, and source relaunches fall back from a dead Vite URL to the built renderer. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins. Rides puppetmaster-ai==1.22.7.
+> Status: v0.9.247, deliberately pre-1.0. One run_implement is one Swarm Tracker lifecycle: the host local-* row owns the card, inline Orchestrator scratch stays off EXTERNAL, and preview route is estimated metadata not selected model. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins. Rides puppetmaster-ai==1.22.8.
 
 ## Documentation
 
@@ -93,7 +93,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.7` (exact registry pins, GPT-5.6 tool reasoning, Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.8` (exact registry pins, GPT-5.6 tool reasoning, Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.246"
+__version__ = "0.9.247"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/cli_job_merge.py
+++ b/harness/cli_job_merge.py
@@ -18,6 +18,56 @@ from harness.diag import note as _diag_note
 
 _merge_failure_logged = False
 
+# Inline Orchestrator stores created by run_agentic_edit / run_cursor_edit.
+# These are never the durable workspace CLI store, even when the process
+# temporarily exports PUPPETMASTER_STATE_DIR to the scratch root.
+HOST_SCRATCH_MARKER_NAME = ".marionette-host-scratch"
+HOST_SCRATCH_DIR_PREFIXES = ("pmh-edit-", "pmh-cursor-edit-")
+
+
+def is_marionette_host_scratch_dir(path: Any) -> bool:
+    """True when ``path`` is a Marionette inline-Orchestrator scratch store.
+
+    Identity is the temp-dir prefix and/or an explicit marker file. Never
+    raises — merge hot paths treat an unreadable candidate as "not scratch".
+    """
+    try:
+        if path is None:
+            return False
+        raw = str(path).strip()
+        if not raw:
+            return False
+        candidate = Path(raw).expanduser()
+        name = candidate.name
+        if name.startswith(HOST_SCRATCH_DIR_PREFIXES):
+            return True
+        return (candidate / HOST_SCRATCH_MARKER_NAME).is_file()
+    except Exception:
+        return False
+
+
+def mark_marionette_host_scratch(path: Any) -> None:
+    """Write the host-scratch marker under ``path``. Best-effort; never raises."""
+    try:
+        if path is None:
+            return
+        raw = str(path).strip()
+        if not raw:
+            return
+        root = Path(raw)
+        root.mkdir(parents=True, exist_ok=True)
+        (root / HOST_SCRATCH_MARKER_NAME).write_text("", encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _durable_workspace_state_dir(workspace_root: str = "") -> Optional[Path]:
+    """Resolve the durable per-workspace store without honoring process env."""
+    from puppetmaster.state import default_state_dir
+
+    cwd = Path(workspace_root or os.getcwd())
+    return default_state_dir(cwd)
+
 
 def reset_merge_diag_for_tests() -> None:
     """Clear the one-shot diagnostics flag (tests only)."""
@@ -46,12 +96,27 @@ def _retry_on_locked(read, attempts: int = 3, delay: float = 0.15):
 
 
 def resolve_cli_state_dir(workspace_root: str = "") -> Optional[str]:
-    """Resolve the Puppetmaster project state dir for ``workspace_root``."""
+    """Resolve the Puppetmaster project state dir for ``workspace_root``.
+
+    A host scratch ``PUPPETMASTER_STATE_DIR`` (inline Orchestrator) is ignored
+    so ``/api/swarm/live`` opens the durable workspace store. Process env is
+    never mutated.
+    """
     try:
         from puppetmaster.state import resolve_state_dir
 
         cwd = Path(workspace_root or os.getcwd())
-        state_path = resolve_state_dir(cwd=cwd)
+        env_value = (os.environ.get("PUPPETMASTER_STATE_DIR") or "").strip()
+        if env_value and is_marionette_host_scratch_dir(env_value):
+            state_path = _durable_workspace_state_dir(str(cwd))
+        else:
+            state_path = resolve_state_dir(cwd=cwd)
+            if is_marionette_host_scratch_dir(state_path):
+                state_path = _durable_workspace_state_dir(str(cwd))
+        if state_path is None:
+            return None
+        if is_marionette_host_scratch_dir(state_path):
+            return None
         if not state_path.is_dir():
             return None
         if not (state_path / "state.sqlite3").is_file():
@@ -90,6 +155,8 @@ def open_cli_durable_at(state_dir: str, *, busy_timeout_ms: int = 5000):
     if not state_dir:
         return None
     try:
+        if is_marionette_host_scratch_dir(state_dir):
+            return None
         from harness.state import DurableState
 
         durable = DurableState(state_dir)
@@ -128,6 +195,8 @@ def _foreign_state_dir_candidates(
         except Exception:
             state_dir = str(project)
         if primary_resolved and state_dir == primary_resolved:
+            continue
+        if is_marionette_host_scratch_dir(state_dir):
             continue
         db = Path(state_dir) / "state.sqlite3"
         if not db.is_file():

--- a/harness/edit_engines.py
+++ b/harness/edit_engines.py
@@ -320,7 +320,7 @@ def run_edit_worker(
     if engine == "cursor":
         result = run_cursor_edit(
             config, goal, session_id=session_id, cwd=target_cwd,
-            expects_diff=expects_diff,
+            expects_diff=expects_diff, job_id=job_id,
         )
         if result.error in _FALLBACK_REASONS:
             _diag("edit_engines.run_edit_worker",
@@ -333,7 +333,7 @@ def run_edit_worker(
     if engine == "agentic":
         result = run_agentic_edit(
             config, goal, session_id=session_id, cwd=target_cwd,
-            expects_diff=expects_diff,
+            expects_diff=expects_diff, job_id=job_id,
         )
         if result.error in _FALLBACK_REASONS:
             if cursor_platform_available():
@@ -341,7 +341,7 @@ def run_edit_worker(
                       msg=f"agentic unavailable ({result.error}); trying cursor")
                 cursor_result = run_cursor_edit(
                     config, goal, session_id=session_id, cwd=target_cwd,
-                    expects_diff=expects_diff,
+                    expects_diff=expects_diff, job_id=job_id,
                 )
                 if cursor_result.error not in _FALLBACK_REASONS:
                     return cursor_result
@@ -427,7 +427,7 @@ def run_native_edit(
 
 def run_cursor_edit(
     config: "HarnessConfig", goal: str, *, session_id: str = "", cwd: str = "",
-    expects_diff: bool = True,
+    expects_diff: bool = True, job_id: str = "",
 ) -> "WorkerResult":
     """Platform Cursor SDK workers (CURSOR_API_KEY) in a managed worktree.
 
@@ -435,6 +435,7 @@ def run_cursor_edit(
     Cursor CLI agent-login pilot auth.
     """
     from harness.worker import WorkerResult
+    from harness.cli_job_merge import mark_marionette_host_scratch
     from harness.job_scoping import job_label_for_session, stamp_task_payload
 
     if not cursor_platform_available():
@@ -502,13 +503,14 @@ def run_cursor_edit(
                 payload=payload,
             )
             tmp = tempfile.mkdtemp(prefix="pmh-cursor-edit-")
+            mark_marionette_host_scratch(tmp)
             try:
                 store = create_store("sqlite", tmp)
                 result = Orchestrator(store).run(
                     goal,
                     specs=[spec],
                     worker_mode="inline",
-                    label=job_label_for_session(session_id),
+                    label=job_label_for_session(session_id, dispatch_id=job_id),
                 )
             finally:
                 shutil.rmtree(tmp, ignore_errors=True)
@@ -551,7 +553,7 @@ def run_cursor_edit(
 
 def run_agentic_edit(
     config: "HarnessConfig", goal: str, *, session_id: str = "", cwd: str = "",
-    expects_diff: bool = True,
+    expects_diff: bool = True, job_id: str = "",
 ) -> "WorkerResult":
     """Puppetmaster agentic adapter in a managed worktree.
 
@@ -568,6 +570,7 @@ def run_agentic_edit(
         coerce_unlabeled_analysis_prose,
         parse_analysis_signal_rows,
     )
+    from harness.cli_job_merge import mark_marionette_host_scratch
     from harness.job_scoping import job_label_for_session, stamp_task_payload
 
     if not agentic_available():
@@ -677,6 +680,7 @@ def run_agentic_edit(
             # never parse prose/stdout. Without the rmtree every agentic
             # implement worker leaked a pmh-edit-* dir (audit finding #3).
             tmp = tempfile.mkdtemp(prefix="pmh-edit-")
+            mark_marionette_host_scratch(tmp)
             mapped_events: list = []
             try:
                 store = create_store("sqlite", tmp)
@@ -684,7 +688,7 @@ def run_agentic_edit(
                     goal,
                     specs=[spec],
                     worker_mode="inline",
-                    label=job_label_for_session(session_id),
+                    label=job_label_for_session(session_id, dispatch_id=job_id),
                 )
                 pm_job_id = str(getattr(getattr(result, "job", None), "id", "") or "")
                 mapped_events = agentic_events_from_store(store, pm_job_id)

--- a/harness/local_job_swarm_view.py
+++ b/harness/local_job_swarm_view.py
@@ -237,7 +237,24 @@ def merge_local_jobs_into_swarm_live(
     local_jobs: Iterable[dict],
 ) -> list[dict]:
     """Merge local rows while durable store identities remain authoritative."""
-    out = list(store_jobs or [])
+    host_local_ids = {
+        str(job.get("id") or "").strip()
+        for job in (local_jobs or [])
+        if isinstance(job, dict)
+        and str(job.get("id") or "").startswith("local-")
+        and str(job.get("id") or "").strip()
+    }
+    # Exact ownership only: a store/cli row stamped dispatch_id=<local-*>
+    # is the host implement's internal Orchestrator job, not a second card.
+    # No goal / time / origin / session heuristic.
+    out = []
+    for job in store_jobs or []:
+        if not isinstance(job, dict):
+            continue
+        dispatch_id = str(job.get("dispatch_id") or "").strip()
+        if dispatch_id and dispatch_id in host_local_ids:
+            continue
+        out.append(job)
     existing_ids = {j.get("id") for j in out if j.get("id")}
     replaced_local_ids = {
         f"local-swarm-{str(job.get('dispatch_id') or '').strip()}"

--- a/harness/local_jobs.py
+++ b/harness/local_jobs.py
@@ -591,13 +591,17 @@ class LocalJobsMixin:
         the live status the UI renders.
 
         ``engine`` is ``agentic`` or ``native`` (never the pilot provider slug).
-        When known, ``model`` is the routed/driver model id; the panel shows
-        ``{engine}/{model}``. Task role is ``{role} ({engine})`` -- never
-        ``provider worker``.
+        When known, ``model`` is the actually selected/driver model id; the
+        panel shows ``{engine}/{model}``. Task role is ``{role} ({engine})``
+        -- never ``provider worker``.
 
         For agentic jobs with no model yet, dry-run the router and stamp a
-        ROUTING artifact + estimate so the tracker shows model/cost mid-flight
-        instead of a bare ``agentic`` badge. Zero-work full reuse passes
+        ROUTING artifact + estimate as metadata only. Preview ``model_id`` is
+        not the selected ``job.model`` — that stays empty until
+        ``_refresh_local_job_routed_model`` or ``_finish_local_job`` receives
+        a real routed id. Orchestrator.run is blocking and does not expose a
+        mid-run routing event without invasive hooks, so mid-flight identity
+        is explicitly provisional. Zero-work full reuse passes
         ``skip_routing_preview=True`` so preview economics are never stamped
         or exported for a job that performs no adapter work.
         """
@@ -626,9 +630,8 @@ class LocalJobsMixin:
                 preview = preview_agentic_route(goal, role=role or "implement")
             except Exception:
                 preview = {}
-            model_id = collapse_engine_prefixes(
-                (preview.get("model_id") or "").strip()
-            ) or (preview.get("model_id") or "").strip()
+            # Estimated routing metadata only — do not present preview
+            # model_id as the selected job.model.
             est_cost = float(preview.get("est_cost_usd") or 0.0)
             routing_saved = float(preview.get("routing_saved_usd") or 0.0)
             routing_basis = str(preview.get("routing_savings_basis") or "")
@@ -691,12 +694,15 @@ class LocalJobsMixin:
                 try:
                     from harness.observability_export import export_routing_savings
 
+                    preview_mid = collapse_engine_prefixes(
+                        (preview.get("model_id") or "").strip()
+                    ) or (preview.get("model_id") or "").strip()
                     export_routing_savings(
                         job_id=job_id,
                         session_id=session_id,
                         routing_saved_usd=routing_saved,
                         routing_savings_basis=routing_basis or "estimated",
-                        model_id=model_id,
+                        model_id=preview_mid or model_id,
                         baseline_model_id=str(preview.get("baseline_model_id") or ""),
                         tokens_compared=int(
                             (preview.get("tokens_in") or 0) + (preview.get("tokens_out") or 0)
@@ -704,6 +710,45 @@ class LocalJobsMixin:
                     )
                 except Exception:
                     pass
+
+    def _refresh_local_job_routed_model(
+        self, job_id: str, model: str, engine: str = "",
+    ) -> None:
+        """Best-effort mid-run stamp of an actually routed model.
+
+        Preview / dry-run ids must not be passed here. Never copies identity
+        from an EXTERNAL card. Never raises. ``_finish_local_job`` remains
+        terminal truth.
+        """
+        try:
+            if not job_id:
+                return
+            model_id = collapse_engine_prefixes((model or "").strip()) or (
+                model or ""
+            ).strip()
+            if not model_id or is_engine_only_model_id(model_id):
+                return
+            with self._local_jobs_lock:
+                job = self._local_jobs.get(job_id)
+                if not isinstance(job, dict):
+                    return
+                status = str(job.get("status") or "").strip().lower()
+                if status in _TERMINAL_LOCAL_JOB_STATUSES:
+                    return
+                engine_label = (engine or job.get("adapter") or "").strip().lower()
+                if engine_label not in ("agentic", "native"):
+                    engine_label = ""
+                display = envelope_model_id(engine_label, model_id)
+                if not display or is_engine_only_model_id(display):
+                    return
+                import time
+                job["model"] = display
+                job["updated_at"] = time.time()
+                if job.get("tasks"):
+                    job["tasks"][0]["model"] = display
+                self._persist_local_jobs_locked()
+        except Exception:
+            return
 
     def _finish_local_job(self, job_id: str, ok: bool, summary: str = "",
                           files: Optional[list] = None, tokens: int = 0,
@@ -763,28 +808,15 @@ class LocalJobsMixin:
                     job["tasks"][0]["adapter"] = engine_label
                     base_role = (job.get("role") or "implement").strip() or "implement"
                     job["tasks"][0]["role"] = f"{base_role} ({engine_label})"
-            # Never downgrade a real ROUTING/preview model to bare agentic/native.
-            # Empty finish-time model promotes from ROUTING artifact or keeps the
-            # existing non-engine-only stamp; prefer empty over eng-only honesty.
+            # Empty / engine-only finish keeps a real mid-run stamp (refresh
+            # seam) but does not promote preview ROUTING metadata to
+            # selected identity. Prefer empty over a dry-run lie.
             if is_engine_only_model_id(model_id):
-                promoted = ""
-                for art in (job.get("artifacts") or []):
-                    if not isinstance(art, dict):
-                        continue
-                    if (art.get("type") or "").strip().upper() != "ROUTING":
-                        continue
-                    art_mid = collapse_engine_prefixes(
-                        str(art.get("model") or art.get("model_id") or "").strip()
-                    ) or str(art.get("model") or art.get("model_id") or "").strip()
-                    if art_mid and not is_engine_only_model_id(art_mid):
-                        promoted = art_mid
-                if not promoted:
-                    existing = (job.get("model") or "").strip()
-                    if existing and not is_engine_only_model_id(existing):
-                        promoted = (
-                            collapse_engine_prefixes(existing) or existing
-                        )
-                model_id = promoted
+                existing = (job.get("model") or "").strip()
+                if existing and not is_engine_only_model_id(existing):
+                    model_id = collapse_engine_prefixes(existing) or existing
+                else:
+                    model_id = ""
             if model_id and not is_engine_only_model_id(model_id):
                 eng = engine_label if engine_label in ("agentic", "native") else ""
                 if not eng:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.246"
+version = "0.9.247"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.7" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.8" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.7"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.8"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.7" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.8" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.7}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.8}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/tests/test_cli_job_merge.py
+++ b/tests/test_cli_job_merge.py
@@ -2,17 +2,23 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 import urllib.parse
 import urllib.request
 from http.server import ThreadingHTTPServer
+from pathlib import Path
 from types import SimpleNamespace
 
 from harness.cli_job_merge import (
+    is_marionette_host_scratch_dir,
+    mark_marionette_host_scratch,
     merge_running_cli_jobs_all_projects,
     merge_scoped_cli_jobs,
+    open_cli_durable_at,
     open_cli_durable_state,
     reset_merge_diag_for_tests,
+    resolve_cli_state_dir,
 )
 from harness.job_scoping import (
     ACCOUNTING_SCOPE_VISIBILITY,
@@ -201,6 +207,86 @@ def test_foreign_state_dir_candidates_skips_stale_and_caps(tmp_path, monkeypatch
     got = _foreign_state_dir_candidates("", max_opens=8, max_age_s=48 * 3600)
     assert any(str(fresh.resolve()) == p or str(fresh) in p for p in got)
     assert not any("stale" in p for p in got)
+
+
+def test_scratch_identity_prefix_and_marker(tmp_path):
+    prefixed = tmp_path / "pmh-edit-abc123"
+    prefixed.mkdir()
+    assert is_marionette_host_scratch_dir(prefixed)
+    cursor = tmp_path / "pmh-cursor-edit-xyz"
+    cursor.mkdir()
+    assert is_marionette_host_scratch_dir(cursor)
+    hashed = tmp_path / "workspace-deadbeef"
+    hashed.mkdir()
+    assert not is_marionette_host_scratch_dir(hashed)
+    mark_marionette_host_scratch(hashed)
+    assert is_marionette_host_scratch_dir(hashed)
+    assert is_marionette_host_scratch_dir("") is False
+    assert is_marionette_host_scratch_dir(None) is False
+
+
+def test_resolve_cli_state_dir_ignores_host_scratch_env(tmp_path, monkeypatch):
+    import subprocess
+
+    from puppetmaster.state import default_state_dir
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    monkeypatch.setattr(
+        "puppetmaster.state.app_state_root",
+        lambda: tmp_path / "pm-root",
+    )
+    ws = default_state_dir(repo)
+    ws.mkdir(parents=True, exist_ok=True)
+    (ws / "state.sqlite3").write_bytes(b"x")
+
+    scratch = tmp_path / "pmh-edit-hijack"
+    scratch.mkdir()
+    (scratch / "state.sqlite3").write_bytes(b"x")
+    mark_marionette_host_scratch(scratch)
+    monkeypatch.setenv("PUPPETMASTER_STATE_DIR", str(scratch))
+
+    got = resolve_cli_state_dir(str(repo))
+    assert got is not None
+    assert Path(got).resolve() == ws.resolve()
+    assert Path(os.environ["PUPPETMASTER_STATE_DIR"]).resolve() == scratch.resolve()
+
+
+def test_resolve_cli_state_dir_honors_non_scratch_env(tmp_path, monkeypatch):
+    override = tmp_path / "operator-store"
+    override.mkdir()
+    (override / "state.sqlite3").write_bytes(b"x")
+    monkeypatch.setenv("PUPPETMASTER_STATE_DIR", str(override))
+    got = resolve_cli_state_dir(str(tmp_path / "unused"))
+    assert Path(got).resolve() == override.resolve()
+
+
+def test_foreign_candidates_skip_host_scratch(tmp_path, monkeypatch):
+    from harness.cli_job_merge import _foreign_state_dir_candidates
+
+    scratch = tmp_path / "pmh-edit-foreign"
+    durable = tmp_path / "durable-ok"
+    scratch.mkdir()
+    durable.mkdir()
+    (scratch / "state.sqlite3").write_bytes(b"")
+    (durable / "state.sqlite3").write_bytes(b"")
+    mark_marionette_host_scratch(scratch)
+    monkeypatch.setattr(
+        "puppetmaster.state.list_project_state_dirs",
+        lambda: [scratch, durable],
+    )
+    got = _foreign_state_dir_candidates("", max_opens=8, max_age_s=48 * 3600)
+    assert not any("pmh-edit" in p for p in got)
+    assert any("durable-ok" in p for p in got)
+
+
+def test_open_cli_durable_at_skips_scratch(tmp_path):
+    scratch = tmp_path / "pmh-edit-open"
+    scratch.mkdir()
+    (scratch / "state.sqlite3").write_bytes(b"x")
+    mark_marionette_host_scratch(scratch)
+    assert open_cli_durable_at(str(scratch)) is None
 
 
 def test_accounting_fields_from_cli_fixture_store(tmp_path):

--- a/tests/test_edit_engines.py
+++ b/tests/test_edit_engines.py
@@ -77,7 +77,7 @@ def _fake_managed_worktree(repo: str, base: str = "HEAD"):
 
 def _install_agentic_mocks(
     monkeypatch, *, orchestrator_result=None, capture_payload=None,
-    capture_specs=None,
+    capture_specs=None, capture_run=None,
 ):
     """Patch Puppetmaster + worktree so run_agentic_edit stays hermetic."""
     monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
@@ -86,6 +86,7 @@ def _install_agentic_mocks(
 
     storage: list[dict] = capture_payload if capture_payload is not None else []
     specs_out: list[dict] = capture_specs if capture_specs is not None else []
+    runs_out: list[dict] = capture_run if capture_run is not None else []
 
     class _CapturingWorkerSpec:
         def __init__(self, role, instruction, adapter, payload):
@@ -106,6 +107,7 @@ def _install_agentic_mocks(
             self.store = store
 
         def run(self, goal, specs=None, worker_mode="inline", **kwargs):
+            runs_out.append({"goal": goal, "worker_mode": worker_mode, **kwargs})
             return orchestrator_result or _fake_pm_result()
 
     monkeypatch.setattr("puppetmaster.workers.WorkerSpec", _CapturingWorkerSpec)
@@ -1046,6 +1048,113 @@ def test_agentic_edit_success_with_patch(monkeypatch):
 # --- run_edit_worker dispatch and fallback ---
 
 
+def test_run_edit_worker_forwards_job_id_to_agentic(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.select_edit_engine", lambda *a, **k: "agentic")
+        seen = {}
+
+        def fake_agentic(config, goal, **kwargs):
+            seen.update(kwargs)
+            return WorkerResult(ok=True, patch="p", summary="ok")
+
+        monkeypatch.setattr("harness.edit_engines.run_agentic_edit", fake_agentic)
+        result = run_edit_worker(
+            cfg, "do it", job_id="local-abc", session_id="sess-1",
+        )
+        assert result.ok is True
+        assert seen["job_id"] == "local-abc"
+        assert seen["session_id"] == "sess-1"
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_marks_scratch_and_stamps_host_dispatch(monkeypatch):
+    import json
+
+    from harness.cli_job_merge import HOST_SCRATCH_MARKER_NAME, is_marionette_host_scratch_dir
+
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        marked = []
+        runs = []
+        from harness.cli_job_merge import mark_marionette_host_scratch as real_mark
+
+        def _spy_mark(path):
+            marked.append(path)
+            real_mark(path)
+            assert is_marionette_host_scratch_dir(path)
+            assert os.path.basename(path).startswith("pmh-edit-")
+            assert os.path.isfile(os.path.join(path, HOST_SCRATCH_MARKER_NAME))
+
+        monkeypatch.setattr(
+            "harness.cli_job_merge.mark_marionette_host_scratch", _spy_mark,
+        )
+        _install_agentic_mocks(
+            monkeypatch,
+            orchestrator_result=_fake_pm_result([
+                _fake_artifact(tokens_out=10, tokens_in=4, stdout="ok"),
+            ]),
+            capture_run=runs,
+        )
+        monkeypatch.setattr(
+            "harness.edit_engines.finalize_worktree_patch",
+            lambda _wt: ("diff --git a/x b/x\n+line", ["x.py"]),
+        )
+        result = run_agentic_edit(
+            cfg, "goal", session_id="sess-z", job_id="local-host-1",
+        )
+        assert result.ok is True
+        assert marked
+        assert os.path.basename(marked[0]).startswith("pmh-edit-")
+        assert runs
+        label = json.loads(runs[0]["label"])
+        assert label["session_id"] == "sess-z"
+        assert label["dispatch_id"] == "local-host-1"
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_cursor_edit_marks_scratch_and_stamps_host_dispatch(monkeypatch):
+    import json
+
+    from harness.edit_engines import run_cursor_edit
+
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        marked = []
+        runs = []
+        from harness.cli_job_merge import mark_marionette_host_scratch as real_mark
+
+        def _spy_mark(path):
+            marked.append(path)
+            real_mark(path)
+
+        monkeypatch.setattr(
+            "harness.cli_job_merge.mark_marionette_host_scratch", _spy_mark,
+        )
+        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: True)
+        _install_agentic_mocks(monkeypatch, capture_run=runs)
+        monkeypatch.setattr(
+            "harness.edit_engines.finalize_worktree_patch",
+            lambda _wt: ("diff --git a/x b/x\n+line", ["x.py"]),
+        )
+        result = run_cursor_edit(
+            cfg, "goal", session_id="sess-c", job_id="local-cur-1",
+        )
+        assert result.ok is True
+        assert marked
+        assert os.path.basename(marked[0]).startswith("pmh-cursor-edit-")
+        label = json.loads(runs[0]["label"])
+        assert label["session_id"] == "sess-c"
+        assert label["dispatch_id"] == "local-cur-1"
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
 def test_run_edit_worker_dispatches_native(monkeypatch):
     repo_dir = create_temp_git_repo()
     try:
@@ -1091,6 +1200,7 @@ def test_run_edit_worker_falls_back_on_agentic_unavailable(monkeypatch):
     try:
         cfg = _cfg(repo_dir)
         monkeypatch.setattr("harness.edit_engines.select_edit_engine", lambda *a, **k: "agentic")
+        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
         monkeypatch.setattr(
             "harness.edit_engines.run_agentic_edit",
             lambda *a, **k: WorkerResult(ok=False, error=AGENTIC_UNAVAILABLE, summary="no key"),
@@ -1131,6 +1241,7 @@ def test_run_edit_worker_falls_back_on_route_and_runtime_errors(monkeypatch):
     try:
         cfg = _cfg(repo_dir)
         monkeypatch.setattr("harness.edit_engines.select_edit_engine", lambda *a, **k: "agentic")
+        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
         native_sentinel = WorkerResult(ok=True, summary="native")
 
         for err in (AGENTIC_ROUTE_FAILED, AGENTIC_ERROR):

--- a/tests/test_implement_fanout_and_metrics.py
+++ b/tests/test_implement_fanout_and_metrics.py
@@ -363,7 +363,7 @@ def test_register_local_job_stamps_routing(monkeypatch):
         engine="agentic", model="",
     )
     job = s._local_jobs["local-route"]
-    assert job["model"] == "agentic/z-ai/glm-4.9"
+    assert job["model"] == ""
     assert abs(job["est_cost_usd"] - 0.0123) < 1e-9
     arts = job["artifacts"]
     assert len(arts) == 1

--- a/tests/test_local_job_labeling.py
+++ b/tests/test_local_job_labeling.py
@@ -108,8 +108,8 @@ def test_failed_local_terminal_artifact_carries_exact_task_id(monkeypatch):
     assert terminal["task_id"] == task_id
 
 
-def test_finish_does_not_clobber_preview_model_with_engine_only(monkeypatch):
-    """Finish with engine but empty model must keep the preview ROUTING stamp."""
+def test_finish_does_not_promote_preview_model_when_terminal_model_empty(monkeypatch):
+    """Preview stays ROUTING metadata; empty finish must not invent a selection."""
     monkeypatch.setattr(
         "harness.local_job_routing.preview_agentic_route",
         lambda *a, **k: {
@@ -129,15 +129,83 @@ def test_finish_does_not_clobber_preview_model_with_engine_only(monkeypatch):
         "local-keep", "edit keep", role="implement",
         engine="agentic", model="",
     )
-    assert s._local_jobs["local-keep"]["model"] == "agentic/z-ai/glm-5.2"
+    assert s._local_jobs["local-keep"]["model"] == ""
+    routing = next(
+        a for a in s._local_jobs["local-keep"]["artifacts"]
+        if a.get("type") == "ROUTING"
+    )
+    assert routing["model"] == "z-ai/glm-5.2"
     s._finish_local_job(
         "local-keep", ok=True, summary="done", files=["a.py"],
         tokens=10, engine="agentic", model="",
     )
     job = s._local_jobs["local-keep"]
     assert job["adapter"] == "agentic"
-    assert job["model"] == "agentic/z-ai/glm-5.2"
+    assert job["model"] == ""
     assert job["model"] != "agentic"
+    assert next(a for a in job["artifacts"] if a.get("type") == "ROUTING")["model"] == (
+        "z-ai/glm-5.2"
+    )
+
+
+def test_preview_is_not_selected_identity_until_finish(monkeypatch):
+    """No-provider preview must not become job.model; finish is terminal truth."""
+    monkeypatch.setattr(
+        "harness.local_job_routing.preview_agentic_route",
+        lambda *a, **k: {
+            "model_id": "gpt-5.6-luna",
+            "est_cost_usd": 0.02,
+            "artifact": {
+                "type": "ROUTING",
+                "headline": "Routed to gpt-5.6-luna",
+                "created_by": "router",
+                "model": "gpt-5.6-luna",
+            },
+        },
+    )
+    s = _session(driver="stub-oracle-v2")
+    s._register_local_job(
+        "local-truth", "edit foo", role="implement",
+        engine="agentic", model="",
+    )
+    job = s._local_jobs["local-truth"]
+    assert job["model"] == ""
+    assert job["artifacts"][0]["model"] == "gpt-5.6-luna"
+    s._finish_local_job(
+        "local-truth", ok=True, summary="done", files=["a.py"],
+        tokens=20, engine="agentic", model="gpt-5",
+    )
+    assert s._local_jobs["local-truth"]["model"] == "agentic/gpt-5"
+
+
+def test_refresh_local_job_routed_model_stamps_actual_only(monkeypatch):
+    monkeypatch.setattr(
+        "harness.local_job_routing.preview_agentic_route",
+        lambda *a, **k: {
+            "model_id": "gpt-5.6-luna",
+            "artifact": {
+                "type": "ROUTING",
+                "headline": "Routed to gpt-5.6-luna",
+                "model": "gpt-5.6-luna",
+            },
+        },
+    )
+    s = _session(driver="stub-oracle-v2")
+    s._register_local_job(
+        "local-ref", "edit foo", role="implement",
+        engine="agentic", model="",
+    )
+    assert s._local_jobs["local-ref"]["model"] == ""
+    s._refresh_local_job_routed_model("local-ref", "gpt-5", engine="agentic")
+    assert s._local_jobs["local-ref"]["model"] == "agentic/gpt-5"
+    assert s._local_jobs["local-ref"]["tasks"][0]["model"] == "agentic/gpt-5"
+
+
+def test_refresh_local_job_routed_model_never_raises():
+    s = _session()
+    s._refresh_local_job_routed_model("", "gpt-5")
+    s._refresh_local_job_routed_model("missing", "gpt-5")
+    s._refresh_local_job_routed_model("local-x", "agentic")
 
 
 def test_worker_result_engine_model_defaults_back_compat():

--- a/tests/test_local_job_routing.py
+++ b/tests/test_local_job_routing.py
@@ -193,8 +193,10 @@ def test_register_registry_shaped_id_never_double_prefixes(monkeypatch, tmp_path
         "local-ds", "edit", role="implement", engine="agentic", model="",
     )
     job = s._local_jobs["local-ds"]
-    assert job["model"] == "agentic/deepseek/deepseek-v4-pro"
-    assert "agentic/agentic/" not in job["model"]
+    assert job["model"] == ""
+    routing = next(a for a in job["artifacts"] if a.get("type") == "ROUTING")
+    assert routing["model"] == "agentic/deepseek/deepseek-v4-pro"
+    assert "agentic/agentic/" not in routing["model"]
 
 
 def test_finish_reconciles_flash_preview_when_pro_is_realized(monkeypatch, tmp_path):

--- a/tests/test_local_job_swarm_view.py
+++ b/tests/test_local_job_swarm_view.py
@@ -223,6 +223,43 @@ def test_merge_keeps_identical_goal_with_different_dispatch_identity():
     ]
 
 
+def test_merge_drops_store_row_owned_by_host_local_dispatch():
+    """Scratch/hashed Orchestrator rows stamped dispatch_id=<local-*> stay hidden."""
+    store = [{
+        "id": "job_scratch",
+        "goal": "same implement goal",
+        "status": "running",
+        "source": "cli",
+        "dispatch_id": "local-e0d790a9",
+    }]
+    local = [_sample_local_job(
+        id="local-e0d790a9",
+        goal="same implement goal",
+        model="",
+    )]
+    merged = merge_local_jobs_into_swarm_live(store, local)
+    assert [job["id"] for job in merged] == ["local-e0d790a9"]
+
+
+def test_merge_keeps_unstamped_external_and_two_local_same_goal():
+    store = [{
+        "id": "job_external",
+        "goal": "same implement goal",
+        "status": "running",
+        "source": "cli",
+    }]
+    local = [
+        _sample_local_job(id="local-one", goal="same implement goal", model=""),
+        _sample_local_job(id="local-two", goal="same implement goal", model=""),
+    ]
+    merged = merge_local_jobs_into_swarm_live(store, local)
+    assert [job["id"] for job in merged] == [
+        "job_external",
+        "local-one",
+        "local-two",
+    ]
+
+
 def test_merge_keeps_placeholder_when_durable_dispatch_identity_is_missing():
     store = [{
         "id": "job_legacy",

--- a/tests/test_local_jobs_mixin.py
+++ b/tests/test_local_jobs_mixin.py
@@ -11,6 +11,7 @@ from harness.local_jobs import LocalJobsMixin
 
 MOVED_METHODS = (
     "_register_local_job",
+    "_refresh_local_job_routed_model",
     "_finish_local_job",
     "_persist_local_jobs_locked",
     "_persist_local_jobs",

--- a/tests/test_swarm_live.py
+++ b/tests/test_swarm_live.py
@@ -3,10 +3,13 @@ import json
 import threading
 import urllib.request
 import urllib.error
+import urllib.parse
 import tempfile
 import shutil
 import os
+import subprocess
 from http.server import ThreadingHTTPServer
+from pathlib import Path
 
 import pytest
 
@@ -162,3 +165,154 @@ def test_session_total_includes_swarm_store_job_cost(monkeypatch):
             httpd.shutdown()
     finally:
         shutil.rmtree(tmp_dir)
+
+
+def _git_repo(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-b", "main"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, capture_output=True)
+    (path / "README").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README"], cwd=path, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, capture_output=True)
+    return path
+
+
+def _set_running(store, job_id: str) -> None:
+    try:
+        store.update_job_status(job_id, "running")
+    except Exception:
+        store.set_job_status(job_id, "running")
+
+
+def _save_cwd_task(store, job_id: str, cwd: str, session_id: str = "") -> None:
+    from harness.job_scoping import stamp_task_payload
+    from puppetmaster.models import Task
+
+    payload = stamp_task_payload({"cwd": cwd}, session_id=session_id, cwd=cwd)
+    if not session_id:
+        payload = {"cwd": cwd}
+    store.save_task(Task(
+        job_id=job_id,
+        role="implement",
+        instruction="do work",
+        adapter="agentic",
+        payload=payload,
+    ))
+
+
+def test_swarm_live_held_open_scratch_hijack_exposes_only_host_local(tmp_path, monkeypatch):
+    """Reproduce PUPPETMASTER_STATE_DIR hijack while scratch job_* and local-* coexist.
+
+    Production merge functions stay live. Cross-project is on, but isolated
+    under a throwaway app_state_root so developer stores are never opened.
+    """
+    from harness.cli_job_merge import (
+        mark_marionette_host_scratch,
+        merge_running_cli_jobs_all_projects,
+        merge_scoped_cli_jobs,
+        resolve_cli_state_dir,
+    )
+    from harness.job_scoping import job_label_for_session
+    import puppetmaster.state as pm_state
+    from puppetmaster.store_factory import create_store
+
+    assert merge_scoped_cli_jobs.__module__ == "harness.cli_job_merge"
+    assert merge_running_cli_jobs_all_projects.__module__ == "harness.cli_job_merge"
+
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.setattr(pm_state, "app_state_root", lambda: tmp_path / "pm-root")
+    monkeypatch.setenv("HARNESS_CLI_CROSS_PROJECT", "1")
+    monkeypatch.setattr(
+        "harness.local_job_routing.preview_agentic_route",
+        lambda *a, **k: {
+            "model_id": "gpt-5.6-luna",
+            "est_cost_usd": 0.01,
+            "artifact": {
+                "type": "ROUTING",
+                "headline": "Routed to gpt-5.6-luna",
+                "model": "gpt-5.6-luna",
+            },
+        },
+    )
+
+    goal = "create proof.txt"
+    ws_dir = pm_state.default_state_dir(repo)
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    ws_store = create_store("sqlite", str(ws_dir))
+    external = ws_store.create_job(goal)
+    _save_cwd_task(ws_store, external.id, str(repo))
+    _set_running(ws_store, external.id)
+
+    foreign_dir = pm_state.app_state_root() / "projects" / "foreign-cli"
+    foreign_dir.mkdir(parents=True, exist_ok=True)
+    foreign_store = create_store("sqlite", str(foreign_dir))
+    foreign = foreign_store.create_job(goal)
+    _save_cwd_task(foreign_store, foreign.id, str(repo))
+    _set_running(foreign_store, foreign.id)
+
+    leaked = pm_state.app_state_root() / "projects" / "pmh-edit-leaked"
+    leaked.mkdir(parents=True, exist_ok=True)
+    mark_marionette_host_scratch(leaked)
+    leaked_store = create_store("sqlite", str(leaked))
+    leaked_job = leaked_store.create_job(goal)
+    _set_running(leaked_store, leaked_job.id)
+
+    scratch = tmp_path / "pmh-edit-hijack"
+    scratch.mkdir()
+    mark_marionette_host_scratch(scratch)
+    scratch_store = create_store("sqlite", str(scratch))
+    httpd, port, srv = _server(str(tmp_path / "harness-state"))
+    try:
+        headers = {"X-Harness-Token": srv._TOKEN}
+        srv._cfg.repo = str(repo)
+        if not srv._sessions.active:
+            srv._sessions.create(
+                "held-open", repo=str(repo), workspace_root=str(repo),
+            )
+        srv._sync_pilot_session_id()
+        sid = srv._pilot.harness_session_id or srv._sessions.active or ""
+
+        scratch_job = scratch_store.create_job(
+            goal,
+            label=job_label_for_session(sid, dispatch_id="local-host-a"),
+        )
+        _save_cwd_task(scratch_store, scratch_job.id, str(repo), session_id=sid)
+        _set_running(scratch_store, scratch_job.id)
+        monkeypatch.setenv("PUPPETMASTER_STATE_DIR", str(scratch))
+
+        resolved = resolve_cli_state_dir(str(repo))
+        assert resolved is not None
+        assert Path(resolved).resolve() == Path(ws_dir).resolve()
+        assert Path(os.environ["PUPPETMASTER_STATE_DIR"]).resolve() == scratch.resolve()
+
+        srv._pilot._register_local_job(
+            "local-host-a", goal, role="implement",
+            cwd=str(repo), engine="agentic", model="",
+        )
+        srv._pilot._register_local_job(
+            "local-host-b", goal, role="implement",
+            cwd=str(repo), engine="agentic", model="",
+        )
+
+        scoped = urllib.parse.quote(str(repo), safe="")
+        data = json.loads(
+            _get(port, f"/api/swarm/live?repo={scoped}", headers=headers).read().decode()
+        )
+        ids = [j.get("id") for j in data["jobs"]]
+        assert "local-host-a" in ids
+        assert "local-host-b" in ids
+        assert external.id in ids
+        assert foreign.id in ids
+        assert scratch_job.id not in ids
+        assert leaked_job.id not in ids
+        locals_ = [j for j in data["jobs"] if str(j.get("id") or "").startswith("local-")]
+        assert len(locals_) == 2
+        assert all(j.get("model") == "" for j in locals_)
+        assert all(j.get("source") == "harness" for j in locals_)
+        ext_row = next(j for j in data["jobs"] if j.get("id") == external.id)
+        assert ext_row["source"] == "cli"
+        assert ext_row["goal"] == goal
+    finally:
+        httpd.shutdown()
+        srv._pilot._local_jobs.clear()

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.7";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.8";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.7";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.8";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 
 // True when `pip show` / `uv pip show` output describes an editable install
@@ -43,7 +43,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.7" }     -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.8" }     -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -65,7 +65,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.7).
+ * to 1.22.8).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -123,6 +123,28 @@ test("planPuppetmasterUpgrade: an editable dev checkout is left untouched", () =
   assert.match(plan.reason, /editable/);
 });
 
+test("operational Puppetmaster pins match DEFAULT_PUPPETMASTER_SPEC", () => {
+  const spec = pm.DEFAULT_PUPPETMASTER_SPEC;
+  assert.match(spec, /^puppetmaster-ai==\d+\.\d+\.\d+$/);
+  const repoRoot = path.join(__dirname, "..", "..");
+  const copies = [
+    "webapp/electron/update-pm.cjs",
+    "webapp/electron/bootstrap.cjs",
+    "scripts/install.sh",
+    "scripts/install.ps1",
+    "scripts/doctor.sh",
+    "scripts/doctor.ps1",
+    ".github/workflows/tests.yml",
+    ".github/workflows/release.yml",
+  ];
+  const escaped = spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const specRe = new RegExp(escaped);
+  for (const rel of copies) {
+    const text = fs.readFileSync(path.join(repoRoot, rel), "utf8");
+    assert.match(text, specRe, `${rel} must pin ${spec}`);
+  }
+});
+
 test("planPuppetmasterUpgrade: a custom MARIONETTE_PUPPETMASTER_SPEC is honored (never clobbered)", () => {
   const plan = pm.planPuppetmasterUpgrade({
     specEnv: "/Users/dev/Puppetmaster",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.246",
+  "version": "0.9.247",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.246",
+      "version": "0.9.247",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.246",
+  "version": "0.9.247",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- One `run_implement` is one Swarm Tracker lifecycle: host `local-*` owns the card; inline Orchestrator scratch (`pmh-edit-*` / `pmh-cursor-edit-*`) stays off EXTERNAL.
- Preview route is estimated metadata only — not selected `job.model`.
- Operational pin moves to `puppetmaster-ai==1.22.8` (desktop + CI).

Closes #62.

## Test plan
- [x] local Python suite: 4606 passed, 74 skipped
- [x] pin-parity / updater node tests: 51 passed
- [x] version consistency (0.9.247)
- [ ] GitHub `tests` workflow green on dest, then on the merged main SHA before tagging