### PR TITLE
Release v0.9.248

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.8"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.9"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           # Floor matches the accounting/routing fixes this release needs.
           # Unpinned `puppetmaster-ai` + pip cache can leave CI on an older
           # wheel (e.g. 1.14.0) and fail fallback-pricing regressions.
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.8"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.9"
 
       # full_auto_safety modules already run inside this job via conftest
       # auto-tagging; a separate named job was redundant PR compute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.8"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.9"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.8` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.9` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.8` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.9` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.247, deliberately pre-1.0. One run_implement is one Swarm Tracker lifecycle: the host local-* row owns the card, inline Orchestrator scratch stays off EXTERNAL, and preview route is estimated metadata not selected model. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins. Rides puppetmaster-ai==1.22.8.
+> Status: v0.9.248, deliberately pre-1.0. Rides puppetmaster-ai==1.22.9 (SWE-bench Bash Only community priors for implement routing; capability_score stays the manual fallback). One run_implement remains one Swarm Tracker lifecycle. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
 
 ## Documentation
 
@@ -93,7 +93,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.8` (exact registry pins, GPT-5.6 tool reasoning, Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.9` (exact registry pins, GPT-5.6 tool reasoning, Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.247"
+__version__ = "0.9.248"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.247"
+version = "0.9.248"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.8" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.9" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.8"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.9"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.8" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.9" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.8}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.9}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.8";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.9";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.8";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.9";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 
 // True when `pip show` / `uv pip show` output describes an editable install
@@ -43,7 +43,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.8" }     -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.9" }     -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -65,7 +65,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.8).
+ * to 1.22.9).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.247",
+  "version": "0.9.248",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.247",
+      "version": "0.9.248",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.247",
+  "version": "0.9.248",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Pin desktop + CI to `puppetmaster-ai==1.22.9`.
- Synchronize Marionette version stamps at v0.9.248.

## Test plan
- [x] local Python suite: 4606 passed, 74 skipped
- [x] pin-parity / updater node tests: 40 passed
- [x] version consistency tests
- [ ] GitHub `tests` workflow green on the merged main SHA before tagging