### PR TITLE
Release v0.9.252

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,12 @@ jobs:
         env:
           CSC_LINK: ${{ matrix.platform == 'mac' && secrets.CSC_LINK || '' }}
           CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.CSC_KEY_PASSWORD || '' }}
+          # Dest->main PRs build the installers the tag later adopts. electron-builder
+          # skips signing on pull_request unless this is set; unsigned mac zips then
+          # fail ShipIt ("code failed to satisfy specified code requirement(s)") on
+          # every existing Developer ID install. Fork PRs still cannot sign: GitHub
+          # does not expose CSC_* secrets to them.
+          CSC_FOR_PULL_REQUEST: ${{ matrix.platform == 'mac' && 'true' || '' }}
           APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
@@ -112,6 +118,11 @@ jobs:
           # (avoids matrix races). publish: in electron-builder.yml is still
           # required so the updater feed files are generated.
           npm run dist -- --${{ matrix.platform }} --publish never
+
+      - name: Require Developer ID signature on mac zip
+        if: matrix.platform == 'mac'
+        shell: bash
+        run: python3 scripts/ci_release_gate.py require-mac-signature --dir webapp/release
 
       - name: Require electron-updater feed metadata
         shell: bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.251, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12 (swarm `timeout_seconds` now reach workers; explicit max timeout is used as given). Composer accepts outside folder and zip drops. Release tags when dest-PR tests are green for this tree. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
+> Status: v0.9.252, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. Dest-PR mac installers are Developer ID-signed so in-app ShipIt updates succeed on existing installs. Release tags when dest-PR tests are green for this tree. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
 
 ## Documentation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -48,8 +48,10 @@ run on that SHA when `merge^{tree}` equals the already-green dest PR tree.
 PR it starts installer builds in parallel with `tests.yml`. On a `v*` tag it
 checks that a successful `tests` run exists for this tree (or this commit),
 reuses those PR installers when the tree matches, and publishes only after
-that check. Users wait `max(tests, builds)`, not tests + builds + a second
-pytest gate.
+that check. Dest-PR mac builds must Developer ID-sign
+(`CSC_FOR_PULL_REQUEST`); an unsigned zip fails ShipIt on existing installs
+and must not be adopted. Users wait `max(tests, builds)`, not tests + builds
++ a second pytest gate.
 
 If a conflict resolution changes the tree, wait for `tests` on the new tree.
 That is the only exception.

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.251"
+__version__ = "0.9.252"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.251"
+version = "0.9.252"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/ci_release_gate.py
+++ b/scripts/ci_release_gate.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional
 
 
 REQUIRED_INSTALLER_NAMES = ("installer-mac", "installer-win", "installer-linux")
+MAC_BUNDLE_IDENTIFIER = "com.marionette.app"
 
 
 def matching_green_run(
@@ -303,6 +304,20 @@ def cmd_adopt_installers(args):
             )
         )
         return 1
+    if platform == "mac":
+        verdict = verify_mac_release_dir(out_dir)
+        if not verdict.get("ok"):
+            for path in moved:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+            sys.stderr.write(
+                "refusing unsigned mac adopt from run {}: {}\n".format(
+                    run_id, verdict.get("error") or "Developer ID check failed"
+                )
+            )
+            return 1
     sys.stdout.write(
         "adopted installer-{} from run {} ({}) for tree {}\n".format(
             platform, run_id, match.get("url") or "", target_tree
@@ -330,6 +345,120 @@ def _flatten_installer_files(src_dir, dest_dir):
     return moved
 
 
+def parse_mac_codesign_dump(text):
+    # type: (str) -> Dict[str, Any]
+    """Parse `codesign -dv --verbose=4` output (fields land on stderr)."""
+    identifier = ""
+    team = ""
+    developer_id = False
+    adhoc = False
+    for raw in str(text or "").splitlines():
+        line = raw.strip()
+        if line.startswith("Identifier="):
+            identifier = line.split("=", 1)[1].strip()
+        elif line.startswith("TeamIdentifier="):
+            team = line.split("=", 1)[1].strip()
+        elif line.startswith("Authority=Developer ID Application"):
+            developer_id = True
+        elif line.startswith("Signature=adhoc") or "adhoc,linker-signed" in line:
+            adhoc = True
+    ok = (
+        identifier == MAC_BUNDLE_IDENTIFIER
+        and developer_id
+        and bool(team)
+        and team != "not set"
+        and not adhoc
+    )
+    return {
+        "ok": ok,
+        "identifier": identifier,
+        "team": team,
+        "developer_id": developer_id,
+        "adhoc": adhoc,
+    }
+
+
+def find_mac_update_zip(directory):
+    # type: (str) -> Optional[str]
+    if not directory or not os.path.isdir(directory):
+        return None
+    names = sorted(os.listdir(directory))
+    for name in names:
+        lower = name.lower()
+        if lower.endswith("-mac.zip") or lower.endswith("universal-mac.zip"):
+            return os.path.join(directory, name)
+    return None
+
+
+def _codesign_dump_for_app(app_path):
+    # type: (str) -> str
+    proc = subprocess.run(
+        ["codesign", "-dv", "--verbose=4", app_path],
+        capture_output=True,
+        text=True,
+    )
+    return (proc.stderr or "") + "\n" + (proc.stdout or "")
+
+
+def inspect_mac_release_zip(zip_path):
+    # type: (str) -> Dict[str, Any]
+    if not zip_path or not os.path.isfile(zip_path):
+        return {"ok": False, "error": "mac update zip not found"}
+    tmp = tempfile.mkdtemp(prefix="marionette-mac-sig-")
+    try:
+        try:
+            subprocess.check_call(["ditto", "-x", "-k", zip_path, tmp])
+        except (OSError, subprocess.CalledProcessError) as exc:
+            return {"ok": False, "error": "failed to extract mac zip: {}".format(exc)}
+        app = os.path.join(tmp, "Marionette.app")
+        if not os.path.isdir(app):
+            for root, _dirs, _files in os.walk(tmp):
+                if os.path.basename(root) == "Marionette.app" and os.path.isdir(root):
+                    app = root
+                    break
+        if not os.path.isdir(app):
+            return {"ok": False, "error": "Marionette.app missing from mac zip"}
+        parsed = parse_mac_codesign_dump(_codesign_dump_for_app(app))
+        if parsed.get("ok"):
+            return parsed
+        parsed["error"] = (
+            "mac zip is not Developer ID signed "
+            "(identifier={identifier} team={team} adhoc={adhoc})".format(
+                identifier=parsed.get("identifier") or "?",
+                team=parsed.get("team") or "?",
+                adhoc=parsed.get("adhoc"),
+            )
+        )
+        return parsed
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def verify_mac_release_dir(directory):
+    # type: (str) -> Dict[str, Any]
+    zip_path = find_mac_update_zip(directory)
+    if zip_path is None:
+        return {"ok": False, "error": "no *-mac.zip in {}".format(directory)}
+    return inspect_mac_release_zip(zip_path)
+
+
+def cmd_require_mac_signature(args):
+    # type: (argparse.Namespace) -> int
+    verdict = verify_mac_release_dir(args.dir)
+    if not verdict.get("ok"):
+        sys.stderr.write(
+            "{}\n".format(verdict.get("error") or "mac zip failed Developer ID check")
+        )
+        return 1
+    sys.stdout.write(
+        "mac zip Developer ID ok identifier={} team={}\n".format(
+            verdict.get("identifier") or "",
+            verdict.get("team") or "",
+        )
+    )
+    return 0
+
+
 def build_parser():
     # type: () -> argparse.ArgumentParser
     parser = argparse.ArgumentParser(description=__doc__)
@@ -354,6 +483,13 @@ def build_parser():
     adopt.add_argument("--repo", default="")
     adopt.add_argument("--limit", type=int, default=20)
     adopt.set_defaults(func=cmd_adopt_installers)
+
+    mac_sig = sub.add_parser(
+        "require-mac-signature",
+        help="fail unless webapp/release contains a Developer ID-signed mac zip",
+    )
+    mac_sig.add_argument("--dir", required=True)
+    mac_sig.set_defaults(func=cmd_require_mac_signature)
     return parser
 
 

--- a/tests/test_ci_release_gate.py
+++ b/tests/test_ci_release_gate.py
@@ -8,8 +8,10 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 from ci_release_gate import (  # noqa: E402
     _flatten_installer_files,
+    find_mac_update_zip,
     matching_green_run,
     matching_installer_run,
+    parse_mac_codesign_dump,
 )
 
 
@@ -115,6 +117,41 @@ def test_flatten_installer_files_lifts_nested_artifact_layout(tmp_path):
     assert (dest / "latest-mac.yml").is_file()
 
 
+def test_parse_mac_codesign_dump_accepts_developer_id():
+    dump = """
+Identifier=com.marionette.app
+Format=app bundle with Mach-O universal (x86_64 arm64)
+Authority=Developer ID Application: Cary Palmer (ZDSDN9VC8M)
+Authority=Developer ID Certification Authority
+TeamIdentifier=ZDSDN9VC8M
+"""
+    parsed = parse_mac_codesign_dump(dump)
+    assert parsed["ok"] is True
+    assert parsed["team"] == "ZDSDN9VC8M"
+    assert parsed["adhoc"] is False
+
+
+def test_parse_mac_codesign_dump_rejects_adhoc_electron_identity():
+    dump = """
+Identifier=Electron
+Format=app bundle with Mach-O universal (x86_64 arm64)
+Signature=adhoc
+TeamIdentifier=not set
+"""
+    parsed = parse_mac_codesign_dump(dump)
+    assert parsed["ok"] is False
+    assert parsed["adhoc"] is True
+    assert parsed["identifier"] == "Electron"
+
+
+def test_find_mac_update_zip_prefers_electron_builder_name(tmp_path):
+    (tmp_path / "Marionette-0.9.251-universal-mac.zip").write_bytes(b"zip")
+    (tmp_path / "notes.txt").write_text("ignore")
+    found = find_mac_update_zip(str(tmp_path))
+    assert found is not None
+    assert found.endswith("Marionette-0.9.251-universal-mac.zip")
+
+
 def test_release_yml_does_not_rerun_pytest():
     text = (ROOT / ".github" / "workflows" / "release.yml").read_text()
     assert "python -m pytest" not in text
@@ -123,6 +160,8 @@ def test_release_yml_does_not_rerun_pytest():
     assert "needs: [tests-already-green, build]" in text
     assert "puppetmaster-ai==" in text
     assert "fetch-depth: 0" in text
+    assert "CSC_FOR_PULL_REQUEST" in text
+    assert "require-mac-signature" in text
 
 
 def test_tests_yml_windows_runner_is_swappable():

--- a/webapp/electron-builder.yml
+++ b/webapp/electron-builder.yml
@@ -30,6 +30,7 @@ mac:
     - target: zip
       arch: universal
   hardenedRuntime: true
+  forceCodeSigning: true
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist

--- a/webapp/electron/packaged-updater.cjs
+++ b/webapp/electron/packaged-updater.cjs
@@ -54,6 +54,19 @@ function readCheckoutPackageVersion(repoRoot) {
   }
 }
 
+function describePackagedUpdateError(message) {
+  const raw = String(message || "").trim();
+  if (!raw) return "packaged update failed";
+  if (/code failed to satisfy specified code requirement/i.test(raw)) {
+    return (
+      "The downloaded mac update is not signed with the same Developer ID as this install. " +
+      "The published zip was likely built on a pull_request without CSC_FOR_PULL_REQUEST. " +
+      raw
+    );
+  }
+  return raw;
+}
+
 function packagedUpdaterEnabled({ isPackaged, env = process.env }) {
   if (!isPackaged) return false;
   if (String(env.MARIONETTE_PACKAGED_UPDATER || "").trim() === "0") return false;
@@ -264,7 +277,7 @@ function registerPackagedUpdater(ipcMain, app, opts = {}) {
     log(`update-downloaded ${version}`);
   });
   autoUpdater.on("error", (err) => {
-    const message = String(err && err.message ? err.message : err || "packaged update failed");
+    const message = describePackagedUpdateError(err && err.message ? err.message : err);
     log(`error ${message}`);
     emitProgress({ stage: "error", message });
     if (checking) emitCheckIdle();
@@ -344,7 +357,7 @@ function registerPackagedUpdater(ipcMain, app, opts = {}) {
       quitTimer.unref?.();
       return { ok: true, installerUpdateRequired: true, packagedInstallPending: true };
     } catch (err) {
-      const message = String(err && err.message ? err.message : err);
+      const message = describePackagedUpdateError(err && err.message ? err.message : err);
       log(`download/install failed: ${message}`);
       emitProgress({ stage: "error", message });
       return { ok: false, error: message };
@@ -380,5 +393,6 @@ module.exports = {
   mergeUpdateAvailability,
   shouldRelaunchAfterSourceUpdate,
   planSeamlessApplyStages,
+  describePackagedUpdateError,
   registerPackagedUpdater,
 };

--- a/webapp/electron/packaged-updater.test.cjs
+++ b/webapp/electron/packaged-updater.test.cjs
@@ -9,8 +9,17 @@ const {
   mergeUpdateAvailability,
   shouldRelaunchAfterSourceUpdate,
   planSeamlessApplyStages,
+  describePackagedUpdateError,
   registerPackagedUpdater,
 } = require("./packaged-updater.cjs");
+
+test("describePackagedUpdateError: ShipIt requirement mismatch names the unsigned zip", () => {
+  const explained = describePackagedUpdateError(
+    "Code signature at URL file:///tmp/Marionette.app/ did not pass validation: code failed to satisfy specified code requirement(s)",
+  );
+  assert.match(explained, /not signed with the same Developer ID/);
+  assert.match(explained, /CSC_FOR_PULL_REQUEST/);
+});
 
 test("compareVersions: basic ordering", () => {
   assert.equal(compareVersions("0.9.161", "0.9.154"), 1);

--- a/webapp/electron/release-config.test.cjs
+++ b/webapp/electron/release-config.test.cjs
@@ -16,6 +16,7 @@ test("mac release uses electron-builder notarization exactly once", () => {
     fs.readFileSync(path.join(webappDir, "package.json"), "utf8"),
   );
 
+  assert.match(config, /^\s*forceCodeSigning\s*:\s*true\s*$/m);
   assert.doesNotMatch(config, /^\s*afterSign\s*:/m);
   assert.equal(
     fs.existsSync(path.join(webappDir, "build", "notarize.cjs")),

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.251",
+  "version": "0.9.252",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.251",
+      "version": "0.9.252",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.251",
+  "version": "0.9.252",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Dest-PR mac installers were published unsigned (`CSC` skipped on `pull_request`). ShipIt then rejected v0.9.250/v0.9.251 on existing Developer ID installs.
- Sign dest-PR mac builds (`CSC_FOR_PULL_REQUEST`), fail unsigned electron-builder output, and refuse unsigned zip adopt so the tag rebuilds a real Developer ID artifact.
- Version bump to v0.9.252 so the in-app updater can install a signed shell.

## Test plan
- [x] `tests/test_ci_release_gate.py` + `test_version_consistency.py`
- [x] `require-mac-signature` refuses the live v0.9.251 zip (`Identifier=Electron`, adhoc)
- [ ] dest-into-main `tests` matrix (3.9, 3.11, Windows, frontend-build)
- [ ] dest-into-main `release` mac log shows Developer ID signing / notarization (not "code signing will be skipped")
- [ ] After tag, `codesign -dv` on the published universal-mac.zip is Developer ID, identifier `com.marionette.app`