### PR TITLE
Release v0.9.253

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.252, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. Dest-PR mac installers are Developer ID-signed so in-app ShipIt updates succeed on existing installs. Release tags when dest-PR tests are green for this tree. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
+> Status: v0.9.253, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. Sandboxed preload no longer requires Node fs (desktop IPC restored). Dest-PR mac installers Developer ID-sign, and tag publish can see dest-PR tests so the signed zip actually ships. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.252"
+__version__ = "0.9.253"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.252"
+version = "0.9.253"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/ci_release_gate.py
+++ b/scripts/ci_release_gate.py
@@ -137,30 +137,44 @@ def _tree_resolver(repo):
         # type: (str) -> Optional[str]
         if sha in cache:
             return cache[sha]
-        # Prefer the API so a shallow tag checkout (fetch-depth 1) can
-        # still match dest-PR head SHAs that are not local objects.
-        tree = _commit_tree_via_api(repo, sha)
+        tree = None
+        # Prefer local git when the object exists (tag checkout is
+        # fetch-depth 0, so dest-PR parent SHAs resolve without the API).
+        try:
+            tree = git_tree_sha(sha)
+        except subprocess.CalledProcessError:
+            tree = None
         if not tree:
-            try:
-                tree = git_tree_sha(sha)
-            except subprocess.CalledProcessError:
-                tree = None
+            tree = _commit_tree_via_api(repo, sha)
         cache[sha] = tree
         return tree
 
     return tree_for
 
 
-def _list_successful_tests_runs(repo, limit):
-    # type: (str, int) -> List[Dict[str, Any]]
+def filter_successful_runs(runs):
+    # type: (Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]
+    """Keep conclusion=success only.
+
+    Do not pass ``gh run list --status success``: on tag jobs GITHUB_TOKEN
+    has omitted dest-PR successes, so ``tests-already-green`` failed and
+    signed mac artifacts never published.
+    """
+    out = []
+    for run in runs:
+        if run.get("conclusion") == "success":
+            out.append(run)
+    return out
+
+
+def _list_workflow_runs(repo, workflow, limit):
+    # type: (str, str, int) -> List[Dict[str, Any]]
     return _gh_json(
         [
             "run",
             "list",
             "--workflow",
-            "tests",
-            "--status",
-            "success",
+            workflow,
             "--limit",
             str(limit),
             "--json",
@@ -168,25 +182,16 @@ def _list_successful_tests_runs(repo, limit):
         ],
         repo=repo,
     )
+
+
+def _list_successful_tests_runs(repo, limit):
+    # type: (str, int) -> List[Dict[str, Any]]
+    return filter_successful_runs(_list_workflow_runs(repo, "tests", limit))
 
 
 def _list_successful_release_runs(repo, limit):
     # type: (str, int) -> List[Dict[str, Any]]
-    return _gh_json(
-        [
-            "run",
-            "list",
-            "--workflow",
-            "release",
-            "--status",
-            "success",
-            "--limit",
-            str(limit),
-            "--json",
-            "headSha,databaseId,url,event,displayTitle,conclusion",
-        ],
-        repo=repo,
-    )
+    return filter_successful_runs(_list_workflow_runs(repo, "release", limit))
 
 
 def _artifact_names(repo, run):
@@ -318,6 +323,16 @@ def cmd_adopt_installers(args):
                 )
             )
             return 1
+    if platform == "linux" and not linux_release_has_appimage(out_dir):
+        for path in moved:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+        sys.stderr.write(
+            "refusing empty linux adopt from run {}: no .AppImage\n".format(run_id)
+        )
+        return 1
     sys.stdout.write(
         "adopted installer-{} from run {} ({}) for tree {}\n".format(
             platform, run_id, match.get("url") or "", target_tree
@@ -376,6 +391,16 @@ def parse_mac_codesign_dump(text):
         "developer_id": developer_id,
         "adhoc": adhoc,
     }
+
+
+def linux_release_has_appimage(directory):
+    # type: (str) -> bool
+    if not directory or not os.path.isdir(directory):
+        return False
+    for name in os.listdir(directory):
+        if name.endswith(".AppImage"):
+            return True
+    return False
 
 
 def find_mac_update_zip(directory):
@@ -470,7 +495,7 @@ def build_parser():
     )
     require.add_argument("--sha", default="HEAD")
     require.add_argument("--repo", default="")
-    require.add_argument("--limit", type=int, default=50)
+    require.add_argument("--limit", type=int, default=80)
     require.set_defaults(func=cmd_require_green)
 
     adopt = sub.add_parser(

--- a/tests/test_ci_release_gate.py
+++ b/tests/test_ci_release_gate.py
@@ -8,7 +8,9 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 from ci_release_gate import (  # noqa: E402
     _flatten_installer_files,
+    filter_successful_runs,
     find_mac_update_zip,
+    linux_release_has_appimage,
     matching_green_run,
     matching_installer_run,
     parse_mac_codesign_dump,
@@ -115,6 +117,23 @@ def test_flatten_installer_files_lifts_nested_artifact_layout(tmp_path):
     names = sorted(Path(path).name for path in moved)
     assert names == ["Marionette.dmg", "latest-mac.yml"]
     assert (dest / "latest-mac.yml").is_file()
+
+
+def test_filter_successful_runs_keeps_only_conclusion_success():
+    runs = [
+        {"headSha": "dest-tip", "conclusion": "success"},
+        {"headSha": "in-flight", "conclusion": "", "status": "in_progress"},
+        {"headSha": "failed", "conclusion": "failure"},
+    ]
+    kept = filter_successful_runs(runs)
+    assert [run["headSha"] for run in kept] == ["dest-tip"]
+
+
+def test_linux_release_has_appimage(tmp_path):
+    (tmp_path / "latest-linux.yml").write_text("path: x.AppImage\n")
+    assert linux_release_has_appimage(str(tmp_path)) is False
+    (tmp_path / "Marionette-0.9.253.AppImage").write_bytes(b"app")
+    assert linux_release_has_appimage(str(tmp_path)) is True
 
 
 def test_parse_mac_codesign_dump_accepts_developer_id():

--- a/webapp/electron/fs-bridge.cjs
+++ b/webapp/electron/fs-bridge.cjs
@@ -25,6 +25,17 @@ function registerFsBridge(ipcMain, opts = {}) {
   const guard = (targetPath) =>
     denyOutsideAllowedRoots(targetPath, getAllowedRoots());
 
+  // A dropped folder may sit outside the current workspace. Return only its
+  // type; all reads remain protected by the workspace-root guard below.
+  ipcMain.handle("fs:isDirectory", async (_event, absPath) => {
+    try {
+      if (typeof absPath !== "string" || !absPath) return false;
+      return (await fs.promises.stat(absPath)).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+
   ipcMain.handle("fs:readDir", (_e, dir) => {
     try {
       const denied = guard(dir);

--- a/webapp/electron/fs-bridge.test.cjs
+++ b/webapp/electron/fs-bridge.test.cjs
@@ -1,8 +1,10 @@
 // Light source-wiring checks for the native fs reveal bridge.
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const { describe, it } = require("node:test");
+const vm = require("node:vm");
 
 describe("fs-bridge revealInFolder", () => {
   it("registers shell.showItemInFolder via fs:revealInFolder", () => {
@@ -16,9 +18,59 @@ describe("fs-bridge revealInFolder", () => {
     assert.match(preload, /revealInFolder:\s*\(absPath\)\s*=>\s*ipcRenderer\.invoke\("fs:revealInFolder"/);
   });
 
-  it("preload exposes harnessIPC.isDirectory for outside-workspace drops", () => {
+  it("sandboxed preload exposes harnessIPC without requiring Node filesystem access", () => {
     const preload = fs.readFileSync(path.join(__dirname, "preload.cjs"), "utf8");
-    assert.match(preload, /isDirectory:\s*\(absPath\)\s*=>/);
-    assert.match(preload, /statSync\(p\)\.isDirectory\(\)/);
+    let exposed = null;
+    const invokes = [];
+    const ipcRenderer = {
+      invoke: (channel, value) => {
+        invokes.push([channel, value]);
+        return Promise.resolve(channel === "fs:isDirectory");
+      },
+      send: () => {},
+      on: () => {},
+      once: () => {},
+      removeListener: () => {},
+    };
+    vm.runInNewContext(preload, {
+      require: (name) => {
+        if (name !== "electron") throw new Error(`sandbox module not found: ${name}`);
+        return {
+          contextBridge: { exposeInMainWorld: (_name, api) => { exposed = api; } },
+          ipcRenderer,
+          webUtils: { getPathForFile: () => "" },
+        };
+      },
+      Uint8Array,
+    });
+    assert.ok(exposed, "preload must expose harnessIPC inside Electron's sandbox");
+    assert.equal(typeof exposed.getJSON, "function");
+    assert.equal(typeof exposed.isDirectory, "function");
+    return exposed.isDirectory("/outside/folder").then((result) => {
+      assert.equal(result, true);
+      assert.deepEqual(invokes, [["fs:isDirectory", "/outside/folder"]]);
+    });
+  });
+
+  it("checks dropped directories in the main process", async () => {
+    const { registerFsBridge } = require("./fs-bridge.cjs");
+    const listeners = new Map();
+    const ipcMain = {
+      handle: (channel, listener) => listeners.set(channel, listener),
+      on: (channel, listener) => listeners.set(channel, listener),
+    };
+    registerFsBridge(ipcMain);
+    const listener = listeners.get("fs:isDirectory");
+    assert.equal(typeof listener, "function");
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mari-drop-dir-"));
+    const file = path.join(dir, "file.txt");
+    fs.writeFileSync(file, "x");
+    try {
+      assert.equal(await listener({}, dir), true);
+      assert.equal(await listener({}, file), false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/webapp/electron/preload.cjs
+++ b/webapp/electron/preload.cjs
@@ -2,7 +2,6 @@
 // (lib/transport.ts checks for window.harnessIPC and routes through it). Plus
 // native fs/git bridges for the file-tree and source-control panels.
 const { contextBridge, ipcRenderer, webUtils } = require("electron");
-const fs = require("fs");
 
 let streamSeq = 0;
 
@@ -23,17 +22,9 @@ contextBridge.exposeInMainWorld("harnessIPC", {
     } catch (_) {}
     return "";
   },
-  // User-initiated drop/open: stat only, not path-confined (outside folders
-  // must still be detectable so the composer can open them).
-  isDirectory: (absPath) => {
-    try {
-      const p = String(absPath || "");
-      if (!p) return false;
-      return fs.statSync(p).isDirectory();
-    } catch (_) {
-      return false;
-    }
-  },
+  // User-initiated drop/open: main owns filesystem access because Electron's
+  // sandboxed preload cannot import Node's fs module.
+  isDirectory: (absPath) => ipcRenderer.invoke("fs:isDirectory", absPath),
   // Fire-and-forget: persist a caught renderer error to the Electron main log so
   // a UI crash is diagnosable from ~/.pmharness/electron.log without devtools.
   logError: (payload) => { try { ipcRenderer.send("harness:rendererError", payload); } catch (_) {} },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.252",
+  "version": "0.9.253",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.252",
+      "version": "0.9.253",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.252",
+  "version": "0.9.253",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -196,12 +196,12 @@ export default function App() {
     const prevent = (e: DragEvent) => {
       if (hasFiles(e)) e.preventDefault();
     };
-    const onDrop = (e: DragEvent) => {
+    const onDrop = async (e: DragEvent) => {
       prevent(e);
       const files = Array.from(e.dataTransfer?.files || []);
       for (const file of files) {
         const osPath = resolveDroppedOsPath(file as { path?: string });
-        if (osPath && droppedPathIsDirectory(osPath)) {
+        if (osPath && await droppedPathIsDirectory(osPath)) {
           openAgentWorkspace(osPath);
         }
       }

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -2789,7 +2789,7 @@ describe("composerInput module", () => {
     expect(detectComposerTrigger("@terminal:term:12 ", 18).kind).toBe("none");
   });
 
-  it("builds inserts, cycles selection, and resolves drop mentions", () => {
+  it("builds inserts, cycles selection, and resolves drop mentions", async () => {
     expect(buildMentionInsert("hi @", 3, 4, "a.ts")).toEqual({
       next: "hi @a.ts ",
       cursor: 9,
@@ -2901,11 +2901,13 @@ describe("composerInput module", () => {
       droppedDirectoryPlan({ osPath: "/Users/me/authority-spoof", repo: "/repo" }),
     ).toEqual({ kind: "open-workspace", path: "/Users/me/authority-spoof" });
     expect(droppedDirectoryPlan({ osPath: "", repo: "/repo" })).toEqual({ kind: "fail" });
-    expect(droppedPathIsDirectory("/Users/me/authority-spoof")).toBe(false);
+    await expect(droppedPathIsDirectory("/Users/me/authority-spoof")).resolves.toBe(false);
     const prevDirIpc = (window as any).harnessIPC;
-    (window as any).harnessIPC = { isDirectory: (p: string) => p.endsWith("/authority-spoof") };
-    expect(droppedPathIsDirectory("/Users/me/authority-spoof")).toBe(true);
-    expect(droppedPathIsDirectory("/Users/me/notes.md")).toBe(false);
+    (window as any).harnessIPC = {
+      isDirectory: async (p: string) => p.endsWith("/authority-spoof"),
+    };
+    await expect(droppedPathIsDirectory("/Users/me/authority-spoof")).resolves.toBe(true);
+    await expect(droppedPathIsDirectory("/Users/me/notes.md")).resolves.toBe(false);
     if (prevDirIpc === undefined) delete (window as any).harnessIPC;
     else (window as any).harnessIPC = prevDirIpc;
     expect(uploadErrorMessage(new Error("Upload failed"), "File upload failed")).toBe(

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -1807,7 +1807,8 @@ export default function Conversation({
       } catch {
         entry = null;
       }
-      const isDirectory = !!(entry && entry.isDirectory) || droppedPathIsDirectory(osPath);
+      const isDirectory = !!(entry && entry.isDirectory)
+        || await droppedPathIsDirectory(osPath);
 
       if (isImage) {
         // Images attach as visual context (upload + thumbnail), as before.

--- a/webapp/src/components/conversation/composerInput.ts
+++ b/webapp/src/components/conversation/composerInput.ts
@@ -276,7 +276,7 @@ export function mentionTokenForDroppedPath(opts: {
 
 type HarnessDropIpc = {
   pathForFile?: (f: unknown) => string;
-  isDirectory?: (absPath: string) => boolean;
+  isDirectory?: (absPath: string) => Promise<boolean>;
 };
 
 function dropIpc(): HarnessDropIpc | undefined {
@@ -285,13 +285,13 @@ function dropIpc(): HarnessDropIpc | undefined {
 }
 
 /** True when Electron can stat `osPath` as a directory (outside-workspace ok). */
-export function droppedPathIsDirectory(osPath: string): boolean {
+export async function droppedPathIsDirectory(osPath: string): Promise<boolean> {
   const path = normalizeOsPath(osPath);
   if (!path) return false;
   const probe = dropIpc()?.isDirectory;
   if (typeof probe !== "function") return false;
   try {
-    return !!probe(path);
+    return !!(await probe(path));
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- Restore desktop IPC after v0.9.249 `require("fs")` in the sandboxed preload aborted before `harnessIPC` was exposed (absorb of #71 / #72).
- Tag `tests-already-green` now lists dest-PR runs without `--status success` (GITHUB_TOKEN omitted those greens on v0.9.252, so signed mac zips never published).
- Refuse linux adopt when the artifact has no AppImage (v0.9.252 tag linux was yml-only).

## Test plan
- [x] `tests/test_ci_release_gate.py` + `test_version_consistency.py`
- [ ] dest-into-main `tests` matrix (3.9, 3.11, Windows, frontend-build)
- [ ] dest-into-main `release` mac log: Developer ID + notarization + `require-mac-signature` ok
- [ ] After tag, GitHub release has `Marionette-0.9.253-universal-mac.zip` (not just `latest-mac.yml`)