### PR TITLE
Release v0.9.256

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.255, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. Operational panel errors share one readiness diagnostic so a missing desktop bridge is not several unrelated empty/error states. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
+> Status: v0.9.256, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. Session export uses authenticated download plus a copyable transcript ID; Settings can enable a Cursor-style glass window. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.255"
+__version__ = "0.9.256"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/sessions.py
+++ b/harness/api/sessions.py
@@ -583,9 +583,64 @@ class SessionExportAttachment:
     data: bytes
 
 
-def get_sessions_export(qs: dict, svc: SessionServices) -> SessionExportAttachment:
+def _sanitize_export_filename_part(value):
+    cleaned = re.sub(r"[^a-zA-Z0-9\-_]", "_", value or "")
+    cleaned = re.sub(r"_+", "_", cleaned).strip("_-")
+    return cleaned or "session"
+
+
+def session_export_filename(title, sid, ext):
+    """Hermes-style `{title}-{id}.{ext}` so the file itself carries the transcript ID."""
+    id_part = _sanitize_export_filename_part(sid or "session")
+    title_part = _sanitize_export_filename_part(title or id_part)
+    if title_part.lower() == id_part.lower():
+        return "%s.%s" % (id_part, ext)
+    return "%s-%s.%s" % (title_part, id_part, ext)
+
+
+def session_transcript_relpath(sid):
+    safe_sid = "".join(c for c in (sid or "") if c.isalnum() or c in ("-", "_"))
+    return "transcripts/%s.json" % (safe_sid or "session")
+
+
+def format_session_export_markdown(payload):
     import datetime
 
+    sid = payload.get("transcript_id") or payload.get("session_id") or ""
+    title = payload.get("title") or "Unknown Session"
+    relpath = payload.get("transcript_relpath") or session_transcript_relpath(sid)
+    created = payload.get("created")
+    exported_at = payload.get("exported_at")
+    created_str = (
+        datetime.datetime.fromtimestamp(created).strftime("%Y-%m-%d %H:%M:%S")
+        if created
+        else "Unknown"
+    )
+    exported_str = (
+        datetime.datetime.fromtimestamp(exported_at).strftime("%Y-%m-%d %H:%M:%S")
+        if exported_at
+        else "Unknown"
+    )
+    md_lines = [
+        "# %s" % title,
+        "",
+        "**Transcript ID:** %s  " % sid,
+        "**Session ID:** %s  " % sid,
+        "**On disk:** `%s`  " % relpath,
+        "**Created:** %s  " % created_str,
+        "**Exported:** %s" % exported_str,
+        "",
+    ]
+    for msg in payload.get("messages") or []:
+        role = (msg.get("role") or "").capitalize()
+        content = msg.get("content", "")
+        if not isinstance(content, str):
+            content = json.dumps(content)
+        md_lines.extend(["## %s" % role, "", content, ""])
+    return "\n".join(md_lines)
+
+
+def get_sessions_export(qs: dict, svc: SessionServices) -> SessionExportAttachment:
     sid = qs.get("session", [None])[0] or svc.sessions.active or ""
     fmt = qs.get("format", ["json"])[0]
 
@@ -597,59 +652,29 @@ def get_sessions_export(qs: dict, svc: SessionServices) -> SessionExportAttachme
         history = data
 
     title = meta.get("title", "Unknown Session") if meta else "Unknown Session"
-    filename_base = meta.get("title") if meta else ""
-    if not filename_base:
-        filename_base = sid or "session"
-
-    safe_title = re.sub(r'[^a-zA-Z0-9\-_]', '_', filename_base)
-    safe_title = re.sub(r'_+', '_', safe_title)
-    safe_title = safe_title.strip('_-')
-    if not safe_title:
-        safe_title = sid or "session"
-
-    if fmt == "md":
-        created = meta.get("created") if meta else None
-        created_str = (
-            datetime.datetime.fromtimestamp(created).strftime('%Y-%m-%d %H:%M:%S')
-            if created else "Unknown"
-        )
-        exported_str = datetime.datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S')
-
-        md_lines = []
-        md_lines.append(f"# {title or 'Unknown Session'}")
-        md_lines.append("")
-        md_lines.append(f"**Session ID:** {sid}  ")
-        md_lines.append(f"**Created:** {created_str}  ")
-        md_lines.append(f"**Exported:** {exported_str}")
-        md_lines.append("")
-
-        for msg in history:
-            role = msg.get("role", "").capitalize()
-            content = msg.get("content", "")
-            md_lines.append(f"## {role}")
-            md_lines.append("")
-            md_lines.append(content)
-            md_lines.append("")
-
-        body = "\n".join(md_lines)
-        return SessionExportAttachment(
-            content_type="text/markdown",
-            filename=f"{safe_title}.md",
-            data=body.encode("utf-8"),
-        )
-
     created = meta.get("created") if meta else None
     export_data = {
+        "transcript_id": sid,
         "session_id": sid,
+        "transcript_relpath": session_transcript_relpath(sid),
         "title": title or "Unknown Session",
         "created": created,
         "exported_at": time.time(),
         "messages": history,
     }
+
+    if fmt == "md":
+        body = format_session_export_markdown(export_data)
+        return SessionExportAttachment(
+            content_type="text/markdown",
+            filename=session_export_filename(title, sid, "md"),
+            data=body.encode("utf-8"),
+        )
+
     body = json.dumps(export_data, indent=2)
     return SessionExportAttachment(
         content_type="application/json",
-        filename=f"{safe_title}.json",
+        filename=session_export_filename(title, sid, "json"),
         data=body.encode("utf-8"),
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.255"
+version = "0.9.256"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -54,11 +54,13 @@ def test_export_json_and_md(tmp_path):
         assert "application/json" in content_type_json
         
         content_disp_json = resp_json.headers.get("Content-Disposition")
-        assert content_disp_json == 'attachment; filename="My_Export_Test_Session.json"'
+        assert content_disp_json == 'attachment; filename="My_Export_Test_Session-%s.json"' % sid
         
         # Check Body JSON
         data_json = json.loads(resp_json.read().decode("utf-8"))
+        assert data_json["transcript_id"] == sid
         assert data_json["session_id"] == sid
+        assert data_json["transcript_relpath"] == "transcripts/%s.json" % sid
         assert data_json["title"] == "My Export Test Session!"
         assert data_json["created"] == sess_meta["created"]
         assert "exported_at" in data_json
@@ -74,12 +76,14 @@ def test_export_json_and_md(tmp_path):
         assert "text/markdown" in content_type_md
         
         content_disp_md = resp_md.headers.get("Content-Disposition")
-        assert content_disp_md == 'attachment; filename="My_Export_Test_Session.md"'
+        assert content_disp_md == 'attachment; filename="My_Export_Test_Session-%s.md"' % sid
         
         # Check Body MD
         body_md = resp_md.read().decode("utf-8")
         assert "# My Export Test Session!" in body_md
+        assert f"**Transcript ID:** {sid}" in body_md
         assert f"**Session ID:** {sid}" in body_md
+        assert f"**On disk:** `transcripts/{sid}.json`" in body_md
         assert "## User" in body_md
         assert "hello pilot" in body_md
         assert "## Assistant" in body_md
@@ -101,10 +105,12 @@ def test_export_unknown_session_does_not_500(tmp_path):
         assert resp.status == 200
         
         content_disp = resp.headers.get("Content-Disposition")
-        assert content_disp == 'attachment; filename="unknown-id.json"'
+        assert content_disp == 'attachment; filename="Unknown_Session-unknown-id.json"'
         
         data = json.loads(resp.read().decode("utf-8"))
+        assert data["transcript_id"] == "unknown-id"
         assert data["session_id"] == "unknown-id"
+        assert data["transcript_relpath"] == "transcripts/unknown-id.json"
         assert data["title"] == "Unknown Session"
         assert data["messages"] == []
         
@@ -150,6 +156,17 @@ def test_export_requires_header_auth_not_query_string(tmp_path):
         assert resp.status == 200
         data = json.loads(resp.read().decode("utf-8"))
         assert data["session_id"] == sid
+        assert data["transcript_id"] == sid
         
     finally:
         httpd.shutdown()
+
+
+def test_session_export_filename_includes_transcript_id():
+    from harness.api.sessions import session_export_filename, session_transcript_relpath
+
+    assert session_export_filename("My Export Test Session!", "a1b2c3d4e5f6", "json") == (
+        "My_Export_Test_Session-a1b2c3d4e5f6.json"
+    )
+    assert session_export_filename("unknown-id", "unknown-id", "md") == "unknown-id.md"
+    assert session_transcript_relpath("a1b2c3d4e5f6") == "transcripts/a1b2c3d4e5f6.json"

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -7,7 +7,7 @@
 // The renderer is the SAME React app as the web build; only the transport
 // implementation differs (IPC here vs fetch/SSE on the web).
 
-const { app, BrowserWindow, ipcMain, dialog, shell, session } = require("electron");
+const { app, BrowserWindow, ipcMain, dialog, shell, session, nativeTheme } = require("electron");
 app.name = "Marionette";
 const { spawn } = require("node:child_process");
 const http = require("node:http");
@@ -39,6 +39,7 @@ const {
   shouldRetryFailedRendererLoad,
   resolveClassicDevRendererSource,
 } = require("./renderer-fallback.cjs");
+const { createTranslucencyController } = require("./translucency.cjs");
 
 // Must run before any git/npm/uv child spawns: on Windows the portable tools
 // installed by first-run bootstrap are only on PATH in-memory, per process.
@@ -389,6 +390,14 @@ let backendPort = 8799;
 /** True when this Electron process spawned the live backend (vs adopted via marker). */
 let backendOwned = false;
 let win = null;
+// Marionette is dark-only. Pin the native appearance so macOS vibrancy does
+// not flash a light NSVisualEffectView on a light-mode Mac before the page
+// covers it.
+try { nativeTheme.themeSource = "dark"; } catch { /* older Electron */ }
+const translucency = createTranslucencyController({
+  getWindow: () => win,
+  log: (msg) => { try { logMain(msg); } catch { /* logging must never throw */ } },
+});
 let quitting = false;
 // Self-dev Vite dev server: when Live Self-Editing is on, we serve the React UI
 // from a Vite dev server (real HMR) instead of the prebuilt dist/, so edits to
@@ -1057,6 +1066,12 @@ async function restartBackend() {
 ipcMain.handle("harness:restart", () => restartBackend());
 ipcMain.handle("harness:selfDev:get", () => ({ enabled: selfDevEnabled(), viable: viteDevViable(resolveRepoRoot()) }));
 ipcMain.handle("harness:selfDev:set", (_e, enabled) => ({ ok: setSelfDevEnabled(!!enabled), enabled: selfDevEnabled() }));
+ipcMain.handle("translucency:get", () => ({
+  state: translucency.getState(),
+  capabilities: translucency.capabilities(),
+}));
+ipcMain.handle("translucency:set", (_e, payload) => translucency.setState(payload));
+ipcMain.handle("translucency:capabilities", () => translucency.capabilities());
 
 // Image upload bridge: the renderer hands us raw bytes (File over IPC can't carry
 // a browser File object), we POST a multipart body to the backend's /api/upload on
@@ -1444,7 +1459,7 @@ function createWindow() {
     width: saved ? saved.width : 1440,
     height: saved ? saved.height : 900,
     ...(saved && Number.isFinite(saved.x) ? { x: saved.x, y: saved.y } : {}),
-    backgroundColor: "#0f1113",
+    ...translucency.surfaceOptions(),
     titleBarStyle: "hiddenInset",
     // Windows/Linux render an in-window "File Edit View..." menu bar that
     // stacks a second ugly strip under the title bar (macOS puts the menu in
@@ -2083,6 +2098,7 @@ app.on("window-all-closed", () => {
 let quitFinalized = false;
 app.on("before-quit", (e) => {
   quitting = true;
+  try { translucency.flush(); } catch { /* persist must not block quit */ }
   if (quitFinalized) return;
   // Hold quit open until the awaited graceful->force shutdown finishes. The
   // previous fire-and-forget setTimeout race let relaunches start while the old

--- a/webapp/electron/preload.cjs
+++ b/webapp/electron/preload.cjs
@@ -93,6 +93,11 @@ contextBridge.exposeInMainWorld("harnessIPC", {
     get: () => ipcRenderer.invoke("harness:selfDev:get"),
     set: (enabled) => ipcRenderer.invoke("harness:selfDev:set", enabled),
   },
+  translucency: {
+    get: () => ipcRenderer.invoke("translucency:get"),
+    set: (state) => ipcRenderer.invoke("translucency:set", state),
+    capabilities: () => ipcRenderer.invoke("translucency:capabilities"),
+  },
   restart: () => ipcRenderer.invoke("harness:restart"),
   // Fired when main respawns the Python backend on a new port. Panels that
   // painted a transient ECONNREFUSED can re-fetch without a full window reload.

--- a/webapp/electron/translucency.cjs
+++ b/webapp/electron/translucency.cjs
@@ -1,0 +1,330 @@
+/**
+ * Window glass — one mapping the main process and tests share.
+ *
+ * Lifted from Hermes Agent's translucency module (NousResearch/hermes-agent,
+ * apps/shared/src/translucency.ts + electron/translucency.ts) and rewritten
+ * for Marionette: no HUD, no Clear-mode fade UI. Glass is the Cursor-style
+ * path — native vibrancy / DWM material under a thinned page, text stays
+ * full contrast.
+ *
+ * One lever, 0–100 (0 = off). Main persists ~/.pmharness/translucency.json so
+ * a cold launch can apply the backing at BrowserWindow construction. Runtime
+ * setBackgroundColor('#00000000') is silently lost on a fresh compositor
+ * (measured by Hermes on macOS 26 / Electron 40), so creation must not rely
+ * on a post-create fixup.
+ */
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const GLASS_MATERIALS = ["under-window", "popover", "titlebar", "header"];
+const DEFAULT_GLASS_MATERIAL = "under-window";
+const WINDOWS_BACKGROUND_MATERIALS = ["acrylic", "tabbed", "mica", "none"];
+const WINDOWS_MATERIAL_BY_FROST = {
+  "under-window": "acrylic",
+  popover: "tabbed",
+  titlebar: "mica",
+  header: "mica",
+};
+const WINDOWS_GLASS_MATERIALS = GLASS_MATERIALS.filter(
+  (material, index) =>
+    GLASS_MATERIALS.findIndex(
+      (rung) => WINDOWS_MATERIAL_BY_FROST[rung] === WINDOWS_MATERIAL_BY_FROST[material],
+    ) === index,
+);
+const WINDOWS_GLASS_MIN_BUILD = 22621;
+const TRANSLUCENCY_MIN = 0;
+const TRANSLUCENCY_MAX = 100;
+const TRANSLUCENCY_OPACITY_FLOOR = 0.3;
+const TRANSLUCENCY_CURVE = 2;
+const THEMED_BACKGROUND = "#0f1113";
+const ENABLE_INTENSITY = 60;
+
+function clampIntensity(value) {
+  const n = Math.round(Number(value));
+  return Number.isFinite(n)
+    ? Math.min(TRANSLUCENCY_MAX, Math.max(TRANSLUCENCY_MIN, n))
+    : TRANSLUCENCY_MIN;
+}
+
+function translucencySupportedOn(platform) {
+  return platform === "darwin" || platform === "win32";
+}
+
+function glassSupportedOn(platform, release) {
+  if (platform === "darwin") return true;
+  if (platform !== "win32") return false;
+  const build = Number.parseInt(String(release || "").split(".")[2] || "", 10);
+  return Number.isFinite(build) && build >= WINDOWS_GLASS_MIN_BUILD;
+}
+
+function normalizeMode(value, glassSupported, legacyIntensity) {
+  if (!glassSupported) return "clear";
+  if (value === "glass" || value === "clear") return value;
+  return (legacyIntensity || 0) > 0 ? "clear" : "glass";
+}
+
+function normalizeMaterial(value) {
+  return GLASS_MATERIALS.includes(value) ? value : DEFAULT_GLASS_MATERIAL;
+}
+
+function normalizeState(payload, glassSupported) {
+  const record = payload && typeof payload === "object" ? payload : {};
+  const intensity = clampIntensity(record.intensity);
+  return {
+    intensity,
+    fade: clampIntensity(record.fade),
+    mode: normalizeMode(record.mode, glassSupported, intensity),
+    material: normalizeMaterial(record.material),
+  };
+}
+
+function opacityRamp(lever) {
+  const ratio = clampIntensity(lever) / TRANSLUCENCY_MAX;
+  return 1 - (1 - TRANSLUCENCY_OPACITY_FLOOR) * Math.pow(ratio, TRANSLUCENCY_CURVE);
+}
+
+function windowOpacityFor(state) {
+  return opacityRamp(state.mode === "glass" ? state.fade : state.intensity);
+}
+
+function glassActive(state) {
+  return state.mode === "glass" && state.intensity > 0;
+}
+
+function glassSurfaceKeep(intensity) {
+  return TRANSLUCENCY_MAX - clampIntensity(intensity);
+}
+
+function vibrancyFor(state) {
+  return glassActive(state) ? state.material : null;
+}
+
+function backgroundMaterialFor(state) {
+  return glassActive(state) ? WINDOWS_MATERIAL_BY_FROST[state.material] : "none";
+}
+
+function glassMaterialsFor(isWindows) {
+  return isWindows ? WINDOWS_GLASS_MATERIALS : GLASS_MATERIALS;
+}
+
+function glassMaterialForPicker(material, isWindows) {
+  if (!isWindows) return normalizeMaterial(material);
+  return (
+    WINDOWS_GLASS_MATERIALS.find(
+      (rung) => WINDOWS_MATERIAL_BY_FROST[rung] === WINDOWS_MATERIAL_BY_FROST[material],
+    ) || DEFAULT_GLASS_MATERIAL
+  );
+}
+
+function windowBackingOptions(state, themedColor) {
+  return glassActive(state) ? {} : { backgroundColor: themedColor || THEMED_BACKGROUND };
+}
+
+function translucencyDiff(previous, next) {
+  return {
+    backing: glassActive(previous) !== glassActive(next),
+    material:
+      vibrancyFor(previous) !== vibrancyFor(next) ||
+      backgroundMaterialFor(previous) !== backgroundMaterialFor(next),
+    opacity: windowOpacityFor(previous) !== windowOpacityFor(next),
+  };
+}
+
+function capabilities(platform, release) {
+  const glassSupported = glassSupportedOn(platform, release);
+  return {
+    translucencySupported: translucencySupportedOn(platform),
+    glassSupported,
+    isWindows: platform === "win32",
+    materials: glassMaterialsFor(platform === "win32" && glassSupported),
+  };
+}
+
+function configPath(homeDir) {
+  return path.join(homeDir || os.homedir(), ".pmharness", "translucency.json");
+}
+
+function readPersistedTranslucency(opts) {
+  const glassSupported = !!(opts && opts.glassSupported);
+  try {
+    return normalizeState(
+      JSON.parse(fs.readFileSync(configPath(opts && opts.homeDir), "utf8")),
+      glassSupported,
+    );
+  } catch {
+    return normalizeState(null, glassSupported);
+  }
+}
+
+function writePersistedTranslucency(state, opts) {
+  const dest = configPath(opts && opts.homeDir);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.writeFileSync(dest, JSON.stringify(state, null, 2), "utf8");
+}
+
+function windowSurfaceOptions(state, opts) {
+  const platform = (opts && opts.platform) || process.platform;
+  const glassSupported = !!(opts && opts.glassSupported);
+  const themed = (opts && opts.themedColor) || THEMED_BACKGROUND;
+  const isMac = platform === "darwin";
+  const isWindows = platform === "win32";
+  const options = {
+    opacity: windowOpacityFor(state),
+    ...windowBackingOptions(state, themed),
+  };
+  if (isMac) {
+    const material = vibrancyFor(state);
+    if (material) {
+      options.vibrancy = material;
+      options.visualEffectState = "active";
+    }
+  }
+  if (isWindows && glassSupported) {
+    // Win11 DWM materials only reach the client area on a transparent window
+    // (electron#49443). Born transparent so a live toggle does not recreate.
+    options.transparent = true;
+    options.backgroundMaterial = backgroundMaterialFor(state);
+  }
+  return options;
+}
+
+function applyWindowTranslucency(win, state, changed, opts) {
+  if (!win || (typeof win.isDestroyed === "function" && win.isDestroyed())) return;
+  const platform = (opts && opts.platform) || process.platform;
+  const glassSupported = !!(opts && opts.glassSupported);
+  const themed = (opts && opts.themedColor) || THEMED_BACKGROUND;
+  const patch = changed || { backing: true, material: true, opacity: true };
+  if (patch.backing && typeof win.setBackgroundColor === "function") {
+    win.setBackgroundColor(glassActive(state) ? "#00000000" : themed);
+  }
+  if (patch.material) {
+    if (platform === "darwin" && typeof win.setVibrancy === "function") {
+      const material = vibrancyFor(state);
+      if (material) win.setVibrancy(material, { animationDuration: 150 });
+      else win.setVibrancy(null);
+    }
+    if (
+      platform === "win32" &&
+      glassSupported &&
+      typeof win.setBackgroundMaterial === "function"
+    ) {
+      win.setBackgroundMaterial(backgroundMaterialFor(state));
+    }
+  }
+  if (patch.opacity && typeof win.setOpacity === "function") {
+    win.setOpacity(windowOpacityFor(state));
+  }
+}
+
+function createTranslucencyController(opts) {
+  const platform = (opts && opts.platform) || process.platform;
+  const release = (opts && opts.release) || os.release();
+  const homeDir = opts && opts.homeDir;
+  const getWindow = opts && opts.getWindow;
+  const log = (opts && opts.log) || (() => {});
+  const caps = capabilities(platform, release);
+  let state = readPersistedTranslucency({
+    homeDir,
+    glassSupported: caps.glassSupported,
+  });
+  let persistTimer = null;
+
+  const persistSoon = () => {
+    if (persistTimer) clearTimeout(persistTimer);
+    persistTimer = setTimeout(() => {
+      persistTimer = null;
+      try {
+        writePersistedTranslucency(state, { homeDir });
+      } catch (err) {
+        log(`[translucency] write failed: ${err && err.message ? err.message : err}`);
+      }
+    }, 120);
+  };
+
+  return {
+    capabilities: () => caps,
+    getState: () => state,
+    surfaceOptions: () =>
+      windowSurfaceOptions(state, {
+        platform,
+        glassSupported: caps.glassSupported,
+        themedColor: THEMED_BACKGROUND,
+      }),
+    applyTo: (win, changed) => {
+      try {
+        applyWindowTranslucency(win, state, changed, {
+          platform,
+          glassSupported: caps.glassSupported,
+          themedColor: THEMED_BACKGROUND,
+        });
+      } catch (err) {
+        log(`[translucency] apply failed: ${err && err.message ? err.message : err}`);
+      }
+    },
+    setState: (payload) => {
+      const next = normalizeState(payload, caps.glassSupported);
+      const changed = translucencyDiff(state, next);
+      state = next;
+      const win = typeof getWindow === "function" ? getWindow() : null;
+      if (win && (changed.backing || changed.material || changed.opacity)) {
+        try {
+          applyWindowTranslucency(win, state, changed, {
+            platform,
+            glassSupported: caps.glassSupported,
+            themedColor: THEMED_BACKGROUND,
+          });
+        } catch (err) {
+          log(`[translucency] apply failed: ${err && err.message ? err.message : err}`);
+        }
+      }
+      persistSoon();
+      return state;
+    },
+    flush: () => {
+      if (!persistTimer) return;
+      clearTimeout(persistTimer);
+      persistTimer = null;
+      try {
+        writePersistedTranslucency(state, { homeDir });
+      } catch (err) {
+        log(`[translucency] write failed: ${err && err.message ? err.message : err}`);
+      }
+    },
+  };
+}
+
+module.exports = {
+  DEFAULT_GLASS_MATERIAL,
+  ENABLE_INTENSITY,
+  GLASS_MATERIALS,
+  THEMED_BACKGROUND,
+  TRANSLUCENCY_MAX,
+  TRANSLUCENCY_MIN,
+  TRANSLUCENCY_OPACITY_FLOOR,
+  WINDOWS_BACKGROUND_MATERIALS,
+  WINDOWS_GLASS_MIN_BUILD,
+  applyWindowTranslucency,
+  backgroundMaterialFor,
+  capabilities,
+  clampIntensity,
+  configPath,
+  createTranslucencyController,
+  glassActive,
+  glassMaterialForPicker,
+  glassMaterialsFor,
+  glassSurfaceKeep,
+  glassSupportedOn,
+  normalizeMaterial,
+  normalizeMode,
+  normalizeState,
+  readPersistedTranslucency,
+  translucencyDiff,
+  translucencySupportedOn,
+  vibrancyFor,
+  windowBackingOptions,
+  windowOpacityFor,
+  windowSurfaceOptions,
+  writePersistedTranslucency,
+};

--- a/webapp/electron/translucency.test.cjs
+++ b/webapp/electron/translucency.test.cjs
@@ -1,0 +1,228 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  ENABLE_INTENSITY,
+  GLASS_MATERIALS,
+  THEMED_BACKGROUND,
+  applyWindowTranslucency,
+  backgroundMaterialFor,
+  capabilities,
+  clampIntensity,
+  createTranslucencyController,
+  glassActive,
+  glassMaterialForPicker,
+  glassMaterialsFor,
+  glassSurfaceKeep,
+  glassSupportedOn,
+  normalizeMode,
+  normalizeState,
+  translucencyDiff,
+  translucencySupportedOn,
+  vibrancyFor,
+  windowBackingOptions,
+  windowOpacityFor,
+  windowSurfaceOptions,
+} = require("./translucency.cjs");
+
+function glass(intensity, material) {
+  return normalizeState(
+    { intensity, mode: "glass", material, fade: 0 },
+    true,
+  );
+}
+
+function clear(intensity) {
+  return normalizeState({ intensity, mode: "clear" }, true);
+}
+
+describe("clampIntensity", () => {
+  it("floors junk and clamps the lever", () => {
+    assert.equal(clampIntensity("nope"), 0);
+    assert.equal(clampIntensity(-4), 0);
+    assert.equal(clampIntensity(140), 100);
+    assert.equal(clampIntensity(55.6), 56);
+  });
+});
+
+describe("platform support", () => {
+  it("offers translucency on macOS and Windows only", () => {
+    assert.equal(translucencySupportedOn("darwin"), true);
+    assert.equal(translucencySupportedOn("win32"), true);
+    assert.equal(translucencySupportedOn("linux"), false);
+  });
+
+  it("requires Windows 11 22H2 for glass", () => {
+    assert.equal(glassSupportedOn("darwin"), true);
+    assert.equal(glassSupportedOn("linux"), false);
+    assert.equal(glassSupportedOn("win32", "10.0.22621"), true);
+    assert.equal(glassSupportedOn("win32", "10.0.19045"), false);
+    assert.equal(glassSupportedOn("win32", ""), false);
+  });
+});
+
+describe("normalizeMode", () => {
+  it("pre-selects glass on a capable OS when nothing is saved", () => {
+    assert.equal(normalizeMode(undefined, true, 0), "glass");
+  });
+
+  it("keeps a legacy non-zero intensity on clear", () => {
+    assert.equal(normalizeMode(undefined, true, 40), "clear");
+  });
+
+  it("forces clear when glass is unsupported", () => {
+    assert.equal(normalizeMode("glass", false, 0), "clear");
+  });
+});
+
+describe("glassActive / keep / opacity", () => {
+  it("is live only for glass with a raised lever", () => {
+    assert.equal(glassActive(glass(0, "header")), false);
+    assert.equal(glassActive(glass(60, "header")), true);
+    assert.equal(glassActive(clear(60)), false);
+  });
+
+  it("thins the tint linearly to zero", () => {
+    assert.equal(glassSurfaceKeep(0), 100);
+    assert.equal(glassSurfaceKeep(60), 40);
+    assert.equal(glassSurfaceKeep(100), 0);
+  });
+
+  it("fades native opacity from fade under glass, intensity under clear", () => {
+    assert.equal(windowOpacityFor(glass(80, "header")), 1);
+    assert.ok(windowOpacityFor(clear(80)) < 1);
+    assert.ok(windowOpacityFor(normalizeState({ intensity: 80, fade: 80, mode: "glass" }, true)) < 1);
+  });
+});
+
+describe("vibrancyFor / backgroundMaterialFor", () => {
+  it("turns native material off when glass is off", () => {
+    assert.equal(vibrancyFor(glass(0, "header")), null);
+    assert.equal(vibrancyFor(clear(60)), null);
+    assert.equal(backgroundMaterialFor(glass(0, "header")), "none");
+  });
+
+  it("maps the sheer to heavy frost ladder", () => {
+    assert.equal(vibrancyFor(glass(60, "header")), "header");
+    assert.equal(backgroundMaterialFor(glass(60, "under-window")), "acrylic");
+    assert.equal(backgroundMaterialFor(glass(60, "popover")), "tabbed");
+    assert.equal(backgroundMaterialFor(glass(60, "titlebar")), "mica");
+    assert.equal(backgroundMaterialFor(glass(60, "header")), "mica");
+  });
+
+  it("drops the duplicate mica rung from the Windows picker", () => {
+    assert.deepEqual(glassMaterialsFor(false), GLASS_MATERIALS);
+    assert.deepEqual(glassMaterialsFor(true), ["under-window", "popover", "titlebar"]);
+    assert.equal(glassMaterialForPicker("header", true), "titlebar");
+    assert.equal(glassMaterialForPicker("header", false), "header");
+  });
+});
+
+describe("windowBackingOptions / surfaceOptions", () => {
+  it("omits backgroundColor while glass is live", () => {
+    assert.deepEqual(windowBackingOptions(glass(60, "header"), THEMED_BACKGROUND), {});
+    assert.deepEqual(windowBackingOptions(glass(0, "header"), THEMED_BACKGROUND), {
+      backgroundColor: THEMED_BACKGROUND,
+    });
+  });
+
+  it("pins macOS vibrancy and visualEffectState only while glass is live", () => {
+    const on = windowSurfaceOptions(glass(60, "popover"), {
+      platform: "darwin",
+      glassSupported: true,
+    });
+    assert.equal(on.vibrancy, "popover");
+    assert.equal(on.visualEffectState, "active");
+    assert.equal(on.backgroundColor, undefined);
+
+    const off = windowSurfaceOptions(glass(0, "popover"), {
+      platform: "darwin",
+      glassSupported: true,
+    });
+    assert.equal(off.vibrancy, undefined);
+    assert.equal(off.backgroundColor, THEMED_BACKGROUND);
+  });
+
+  it("marks glass-capable Windows windows transparent for DWM", () => {
+    const on = windowSurfaceOptions(glass(60, "under-window"), {
+      platform: "win32",
+      glassSupported: true,
+    });
+    assert.equal(on.transparent, true);
+    assert.equal(on.backgroundMaterial, "acrylic");
+
+    const oldWin = windowSurfaceOptions(glass(60, "under-window"), {
+      platform: "win32",
+      glassSupported: false,
+    });
+    assert.equal(oldWin.transparent, undefined);
+    assert.equal(oldWin.backgroundMaterial, undefined);
+  });
+});
+
+describe("translucencyDiff", () => {
+  it("ignores tint-only glass drags so setVibrancy is not reissued", () => {
+    const changed = translucencyDiff(glass(20, "header"), glass(80, "header"));
+    assert.deepEqual(changed, { backing: false, material: false, opacity: false });
+  });
+
+  it("flags a frost hop and a glass on/off flip", () => {
+    assert.equal(translucencyDiff(glass(60, "header"), glass(60, "popover")).material, true);
+    assert.equal(translucencyDiff(glass(0, "header"), glass(60, "header")).backing, true);
+    assert.equal(translucencyDiff(glass(0, "header"), glass(60, "header")).material, true);
+  });
+});
+
+describe("applyWindowTranslucency", () => {
+  it("sets vibrancy only on a material change", () => {
+    const calls = [];
+    const win = {
+      setVibrancy: (material) => calls.push(["vibrancy", material]),
+      setBackgroundColor: (color) => calls.push(["bg", color]),
+      setOpacity: (n) => calls.push(["opacity", n]),
+    };
+    applyWindowTranslucency(win, glass(60, "popover"), { material: true }, {
+      platform: "darwin",
+      glassSupported: true,
+    });
+    assert.deepEqual(calls, [["vibrancy", "popover"]]);
+
+    calls.length = 0;
+    applyWindowTranslucency(win, glass(0, "popover"), { material: true }, {
+      platform: "darwin",
+      glassSupported: true,
+    });
+    assert.deepEqual(calls, [["vibrancy", null]]);
+  });
+});
+
+describe("createTranslucencyController", () => {
+  it("persists a set and reapplies on the next controller", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "marionette-glass-"));
+    const first = createTranslucencyController({
+      platform: "darwin",
+      release: "25.4.0",
+      homeDir,
+    });
+    assert.equal(first.getState().intensity, 0);
+    first.setState({ intensity: ENABLE_INTENSITY, mode: "glass", material: "titlebar" });
+    first.flush();
+
+    const second = createTranslucencyController({
+      platform: "darwin",
+      release: "25.4.0",
+      homeDir,
+    });
+    assert.equal(second.getState().intensity, ENABLE_INTENSITY);
+    assert.equal(second.getState().material, "titlebar");
+    assert.equal(second.surfaceOptions().vibrancy, "titlebar");
+  });
+
+  it("reports Linux as unsupported", () => {
+    const caps = capabilities("linux", "6.8.0");
+    assert.equal(caps.translucencySupported, false);
+    assert.equal(caps.glassSupported, false);
+  });
+});

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -5,6 +5,27 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Marionette</title>
+    <script>
+      // Pre-paint the chrome (or glass) before the module graph loads so a
+      // cold launch does not flash the UA-default page over vibrancy.
+      try {
+        var THEMED = "#0f1113";
+        var raw = localStorage.getItem("pmharness.translucency.v1");
+        var state = raw ? JSON.parse(raw) : null;
+        var glass = !!(state && state.mode !== "clear" && Number(state.intensity) > 0);
+        document.documentElement.style.colorScheme = "dark";
+        if (glass) {
+          document.documentElement.setAttribute("data-marionette-glass", "");
+          var keep = Math.max(0, 100 - Math.round(Number(state.intensity) || 0));
+          document.documentElement.style.setProperty("--translucency-glass-keep", keep + "%");
+          document.documentElement.style.backgroundColor = "transparent";
+        } else {
+          document.documentElement.style.backgroundColor = THEMED;
+        }
+      } catch (e) {
+        document.documentElement.style.backgroundColor = "#0f1113";
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.255",
+  "version": "0.9.256",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.255",
+      "version": "0.9.256",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.255",
+  "version": "0.9.256",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/WindowGlassSettings.test.tsx
+++ b/webapp/src/__tests__/WindowGlassSettings.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import WindowGlassSettings from "../components/WindowGlassSettings";
+import { TRANSLUCENCY_STORAGE_KEY } from "../lib/windowGlass";
+
+afterEach(() => {
+  localStorage.removeItem(TRANSLUCENCY_STORAGE_KEY);
+  document.documentElement.removeAttribute("data-marionette-glass");
+  delete (window as { harnessIPC?: unknown }).harnessIPC;
+});
+
+describe("WindowGlassSettings", () => {
+  it("hides the row when the desktop bridge is missing", async () => {
+    const { container } = render(<WindowGlassSettings />);
+    await waitFor(() => {
+      expect(container.querySelector("[data-testid='window-glass-settings']")).toBeNull();
+    });
+  });
+
+  it("toggles glass on and paints the root attribute", async () => {
+    const setCalls: unknown[] = [];
+    (window as { harnessIPC?: unknown }).harnessIPC = {
+      translucency: {
+        get: async () => ({
+          state: { intensity: 0, fade: 0, mode: "glass", material: "under-window" },
+          capabilities: {
+            translucencySupported: true,
+            glassSupported: true,
+            isWindows: false,
+            materials: ["under-window", "popover", "titlebar", "header"],
+          },
+        }),
+        set: async (state: unknown) => {
+          setCalls.push(state);
+          return state;
+        },
+        capabilities: async () => ({
+          translucencySupported: true,
+          glassSupported: true,
+          isWindows: false,
+          materials: ["under-window", "popover", "titlebar", "header"],
+        }),
+      },
+    };
+    render(<WindowGlassSettings />);
+    const toggle = await screen.findByRole("button", { name: /glass window/i });
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(setCalls.length).toBeGreaterThan(0);
+      expect(document.documentElement.hasAttribute("data-marionette-glass")).toBe(true);
+    });
+  });
+});

--- a/webapp/src/__tests__/sessionExport.test.ts
+++ b/webapp/src/__tests__/sessionExport.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  copyTranscriptId,
+  downloadTextFile,
+  formatSessionExportMarkdown,
+  sessionExportFilename,
+  transcriptIdOf,
+  transcriptRelpathOf,
+} from "../lib/sessionExport";
+
+describe("sessionExport", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("puts the full transcript id in the download name", () => {
+    expect(sessionExportFilename("My Export Test Session!", "a1b2c3d4e5f6", "json"))
+      .toBe("My_Export_Test_Session-a1b2c3d4e5f6.json");
+    expect(sessionExportFilename("unknown-id", "unknown-id", "md")).toBe("unknown-id.md");
+  });
+
+  it("prefers transcript_id and a stable on-disk locator", () => {
+    expect(transcriptIdOf({ session_id: "old", transcript_id: "new" })).toBe("new");
+    expect(transcriptRelpathOf({ transcript_id: "abc123" })).toBe("transcripts/abc123.json");
+  });
+
+  it("writes markdown a later agent can grep by transcript id", () => {
+    const md = formatSessionExportMarkdown({
+      transcript_id: "a1b2c3d4e5f6",
+      session_id: "a1b2c3d4e5f6",
+      transcript_relpath: "transcripts/a1b2c3d4e5f6.json",
+      title: "My Export Test Session!",
+      created: 1_700_000_000,
+      exported_at: 1_700_000_100,
+      messages: [
+        { role: "user", content: "hello pilot" },
+        { role: "assistant", content: "hello human" },
+      ],
+    });
+    expect(md).toContain("# My Export Test Session!");
+    expect(md).toContain("**Transcript ID:** a1b2c3d4e5f6");
+    expect(md).toContain("**Session ID:** a1b2c3d4e5f6");
+    expect(md).toContain("**On disk:** `transcripts/a1b2c3d4e5f6.json`");
+    expect(md).toContain("## User");
+    expect(md).toContain("hello pilot");
+    expect(md).toContain("## Assistant");
+    expect(md).toContain("hello human");
+  });
+
+  it("downloads a blob instead of navigating to /api/sessions/export", () => {
+    const clicks: string[] = [];
+    const created: Array<{ download: string; href: string; click: () => void }> = [];
+    vi.stubGlobal("URL", {
+      createObjectURL: () => "blob:session-export",
+      revokeObjectURL: () => undefined,
+    });
+    const nativeCreate = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      if (tag !== "a") return nativeCreate(tag);
+      const a = {
+        href: "",
+        download: "",
+        click() {
+          clicks.push(`${this.download}|${this.href}`);
+        },
+      };
+      created.push(a);
+      return a as unknown as HTMLElement;
+    });
+    vi.spyOn(document.body, "appendChild").mockImplementation((node) => node);
+    vi.spyOn(document.body, "removeChild").mockImplementation((node) => node);
+
+    downloadTextFile("My_Export-a1b2c3d4e5f6.md", "# hi", "text/markdown");
+
+    expect(clicks).toEqual(["My_Export-a1b2c3d4e5f6.md|blob:session-export"]);
+    expect(created[0]?.href).not.toContain("/api/sessions/export");
+  });
+
+  it("copies the transcript id for other sessions", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    await expect(copyTranscriptId("a1b2c3d4e5f6")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("a1b2c3d4e5f6");
+  });
+});

--- a/webapp/src/__tests__/windowGlass.test.ts
+++ b/webapp/src/__tests__/windowGlass.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyGlassSurfaces,
+  beginTranslucencyPeek,
+  endTranslucencyPeek,
+  glassActive,
+  glassSurfaceKeep,
+  normalizeRendererState,
+  resetTranslucencyPeek,
+} from "../lib/windowGlass";
+
+afterEach(() => {
+  resetTranslucencyPeek(document.documentElement);
+  document.documentElement.removeAttribute("data-marionette-glass");
+  document.documentElement.style.removeProperty("--translucency-glass-keep");
+  document.documentElement.style.removeProperty("background-color");
+});
+
+describe("normalizeRendererState", () => {
+  it("defaults to glass off on junk", () => {
+    expect(normalizeRendererState(null)).toEqual({
+      intensity: 0,
+      fade: 0,
+      mode: "glass",
+      material: "under-window",
+    });
+  });
+
+  it("keeps a saved frost rung", () => {
+    expect(normalizeRendererState({ intensity: 60, mode: "glass", material: "titlebar" }).material)
+      .toBe("titlebar");
+  });
+});
+
+describe("applyGlassSurfaces", () => {
+  it("marks the root and publishes the keep token while glass is live", () => {
+    applyGlassSurfaces({ intensity: 60, fade: 0, mode: "glass", material: "header" });
+    expect(document.documentElement.hasAttribute("data-marionette-glass")).toBe(true);
+    expect(document.documentElement.style.getPropertyValue("--translucency-glass-keep")).toBe("40%");
+    expect(glassActive({ intensity: 60, fade: 0, mode: "glass", material: "header" })).toBe(true);
+    expect(glassSurfaceKeep(60)).toBe(40);
+  });
+
+  it("clears the mark when the lever is off", () => {
+    applyGlassSurfaces({ intensity: 60, fade: 0, mode: "glass", material: "header" });
+    applyGlassSurfaces({ intensity: 0, fade: 0, mode: "glass", material: "header" });
+    expect(document.documentElement.hasAttribute("data-marionette-glass")).toBe(false);
+    expect(document.documentElement.style.getPropertyValue("--translucency-glass-keep")).toBe("");
+  });
+});
+
+describe("translucency peek", () => {
+  it("holds the peek attribute across overlapping begins", () => {
+    beginTranslucencyPeek();
+    beginTranslucencyPeek();
+    expect(document.documentElement.hasAttribute("data-marionette-glass-peek")).toBe(true);
+    endTranslucencyPeek();
+    expect(document.documentElement.hasAttribute("data-marionette-glass-peek")).toBe(true);
+    endTranslucencyPeek();
+    expect(document.documentElement.hasAttribute("data-marionette-glass-peek")).toBe(false);
+  });
+});

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -7,6 +7,13 @@ import { repoPathsEqual } from "../lib/pathNormalize";
 import { mapSessionSearchHits, type SessionSearchRow } from "../lib/sessionSearch";
 import { usePolling } from "../lib/usePolling";
 import { readSWRCache, writeSWRCache, useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
+import {
+  copyTranscriptId,
+  downloadTextFile,
+  formatSessionExportMarkdown,
+  sessionExportFilename,
+  transcriptIdOf,
+} from "../lib/sessionExport";
 import { writeTranscriptCache } from "./Conversation";
 import { sharedReadinessNotice } from "../lib/operationalDiagnostic";
 import { useOperationalDiagnostic } from "../lib/useOperationalDiagnostic";
@@ -866,14 +873,34 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     }
   };
 
-  const handleExport = (sid: string, format: "md" | "json") => {
-    const url = api.exportUrl(sid, format);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "";
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
+  const handleExport = async (sid: string, format: "md" | "json") => {
+    try {
+      const payload = await api.exportSession(sid);
+      const id = transcriptIdOf(payload, sid);
+      const title = payload.title || "session";
+      if (format === "json") {
+        downloadTextFile(
+          sessionExportFilename(title, id, "json"),
+          JSON.stringify(payload, null, 2),
+          "application/json",
+        );
+      } else {
+        downloadTextFile(
+          sessionExportFilename(title, id, "md"),
+          formatSessionExportMarkdown(payload, sid),
+          "text/markdown",
+        );
+      }
+      toast(`Exported ${format.toUpperCase()} · ${id}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Export failed";
+      toast(msg);
+    }
+  };
+
+  const handleCopyTranscriptId = async (sid: string) => {
+    const ok = await copyTranscriptId(sid);
+    toast(ok ? `Copied transcript ID ${sid}` : "Could not copy transcript ID");
   };
 
   const handleContextMenu = (e: React.MouseEvent, s: Session, allowSettle: boolean) => {
@@ -2010,7 +2037,16 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
           <div className="border-t border-edge my-1" />
           <button
             onClick={() => {
-              handleExport(contextMenu.sessionId, "md");
+              void handleCopyTranscriptId(contextMenu.sessionId);
+              setContextMenu(null);
+            }}
+            className="w-full text-left px-3 py-1.5 hover:bg-panel2 text-txt transition-colors"
+          >
+            Copy transcript ID
+          </button>
+          <button
+            onClick={() => {
+              void handleExport(contextMenu.sessionId, "md");
               setContextMenu(null);
             }}
             className="w-full text-left px-3 py-1.5 hover:bg-panel2 text-txt transition-colors"
@@ -2019,7 +2055,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
           </button>
           <button
             onClick={() => {
-              handleExport(contextMenu.sessionId, "json");
+              void handleExport(contextMenu.sessionId, "json");
               setContextMenu(null);
             }}
             className="w-full text-left px-3 py-1.5 hover:bg-panel2 text-txt transition-colors"

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -20,6 +20,7 @@ import {
 } from "./settingsSnapshot";
 import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 import { SettingsCollapse } from "./SettingsCollapse";
+import WindowGlassSettings from "./WindowGlassSettings";
 
 export type SettingsSection = "general" | "safety" | "providers" | "notifications" | "plugins" | "advanced";
 
@@ -986,6 +987,9 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
         </div>
 
         </>)}
+        {gate("general", "transparent background glass vibrancy acrylic mica frost window") && (
+          <WindowGlassSettings />
+        )}
         {gate("general", "driver model select") && settings && (<>
         {/* Driver Select */}
         <div className="space-y-1.5">

--- a/webapp/src/components/WindowGlassSettings.tsx
+++ b/webapp/src/components/WindowGlassSettings.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import {
+  ENABLE_INTENSITY,
+  FROST_LABELS,
+  beginTranslucencyPeek,
+  defaultTranslucencyState,
+  endTranslucencyPeek,
+  hydrateWindowGlass,
+  loadTranslucencyCapabilities,
+  pulseTranslucencyPeek,
+  resetTranslucencyPeek,
+  setWindowGlass,
+  type GlassMaterial,
+  type TranslucencyCapabilities,
+  type TranslucencyState,
+} from "../lib/windowGlass";
+
+export default function WindowGlassSettings() {
+  const [caps, setCaps] = useState<TranslucencyCapabilities | null>(null);
+  const [state, setState] = useState<TranslucencyState>(() => defaultTranslucencyState());
+
+  useEffect(() => {
+    setState(hydrateWindowGlass());
+    void loadTranslucencyCapabilities().then(setCaps);
+    return () => resetTranslucencyPeek();
+  }, []);
+
+  if (!caps?.translucencySupported || !caps.glassSupported) return null;
+
+  const on = state.mode === "glass" && state.intensity > 0;
+
+  const commit = async (partial: Partial<TranslucencyState>) => {
+    const next = await setWindowGlass(partial);
+    setState(next);
+  };
+
+  return (
+    <div className="space-y-1.5" data-testid="window-glass-settings">
+      <label className="block uppercase tracking-wider text-[10px] text-faint font-semibold">
+        Transparent background
+      </label>
+      <button
+        type="button"
+        onClick={() => {
+          void commit({
+            mode: "glass",
+            intensity: on ? 0 : Math.max(state.intensity, ENABLE_INTENSITY),
+          });
+          pulseTranslucencyPeek();
+        }}
+        className={`w-full flex items-center justify-between px-3 py-2 rounded border transition text-left ${
+          on ? "bg-accent/10 border-accent/30 text-accent" : "bg-panel2 border-edge text-muted"
+        }`}
+      >
+        <span className="font-medium text-[11px]">Glass window (Cursor-style frost)</span>
+        <span className="text-[10px] uppercase font-bold tracking-wider">{on ? "on" : "off"}</span>
+      </button>
+      {on && (
+        <>
+          <div className="flex items-center gap-2 pt-1">
+            <span className="text-[10px] text-muted w-10 shrink-0">Tint</span>
+            <input
+              type="range"
+              min={1}
+              max={100}
+              value={state.intensity}
+              aria-label="Glass tint"
+              onPointerDown={() => beginTranslucencyPeek()}
+              onPointerUp={() => endTranslucencyPeek()}
+              onPointerCancel={() => endTranslucencyPeek()}
+              onChange={(e) => {
+                void commit({ intensity: Number(e.target.value) });
+              }}
+              className="flex-1 accent-accent"
+            />
+            <span className="text-[10px] font-mono text-faint w-8 text-right">{state.intensity}</span>
+          </div>
+          <div className="flex flex-wrap gap-1 pt-0.5">
+            {caps.materials.map((material) => {
+              const selected = caps.isWindows && state.material === "header" ? "titlebar" : state.material;
+              const active = selected === material;
+              return (
+                <button
+                  key={material}
+                  type="button"
+                  onClick={() => {
+                    void commit({ material: material as GlassMaterial });
+                    pulseTranslucencyPeek();
+                  }}
+                  className={`px-2 py-1 rounded border text-[10px] uppercase tracking-wider font-semibold transition ${
+                    active
+                      ? "bg-accent/15 border-accent/40 text-accent"
+                      : "bg-panel2 border-edge text-muted hover:text-txt"
+                  }`}
+                >
+                  {FROST_LABELS[material]}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+      <p className="text-[10px] text-muted">
+        Lets the desktop show through a matte blur. Raise Tint toward bare glass;
+        Frost picks the native material (macOS vibrancy or Windows acrylic/mica).
+      </p>
+    </div>
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -74,6 +74,25 @@ body {
   --shell-panel-radius: 12px;
 }
 
+/* Window glass (Settings → General → Transparent background).
+   Native vibrancy / DWM acrylic composites BELOW the page. Field tokens go
+   transparent so <body> is the only painter; inset panels and cards keep
+   their own fills for contrast. Tint is --translucency-glass-keep. */
+:root[data-marionette-glass] {
+  background-color: transparent !important;
+  --shell-chrome: transparent;
+  --shell-chat: transparent;
+}
+
+:root[data-marionette-glass] body {
+  background: color-mix(in srgb, #0f1113 var(--translucency-glass-keep, 100%), transparent);
+}
+
+:root[data-marionette-glass-peek] [data-testid="settings-shell"] {
+  background: color-mix(in srgb, #0f1113 22%, transparent) !important;
+  opacity: 0.22;
+}
+
 /* Side rails + footer sit "within" the window: rounded, lightly bordered,
    with gutter from the window edge instead of flush hard dividers. */
 .shell-inset-panel {

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -17,6 +17,7 @@ import {
   normalizeSessionSearchHits,
   type SessionSearchHit,
 } from "./sessionSearch";
+import type { SessionExportPayload } from "./sessionExport";
 
 export type { ChatEventFrame, StoreEvent } from "./transport";
 export type { SessionSearchHit } from "./sessionSearch";
@@ -1404,8 +1405,11 @@ export const api = {
       cancelStream?.();
     };
   },
-  exportUrl: (sessionId: string, format: "md" | "json") =>
-    withToken(`/api/sessions/export?session=${encodeURIComponent(sessionId)}&format=${format}`),
+  /** Authenticated JSON envelope. The desktop must not navigate to /api/sessions/export. */
+  exportSession: (sessionId: string) =>
+    getJSON<SessionExportPayload>(
+      `/api/sessions/export?session=${encodeURIComponent(sessionId)}&format=json`,
+    ),
 
   getWorktrees: () => getJSON<{ worktrees: Worktree[]; max: number }>("/api/worktrees"),
   addWorktree: (branch: string, base?: string) => postJSON<Worktree>("/api/worktrees/add", { branch, base }),

--- a/webapp/src/lib/sessionExport.ts
+++ b/webapp/src/lib/sessionExport.ts
@@ -1,0 +1,112 @@
+/** Session export helpers — authenticated payload -> blob download + transcript ID. */
+
+export type SessionExportMessage = {
+  role?: string;
+  content?: unknown;
+};
+
+export type SessionExportPayload = {
+  transcript_id?: string;
+  session_id?: string;
+  transcript_relpath?: string;
+  title?: string;
+  created?: number | null;
+  exported_at?: number;
+  messages?: SessionExportMessage[];
+};
+
+export function transcriptIdOf(payload: SessionExportPayload, fallback = ""): string {
+  const id = String(payload.transcript_id || payload.session_id || fallback || "").trim();
+  return id;
+}
+
+export function sanitizeExportFilenamePart(value: string): string {
+  const cleaned = String(value || "")
+    .replace(/[^a-zA-Z0-9\-_]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^[_-]+|[_-]+$/g, "");
+  return cleaned || "session";
+}
+
+/** Hermes-style `{title}-{id}.{ext}` so the file itself carries the transcript ID. */
+export function sessionExportFilename(
+  title: string,
+  transcriptId: string,
+  ext: "md" | "json",
+): string {
+  const idPart = sanitizeExportFilenamePart(transcriptId);
+  const titlePart = sanitizeExportFilenamePart(title || idPart);
+  if (titlePart.toLowerCase() === idPart.toLowerCase()) {
+    return `${idPart}.${ext}`;
+  }
+  return `${titlePart}-${idPart}.${ext}`;
+}
+
+export function transcriptRelpathOf(payload: SessionExportPayload, fallbackId = ""): string {
+  const explicit = String(payload.transcript_relpath || "").trim();
+  if (explicit) return explicit;
+  const id = sanitizeExportFilenamePart(transcriptIdOf(payload, fallbackId));
+  return `transcripts/${id}.json`;
+}
+
+function formatLocalStamp(ts: number | null | undefined): string {
+  if (ts == null || !Number.isFinite(Number(ts))) return "Unknown";
+  const d = new Date(Number(ts) * 1000);
+  if (Number.isNaN(d.getTime())) return "Unknown";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+function messageContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (content == null) return "";
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return String(content);
+  }
+}
+
+export function formatSessionExportMarkdown(payload: SessionExportPayload, fallbackId = ""): string {
+  const id = transcriptIdOf(payload, fallbackId);
+  const title = String(payload.title || "Unknown Session");
+  const relpath = transcriptRelpathOf(payload, id);
+  const lines = [
+    `# ${title}`,
+    "",
+    `**Transcript ID:** ${id}  `,
+    `**Session ID:** ${id}  `,
+    `**On disk:** \`${relpath}\`  `,
+    `**Created:** ${formatLocalStamp(payload.created)}  `,
+    `**Exported:** ${formatLocalStamp(payload.exported_at)}`,
+    "",
+  ];
+  for (const msg of payload.messages || []) {
+    const role = String(msg.role || "").replace(/^./, (ch) => ch.toUpperCase());
+    lines.push(`## ${role}`, "", messageContent(msg.content), "");
+  }
+  return lines.join("\n");
+}
+
+export function downloadTextFile(filename: string, body: string, mime: string): void {
+  const blob = new Blob([body], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export async function copyTranscriptId(transcriptId: string): Promise<boolean> {
+  const id = String(transcriptId || "").trim();
+  if (!id) return false;
+  try {
+    await navigator.clipboard.writeText(id);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/webapp/src/lib/windowGlass.ts
+++ b/webapp/src/lib/windowGlass.ts
@@ -1,0 +1,196 @@
+/**
+ * Renderer half of window glass. Main owns the native material; this module
+ * thins field surfaces and mirrors the lever over IPC / localStorage so a
+ * reload paints before React.
+ */
+
+export type GlassMaterial = "under-window" | "popover" | "titlebar" | "header";
+
+export type TranslucencyState = {
+  intensity: number;
+  fade: number;
+  mode: "clear" | "glass";
+  material: GlassMaterial;
+};
+
+export type TranslucencyCapabilities = {
+  translucencySupported: boolean;
+  glassSupported: boolean;
+  isWindows: boolean;
+  materials: GlassMaterial[];
+};
+
+export const TRANSLUCENCY_STORAGE_KEY = "pmharness.translucency.v1";
+export const ENABLE_INTENSITY = 60;
+export const FROST_LABELS: Record<GlassMaterial, string> = {
+  "under-window": "Deep",
+  popover: "Soft",
+  titlebar: "Bright",
+  header: "Glare",
+};
+
+const PEEK_ATTR = "data-marionette-glass-peek";
+const GLASS_ATTR = "data-marionette-glass";
+
+function clampIntensity(value: unknown): number {
+  const n = Math.round(Number(value));
+  return Number.isFinite(n) ? Math.min(100, Math.max(0, n)) : 0;
+}
+
+export function glassSurfaceKeep(intensity: number): number {
+  return 100 - clampIntensity(intensity);
+}
+
+export function glassActive(state: TranslucencyState): boolean {
+  return state.mode === "glass" && state.intensity > 0;
+}
+
+export function defaultTranslucencyState(): TranslucencyState {
+  return { intensity: 0, fade: 0, mode: "glass", material: "under-window" };
+}
+
+export function normalizeRendererState(payload: unknown): TranslucencyState {
+  const record = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const material = record.material;
+  return {
+    intensity: clampIntensity(record.intensity),
+    fade: clampIntensity(record.fade),
+    mode: record.mode === "clear" ? "clear" : "glass",
+    material:
+      material === "popover" || material === "titlebar" || material === "header"
+        ? material
+        : "under-window",
+  };
+}
+
+function translucencyIpc(): {
+  get?: () => Promise<{ state: TranslucencyState; capabilities: TranslucencyCapabilities }>;
+  set?: (state: TranslucencyState) => Promise<TranslucencyState>;
+  capabilities?: () => Promise<TranslucencyCapabilities>;
+} | null {
+  if (typeof window === "undefined") return null;
+  return (window as { harnessIPC?: { translucency?: ReturnType<typeof translucencyIpc> } }).harnessIPC
+    ?.translucency || null;
+}
+
+export function readStoredTranslucency(): TranslucencyState {
+  try {
+    const raw = localStorage.getItem(TRANSLUCENCY_STORAGE_KEY);
+    return normalizeRendererState(raw ? JSON.parse(raw) : null);
+  } catch {
+    return defaultTranslucencyState();
+  }
+}
+
+export function writeStoredTranslucency(state: TranslucencyState): void {
+  try {
+    localStorage.setItem(TRANSLUCENCY_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    /* storage pressure must not break Settings */
+  }
+}
+
+export function applyGlassSurfaces(
+  state: TranslucencyState,
+  root: HTMLElement | null = typeof document === "undefined" ? null : document.documentElement,
+): void {
+  if (!root) return;
+  const live = glassActive(state);
+  root.toggleAttribute(GLASS_ATTR, live);
+  if (live) {
+    root.style.setProperty("--translucency-glass-keep", `${glassSurfaceKeep(state.intensity)}%`);
+    root.style.backgroundColor = "transparent";
+  } else {
+    root.style.removeProperty("--translucency-glass-keep");
+    root.style.removeProperty("background-color");
+  }
+}
+
+let peekCount = 0;
+
+export function beginTranslucencyPeek(
+  root: HTMLElement | null = typeof document === "undefined" ? null : document.documentElement,
+): void {
+  peekCount += 1;
+  if (root && peekCount > 0) root.toggleAttribute(PEEK_ATTR, true);
+}
+
+export function endTranslucencyPeek(
+  root: HTMLElement | null = typeof document === "undefined" ? null : document.documentElement,
+): void {
+  peekCount = Math.max(0, peekCount - 1);
+  if (root) root.toggleAttribute(PEEK_ATTR, peekCount > 0);
+}
+
+export function resetTranslucencyPeek(
+  root: HTMLElement | null = typeof document === "undefined" ? null : document.documentElement,
+): void {
+  peekCount = 0;
+  if (root) root.removeAttribute(PEEK_ATTR);
+}
+
+export function pulseTranslucencyPeek(ms = 900): void {
+  beginTranslucencyPeek();
+  if (typeof window === "undefined") {
+    endTranslucencyPeek();
+    return;
+  }
+  window.setTimeout(endTranslucencyPeek, ms);
+}
+
+export function hydrateWindowGlass(): TranslucencyState {
+  const stored = readStoredTranslucency();
+  applyGlassSurfaces(stored);
+  const ipc = translucencyIpc();
+  if (ipc?.get) {
+    void ipc.get().then((payload) => {
+      const next = normalizeRendererState(payload?.state);
+      writeStoredTranslucency(next);
+      applyGlassSurfaces(next);
+    }).catch(() => {});
+  }
+  return stored;
+}
+
+export async function setWindowGlass(partial: Partial<TranslucencyState>): Promise<TranslucencyState> {
+  const next = normalizeRendererState({ ...readStoredTranslucency(), ...partial });
+  writeStoredTranslucency(next);
+  applyGlassSurfaces(next);
+  const ipc = translucencyIpc();
+  if (ipc?.set) {
+    try {
+      const applied = normalizeRendererState(await ipc.set(next));
+      writeStoredTranslucency(applied);
+      applyGlassSurfaces(applied);
+      return applied;
+    } catch {
+      return next;
+    }
+  }
+  return next;
+}
+
+export async function loadTranslucencyCapabilities(): Promise<TranslucencyCapabilities> {
+  const ipc = translucencyIpc();
+  if (ipc?.capabilities) {
+    try {
+      return await ipc.capabilities();
+    } catch {
+      /* fall through */
+    }
+  }
+  if (ipc?.get) {
+    try {
+      const payload = await ipc.get();
+      if (payload?.capabilities) return payload.capabilities;
+    } catch {
+      /* fall through */
+    }
+  }
+  return {
+    translucencySupported: false,
+    glassSupported: false,
+    isWindows: false,
+    materials: ["under-window", "popover", "titlebar", "header"],
+  };
+}

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -3,6 +3,9 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import ErrorBoundary from "./components/ErrorBoundary";
+import { hydrateWindowGlass } from "./lib/windowGlass";
+
+hydrateWindowGlass();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- Settings glass window (Hermes vibrancy lift): tint + frost, persisted locally.
- Session export actually downloads: authenticated JSON envelope, Hermes-style `{title}-{id}.md|.json` blob, plus Copy transcript ID for other agents.

## Test plan
- [x] `tests/test_export.py` + `tests/test_version_consistency.py`
- [x] vitest sessionExport / windowGlass / WindowGlassSettings
- [x] electron translucency tests
- [x] local `pytest tests -q` (4621 passed)
- [ ] dest-into-main `tests` matrix (3.9, 3.11, Windows, frontend-build)
- [ ] dest-into-main `release` mac: Developer ID + notarization
- [ ] After tag, GitHub release has `Marionette-0.9.256-universal-mac.zip`