### PR TITLE
absorb #78: one truthful Economics surface

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -444,7 +444,8 @@ export default function App() {
       <div className="shrink-0 px-px py-px">
         <StatusBar config={config} update={availableUpdate}
           leftOpen={leftOpen} rightOpen={rightOpen}
-          onToggleLeft={() => setLeftOpen((v) => !v)} onToggleRight={() => setRightOpen((v) => !v)} />
+          onToggleLeft={() => setLeftOpen((v) => !v)} onToggleRight={() => setRightOpen((v) => !v)}
+          onOpenEconomics={() => openRightTo("economics")} />
       </div>
 
       {showWizard && <RegistryWizard onClose={() => { localStorage.setItem("pmharness.wizardSeen", "1"); setShowWizard(false); }} />}

--- a/webapp/src/__tests__/CostBreakdown.test.tsx
+++ b/webapp/src/__tests__/CostBreakdown.test.tsx
@@ -5,7 +5,9 @@ import CostBreakdown, {
   compactionAdvicePresentation,
   delegationSavingsCredited,
   formatCacheHitPercent,
+  listPriceValueHeading,
   listPriceValueTotal,
+  listPriceValueWeakestBasis,
   routingSavingsCredited,
   shortPilotModel,
   spendIsEstimated,
@@ -102,7 +104,9 @@ describe("CostBreakdown", () => {
   it("renders the session cost fields it is given", () => {
     render(<CostBreakdown data={baseData} />);
 
-    expect(screen.getByText("Session cost")).toBeInTheDocument();
+    expect(screen.getByText("This app run")).toBeInTheDocument();
+    expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+    expect(screen.getByText(/Resets on full quit/i)).toBeInTheDocument();
     expect(screen.getByText("Estimated spend")).toBeInTheDocument();
     expect(screen.getByText("~$0.04")).toBeInTheDocument();
     expect(screen.getByText("Prompt-cache value")).toBeInTheDocument();
@@ -139,13 +143,55 @@ describe("CostBreakdown", () => {
       tool_output_savings_usd: 0.76,
     };
     expect(listPriceValueTotal(data)).toBeCloseTo(4.58, 8);
+    expect(listPriceValueWeakestBasis(data)).toBe("estimated");
     render(<CostBreakdown data={data} />);
-    const totalRow = screen.getByText("Total value saved").closest("div");
+    const totalRow = screen.getByText("List-price value (est.)").closest("div");
     expect(within(totalRow!).getByText("~$4.58")).toBeInTheDocument();
     expect(totalRow).toHaveAttribute(
       "title",
       expect.stringMatching(/not a cash refund/i),
     );
+    expect(screen.queryByText("Total value saved")).not.toBeInTheDocument();
+    expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+  });
+
+  it("labels the combined list-price total with the weakest included basis", () => {
+    const estimated: CostBreakdownData = {
+      tokens_used: 1000,
+      est_cost_usd: 0.10,
+      cache_savings_usd: 0.20,
+      cache_savings_basis: "catalog",
+      routing_saved_usd: 0.40,
+      routing_savings_basis: "estimated",
+    };
+    expect(listPriceValueWeakestBasis(estimated)).toBe("estimated");
+    expect(listPriceValueHeading("estimated")).toBe("List-price value (est.)");
+    const { rerender } = render(<CostBreakdown data={estimated} />);
+    expect(screen.getByText("List-price value (est.)")).toBeInTheDocument();
+
+    const partial: CostBreakdownData = {
+      tokens_used: 1000,
+      est_cost_usd: 0.10,
+      cache_saved_usd_swarm: 0.22,
+      swarm_cache_savings_basis: "unknown",
+      swarm_cache_unpriced_tokens: 12_500,
+    };
+    expect(listPriceValueWeakestBasis(partial)).toBe("partial");
+    rerender(<CostBreakdown data={partial} />);
+    expect(screen.getByText("List-price value (partial)")).toBeInTheDocument();
+
+    const unknown: CostBreakdownData = {
+      tokens_used: 1000,
+      est_cost_usd: 0.01,
+      routing_saved_usd: 1.25,
+      routing_savings_basis: "unknown",
+    };
+    expect(listPriceValueTotal(unknown)).toBe(0);
+    expect(listPriceValueWeakestBasis(unknown)).toBeNull();
+    rerender(<CostBreakdown data={unknown} />);
+    expect(screen.getByText("unknown basis")).toBeInTheDocument();
+    expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
+    expect(screen.queryByText("List-price value")).not.toBeInTheDocument();
   });
 
   it("labels swarm cache value as partial when some tokens are unpriced", () => {
@@ -578,7 +624,7 @@ describe("CostBreakdown", () => {
     );
     expect(screen.getByText("Standing context floor (est.)")).toBeInTheDocument();
     expect(screen.getByText("Prompt-cache TTL (est.)")).toBeInTheDocument();
-    expect(screen.getByText(/warm/)).toBeInTheDocument();
+    expect(screen.getByText(/warm ·/)).toBeInTheDocument();
   });
 
   it("hides standing economics when flag-off omits fields", () => {

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -1,0 +1,87 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import EconomicsPane from "../components/EconomicsPane";
+import { api } from "../lib/api";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    getUsage: vi.fn(),
+    compactSession: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/usePolling", () => ({
+  usePolling: (fn: () => unknown) => {
+    void fn();
+  },
+}));
+
+const mockGetUsage = vi.mocked(api.getUsage);
+
+describe("EconomicsPane", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows spend and list-price value from getUsage", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: {
+        tokens_used: 8000,
+        est_cost_usd: 0.12,
+        driver: "anthropic:claude-sonnet",
+        price_in: 3,
+        price_out: 15,
+        cache_savings_usd: 0.04,
+        tool_output_savings_usd: 0.02,
+      },
+      jobs: [],
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("This app run")).toBeInTheDocument();
+    expect(screen.getByText("Estimated spend")).toBeInTheDocument();
+    expect(screen.getByText("~$0.12")).toBeInTheDocument();
+    expect(screen.getByText("Prompt-cache value")).toBeInTheDocument();
+    expect(screen.getByText("List-price value (est.)")).toBeInTheDocument();
+    expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+  });
+
+  it("refetches on harness-usage-refresh", async () => {
+    mockGetUsage
+      .mockResolvedValueOnce({
+        session: {
+          tokens_used: 1000,
+          est_cost_usd: 0.05,
+          driver: "anthropic:claude-sonnet",
+          price_in: 3,
+          price_out: 15,
+        },
+        jobs: [],
+      })
+      .mockResolvedValue({
+        session: {
+          tokens_used: 4000,
+          est_cost_usd: 0.22,
+          driver: "anthropic:claude-sonnet",
+          price_in: 3,
+          price_out: 15,
+          cache_savings_usd: 0.10,
+        },
+        jobs: [],
+      });
+
+    render(<EconomicsPane />);
+    expect(await screen.findByText("~$0.05")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new Event("harness-usage-refresh"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("~$0.22")).toBeInTheDocument();
+    });
+    expect(screen.getByText("List-price value")).toBeInTheDocument();
+    expect(mockGetUsage.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/webapp/src/__tests__/RightPane.collapse.test.tsx
+++ b/webapp/src/__tests__/RightPane.collapse.test.tsx
@@ -42,6 +42,9 @@ vi.mock("../components/DiffReviewPane", () => ({
       : <div data-testid="diff-review-pane" />,
 }));
 vi.mock("../components/SwarmPane", () => ({ default: () => <div /> }));
+vi.mock("../components/EconomicsPane", () => ({
+  default: () => <div data-testid="economics-pane" />,
+}));
 vi.mock("../components/ErrorBoundary", () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -656,6 +659,16 @@ describe("RightPane add-panel menu", () => {
     localStorage.setItem("pmharness.tabOrder.mcpMerged", "1");
   });
 
+  it("opens the Economics panel from harness-focus-tab", async () => {
+    render(<RightPane {...baseProps} />);
+    expect(screen.queryByRole("region", { name: "Economics panel" })).toBeNull();
+
+    window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: "economics" }));
+
+    expect(await screen.findByRole("region", { name: "Economics panel" })).toBeInTheDocument();
+    expect(screen.getByTestId("economics-pane")).toBeInTheDocument();
+  });
+
   it("adds a closed panel from the menu without an optional-panels gate", () => {
     const onOpenTab = (tab: string) => {
       window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: tab }));
@@ -665,6 +678,7 @@ describe("RightPane add-panel menu", () => {
     expect(screen.queryByRole("region", { name: "Worktrees panel" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Add panel" }));
     expect(screen.getByRole("menu", { name: "Add panel" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Economics" })).toBeInTheDocument();
     expect(screen.queryByText("Optional panels")).toBeNull();
     expect(screen.queryByRole("checkbox", { name: "Worktrees" })).toBeNull();
 

--- a/webapp/src/__tests__/StatusBar.test.tsx
+++ b/webapp/src/__tests__/StatusBar.test.tsx
@@ -44,6 +44,7 @@ const statusBarProps = {
   rightOpen: false,
   onToggleLeft: vi.fn(),
   onToggleRight: vi.fn(),
+  onOpenEconomics: vi.fn(),
 };
 
 function AppUpdateChromeHarness() {
@@ -196,8 +197,8 @@ describe("StatusBar usage pills", () => {
 
     render(<StatusBar {...statusBarProps} />);
 
-    const saved = await screen.findByText("~$0.05 saved");
-    expect(saved.closest("span")).toHaveAttribute(
+    const saved = await screen.findByRole("button", { name: /~\$0\.05 saved/ });
+    expect(saved).toHaveAttribute(
       "title",
       expect.stringMatching(/8k tokens unpriced/i),
     );
@@ -240,6 +241,32 @@ describe("StatusBar usage pills", () => {
     await waitFor(() => {
       expect(screen.getByText("~$0.05")).toBeInTheDocument();
     });
+  });
+
+  it("opens Economics from both the spend and savings pills", async () => {
+    const onOpenEconomics = vi.fn();
+    mockGetUsage.mockResolvedValue({
+      session: {
+        tokens_used: 8000,
+        est_cost_usd: 0.12,
+        driver: "anthropic:claude-sonnet",
+        price_in: 3,
+        price_out: 15,
+        tokens_cached: 2000,
+        cache_savings_usd: 0.04,
+        tool_output_savings_usd: 0.02,
+      },
+      jobs: [],
+    });
+
+    render(<StatusBar {...statusBarProps} onOpenEconomics={onOpenEconomics} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "~$0.12" }));
+    expect(onOpenEconomics).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "$0.06 saved" }));
+    expect(onOpenEconomics).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+    expect(screen.queryByText(/click for the full cost breakdown/i)).not.toBeInTheDocument();
   });
 
   it("labels process-wide spend to distinguish from Swarm pane session spend", async () => {

--- a/webapp/src/__tests__/rightPaneTabVisibility.test.ts
+++ b/webapp/src/__tests__/rightPaneTabVisibility.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_RIGHT_PANE_TAB_VISIBILITY,
   loadRightPaneTabVisibility,
   normalizeRightPaneTabVisibility,
+  RIGHT_PANE_OPTIONAL_TAB_IDS,
   RIGHT_PANE_TAB_VISIBILITY_KEY,
   saveRightPaneTabVisibility,
   toggleRightPaneTabVisibility,
@@ -15,6 +16,7 @@ describe("rightPaneTabVisibility", () => {
     expect(DEFAULT_RIGHT_PANE_TAB_VISIBILITY).toMatchObject({
       state: true,
       swarm: true,
+      economics: true,
       files: true,
       git: true,
       terminal: true,
@@ -25,6 +27,7 @@ describe("rightPaneTabVisibility", () => {
       checkpoints: false,
     });
     expect(loadRightPaneTabVisibility()).toEqual(DEFAULT_RIGHT_PANE_TAB_VISIBILITY);
+    expect(RIGHT_PANE_OPTIONAL_TAB_IDS).not.toContain("economics");
   });
 
   it("persists optional tab choices under the versioned key", () => {

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -1,4 +1,4 @@
-// CostBreakdown -- a compact, presentational cost popover for the StatusBar.
+// CostBreakdown -- the Economics pane body (process / this-app-run meters).
 //
 // It turns Marionette's per-task model routing into a visible value prop:
 // "why this model / what it saved". It consumes ONLY fields already served by
@@ -7,7 +7,7 @@
 // absent or zero simply renders nothing rather than "$0.000000" noise or NaN.
 
 import { useState } from "react";
-import { api } from "../lib/api";
+import { api, type UsageData } from "../lib/api";
 
 export type CostBreakdownData = {
   tokens_used: number;
@@ -90,6 +90,68 @@ export type CostBreakdownData = {
     tokens_cached?: number;
   }>;
 };
+
+/** Map GET /api/usage session meters into the Economics panel body. */
+export function usageToCostBreakdownData(
+  session: UsageData["session"],
+): CostBreakdownData {
+  return {
+    tokens_used: session.tokens_used,
+    est_cost_usd: session.est_cost_usd,
+    cost_source: session.cost_source,
+    price_source: session.price_source,
+    estimated: session.estimated,
+    tokens_cached: session.tokens_cached,
+    pilot_input_tokens: session.pilot_input_tokens,
+    pilot_cache_read_tokens: session.pilot_cache_read_tokens,
+    pilot_cache_hit_ratio: session.pilot_cache_hit_ratio,
+    swarm_input_tokens: session.swarm_input_tokens,
+    swarm_cache_read_tokens: session.swarm_cache_read_tokens,
+    swarm_cache_hit_ratio: session.swarm_cache_hit_ratio,
+    prompt_input_tokens: session.prompt_input_tokens,
+    prompt_cache_read_tokens: session.prompt_cache_read_tokens,
+    prompt_cache_hit_ratio: session.prompt_cache_hit_ratio,
+    cache_savings_usd: session.cache_savings_usd,
+    cache_savings_gross_usd: session.cache_savings_gross_usd,
+    cache_savings_basis: session.cache_savings_basis,
+    routing_saved_usd: session.routing_saved_usd,
+    routing_savings_basis: session.routing_savings_basis,
+    routing_tokens_compared: session.routing_tokens_compared,
+    delegation_saved_usd: session.delegation_saved_usd,
+    delegation_savings_basis: session.delegation_savings_basis,
+    delegation_tokens_compared: session.delegation_tokens_compared,
+    cache_saved_usd_swarm: session.cache_saved_usd_swarm,
+    swarm_cache_savings_basis: session.swarm_cache_savings_basis,
+    swarm_cache_unpriced_tokens: session.swarm_cache_unpriced_tokens,
+    tool_output_tokens_saved: session.tool_output_tokens_saved,
+    tool_output_savings_usd: session.tool_output_savings_usd,
+    history_compactions: session.history_compactions,
+    history_tokens_saved: session.history_tokens_saved,
+    history_cache_bust_tokens: session.history_cache_bust_tokens,
+    history_thrash_events: session.history_thrash_events,
+    history_compaction_cost_usd: session.history_compaction_cost_usd,
+    spill_count: session.spill_count,
+    spill_chars: session.spill_chars,
+    evals_recorded: session.evals_recorded,
+    evals_failed: session.evals_failed,
+    memory_layers: session.memory_layers,
+    compaction_advice: session.compaction_advice,
+    history_compaction_ran: session.history_compaction_ran,
+    standing_economics_basis: session.standing_economics_basis,
+    standing_system_tokens: session.standing_system_tokens,
+    standing_tool_tokens: session.standing_tool_tokens,
+    standing_floor_tokens: session.standing_floor_tokens,
+    standing_floor_cost_usd: session.standing_floor_cost_usd,
+    standing_floor_cost_cached_usd: session.standing_floor_cost_cached_usd,
+    prompt_cache_ttl_ms: session.prompt_cache_ttl_ms,
+    prompt_cache_age_ms: session.prompt_cache_age_ms,
+    prompt_cache_expires_in_ms: session.prompt_cache_expires_in_ms,
+    prompt_cache_state: session.prompt_cache_state,
+    price_in: session.price_in,
+    price_out: session.price_out,
+    pilot_by_model: session.pilot_by_model,
+  };
+}
 
 /** Credit routing USD only when basis is actual or estimated — never unknown. */
 export function routingSavingsCredited(
@@ -269,6 +331,112 @@ export function listPriceValueTotal(
   );
 }
 
+export type ListPriceEvidenceBasis = "measured" | "estimated" | "partial" | "unknown";
+
+const EVIDENCE_RANK: Record<ListPriceEvidenceBasis, number> = {
+  measured: 0,
+  estimated: 1,
+  partial: 2,
+  unknown: 3,
+};
+
+function weakerEvidence(
+  current: ListPriceEvidenceBasis | null,
+  next: ListPriceEvidenceBasis,
+): ListPriceEvidenceBasis {
+  if (!current) return next;
+  return EVIDENCE_RANK[next] > EVIDENCE_RANK[current] ? next : current;
+}
+
+/** Weakest evidence basis among lines credited into listPriceValueTotal.
+ *
+ * Unknown / partial / estimated beat measured. Does not change the dollar math.
+ */
+export function listPriceValueWeakestBasis(
+  data: Pick<
+    CostBreakdownData,
+    | "cache_savings_gross_usd"
+    | "cache_savings_usd"
+    | "cache_savings_basis"
+    | "cache_saved_usd_swarm"
+    | "swarm_cache_savings_basis"
+    | "swarm_cache_unpriced_tokens"
+    | "delegation_saved_usd"
+    | "delegation_savings_basis"
+    | "routing_saved_usd"
+    | "routing_savings_basis"
+    | "tool_output_savings_usd"
+  >,
+): ListPriceEvidenceBasis | null {
+  const positive = (value: unknown) =>
+    typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+  const pilotCache =
+    typeof data.cache_savings_gross_usd === "number" &&
+    Number.isFinite(data.cache_savings_gross_usd)
+      ? positive(data.cache_savings_gross_usd)
+      : positive(data.cache_savings_usd);
+  const swarm = positive(data.cache_saved_usd_swarm);
+  const delegationMeasured = data.delegation_savings_basis === "actual_usage";
+  const delegation = delegationSavingsCredited(
+    data.delegation_savings_basis,
+    data.delegation_saved_usd,
+  );
+  const routing = routingSavingsCredited(
+    data.routing_savings_basis,
+    data.routing_saved_usd,
+  );
+  const modelSelection = delegationMeasured
+    ? delegation
+    : (delegation > 0 ? delegation : routing);
+  const compact = positive(data.tool_output_savings_usd);
+
+  let weakest: ListPriceEvidenceBasis | null = null;
+  if (pilotCache > 0) {
+    weakest = weakerEvidence(
+      weakest,
+      data.cache_savings_basis === "unknown"
+        ? "unknown"
+        : data.cache_savings_basis === "capped"
+          ? "estimated"
+          : "measured",
+    );
+  }
+  if (swarm > 0) {
+    const unpriced =
+      typeof data.swarm_cache_unpriced_tokens === "number"
+      && Number.isFinite(data.swarm_cache_unpriced_tokens)
+      && data.swarm_cache_unpriced_tokens > 0;
+    weakest = weakerEvidence(
+      weakest,
+      data.swarm_cache_savings_basis === "unknown" || unpriced
+        ? "partial"
+        : data.swarm_cache_savings_basis === "estimated"
+          ? "estimated"
+          : "measured",
+    );
+  }
+  if (modelSelection > 0) {
+    const modelBasis: ListPriceEvidenceBasis =
+      delegationMeasured || (delegation > 0 && data.delegation_savings_basis !== "estimated")
+        ? "measured"
+        : data.routing_savings_basis === "estimated" || data.routing_savings_basis == null
+          ? "estimated"
+          : "measured";
+    weakest = weakerEvidence(weakest, modelBasis);
+  }
+  if (compact > 0) weakest = weakerEvidence(weakest, "estimated");
+  return weakest;
+}
+
+export function listPriceValueHeading(
+  basis: ListPriceEvidenceBasis | null,
+): string {
+  if (basis === "unknown") return "List-price value (unknown basis)";
+  if (basis === "partial") return "List-price value (partial)";
+  if (basis === "estimated") return "List-price value (est.)";
+  return "List-price value";
+}
+
 function fmtDurationMs(ms: number): string {
   if (ms > 0 && ms < 60_000) return "<1m";
   const mins = Math.max(0, Math.round(ms / 60_000));
@@ -407,6 +575,8 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       ? data.tool_output_savings_usd
       : 0;
   const valueTotal = listPriceValueTotal(data);
+  const valueBasis = listPriceValueWeakestBasis(data);
+  const valueHeading = listPriceValueHeading(valueBasis);
   const compactTokens =
     typeof data.tool_output_tokens_saved === "number" && isFinite(data.tool_output_tokens_saved) && data.tool_output_tokens_saved > 0
       ? data.tool_output_tokens_saved
@@ -508,6 +678,14 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
           (data.history_compaction_ran ? "history compaction ran under context pressure" : ""))
       : "";
   const adviceCopy = compactionAdvicePresentation(compactionAdviceLevel);
+  const showContextHealth =
+    historyCompactions > 0
+    || standingFloorCost > 0
+    || (cacheTtlMs > 0 && Boolean(cacheState))
+    || spillCount > 0
+    || evalsRecorded > 0
+    || l1Bytes > 0
+    || showCompactionAdvice;
 
   const layerLabel = (id: string) => {
     const layer = data.memory_layers?.[id];
@@ -555,10 +733,13 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
   };
 
   return (
-    <div className="w-[260px] rounded-md border border-edge bg-panel shadow-lg p-3 text-[11px] text-txt">
-      <div className="text-[10px] uppercase tracking-wide text-faint mb-2">Session cost</div>
+    <div className="w-full min-h-0 overflow-auto px-3 py-3 text-[11px] text-txt">
+      <div className="text-[10px] uppercase tracking-wide text-faint">This app run</div>
+      <p className="text-[10px] text-muted mb-2 leading-snug">
+        Process spend since launch. Resets on full quit — not Swarm pane repo-session spend, not conversation lifetime.
+      </p>
 
-      {/* (a) Session spend. Provider-billed when OpenRouter (etc.) returned usage.cost. */}
+      {/* (a) App-run spend. Provider-billed when OpenRouter (etc.) returned usage.cost. */}
       {est > 0 ? (
         <div className="flex items-center justify-between mb-1">
           <span className="text-muted">{spendLabel}</span>
@@ -666,13 +847,15 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
         </div>
       ) : null}
 
-      {valueTotal > 0 ? (
+      {valueTotal > 0 || valueBasis === "unknown" ? (
         <div
           className="mt-1.5 pt-1.5 border-t border-edge/50 flex items-center justify-between font-medium"
-          title="Prompt-cache value + model-selection value + compact-output value. Additive list-price value, not a cash refund or billed-spend subtraction."
+          title="Prompt-cache value + model-selection value + compact-output value. Additive list-price value, not a cash refund or billed-spend subtraction. Label follows the weakest included evidence basis."
         >
-          <span className="text-txt">Total value saved</span>
-          <span className="text-good tabular-nums">~{fmtCost(valueTotal)}</span>
+          <span className="text-txt">{valueHeading}</span>
+          <span className="text-good tabular-nums">
+            {valueTotal > 0 ? `~${fmtCost(valueTotal)}` : (valueBasis === "unknown" ? "unknown basis" : "—")}
+          </span>
         </div>
       ) : null}
 
@@ -683,6 +866,9 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
         </div>
       ) : null}
 
+      {showContextHealth ? (
+      <div className="mt-3 pt-2 border-t border-edge/60">
+        <div className="text-[10px] uppercase tracking-wide text-faint mb-2">Context health</div>
       {historyCompactions > 0 ? (
         <div
           className="flex items-center justify-between mb-1 text-faint"
@@ -701,7 +887,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       {standingFloorCost > 0 ? (
         <div
           className="flex items-center justify-between mb-1 text-faint"
-          title="Estimated per-turn cost of the standing system+tools prefix at current list rates. Not billed spend and not part of Total value saved."
+          title="Estimated per-turn cost of the standing system+tools prefix at current list rates. Not billed spend and not part of list-price value."
         >
           <span>Standing context floor (est.)</span>
           <span className="tabular-nums">
@@ -788,6 +974,8 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
               : adviceCopy.message}
           </p>
         </div>
+      ) : null}
+      </div>
       ) : null}
 
       {/* (c) Additive value framing — routing list-price + cache + compact

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { api, type UsageData } from "../lib/api";
+import { usePolling } from "../lib/usePolling";
+import CostBreakdown, { usageToCostBreakdownData } from "./CostBreakdown";
+
+/** Right-pane Economics card: live process / this-app-run spend and list-price value. */
+export default function EconomicsPane() {
+  const [session, setSession] = useState<UsageData["session"] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadUsage = () =>
+    api.getUsage()
+      .then((data) => {
+        if (data?.session) {
+          setSession(data.session);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to load usage in EconomicsPane", err);
+        setError("Couldn't load this app run's spend.");
+      });
+
+  usePolling(loadUsage, 10000);
+
+  useEffect(() => {
+    const onRefresh = () => { void loadUsage(); };
+    window.addEventListener("harness-usage-refresh", onRefresh);
+    window.addEventListener("harness-session-changed", onRefresh);
+    return () => {
+      window.removeEventListener("harness-usage-refresh", onRefresh);
+      window.removeEventListener("harness-session-changed", onRefresh);
+    };
+  }, []);
+
+  if (!session && error) {
+    return <p className="px-3 py-3 text-[11px] text-muted">{error}</p>;
+  }
+  if (!session) {
+    return <p className="px-3 py-3 text-[11px] text-muted">Loading this app run…</p>;
+  }
+  return <CostBreakdown data={usageToCostBreakdownData(session)} />;
+}

--- a/webapp/src/components/RightDock.tsx
+++ b/webapp/src/components/RightDock.tsx
@@ -7,6 +7,7 @@ import {
   GitPullRequest,
   Globe,
   History,
+  Coins,
   Network,
   PanelRight,
   PanelRightClose,
@@ -56,6 +57,7 @@ const DOCK_LINKS: { id: string; tab: string; icon: ReactNode; title: string }[] 
 const PANEL_OPTIONS = [
   { tab: "state", label: "State", icon: <Database size={12} /> },
   { tab: "swarm", label: "Swarm", icon: <Network size={12} /> },
+  { tab: "economics", label: "Economics", icon: <Coins size={12} /> },
   { tab: "files", label: "Files", icon: <FolderTree size={12} /> },
   { tab: "git", label: "Git", icon: <GitBranch size={12} /> },
   { tab: "worktrees", label: "Worktrees", icon: <GitFork size={12} /> },
@@ -194,10 +196,13 @@ export default function RightDock({
           {addMenuOpen && (
             <div key={menuVersion} role="menu" aria-label="Add panel" className="right-pane-add-menu right-[calc(100%+8px)] left-auto top-0">
               <div className="px-2 py-1 text-[9px] uppercase tracking-wider text-faint">Add panel</div>
-              {(readStoredList("pmharness.tabOrder").length > 0
-                ? readStoredList("pmharness.tabOrder")
-                : PANEL_OPTIONS.map(option => option.tab)
-              ).filter(tab => tab !== "settings").map(tab => {
+              {(() => {
+                const stored = readStoredList("pmharness.tabOrder");
+                const fallback = PANEL_OPTIONS.map(option => option.tab);
+                return stored.length > 0
+                  ? [...stored, ...fallback.filter(tab => !stored.includes(tab))]
+                  : fallback;
+              })().filter(tab => tab !== "settings").map(tab => {
                 const option = PANEL_OPTIONS.find(item => item.tab === tab);
                 if (!option || readStoredList("pmharness.board.openCards").includes(tab)) return null;
                 return (

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -10,6 +10,7 @@ import TerminalPane from "./TerminalPane";
 import CheckpointsPane from "./CheckpointsPane";
 import DiffReviewPane from "./DiffReviewPane";
 import SwarmPane from "./SwarmPane";
+import EconomicsPane from "./EconomicsPane";
 import ErrorBoundary from "./ErrorBoundary";
 import { api, type PendingReview } from "../lib/api";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
@@ -59,7 +60,7 @@ import {
   stackRowTemplateN,
 } from "../lib/stackSplit";
 
-type Tab = "state" | "files" | "git" | "worktrees" | "terminal" | "browser" | "settings" | "checkpoints" | "review" | "swarm";
+type Tab = "state" | "files" | "git" | "worktrees" | "terminal" | "browser" | "settings" | "checkpoints" | "review" | "swarm" | "economics";
 
 const TAB_CONFIG: Record<Tab, { label: string }> = {
   state: { label: "State" },
@@ -72,10 +73,11 @@ const TAB_CONFIG: Record<Tab, { label: string }> = {
   checkpoints: { label: "History" },
   review: { label: "Review" },
   swarm: { label: "Swarm" },
+  economics: { label: "Economics" },
 };
 
 const TAB_GROUPS: { group: string; tabs: Tab[] }[] = [
-  { group: "workspace", tabs: ["state", "swarm", "files", "git", "worktrees", "terminal"] },
+  { group: "workspace", tabs: ["state", "swarm", "economics", "files", "git", "worktrees", "terminal"] },
   { group: "changes", tabs: ["review", "checkpoints"] },
   { group: "tools", tabs: ["browser"] },
 ];
@@ -570,7 +572,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
           return;
         }
         const targetTab = e.detail as Tab;
-        const validTabs: Tab[] = ["state", "files", "git", "worktrees", "terminal", "browser", "settings", "swarm", "checkpoints", "review"];
+        const validTabs: Tab[] = ["state", "files", "git", "worktrees", "terminal", "browser", "settings", "swarm", "economics", "checkpoints", "review"];
         if (validTabs.includes(targetTab)) {
           if (targetTab === "settings") {
             openSettings();
@@ -608,6 +610,8 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
         return <CheckpointsPane />;
       case "swarm":
         return <SwarmPane />;
+      case "economics":
+        return <EconomicsPane />;
       case "review":
         return (
           <DiffReviewPane

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -2384,11 +2384,19 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
             <div className="space-y-2.5 bg-panel2 border border-edge/50 rounded p-2.5">
               <div className="space-y-1">
                 <div className="flex items-center justify-between text-[11px]">
-                  <span className="text-faint">Session Tokens:</span>
+                  <span className="text-faint">This app run tokens:</span>
                   <span className="text-txt font-mono font-medium">{usage.session.tokens_used.toLocaleString()}</span>
                 </div>
                 <div className="flex items-center justify-between text-[11px]">
-                  <span className="text-faint">Session Cost (estimated):</span>
+                  <span className="text-faint">
+                    {usage.session.cost_source === "provider" && usage.session.estimated !== true
+                      ? "This app run (provider-billed):"
+                      : usage.session.cost_source === "mixed"
+                        ? "This app run (mixed):"
+                        : usage.session.cost_source === "plan_estimated"
+                          ? "This app run (plan):"
+                          : "This app run (estimated):"}
+                  </span>
                   <span className="text-good font-mono font-medium">${usage.session.est_cost_usd.toFixed(6)}</span>
                 </div>
                 <div className="flex flex-wrap items-center justify-between gap-1 text-[11px] border-t border-edge/30 pt-1 mt-1">
@@ -2422,7 +2430,8 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
             <p className="text-[10px] text-muted">Loading usage statistics...</p>
           )}
           <p className="text-[9px] text-muted font-mono">
-            All costs are estimated locally based on catalog rates. No live billing APIs are called.
+            This app run resets on full quit — not Swarm pane repo-session spend or conversation lifetime.
+            Spend basis may be provider-billed, mixed, estimated from catalog rates, or a plan-credit estimate.
           </p>
         </div>
 

--- a/webapp/src/components/StatusBar.tsx
+++ b/webapp/src/components/StatusBar.tsx
@@ -23,7 +23,7 @@ import {
 } from "../lib/taskProfileChrome";
 import { isDesktop } from "../lib/transport";
 import { usePolling } from "../lib/usePolling";
-import CostBreakdown, {
+import {
   cacheHitDisplay,
   delegationSavingsCredited,
   listPriceValueTotal,
@@ -79,16 +79,15 @@ function truncateGoalText(text: string, max = 36): string {
 // in LeftRail SESSION JOBS -- a footer total was stale across dir swaps and
 // disagreed with the scoped list, so it was removed. Narrow widths hide
 // secondary labels via container queries instead of overlapping the clusters.
-export default function StatusBar({ config, update, leftOpen, rightOpen, onToggleLeft, onToggleRight }: {
+export default function StatusBar({ config, update, leftOpen, rightOpen, onToggleLeft, onToggleRight, onOpenEconomics }: {
   config: Config | null;
   update: UpdateAvailability | null;
   leftOpen: boolean; rightOpen: boolean;
   onToggleLeft: () => void; onToggleRight: () => void;
+  onOpenEconomics: () => void;
 }) {
   const [branch, setBranch] = useState("");
   const [usage, setUsage] = useState<UsageData["session"] | null>(null);
-  const [costOpen, setCostOpen] = useState(false);
-  const costRef = useRef<HTMLDivElement | null>(null);
   const [apply, setApply] = useState<{ stage: string; message: string; percent: number | null } | null>(null);
   const [toast, setToast] = useState<{
     message: string;
@@ -278,22 +277,6 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
     };
   }, [usageBusy]);
 
-  // Dismiss the cost breakdown popover on outside click or Escape, matching the
-  // PilotPicker dropdown behavior so the status bar has one consistent pattern.
-  useEffect(() => {
-    if (!costOpen) return;
-    const onDown = (e: MouseEvent) => {
-      if (costRef.current && !costRef.current.contains(e.target as Node)) setCostOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setCostOpen(false); };
-    document.addEventListener("mousedown", onDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [costOpen]);
-
   const formatTokens = (num: number) => {
     if (num >= 1000000) {
       return (num / 1000000).toFixed(1).replace(/\.0$/, "") + "M";
@@ -482,7 +465,9 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
                   : "",
               ].filter(Boolean).join("  ·  ");
               return (
-                <span
+                <button
+                  type="button"
+                  onClick={onOpenEconomics}
                   className="status-bar-optional-sm inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-good/10 border border-good/20 text-good/90"
                   title={`${hit.title} List-price value from model selection, prompt-cache, and compaction (additive, not overlapping cash refunds): ${detail}`}
                 >
@@ -498,95 +483,30 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
                     : (cached > 0 || compacted > 0)
                       ? `${formatTokens(cached + compacted)} saved`
                       : null}
-                </span>
+                </button>
               );
             })()}
-            {/* The estimated cost is now a click/hover trigger for a compact
-                routing-value breakdown (why this model / what it saved). It
-                stays a plain figure when there is nothing meaningful to expand. */}
-            <span className="relative inline-flex items-center gap-1 shrink-0" ref={costRef}>
+            <span className="relative inline-flex items-center gap-1 shrink-0">
               <button
                 type="button"
-                onClick={() => setCostOpen((v) => !v)}
+                onClick={onOpenEconomics}
                 title={
                   !spendIsEstimated(usage)
-                    ? "Process-wide billed spend since app launch (provider usage.cost) -- click for the full cost breakdown"
+                    ? "Process-wide billed spend since app launch (provider usage.cost) -- click to open Economics"
                     : usage.cost_source === "plan_estimated"
-                      ? "Process-wide plan-credit estimate since app launch (subscription pilots; not an API receipt) -- click for the full cost breakdown"
+                      ? "Process-wide plan-credit estimate since app launch (subscription pilots; not an API receipt) -- click to open Economics"
                       : usage.price_source === "default"
-                        ? "Process-wide estimated spend using default rates (live/catalog pricing unavailable) -- click for the full cost breakdown"
+                        ? "Process-wide estimated spend using default rates (live/catalog pricing unavailable) -- click to open Economics"
                         : usage.price_source === "unknown"
-                          ? "Process-wide spend with unavailable model rates (no fabricated dollars) -- click for the full cost breakdown"
-                          : "Process-wide estimated spend since app launch -- click for the full cost breakdown (Swarm pane shows per-repo session spend)"
+                          ? "Process-wide spend with unavailable model rates (no fabricated dollars) -- click to open Economics"
+                          : "Process-wide estimated spend since app launch -- click to open Economics (Swarm pane shows per-repo session spend)"
                 }
-                className="inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-panel2 border border-edge text-txt/90 font-medium hover:border-good/40 hover:text-good transition cursor-pointer"
+                className="inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-panel2 border border-edge text-txt/90 font-medium hover:border-edge hover:text-txt transition cursor-pointer"
               >
                 {spendIsEstimated(usage) ? "~" : ""}
                 {formatCost(usage.est_cost_usd)}
               </button>
               <span className="text-faint/70 normal-case font-sans tracking-normal status-bar-optional-lg">process</span>
-              {costOpen && (
-                <div className="absolute bottom-full right-0 mb-1.5 z-50">
-                  <CostBreakdown
-                    data={{
-                      tokens_used: usage.tokens_used,
-                      est_cost_usd: usage.est_cost_usd,
-                      cost_source: usage.cost_source,
-                      price_source: usage.price_source,
-                      estimated: usage.estimated,
-                      tokens_cached: usage.tokens_cached,
-                      pilot_input_tokens: usage.pilot_input_tokens,
-                      pilot_cache_read_tokens: usage.pilot_cache_read_tokens,
-                      pilot_cache_hit_ratio: usage.pilot_cache_hit_ratio,
-                      swarm_input_tokens: usage.swarm_input_tokens,
-                      swarm_cache_read_tokens: usage.swarm_cache_read_tokens,
-                      swarm_cache_hit_ratio: usage.swarm_cache_hit_ratio,
-                      prompt_input_tokens: usage.prompt_input_tokens,
-                      prompt_cache_read_tokens: usage.prompt_cache_read_tokens,
-                      prompt_cache_hit_ratio: usage.prompt_cache_hit_ratio,
-                      cache_savings_usd: usage.cache_savings_usd,
-                      cache_savings_gross_usd: usage.cache_savings_gross_usd,
-                      cache_savings_basis: usage.cache_savings_basis,
-                      routing_saved_usd: usage.routing_saved_usd,
-                      routing_savings_basis: usage.routing_savings_basis,
-                      routing_tokens_compared: usage.routing_tokens_compared,
-                      delegation_saved_usd: usage.delegation_saved_usd,
-                      delegation_savings_basis: usage.delegation_savings_basis,
-                      delegation_tokens_compared: usage.delegation_tokens_compared,
-                      cache_saved_usd_swarm: usage.cache_saved_usd_swarm,
-                      swarm_cache_savings_basis: usage.swarm_cache_savings_basis,
-                      swarm_cache_unpriced_tokens: usage.swarm_cache_unpriced_tokens,
-                      tool_output_tokens_saved: usage.tool_output_tokens_saved,
-                      tool_output_savings_usd: usage.tool_output_savings_usd,
-                      history_compactions: usage.history_compactions,
-                      history_tokens_saved: usage.history_tokens_saved,
-                      history_cache_bust_tokens: usage.history_cache_bust_tokens,
-                      history_thrash_events: usage.history_thrash_events,
-                      history_compaction_cost_usd: usage.history_compaction_cost_usd,
-                      spill_count: usage.spill_count,
-                      spill_chars: usage.spill_chars,
-                      evals_recorded: usage.evals_recorded,
-                      evals_failed: usage.evals_failed,
-                      memory_layers: usage.memory_layers,
-                      compaction_advice: usage.compaction_advice,
-                      history_compaction_ran: usage.history_compaction_ran,
-                      standing_economics_basis: usage.standing_economics_basis,
-                      standing_system_tokens: usage.standing_system_tokens,
-                      standing_tool_tokens: usage.standing_tool_tokens,
-                      standing_floor_tokens: usage.standing_floor_tokens,
-                      standing_floor_cost_usd: usage.standing_floor_cost_usd,
-                      standing_floor_cost_cached_usd: usage.standing_floor_cost_cached_usd,
-                      prompt_cache_ttl_ms: usage.prompt_cache_ttl_ms,
-                      prompt_cache_age_ms: usage.prompt_cache_age_ms,
-                      prompt_cache_expires_in_ms: usage.prompt_cache_expires_in_ms,
-                      prompt_cache_state: usage.prompt_cache_state,
-                      price_in: usage.price_in,
-                      price_out: usage.price_out,
-                      pilot_by_model: usage.pilot_by_model,
-                    }}
-                  />
-                </div>
-              )}
             </span>
           </span>
         </>

--- a/webapp/src/lib/rightPaneTabVisibility.ts
+++ b/webapp/src/lib/rightPaneTabVisibility.ts
@@ -3,6 +3,7 @@
 export type RightPaneTabId =
   | "state"
   | "swarm"
+  | "economics"
   | "files"
   | "git"
   | "worktrees"
@@ -26,6 +27,7 @@ export type RightPaneTabVisibility = Record<RightPaneTabId, boolean>;
 export const DEFAULT_RIGHT_PANE_TAB_VISIBILITY: RightPaneTabVisibility = {
   state: true,
   swarm: true,
+  economics: true,
   files: true,
   git: true,
   worktrees: false,


### PR DESCRIPTION
## Summary
- Absorb [issue #78](https://github.com/professorpalmer/marionette/issues/78) Slice 1 from @kbentonferguson: one right-pane Economics card instead of the clipped footer CostBreakdown popover.
- Spend and savings pills both open that surface. Labels are process / this-app-run, and the combined list-price total reflects the weakest included evidence basis.
- No new accounting engine. Slice 2 (durable PM savings/receipts) stays deferred.

## Test plan
- [x] `npx vitest run` on StatusBar, CostBreakdown, EconomicsPane, rightPaneTabVisibility, RightPane.collapse, openRightTo.focus (110 passed)
- [ ] Click footer spend and savings pills in a live window; right pane opens Economics
- [ ] Confirm no clipped popover and Settings no longer claims every cost is estimated