### PR TITLE
absorb #74: operational diagnostic contract

### DIFF
--- a/webapp/src/__tests__/operationalDiagnostic.test.ts
+++ b/webapp/src/__tests__/operationalDiagnostic.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+  DESKTOP_BRIDGE_MISSING,
+  TRANSPORT_HTTP,
+  TRANSPORT_UNCERTAIN,
+  belongsToActiveScope,
+  classifyFailure,
+  createOperationalDiagnostic,
+  desktopBridgeMissing,
+  desktopBridgeMissingDiagnostic,
+  desktopShellExpected,
+  fromTransportFailure,
+  isOperationalDiagnostic,
+  isUncertainTransport,
+  nextDiagnostic,
+  resolveRepaired,
+  sameRoot,
+  sanitizeDiagnosticText,
+} from "../lib/operationalDiagnostic";
+
+describe("classifyFailure", () => {
+  it("keeps form, upload, and validation local", () => {
+    expect(classifyFailure({ kind: "form" })).toBe("local");
+    expect(classifyFailure({ kind: "upload" })).toBe("local");
+    expect(classifyFailure({ kind: "validation" })).toBe("local");
+  });
+
+  it("treats readiness and transport failures as operational", () => {
+    expect(classifyFailure({ kind: "operational", scope: "prompt_queue" })).toBe("operational");
+    expect(classifyFailure({ scope: "desktop_bridge" })).toBe("operational");
+  });
+});
+
+describe("sanitizeDiagnosticText", () => {
+  it("redacts bearer and api-key material", () => {
+    expect(sanitizeDiagnosticText("Authorization: Bearer sk-abc123456789")).toContain("[redacted]");
+    expect(sanitizeDiagnosticText("api_key=secret-value")).toContain("[redacted]");
+    expect(sanitizeDiagnosticText("Authorization: Bearer sk-abc123456789")).not.toMatch(/sk-abc/);
+  });
+
+  it("keeps a single line and bounds length", () => {
+    expect(sanitizeDiagnosticText("first\nsecond stack")).toBe("first");
+    expect(sanitizeDiagnosticText("x".repeat(200)).length).toBeLessThanOrEqual(160);
+  });
+});
+
+describe("desktop bridge detection", () => {
+  it("expects a desktop shell from an Electron userAgent", () => {
+    expect(desktopShellExpected({ userAgent: "Mozilla/5.0 Electron/39.0.0" })).toBe(true);
+    expect(desktopShellExpected({ userAgent: "Mozilla/5.0 Chrome/128" })).toBe(false);
+    expect(desktopShellExpected({ shellFlag: true, userAgent: "Chrome" })).toBe(true);
+  });
+
+  it("flags the preload-crash case: shell expected, harnessIPC missing", () => {
+    expect(
+      desktopBridgeMissing({
+        userAgent: "Mozilla/5.0 Electron/39.0.0",
+        hasBridge: false,
+      }),
+    ).toBe(true);
+    expect(
+      desktopBridgeMissing({
+        userAgent: "Mozilla/5.0 Electron/39.0.0",
+        hasBridge: true,
+      }),
+    ).toBe(false);
+    expect(
+      desktopBridgeMissing({
+        userAgent: "Mozilla/5.0 Chrome/128",
+        hasBridge: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("desktopBridgeMissingDiagnostic", () => {
+  it("is one scoped root cause with a real recovery and known-safe data", () => {
+    const diag = desktopBridgeMissingDiagnostic({ operation: "startup" });
+    expect(isOperationalDiagnostic(diag)).toBe(true);
+    expect(diag.scope).toBe("desktop_bridge");
+    expect(diag.code).toBe(DESKTOP_BRIDGE_MISSING);
+    expect(diag.summary).toBe("Desktop bridge is missing");
+    expect(diag.dataSafe).toBe(true);
+    expect(diag.retryable).toBe(false);
+    expect(diag.recovery).toEqual({ kind: "relaunch", label: "Relaunch Marionette" });
+    expect(diag.summary.toLowerCase()).not.toBe("error");
+  });
+});
+
+describe("fromTransportFailure", () => {
+  it("collapses a desktop-without-bridge failure to the preload diagnostic", () => {
+    const diag = fromTransportFailure({
+      operation: "getJSON",
+      path: "/api/workspaces",
+      err: new Error("Failed to fetch"),
+      userAgent: "Electron/39.0.0",
+      hasBridge: false,
+    });
+    expect(diag.code).toBe(DESKTOP_BRIDGE_MISSING);
+    expect(diag.scope).toBe("desktop_bridge");
+  });
+
+  it("keeps transient connection flaps uncertain instead of inventing a root cause", () => {
+    const diag = fromTransportFailure({
+      operation: "getJSON",
+      err: new Error("connect ECONNREFUSED 127.0.0.1:49376"),
+      isTransient: true,
+      userAgent: "Chrome",
+      hasBridge: false,
+    });
+    expect(diag.code).toBe(TRANSPORT_UNCERTAIN);
+    expect(diag.retryable).toBe(true);
+    expect(isUncertainTransport(diag)).toBe(true);
+  });
+
+  it("records a web HTTP failure without claiming the desktop bridge died", () => {
+    const diag = fromTransportFailure({
+      operation: "refreshQueue",
+      path: "/api/prompt-queue",
+      err: new Error("/api/prompt-queue -> 500"),
+      userAgent: "Chrome",
+      hasBridge: false,
+    });
+    expect(diag.code).toBe(TRANSPORT_HTTP);
+    expect(diag.scope).toBe("transport");
+  });
+});
+
+describe("scope and retry rules", () => {
+  it("does not attach a session-scoped diagnostic after a session switch", () => {
+    const diag = createOperationalDiagnostic({
+      scope: "conversation",
+      operation: "send",
+      summary: "Turn failed",
+      severity: "error",
+      retryable: true,
+      sessionId: "sess-a",
+    });
+    expect(belongsToActiveScope(diag, { sessionId: "sess-a" })).toBe(true);
+    expect(belongsToActiveScope(diag, { sessionId: "sess-b" })).toBe(false);
+  });
+
+  it("does not let uncertain transport erase a known failure", () => {
+    const known = desktopBridgeMissingDiagnostic();
+    const flap = fromTransportFailure({
+      operation: "getJSON",
+      isTransient: true,
+      userAgent: "Chrome",
+      hasBridge: false,
+    });
+    expect(nextDiagnostic(known, flap)).toBe(known);
+    expect(nextDiagnostic(null, flap)).toBe(flap);
+  });
+
+  it("clears only the diagnostic a successful retry repaired", () => {
+    const queue = createOperationalDiagnostic({
+      scope: "prompt_queue",
+      operation: "refresh",
+      code: TRANSPORT_HTTP,
+      summary: "Could not refresh prompt queue",
+      severity: "error",
+      retryable: true,
+    });
+    const other = desktopBridgeMissingDiagnostic();
+    expect(resolveRepaired(queue, queue)).toBeNull();
+    expect(resolveRepaired(other, queue)).toBe(other);
+    expect(sameRoot(queue, { id: "other", code: TRANSPORT_HTTP, scope: "prompt_queue", operation: "refresh" })).toBe(true);
+  });
+});
+
+describe("createOperationalDiagnostic", () => {
+  it("sanitizes caller-supplied summary and detail", () => {
+    const diag = createOperationalDiagnostic({
+      scope: "config",
+      operation: "save",
+      summary: "Authorization: Bearer sk-abcdefghijklmnopqrst",
+      detail: "line1\napi_key=supersecret",
+      severity: "error",
+      retryable: true,
+    });
+    expect(diag.summary).not.toMatch(/sk-abcd/);
+    expect(diag.detail).toBe("line1");
+    expect(diag.recovery).toEqual({ kind: "none" });
+  });
+});

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -1,0 +1,250 @@
+/**
+ * Renderer-owned operational diagnostic contract (issue #74 PR 1).
+ *
+ * Lifecycle (idle / thinking / error) stays how a turn is progressing.
+ * Puppetmaster artifacts stay authoritative for worker outcome quality.
+ * This record is only the safe, presentable explanation of an application
+ * failure — not a second durable store, not form validation, not a PM taxonomy.
+ */
+
+export type DiagnosticScope =
+  | "desktop_bridge"
+  | "transport"
+  | "backend"
+  | "conversation"
+  | "workspace"
+  | "projects"
+  | "sessions"
+  | "prompt_queue"
+  | "config"
+  | "update"
+  | "panel";
+
+export type DiagnosticSeverity = "info" | "warning" | "error";
+
+export type DiagnosticRecovery =
+  | { kind: "none" }
+  | { kind: "retry"; label: string }
+  | { kind: "relaunch"; label: string };
+
+export type FailureClass = "operational" | "local";
+
+export type OperationalDiagnostic = {
+  id: string;
+  scope: DiagnosticScope;
+  operation: string;
+  code?: string;
+  summary: string;
+  detail?: string;
+  severity: DiagnosticSeverity;
+  retryable: boolean;
+  /** Undefined when we do not know. Never invent "unsafe". */
+  dataSafe?: boolean;
+  recovery: DiagnosticRecovery;
+  sessionId?: string;
+  repo?: string;
+  jobId?: string;
+  taskId?: string;
+  createdAt: number;
+};
+
+export const DESKTOP_BRIDGE_MISSING = "desktop_bridge_missing";
+export const TRANSPORT_HTTP = "transport_http";
+export const TRANSPORT_IPC = "transport_ipc";
+export const TRANSPORT_UNCERTAIN = "transport_uncertain";
+export const TRANSPORT_BUSY = "transport_busy";
+
+const SUMMARY_MAX = 160;
+const DETAIL_MAX = 280;
+
+const SECRET_LIKE =
+  /(?:bearer\s+[a-z0-9._\-+=\/]+|sk-[a-z0-9]{8,}|api[_-]?key\s*[:=]\s*\S+|x-harness-token\s*[:=]\s*\S+|authorization\s*[:=]\s*\S+)/gi;
+
+let nextId = 0;
+
+function newDiagnosticId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  nextId += 1;
+  return `diag-${nextId}`;
+}
+
+/** Form, upload, and field validation stay beside their controls. */
+export function classifyFailure(input: {
+  kind?: "validation" | "upload" | "form" | "operational";
+  scope?: DiagnosticScope;
+}): FailureClass {
+  if (input.kind === "validation" || input.kind === "upload" || input.kind === "form") {
+    return "local";
+  }
+  return "operational";
+}
+
+export function isOperationalDiagnostic(value: unknown): value is OperationalDiagnostic {
+  if (!value || typeof value !== "object") return false;
+  const d = value as OperationalDiagnostic;
+  return Boolean(d.id && d.scope && d.operation && d.summary && d.severity && d.recovery);
+}
+
+export function sanitizeDiagnosticText(text: string, max = SUMMARY_MAX): string {
+  const cut = String(text || "").replace(/\r/g, "").split("\n")[0] || "";
+  const redacted = cut.replace(SECRET_LIKE, "[redacted]").replace(SECRET_LIKE, "[redacted]");
+  if (redacted.length <= max) return redacted;
+  return redacted.slice(0, Math.max(0, max - 1)).trimEnd() + "…";
+}
+
+export function desktopShellExpected(env?: {
+  userAgent?: string;
+  shellFlag?: boolean;
+}): boolean {
+  if (env?.shellFlag) return true;
+  const ua = env?.userAgent ?? (typeof navigator !== "undefined" ? navigator.userAgent : "");
+  return /Electron/i.test(ua);
+}
+
+export function desktopBridgeMissing(env?: {
+  userAgent?: string;
+  shellFlag?: boolean;
+  hasBridge?: boolean;
+}): boolean {
+  const expected = desktopShellExpected(env);
+  const hasBridge = env?.hasBridge ?? (
+    typeof window !== "undefined" && !!(window as { harnessIPC?: unknown }).harnessIPC
+  );
+  return expected && !hasBridge;
+}
+
+export function createOperationalDiagnostic(
+  input: Omit<OperationalDiagnostic, "id" | "createdAt" | "summary" | "detail" | "recovery"> & {
+    summary: string;
+    detail?: string;
+    recovery?: DiagnosticRecovery;
+    id?: string;
+    createdAt?: number;
+  },
+): OperationalDiagnostic {
+  const recovery = input.recovery || { kind: "none" };
+  return {
+    ...input,
+    id: input.id || newDiagnosticId(),
+    createdAt: input.createdAt ?? Date.now(),
+    summary: sanitizeDiagnosticText(input.summary, SUMMARY_MAX),
+    detail: input.detail ? sanitizeDiagnosticText(input.detail, DETAIL_MAX) : undefined,
+    recovery,
+  };
+}
+
+/** One root cause for the v0.9.249–v0.9.252 sandboxed-preload crash. */
+export function desktopBridgeMissingDiagnostic(opts?: {
+  operation?: string;
+  sessionId?: string;
+  repo?: string;
+}): OperationalDiagnostic {
+  return createOperationalDiagnostic({
+    scope: "desktop_bridge",
+    operation: opts?.operation || "preload",
+    code: DESKTOP_BRIDGE_MISSING,
+    summary: "Desktop bridge is missing",
+    detail:
+      "The Electron preload did not expose harnessIPC. Backend data can still be intact; panels fail independently until the shell is relaunched.",
+    severity: "error",
+    retryable: false,
+    dataSafe: true,
+    recovery: { kind: "relaunch", label: "Relaunch Marionette" },
+    sessionId: opts?.sessionId,
+    repo: opts?.repo,
+  });
+}
+
+export function fromTransportFailure(input: {
+  operation: string;
+  err?: unknown;
+  path?: string;
+  isTransient?: boolean;
+  hasBridge?: boolean;
+  userAgent?: string;
+  shellFlag?: boolean;
+  sessionId?: string;
+  repo?: string;
+}): OperationalDiagnostic {
+  if (desktopBridgeMissing(input)) {
+    return desktopBridgeMissingDiagnostic({
+      operation: input.operation,
+      sessionId: input.sessionId,
+      repo: input.repo,
+    });
+  }
+  const err = input.err as { message?: string; code?: string; status?: number } | undefined;
+  const raw = String(err?.message || err || "request failed");
+  if (input.isTransient) {
+    return createOperationalDiagnostic({
+      scope: "transport",
+      operation: input.operation,
+      code: TRANSPORT_UNCERTAIN,
+      summary: "Backend connection is uncertain",
+      detail: sanitizeDiagnosticText(raw, DETAIL_MAX),
+      severity: "warning",
+      retryable: true,
+      recovery: { kind: "retry", label: "Retry" },
+      sessionId: input.sessionId,
+      repo: input.repo,
+    });
+  }
+  const viaIpc = input.hasBridge ?? (
+    typeof window !== "undefined" && !!(window as { harnessIPC?: unknown }).harnessIPC
+  );
+  return createOperationalDiagnostic({
+    scope: "transport",
+    operation: input.operation,
+    code: viaIpc ? TRANSPORT_IPC : TRANSPORT_HTTP,
+    summary: "Request failed",
+    detail: sanitizeDiagnosticText(input.path ? `${input.path}: ${raw}` : raw, DETAIL_MAX),
+    severity: "error",
+    retryable: true,
+    recovery: { kind: "retry", label: "Retry" },
+    sessionId: input.sessionId,
+    repo: input.repo,
+  });
+}
+
+export function sameRoot(
+  a: Pick<OperationalDiagnostic, "id" | "code" | "scope" | "operation">,
+  b: Pick<OperationalDiagnostic, "id" | "code" | "scope" | "operation">,
+): boolean {
+  if (a.id && b.id && a.id === b.id) return true;
+  return Boolean(a.code && a.code === b.code && a.scope === b.scope && a.operation === b.operation);
+}
+
+export function belongsToActiveScope(
+  diag: OperationalDiagnostic,
+  active: { sessionId?: string; repo?: string },
+): boolean {
+  if (diag.sessionId && active.sessionId && diag.sessionId !== active.sessionId) return false;
+  if (diag.repo && active.repo && diag.repo !== active.repo) return false;
+  return true;
+}
+
+export function isUncertainTransport(diag: OperationalDiagnostic): boolean {
+  return diag.code === TRANSPORT_UNCERTAIN || diag.code === TRANSPORT_BUSY;
+}
+
+/** Busy or uncertain transport must not erase a known failure. */
+export function nextDiagnostic(
+  current: OperationalDiagnostic | null,
+  incoming: OperationalDiagnostic | null,
+): OperationalDiagnostic | null {
+  if (!incoming) return current;
+  if (!current) return incoming;
+  if (isUncertainTransport(incoming) && !isUncertainTransport(current)) return current;
+  return incoming;
+}
+
+/** A successful retry clears only the diagnostic it repaired. */
+export function resolveRepaired(
+  current: OperationalDiagnostic | null,
+  repaired: Pick<OperationalDiagnostic, "id" | "code" | "scope" | "operation">,
+): OperationalDiagnostic | null {
+  if (!current) return null;
+  return sameRoot(current, repaired) ? null : current;
+}


### PR DESCRIPTION
## Summary
- First slice of #74: renderer-owned operational diagnostic contract, no UI.
- Encodes one-root-cause, scope isolation, uncertain-transport retain, secret redaction, and the missing-`harnessIPC` desktop-bridge diagnostic from the v0.9.249–v0.9.252 preload incident.
- Credit: @kbentonferguson. Tracking issue stays open for later slices.

## Test plan
- [x] `npx vitest run src/__tests__/operationalDiagnostic.test.ts` (14 passed)