### PR TITLE
Release v0.9.249

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,46 @@
 name: release
 
-# Build thin Electron shell installers on tag push. The packaged app bootstraps a
-# source checkout on first launch; it does NOT bundle Python or a PyInstaller backend.
+# Thin Electron shell installers. The packaged app bootstraps a source checkout
+# on first launch; it does NOT bundle Python or a PyInstaller backend.
+#
+# Dest->main PRs start installer builds in parallel with tests.yml. A v* tag
+# publishes only after a successful `tests` workflow exists for this git tree
+# (commit or same-tree dest PR). release.yml does not re-run pytest.
 
 on:
+  pull_request:
+    branches: [main]
   push:
     tags:
       - "v*"
   workflow_dispatch:
 
+# Operational pin (installers inherit Puppetmaster from the checkout).
+# Kept here so desktop/CI pin-parity tests stay honest.
+env:
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.11
+
 permissions:
   contents: write
+  actions: read
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Hard gate: a tag build must prove the suite green before any installer is
-  # built or uploaded. Releases can never ship from a red tree.
-  test-gate:
+  tests-already-green:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        # Floor (3.9, the requires-python minimum) + the dev interpreter (3.11).
-        python-version: ["3.9", "3.11"]
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-
-      - name: Install (rig + dev extras + Puppetmaster from PyPI)
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.9"
-
-      - name: Run the offline test suite
-        run: python -m pytest -q -p no:cacheprovider
+      - name: Require a successful tests workflow for this tree
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/ci_release_gate.py require-green
 
   build:
-    needs: test-gate
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +55,29 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Set up Python (tag adopt)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Reuse same-tree installers from dest PR
+        id: reuse
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if python scripts/ci_release_gate.py adopt-installers \
+               --platform "${{ matrix.platform }}" \
+               --out webapp/release; then
+            echo "adopted=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "adopted=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Node
+        if: steps.reuse.outputs.adopted != 'true'
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -63,15 +85,16 @@ jobs:
           cache-dependency-path: webapp/package-lock.json
 
       - name: Install uv (Unix)
-        if: runner.os != 'Windows'
+        if: steps.reuse.outputs.adopted != 'true' && runner.os != 'Windows'
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Install uv (Windows)
-        if: runner.os == 'Windows'
+        if: steps.reuse.outputs.adopted != 'true' && runner.os == 'Windows'
         shell: pwsh
         run: irm https://astral.sh/uv/install.ps1 | iex
 
       - name: Build renderer + package Electron shell
+        if: steps.reuse.outputs.adopted != 'true'
         working-directory: webapp
         shell: bash
         env:
@@ -102,7 +125,7 @@ jobs:
           printf '  %s\n' "${feeds[@]}"
 
       # Stage installers as Actions artifacts. Do NOT call the Releases API from
-      # the matrix â€” three parallel softprops uploads race and flake hard when
+      # the matrix -- three parallel softprops uploads race and flake hard when
       # GitHub returns HTML 503/unicorn pages for /releases.
       - name: Stage installer artifacts
         uses: actions/upload-artifact@v4
@@ -119,7 +142,8 @@ jobs:
           retention-days: 7
 
   publish:
-    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [tests-already-green, build]
     runs-on: ubuntu-latest
     steps:
       # Checkout so `gh release create --generate-notes` can read git history.
@@ -142,7 +166,7 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          # Keep the finder free of escaped parens â€” Actions wraps this into a
+          # Keep the finder free of escaped parens -- Actions wraps this into a
           # temp .sh and `find \( ... \)` has failed with syntax errors.
           mapfile -t ALL < <(find dist -type f | sort)
           FILTERED=()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,14 @@ jobs:
       matrix:
         # Floor (3.9, the requires-python minimum) + the dev interpreter (3.11),
         # on every OS users actually run: Linux, macOS, and Windows.
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # CI_WINDOWS_RUNNER swaps GitHub-hosted windows-latest for a faster
+        # machine (Blacksmith `blacksmith-4vcpu-windows-2025`) without a new
+        # workflow. Unset keeps windows-latest so CI never queues on a missing
+        # runner label.
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}
         python-version: ["3.9", "3.11"]
         exclude:
           # actions/setup-python has no CPython 3.9 build for arm64 macOS.
@@ -46,7 +53,7 @@ jobs:
           # Floor matches the accounting/routing fixes this release needs.
           # Unpinned `puppetmaster-ai` + pip cache can leave CI on an older
           # wheel (e.g. 1.14.0) and fail fallback-pricing regressions.
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.9"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.11"
 
       # full_auto_safety modules already run inside this job via conftest
       # auto-tagging; a separate named job was redundant PR compute.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,15 +31,18 @@ Ownership rule: new pilot tools -> `pilot.py` schema + `tool_dispatch` /
 - Tests before claiming done: `.venv/bin/python -m pytest -q`. The offline E2E
   test drives real Puppetmaster and must stay green with zero API keys.
 - Releases only from green CI: never push a release tag until the `tests`
-  workflow is green on the target commit (both the 3.9 floor and 3.11 legs).
-  The release workflow re-runs the suite as a hard gate before building
-  installers, but do not rely on it -- check first, tag second. Local tests
+  workflow is green for this git tree (3.9 floor, 3.11, Windows, frontend-build).
+  If dest-into-main `merge^{tree}` equals the dest PR tree that already passed,
+  tag immediately -- do not wait for main to run the same suite again. The
+  release workflow must not re-run pytest; it only checks that a successful
+  `tests` run exists for the tree, then publishes installers. Local tests
   pass on the dev interpreter only; CI is what proves the 3.9 floor.
 - Never commit keys or `results/*.sqlite`.
 - Git flow: day-to-day work is on `dev`. Feature PRs target `dev`. Ship by
-  merging `dev` into `main`, waiting for `tests` CI green on that SHA, then
-  tagging `main`. Never push product work or `pmedit-*` worker branches to
-  `main` / origin scratch.
+  merging `dev` into `main` (dest contains `main` first), tagging when the
+  dest-into-main PR `tests` matrix is green and `merge^{tree}` matches, then
+  pushing `vX.Y.Z` on `main`. Never push product work or `pmedit-*` worker
+  branches to `main` / origin scratch.
 
 <!-- puppetmaster:rules:begin -->
 <!-- managed by `puppetmaster install-rules`; delete this whole block to disable -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.9"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.11"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 
@@ -64,7 +64,7 @@ runs from source.
 Marionette self-updates from git, Hermes-style: every source checkout tracks
 `main` and shows an `update (N)` pill when it's behind, then pulls + rebuilds +
 relaunches in place. So **merging `dev` into `main` (green `tests` CI on that
-SHA) ships your change to every source install** on their next relaunch. Tagged
+tree) ships your change to every source install** on their next relaunch. Tagged
 releases also rebuild the thin Electron installers (macOS, Windows, Linux) via
 CI; those users pick up changes after bootstrap + update or by installing a
 newer Release.

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.9` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.11` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.9` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.11` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.248, deliberately pre-1.0. Rides puppetmaster-ai==1.22.9 (SWE-bench Bash Only community priors for implement routing; capability_score stays the manual fallback). One run_implement remains one Swarm Tracker lifecycle. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
+> Status: v0.9.249, deliberately pre-1.0. Rides puppetmaster-ai==1.22.11 (Sonnet 5 curated catalogs, discovery-origin provenance, spawned-worker exemption from the delegate-first gate). Composer accepts outside folder and zip drops. Release tags when dest-PR tests are green for this tree. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
 
 ## Documentation
 
@@ -93,7 +93,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.9` (exact registry pins, GPT-5.6 tool reasoning, Grok 4.6 starter overlay, plus shared verified context / Frontier, Codex swarm fixes, model allowlists, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.11` (Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,18 +39,50 @@ tagged installer from Releases.
 ## Cutting a version tag
 
 Tags/versions label what checkouts and installers report via `app.getVersion()`.
-Pushing a `v*` tag triggers `.github/workflows/release.yml`: the offline test
-suite must pass, then macOS, Windows, and Linux Electron shells are built and
-uploaded to the GitHub Release (DMG/zip, `.exe`, AppImage, blockmaps, and
-`latest*.yml` auto-update metadata).
+Green CI Before Tag still holds: the `tests` workflow (3.9 floor, 3.11,
+Windows, frontend-build) must be green for **this git tree**. The tag may
+point at the dest-into-main merge commit; it does not need a second `tests`
+run on that SHA when `merge^{tree}` equals the already-green dest PR tree.
+
+`.github/workflows/release.yml` does **not** re-run pytest. On a dest-into-main
+PR it starts installer builds in parallel with `tests.yml`. On a `v*` tag it
+checks that a successful `tests` run exists for this tree (or this commit),
+reuses those PR installers when the tree matches, and publishes only after
+that check. Users wait `max(tests, builds)`, not tests + builds + a second
+pytest gate.
+
+If a conflict resolution changes the tree, wait for `tests` on the new tree.
+That is the only exception.
 
 ```bash
+# Preferred ship path (version bump already on dest, dest contains main):
+# 1. Open dest -> main. Wait for that PR's tests matrix.
+# 2. Merge. Confirm merge^{tree} == dest^{tree}.
+# 3. Tag immediately:
+git tag vX.Y.Z
+git push origin vX.Y.Z
+
+# Or the source-run helper (refuses to tag a red/unknown tree):
 bash scripts/release.sh X.Y.Z "release notes"
 ```
 
-This bumps `webapp/package.json`, commits `release: vX.Y.Z`, tags it, pushes
-`main` + the tag, and creates/updates the GitHub Release notes. CI attaches the
-platform binaries when the workflow completes.
+`scripts/release.sh` bumps `webapp/package.json`, commits `release: vX.Y.Z` if
+needed, requires a green `tests` workflow for the resulting tree, then tags
+and pushes. A version bump on `main` that was not in the dest PR changes the
+tree; wait for `tests` on that commit.
+
+### Faster Windows (optional)
+
+`tests.yml` reads `vars.CI_WINDOWS_RUNNER` and falls back to `windows-latest`.
+After the Blacksmith GitHub App is installed on this repo, set:
+
+```bash
+gh variable set CI_WINDOWS_RUNNER --body blacksmith-4vcpu-windows-2025 \
+  --repo professorpalmer/marionette
+```
+
+Same YAML, different machines. Do not hardcode the Blacksmith label until the
+app is installed or Windows jobs queue forever.
 
 ## Diverged / self-edited checkouts
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.248"
+__version__ = "0.9.249"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/files.py
+++ b/harness/api/files.py
@@ -399,8 +399,14 @@ _DOCUMENT_UPLOAD_EXTS = frozenset({
     ".cjs", ".mjs", ".html", ".css", ".csv", ".xml", ".yml", ".yaml",
     ".toml", ".rst", ".tex", ".ipynb", ".rtf", ".log", ".cfg", ".ini",
     ".svg",
+    ".go", ".rs", ".java", ".kt", ".c", ".h", ".cc", ".cpp", ".hpp",
+    ".rb", ".php", ".swift", ".cs", ".sh", ".bash", ".zsh", ".ps1",
+    ".sql", ".proto", ".vue", ".svelte", ".jsx",
 })
-_UPLOAD_EXTS = _IMAGE_UPLOAD_EXTS | _DOCUMENT_UPLOAD_EXTS
+_ARCHIVE_UPLOAD_EXTS = frozenset({
+    ".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z",
+})
+_UPLOAD_EXTS = _IMAGE_UPLOAD_EXTS | _DOCUMENT_UPLOAD_EXTS | _ARCHIVE_UPLOAD_EXTS
 
 
 def save_upload(body: bytes, content_type: str, upload_dir: str) -> tuple[int, dict]:
@@ -426,8 +432,8 @@ def save_upload(body: bytes, content_type: str, upload_dir: str) -> tuple[int, d
     if skipped:
         return 400, {
             "error": (
-                "This file type cannot be attached. Drop an image or a "
-                "document (md, txt, pdf, json, source), or drop a file "
+                "This file type cannot be attached. Drop an image, "
+                "document, archive (zip), or source file, or drop a file "
                 "from the open workspace to @-mention it."
             ),
             "saved": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.248"
+version = "0.9.249"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/ci_release_gate.py
+++ b/scripts/ci_release_gate.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Release CI helpers: tree-green tests check, same-tree installer reuse.
+
+Green CI Before Tag stays: a successful `tests` workflow must exist for this
+git tree (commit or dest-PR merge with the same tree). release.yml must not
+re-run pytest. See RELEASING.md.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+
+REQUIRED_INSTALLER_NAMES = ("installer-mac", "installer-win", "installer-linux")
+
+
+def matching_green_run(
+    target_tree,  # type: str
+    runs,  # type: Iterable[Dict[str, Any]]
+    tree_for_sha,  # type: Callable[[str], Optional[str]]
+):
+    # type: (...) -> Optional[Dict[str, Any]]
+    """Return the first successful tests run whose head commit tree matches."""
+    if not target_tree:
+        return None
+    for run in runs:
+        conclusion = run.get("conclusion")
+        if conclusion not in (None, "", "success"):
+            continue
+        head = run.get("headSha") or run.get("head_sha") or ""
+        if not head:
+            continue
+        tree = tree_for_sha(head)
+        if tree and tree == target_tree:
+            return run
+    return None
+
+
+def matching_installer_run(
+    target_tree,  # type: str
+    runs,  # type: Iterable[Dict[str, Any]]
+    tree_for_sha,  # type: Callable[[str], Optional[str]]
+    artifact_names_for_run,  # type: Callable[[Dict[str, Any]], Iterable[str]]
+    platform,  # type: str
+    skip_run_ids=None,  # type: Optional[Iterable[Any]]
+):
+    # type: (...) -> Optional[Dict[str, Any]]
+    """Return a successful release run that already built this tree's installer."""
+    skip = {str(x) for x in (skip_run_ids or ()) if x is not None}
+    wanted = "installer-{}".format(platform)
+    for run in runs:
+        run_id = run.get("databaseId") or run.get("id")
+        if run_id is not None and str(run_id) in skip:
+            continue
+        conclusion = run.get("conclusion")
+        if conclusion not in (None, "", "success"):
+            continue
+        head = run.get("headSha") or run.get("head_sha") or ""
+        if not head:
+            continue
+        tree = tree_for_sha(head)
+        if not tree or tree != target_tree:
+            continue
+        names = set(artifact_names_for_run(run))
+        if wanted in names:
+            return run
+    return None
+
+
+def git_tree_sha(rev="HEAD"):
+    # type: (str) -> str
+    return subprocess.check_output(
+        ["git", "rev-parse", "{}^{{tree}}".format(rev)],
+        text=True,
+    ).strip()
+
+
+def git_commit_sha(rev="HEAD"):
+    # type: (str) -> str
+    return subprocess.check_output(
+        ["git", "rev-parse", "{}^{{commit}}".format(rev)],
+        text=True,
+    ).strip()
+
+
+def _gh_json(args, repo=None):
+    # type: (List[str], Optional[str]) -> Any
+    cmd = ["gh"] + args
+    if repo and "--repo" not in args:
+        cmd[1:1] = ["--repo", repo]
+    return json.loads(subprocess.check_output(cmd, text=True))
+
+
+def _detect_repo():
+    # type: () -> str
+    env = os.environ.get("GITHUB_REPOSITORY") or ""
+    if env:
+        return env
+    data = json.loads(
+        subprocess.check_output(
+            ["gh", "repo", "view", "--json", "nameWithOwner"],
+            text=True,
+        )
+    )
+    return data["nameWithOwner"]
+
+
+def _commit_tree_via_api(repo, sha):
+    # type: (str, str) -> Optional[str]
+    try:
+        payload = json.loads(
+            subprocess.check_output(
+                ["gh", "api", "repos/{}/commits/{}".format(repo, sha)],
+                text=True,
+            )
+        )
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return None
+    commit = payload.get("commit") or {}
+    tree = commit.get("tree") or {}
+    sha_out = tree.get("sha")
+    return sha_out if isinstance(sha_out, str) and sha_out else None
+
+
+def _tree_resolver(repo):
+    # type: (str) -> Callable[[str], Optional[str]]
+    cache = {}  # type: Dict[str, Optional[str]]
+
+    def tree_for(sha):
+        # type: (str) -> Optional[str]
+        if sha in cache:
+            return cache[sha]
+        tree = None  # type: Optional[str]
+        try:
+            tree = git_tree_sha(sha)
+        except subprocess.CalledProcessError:
+            tree = _commit_tree_via_api(repo, sha)
+        cache[sha] = tree
+        return tree
+
+    return tree_for
+
+
+def _list_successful_tests_runs(repo, limit):
+    # type: (str, int) -> List[Dict[str, Any]]
+    return _gh_json(
+        [
+            "run",
+            "list",
+            "--workflow",
+            "tests",
+            "--status",
+            "success",
+            "--limit",
+            str(limit),
+            "--json",
+            "headSha,databaseId,url,event,displayTitle,conclusion",
+        ],
+        repo=repo,
+    )
+
+
+def _list_successful_release_runs(repo, limit):
+    # type: (str, int) -> List[Dict[str, Any]]
+    return _gh_json(
+        [
+            "run",
+            "list",
+            "--workflow",
+            "release",
+            "--status",
+            "success",
+            "--limit",
+            str(limit),
+            "--json",
+            "headSha,databaseId,url,event,displayTitle,conclusion",
+        ],
+        repo=repo,
+    )
+
+
+def _artifact_names(repo, run):
+    # type: (str, Dict[str, Any]) -> List[str]
+    run_id = run.get("databaseId") or run.get("id")
+    if run_id is None:
+        return []
+    try:
+        payload = json.loads(
+            subprocess.check_output(
+                [
+                    "gh",
+                    "api",
+                    "repos/{}/actions/runs/{}/artifacts".format(repo, run_id),
+                ],
+                text=True,
+            )
+        )
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return []
+    artifacts = payload.get("artifacts") or []
+    names = []
+    for item in artifacts:
+        name = item.get("name")
+        if isinstance(name, str) and name:
+            names.append(name)
+    return names
+
+
+def cmd_require_green(args):
+    # type: (argparse.Namespace) -> int
+    repo = args.repo or _detect_repo()
+    rev = args.sha
+    target_tree = git_tree_sha(rev)
+    target_commit = git_commit_sha(rev)
+    runs = _list_successful_tests_runs(repo, args.limit)
+    match = matching_green_run(target_tree, runs, _tree_resolver(repo))
+    if match is None:
+        sys.stderr.write(
+            "No successful `tests` workflow for tree {} (commit {}).\n"
+            "Wait for dest->main PR tests if merge^{{tree}} matches, or for "
+            "main tests if a conflict resolution changed the tree.\n".format(
+                target_tree, target_commit
+            )
+        )
+        return 1
+    url = match.get("url") or ""
+    head = match.get("headSha") or match.get("head_sha") or ""
+    sys.stdout.write(
+        "tests workflow green for tree {} via {} {}\n".format(target_tree, head, url)
+    )
+    return 0
+
+
+def cmd_adopt_installers(args):
+    # type: (argparse.Namespace) -> int
+    repo = args.repo or _detect_repo()
+    platform = args.platform
+    if platform not in ("mac", "win", "linux"):
+        sys.stderr.write("platform must be mac, win, or linux\n")
+        return 2
+    target_tree = git_tree_sha(args.sha)
+    skip_ids = []
+    current = os.environ.get("GITHUB_RUN_ID")
+    if current:
+        skip_ids.append(current)
+    runs = _list_successful_release_runs(repo, args.limit)
+    resolver = _tree_resolver(repo)
+
+    def names_for(run):
+        # type: (Dict[str, Any]) -> List[str]
+        return _artifact_names(repo, run)
+
+    match = matching_installer_run(
+        target_tree,
+        runs,
+        resolver,
+        names_for,
+        platform,
+        skip_run_ids=skip_ids,
+    )
+    if match is None:
+        sys.stderr.write(
+            "No reusable installer-{} artifact for tree {}.\n".format(
+                platform, target_tree
+            )
+        )
+        return 1
+    run_id = match.get("databaseId") or match.get("id")
+    out_dir = args.out
+    os.makedirs(out_dir, exist_ok=True)
+    tmp = tempfile.mkdtemp(prefix="marionette-adopt-")
+    try:
+        subprocess.check_call(
+            [
+                "gh",
+                "run",
+                "download",
+                str(run_id),
+                "--repo",
+                repo,
+                "-n",
+                "installer-{}".format(platform),
+                "-D",
+                tmp,
+            ]
+        )
+        moved = _flatten_installer_files(tmp, out_dir)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    if not moved:
+        sys.stderr.write(
+            "adopter downloaded installer-{} from run {} but found no assets\n".format(
+                platform, run_id
+            )
+        )
+        return 1
+    sys.stdout.write(
+        "adopted installer-{} from run {} ({}) for tree {}\n".format(
+            platform, run_id, match.get("url") or "", target_tree
+        )
+    )
+    return 0
+
+
+def _flatten_installer_files(src_dir, dest_dir):
+    # type: (str, str) -> List[str]
+    """Copy installer/feed files to dest_dir regardless of artifact nesting."""
+    wanted_ext = (".dmg", ".zip", ".exe", ".AppImage", ".blockmap")
+    moved = []
+    for root, _dirs, files in os.walk(src_dir):
+        for name in files:
+            lower = name.lower()
+            keep = lower.endswith(wanted_ext) or (
+                lower.startswith("latest") and lower.endswith(".yml")
+            )
+            if not keep:
+                continue
+            dest = os.path.join(dest_dir, name)
+            shutil.copy2(os.path.join(root, name), dest)
+            moved.append(dest)
+    return moved
+
+
+def build_parser():
+    # type: () -> argparse.ArgumentParser
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    require = sub.add_parser(
+        "require-green",
+        help="fail unless a successful tests workflow exists for this tree",
+    )
+    require.add_argument("--sha", default="HEAD")
+    require.add_argument("--repo", default="")
+    require.add_argument("--limit", type=int, default=50)
+    require.set_defaults(func=cmd_require_green)
+
+    adopt = sub.add_parser(
+        "adopt-installers",
+        help="download same-tree installer artifacts from a prior release run",
+    )
+    adopt.add_argument("--platform", required=True, choices=("mac", "win", "linux"))
+    adopt.add_argument("--out", required=True)
+    adopt.add_argument("--sha", default="HEAD")
+    adopt.add_argument("--repo", default="")
+    adopt.add_argument("--limit", type=int, default=20)
+    adopt.set_defaults(func=cmd_adopt_installers)
+    return parser
+
+
+def main(argv=None):
+    # type: (Optional[List[str]]) -> int
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.9" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.11" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.9"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.11"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.9" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.11" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.9}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.11}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -67,6 +67,10 @@ git -c user.name=professorpalmer -c user.email=professorpalmer@users.noreply.git
   add webapp/package.json pyproject.toml harness/__init__.py
 git -c user.name=professorpalmer -c user.email=professorpalmer@users.noreply.github.com \
   commit -q -m "release: ${TAG}" || echo "(nothing to commit)"
+
+echo "== require green tests for this tree =="
+python3 "$REPO_ROOT/scripts/ci_release_gate.py" require-green
+
 git tag -f "$TAG"
 git push origin main
 git push -f origin "$TAG"

--- a/tests/test_ci_release_gate.py
+++ b/tests/test_ci_release_gate.py
@@ -1,0 +1,130 @@
+"""Tree-green release gate: same code is enough; SHA identity is not required."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+from ci_release_gate import (  # noqa: E402
+    _flatten_installer_files,
+    matching_green_run,
+    matching_installer_run,
+)
+
+
+def _tree_map(mapping):
+    def tree_for(sha):
+        return mapping.get(sha)
+
+    return tree_for
+
+
+def test_matching_green_run_accepts_same_tree_from_pr_head():
+    target = "tree-dest"
+    runs = [
+        {"headSha": "dest-tip", "url": "https://example/pr", "conclusion": "success"},
+        {"headSha": "other", "url": "https://example/other", "conclusion": "success"},
+    ]
+    match = matching_green_run(
+        target,
+        runs,
+        _tree_map({"dest-tip": "tree-dest", "other": "tree-other"}),
+    )
+    assert match is not None
+    assert match["headSha"] == "dest-tip"
+
+
+def test_matching_green_run_rejects_different_tree():
+    match = matching_green_run(
+        "tree-main-conflict",
+        [{"headSha": "dest-tip", "conclusion": "success"}],
+        _tree_map({"dest-tip": "tree-dest"}),
+    )
+    assert match is None
+
+
+def test_matching_green_run_skips_non_success():
+    match = matching_green_run(
+        "tree-a",
+        [{"headSha": "sha-a", "conclusion": "failure"}],
+        _tree_map({"sha-a": "tree-a"}),
+    )
+    assert match is None
+
+
+def test_matching_green_run_empty_tree_is_fail_closed():
+    match = matching_green_run(
+        "",
+        [{"headSha": "sha-a", "conclusion": "success"}],
+        _tree_map({"sha-a": ""}),
+    )
+    assert match is None
+
+
+def test_matching_installer_run_requires_platform_artifact_and_skips_self():
+    runs = [
+        {
+            "databaseId": 11,
+            "headSha": "dest-tip",
+            "conclusion": "success",
+        },
+        {
+            "databaseId": 22,
+            "headSha": "dest-tip",
+            "conclusion": "success",
+        },
+    ]
+    artifacts = {
+        11: ["installer-mac", "installer-win", "installer-linux"],
+        22: ["installer-mac"],
+    }
+    match = matching_installer_run(
+        "tree-dest",
+        runs,
+        _tree_map({"dest-tip": "tree-dest"}),
+        lambda run: artifacts[run["databaseId"]],
+        "win",
+        skip_run_ids=[11],
+    )
+    assert match is None
+
+    match = matching_installer_run(
+        "tree-dest",
+        runs,
+        _tree_map({"dest-tip": "tree-dest"}),
+        lambda run: artifacts[run["databaseId"]],
+        "mac",
+        skip_run_ids=[99],
+    )
+    assert match is not None
+    assert match["databaseId"] == 11
+
+
+def test_flatten_installer_files_lifts_nested_artifact_layout(tmp_path):
+    nested = tmp_path / "dl" / "webapp" / "release"
+    nested.mkdir(parents=True)
+    (nested / "latest-mac.yml").write_text("path: Marionette.dmg\n")
+    (nested / "Marionette.dmg").write_bytes(b"dmg")
+    (nested / "notes.txt").write_text("ignore")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    moved = _flatten_installer_files(str(tmp_path / "dl"), str(dest))
+    names = sorted(Path(path).name for path in moved)
+    assert names == ["Marionette.dmg", "latest-mac.yml"]
+    assert (dest / "latest-mac.yml").is_file()
+
+
+def test_release_yml_does_not_rerun_pytest():
+    text = (ROOT / ".github" / "workflows" / "release.yml").read_text()
+    assert "python -m pytest" not in text
+    assert "test-gate" not in text
+    assert "tests-already-green" in text
+    assert "needs: [tests-already-green, build]" in text
+    assert "puppetmaster-ai==" in text
+
+
+def test_tests_yml_windows_runner_is_swappable():
+    text = (ROOT / ".github" / "workflows" / "tests.yml").read_text()
+    assert "vars.CI_WINDOWS_RUNNER" in text
+    assert "windows-latest" in text

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -252,6 +252,19 @@ def test_save_upload_accepts_markdown(tmp_path):
     assert os.path.exists(payload["saved"][0]["path"])
 
 
+def test_save_upload_accepts_zip(tmp_path):
+    from harness.api.files import save_upload
+
+    body, ctype = _multipart(
+        "file", "bundle.zip", b"PK\x03\x04payload", "application/zip"
+    )
+    status, payload = save_upload(body, ctype, str(tmp_path))
+    assert status == 200
+    assert payload["saved"]
+    assert payload["saved"][0]["path"].endswith(".zip")
+    assert os.path.exists(payload["saved"][0]["path"])
+
+
 def test_save_upload_rejects_exe_and_extensionless(tmp_path):
     from harness.api.files import save_upload
 

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.9";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.11";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/fs-bridge.test.cjs
+++ b/webapp/electron/fs-bridge.test.cjs
@@ -15,4 +15,10 @@ describe("fs-bridge revealInFolder", () => {
     const preload = fs.readFileSync(path.join(__dirname, "preload.cjs"), "utf8");
     assert.match(preload, /revealInFolder:\s*\(absPath\)\s*=>\s*ipcRenderer\.invoke\("fs:revealInFolder"/);
   });
+
+  it("preload exposes harnessIPC.isDirectory for outside-workspace drops", () => {
+    const preload = fs.readFileSync(path.join(__dirname, "preload.cjs"), "utf8");
+    assert.match(preload, /isDirectory:\s*\(absPath\)\s*=>/);
+    assert.match(preload, /statSync\(p\)\.isDirectory\(\)/);
+  });
 });

--- a/webapp/electron/preload.cjs
+++ b/webapp/electron/preload.cjs
@@ -2,6 +2,7 @@
 // (lib/transport.ts checks for window.harnessIPC and routes through it). Plus
 // native fs/git bridges for the file-tree and source-control panels.
 const { contextBridge, ipcRenderer, webUtils } = require("electron");
+const fs = require("fs");
 
 let streamSeq = 0;
 
@@ -21,6 +22,17 @@ contextBridge.exposeInMainWorld("harnessIPC", {
       }
     } catch (_) {}
     return "";
+  },
+  // User-initiated drop/open: stat only, not path-confined (outside folders
+  // must still be detectable so the composer can open them).
+  isDirectory: (absPath) => {
+    try {
+      const p = String(absPath || "");
+      if (!p) return false;
+      return fs.statSync(p).isDirectory();
+    } catch (_) {
+      return false;
+    }
   },
   // Fire-and-forget: persist a caught renderer error to the Electron main log so
   // a UI crash is diagnosable from ~/.pmharness/electron.log without devtools.

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.9";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.11";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 
 // True when `pip show` / `uv pip show` output describes an editable install
@@ -43,7 +43,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.9" }     -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.11" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -65,7 +65,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.9).
+ * to 1.22.11).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.248",
+  "version": "0.9.249",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.248",
+      "version": "0.9.249",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.248",
+  "version": "0.9.249",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -12,6 +12,11 @@ import Resizer from "./components/Resizer";
 import RegistryWizard from "./components/RegistryWizard";
 import ErrorBoundary from "./components/ErrorBoundary";
 import CommandPalette from "./components/CommandPalette";
+import {
+  droppedPathIsDirectory,
+  resolveDroppedOsPath,
+} from "./components/conversation/composerInput";
+import { openAgentWorkspace } from "./lib/agentLinks";
 
 const LS = {
   left: "pmharness.leftW",
@@ -184,17 +189,28 @@ export default function App() {
   // outside an explicit drop target (the default would replace the whole app
   // with the file). Composer + message drop zones stopPropagation, so they keep
   // working; this is the safety net for drops that miss those targets.
+  // Folders that miss the composer open as the workspace (Hermes-style).
   useEffect(() => {
+    const hasFiles = (e: DragEvent) =>
+      !!(e.dataTransfer && Array.from(e.dataTransfer.types || []).includes("Files"));
     const prevent = (e: DragEvent) => {
-      if (e.dataTransfer && Array.from(e.dataTransfer.types || []).includes("Files")) {
-        e.preventDefault();
+      if (hasFiles(e)) e.preventDefault();
+    };
+    const onDrop = (e: DragEvent) => {
+      prevent(e);
+      const files = Array.from(e.dataTransfer?.files || []);
+      for (const file of files) {
+        const osPath = resolveDroppedOsPath(file as { path?: string });
+        if (osPath && droppedPathIsDirectory(osPath)) {
+          openAgentWorkspace(osPath);
+        }
       }
     };
     window.addEventListener("dragover", prevent);
-    window.addEventListener("drop", prevent);
+    window.addEventListener("drop", onDrop);
     return () => {
       window.removeEventListener("dragover", prevent);
-      window.removeEventListener("drop", prevent);
+      window.removeEventListener("drop", onDrop);
     };
   }, []);
 

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -185,6 +185,10 @@ import {
   detectComposerTrigger,
   filterMentionPaths,
   filterSlashCommands,
+  collectFilesFromDirectoryEntry,
+  DROP_FOLDER_FILE_CAP,
+  droppedDirectoryPlan,
+  droppedPathIsDirectory,
   mentionTokenForDroppedPath,
   normalizeOsPath,
   pathIsInsideRepo,
@@ -2889,6 +2893,20 @@ describe("composerInput module", () => {
         repo: "/repo",
       }),
     ).toBeNull();
+    expect(
+      droppedDirectoryPlan({ osPath: "/repo/src", repo: "/repo" }),
+    ).toEqual({ kind: "mention", token: "@folder:src" });
+    expect(
+      droppedDirectoryPlan({ osPath: "/Users/me/authority-spoof", repo: "/repo" }),
+    ).toEqual({ kind: "open-workspace", path: "/Users/me/authority-spoof" });
+    expect(droppedDirectoryPlan({ osPath: "", repo: "/repo" })).toEqual({ kind: "fail" });
+    expect(droppedPathIsDirectory("/Users/me/authority-spoof")).toBe(false);
+    const prevDirIpc = (window as any).harnessIPC;
+    (window as any).harnessIPC = { isDirectory: (p: string) => p.endsWith("/authority-spoof") };
+    expect(droppedPathIsDirectory("/Users/me/authority-spoof")).toBe(true);
+    expect(droppedPathIsDirectory("/Users/me/notes.md")).toBe(false);
+    if (prevDirIpc === undefined) delete (window as any).harnessIPC;
+    else (window as any).harnessIPC = prevDirIpc;
     expect(uploadErrorMessage(new Error("Upload failed"), "File upload failed")).toBe(
       "File upload failed",
     );
@@ -2900,6 +2918,89 @@ describe("composerInput module", () => {
     expect(resolveDroppedOsPath({ path: "" })).toBe("/abs/dropped.md");
     if (prevIpc === undefined) delete (window as any).harnessIPC;
     else (window as any).harnessIPC = prevIpc;
+  });
+
+  it("walks dropped directory entries, skips noise dirs, and caps files", async () => {
+    const fileEntry = (name: string): any => ({
+      isFile: true,
+      isDirectory: false,
+      name,
+      file: (ok: (f: File) => void) => ok(new File([name], name)),
+    });
+    let remaining = [
+      fileEntry("readme.md"),
+      fileEntry("notes.txt"),
+      {
+        isFile: false,
+        isDirectory: true,
+        name: "node_modules",
+        createReader: () => ({
+          readEntries: (ok: (entries: unknown[]) => void) => ok([fileEntry("secret.js")]),
+        }),
+      },
+      {
+        isFile: false,
+        isDirectory: true,
+        name: "src",
+        createReader: () => {
+          let sent = false;
+          return {
+            readEntries: (ok: (entries: unknown[]) => void) => {
+              if (sent) {
+                ok([]);
+                return;
+              }
+              sent = true;
+              ok([fileEntry("a.ts"), fileEntry("b.ts")]);
+            },
+          };
+        },
+      },
+    ];
+    const root = {
+      isFile: false,
+      isDirectory: true,
+      name: "authority-spoof",
+      createReader: () => ({
+        readEntries: (ok: (entries: unknown[]) => void) => {
+          const batch = remaining;
+          remaining = [];
+          ok(batch);
+        },
+      }),
+    };
+    const walked = await collectFilesFromDirectoryEntry(root);
+    expect(walked.files.map((row) => row.relPath).sort()).toEqual([
+      "notes.txt",
+      "readme.md",
+      "src/a.ts",
+      "src/b.ts",
+    ]);
+    expect(walked.truncated).toBe(false);
+
+    const tiny = {
+      isFile: false,
+      isDirectory: true,
+      name: "bundle",
+      createReader: () => {
+        let sent = false;
+        return {
+          readEntries: (ok: (entries: unknown[]) => void) => {
+            if (sent) {
+              ok([]);
+              return;
+            }
+            sent = true;
+            ok([fileEntry("one.md"), fileEntry("two.md")]);
+          },
+        };
+      },
+    };
+    const limited = await collectFilesFromDirectoryEntry(tiny, { cap: 1 });
+    expect(limited.files).toHaveLength(1);
+    expect(limited.truncated).toBe(true);
+    expect(limited.files[0].relPath).toBe("one.md");
+    expect(DROP_FOLDER_FILE_CAP).toBe(40);
   });
 });
 

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -194,6 +194,7 @@ import {
   pathIsInsideRepo,
   resolveDroppedOsPath,
   uploadErrorMessage,
+  type DirectoryEntryLike,
 } from "../components/conversation/composerInput";
 import {
   blankMsgQueueOnSessionSwitch,
@@ -2921,13 +2922,13 @@ describe("composerInput module", () => {
   });
 
   it("walks dropped directory entries, skips noise dirs, and caps files", async () => {
-    const fileEntry = (name: string): any => ({
+    const fileEntry = (name: string): DirectoryEntryLike => ({
       isFile: true,
       isDirectory: false,
       name,
       file: (ok: (f: File) => void) => ok(new File([name], name)),
     });
-    let remaining = [
+    let remaining: DirectoryEntryLike[] = [
       fileEntry("readme.md"),
       fileEntry("notes.txt"),
       {
@@ -2935,7 +2936,7 @@ describe("composerInput module", () => {
         isDirectory: true,
         name: "node_modules",
         createReader: () => ({
-          readEntries: (ok: (entries: unknown[]) => void) => ok([fileEntry("secret.js")]),
+          readEntries: (ok: (entries: DirectoryEntryLike[]) => void) => ok([fileEntry("secret.js")]),
         }),
       },
       {
@@ -2945,7 +2946,7 @@ describe("composerInput module", () => {
         createReader: () => {
           let sent = false;
           return {
-            readEntries: (ok: (entries: unknown[]) => void) => {
+            readEntries: (ok: (entries: DirectoryEntryLike[]) => void) => {
               if (sent) {
                 ok([]);
                 return;
@@ -2962,7 +2963,7 @@ describe("composerInput module", () => {
       isDirectory: true,
       name: "authority-spoof",
       createReader: () => ({
-        readEntries: (ok: (entries: unknown[]) => void) => {
+        readEntries: (ok: (entries: DirectoryEntryLike[]) => void) => {
           const batch = remaining;
           remaining = [];
           ok(batch);
@@ -2985,7 +2986,7 @@ describe("composerInput module", () => {
       createReader: () => {
         let sent = false;
         return {
-          readEntries: (ok: (entries: unknown[]) => void) => {
+          readEntries: (ok: (entries: DirectoryEntryLike[]) => void) => {
             if (sent) {
               ok([]);
               return;

--- a/webapp/src/__tests__/transcriptVirtualWindow.test.ts
+++ b/webapp/src/__tests__/transcriptVirtualWindow.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  chatColumnMountClass,
+  isChatColumnActive,
   isOccludedScrollParentSize,
   restoreFeedScrollAfterFocus,
   shouldUseVirtualTranscriptWindow,
@@ -58,5 +60,17 @@ describe("transcriptVirtualWindow", () => {
         scrollHeight: 8000,
       }),
     ).toBe(8000);
+  });
+
+  it("keeps the chat column mounted (hidden) when a file tab is active", () => {
+    expect(isChatColumnActive("chat")).toBe(true);
+    expect(isChatColumnActive("src/a.ts")).toBe(false);
+    const chat = chatColumnMountClass("chat");
+    const file = chatColumnMountClass("src/a.ts");
+    expect(chat).toContain("flex-1");
+    expect(chat).not.toContain("invisible");
+    expect(file).toContain("invisible");
+    expect(file).toContain("absolute");
+    expect(file).not.toContain("hidden");
   });
 });

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -102,7 +102,11 @@ import {
   peekTerminalSelections,
   putTerminalSelection,
 } from "./conversation/terminalSelectionCache";
-import { restoreFeedScrollAfterFocus } from "./conversation/transcriptVirtualWindow";
+import {
+  chatColumnMountClass,
+  isChatColumnActive,
+  restoreFeedScrollAfterFocus,
+} from "./conversation/transcriptVirtualWindow";
 import {
   STREAM_ABORT_MESSAGE,
   streamErrorText,
@@ -123,10 +127,16 @@ import {
   detectComposerTrigger,
   filterMentionPaths,
   filterSlashCommands,
+  collectFilesFromDirectoryEntry,
+  DROP_FOLDER_FILE_CAP,
+  droppedDirectoryPlan,
+  droppedPathIsDirectory,
   mentionTokenForDroppedPath,
   resolveDroppedOsPath,
   uploadErrorMessage,
+  type DirectoryEntryLike,
 } from "./conversation/composerInput";
+import { openAgentWorkspace } from "../lib/agentLinks";
 import {
   blankMsgQueueOnSessionSwitch,
   blankQueueItemsOnSessionSwitch,
@@ -1235,6 +1245,30 @@ export default function Conversation({
     };
   }, []);
 
+  // Opening a file used to unmount the chat column; coming back remounted the
+  // virtualizer at 0. Chat stays mounted (hidden). Still restore the last
+  // offset in case the hide pass reported a 0-height scroll parent.
+  const fileTabScrollTopRef = useRef(0);
+  const prevActiveTabRef = useRef(activeTab);
+  useLayoutEffect(() => {
+    const prev = prevActiveTabRef.current;
+    prevActiveTabRef.current = activeTab;
+    const node = feedRef.current;
+    if (!node) return;
+    if (isChatColumnActive(prev) && !isChatColumnActive(activeTab)) {
+      fileTabScrollTopRef.current = node.scrollTop;
+      return;
+    }
+    if (!isChatColumnActive(prev) && isChatColumnActive(activeTab)) {
+      node.scrollTop = restoreFeedScrollAfterFocus({
+        savedScrollTop: fileTabScrollTopRef.current,
+        pinned: pinnedToBottomRef.current,
+        settling: scrollSettlingRef.current,
+        scrollHeight: node.scrollHeight,
+      });
+    }
+  }, [activeTab]);
+
   const contextUsageFetchGenRef = useRef(0);
   const fetchContextUsage = () => {
     if (!activeSessionId) return;
@@ -1767,13 +1801,13 @@ export default function Conversation({
       const file = files[i];
       const isImage = file.type.startsWith("image/");
       const osPath = resolveDroppedOsPath(file as { path?: string });
-      let isDirectory = false;
+      let entry: DirectoryEntryLike | null = null;
       try {
-        const entry = items[i]?.webkitGetAsEntry?.();
-        isDirectory = !!entry && entry.isDirectory;
+        entry = (items[i]?.webkitGetAsEntry?.() as DirectoryEntryLike | null) || null;
       } catch {
-        isDirectory = false;
+        entry = null;
       }
+      const isDirectory = !!(entry && entry.isDirectory) || droppedPathIsDirectory(osPath);
 
       if (isImage) {
         // Images attach as visual context (upload + thumbnail), as before.
@@ -1797,18 +1831,46 @@ export default function Conversation({
       }
 
       if (isDirectory) {
-        const folderToken = mentionTokenForDroppedPath({
-          osPath,
-          repo,
-          isDirectory: true,
-        });
-        if (folderToken) {
-          mentions.push(folderToken);
+        const plan = droppedDirectoryPlan({ osPath, repo });
+        if (plan.kind === "mention") {
+          mentions.push(plan.token);
           continue;
         }
-        flashUploadError(
-          "Folders outside the open workspace cannot be attached. Open that folder as the workspace, or drop a file from it.",
-        );
+        if (entry?.isDirectory) {
+          try {
+            const collected = await collectFilesFromDirectoryEntry(entry);
+            if (collected.files.length > 0) {
+              for (const inner of collected.files) {
+                try {
+                  const uploaded = await api.uploadImage(inner.file);
+                  const token = mentionTokenForDroppedPath({
+                    osPath: "",
+                    repo,
+                    uploadedPath: uploaded.path,
+                  });
+                  if (token) mentions.push(token);
+                  else flashUploadError("Dropped file could not be attached");
+                } catch (err) {
+                  console.error("Failed to upload dropped folder file:", err);
+                  flashUploadError(uploadErrorMessage(err, "File upload failed"));
+                }
+              }
+              if (collected.truncated) {
+                flashUploadError(
+                  `Attached the first ${DROP_FOLDER_FILE_CAP} files from that folder.`,
+                );
+              }
+              continue;
+            }
+          } catch (err) {
+            console.error("Failed to read dropped folder:", err);
+          }
+        }
+        if (plan.kind === "open-workspace") {
+          openAgentWorkspace(plan.path);
+          continue;
+        }
+        flashUploadError("Could not open that folder.");
         continue;
       }
 
@@ -3068,7 +3130,11 @@ export default function Conversation({
         onCloseContextMenu={() => setTabContextMenu(null)}
       />
 
-      {activeTab === "chat" ? (
+      <div className="relative flex flex-col flex-1 min-h-0 min-w-0">
+      <div
+        className={chatColumnMountClass(activeTab)}
+        aria-hidden={!isChatColumnActive(activeTab)}
+      >
         <ConversationChatColumn
           feedRef={feedRef}
           transcriptStale={transcriptStale}
@@ -3179,7 +3245,8 @@ export default function Conversation({
       />
       )}
         />
-  ) : (
+      </div>
+      {!isChatColumnActive(activeTab) ? (
     <FileEditorPane
       path={activeTab}
       line={openTabs.find((t) => t.path === activeTab)?.line}
@@ -3187,7 +3254,8 @@ export default function Conversation({
       onClose={() => handleCloseTab(activeTab)}
       onDirtyChange={(dirty) => handleTabDirtyChange(activeTab, dirty)}
     />
-  )}
+      ) : null}
+      </div>
 
       {lightboxUrl && (
         <ImageLightbox url={lightboxUrl} onClose={() => setLightboxUrl(null)} />

--- a/webapp/src/components/conversation/composerInput.ts
+++ b/webapp/src/components/conversation/composerInput.ts
@@ -274,6 +274,170 @@ export function mentionTokenForDroppedPath(opts: {
   return formatMentionToken(rel, kind);
 }
 
+type HarnessDropIpc = {
+  pathForFile?: (f: unknown) => string;
+  isDirectory?: (absPath: string) => boolean;
+};
+
+function dropIpc(): HarnessDropIpc | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as unknown as { harnessIPC?: HarnessDropIpc }).harnessIPC;
+}
+
+/** True when Electron can stat `osPath` as a directory (outside-workspace ok). */
+export function droppedPathIsDirectory(osPath: string): boolean {
+  const path = normalizeOsPath(osPath);
+  if (!path) return false;
+  const probe = dropIpc()?.isDirectory;
+  if (typeof probe !== "function") return false;
+  try {
+    return !!probe(path);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Same noise dirs `harness/mention_context.py` skips when expanding `@folder:`.
+ * Keep in sync when that set changes.
+ */
+export const DROP_FOLDER_SKIP_DIRS = new Set([
+  ".git",
+  "node_modules",
+  ".venv",
+  ".codegraph",
+  "dist",
+  "build",
+  ".pytest_cache",
+  "__pycache__",
+  ".mypy_cache",
+  ".ruff_cache",
+  ".idea",
+  ".vscode",
+  "venv",
+  ".next",
+  "coverage",
+  ".hermes",
+  "release",
+  "backend-dist",
+]);
+
+/** Aligns with `DEFAULT_FOLDER_ENTRY_CAP` in mention_context. */
+export const DROP_FOLDER_FILE_CAP = 40;
+
+type DirectoryReaderLike = {
+  readEntries: (
+    success: (entries: DirectoryEntryLike[]) => void,
+    error?: (err: unknown) => void,
+  ) => void;
+};
+
+export type DirectoryEntryLike = {
+  isFile: boolean;
+  isDirectory: boolean;
+  name: string;
+  createReader?: () => DirectoryReaderLike;
+  file?: (
+    success: (file: File) => void,
+    error?: (err: unknown) => void,
+  ) => void;
+};
+
+async function readAllDirectoryEntries(
+  reader: DirectoryReaderLike,
+): Promise<DirectoryEntryLike[]> {
+  const all: DirectoryEntryLike[] = [];
+  for (;;) {
+    const batch = await new Promise<DirectoryEntryLike[]>((resolve) => {
+      try {
+        reader.readEntries((entries) => resolve(entries || []), () => resolve([]));
+      } catch {
+        resolve([]);
+      }
+    });
+    if (!batch.length) break;
+    all.push(...batch);
+  }
+  return all;
+}
+
+function fileFromEntry(ent: DirectoryEntryLike): Promise<File | null> {
+  if (typeof ent.file !== "function") return Promise.resolve(null);
+  return new Promise((resolve) => {
+    try {
+      ent.file!((f) => resolve(f), () => resolve(null));
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/** Walk a dropped directory entry; skip noise dirs; hard-cap file count. */
+export async function collectFilesFromDirectoryEntry(
+  entry: DirectoryEntryLike,
+  opts?: { cap?: number; skipDirs?: ReadonlySet<string> },
+): Promise<{ files: Array<{ file: File; relPath: string }>; truncated: boolean }> {
+  const cap = opts?.cap ?? DROP_FOLDER_FILE_CAP;
+  const skipDirs = opts?.skipDirs ?? DROP_FOLDER_SKIP_DIRS;
+  const files: Array<{ file: File; relPath: string }> = [];
+  let truncated = false;
+
+  const walkDir = async (dir: DirectoryEntryLike, dirRel: string): Promise<void> => {
+    const reader = dir.createReader?.();
+    if (!reader) return;
+    const children = await readAllDirectoryEntries(reader);
+    for (const child of children) {
+      if (files.length >= cap) {
+        truncated = true;
+        return;
+      }
+      const childRel = dirRel ? `${dirRel}/${child.name}` : child.name;
+      if (child.isDirectory) {
+        if (skipDirs.has(child.name)) continue;
+        await walkDir(child, childRel);
+        continue;
+      }
+      if (!child.isFile) continue;
+      const file = await fileFromEntry(child);
+      if (file) files.push({ file, relPath: childRel });
+    }
+  };
+
+  if (entry.isFile) {
+    const file = await fileFromEntry(entry);
+    if (file) files.push({ file, relPath: entry.name });
+    return { files, truncated };
+  }
+  if (entry.isDirectory) {
+    await walkDir(entry, "");
+  }
+  return { files, truncated };
+}
+
+export type DroppedDirectoryPlan =
+  | { kind: "mention"; token: string }
+  | { kind: "open-workspace"; path: string }
+  | { kind: "fail" };
+
+/**
+ * Inside the open repo: @folder mention. Anywhere else with an OS path:
+ * open that folder as the workspace (window-drop / walk-empty fallback).
+ */
+export function droppedDirectoryPlan(opts: {
+  osPath: string;
+  repo: string;
+}): DroppedDirectoryPlan {
+  const token = mentionTokenForDroppedPath({
+    osPath: opts.osPath,
+    repo: opts.repo,
+    isDirectory: true,
+  });
+  if (token) return { kind: "mention", token };
+  const path = normalizeOsPath(opts.osPath);
+  if (path) return { kind: "open-workspace", path };
+  return { kind: "fail" };
+}
+
 /** Prefer the server/upload Error message over a generic flash. */
 export function uploadErrorMessage(err: unknown, fallback: string): string {
   if (err instanceof Error) {

--- a/webapp/src/components/conversation/transcriptVirtualWindow.ts
+++ b/webapp/src/components/conversation/transcriptVirtualWindow.ts
@@ -31,3 +31,18 @@ export function restoreFeedScrollAfterFocus(opts: {
   if (opts.pinned || opts.settling) return Math.max(0, opts.scrollHeight);
   return Math.max(0, opts.savedScrollTop);
 }
+
+/**
+ * Keep the chat column mounted while a file tab is selected.
+ * Unmounting remounts the virtualizer at offset 0 — the same snap-to-top
+ * as an occluded unvirtualized fallback. Hide in-place instead.
+ */
+export function chatColumnMountClass(activeTab: string): string {
+  const base = "flex flex-col min-h-0 min-w-0";
+  if (activeTab === "chat") return `${base} flex-1`;
+  return `${base} pointer-events-none invisible absolute inset-0`;
+}
+
+export function isChatColumnActive(activeTab: string): boolean {
+  return activeTab === "chat";
+}


### PR DESCRIPTION
## Summary
- Pin `puppetmaster-ai==1.22.11` across desktop, CI, install, and doctor.
- Tag when dest-PR `tests` is green for this tree (`merge^{tree}` match); do not rerun pytest in `release.yml`.
- Keep the chat column mounted when a file tab opens so the transcript does not jump to the top.
- Composer and window drops open or attach folders and zips from outside the workspace.

## Test plan
- [x] Local `pytest` 4615 passed, 74 skipped
- [x] Pin-parity + version-consistency + upload/zip + composer drop helpers
- [ ] Dest→main `tests` matrix: 3.9 floor, 3.11, Windows, frontend-build
- [ ] `merge^{tree}` matches dest tree, then tag `v0.9.249`