### PR TITLE
Release v0.9.250

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Require a successful tests workflow for this tree
         env:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.11` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.249, deliberately pre-1.0. Rides puppetmaster-ai==1.22.11 (Sonnet 5 curated catalogs, discovery-origin provenance, spawned-worker exemption from the delegate-first gate). Composer accepts outside folder and zip drops. Release tags when dest-PR tests are green for this tree. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
+> Status: v0.9.250, deliberately pre-1.0. Rides puppetmaster-ai==1.22.11 (Sonnet 5 curated catalogs, discovery-origin provenance, spawned-worker exemption from the delegate-first gate). Composer accepts outside folder and zip drops. Release tags when dest-PR tests are green for this tree. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.249"
+__version__ = "0.9.250"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.249"
+version = "0.9.250"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/ci_release_gate.py
+++ b/scripts/ci_release_gate.py
@@ -136,11 +136,14 @@ def _tree_resolver(repo):
         # type: (str) -> Optional[str]
         if sha in cache:
             return cache[sha]
-        tree = None  # type: Optional[str]
-        try:
-            tree = git_tree_sha(sha)
-        except subprocess.CalledProcessError:
-            tree = _commit_tree_via_api(repo, sha)
+        # Prefer the API so a shallow tag checkout (fetch-depth 1) can
+        # still match dest-PR head SHAs that are not local objects.
+        tree = _commit_tree_via_api(repo, sha)
+        if not tree:
+            try:
+                tree = git_tree_sha(sha)
+            except subprocess.CalledProcessError:
+                tree = None
         cache[sha] = tree
         return tree
 

--- a/tests/test_ci_release_gate.py
+++ b/tests/test_ci_release_gate.py
@@ -122,6 +122,7 @@ def test_release_yml_does_not_rerun_pytest():
     assert "tests-already-green" in text
     assert "needs: [tests-already-green, build]" in text
     assert "puppetmaster-ai==" in text
+    assert "fetch-depth: 0" in text
 
 
 def test_tests_yml_windows_runner_is_swappable():

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.249",
+  "version": "0.9.250",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.249",
+      "version": "0.9.250",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.249",
+  "version": "0.9.250",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Supersede v0.9.249 installer publish: `tests-already-green` now resolves dest-PR commit trees via the GitHub API and checks out full history (`fetch-depth: 0`).
- Same product as v0.9.249 (`puppetmaster-ai==1.22.11`, folder/zip drops, dest-PR tree-green tagging). Do not move the v0.9.249 tag.

## Test plan
- [x] `test_ci_release_gate` + version consistency
- [ ] Dest→main `tests` matrix green
- [ ] Tag `v0.9.250` when `merge^{tree}` matches; confirm `tests-already-green` passes on the tag