### PR TITLE
Release v0.9.257

### DIFF
--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -1,0 +1,75 @@
+name: tests-full
+
+# Nightly / manual copy of the old five-cell matrix. Dest-into-main does not
+# wait on this. Includes macOS, Python 3.11, both Windows Pythons, and
+# @pytest.mark.resource_soak (the million-token compaction walk).
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: tests-full-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}
+        python-version: ["3.9", "3.11"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.9"
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install (rig + dev extras + Puppetmaster from PyPI)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.12"
+
+      - name: Run the offline test suite
+        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'
+        run: python -m pytest -q -p no:cacheprovider --resource-soak
+
+      - name: Run the offline test suite (durations)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+        run: python -m pytest -q -p no:cacheprovider --resource-soak --durations=25
+
+  frontend-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: webapp/package-lock.json
+
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install + vitest + Electron unit tests + build
+        working-directory: webapp
+        env:
+          DISPLAY: ":99"
+        run: |
+          npm ci
+          npm test
+          xvfb-run -a npm run test:electron
+          npm run build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
 name: tests
 
-# Gate every PR and every push to main on the offline test suite. No API keys,
-# no Apple secrets -- this only runs pytest in a clean venv with PyPI deps, which
-# is exactly how a contributor's machine installs the rig (verified: 584 pass
-# with `pip install -e .[dev] puppetmaster-ai`).
+# Fast dest-into-main / main-push gate. Wall clock target is ~5 minutes:
+# Ubuntu 3.9 with xdist, Windows 3.9 split into 4 shards, frontend-build.
+# The 3.9 floor and one Windows cell stay required. macOS, 3.11, and the
+# million-token soak live in tests-full.yml (nightly / manual).
 
 on:
   pull_request:
@@ -11,61 +11,58 @@ on:
   push:
     branches: [main]
 
-# Cancel an in-flight run when a new commit is pushed to the same PR/branch.
 concurrency:
   group: tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  pytest:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # Floor (3.9, the requires-python minimum) + the dev interpreter (3.11),
-        # on every OS users actually run: Linux, macOS, and Windows.
-        # CI_WINDOWS_RUNNER swaps GitHub-hosted windows-latest for a faster
-        # machine (Blacksmith `blacksmith-4vcpu-windows-2025`) without a new
-        # workflow. Unset keeps windows-latest so CI never queues on a missing
-        # runner label.
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}
-        python-version: ["3.9", "3.11"]
-        exclude:
-          # actions/setup-python has no CPython 3.9 build for arm64 macOS.
-          # The 3.9 floor is still proven on Linux and Windows.
-          - os: macos-latest
-            python-version: "3.9"
+  pytest-linux:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.9
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.9"
           cache: pip
 
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          # Floor matches the accounting/routing fixes this release needs.
-          # Unpinned `puppetmaster-ai` + pip cache can leave CI on an older
-          # wheel (e.g. 1.14.0) and fail fallback-pricing regressions.
           pip install -e ".[dev]" "puppetmaster-ai==1.22.12"
 
-      # full_auto_safety modules already run inside this job via conftest
-      # auto-tagging; a separate named job was redundant PR compute.
       - name: Run the offline test suite
-        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'
-        run: python -m pytest -q -p no:cacheprovider
+        run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
 
-      # One cell keeps a slow-test ranking in CI logs without paying for it
-      # on every OS/Python combination.
-      - name: Run the offline test suite (durations)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        run: python -m pytest -q -p no:cacheprovider --durations=25
+  pytest-windows:
+    # CI_WINDOWS_RUNNER swaps GitHub-hosted windows-latest for a faster
+    # machine (Blacksmith `blacksmith-4vcpu-windows-2025`) without a new
+    # workflow. Unset keeps windows-latest so CI never queues on a missing
+    # runner label.
+    runs-on: ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.9"
+          cache: pip
+
+      - name: Install (rig + dev extras + Puppetmaster from PyPI)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.12"
+
+      - name: Run the offline test suite (shard)
+        env:
+          PYTEST_SHARD: ${{ matrix.shard }}/4
+        run: python -m pytest -q -p no:cacheprovider
 
   frontend-build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.256, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. Session export uses authenticated download plus a copyable transcript ID; Settings can enable a Cursor-style glass window. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
+> Status: v0.9.257, deliberately pre-1.0. Rides puppetmaster-ai==1.22.12. Cursor CLI pilots now verify requested-versus-served identity and use bounded `--model` sessions; macOS glass uses a crash-safe transparent vibrancy surface shared by the shell panels. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
 
 ## Documentation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,8 +39,10 @@ tagged installer from Releases.
 ## Cutting a version tag
 
 Tags/versions label what checkouts and installers report via `app.getVersion()`.
-Green CI Before Tag still holds: the `tests` workflow (3.9 floor, 3.11,
-Windows, frontend-build) must be green for **this git tree**. The tag may
+Green CI Before Tag still holds: the `tests` workflow (Ubuntu 3.9 xdist,
+Windows 3.9 four-way shard, frontend-build) must be green for **this git
+tree**. macOS, Python 3.11, and `@pytest.mark.resource_soak` run in
+`tests-full.yml` (nightly / manual) and do not block the tag. The tag may
 point at the dest-into-main merge commit; it does not need a second `tests`
 run on that SHA when `merge^{tree}` equals the already-green dest PR tree.
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.256"
+__version__ = "0.9.257"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/providers.py
+++ b/harness/providers.py
@@ -557,10 +557,11 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
     if provider.api_mode == "cursor_cli":
         # Workspace trust / --workspace follow the open project (HARNESS_REPO).
         cwd = (os.environ.get("HARNESS_REPO") or "").strip() or None
-        # Warm ACP is default (turn-2 ~2s in probe). HARNESS_CURSOR_ACP=0
-        # forces classic per-turn `agent --print`.
+        # ACP is opt-in (HARNESS_CURSOR_ACP=1) and only for auto/empty.
+        # Explicit picker models always use --print --model so served
+        # identity can be verified. ACP does not pin or report the model.
         from pmharness.drivers.cursor_acp import CursorAcpDriver, cursor_acp_enabled
-        if cursor_acp_enabled():
+        if cursor_acp_enabled(model):
             return _finalize_driver(
                 CursorAcpDriver(
                     name=spec, model=model, max_tokens=max_tokens, cwd=cwd,

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -1244,6 +1244,55 @@ def _receipt_model_label(session: Any, resp: Any, driver: str) -> str:
     return driver
 
 
+def _receipt_meta_label(meta: Any, key: str) -> str:
+    if not isinstance(meta, dict):
+        return ""
+    raw = meta.get(key)
+    if not isinstance(raw, str):
+        return ""
+    text = raw.strip()
+    if not text or "\n" in text or "\x00" in text or len(text) > 128:
+        return ""
+    return text
+
+
+def _receipt_identity_kwargs(resp: Any, driver: str) -> Dict[str, Any]:
+    """Pull requested/served identity + token totals off a driver response."""
+    meta = getattr(resp, "meta", None) if resp is not None else None
+    if not isinstance(meta, dict):
+        meta = {}
+    requested = _receipt_meta_label(meta, "requested_model")
+    if not requested and ":" in driver:
+        requested = driver.split(":", 1)[-1].strip()
+    served = _receipt_meta_label(meta, "served_model")
+    identity = _receipt_meta_label(meta, "identity_status").lower()
+    token_basis = _receipt_meta_label(meta, "token_basis").lower()
+    out: Dict[str, Any] = {}
+    if requested:
+        out["requested_model"] = requested
+    if served:
+        out["served_model"] = served
+    if identity:
+        out["identity_status"] = identity
+    if token_basis:
+        out["token_basis"] = token_basis
+    elif meta.get("raw_usage") or served or requested:
+        out["token_basis"] = (
+            "provider" if isinstance(meta.get("raw_usage"), dict) else "unknown"
+        )
+    if resp is not None:
+        for attr, key in (("tokens_in", "tokens_in"), ("tokens_out", "tokens_out")):
+            value = getattr(resp, attr, None)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                out[key] = value
+    for key in ("cache_read_tokens", "cache_write_tokens"):
+        if key in meta:
+            value = meta.get(key)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                out[key] = value
+    return out
+
+
 def record_provider_stream_receipt(
     session: Any,
     resp: Any = None,
@@ -1307,6 +1356,7 @@ def record_provider_stream_receipt(
             driver=driver,
             model=_receipt_model_label(session, resp, driver),
             status=status,
+            **_receipt_identity_kwargs(resp, driver),
         )
         StreamPerformanceReceiptStore(state_dir).record(sid, receipt)
     except Exception:

--- a/harness/stream_performance_store.py
+++ b/harness/stream_performance_store.py
@@ -45,6 +45,10 @@ from .stream_performance import (
 RECEIPT_SCHEMA_VERSION = 1
 MAX_RECEIPTS_PER_SESSION = 200
 RECEIPT_STATUSES = frozenset({"success", "error", "context_overflow"})
+RECEIPT_IDENTITY_STATUSES = frozenset({
+    "verified", "mismatch", "unreported", "auto",
+})
+RECEIPT_TOKEN_BASES = frozenset({"provider", "unknown"})
 PERFORMANCE_SUBDIR = "stream_performance"
 _LOAD_MAX_BYTES = 2 * 1024 * 1024
 _MAX_LABEL_CHARS = 128
@@ -442,6 +446,14 @@ def build_receipt(
     model: Any = "",
     status: Any = "success",
     captured_at: Any = None,
+    requested_model: Any = "",
+    served_model: Any = "",
+    identity_status: Any = "",
+    tokens_in: Any = None,
+    tokens_out: Any = None,
+    cache_read_tokens: Any = None,
+    cache_write_tokens: Any = None,
+    token_basis: Any = "",
 ) -> Dict[str, Any]:
     """Fixed JSON-safe receipt. Unknown / unsafe fields are dropped."""
     sid = safe_session_id(str(session_id or ""))
@@ -478,6 +490,30 @@ def build_receipt(
             ordinal = None
         if ordinal is not None and 0 <= ordinal <= _MAX_NONNEG_INT:
             receipt["user_ordinal"] = ordinal
+    requested_s = _safe_label(requested_model)
+    if requested_s:
+        receipt["requested_model"] = requested_s
+    served_s = _safe_label(served_model)
+    if served_s:
+        receipt["served_model"] = served_s
+    ident = str(identity_status or "").strip().lower()
+    if ident in RECEIPT_IDENTITY_STATUSES:
+        receipt["identity_status"] = ident
+    for key, value in (
+        ("tokens_in", tokens_in),
+        ("tokens_out", tokens_out),
+        ("cache_read_tokens", cache_read_tokens),
+        ("cache_write_tokens", cache_write_tokens),
+    ):
+        if value is None:
+            continue
+        number = _bounded_nonneg_int(value)
+        if number is None:
+            continue
+        receipt[key] = number
+    basis = str(token_basis or "").strip().lower()
+    if basis in RECEIPT_TOKEN_BASES:
+        receipt["token_basis"] = basis
     return receipt
 
 
@@ -498,6 +534,14 @@ def sanitize_receipt(raw: Any) -> Optional[Dict[str, Any]]:
         model=raw.get("model", ""),
         status=raw.get("status", "success"),
         captured_at=raw.get("captured_at"),
+        requested_model=raw.get("requested_model", ""),
+        served_model=raw.get("served_model", ""),
+        identity_status=raw.get("identity_status", ""),
+        tokens_in=raw.get("tokens_in"),
+        tokens_out=raw.get("tokens_out"),
+        cache_read_tokens=raw.get("cache_read_tokens"),
+        cache_write_tokens=raw.get("cache_write_tokens"),
+        token_basis=raw.get("token_basis", ""),
     )
 
 
@@ -721,6 +765,8 @@ __all__ = (
     "MAX_RECEIPTS_PER_SESSION",
     "RECEIPT_SCHEMA_VERSION",
     "RECEIPT_STATUSES",
+    "RECEIPT_IDENTITY_STATUSES",
+    "RECEIPT_TOKEN_BASES",
     "STREAM_PERFORMANCE_KEY",
     "StreamPerformanceReceiptStore",
     "build_receipt",

--- a/pmharness/drivers/cursor_acp.py
+++ b/pmharness/drivers/cursor_acp.py
@@ -31,16 +31,23 @@ from .cursor_cli import (
     resolve_agent_exec,
     resolve_cursor_execution_mode,
 )
-def cursor_acp_enabled() -> bool:
-    """Warm ACP path (default ON). Set ``HARNESS_CURSOR_ACP=0`` to force --print.
+from .cursor_identity import IDENTITY_AUTO, is_unpinned_cursor_model
 
-    Live probe on Windows: turn-1 ``session/prompt`` ~11s, turn-2 on the same
-    process ~2s. Per-turn ``--print`` stays ~10–12s forever — so warm ACP is
-    the daily-driver default. Auth is best-effort (short timeout); a hung
-    authenticate must not block the session.
+
+def cursor_acp_enabled(model: Optional[str] = None) -> bool:
+    """Warm ACP path (default OFF). Set ``HARNESS_CURSOR_ACP=1`` to opt in.
+
+    ACP never pins ``--model`` and never reports served identity, so even
+    when opted in it is only allowed for unpinned models (``auto`` / empty)
+    where substitution is intentional. Explicit picker ids use
+    ``CursorCliDriver --print --model``.
     """
-    raw = (os.environ.get("HARNESS_CURSOR_ACP") or "1").strip().lower()
-    return raw not in ("0", "false", "no", "off")
+    raw = (os.environ.get("HARNESS_CURSOR_ACP") or "").strip().lower()
+    if raw not in ("1", "true", "yes", "on"):
+        return False
+    if model is None:
+        return True
+    return is_unpinned_cursor_model(model)
 
 
 def _normalize_workspace(cwd: Optional[str]) -> Optional[str]:
@@ -1043,6 +1050,7 @@ class CursorAcpDriver:
             raise RuntimeError(self._acp_fail_reason)
         tin = int(out.get("tokens_in") or 0)
         tout = int(out.get("tokens_out") or 0)
+        requested = (self.model or "").strip()
         meta = {
             "tool_calls": [],
             "session_id": out.get("session_id") or "",
@@ -1054,6 +1062,11 @@ class CursorAcpDriver:
             # Plan credits — $ meter is estimate-only unless agent returns cost.
             "billing": "plan",
             "reasoning": str(out.get("reasoning") or ""),
+            "requested_model": requested,
+            # ACP never reports served identity; auto/empty is the only
+            # allowed ACP pin (substitution is intentional).
+            "identity_status": IDENTITY_AUTO,
+            "token_basis": "provider" if (tin or tout) else "unknown",
         }
         cost = out.get("provider_cost_usd")
         if cost is not None:
@@ -1087,7 +1100,7 @@ class CursorAcpDriver:
         on_tool_hint: Callable[[str], None] | None = None,
     ) -> DriverResponse:
         _ = tools
-        if cursor_acp_enabled() and not self._acp_disabled:
+        if cursor_acp_enabled(self.model) and not self._acp_disabled:
             try:
                 return self._run_acp(
                     messages,

--- a/pmharness/drivers/cursor_cli.py
+++ b/pmharness/drivers/cursor_cli.py
@@ -20,6 +20,11 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple
 
 from .base import SYSTEM_PROMPT, DriverResponse
+from .cursor_identity import (
+    IDENTITY_MISMATCH,
+    cursor_identity_mismatch_message,
+    cursor_identity_status,
+)
 
 # CreateProcess cmdline budget is ~32k. We spawn node+index.js directly
 # (no agent.cmd→PowerShell), so short prompts stay on argv. Only spill to a
@@ -1132,6 +1137,17 @@ class CursorCliDriver:
                     f"{detail}"
                 )
 
+            requested = (self.model or "").strip()
+            served = ""
+            raw_served = parsed.get("model")
+            if isinstance(raw_served, str) and raw_served.strip():
+                served = raw_served.strip()
+            identity_status = cursor_identity_status(requested, served)
+            mismatch = cursor_identity_mismatch_message(requested, served)
+            if mismatch and not err:
+                err = mismatch
+                self._clear_native_chat()
+
             native_from_stream = str(parsed.get("session_id") or "").strip()
             if not err and native_from_stream:
                 self._remember_native_chat(
@@ -1144,6 +1160,7 @@ class CursorCliDriver:
                 for tc in (parsed.get("tool_calls") or [])
                 if isinstance(tc, dict)
             ]
+
             meta = {
                 # Critical: Cursor Agent already executed these internally.
                 # Returning them as OpenAI tool_calls makes Marionette try
@@ -1159,12 +1176,17 @@ class CursorCliDriver:
                 "host_tools_ignored": True,
                 "billing": "plan",
                 "reasoning": str(parsed.get("reasoning") or ""),
+                "requested_model": requested,
+                "identity_status": identity_status,
+                "token_basis": (
+                    "provider" if isinstance(usage_blob, dict) and usage_blob
+                    else "unknown"
+                ),
             }
             if provider_cost is not None:
                 meta["provider_cost_usd"] = provider_cost
-            served = parsed.get("model")
-            if isinstance(served, str) and served.strip():
-                meta["served_model"] = served.strip()
+            if served:
+                meta["served_model"] = served
             if isinstance(usage_blob, dict) and usage_blob:
                 meta["raw_usage"] = usage_blob
             # Preserve explicit zeros only when usage actually reports the field.
@@ -1174,12 +1196,18 @@ class CursorCliDriver:
                 meta["cache_write_tokens"] = int(cache_write)
             attach_modality_fields(meta, usage_detail)
 
+            # Verified exact requested model keeps the picker label. A true
+            # mismatch must not stamp that label as the served fact.
+            response_model = self.name
+            if identity_status == IDENTITY_MISMATCH:
+                response_model = served
+
             return DriverResponse(
                 text=parsed.get("text") or "",
                 tokens_in=tokens_in,
                 tokens_out=tokens_out,
                 latency_ms=latency,
-                model=self.name,
+                model=response_model,
                 error=err,
                 meta=meta,
             )

--- a/pmharness/drivers/cursor_identity.py
+++ b/pmharness/drivers/cursor_identity.py
@@ -1,0 +1,174 @@
+"""Cursor CLI requested-vs-served model identity.
+
+The ``--print`` path reports the init ``model`` display label. ACP never
+does. Compare family + effort after stripping Cursor chrome (context
+sizes, ``No Thinking``) so picker receipts cannot stamp a requested id
+as fact when Cursor actually served a different line (Fable vs Luna).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import FrozenSet, Optional, Tuple
+
+UNPINNED_CURSOR_MODELS = frozenset({"", "auto"})
+
+IDENTITY_AUTO = "auto"
+IDENTITY_UNREPORTED = "unreported"
+IDENTITY_VERIFIED = "verified"
+IDENTITY_MISMATCH = "mismatch"
+
+IDENTITY_STATUSES = frozenset({
+    IDENTITY_AUTO,
+    IDENTITY_UNREPORTED,
+    IDENTITY_VERIFIED,
+    IDENTITY_MISMATCH,
+})
+
+_EFFORT = {
+    "high": "high",
+    "medium": "medium",
+    "med": "medium",
+    "low": "low",
+    "xhigh": "xhigh",
+    "extra-high": "xhigh",
+    "extrahigh": "xhigh",
+}
+
+_SPEED = frozenset({"fast", "slow"})
+
+_BRANDS = frozenset({
+    "fable",
+    "luna",
+    "sol",
+    "composer",
+    "grok",
+    "opus",
+    "sonnet",
+    "haiku",
+    "gpt",
+    "claude",
+    "gemini",
+    "codex",
+})
+
+# Distinctive Cursor lines: version display may disagree with the slug
+# (``claude-fable-5-high`` vs ``Claude 4.5 Fable High``) without a swap.
+_VERSIONLESS_LINES = frozenset({"fable", "luna", "sol"})
+
+# Cursor chrome: 200K / 272k context / (200K) / No Thinking / thinking
+_DECORATION_RE = re.compile(
+    r"(?:"
+    r"\d+(?:\.\d+)?\s*k(?:b)?(?:\s*context)?"
+    r"|no\s*thinking"
+    r"|thinking"
+    r"|context"
+    r")",
+    re.IGNORECASE,
+)
+
+_SEP_RE = re.compile(r"[\s_/:+·•,;|()[\]{}]+")
+_NUMERIC_RE = re.compile(r"\d+(?:\.\d+)?")
+
+
+def is_unpinned_cursor_model(model: str) -> bool:
+    """True when the picker left model selection to Cursor (``auto`` / empty)."""
+    return (model or "").strip().lower() in UNPINNED_CURSOR_MODELS
+
+
+def normalize_cursor_model_label(label: str) -> str:
+    """Lowercase hyphen slug with Cursor display chrome removed."""
+    text = (label or "").strip().lower()
+    if not text:
+        return ""
+    text = _DECORATION_RE.sub(" ", text)
+    text = _SEP_RE.sub("-", text)
+    text = re.sub(r"-{2,}", "-", text)
+    return text.strip("-")
+
+
+def _tokens(label: str) -> Tuple[str, ...]:
+    slug = normalize_cursor_model_label(label)
+    if not slug:
+        return ()
+    return tuple(part for part in slug.split("-") if part and part not in _SPEED)
+
+
+def _effort(tokens: Tuple[str, ...]) -> Optional[str]:
+    found = None
+    for tok in tokens:
+        mapped = _EFFORT.get(tok)
+        if mapped:
+            found = mapped
+    return found
+
+
+def _family_tokens(tokens: Tuple[str, ...]) -> FrozenSet[str]:
+    return frozenset(tok for tok in tokens if tok not in _EFFORT)
+
+
+def _brands(tokens: FrozenSet[str]) -> FrozenSet[str]:
+    return tokens & _BRANDS
+
+
+def _numeric(tokens: FrozenSet[str]) -> FrozenSet[str]:
+    return frozenset(tok for tok in tokens if _NUMERIC_RE.fullmatch(tok))
+
+
+def cursor_models_compatible(requested: str, served: str) -> bool:
+    """True when served is the requested family + effort (decorations ignored)."""
+    req = _tokens(requested)
+    srv = _tokens(served)
+    if not req or not srv:
+        return True
+    req_fam = _family_tokens(req)
+    srv_fam = _family_tokens(srv)
+    req_brands = _brands(req_fam)
+    srv_brands = _brands(srv_fam)
+    if req_brands and srv_brands and req_brands.isdisjoint(srv_brands):
+        return False
+    req_effort = _effort(req)
+    srv_effort = _effort(srv)
+    if req_effort and srv_effort and req_effort != srv_effort:
+        return False
+    shared_line = (req_brands & srv_brands) & _VERSIONLESS_LINES
+    if not shared_line:
+        req_nums = _numeric(req_fam)
+        srv_nums = _numeric(srv_fam)
+        if req_nums and srv_nums and req_nums.isdisjoint(srv_nums):
+            return False
+    if not req_brands and not srv_brands:
+        req_slug = "-".join(tok for tok in req if tok not in _EFFORT)
+        srv_slug = "-".join(tok for tok in srv if tok not in _EFFORT)
+        if req_slug == srv_slug:
+            return True
+        return (
+            srv_slug.startswith(req_slug + "-")
+            or req_slug.startswith(srv_slug + "-")
+        )
+    req_core = req_fam - _numeric(req_fam)
+    srv_core = srv_fam - _numeric(srv_fam)
+    if req_core and srv_core:
+        return bool(req_core & srv_core)
+    return True
+
+
+def cursor_identity_status(requested: str, served: str) -> str:
+    """Classify requested vs provider-reported served identity."""
+    if is_unpinned_cursor_model(requested):
+        return IDENTITY_AUTO
+    if not (served or "").strip():
+        return IDENTITY_UNREPORTED
+    if cursor_models_compatible(requested, served):
+        return IDENTITY_VERIFIED
+    return IDENTITY_MISMATCH
+
+
+def cursor_identity_mismatch_message(requested: str, served: str) -> Optional[str]:
+    """Closed-fail text when served is a different family or effort."""
+    if cursor_identity_status(requested, served) != IDENTITY_MISMATCH:
+        return None
+    return (
+        "Cursor served {0!r} instead of requested {1!r} "
+        "(refusing to stamp the picker label as fact)"
+    ).format(served, requested)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.256"
+version = "0.9.257"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [
@@ -19,7 +19,8 @@ harness = "harness.cli:main"
 # editable from the local checkout in dev; not pinned here to avoid coupling
 # the research rig to a PyPI release of an internal tool.
 dev = [
-    "pytest>=7"
+    "pytest>=7",
+    "pytest-xdist>=3.5",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,11 +176,47 @@ def pytest_addoption(parser):
                      help="allow tests marked @pytest.mark.network to use the network")
     parser.addoption("--swarm", action="store_true", default=False,
                      help="run tests marked @pytest.mark.swarm (real Puppetmaster, slow)")
+    parser.addoption(
+        "--resource-soak",
+        action="store_true",
+        default=False,
+        help="run tests marked @pytest.mark.resource_soak (million-token walks)",
+    )
+
+
+def parse_pytest_shard(spec):
+    """Parse ``PYTEST_SHARD=2/4`` into a 1-based (index, total) pair."""
+    raw = (spec or "").strip()
+    if not raw:
+        return None
+    try:
+        idx_s, total_s = raw.split("/", 1)
+        idx = int(idx_s)
+        total = int(total_s)
+    except ValueError:
+        return None
+    if total < 2 or idx < 1 or idx > total:
+        return None
+    return idx, total
+
+
+def select_pytest_shard(items, spec):
+    """Stable interleave so one fat test cannot land with all of its neighbors."""
+    parsed = parse_pytest_shard(spec)
+    if parsed is None:
+        return list(items)
+    idx, total = parsed
+    ordered = sorted(items, key=lambda item: getattr(item, "nodeid", str(item)))
+    return [item for i, item in enumerate(ordered) if i % total == (idx - 1)]
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "network: test requires real network access")
     config.addinivalue_line("markers", "swarm: test drives real Puppetmaster (slow subprocess spawns)")
+    config.addinivalue_line(
+        "markers",
+        "resource_soak: optional FD/RSS cleanup soak (manual/CI opt-in)",
+    )
     config.addinivalue_line(
         "markers",
         "full_auto_safety: offline full-auto safety invariants "
@@ -197,12 +233,24 @@ def pytest_collection_modifyitems(config, items):
         if leaf in _FULL_AUTO_SAFETY_MODULES:
             item.add_marker(safety)
 
-    if config.getoption("--swarm"):
-        return
-    skip = pytest.mark.skip(reason="real-Puppetmaster swarm test; run with --swarm")
-    for item in items:
-        if item.get_closest_marker("swarm"):
-            item.add_marker(skip)
+    if not config.getoption("--swarm"):
+        skip_swarm = pytest.mark.skip(reason="real-Puppetmaster swarm test; run with --swarm")
+        for item in items:
+            if item.get_closest_marker("swarm"):
+                item.add_marker(skip_swarm)
+
+    if not config.getoption("--resource-soak"):
+        skip_soak = pytest.mark.skip(
+            reason="resource soak; run with --resource-soak (tests-full.yml)"
+        )
+        for item in items:
+            if item.get_closest_marker("resource_soak"):
+                item.add_marker(skip_soak)
+
+    shard_spec = os.environ.get("PYTEST_SHARD") or ""
+    selected = select_pytest_shard(items, shard_spec)
+    if selected is not items and len(selected) != len(items):
+        items[:] = selected
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_ci_release_gate.py
+++ b/tests/test_ci_release_gate.py
@@ -187,3 +187,17 @@ def test_tests_yml_windows_runner_is_swappable():
     text = (ROOT / ".github" / "workflows" / "tests.yml").read_text()
     assert "vars.CI_WINDOWS_RUNNER" in text
     assert "windows-latest" in text
+
+
+def test_tests_yml_is_the_fast_dest_into_main_gate():
+    text = (ROOT / ".github" / "workflows" / "tests.yml").read_text()
+    assert "pytest-linux" in text
+    assert "pytest-windows" in text
+    assert "-n 4" in text
+    assert "--dist loadscope" in text
+    assert "PYTEST_SHARD" in text
+    assert "python-version: \"3.9\"" in text
+    assert "macos-latest" not in text
+    full = (ROOT / ".github" / "workflows" / "tests-full.yml").read_text()
+    assert "--resource-soak" in full
+    assert "macos-latest" in full

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -575,6 +575,7 @@ def test_advisory_compact_once_per_user_turn_not_per_tool_step(monkeypatch, tmp_
     assert any(c["force"] for c in compact_calls)
 
 
+@pytest.mark.resource_soak
 def test_million_token_window_keeps_bounded_tail_and_reduces_large_session():
     cfg = HarnessConfig(max_context_tokens=1_048_576)
     session = ConversationalSession(cfg)

--- a/tests/test_context_usage.py
+++ b/tests/test_context_usage.py
@@ -161,6 +161,15 @@ def test_context_usage_limit_follows_live_driver_when_unpinned(monkeypatch):
     monkeypatch.setenv("PMHARNESS_OR_LIVE_WINDOWS", "0")
     import pmharness.registry as reg
     monkeypatch.setattr(reg, "_CW_MEM", None, raising=False)
+    monkeypatch.setattr(
+        "harness.providers.build_pilot",
+        lambda driver: MockPilot(),
+    )
+    monkeypatch.setattr(
+        reg,
+        "context_window",
+        lambda driver, default=200000: 1_000_000 if driver == "glm-5.3" else default,
+    )
     cfg = HarnessConfig(driver="glm-5.3", max_context_tokens=128000)
     cfg.max_context_tokens_pinned = False
     s = ConversationalSession(cfg)

--- a/tests/test_cursor_acp_driver.py
+++ b/tests/test_cursor_acp_driver.py
@@ -170,9 +170,45 @@ class _FakeProc:
 
 def test_cursor_acp_enabled_default(monkeypatch):
     monkeypatch.delenv("HARNESS_CURSOR_ACP", raising=False)
+    assert cursor_acp_enabled() is False
+    assert cursor_acp_enabled("auto") is False
+    monkeypatch.setenv("HARNESS_CURSOR_ACP", "1")
     assert cursor_acp_enabled() is True
+    assert cursor_acp_enabled("auto") is True
+    assert cursor_acp_enabled("") is True
+    assert cursor_acp_enabled("claude-fable-5-high") is False
     monkeypatch.setenv("HARNESS_CURSOR_ACP", "0")
     assert cursor_acp_enabled() is False
+    assert cursor_acp_enabled("auto") is False
+
+
+def test_cursor_acp_refuses_explicit_model_even_when_opted_in(monkeypatch):
+    """Opt-in ACP is only for auto/empty — explicit pins must use --print."""
+    monkeypatch.setenv("HARNESS_CURSOR_ACP", "1")
+    assert cursor_acp_enabled("claude-fable-5-high") is False
+    assert cursor_acp_enabled("gpt-5.6-luna-medium") is False
+    assert cursor_acp_enabled("auto") is True
+
+    class Fallback:
+        def _run_stream(self, *a, **k):
+            from pmharness.drivers.base import DriverResponse
+            return DriverResponse(text="print-path", model="cursor-cli:fable")
+
+    class MustNotPrompt(WarmAcpSession):
+        def prompt(self, *a, **k):
+            raise AssertionError("ACP must not run for explicit picker models")
+
+    drv = CursorAcpDriver(
+        name="cursor-cli:claude-fable-5-high",
+        model="claude-fable-5-high",
+        session=MustNotPrompt(model="claude-fable-5-high", cwd=None),
+        fallback=Fallback(),  # type: ignore[arg-type]
+    )
+    resp = drv.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        on_delta=lambda _t: None,
+    )
+    assert resp.text == "print-path"
 
 
 def test_extract_update_text_chunk():
@@ -284,9 +320,9 @@ def test_driver_falls_back_to_print_when_acp_handshake_fails(monkeypatch):
 
     fb = Fallback()
     drv = CursorAcpDriver(
-        name="cursor-cli:x",
-        model="x",
-        session=BoomSession(model="x", cwd=None),
+        name="cursor-cli:auto",
+        model="auto",
+        session=BoomSession(model="auto", cwd=None),
         fallback=fb,  # type: ignore[arg-type]
     )
     monkeypatch.setenv("HARNESS_CURSOR_ACP", "1")
@@ -304,7 +340,7 @@ def test_driver_uses_acp_when_session_works(monkeypatch):
     proc = _FakeProc()
     transport = AcpTransport(proc)
     session = WarmAcpSession(
-        model="m",
+        model="auto",
         cwd="C:\\ws",
         transport_factory=lambda: transport,
     )
@@ -314,8 +350,8 @@ def test_driver_uses_acp_when_session_works(monkeypatch):
             raise AssertionError("must not fall back")
 
     drv = CursorAcpDriver(
-        name="cursor-cli:m",
-        model="m",
+        name="cursor-cli:auto",
+        model="auto",
         session=session,
         fallback=NoFallback(),  # type: ignore[arg-type]
     )
@@ -328,6 +364,8 @@ def test_driver_uses_acp_when_session_works(monkeypatch):
     assert resp.text == "pong-ok"
     assert resp.meta.get("cursor_acp") is True
     assert resp.meta.get("billing") == "plan"
+    assert resp.meta.get("requested_model") == "auto"
+    assert resp.meta.get("identity_status") == "auto"
     assert resp.meta.get("tool_calls") == []
     assert resp.tokens_in == 120
     assert resp.tokens_out == 8

--- a/tests/test_cursor_cli_driver.py
+++ b/tests/test_cursor_cli_driver.py
@@ -1162,3 +1162,125 @@ def test_driver_meta_preserves_explicit_zero_cache_and_served_model(
     assert "cache_write_tokens" not in resp2.meta
     assert resp2.meta.get("raw_usage") == {"inputTokens": 10, "outputTokens": 1}
     assert resp2.meta.get("served_model") == "composer-2.5-served"
+    assert resp2.meta.get("requested_model") == "composer-2.5"
+    assert resp2.meta.get("identity_status") == "verified"
+    assert resp2.error is None
+    assert resp2.model == "cursor-cli:m"
+
+
+def test_cursor_fable_display_is_compatible():
+    from pmharness.drivers.cursor_identity import cursor_models_compatible
+
+    assert cursor_models_compatible(
+        "claude-fable-5-high",
+        "Claude Fable 5 High (200K)",
+    )
+    assert cursor_models_compatible(
+        "claude-fable-5-high",
+        "Claude Fable 5 High · No Thinking",
+    )
+    assert cursor_models_compatible(
+        "claude-fable-5-high",
+        "claude-fable-5-high",
+    )
+    assert not cursor_models_compatible(
+        "claude-fable-5-high",
+        "claude-fable-5-medium",
+    )
+
+
+def test_cursor_fable_vs_luna_is_incompatible():
+    from pmharness.drivers.cursor_identity import cursor_models_compatible
+
+    assert not cursor_models_compatible(
+        "claude-fable-5-high",
+        "gpt-5.6-luna-medium",
+    )
+    assert not cursor_models_compatible(
+        "claude-fable-5-high",
+        "GPT-5.6 Luna Medium 272K",
+    )
+
+
+def _print_stream(model, usage=None):
+    return "\n".join([
+        json.dumps({
+            "type": "system",
+            "subtype": "init",
+            "session_id": "native-1",
+            "model": model,
+        }),
+        json.dumps({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hi"}],
+            },
+        }),
+        json.dumps({
+            "type": "result",
+            "is_error": False,
+            "result": "hi",
+            "session_id": "native-1",
+            "usage": usage or {"inputTokens": 12, "outputTokens": 3},
+        }),
+        "",
+    ])
+
+
+class _PrintProc:
+    def __init__(self, stream):
+        self.returncode = 0
+        self.stdout = io.StringIO(stream)
+        self.stderr = io.StringIO("")
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        pass
+
+
+def test_print_path_accepts_fable_display_label(monkeypatch, tmp_path):
+    fake_bin = tmp_path / "agent"
+    fake_bin.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(
+        "pmharness.drivers.cursor_cli.subprocess.Popen",
+        lambda *a, **k: _PrintProc(
+            _print_stream("Claude Fable 5 High (200K) No Thinking")
+        ),
+    )
+    d = CursorCliDriver(
+        name="cursor-cli:claude-fable-5-high",
+        model="claude-fable-5-high",
+        agent_binary=str(fake_bin),
+    )
+    resp = d.chat([{"role": "user", "content": "hi"}])
+    assert resp.error is None
+    assert resp.model == "cursor-cli:claude-fable-5-high"
+    assert resp.meta["requested_model"] == "claude-fable-5-high"
+    assert resp.meta["served_model"] == "Claude Fable 5 High (200K) No Thinking"
+    assert resp.meta["identity_status"] == "verified"
+
+
+def test_print_path_fails_closed_on_fable_vs_luna(monkeypatch, tmp_path):
+    fake_bin = tmp_path / "agent"
+    fake_bin.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(
+        "pmharness.drivers.cursor_cli.subprocess.Popen",
+        lambda *a, **k: _PrintProc(_print_stream("gpt-5.6-luna-medium")),
+    )
+    d = CursorCliDriver(
+        name="cursor-cli:claude-fable-5-high",
+        model="claude-fable-5-high",
+        agent_binary=str(fake_bin),
+    )
+    resp = d.chat([{"role": "user", "content": "hi"}])
+    assert resp.error
+    assert "gpt-5.6-luna-medium" in resp.error
+    assert "claude-fable-5-high" in resp.error
+    assert resp.model == "gpt-5.6-luna-medium"
+    assert resp.meta["requested_model"] == "claude-fable-5-high"
+    assert resp.meta["served_model"] == "gpt-5.6-luna-medium"
+    assert resp.meta["identity_status"] == "mismatch"
+    assert d._native_chat_id is None

--- a/tests/test_driver_resolution_fallback.py
+++ b/tests/test_driver_resolution_fallback.py
@@ -100,8 +100,14 @@ def test_curated_enabled_drops_compiled_in_default(monkeypatch):
         "harness.model_visibility.enabled_pilots",
         lambda: ["openrouter:deepseek/deepseek-v4-pro"],
     )
+    enabled_spec = "openrouter:deepseek/deepseek-v4-pro"
+    monkeypatch.setattr(
+        srv,
+        "_driver_provider_available",
+        lambda spec: spec == enabled_spec,
+    )
     srv._resolve_available_driver()
-    assert srv._cfg.driver == "openrouter:deepseek/deepseek-v4-pro"
+    assert srv._cfg.driver == enabled_spec
 
 
 def test_available_pilots_does_not_inject_stale_default(monkeypatch):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -134,12 +134,18 @@ def test_build_pilot_selects_cursor_cli_driver(monkeypatch):
         "harness.cursor_cli_auth.is_authenticated",
         lambda: True,
     )
-    # Default: warm ACP. Opt out with HARNESS_CURSOR_ACP=0 for --print.
+    # Default: --print. ACP is opt-in and only for auto/empty.
     monkeypatch.delenv("HARNESS_CURSOR_ACP", raising=False)
     d = prov.build_pilot("cursor-cli:auto")
-    assert isinstance(d, CursorAcpDriver)
+    assert isinstance(d, CursorCliDriver)
     assert d.model == "auto"
     assert d.supports_streaming is True
+    monkeypatch.setenv("HARNESS_CURSOR_ACP", "1")
+    d_acp = prov.build_pilot("cursor-cli:auto")
+    assert isinstance(d_acp, CursorAcpDriver)
+    d_explicit = prov.build_pilot("cursor-cli:claude-fable-5-high")
+    assert isinstance(d_explicit, CursorCliDriver)
+    assert d_explicit.model == "claude-fable-5-high"
     monkeypatch.setenv("HARNESS_CURSOR_ACP", "0")
     d2 = prov.build_pilot("cursor-cli:auto")
     assert isinstance(d2, CursorCliDriver)

--- a/tests/test_pytest_shard.py
+++ b/tests/test_pytest_shard.py
@@ -1,0 +1,26 @@
+"""Windows dest-into-main shards must interleave stably."""
+from conftest import parse_pytest_shard, select_pytest_shard
+
+
+class _Item:
+    def __init__(self, nodeid):
+        self.nodeid = nodeid
+
+
+def test_parse_pytest_shard_rejects_junk():
+    assert parse_pytest_shard("") is None
+    assert parse_pytest_shard("nope") is None
+    assert parse_pytest_shard("0/4") is None
+    assert parse_pytest_shard("5/4") is None
+    assert parse_pytest_shard("2/4") == (2, 4)
+
+
+def test_select_pytest_shard_interleaves_without_overlap():
+    items = [_Item("tests/test_%02d.py::t" % i) for i in range(8)]
+    parts = [select_pytest_shard(items, "%s/4" % n) for n in (1, 2, 3, 4)]
+    ids = [[item.nodeid for item in part] for part in parts]
+    flat = [nodeid for part in ids for nodeid in part]
+    assert len(flat) == 8
+    assert len(set(flat)) == 8
+    assert ids[0][0].endswith("00.py::t")
+    assert ids[1][0].endswith("01.py::t")

--- a/tests/test_session_naming.py
+++ b/tests/test_session_naming.py
@@ -5,6 +5,7 @@ import urllib.request
 import urllib.error
 import urllib.parse
 import os
+import time
 from http.server import ThreadingHTTPServer
 
 import pytest
@@ -125,7 +126,15 @@ def test_first_message_auto_titles(tmp_path):
             # We don't care if the actual stream fails (e.g. key/preflight issues)
             # because the auto-titling logic runs first
             pass
-            
+
+        # urlopen returns as soon as the SSE headers arrive; the handler updates
+        # the title immediately after those headers on another thread.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if srv._sessions.list()[0]["title"] != "New session":
+                break
+            time.sleep(0.01)
+
         # Check if the title was updated
         get_resp = _get(port, "/api/sessions")
         sessions = json.loads(get_resp.read().decode())

--- a/tests/test_stream_performance_store.py
+++ b/tests/test_stream_performance_store.py
@@ -280,6 +280,60 @@ def test_record_helper_does_not_mutate_resp_meta(tmp_path):
     assert not hasattr(session, "StreamTimingAccumulator")
 
 
+def test_receipt_persists_requested_served_identity_and_tokens(tmp_path):
+    from harness.send_loop_phases import record_provider_stream_receipt
+    from harness.stream_performance_store import sanitize_receipt
+
+    meta = {
+        STREAM_PERFORMANCE_KEY: {PROVIDER_CALL_TOTAL_MS: 8.0},
+        "requested_model": "claude-fable-5-high",
+        "served_model": "Claude Fable 5 High (200K)",
+        "identity_status": "verified",
+        "token_basis": "provider",
+        "cache_read_tokens": 40,
+        "cache_write_tokens": 2,
+        "secret_prompt": "do-not-persist",
+    }
+    resp = DriverResponse(
+        text="ok",
+        tokens_in=120,
+        tokens_out=9,
+        latency_ms=1.0,
+        meta=meta,
+    )
+    session = SimpleNamespace(
+        harness_session_id="sess-id",
+        state_dir=str(tmp_path),
+        config=SimpleNamespace(driver="cursor-cli:claude-fable-5-high"),
+        _current_user_ordinal=lambda: 0,
+    )
+    record_provider_stream_receipt(session, resp, provider_step=1, provider_attempt=0)
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-id")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["requested_model"] == "claude-fable-5-high"
+    assert row["served_model"] == "Claude Fable 5 High (200K)"
+    assert row["identity_status"] == "verified"
+    assert row["tokens_in"] == 120
+    assert row["tokens_out"] == 9
+    assert row["cache_read_tokens"] == 40
+    assert row["cache_write_tokens"] == 2
+    assert row["token_basis"] == "provider"
+    assert "secret_prompt" not in row
+    cleaned = sanitize_receipt({
+        **row,
+        "identity_status": "forged",
+        "token_basis": "invented",
+        "nested": {"leak": 1},
+    })
+    assert cleaned is not None
+    assert "identity_status" not in cleaned
+    assert "token_basis" not in cleaned
+    assert "nested" not in cleaned
+    assert cleaned["requested_model"] == "claude-fable-5-high"
+    assert cleaned["tokens_in"] == 120
+
+
 def test_record_helper_swallows_sink_failure(tmp_path, monkeypatch):
     from harness.send_loop_phases import record_provider_stream_receipt
 

--- a/tests/test_v09216_live_path.py
+++ b/tests/test_v09216_live_path.py
@@ -123,7 +123,7 @@ def test_http_interrupt_empty_busy_turn_has_no_phantom_steer_drop():
 
         def _run_chat():
             try:
-                msg = urllib.parse.quote("audit the repository please")
+                msg = urllib.parse.quote("hello")
                 req = urllib.request.Request(
                     "http://127.0.0.1:%d/api/chat?message=%s" % (port, msg),
                     headers={"X-Harness-Token": srv._TOKEN},

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -71,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.215"
+version = "0.9.257"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },
@@ -81,12 +90,14 @@ dependencies = [
 dev = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "pypdf" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
 ]
 provides-extras = ["dev"]
 
@@ -151,6 +162,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]

--- a/webapp/electron/translucency.cjs
+++ b/webapp/electron/translucency.cjs
@@ -8,10 +8,14 @@
  * full contrast.
  *
  * One lever, 0–100 (0 = off). Main persists ~/.pmharness/translucency.json so
- * a cold launch can apply the backing at BrowserWindow construction. Runtime
- * setBackgroundColor('#00000000') is silently lost on a fresh compositor
- * (measured by Hermes on macOS 26 / Electron 40), so creation must not rely
- * on a post-create fixup.
+ * a cold launch can apply the backing at BrowserWindow construction.
+ *
+ * Marionette ships Electron 33. On darwin the window is born transparent and
+ * vibrancy-backed, then stays that way: CSS paints the opaque theme when glass
+ * is off. `transparent: true` is safe and is what lets WebContents alpha reach
+ * the native material. Do not also stamp backgroundColor '#00000000' at create
+ * or call setBackgroundColor / setVibrancy(null) on that path — those
+ * combinations crash Electron 33 on macOS 26.
  */
 
 const fs = require("node:fs");
@@ -172,14 +176,17 @@ function windowSurfaceOptions(state, opts) {
   const isWindows = platform === "win32";
   const options = {
     opacity: windowOpacityFor(state),
-    ...windowBackingOptions(state, themed),
   };
   if (isMac) {
-    const material = vibrancyFor(state);
-    if (material) {
-      options.vibrancy = material;
-      options.visualEffectState = "active";
-    }
+    // Born transparent + vibrancy-backed so WebContents alpha reaches the
+    // NSVisualEffectView and a live toggle only thins CSS. Electron 33 accepts
+    // this pairing; the crashing combination is vibrancy plus an explicit
+    // transparent backgroundColor (or later setVibrancy(null)).
+    options.transparent = true;
+    options.vibrancy = vibrancyFor(state) || normalizeMaterial(state.material);
+    options.visualEffectState = "active";
+  } else {
+    Object.assign(options, windowBackingOptions(state, themed));
   }
   if (isWindows && glassSupported) {
     // Win11 DWM materials only reach the client area on a transparent window
@@ -196,14 +203,13 @@ function applyWindowTranslucency(win, state, changed, opts) {
   const glassSupported = !!(opts && opts.glassSupported);
   const themed = (opts && opts.themedColor) || THEMED_BACKGROUND;
   const patch = changed || { backing: true, material: true, opacity: true };
-  if (patch.backing && typeof win.setBackgroundColor === "function") {
+  if (patch.backing && typeof win.setBackgroundColor === "function" && platform !== "darwin") {
     win.setBackgroundColor(glassActive(state) ? "#00000000" : themed);
   }
   if (patch.material) {
     if (platform === "darwin" && typeof win.setVibrancy === "function") {
-      const material = vibrancyFor(state);
-      if (material) win.setVibrancy(material, { animationDuration: 150 });
-      else win.setVibrancy(null);
+      const material = vibrancyFor(state) || normalizeMaterial(state.material);
+      win.setVibrancy(material);
     }
     if (
       platform === "win32" &&

--- a/webapp/electron/translucency.test.cjs
+++ b/webapp/electron/translucency.test.cjs
@@ -128,11 +128,12 @@ describe("windowBackingOptions / surfaceOptions", () => {
     });
   });
 
-  it("pins macOS vibrancy and visualEffectState only while glass is live", () => {
+  it("makes macOS WebContents transparent over pinned vibrancy", () => {
     const on = windowSurfaceOptions(glass(60, "popover"), {
       platform: "darwin",
       glassSupported: true,
     });
+    assert.equal(on.transparent, true);
     assert.equal(on.vibrancy, "popover");
     assert.equal(on.visualEffectState, "active");
     assert.equal(on.backgroundColor, undefined);
@@ -141,8 +142,10 @@ describe("windowBackingOptions / surfaceOptions", () => {
       platform: "darwin",
       glassSupported: true,
     });
-    assert.equal(off.vibrancy, undefined);
-    assert.equal(off.backgroundColor, THEMED_BACKGROUND);
+    assert.equal(off.transparent, true);
+    assert.equal(off.vibrancy, "popover");
+    assert.equal(off.visualEffectState, "active");
+    assert.equal(off.backgroundColor, undefined);
   });
 
   it("marks glass-capable Windows windows transparent for DWM", () => {
@@ -176,6 +179,20 @@ describe("translucencyDiff", () => {
 });
 
 describe("applyWindowTranslucency", () => {
+  it("does not restamp a transparent backgroundColor on macOS", () => {
+    const calls = [];
+    const win = {
+      setVibrancy: (material) => calls.push(["vibrancy", material]),
+      setBackgroundColor: (color) => calls.push(["bg", color]),
+      setOpacity: (n) => calls.push(["opacity", n]),
+    };
+    applyWindowTranslucency(win, glass(60, "popover"), { backing: true, material: true }, {
+      platform: "darwin",
+      glassSupported: true,
+    });
+    assert.deepEqual(calls, [["vibrancy", "popover"]]);
+  });
+
   it("sets vibrancy only on a material change", () => {
     const calls = [];
     const win = {
@@ -194,7 +211,7 @@ describe("applyWindowTranslucency", () => {
       platform: "darwin",
       glassSupported: true,
     });
-    assert.deepEqual(calls, [["vibrancy", null]]);
+    assert.deepEqual(calls, [["vibrancy", "popover"]]);
   });
 });
 
@@ -218,6 +235,14 @@ describe("createTranslucencyController", () => {
     assert.equal(second.getState().intensity, ENABLE_INTENSITY);
     assert.equal(second.getState().material, "titlebar");
     assert.equal(second.surfaceOptions().vibrancy, "titlebar");
+    const off = createTranslucencyController({
+      platform: "darwin",
+      release: "25.4.0",
+      homeDir,
+    });
+    off.setState({ intensity: 0, mode: "glass", material: "titlebar" });
+    assert.equal(off.surfaceOptions().vibrancy, "titlebar");
+    assert.equal(off.surfaceOptions().backgroundColor, undefined);
   });
 
   it("reports Linux as unsupported", () => {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.256",
+  "version": "0.9.257",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.256",
+      "version": "0.9.257",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.256",
+  "version": "0.9.257",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/components/WindowGlassSettings.tsx
+++ b/webapp/src/components/WindowGlassSettings.tsx
@@ -2,12 +2,9 @@ import { useEffect, useState } from "react";
 import {
   ENABLE_INTENSITY,
   FROST_LABELS,
-  beginTranslucencyPeek,
   defaultTranslucencyState,
-  endTranslucencyPeek,
   hydrateWindowGlass,
   loadTranslucencyCapabilities,
-  pulseTranslucencyPeek,
   resetTranslucencyPeek,
   setWindowGlass,
   type GlassMaterial,
@@ -46,7 +43,6 @@ export default function WindowGlassSettings() {
             mode: "glass",
             intensity: on ? 0 : Math.max(state.intensity, ENABLE_INTENSITY),
           });
-          pulseTranslucencyPeek();
         }}
         className={`w-full flex items-center justify-between px-3 py-2 rounded border transition text-left ${
           on ? "bg-accent/10 border-accent/30 text-accent" : "bg-panel2 border-edge text-muted"
@@ -65,9 +61,6 @@ export default function WindowGlassSettings() {
               max={100}
               value={state.intensity}
               aria-label="Glass tint"
-              onPointerDown={() => beginTranslucencyPeek()}
-              onPointerUp={() => endTranslucencyPeek()}
-              onPointerCancel={() => endTranslucencyPeek()}
               onChange={(e) => {
                 void commit({ intensity: Number(e.target.value) });
               }}
@@ -85,7 +78,6 @@ export default function WindowGlassSettings() {
                   type="button"
                   onClick={() => {
                     void commit({ material: material as GlassMaterial });
-                    pulseTranslucencyPeek();
                   }}
                   className={`px-2 py-1 rounded border text-[10px] uppercase tracking-wider font-semibold transition ${
                     active

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -81,16 +81,15 @@ body {
 :root[data-marionette-glass] {
   background-color: transparent !important;
   --shell-chrome: transparent;
-  --shell-chat: transparent;
+  /* Keep every shell surface on one glass curve. Panels retain their borders
+     and slightly lighter base, but no longer become opaque islands. */
+  --shell-chat: color-mix(in srgb, #0f1113 var(--translucency-glass-keep, 80%), transparent);
+  --shell-panel: color-mix(in srgb, #13161a var(--translucency-glass-keep, 80%), transparent);
+  --shell-panel-border: rgba(255, 255, 255, 0.08);
 }
 
 :root[data-marionette-glass] body {
   background: color-mix(in srgb, #0f1113 var(--translucency-glass-keep, 100%), transparent);
-}
-
-:root[data-marionette-glass-peek] [data-testid="settings-shell"] {
-  background: color-mix(in srgb, #0f1113 22%, transparent) !important;
-  opacity: 0.22;
 }
 
 /* Side rails + footer sit "within" the window: rounded, lightly bordered,


### PR DESCRIPTION
## Summary
- cut the fast release gate to Linux xdist, four Windows shards, and frontend validation while retaining the full nightly/manual matrix
- verify Cursor CLI requested-versus-served model identity and persist provider token/cache receipts
- restore crash-safe macOS glass and apply one tint curve across chat and side panels

## Test plan
- [x] `uv run --extra dev python -m pytest -q -n 4 --dist loadscope` (4,628 passed, 76 skipped)
- [x] `npm test` (1,096 passed)
- [x] `npm run test:electron` (183 passed)
- [x] `npm run build`
- [ ] GitHub `tests` release matrix