### PR TITLE
Release v0.9.254

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.253, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. Sandboxed preload no longer requires Node fs (desktop IPC restored). Dest-PR mac installers Developer ID-sign, and tag publish can see dest-PR tests so the signed zip actually ships. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
+> Status: v0.9.254, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. A missing desktop bridge is one operational diagnostic (status-pill hover, projects, folder chip, prompt queue) instead of several unrelated empty/error states. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.253"
+__version__ = "0.9.254"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.253"
+version = "0.9.254"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.253",
+  "version": "0.9.254",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.253",
+      "version": "0.9.254",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.253",
+  "version": "0.9.254",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -65,6 +65,7 @@ import { workspaceLeafName } from "../components/conversation/workspaceDisplay";
 import {
   statusPillClickable,
   statusPillDotClass,
+  statusPillHoverText,
   statusPillLabel,
   statusPillTextClass,
 } from "../components/conversation/StatusPill";
@@ -1082,6 +1083,9 @@ describe("pillStatus + workspaceDisplay + StatusPill chrome", () => {
     expect(statusPillLabel("idle")).toBe("Ready");
     expect(statusPillLabel("done")).toBe("Done");
     expect(statusPillLabel("error")).toBe("Error");
+    expect(statusPillLabel("error", "Desktop bridge is missing")).toBe("Error");
+    expect(statusPillHoverText("error", "Desktop bridge is missing")).toBe("Desktop bridge is missing");
+    expect(statusPillHoverText("idle")).toBe("idle");
     expect(statusPillTextClass("error")).toContain("risk");
     expect(statusPillDotClass("streaming")).toContain("animate-pulse");
     expect(statusPillDotClass("investigating")).toContain("animate-pulse");

--- a/webapp/src/__tests__/operationalDiagnostic.test.ts
+++ b/webapp/src/__tests__/operationalDiagnostic.test.ts
@@ -5,6 +5,7 @@ import {
   TRANSPORT_UNCERTAIN,
   belongsToActiveScope,
   classifyFailure,
+  conversationLifecycleAfterFailure,
   createOperationalDiagnostic,
   desktopBridgeMissing,
   desktopBridgeMissingDiagnostic,
@@ -16,7 +17,13 @@ import {
   resolveRepaired,
   sameRoot,
   sanitizeDiagnosticText,
+  sharedReadinessNotice,
 } from "../lib/operationalDiagnostic";
+import {
+  getActiveDiagnostic,
+  publishDiagnostic,
+  resetDiagnosticBus,
+} from "../lib/operationalDiagnosticBus";
 
 describe("classifyFailure", () => {
   it("keeps form, upload, and validation local", () => {
@@ -165,6 +172,36 @@ describe("scope and retry rules", () => {
     expect(resolveRepaired(queue, queue)).toBeNull();
     expect(resolveRepaired(other, queue)).toBe(other);
     expect(sameRoot(queue, { id: "other", code: TRANSPORT_HTTP, scope: "prompt_queue", operation: "refresh" })).toBe(true);
+  });
+});
+
+describe("shared readiness copy", () => {
+  it("replaces unrelated empty/error labels with the desktop-bridge root", () => {
+    const diag = desktopBridgeMissingDiagnostic();
+    expect(sharedReadinessNotice("No projects", diag)).toBe("Desktop bridge is missing");
+    expect(sharedReadinessNotice("No folder", diag)).toBe("Desktop bridge is missing");
+    expect(sharedReadinessNotice("Couldn’t refresh prompt queue", diag)).toBe("Desktop bridge is missing");
+    expect(sharedReadinessNotice("No projects", null)).toBe("No projects");
+  });
+
+  it("treats a failed turn as settled lifecycle plus diagnostic", () => {
+    expect(conversationLifecycleAfterFailure()).toBe("idle");
+  });
+});
+
+describe("diagnostic bus", () => {
+  it("keeps one desktop-bridge root when later uncertain transport arrives", () => {
+    resetDiagnosticBus();
+    publishDiagnostic(desktopBridgeMissingDiagnostic());
+    const flap = fromTransportFailure({
+      operation: "getJSON",
+      isTransient: true,
+      userAgent: "Chrome",
+      hasBridge: false,
+    });
+    publishDiagnostic(flap);
+    expect(getActiveDiagnostic()?.code).toBe(DESKTOP_BRIDGE_MISSING);
+    resetDiagnosticBus();
   });
 });
 

--- a/webapp/src/__tests__/operationalDiagnostic.test.ts
+++ b/webapp/src/__tests__/operationalDiagnostic.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+  DESKTOP_BRIDGE_MISSING,
+  TRANSPORT_HTTP,
+  TRANSPORT_UNCERTAIN,
+  belongsToActiveScope,
+  classifyFailure,
+  createOperationalDiagnostic,
+  desktopBridgeMissing,
+  desktopBridgeMissingDiagnostic,
+  desktopShellExpected,
+  fromTransportFailure,
+  isOperationalDiagnostic,
+  isUncertainTransport,
+  nextDiagnostic,
+  resolveRepaired,
+  sameRoot,
+  sanitizeDiagnosticText,
+} from "../lib/operationalDiagnostic";
+
+describe("classifyFailure", () => {
+  it("keeps form, upload, and validation local", () => {
+    expect(classifyFailure({ kind: "form" })).toBe("local");
+    expect(classifyFailure({ kind: "upload" })).toBe("local");
+    expect(classifyFailure({ kind: "validation" })).toBe("local");
+  });
+
+  it("treats readiness and transport failures as operational", () => {
+    expect(classifyFailure({ kind: "operational", scope: "prompt_queue" })).toBe("operational");
+    expect(classifyFailure({ scope: "desktop_bridge" })).toBe("operational");
+  });
+});
+
+describe("sanitizeDiagnosticText", () => {
+  it("redacts bearer and api-key material", () => {
+    expect(sanitizeDiagnosticText("Authorization: Bearer sk-abc123456789")).toContain("[redacted]");
+    expect(sanitizeDiagnosticText("api_key=secret-value")).toContain("[redacted]");
+    expect(sanitizeDiagnosticText("Authorization: Bearer sk-abc123456789")).not.toMatch(/sk-abc/);
+  });
+
+  it("keeps a single line and bounds length", () => {
+    expect(sanitizeDiagnosticText("first\nsecond stack")).toBe("first");
+    expect(sanitizeDiagnosticText("x".repeat(200)).length).toBeLessThanOrEqual(160);
+  });
+});
+
+describe("desktop bridge detection", () => {
+  it("expects a desktop shell from an Electron userAgent", () => {
+    expect(desktopShellExpected({ userAgent: "Mozilla/5.0 Electron/39.0.0" })).toBe(true);
+    expect(desktopShellExpected({ userAgent: "Mozilla/5.0 Chrome/128" })).toBe(false);
+    expect(desktopShellExpected({ shellFlag: true, userAgent: "Chrome" })).toBe(true);
+  });
+
+  it("flags the preload-crash case: shell expected, harnessIPC missing", () => {
+    expect(
+      desktopBridgeMissing({
+        userAgent: "Mozilla/5.0 Electron/39.0.0",
+        hasBridge: false,
+      }),
+    ).toBe(true);
+    expect(
+      desktopBridgeMissing({
+        userAgent: "Mozilla/5.0 Electron/39.0.0",
+        hasBridge: true,
+      }),
+    ).toBe(false);
+    expect(
+      desktopBridgeMissing({
+        userAgent: "Mozilla/5.0 Chrome/128",
+        hasBridge: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("desktopBridgeMissingDiagnostic", () => {
+  it("is one scoped root cause with a real recovery and known-safe data", () => {
+    const diag = desktopBridgeMissingDiagnostic({ operation: "startup" });
+    expect(isOperationalDiagnostic(diag)).toBe(true);
+    expect(diag.scope).toBe("desktop_bridge");
+    expect(diag.code).toBe(DESKTOP_BRIDGE_MISSING);
+    expect(diag.summary).toBe("Desktop bridge is missing");
+    expect(diag.dataSafe).toBe(true);
+    expect(diag.retryable).toBe(false);
+    expect(diag.recovery).toEqual({ kind: "relaunch", label: "Relaunch Marionette" });
+    expect(diag.summary.toLowerCase()).not.toBe("error");
+  });
+});
+
+describe("fromTransportFailure", () => {
+  it("collapses a desktop-without-bridge failure to the preload diagnostic", () => {
+    const diag = fromTransportFailure({
+      operation: "getJSON",
+      path: "/api/workspaces",
+      err: new Error("Failed to fetch"),
+      userAgent: "Electron/39.0.0",
+      hasBridge: false,
+    });
+    expect(diag.code).toBe(DESKTOP_BRIDGE_MISSING);
+    expect(diag.scope).toBe("desktop_bridge");
+  });
+
+  it("keeps transient connection flaps uncertain instead of inventing a root cause", () => {
+    const diag = fromTransportFailure({
+      operation: "getJSON",
+      err: new Error("connect ECONNREFUSED 127.0.0.1:49376"),
+      isTransient: true,
+      userAgent: "Chrome",
+      hasBridge: false,
+    });
+    expect(diag.code).toBe(TRANSPORT_UNCERTAIN);
+    expect(diag.retryable).toBe(true);
+    expect(isUncertainTransport(diag)).toBe(true);
+  });
+
+  it("records a web HTTP failure without claiming the desktop bridge died", () => {
+    const diag = fromTransportFailure({
+      operation: "refreshQueue",
+      path: "/api/prompt-queue",
+      err: new Error("/api/prompt-queue -> 500"),
+      userAgent: "Chrome",
+      hasBridge: false,
+    });
+    expect(diag.code).toBe(TRANSPORT_HTTP);
+    expect(diag.scope).toBe("transport");
+  });
+});
+
+describe("scope and retry rules", () => {
+  it("does not attach a session-scoped diagnostic after a session switch", () => {
+    const diag = createOperationalDiagnostic({
+      scope: "conversation",
+      operation: "send",
+      summary: "Turn failed",
+      severity: "error",
+      retryable: true,
+      sessionId: "sess-a",
+    });
+    expect(belongsToActiveScope(diag, { sessionId: "sess-a" })).toBe(true);
+    expect(belongsToActiveScope(diag, { sessionId: "sess-b" })).toBe(false);
+  });
+
+  it("does not let uncertain transport erase a known failure", () => {
+    const known = desktopBridgeMissingDiagnostic();
+    const flap = fromTransportFailure({
+      operation: "getJSON",
+      isTransient: true,
+      userAgent: "Chrome",
+      hasBridge: false,
+    });
+    expect(nextDiagnostic(known, flap)).toBe(known);
+    expect(nextDiagnostic(null, flap)).toBe(flap);
+  });
+
+  it("clears only the diagnostic a successful retry repaired", () => {
+    const queue = createOperationalDiagnostic({
+      scope: "prompt_queue",
+      operation: "refresh",
+      code: TRANSPORT_HTTP,
+      summary: "Could not refresh prompt queue",
+      severity: "error",
+      retryable: true,
+    });
+    const other = desktopBridgeMissingDiagnostic();
+    expect(resolveRepaired(queue, queue)).toBeNull();
+    expect(resolveRepaired(other, queue)).toBe(other);
+    expect(sameRoot(queue, { id: "other", code: TRANSPORT_HTTP, scope: "prompt_queue", operation: "refresh" })).toBe(true);
+  });
+});
+
+describe("createOperationalDiagnostic", () => {
+  it("sanitizes caller-supplied summary and detail", () => {
+    const diag = createOperationalDiagnostic({
+      scope: "config",
+      operation: "save",
+      summary: "Authorization: Bearer sk-abcdefghijklmnopqrst",
+      detail: "line1\napi_key=supersecret",
+      severity: "error",
+      retryable: true,
+    });
+    expect(diag.summary).not.toMatch(/sk-abcd/);
+    expect(diag.detail).toBe("line1");
+    expect(diag.recovery).toEqual({ kind: "none" });
+  });
+});

--- a/webapp/src/__tests__/transportConn.test.ts
+++ b/webapp/src/__tests__/transportConn.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { DESKTOP_BRIDGE_MISSING } from "../lib/operationalDiagnostic";
+import { getActiveDiagnostic, resetDiagnosticBus } from "../lib/operationalDiagnosticBus";
 import {
   getHarnessIpc,
+  getJSON,
   isDesktop,
   isTransientHarnessConnError,
   stream,
@@ -26,6 +29,27 @@ describe("getHarnessIpc", () => {
     const bridge = { stream: () => () => {} };
     w.harnessIPC = bridge;
     expect(getHarnessIpc()).toBe(bridge);
+    if (prev === undefined) delete w.harnessIPC;
+    else w.harnessIPC = prev;
+  });
+});
+
+describe("desktop bridge refuse", () => {
+  afterEach(() => {
+    resetDiagnosticBus();
+    vi.restoreAllMocks();
+  });
+
+  it("throws one desktop-bridge diagnostic instead of fetching", async () => {
+    const w = window as any;
+    const prev = w.harnessIPC;
+    delete w.harnessIPC;
+    vi.spyOn(navigator, "userAgent", "get").mockReturnValue("Mozilla/5.0 Electron/39.0.0");
+    await expect(getJSON("/api/workspaces")).rejects.toMatchObject({
+      code: DESKTOP_BRIDGE_MISSING,
+      message: "Desktop bridge is missing",
+    });
+    expect(getActiveDiagnostic()?.code).toBe(DESKTOP_BRIDGE_MISSING);
     if (prev === undefined) delete w.harnessIPC;
     else w.harnessIPC = prev;
   });

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -137,6 +137,9 @@ import {
   type DirectoryEntryLike,
 } from "./conversation/composerInput";
 import { openAgentWorkspace } from "../lib/agentLinks";
+import { sharedReadinessNotice } from "../lib/operationalDiagnostic";
+import { getActiveDiagnostic } from "../lib/operationalDiagnosticBus";
+import { useOperationalDiagnostic } from "../lib/useOperationalDiagnostic";
 import {
   blankMsgQueueOnSessionSwitch,
   blankQueueItemsOnSessionSwitch,
@@ -500,6 +503,7 @@ export default function Conversation({
   const queueItemsRef = useRef<{ id: string; text: string; images?: string[]; model?: string }[]>([]);
   useEffect(() => { queueItemsRef.current = queueItems; }, [queueItems]);
   const [queueLoadError, setQueueLoadError] = useState<string | null>(null);
+  const operationalDiagnostic = useOperationalDiagnostic();
   const queueFetchGenRef = useRef(0);
   const [queueDragIndex, setQueueDragIndex] = useState<number | null>(null);
   const [queueDragOverIndex, setQueueDragOverIndex] = useState<number | null>(null);
@@ -535,7 +539,9 @@ export default function Conversation({
     holdSwarmAwait,
     turnOpen,
   });
-  const pillStatus: string = derivePillStatus({
+  // Mouth ≠ runner. awaiting_swarm / holdSwarmAwait keep the fold, not Stop.
+  const composerBusy = isPilotMouthBusy(turnOpen, status);
+  const derivedPillStatus: string = derivePillStatus({
     transcriptStale,
     answerChromeIdle: false,
     liveInvestigation,
@@ -544,8 +550,14 @@ export default function Conversation({
     awaitingSwarm: swarmPausePoint,
     agentLoopOpen,
   });
-  // Mouth ≠ runner. awaiting_swarm / holdSwarmAwait keep the fold, not Stop.
-  const composerBusy = isPilotMouthBusy(turnOpen, status);
+  // Operational diagnostic is settled failure, not a live turn lifecycle.
+  const pillStatus: string = (
+    operationalDiagnostic
+    && operationalDiagnostic.severity === "error"
+    && !composerBusy
+      ? "error"
+      : derivedPillStatus
+  );
   // Keep the busy footer clock alive while holdSwarmAwait outlives status flaps.
   useEffect(() => {
     if (holdSwarmAwait) {
@@ -787,7 +799,7 @@ export default function Conversation({
           return;
         }
         console.error("Failed to load prompt queue:", err);
-        setQueueLoadError(QUEUE_LOAD_FAIL_NOTICE);
+        setQueueLoadError(sharedReadinessNotice(QUEUE_LOAD_FAIL_NOTICE, getActiveDiagnostic()));
       });
   };
 
@@ -3092,19 +3104,23 @@ export default function Conversation({
       <ConversationHeader
         pillStatus={pillStatus}
         detail={
-          !transcriptStale && pillStatus !== "idle" && composerBusy
-            ? (
-              busyProgress.label
-                ? busyProgress.pill
-                // Sticky busy without a footer line: pause-point Still working…
-                // wins over hold-sticky liveInvestigation (matches Explored fold).
-                : derivePillBusyDetail({
-                  liveInvestigation,
-                  pillStatus,
-                  agentLoopOpen,
-                })
+          pillStatus === "error" && operationalDiagnostic
+            ? operationalDiagnostic.summary
+            : (
+              !transcriptStale && pillStatus !== "idle" && composerBusy
+                ? (
+                  busyProgress.label
+                    ? busyProgress.pill
+                    // Sticky busy without a footer line: pause-point Still working…
+                    // wins over hold-sticky liveInvestigation (matches Explored fold).
+                    : derivePillBusyDetail({
+                      liveInvestigation,
+                      pillStatus,
+                      agentLoopOpen,
+                    })
+                )
+                : undefined
             )
-            : undefined
         }
         onBusyDetailClick={() => {
           // Worker / shell busy chrome → terminal, never the file editor.

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -8,6 +8,8 @@ import { mapSessionSearchHits, type SessionSearchRow } from "../lib/sessionSearc
 import { usePolling } from "../lib/usePolling";
 import { readSWRCache, writeSWRCache, useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
 import { writeTranscriptCache } from "./Conversation";
+import { sharedReadinessNotice } from "../lib/operationalDiagnostic";
+import { useOperationalDiagnostic } from "../lib/useOperationalDiagnostic";
 
 export {
   SESSION_LEASE_EXHAUSTED_MESSAGE,
@@ -58,6 +60,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
   onSessionChange?: (id: string) => void;
 }) {
   const [swapping, setSwapping] = useState<string | null>(null);
+  const operationalDiagnostic = useOperationalDiagnostic();
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -1375,7 +1378,9 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       {railTab === "projects" && (
       <div ref={projectsSectionRef} className="pb-1">
       <div className="px-2 pt-3 pb-2 shrink-0 min-w-0">
-        {projects.length === 0 && !panelSwitching && <Empty>No projects</Empty>}
+        {projects.length === 0 && !panelSwitching && (
+          <Empty>{sharedReadinessNotice("No projects", operationalDiagnostic)}</Empty>
+        )}
       <div className="space-y-0.5 -mx-2">
           {projects.map((projectPath) => {
             const basename = getWorkspaceBasename(projectPath) || "Untitled Project";

--- a/webapp/src/components/conversation/StatusPill.tsx
+++ b/webapp/src/components/conversation/StatusPill.tsx
@@ -56,6 +56,12 @@ export function statusPillLabel(status: string, detail?: string): string {
   return status;
 }
 
+/** Hover text: error keeps the compact label and discloses the safe reason. */
+export function statusPillHoverText(status: string, detail?: string): string {
+  if (status === "error" && detail) return detail;
+  return detail || status;
+}
+
 export function statusPillTextClass(status: string): string {
   return STATUS_TEXT[status] || STATUS_TEXT.idle;
 }
@@ -75,6 +81,7 @@ export default function StatusPill({
   onDetailClick?: () => void;
 }) {
   const label = statusPillLabel(status, detail);
+  const hoverText = statusPillHoverText(status, detail);
   const clickable = statusPillClickable(status, detail, onDetailClick);
   const className =
     `text-[10.5px] flex items-center gap-1.5 min-w-0 max-w-[42ch] ${statusPillTextClass(status)}`
@@ -95,7 +102,7 @@ export default function StatusPill({
   return (
     <span
       className={className}
-      title={detail || status}
+      title={hoverText}
     >
       <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusPillDotClass(status)}`} />
       <span className="truncate">{label}</span>

--- a/webapp/src/components/conversation/WorkspaceChip.tsx
+++ b/webapp/src/components/conversation/WorkspaceChip.tsx
@@ -3,6 +3,8 @@ import { ChevronDown, Folder, GitBranch, Home } from "lucide-react";
 import { api } from "../../lib/api";
 import { repoPathsEqual } from "../../lib/pathNormalize";
 import { pickFolder } from "../../lib/transport";
+import { sharedReadinessNotice } from "../../lib/operationalDiagnostic";
+import { useOperationalDiagnostic } from "../../lib/useOperationalDiagnostic";
 import {
   formatWorkspaceOpenLeaseExhaustedMessage,
   isWorkspaceOpenLeaseExhausted,
@@ -39,6 +41,7 @@ export const WORKSPACE_CHIP_ROW_CLASS =
   "w-full max-w-full min-w-0 overflow-hidden text-left px-3 py-1.5 hover:bg-panel2 transition";
 
 export default function WorkspaceChip() {
+  const operationalDiagnostic = useOperationalDiagnostic();
   const [ws, setWs] = useState<{ repo: string; branch: string; recents?: string[]; home?: string } | null>(null);
   const [open, setOpen] = useState(false);
   const [openError, setOpenError] = useState<string | null>(null);
@@ -93,7 +96,9 @@ export default function WorkspaceChip() {
     const picked = await pickFolder();
     if (picked) await openPath(picked);
   };
-  const name = ws?.repo ? base(ws.repo) : (ws?.home ? "Home" : "No folder");
+  const name = ws?.repo
+    ? base(ws.repo)
+    : (ws?.home ? "Home" : sharedReadinessNotice("No folder", operationalDiagnostic));
   const home = ws?.home;
   const homeActive = isWorkspaceHomeActive(ws?.repo, home);
   const recents = workspaceChipRecents(ws?.recents, ws?.repo, home);

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -248,3 +248,19 @@ export function resolveRepaired(
   if (!current) return null;
   return sameRoot(current, repaired) ? null : current;
 }
+
+/** Shared readiness surfaces reuse one root summary instead of inventing local causes. */
+export function sharedReadinessNotice(
+  fallback: string,
+  diag: OperationalDiagnostic | null | undefined,
+): string {
+  if (diag && (diag.scope === "desktop_bridge" || diag.scope === "backend")) {
+    return diag.summary;
+  }
+  return fallback;
+}
+
+/** Failed-turn lifecycle is settled; the diagnostic owns the explanation. */
+export function conversationLifecycleAfterFailure(): "idle" {
+  return "idle";
+}

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -1,0 +1,250 @@
+/**
+ * Renderer-owned operational diagnostic contract (issue #74 PR 1).
+ *
+ * Lifecycle (idle / thinking / error) stays how a turn is progressing.
+ * Puppetmaster artifacts stay authoritative for worker outcome quality.
+ * This record is only the safe, presentable explanation of an application
+ * failure — not a second durable store, not form validation, not a PM taxonomy.
+ */
+
+export type DiagnosticScope =
+  | "desktop_bridge"
+  | "transport"
+  | "backend"
+  | "conversation"
+  | "workspace"
+  | "projects"
+  | "sessions"
+  | "prompt_queue"
+  | "config"
+  | "update"
+  | "panel";
+
+export type DiagnosticSeverity = "info" | "warning" | "error";
+
+export type DiagnosticRecovery =
+  | { kind: "none" }
+  | { kind: "retry"; label: string }
+  | { kind: "relaunch"; label: string };
+
+export type FailureClass = "operational" | "local";
+
+export type OperationalDiagnostic = {
+  id: string;
+  scope: DiagnosticScope;
+  operation: string;
+  code?: string;
+  summary: string;
+  detail?: string;
+  severity: DiagnosticSeverity;
+  retryable: boolean;
+  /** Undefined when we do not know. Never invent "unsafe". */
+  dataSafe?: boolean;
+  recovery: DiagnosticRecovery;
+  sessionId?: string;
+  repo?: string;
+  jobId?: string;
+  taskId?: string;
+  createdAt: number;
+};
+
+export const DESKTOP_BRIDGE_MISSING = "desktop_bridge_missing";
+export const TRANSPORT_HTTP = "transport_http";
+export const TRANSPORT_IPC = "transport_ipc";
+export const TRANSPORT_UNCERTAIN = "transport_uncertain";
+export const TRANSPORT_BUSY = "transport_busy";
+
+const SUMMARY_MAX = 160;
+const DETAIL_MAX = 280;
+
+const SECRET_LIKE =
+  /(?:bearer\s+[a-z0-9._\-+=\/]+|sk-[a-z0-9]{8,}|api[_-]?key\s*[:=]\s*\S+|x-harness-token\s*[:=]\s*\S+|authorization\s*[:=]\s*\S+)/gi;
+
+let nextId = 0;
+
+function newDiagnosticId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  nextId += 1;
+  return `diag-${nextId}`;
+}
+
+/** Form, upload, and field validation stay beside their controls. */
+export function classifyFailure(input: {
+  kind?: "validation" | "upload" | "form" | "operational";
+  scope?: DiagnosticScope;
+}): FailureClass {
+  if (input.kind === "validation" || input.kind === "upload" || input.kind === "form") {
+    return "local";
+  }
+  return "operational";
+}
+
+export function isOperationalDiagnostic(value: unknown): value is OperationalDiagnostic {
+  if (!value || typeof value !== "object") return false;
+  const d = value as OperationalDiagnostic;
+  return Boolean(d.id && d.scope && d.operation && d.summary && d.severity && d.recovery);
+}
+
+export function sanitizeDiagnosticText(text: string, max = SUMMARY_MAX): string {
+  const cut = String(text || "").replace(/\r/g, "").split("\n")[0] || "";
+  const redacted = cut.replace(SECRET_LIKE, "[redacted]").replace(SECRET_LIKE, "[redacted]");
+  if (redacted.length <= max) return redacted;
+  return redacted.slice(0, Math.max(0, max - 1)).trimEnd() + "…";
+}
+
+export function desktopShellExpected(env?: {
+  userAgent?: string;
+  shellFlag?: boolean;
+}): boolean {
+  if (env?.shellFlag) return true;
+  const ua = env?.userAgent ?? (typeof navigator !== "undefined" ? navigator.userAgent : "");
+  return /Electron/i.test(ua);
+}
+
+export function desktopBridgeMissing(env?: {
+  userAgent?: string;
+  shellFlag?: boolean;
+  hasBridge?: boolean;
+}): boolean {
+  const expected = desktopShellExpected(env);
+  const hasBridge = env?.hasBridge ?? (
+    typeof window !== "undefined" && !!(window as { harnessIPC?: unknown }).harnessIPC
+  );
+  return expected && !hasBridge;
+}
+
+export function createOperationalDiagnostic(
+  input: Omit<OperationalDiagnostic, "id" | "createdAt" | "summary" | "detail" | "recovery"> & {
+    summary: string;
+    detail?: string;
+    recovery?: DiagnosticRecovery;
+    id?: string;
+    createdAt?: number;
+  },
+): OperationalDiagnostic {
+  const recovery = input.recovery || { kind: "none" };
+  return {
+    ...input,
+    id: input.id || newDiagnosticId(),
+    createdAt: input.createdAt ?? Date.now(),
+    summary: sanitizeDiagnosticText(input.summary, SUMMARY_MAX),
+    detail: input.detail ? sanitizeDiagnosticText(input.detail, DETAIL_MAX) : undefined,
+    recovery,
+  };
+}
+
+/** One root cause for the v0.9.249–v0.9.252 sandboxed-preload crash. */
+export function desktopBridgeMissingDiagnostic(opts?: {
+  operation?: string;
+  sessionId?: string;
+  repo?: string;
+}): OperationalDiagnostic {
+  return createOperationalDiagnostic({
+    scope: "desktop_bridge",
+    operation: opts?.operation || "preload",
+    code: DESKTOP_BRIDGE_MISSING,
+    summary: "Desktop bridge is missing",
+    detail:
+      "The Electron preload did not expose harnessIPC. Backend data can still be intact; panels fail independently until the shell is relaunched.",
+    severity: "error",
+    retryable: false,
+    dataSafe: true,
+    recovery: { kind: "relaunch", label: "Relaunch Marionette" },
+    sessionId: opts?.sessionId,
+    repo: opts?.repo,
+  });
+}
+
+export function fromTransportFailure(input: {
+  operation: string;
+  err?: unknown;
+  path?: string;
+  isTransient?: boolean;
+  hasBridge?: boolean;
+  userAgent?: string;
+  shellFlag?: boolean;
+  sessionId?: string;
+  repo?: string;
+}): OperationalDiagnostic {
+  if (desktopBridgeMissing(input)) {
+    return desktopBridgeMissingDiagnostic({
+      operation: input.operation,
+      sessionId: input.sessionId,
+      repo: input.repo,
+    });
+  }
+  const err = input.err as { message?: string; code?: string; status?: number } | undefined;
+  const raw = String(err?.message || err || "request failed");
+  if (input.isTransient) {
+    return createOperationalDiagnostic({
+      scope: "transport",
+      operation: input.operation,
+      code: TRANSPORT_UNCERTAIN,
+      summary: "Backend connection is uncertain",
+      detail: sanitizeDiagnosticText(raw, DETAIL_MAX),
+      severity: "warning",
+      retryable: true,
+      recovery: { kind: "retry", label: "Retry" },
+      sessionId: input.sessionId,
+      repo: input.repo,
+    });
+  }
+  const viaIpc = input.hasBridge ?? (
+    typeof window !== "undefined" && !!(window as { harnessIPC?: unknown }).harnessIPC
+  );
+  return createOperationalDiagnostic({
+    scope: "transport",
+    operation: input.operation,
+    code: viaIpc ? TRANSPORT_IPC : TRANSPORT_HTTP,
+    summary: "Request failed",
+    detail: sanitizeDiagnosticText(input.path ? `${input.path}: ${raw}` : raw, DETAIL_MAX),
+    severity: "error",
+    retryable: true,
+    recovery: { kind: "retry", label: "Retry" },
+    sessionId: input.sessionId,
+    repo: input.repo,
+  });
+}
+
+export function sameRoot(
+  a: Pick<OperationalDiagnostic, "id" | "code" | "scope" | "operation">,
+  b: Pick<OperationalDiagnostic, "id" | "code" | "scope" | "operation">,
+): boolean {
+  if (a.id && b.id && a.id === b.id) return true;
+  return Boolean(a.code && a.code === b.code && a.scope === b.scope && a.operation === b.operation);
+}
+
+export function belongsToActiveScope(
+  diag: OperationalDiagnostic,
+  active: { sessionId?: string; repo?: string },
+): boolean {
+  if (diag.sessionId && active.sessionId && diag.sessionId !== active.sessionId) return false;
+  if (diag.repo && active.repo && diag.repo !== active.repo) return false;
+  return true;
+}
+
+export function isUncertainTransport(diag: OperationalDiagnostic): boolean {
+  return diag.code === TRANSPORT_UNCERTAIN || diag.code === TRANSPORT_BUSY;
+}
+
+/** Busy or uncertain transport must not erase a known failure. */
+export function nextDiagnostic(
+  current: OperationalDiagnostic | null,
+  incoming: OperationalDiagnostic | null,
+): OperationalDiagnostic | null {
+  if (!incoming) return current;
+  if (!current) return incoming;
+  if (isUncertainTransport(incoming) && !isUncertainTransport(current)) return current;
+  return incoming;
+}
+
+/** A successful retry clears only the diagnostic it repaired. */
+export function resolveRepaired(
+  current: OperationalDiagnostic | null,
+  repaired: Pick<OperationalDiagnostic, "id" | "code" | "scope" | "operation">,
+): OperationalDiagnostic | null {
+  if (!current) return null;
+  return sameRoot(current, repaired) ? null : current;
+}

--- a/webapp/src/lib/operationalDiagnosticBus.ts
+++ b/webapp/src/lib/operationalDiagnosticBus.ts
@@ -1,0 +1,49 @@
+/**
+ * In-memory renderer diagnostic. Not durable — transcripts, logs, and
+ * Puppetmaster artifacts remain the authorities for their own records.
+ */
+import {
+  nextDiagnostic,
+  resolveRepaired,
+  type OperationalDiagnostic,
+} from "./operationalDiagnostic";
+
+let current: OperationalDiagnostic | null = null;
+const listeners = new Set<(diag: OperationalDiagnostic | null) => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener(current);
+}
+
+export function getActiveDiagnostic(): OperationalDiagnostic | null {
+  return current;
+}
+
+export function publishDiagnostic(incoming: OperationalDiagnostic | null): OperationalDiagnostic | null {
+  current = nextDiagnostic(current, incoming);
+  emit();
+  return current;
+}
+
+export function clearDiagnostic(
+  repaired?: Pick<OperationalDiagnostic, "id" | "code" | "scope" | "operation">,
+): OperationalDiagnostic | null {
+  current = repaired ? resolveRepaired(current, repaired) : null;
+  emit();
+  return current;
+}
+
+export function resetDiagnosticBus(): void {
+  current = null;
+  emit();
+}
+
+export function subscribeDiagnostic(
+  listener: (diag: OperationalDiagnostic | null) => void,
+): () => void {
+  listeners.add(listener);
+  listener(current);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/webapp/src/lib/transport.ts
+++ b/webapp/src/lib/transport.ts
@@ -5,6 +5,13 @@
 // ONLY this file changes: getJSON/postJSON/stream route through window.harnessIPC
 // (preload bridge) instead of HTTP. Components never know the difference.
 
+import {
+  DESKTOP_BRIDGE_MISSING,
+  desktopBridgeMissing,
+  desktopBridgeMissingDiagnostic,
+} from "./operationalDiagnostic";
+import { publishDiagnostic } from "./operationalDiagnosticBus";
+
 /**
  * Live SSE payload from /api/chat, /api/auto, /api/run.
  * Chat/auto omit `turn` (ConvEvent); classic /run includes it (SessionEvent).
@@ -93,6 +100,18 @@ export function getHarnessIpc(): any {
   return (window as any).harnessIPC || null;
 }
 
+/** Desktop shell without harnessIPC — one root diagnostic, do not fetch. */
+function refuseIfDesktopBridgeMissing(operation: string, path?: string): void {
+  if (!desktopBridgeMissing()) return;
+  const diag = desktopBridgeMissingDiagnostic({ operation });
+  publishDiagnostic(diag);
+  const err = new Error(diag.summary) as Error & { diagnostic?: typeof diag; code?: string; path?: string };
+  err.diagnostic = diag;
+  err.code = DESKTOP_BRIDGE_MISSING;
+  if (path) err.path = path;
+  throw err;
+}
+
 // Web/vite builds may set window.__HARNESS_TOKEN__ for headered fetch.
 // Desktop Electron does not inject the token into the renderer — API calls
 // go through harnessIPC (main attaches X-Harness-Token) or webRequest
@@ -128,6 +147,7 @@ export function isTransientHarnessConnError(err: unknown): boolean {
 
 /** Like getJSON but returns parsed JSON for non-2xx responses instead of throwing. */
 export async function getJSONSoft<T = any>(path: string): Promise<T> {
+  refuseIfDesktopBridgeMissing("getJSONSoft", path);
   const bridge = getHarnessIpc();
   if (bridge?.getJSON) return bridge.getJSON(path);
   const r = await fetch(path, { headers: { "X-Harness-Token": authToken() } });
@@ -142,6 +162,7 @@ export async function getJSONSoft<T = any>(path: string): Promise<T> {
 }
 
 export async function getJSON<T = any>(path: string): Promise<T> {
+  refuseIfDesktopBridgeMissing("getJSON", path);
   const bridge = getHarnessIpc();
   if (bridge?.getJSON) return bridge.getJSON(path);
   const r = await fetch(path, { headers: { "X-Harness-Token": authToken() } });
@@ -150,6 +171,7 @@ export async function getJSON<T = any>(path: string): Promise<T> {
 }
 
 export async function postJSON<T = any>(path: string, body: any): Promise<T> {
+  refuseIfDesktopBridgeMissing("postJSON", path);
   const bridge = getHarnessIpc();
   if (bridge?.postJSON) return bridge.postJSON(path, body);
   const r = await fetch(path, {
@@ -185,6 +207,12 @@ export function stream(
   onDone?: () => void,
   onError?: (e: any) => void
 ): () => void {
+  try {
+    refuseIfDesktopBridgeMissing("stream", path);
+  } catch (err) {
+    onError?.(err);
+    return () => {};
+  }
   const bridge = getHarnessIpc();
   if (bridge?.stream) return bridge.stream(path, onEvent, onDone, onError);
 
@@ -262,6 +290,7 @@ export function stream(
 // process, which POSTs a multipart body to the loopback backend. On the web build
 // (real same-origin server) we use a normal multipart fetch.
 export async function uploadFile(file: File): Promise<{ path: string; name: string }[]> {
+  refuseIfDesktopBridgeMissing("uploadFile");
   const bridge = getHarnessIpc();
   if (bridge?.uploadFile) {
     const buf = await file.arrayBuffer();

--- a/webapp/src/lib/useOperationalDiagnostic.ts
+++ b/webapp/src/lib/useOperationalDiagnostic.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+import {
+  getActiveDiagnostic,
+  subscribeDiagnostic,
+} from "./operationalDiagnosticBus";
+import type { OperationalDiagnostic } from "./operationalDiagnostic";
+
+export function useOperationalDiagnostic(): OperationalDiagnostic | null {
+  const [diag, setDiag] = useState<OperationalDiagnostic | null>(getActiveDiagnostic);
+  useEffect(() => subscribeDiagnostic(setDiag), []);
+  return diag;
+}


### PR DESCRIPTION
## Summary
- Absorb #74 operational diagnostics: one desktop-bridge root when `harnessIPC` is missing, reused on the status pill (hover), projects empty state, folder chip, and prompt-queue notice.
- Credit: @kbentonferguson. Tracking issue stays open for later panel migration.

## Test plan
- [x] `npx vitest run` operationalDiagnostic + transportConn + conversation.helpers
- [x] `tests/test_version_consistency.py`
- [ ] dest-into-main `tests` matrix (3.9, 3.11, Windows, frontend-build)
- [ ] dest-into-main `release` mac: Developer ID + notarization + `require-mac-signature`
- [ ] After tag, GitHub release has `Marionette-0.9.254-universal-mac.zip`