### PR TITLE
absorb #71: restore sandboxed preload IPC

### DIFF
--- a/webapp/electron/fs-bridge.cjs
+++ b/webapp/electron/fs-bridge.cjs
@@ -25,6 +25,17 @@ function registerFsBridge(ipcMain, opts = {}) {
   const guard = (targetPath) =>
     denyOutsideAllowedRoots(targetPath, getAllowedRoots());
 
+  // A dropped folder may sit outside the current workspace. Return only its
+  // type; all reads remain protected by the workspace-root guard below.
+  ipcMain.handle("fs:isDirectory", async (_event, absPath) => {
+    try {
+      if (typeof absPath !== "string" || !absPath) return false;
+      return (await fs.promises.stat(absPath)).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+
   ipcMain.handle("fs:readDir", (_e, dir) => {
     try {
       const denied = guard(dir);

--- a/webapp/electron/fs-bridge.test.cjs
+++ b/webapp/electron/fs-bridge.test.cjs
@@ -1,8 +1,10 @@
 // Light source-wiring checks for the native fs reveal bridge.
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const { describe, it } = require("node:test");
+const vm = require("node:vm");
 
 describe("fs-bridge revealInFolder", () => {
   it("registers shell.showItemInFolder via fs:revealInFolder", () => {
@@ -16,9 +18,59 @@ describe("fs-bridge revealInFolder", () => {
     assert.match(preload, /revealInFolder:\s*\(absPath\)\s*=>\s*ipcRenderer\.invoke\("fs:revealInFolder"/);
   });
 
-  it("preload exposes harnessIPC.isDirectory for outside-workspace drops", () => {
+  it("sandboxed preload exposes harnessIPC without requiring Node filesystem access", () => {
     const preload = fs.readFileSync(path.join(__dirname, "preload.cjs"), "utf8");
-    assert.match(preload, /isDirectory:\s*\(absPath\)\s*=>/);
-    assert.match(preload, /statSync\(p\)\.isDirectory\(\)/);
+    let exposed = null;
+    const invokes = [];
+    const ipcRenderer = {
+      invoke: (channel, value) => {
+        invokes.push([channel, value]);
+        return Promise.resolve(channel === "fs:isDirectory");
+      },
+      send: () => {},
+      on: () => {},
+      once: () => {},
+      removeListener: () => {},
+    };
+    vm.runInNewContext(preload, {
+      require: (name) => {
+        if (name !== "electron") throw new Error(`sandbox module not found: ${name}`);
+        return {
+          contextBridge: { exposeInMainWorld: (_name, api) => { exposed = api; } },
+          ipcRenderer,
+          webUtils: { getPathForFile: () => "" },
+        };
+      },
+      Uint8Array,
+    });
+    assert.ok(exposed, "preload must expose harnessIPC inside Electron's sandbox");
+    assert.equal(typeof exposed.getJSON, "function");
+    assert.equal(typeof exposed.isDirectory, "function");
+    return exposed.isDirectory("/outside/folder").then((result) => {
+      assert.equal(result, true);
+      assert.deepEqual(invokes, [["fs:isDirectory", "/outside/folder"]]);
+    });
+  });
+
+  it("checks dropped directories in the main process", async () => {
+    const { registerFsBridge } = require("./fs-bridge.cjs");
+    const listeners = new Map();
+    const ipcMain = {
+      handle: (channel, listener) => listeners.set(channel, listener),
+      on: (channel, listener) => listeners.set(channel, listener),
+    };
+    registerFsBridge(ipcMain);
+    const listener = listeners.get("fs:isDirectory");
+    assert.equal(typeof listener, "function");
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mari-drop-dir-"));
+    const file = path.join(dir, "file.txt");
+    fs.writeFileSync(file, "x");
+    try {
+      assert.equal(await listener({}, dir), true);
+      assert.equal(await listener({}, file), false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/webapp/electron/preload.cjs
+++ b/webapp/electron/preload.cjs
@@ -2,7 +2,6 @@
 // (lib/transport.ts checks for window.harnessIPC and routes through it). Plus
 // native fs/git bridges for the file-tree and source-control panels.
 const { contextBridge, ipcRenderer, webUtils } = require("electron");
-const fs = require("fs");
 
 let streamSeq = 0;
 
@@ -23,17 +22,9 @@ contextBridge.exposeInMainWorld("harnessIPC", {
     } catch (_) {}
     return "";
   },
-  // User-initiated drop/open: stat only, not path-confined (outside folders
-  // must still be detectable so the composer can open them).
-  isDirectory: (absPath) => {
-    try {
-      const p = String(absPath || "");
-      if (!p) return false;
-      return fs.statSync(p).isDirectory();
-    } catch (_) {
-      return false;
-    }
-  },
+  // User-initiated drop/open: main owns filesystem access because Electron's
+  // sandboxed preload cannot import Node's fs module.
+  isDirectory: (absPath) => ipcRenderer.invoke("fs:isDirectory", absPath),
   // Fire-and-forget: persist a caught renderer error to the Electron main log so
   // a UI crash is diagnosable from ~/.pmharness/electron.log without devtools.
   logError: (payload) => { try { ipcRenderer.send("harness:rendererError", payload); } catch (_) {} },

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -196,12 +196,12 @@ export default function App() {
     const prevent = (e: DragEvent) => {
       if (hasFiles(e)) e.preventDefault();
     };
-    const onDrop = (e: DragEvent) => {
+    const onDrop = async (e: DragEvent) => {
       prevent(e);
       const files = Array.from(e.dataTransfer?.files || []);
       for (const file of files) {
         const osPath = resolveDroppedOsPath(file as { path?: string });
-        if (osPath && droppedPathIsDirectory(osPath)) {
+        if (osPath && await droppedPathIsDirectory(osPath)) {
           openAgentWorkspace(osPath);
         }
       }

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -2789,7 +2789,7 @@ describe("composerInput module", () => {
     expect(detectComposerTrigger("@terminal:term:12 ", 18).kind).toBe("none");
   });
 
-  it("builds inserts, cycles selection, and resolves drop mentions", () => {
+  it("builds inserts, cycles selection, and resolves drop mentions", async () => {
     expect(buildMentionInsert("hi @", 3, 4, "a.ts")).toEqual({
       next: "hi @a.ts ",
       cursor: 9,
@@ -2901,11 +2901,13 @@ describe("composerInput module", () => {
       droppedDirectoryPlan({ osPath: "/Users/me/authority-spoof", repo: "/repo" }),
     ).toEqual({ kind: "open-workspace", path: "/Users/me/authority-spoof" });
     expect(droppedDirectoryPlan({ osPath: "", repo: "/repo" })).toEqual({ kind: "fail" });
-    expect(droppedPathIsDirectory("/Users/me/authority-spoof")).toBe(false);
+    await expect(droppedPathIsDirectory("/Users/me/authority-spoof")).resolves.toBe(false);
     const prevDirIpc = (window as any).harnessIPC;
-    (window as any).harnessIPC = { isDirectory: (p: string) => p.endsWith("/authority-spoof") };
-    expect(droppedPathIsDirectory("/Users/me/authority-spoof")).toBe(true);
-    expect(droppedPathIsDirectory("/Users/me/notes.md")).toBe(false);
+    (window as any).harnessIPC = {
+      isDirectory: async (p: string) => p.endsWith("/authority-spoof"),
+    };
+    await expect(droppedPathIsDirectory("/Users/me/authority-spoof")).resolves.toBe(true);
+    await expect(droppedPathIsDirectory("/Users/me/notes.md")).resolves.toBe(false);
     if (prevDirIpc === undefined) delete (window as any).harnessIPC;
     else (window as any).harnessIPC = prevDirIpc;
     expect(uploadErrorMessage(new Error("Upload failed"), "File upload failed")).toBe(

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -1807,7 +1807,8 @@ export default function Conversation({
       } catch {
         entry = null;
       }
-      const isDirectory = !!(entry && entry.isDirectory) || droppedPathIsDirectory(osPath);
+      const isDirectory = !!(entry && entry.isDirectory)
+        || await droppedPathIsDirectory(osPath);
 
       if (isImage) {
         // Images attach as visual context (upload + thumbnail), as before.

--- a/webapp/src/components/conversation/composerInput.ts
+++ b/webapp/src/components/conversation/composerInput.ts
@@ -276,7 +276,7 @@ export function mentionTokenForDroppedPath(opts: {
 
 type HarnessDropIpc = {
   pathForFile?: (f: unknown) => string;
-  isDirectory?: (absPath: string) => boolean;
+  isDirectory?: (absPath: string) => Promise<boolean>;
 };
 
 function dropIpc(): HarnessDropIpc | undefined {
@@ -285,13 +285,13 @@ function dropIpc(): HarnessDropIpc | undefined {
 }
 
 /** True when Electron can stat `osPath` as a directory (outside-workspace ok). */
-export function droppedPathIsDirectory(osPath: string): boolean {
+export async function droppedPathIsDirectory(osPath: string): Promise<boolean> {
   const path = normalizeOsPath(osPath);
   if (!path) return false;
   const probe = dropIpc()?.isDirectory;
   if (typeof probe !== "function") return false;
   try {
-    return !!probe(path);
+    return !!(await probe(path));
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- Absorb kbentonferguson#71: sandboxed preload cannot `require("fs")`, so harnessIPC never exposed (broken desktop IPC from v0.9.249 through v0.9.252).
- Keep Benton/bferguson authorship. Move directory probe to main `fs:isDirectory` (boolean only; reads stay workspace-guarded).
- Do not merge the fork PR into main.

## Test plan
- [x] `node --test webapp/electron/fs-bridge.test.cjs` (4 passed)
- [x] `npx vitest run src/__tests__/conversation.helpers.test.ts` (144 passed)
- [ ] dest CI if it finishes in-session
