### PR TITLE
Release v0.9.255

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.254, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. A missing desktop bridge is one operational diagnostic (status-pill hover, projects, folder chip, prompt queue) instead of several unrelated empty/error states. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
+> Status: v0.9.255, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. Operational panel errors share one readiness diagnostic so a missing desktop bridge is not several unrelated empty/error states. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.254"
+__version__ = "0.9.255"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.254"
+version = "0.9.255"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.254",
+  "version": "0.9.255",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.254",
+      "version": "0.9.255",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.254",
+  "version": "0.9.255",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/operationalDiagnostic.test.ts
+++ b/webapp/src/__tests__/operationalDiagnostic.test.ts
@@ -14,6 +14,7 @@ import {
   isOperationalDiagnostic,
   isUncertainTransport,
   nextDiagnostic,
+  panelNotice,
   resolveRepaired,
   sameRoot,
   sanitizeDiagnosticText,
@@ -182,6 +183,24 @@ describe("shared readiness copy", () => {
     expect(sharedReadinessNotice("No folder", diag)).toBe("Desktop bridge is missing");
     expect(sharedReadinessNotice("Couldn’t refresh prompt queue", diag)).toBe("Desktop bridge is missing");
     expect(sharedReadinessNotice("No projects", null)).toBe("No projects");
+  });
+
+  it("lets a panel keep local operational copy unless a readiness root exists", () => {
+    expect(panelNotice("Failed to get workspace files", null)).toBe("Failed to get workspace files");
+    expect(panelNotice("Failed to get workspace files", desktopBridgeMissingDiagnostic())).toBe(
+      "Desktop bridge is missing",
+    );
+    const files = createOperationalDiagnostic({
+      scope: "panel",
+      operation: "readDir",
+      summary: "Workspace files could not be listed",
+      severity: "error",
+      retryable: true,
+    });
+    expect(panelNotice("Failed to get workspace files", files, "panel")).toBe(
+      "Workspace files could not be listed",
+    );
+    expect(panelNotice("Failed to load settings", files, "config")).toBe("Failed to load settings");
   });
 
   it("treats a failed turn as settled lifecycle plus diagnostic", () => {

--- a/webapp/src/components/CheckpointsPane.tsx
+++ b/webapp/src/components/CheckpointsPane.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { History, Play, ShieldAlert, Check, RefreshCw, Eye, EyeOff } from "lucide-react";
 import { api, type Checkpoint, type CheckpointDiff } from "../lib/api";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 export default function CheckpointsPane() {
   const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([]);
@@ -10,6 +11,7 @@ export default function CheckpointsPane() {
   const [snapshotLabel, setSnapshotLabel] = useState("");
   const [isCreatingSnapshot, setIsCreatingSnapshot] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const errorNotice = usePanelNotice(error);
   const [success, setSuccess] = useState<{ text: string; undoId?: string } | null>(null);
 
   const [expandedDiffs, setExpandedDiffs] = useState<Record<string, boolean>>({});
@@ -254,10 +256,10 @@ export default function CheckpointsPane() {
       </div>
 
       {/* Status messages */}
-      {error && (
+      {errorNotice && (
         <div className="mx-2 mt-1.5 p-1.5 bg-risk/10 border border-risk/20 text-risk rounded flex items-start gap-1.5 shrink-0 text-[10px]">
           <ShieldAlert size={12} className="shrink-0 mt-0.5" />
-          <span className="leading-snug">{error}</span>
+          <span className="leading-snug">{errorNotice}</span>
         </div>
       )}
       {success && (

--- a/webapp/src/components/DiffReviewPane.tsx
+++ b/webapp/src/components/DiffReviewPane.tsx
@@ -5,6 +5,7 @@ import {
   reviewHunkDecisionKey,
   seedApplyDecisions,
 } from "../lib/reviewDecisions";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 export { reviewHunkDecisionKey, seedApplyDecisions };
 
@@ -14,6 +15,7 @@ export default function DiffReviewPane({ reviews, onRefresh, loadError = null }:
   /** Sticky honesty when RightPane getReviews fails (do not claim empty queue). */
   loadError?: string | null;
 }) {
+  const reviewsNotice = usePanelNotice(loadError);
   const [decisions, setDecisions] = useState<Record<string, "accept" | "reject">>({});
   const [loading, setLoading] = useState<string | null>(null);
   const [msg, setMsg] = useState<{ text: string; type: "success" | "error" } | null>(null);
@@ -218,14 +220,14 @@ export default function DiffReviewPane({ reviews, onRefresh, loadError = null }:
   };
 
   if (reviews.length === 0) {
-    if (loadError) {
+    if (reviewsNotice) {
       return (
         <div
           data-testid="reviews-load-error"
           className="flex flex-col items-center justify-center h-full p-6 text-center text-muted"
         >
           <AlertCircle size={24} className="mb-2 text-risk" />
-          <span className="text-xs font-medium text-risk">{loadError}</span>
+          <span className="text-xs font-medium text-risk">{reviewsNotice}</span>
           <button
             type="button"
             onClick={onRefresh}
@@ -264,13 +266,13 @@ export default function DiffReviewPane({ reviews, onRefresh, loadError = null }:
           animation: scale-up 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
         }
       `}</style>
-      {loadError && (
+      {reviewsNotice && (
         <div
           data-testid="reviews-load-error"
           className="p-2 rounded text-[11px] flex items-start gap-1.5 bg-risk/10 border border-risk/20 text-risk"
         >
           <AlertCircle size={12} className="shrink-0 mt-0.5" />
-          <span className="flex-1">{loadError}</span>
+          <span className="flex-1">{reviewsNotice}</span>
           <button
             type="button"
             onClick={onRefresh}

--- a/webapp/src/components/FileEditorPane.tsx
+++ b/webapp/src/components/FileEditorPane.tsx
@@ -19,6 +19,7 @@ import {
   subscribeWorkspaceMutations,
 } from "../lib/workspaceMutationEvents";
 import { useInFileReview } from "./useInFileReview";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 interface FileEditorPaneProps {
   path: string;
@@ -156,6 +157,7 @@ export default function FileEditorPane({ path, line, col, onClose, onDirtyChange
   const [originalContent, setOriginalContent] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const notice = usePanelNotice(error);
   const [isDirty, setIsDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
@@ -496,10 +498,10 @@ export default function FileEditorPane({ path, line, col, onClose, onDirtyChange
     );
   }
 
-  if (error && kind !== "binary" && kind !== "pdf" && kind !== "image") {
+  if (notice && kind !== "binary" && kind !== "pdf" && kind !== "image") {
     return (
       <div className="flex-1 flex flex-col items-center justify-center bg-bg px-6 text-center">
-        <span className="text-risk font-semibold text-[13px] mb-2">{error}</span>
+        <span className="text-risk font-semibold text-[13px] mb-2">{notice}</span>
         <button
           onClick={onClose}
           className="text-[11px] text-muted hover:text-txt underline transition-colors"

--- a/webapp/src/components/FileTree.tsx
+++ b/webapp/src/components/FileTree.tsx
@@ -11,6 +11,7 @@ import {
   notifyWorkspaceMutated,
   subscribeWorkspaceMutations,
 } from "../lib/workspaceMutationEvents";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 interface FileNode {
   name: string;
@@ -198,6 +199,7 @@ export default function FileTree() {
   const [rootNodes, setRootNodes] = useState<FileNode[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const notice = usePanelNotice(error);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<FileContextMenu | null>(null);
   const [confirmDeletePath, setConfirmDeletePath] = useState<string | null>(null);
@@ -549,8 +551,8 @@ export default function FileTree() {
         {loading && rootNodes.length === 0 && (
           <div className="text-[11px] text-muted p-2">Loading workspace...</div>
         )}
-        {error && <div className="text-[11px] text-risk p-2">{error}</div>}
-        {!loading && !error && rootNodes.length === 0 && (
+        {notice && <div className="text-[11px] text-risk p-2">{notice}</div>}
+        {!loading && !notice && rootNodes.length === 0 && (
           <div className="text-[11px] text-muted italic p-2">No files found</div>
         )}
         {rootNodes.map((n) => (

--- a/webapp/src/components/MemoryPane.tsx
+++ b/webapp/src/components/MemoryPane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Brain, Trash2, Plus } from "lucide-react";
 import { api } from "../lib/api";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 interface MemoryEntry {
   id: string;
@@ -35,6 +36,7 @@ export default function MemoryPane({ embedded = false }: { embedded?: boolean })
   const [newCategory, setNewCategory] = useState("general");
   const [busy, setBusy] = useState("");
   const [msg, setMsg] = useState("");
+  const msgNotice = usePanelNotice(msg || null);
 
   const refresh = async () => {
     try {
@@ -113,7 +115,7 @@ export default function MemoryPane({ embedded = false }: { embedded?: boolean })
           />
         </div>
 
-        {msg && <div className="text-[10px] text-muted px-1 mb-2">{msg}</div>}
+        {msgNotice && <div className="text-[10px] text-muted px-1 mb-2">{msgNotice}</div>}
 
         <form onSubmit={handleAdd} className="space-y-1.5 mb-3 bg-panel2/20 p-2 rounded border border-edge/30">
           <div className="text-[10px] uppercase tracking-wider text-faint font-semibold">

--- a/webapp/src/components/PluginsPane.tsx
+++ b/webapp/src/components/PluginsPane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Puzzle, Power, PowerOff, FolderPlus } from "lucide-react";
 import { api, type AgentPlugin } from "../lib/api";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 /** Minimal Agent Plugins v1 Settings pane: list, enable/disable, install path. */
 export default function PluginsPane({ embedded = false }: { embedded?: boolean }) {
@@ -9,11 +10,17 @@ export default function PluginsPane({ embedded = false }: { embedded?: boolean }
   const [msg, setMsg] = useState("");
   const [installPath, setInstallPath] = useState("");
   const [error, setError] = useState("");
+  const errorNotice = usePanelNotice(error || null);
 
   const refresh = () => {
     api.plugins()
-      .then((r) => setPlugins(r.plugins || []))
-      .catch(() => {});
+      .then((r) => {
+        setPlugins(r.plugins || []);
+        setError("");
+      })
+      .catch((err: { message?: string }) => {
+        setError(err?.message || "Failed to load plugins");
+      });
   };
   useEffect(() => {
     refresh();
@@ -102,8 +109,8 @@ export default function PluginsPane({ embedded = false }: { embedded?: boolean }
       </div>
 
       {(msg || error) && (
-        <div className={`text-[11px] ${error ? "text-red-400" : "text-muted"}`}>
-          {error || msg}
+        <div className={`text-[11px] ${errorNotice ? "text-red-400" : "text-muted"}`}>
+          {errorNotice || msg}
         </div>
       )}
 

--- a/webapp/src/components/RegistryWizard.tsx
+++ b/webapp/src/components/RegistryWizard.tsx
@@ -7,6 +7,7 @@ import {
   onboardingCopy,
   openOnboardingKeyUrl,
 } from "../lib/onboardingProviders";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 interface RegistryWizardProps {
   onClose: () => void;
@@ -27,6 +28,7 @@ export default function RegistryWizard({ onClose }: RegistryWizardProps) {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+  const errorNotice = usePanelNotice(error || null);
 
   const tiles = useMemo(() => onboardableProviders(providers), [providers]);
   const copy = onboardingCopy(selected);
@@ -188,9 +190,9 @@ export default function RegistryWizard({ onClose }: RegistryWizardProps) {
                 disabled={saving || !selected}
                 className="w-full bg-bg border border-edge rounded-lg px-3 py-2.5 text-[13px] font-mono text-txt placeholder:text-faint focus:outline-none focus:border-accent disabled:opacity-50"
               />
-              {error ? (
+              {errorNotice ? (
                 <p className="mt-2 text-[12px] text-risk" role="alert">
-                  {error}
+                  {errorNotice}
                 </p>
               ) : null}
               <div className="mt-3 flex justify-end">

--- a/webapp/src/components/SchedulesPane.tsx
+++ b/webapp/src/components/SchedulesPane.tsx
@@ -5,6 +5,7 @@ import {
   type ScheduleInfo,
   type ScheduleRun,
 } from "../lib/api";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 /**
  * Thin Settings schedules control: list / enable / disable / run-now / history.
@@ -13,6 +14,7 @@ import {
 export default function SchedulesPane() {
   const [schedules, setSchedules] = useState<ScheduleInfo[]>([]);
   const [error, setError] = useState("");
+  const errorNotice = usePanelNotice(error || null);
   const [status, setStatus] = useState("");
   const [expanded, setExpanded] = useState<string | null>(null);
   const [history, setHistory] = useState<Record<string, ScheduleRun[]>>({});
@@ -71,7 +73,7 @@ export default function SchedulesPane() {
 
   return (
     <div className="space-y-2">
-      {error && <div className="text-risk text-[10px] font-medium">{error}</div>}
+      {errorNotice && <div className="text-risk text-[10px] font-medium">{errorNotice}</div>}
       {status && <div className="text-good text-[10px] font-medium">{status}</div>}
       <div className="text-[10px] text-muted leading-snug">
         Cron fire still needs the local schedule daemon. This panel polls; SSE is deferred.

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -18,6 +18,7 @@ import {
   readSettingsSnapshot,
   writeSettingsSnapshot,
 } from "./settingsSnapshot";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 import { SettingsCollapse } from "./SettingsCollapse";
 
 export type SettingsSection = "general" | "safety" | "providers" | "notifications" | "plugins" | "advanced";
@@ -58,6 +59,7 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState("");
   const [error, setError] = useState("");
+  const errorNotice = usePanelNotice(error || null);
   const [usage, setUsage] = useState<UsageData | null>(null);
   const [wikiCfg, setWikiCfg] = useState<{ api_base: string; has_token: boolean } | null>(null);
   const [wikiBase, setWikiBase] = useState("");
@@ -917,7 +919,7 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
   if (!settings && !canRenderWithoutSettings) {
     return (
       <div className="flex flex-col h-full text-[12px] p-4 text-faint">
-        {error ? error : "Loading settings..."}
+        {errorNotice ? errorNotice : "Loading settings..."}
       </div>
     );
   }
@@ -934,7 +936,7 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
                         animate-in fade-in slide-in-from-bottom-2 duration-150
                         border-edge">
           {status && <span className="text-good text-[11px] font-medium">{status}</span>}
-          {error && <span className="text-risk text-[11px] font-medium">{error}</span>}
+          {errorNotice && <span className="text-risk text-[11px] font-medium">{errorNotice}</span>}
         </div>
       )}
 

--- a/webapp/src/components/SourceControl.tsx
+++ b/webapp/src/components/SourceControl.tsx
@@ -4,6 +4,7 @@ import { nativeGit, gitWritesAvailable } from "../lib/transport";
 import { api } from "../lib/api";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
 import { subscribeWorkspaceMutations } from "../lib/workspaceMutationEvents";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 interface ChangedFile {
   status: string;
@@ -38,6 +39,9 @@ export default function SourceControl() {
   const [commitLoading, setCommitLoading] = useState(false);
   const [commitError, setCommitError] = useState<string | null>(null);
   const [commitStatus, setCommitStatus] = useState<string | null>(null);
+  const errorNotice = usePanelNotice(error);
+  const diffNotice = usePanelNotice(diffError);
+  const commitNotice = usePanelNotice(commitError);
   const readOnly = !gitWritesAvailable();
 
   const clearGitUiState = useCallback(() => {
@@ -396,7 +400,7 @@ export default function SourceControl() {
       </div>
 
       <div className="flex-1 overflow-y-auto px-3 py-2 flex flex-col gap-3">
-        {error && <div className="text-[11px] text-risk">{error}</div>}
+        {errorNotice && <div className="text-[11px] text-risk">{errorNotice}</div>}
 
         <div>
           <div className="text-[9px] uppercase tracking-wider text-muted mb-1.5 font-semibold">
@@ -564,7 +568,7 @@ export default function SourceControl() {
             {commitLoading ? "Committing..." : "Commit"}
           </button>
         </div>
-        {commitError && <div className="text-[10px] text-risk mt-1">{commitError}</div>}
+        {commitNotice && <div className="text-[10px] text-risk mt-1">{commitNotice}</div>}
       </div>
       )}
 
@@ -591,15 +595,15 @@ export default function SourceControl() {
           {diffLoading && (
             <div className="text-[11px] text-muted">Generating diff view...</div>
           )}
-          {diffError && <div className="text-[11px] text-risk">{diffError}</div>}
+          {diffNotice && <div className="text-[11px] text-risk">{diffNotice}</div>}
           
-          {!diffLoading && !diffError && diffText !== null && !hasHunks && (
+          {!diffLoading && !diffNotice && diffText !== null && !hasHunks && (
             <div className="space-y-0.5 select-text">
               {diffText.split("\n").map((line, idx) => renderDiffLine(line, idx))}
             </div>
           )}
 
-          {!diffLoading && !diffError && diffText !== null && hasHunks && (
+          {!diffLoading && !diffNotice && diffText !== null && hasHunks && (
             <div className="space-y-4">
               {headerLines.length > 0 && (
                 <div className="p-1.5 bg-panel2/30 border border-edge/10 rounded text-muted font-mono text-[10px] select-text">
@@ -632,7 +636,7 @@ export default function SourceControl() {
             </div>
           )}
 
-          {!diffLoading && !diffError && diffText === null && (
+          {!diffLoading && !diffNotice && diffText === null && (
             <div className="text-[11px] text-muted italic">
               Select a changed file above to view its diff
             </div>

--- a/webapp/src/components/StatePane.tsx
+++ b/webapp/src/components/StatePane.tsx
@@ -13,6 +13,7 @@ import {
 } from "../lib/statePaneVisibility";
 import { useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
 import McpPane from "./McpPane";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 // Re-enable when a better presentation exists. Artifacts stay fully
 // logged/stored on the backend; this flag is display-only.
@@ -135,6 +136,7 @@ export default function StatePane({ artifacts }: {
   const [envReady, setEnvReady] = useState<EnvironmentReadiness | null>(null);
   const [envLoading, setEnvLoading] = useState(false);
   const [envFetchError, setEnvFetchError] = useState("");
+  const envNotice = usePanelNotice(envFetchError || null);
   const toggleCg = () => setCgOpen((v) => { localStorage.setItem("pmharness.statePane.cgOpen", v ? "0" : "1"); return !v; });
   const toggleWiki = () => setWikiOpen((v) => { localStorage.setItem("pmharness.statePane.wikiOpen", v ? "0" : "1"); return !v; });
   const toggleMcp = () => setMcpOpen((v) => { localStorage.setItem("pmharness.statePane.mcpOpen", v ? "0" : "1"); return !v; });
@@ -456,6 +458,10 @@ export default function StatePane({ artifacts }: {
   const wikiOk = wiki?.status === "ok";
   const wikiNeedsAuth = wiki?.status === "needs_auth";
   const wikiErr = wiki?.status === "error";
+  const wikiStatusNotice = usePanelNotice(wikiErr ? (wiki?.error || "Failed to fetch wiki status") : null);
+  const wikiGraphNotice = usePanelNotice(
+    wikiGraph?.status === "error" ? (wikiGraph.error || "Could not load wiki graph") : null,
+  );
   const wikiDot = wikiOk
     ? "bg-good"
     : wikiNeedsAuth
@@ -685,7 +691,7 @@ export default function StatePane({ artifacts }: {
             <div className="px-2.5 pb-2 pt-1.5 border-t border-edge/30 text-[10px]">
               {wikiErr ? (
                 <div className="flex flex-col gap-1.5">
-                  <div className="text-risk italic">{wiki?.error || "Failed to fetch wiki status"}</div>
+                  <div className="text-risk italic">{wikiStatusNotice || wiki?.error || "Failed to fetch wiki status"}</div>
                   <div className="flex items-center justify-between gap-2">
                     {wiki?.base_url
                       ? <span className="text-[8px] text-faint truncate">{wiki.base_url}</span>
@@ -798,7 +804,7 @@ export default function StatePane({ artifacts }: {
                     </div>
                   ) : wikiGraph?.status === "error" ? (
                     <div className="text-[9px] text-risk/90 leading-snug">
-                      {wikiGraph.error || "Could not load wiki graph"}
+                      {wikiGraphNotice || wikiGraph.error || "Could not load wiki graph"}
                     </div>
                   ) : wikiGraph?.status === "needs_auth" ? (
                     <div className="text-[9px] text-warn leading-snug">
@@ -872,22 +878,22 @@ export default function StatePane({ artifacts }: {
             <span className="uppercase tracking-wider font-semibold text-faint">Environment</span>
             {envLoading
               ? <Loader2 className="w-2.5 h-2.5 animate-spin text-accent shrink-0" />
-              : <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${envFetchError ? "bg-risk" : envDot}`} aria-hidden />}
-            <span className="text-muted lowercase">{envFetchError ? "error" : envWord}</span>
+              : <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${envNotice ? "bg-risk" : envDot}`} aria-hidden />}
+            <span className="text-muted lowercase">{envNotice ? "error" : envWord}</span>
             <span className="flex-1" />
             {envMetric && <span className="text-faint tabular-nums truncate">{envMetric}</span>}
           </button>
           {envOpen && (
             <div className="px-2.5 pb-2 pt-1 border-t border-edge/30 space-y-2">
-              {envFetchError && (
+              {envNotice && (
                 <div
                   role="alert"
                   className="text-risk text-[10px] leading-snug bg-risk/10 border border-risk/35 rounded px-2 py-1.5 break-words"
                 >
-                  {envFetchError}
+                  {envNotice}
                 </div>
               )}
-              {!envReady && !envFetchError && (
+              {!envReady && !envNotice && (
                 <div role="status" className="text-[9px] text-faint leading-snug">
                   {envLoading ? "Checking optional tools…" : "No readiness data yet."}
                 </div>

--- a/webapp/src/components/WorktreesPane.tsx
+++ b/webapp/src/components/WorktreesPane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { GitFork, Plus, Trash2 } from "lucide-react";
 import { api, type Worktree } from "../lib/api";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
 export default function WorktreesPane() {
   const [worktrees, setWorktrees] = useState<Worktree[]>([]);
@@ -11,6 +12,7 @@ export default function WorktreesPane() {
   const [newWtBranch, setNewWtBranch] = useState("");
   const [newWtBase, setNewWtBase] = useState("HEAD");
   const [wtError, setWtError] = useState("");
+  const wtNotice = usePanelNotice(wtError || null);
   const [wtStatus, setWtStatus] = useState("");
 
   const loadWorktrees = async () => {
@@ -20,7 +22,10 @@ export default function WorktreesPane() {
       setWorktrees(data.worktrees || []);
       setMaxWorktrees(data.max ?? 25);
     } catch (err) {
-      console.error("Failed to load worktrees", err);
+      const message = err && typeof err === "object" && "error" in err
+        ? String((err as { error?: string }).error)
+        : "";
+      setWtError(message || "Failed to load worktrees");
     } finally {
       setLoading(false);
     }
@@ -113,9 +118,9 @@ export default function WorktreesPane() {
       {/* Scrollable Container */}
       <div className="flex-1 overflow-y-auto p-2.5 flex flex-col gap-3">
         {/* Status messages */}
-        {wtError && (
+        {wtNotice && (
           <div className="p-2 bg-risk/10 border border-risk/30 rounded text-risk text-[10.5px] font-medium leading-relaxed">
-            {wtError}
+            {wtNotice}
           </div>
         )}
         {wtStatus && (

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -35,6 +35,7 @@ import {
   formatTokenK,
 } from "./contextUsageColors";
 import { showStandaloneEditNoticeDismiss } from "./composerSend";
+import { usePanelNotice } from "../../lib/useOperationalDiagnostic";
 
 export type AttachedImage = { path: string; name: string; previewUrl: string };
 export type MsgQueueItem = { text: string; auto: boolean; plan?: boolean };
@@ -228,6 +229,7 @@ export default function ComposerDock({
   stop: () => void;
   send: (mode?: "interrupt") => void;
 }) {
+  const queueNotice = usePanelNotice(queueLoadError);
   const matchingSlash =
     slashSearch !== null
       ? filterSlashCommands(allSlashCommands, slashSearch)
@@ -468,9 +470,9 @@ export default function ComposerDock({
         {/* Server-side PROMPT QUEUE, stacked ABOVE the composer (Cursor-style)
             so the "runs next" items are always visible right over the input.
             These prompts are drained by the backend one full turn at a time. */}
-        {queueLoadError && (
+        {queueNotice && (
           <div className="mb-2 px-1 text-[10px] text-danger/90">
-            {queueLoadError}
+            {queueNotice}
           </div>
         )}
         {queueItems.length > 0 && (

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -249,14 +249,28 @@ export function resolveRepaired(
   return sameRoot(current, repaired) ? null : current;
 }
 
+export function isReadinessDiagnostic(
+  diag: OperationalDiagnostic | null | undefined,
+): diag is OperationalDiagnostic {
+  return Boolean(diag && (diag.scope === "desktop_bridge" || diag.scope === "backend"));
+}
+
 /** Shared readiness surfaces reuse one root summary instead of inventing local causes. */
 export function sharedReadinessNotice(
   fallback: string,
   diag: OperationalDiagnostic | null | undefined,
 ): string {
-  if (diag && (diag.scope === "desktop_bridge" || diag.scope === "backend")) {
-    return diag.summary;
-  }
+  return panelNotice(fallback, diag);
+}
+
+/** Panel operational copy: readiness root wins; matching scope wins; else fallback. */
+export function panelNotice(
+  fallback: string,
+  diag: OperationalDiagnostic | null | undefined,
+  scope?: DiagnosticScope,
+): string {
+  if (isReadinessDiagnostic(diag)) return diag.summary;
+  if (scope && diag?.scope === scope) return diag.summary;
   return fallback;
 }
 

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -251,7 +251,7 @@ export function resolveRepaired(
 
 export function isReadinessDiagnostic(
   diag: OperationalDiagnostic | null | undefined,
-): diag is OperationalDiagnostic {
+): boolean {
   return Boolean(diag && (diag.scope === "desktop_bridge" || diag.scope === "backend"));
 }
 
@@ -269,8 +269,8 @@ export function panelNotice(
   diag: OperationalDiagnostic | null | undefined,
   scope?: DiagnosticScope,
 ): string {
-  if (isReadinessDiagnostic(diag)) return diag.summary;
-  if (scope && diag?.scope === scope) return diag.summary;
+  if (diag && isReadinessDiagnostic(diag)) return diag.summary;
+  if (scope && diag && diag.scope === scope) return diag.summary;
   return fallback;
 }
 

--- a/webapp/src/lib/useOperationalDiagnostic.ts
+++ b/webapp/src/lib/useOperationalDiagnostic.ts
@@ -3,10 +3,27 @@ import {
   getActiveDiagnostic,
   subscribeDiagnostic,
 } from "./operationalDiagnosticBus";
-import type { OperationalDiagnostic } from "./operationalDiagnostic";
+import {
+  isReadinessDiagnostic,
+  panelNotice,
+  type DiagnosticScope,
+  type OperationalDiagnostic,
+} from "./operationalDiagnostic";
 
 export function useOperationalDiagnostic(): OperationalDiagnostic | null {
   const [diag, setDiag] = useState<OperationalDiagnostic | null>(getActiveDiagnostic);
   useEffect(() => subscribeDiagnostic(setDiag), []);
   return diag;
+}
+
+/** Operational error text for a panel. Readiness root replaces local copy. */
+export function usePanelNotice(
+  fallback: string | null | undefined,
+  scope?: DiagnosticScope,
+): string | null {
+  const diag = useOperationalDiagnostic();
+  if (isReadinessDiagnostic(diag) || (scope && diag?.scope === scope)) {
+    return panelNotice(fallback || "", diag, scope);
+  }
+  return fallback ?? null;
 }


### PR DESCRIPTION
## Summary
- Finish #74: panel operational error copy shares one readiness diagnostic (desktop-bridge / backend root).
- Credit: @kbentonferguson.

## Test plan
- [x] operationalDiagnostic + DiffReview / Settings / RightPane panel tests
- [x] `tests/test_version_consistency.py`
- [ ] dest-into-main `tests` matrix (3.9, 3.11, Windows, frontend-build)
- [ ] dest-into-main `release` mac: Developer ID + notarization
- [ ] After tag, GitHub release has `Marionette-0.9.255-universal-mac.zip`