### PR TITLE
absorb #78 Slice 2: durable PM savings, cost, and receipt

### DIFF
--- a/harness/api/economics.py
+++ b/harness/api/economics.py
@@ -1,0 +1,515 @@
+"""Read-only Economics projection of Puppetmaster savings / cost / receipt.
+
+Owns ``GET /api/economics``. Auth stays on ``server.Handler``; this module
+never imports ``harness.server``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional, Union
+
+from harness.job_scoping import apply_job_economics_policy, filter_accountable_jobs
+
+
+SCOPES = ("repo", "window30", "all_projects", "conversation")
+RECENT_JOB_LIMIT = 12
+COST_BASIS = "measured_usage_x_registry_price"
+COUNTERFACTUAL_LABEL = (
+    "list-price vs the named reference model, not a cash refund"
+)
+LABELS = {
+    "routing_saved_usd": "measured when the router snapshotted a baseline",
+    "codegraph_dollars_saved_est": "estimated",
+    "plan_routed": "$0 marginal, not measured cash",
+    "counterfactual": COUNTERFACTUAL_LABEL,
+    "unknown": "unknown stays unknown; never measured $0",
+}
+
+
+@dataclass
+class EconomicsServices:
+    """Explicit deps for the economics HTTP handler (injected by ``server.py``)."""
+
+    cfg: Any
+    scoped_jobs_with_stores: Callable[..., tuple]
+    diag: Callable[..., Any]
+    active_session_id: Callable[[], str]
+
+
+JsonPayload = Union[dict, list]
+
+
+def get_economics(qs: dict, svc: EconomicsServices) -> tuple[int, JsonPayload]:
+    """GET /api/economics?scope=repo|window30|all_projects|conversation."""
+    scope = _qs_scope(qs)
+    if scope not in SCOPES:
+        return 400, {
+            "error": "scope must be repo, window30, all_projects, or conversation",
+        }
+    try:
+        return 200, _project_economics(scope, svc)
+    except Exception as exc:
+        try:
+            svc.diag("server.economics", exc)
+        except Exception:
+            pass
+        return 200, _unavailable_payload(scope, exc)
+
+
+def _qs_scope(qs: Optional[dict]) -> str:
+    if not qs:
+        return "repo"
+    values = qs.get("scope") or [""]
+    raw = (values[0] if values else "") or ""
+    return str(raw).strip() or "repo"
+
+
+def _workspace_root(svc: EconomicsServices) -> str:
+    repo = str(getattr(svc.cfg, "repo", None) or "").strip()
+    return repo or os.getcwd()
+
+
+def _short_error(exc: BaseException) -> str:
+    text = str(exc).strip() or type(exc).__name__
+    if len(text) > 200:
+        return text[:197] + "..."
+    return text
+
+
+def _scope_window_days(scope: str) -> Optional[float]:
+    if scope == "window30":
+        return 30.0
+    return None
+
+
+def _unavailable_payload(scope: str, exc: BaseException) -> dict:
+    return {
+        "scope": scope,
+        "window_days": _scope_window_days(scope),
+        "all_projects": scope == "all_projects",
+        "available": False,
+        "error": _short_error(exc),
+        "savings": None,
+        "counterfactual": None,
+        "recent_jobs": [],
+        "owned_jobs_considered": 0,
+        "owned_actual_marginal_usd": None,
+        "owned_avoided_usd": None,
+        "labels": dict(LABELS),
+    }
+
+
+def _as_dict(value: Any) -> Optional[dict]:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return dict(value)
+    try:
+        return asdict(value)
+    except TypeError:
+        raw = getattr(value, "__dict__", None)
+        if isinstance(raw, dict):
+            return {k: v for k, v in raw.items() if not str(k).startswith("_")}
+        return None
+
+
+def _routing_pct_cheaper(routing: Any) -> float:
+    if routing is None:
+        return 0.0
+    pct = getattr(routing, "pct_cheaper", None)
+    if pct is not None:
+        try:
+            return round(float(pct), 1)
+        except (TypeError, ValueError):
+            return 0.0
+    if isinstance(routing, dict):
+        if routing.get("pct_cheaper") is not None:
+            try:
+                return round(float(routing.get("pct_cheaper") or 0.0), 1)
+            except (TypeError, ValueError):
+                return 0.0
+        try:
+            baseline = float(routing.get("baseline_usd") or 0.0)
+            saved = float(routing.get("saved_usd") or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+        return round((saved / baseline * 100.0) if baseline else 0.0, 1)
+    return 0.0
+
+
+def _serialize_savings(report: Optional[dict]) -> Optional[dict]:
+    if not report:
+        return None
+    routing = report.get("routing")
+    heal = report.get("self_heal")
+    cf = report.get("counterfactual")
+    return {
+        "window_days": report.get("window_days"),
+        "jobs_considered": report.get("jobs_considered"),
+        "routing": _as_dict(routing) or {},
+        "routing_pct_cheaper": _routing_pct_cheaper(routing),
+        "self_heal": _as_dict(heal) or {},
+        "codegraph": report.get("codegraph"),
+        "reads": report.get("reads"),
+        "memory_cost": report.get("memory_cost"),
+        "tool_offload": report.get("tool_offload")
+        or {"offloads": 0, "tokens_saved": 0, "chars_saved": 0},
+        "metrics": report.get("metrics"),
+        "counterfactual": _as_dict(cf),
+    }
+
+
+def _with_counterfactual_label(cf: Optional[dict]) -> Optional[dict]:
+    if not cf:
+        return None
+    out = dict(cf)
+    out["label"] = COUNTERFACTUAL_LABEL
+    return out
+
+
+def _path_exists(path: Any) -> bool:
+    try:
+        exists = getattr(path, "exists", None)
+        if callable(exists):
+            return bool(exists())
+        return os.path.isdir(str(path))
+    except Exception:
+        return False
+
+
+def _path_resolved(path: Any) -> str:
+    try:
+        resolve = getattr(path, "resolve", None)
+        if callable(resolve):
+            return str(resolve())
+        return os.path.abspath(os.path.expanduser(str(path)))
+    except Exception:
+        return str(path)
+
+
+def _savings_state_dirs(scope: str, workspace: str) -> list:
+    from harness.cli_job_merge import (
+        is_marionette_host_scratch_dir,
+        resolve_cli_state_dir,
+    )
+
+    dirs: list = []
+    seen: set = set()
+
+    primary = resolve_cli_state_dir(workspace)
+    if primary and not is_marionette_host_scratch_dir(primary):
+        key = _path_resolved(primary)
+        seen.add(key)
+        dirs.append(primary)
+
+    if scope == "all_projects":
+        from puppetmaster.state import list_project_state_dirs
+
+        for extra in list_project_state_dirs() or []:
+            if extra is None:
+                continue
+            if not _path_exists(extra):
+                continue
+            if is_marionette_host_scratch_dir(extra):
+                continue
+            key = _path_resolved(extra)
+            if key in seen:
+                continue
+            seen.add(key)
+            dirs.append(extra)
+    return dirs
+
+
+def _open_savings_stores(dirs: list) -> list:
+    from puppetmaster.store_factory import create_store
+
+    stores = []
+    for state_dir in dirs:
+        try:
+            stores.append(create_store("sqlite", state_dir))
+        except Exception as exc:
+            if "locked" in str(exc).lower():
+                raise
+            continue
+    return stores
+
+
+def _build_savings(scope: str, workspace: str) -> Optional[dict]:
+    from puppetmaster.savings import build_report
+
+    dirs = _savings_state_dirs(scope, workspace)
+    stores = _open_savings_stores(dirs)
+    return build_report(stores, window_days=_scope_window_days(scope))
+
+
+def _created_at_key(job: dict) -> float:
+    raw = job.get("created_at") if isinstance(job, dict) else None
+    if raw is None:
+        return 0.0
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    text = str(raw).strip()
+    if not text:
+        return 0.0
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    try:
+        ts = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return ts.timestamp()
+    except Exception:
+        return 0.0
+
+
+def _owning_store(job: dict, harness_store: Any, cli_store: Any) -> Any:
+    if str(job.get("source") or "").strip().lower() == "cli":
+        return cli_store or harness_store
+    return harness_store or cli_store
+
+
+def _conversation_jobs(jobs: list, active_session_id: str) -> list:
+    active = (active_session_id or "").strip()
+    owned = filter_accountable_jobs(jobs)
+    if not active:
+        return owned
+    out = []
+    for job in owned:
+        sid = str(job.get("session_id") or "").strip()
+        if sid and sid != active:
+            continue
+        out.append(job)
+    return out
+
+
+def _serialize_job_counterfactual(cf: Any) -> Optional[dict]:
+    data = _as_dict(cf)
+    if not data:
+        return None
+    return {
+        "reference_model_id": data.get("reference_model_id"),
+        "reference_priced": data.get("reference_priced"),
+        "naive_cost_usd": data.get("naive_cost_usd"),
+        "actual_cost_usd": data.get("actual_cost_usd"),
+        "avoided_usd": data.get("avoided_usd"),
+    }
+
+
+def _models_from_job_cost(job_cost: Any) -> list:
+    by_model = getattr(job_cost, "by_model", None) or {}
+    rows = []
+    for model_id, bucket in by_model.items():
+        info = bucket if isinstance(bucket, dict) else {}
+        rows.append({
+            "model_id": model_id,
+            "billing": info.get("billing"),
+            "calls": info.get("calls"),
+            "tokens_in": info.get("tokens_in"),
+            "tokens_out": info.get("tokens_out"),
+        })
+    return rows
+
+
+def _receipt_tokens(receipt: dict) -> Optional[int]:
+    tokens = receipt.get("tokens") if isinstance(receipt, dict) else None
+    if isinstance(tokens, dict) and tokens.get("total_tokens") is not None:
+        try:
+            return int(tokens.get("total_tokens") or 0)
+        except (TypeError, ValueError):
+            return None
+    if isinstance(tokens, dict):
+        parts = (
+            tokens.get("measured_tokens_in"),
+            tokens.get("measured_tokens_out"),
+            tokens.get("estimated_tokens_in"),
+            tokens.get("estimated_tokens_out"),
+        )
+        if any(p is not None for p in parts):
+            try:
+                return int(sum(int(p or 0) for p in parts))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _project_job_row(
+    job: dict,
+    store: Any,
+    registry: list,
+) -> dict:
+    from puppetmaster.cost import job_counterfactual, price_job
+    from puppetmaster.receipt import build_job_receipt
+
+    jid = job.get("id")
+    gated = apply_job_economics_policy(job)
+    owned = bool(gated.get("accounting_owned"))
+    artifacts: list = []
+    receipt: dict = {}
+    job_cost = None
+    cf = None
+    if store is not None and jid:
+        try:
+            artifacts = store.list_artifacts(jid) or []
+        except Exception:
+            artifacts = []
+        try:
+            receipt = build_job_receipt(store, jid) or {}
+        except Exception:
+            receipt = {}
+        try:
+            job_cost = price_job(artifacts, registry)
+            cf = job_counterfactual(job_cost, registry)
+        except Exception:
+            job_cost = None
+            cf = None
+
+    models = _models_from_job_cost(job_cost) if job_cost is not None else []
+    arts = receipt.get("artifacts") if isinstance(receipt, dict) else None
+    efficiency = receipt.get("efficiency") if isinstance(receipt, dict) else None
+    tasks = receipt.get("tasks") if isinstance(receipt, dict) else None
+    typed = arts.get("typed_total") if isinstance(arts, dict) else None
+    tokens_per = (
+        efficiency.get("tokens_per_typed_artifact")
+        if isinstance(efficiency, dict)
+        else None
+    )
+    degraded_rate = (
+        efficiency.get("degraded_rate") if isinstance(efficiency, dict) else None
+    )
+    degraded_tasks = tasks.get("degraded") if isinstance(tasks, dict) else None
+
+    row = {
+        "job_id": jid,
+        "status": job.get("status"),
+        "source": job.get("source"),
+        "accounting_owned": owned,
+        "accounting_scope": job.get("accounting_scope"),
+        "models": models,
+        "billing": [m.get("billing") for m in models if m.get("billing") is not None],
+        "tokens": _receipt_tokens(receipt),
+        "actual_marginal_usd": None,
+        "measured_cost_usd": None,
+        "estimated_cost_usd": None,
+        "cost_basis": None,
+        "counterfactual": None,
+        "typed_artifacts": typed,
+        "tokens_per_typed_artifact": tokens_per,
+        "degraded_rate": degraded_rate,
+        "degraded_tasks": degraded_tasks,
+    }
+    # Visibility-only / unstamped CLI jobs stay listed but cannot be summed.
+    if owned and job_cost is not None:
+        row["actual_marginal_usd"] = getattr(job_cost, "total_marginal_cost_usd", None)
+        row["measured_cost_usd"] = getattr(job_cost, "measured_cost_usd", None)
+        row["estimated_cost_usd"] = getattr(job_cost, "estimated_cost_usd", None)
+        row["cost_basis"] = COST_BASIS
+        row["counterfactual"] = _serialize_job_counterfactual(cf)
+    return row
+
+
+def _sum_known(values: list) -> Optional[float]:
+    known = []
+    for value in values:
+        if value is None:
+            continue
+        try:
+            known.append(float(value))
+        except (TypeError, ValueError):
+            continue
+    if not known:
+        return None
+    return round(sum(known), 6)
+
+
+def _owned_totals(recent_jobs: list) -> dict:
+    owned = filter_accountable_jobs(recent_jobs)
+    actuals = [row.get("actual_marginal_usd") for row in owned]
+    avoided = []
+    for row in owned:
+        cf = row.get("counterfactual") or {}
+        if isinstance(cf, dict):
+            avoided.append(cf.get("avoided_usd"))
+        else:
+            avoided.append(None)
+    return {
+        "owned_jobs_considered": len(owned),
+        "owned_actual_marginal_usd": _sum_known(actuals),
+        "owned_avoided_usd": _sum_known(avoided),
+    }
+
+
+def _recent_job_rows(scope: str, svc: EconomicsServices) -> list:
+    repo = str(getattr(svc.cfg, "repo", None) or "").strip()
+    jobs, harness_store, cli_store = svc.scoped_jobs_with_stores(
+        repo_root=repo or None
+    )
+    jobs = list(jobs or [])
+    if scope == "conversation":
+        jobs = _conversation_jobs(jobs, svc.active_session_id())
+    jobs.sort(key=_created_at_key, reverse=True)
+    jobs = jobs[:RECENT_JOB_LIMIT]
+    registry: list = []
+    if jobs:
+        from puppetmaster.model_registry import load_registry
+
+        try:
+            registry = load_registry() or []
+        except Exception:
+            registry = []
+    rows = []
+    for job in jobs:
+        store = _owning_store(job, harness_store, cli_store)
+        try:
+            rows.append(_project_job_row(job, store, registry))
+        except Exception as exc:
+            try:
+                svc.diag("server.economics_job", exc, msg="job=%s" % job.get("id"))
+            except Exception:
+                pass
+            rows.append({
+                "job_id": job.get("id"),
+                "status": job.get("status"),
+                "source": job.get("source"),
+                "accounting_owned": bool(job.get("accounting_owned")),
+                "accounting_scope": job.get("accounting_scope"),
+                "models": [],
+                "billing": [],
+                "tokens": None,
+                "actual_marginal_usd": None,
+                "measured_cost_usd": None,
+                "estimated_cost_usd": None,
+                "cost_basis": None,
+                "counterfactual": None,
+                "typed_artifacts": None,
+                "tokens_per_typed_artifact": None,
+                "degraded_rate": None,
+                "degraded_tasks": None,
+            })
+    return rows
+
+
+def _project_economics(scope: str, svc: EconomicsServices) -> dict:
+    workspace = _workspace_root(svc)
+    report = _build_savings(scope, workspace)
+    savings = _serialize_savings(report)
+    counterfactual = _with_counterfactual_label(
+        (savings or {}).get("counterfactual") if savings else None
+    )
+    recent_jobs = _recent_job_rows(scope, svc)
+    totals = _owned_totals(recent_jobs)
+    return {
+        "scope": scope,
+        "window_days": _scope_window_days(scope),
+        "all_projects": scope == "all_projects",
+        "available": True,
+        "savings": savings,
+        "counterfactual": counterfactual,
+        "recent_jobs": recent_jobs,
+        "labels": dict(LABELS),
+        **totals,
+    }

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -405,6 +405,7 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
     from .api import checkpoints as _ckpt_api
     from .api import codegraph as _cg_api
     from .api import commands as _cmd_api
+    from .api import economics as _econ_api
     from .api import environment as _env_api
     from .api import files as _files_api
     from .api import git as _git_api
@@ -671,6 +672,8 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         "/api/jobs": _get_jobs,
         "/api/usage": get_json(
             _usage_api.get_usage, services=svc.usage_services, qs_arg="repo"),
+        "/api/economics": get_json(
+            _econ_api.get_economics, services=svc.economics_services, pass_qs=True),
         "/api/artifacts": get_json(
             _jobs_api.get_artifacts, services=svc.job_services, qs_arg="job_id"),
         "/api/swarm/live": _get_swarm_live,

--- a/harness/server.py
+++ b/harness/server.py
@@ -1868,6 +1868,30 @@ def _usage_services():
     )
 
 
+def _economics_services():
+    """Build EconomicsServices from live server module globals (call-time lookup)."""
+    from .api.economics import EconomicsServices
+
+    def _active_session_id():
+        try:
+            sid = (_sessions.active or "") if _sessions is not None else ""
+        except Exception:
+            sid = ""
+        if not sid:
+            try:
+                sid = getattr(_pilot, "harness_session_id", "") or ""
+            except Exception:
+                sid = ""
+        return sid or ""
+
+    return EconomicsServices(
+        cfg=_cfg,
+        scoped_jobs_with_stores=_scoped_jobs_with_stores,
+        diag=_diag,
+        active_session_id=_active_session_id,
+    )
+
+
 def _provider_services():
     """Build ProviderServices from live server module globals (call-time lookup)."""
     from .api.providers import ProviderServices
@@ -2465,6 +2489,7 @@ def _route_services():
         hooks_services=_hooks_services,
         git_services=_git_services,
         usage_services=_usage_services,
+        economics_services=_economics_services,
         sse_services=_sse_services,
         handle_session_relocate=_handle_session_relocate,
         host_ok=_host_ok,

--- a/tests/test_api_economics_peel.py
+++ b/tests/test_api_economics_peel.py
@@ -1,0 +1,318 @@
+"""Characterization tests for the economics API peel."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from harness.api.economics import EconomicsServices, get_economics
+
+
+def _svc(*, repo="/workspace", jobs=None, session_id="sess-1"):
+    jobs = list(jobs or [])
+
+    return EconomicsServices(
+        cfg=SimpleNamespace(repo=repo),
+        scoped_jobs_with_stores=lambda repo_root=None: (list(jobs), _Store(), _Store()),
+        diag=lambda *a, **k: None,
+        active_session_id=lambda: session_id,
+    )
+
+
+class _Store:
+    def list_artifacts(self, job_id):
+        return []
+
+    def get_job(self, job_id):
+        return SimpleNamespace(status="complete", created_at="", completed_at=None)
+
+    def list_tasks(self, job_id):
+        return []
+
+
+class _JobCost:
+    def __init__(self, usd=1.25, avoided=2.5, model="composer-2"):
+        self.total_marginal_cost_usd = usd
+        self.measured_cost_usd = usd
+        self.estimated_cost_usd = 0.0
+        self.by_model = {
+            model: {
+                "calls": 1,
+                "tokens_in": 100,
+                "tokens_out": 50,
+                "marginal_cost_usd": usd,
+                "billing": "metered",
+            }
+        }
+        self.tasks = []
+
+
+def _report(*, window_days=None, reference_model_id="anthropic/claude-opus-4"):
+    return {
+        "window_days": window_days,
+        "jobs_considered": 1,
+        "routing": SimpleNamespace(
+            saved_usd=1.5,
+            baseline_usd=3.0,
+            chosen_usd=1.5,
+            pct_cheaper=50.0,
+            plan_routed_tasks=1,
+            tasks_total=2,
+            tasks_without_baseline=0,
+            cost_optimizing_tasks=1,
+            deliberate_spend_usd=0.0,
+            deliberate_tasks=0,
+        ),
+        "self_heal": SimpleNamespace(fallbacks=0, escalations=0),
+        "codegraph": {"dollars_saved_est": 0.4, "queries": 2, "context_tokens_fed": 1000},
+        "reads": {},
+        "memory_cost": {},
+        "tool_offload": {"offloads": 0, "tokens_saved": 0, "chars_saved": 0},
+        "metrics": {},
+        "counterfactual": SimpleNamespace(
+            reference_model_id=reference_model_id,
+            reference_priced=True,
+            naive_cost_usd=9.0,
+            actual_cost_usd=2.0,
+            avoided_usd=7.0,
+            tasks=2,
+        ),
+    }
+
+
+def _patch_pm(monkeypatch, *, build_report=None, extra_dirs=None, opened=None):
+    opened = opened if opened is not None else []
+    reports = []
+
+    def fake_build_report(stores, window_days=None):
+        reports.append({"stores": list(stores), "window_days": window_days})
+        if build_report is not None:
+            return build_report(stores, window_days=window_days)
+        return _report(window_days=window_days)
+
+    monkeypatch.setattr("harness.cli_job_merge.resolve_cli_state_dir", lambda ws: "/tmp/pm-primary")
+    monkeypatch.setattr(
+        "harness.cli_job_merge.is_marionette_host_scratch_dir",
+        lambda path: False,
+    )
+    monkeypatch.setattr(
+        "puppetmaster.store_factory.create_store",
+        lambda backend, path: opened.append((backend, str(path))) or object(),
+    )
+    monkeypatch.setattr("puppetmaster.savings.build_report", fake_build_report)
+    monkeypatch.setattr(
+        "puppetmaster.state.list_project_state_dirs",
+        lambda: list(extra_dirs or []),
+    )
+    monkeypatch.setattr("puppetmaster.model_registry.load_registry", lambda: [])
+    monkeypatch.setattr("puppetmaster.cost.price_job", lambda arts, reg: _JobCost())
+    monkeypatch.setattr(
+        "puppetmaster.cost.job_counterfactual",
+        lambda job_cost, reg: SimpleNamespace(
+            reference_model_id="anthropic/claude-opus-4",
+            reference_priced=True,
+            naive_cost_usd=4.0,
+            actual_cost_usd=1.25,
+            avoided_usd=2.75,
+            tasks=1,
+        ),
+    )
+    monkeypatch.setattr(
+        "puppetmaster.receipt.build_job_receipt",
+        lambda store, job_id: {
+            "tokens": {"total_tokens": 800},
+            "artifacts": {"typed_total": 2},
+            "efficiency": {"tokens_per_typed_artifact": 400.0, "degraded_rate": 0.0},
+            "tasks": {"degraded": 0},
+        },
+    )
+    return reports, opened
+
+
+def test_get_economics_default_scope_repo(monkeypatch):
+    reports, opened = _patch_pm(monkeypatch)
+    code, payload = get_economics({}, _svc())
+    assert code == 200
+    assert payload["available"] is True
+    assert payload["scope"] == "repo"
+    assert payload["all_projects"] is False
+    assert payload["window_days"] is None
+    assert reports == [{"stores": reports[0]["stores"], "window_days": None}]
+    assert reports[0]["window_days"] is None
+    assert len(opened) == 1
+    assert opened[0] == ("sqlite", "/tmp/pm-primary")
+
+
+def test_get_economics_window30_passes_window_days(monkeypatch):
+    reports, _opened = _patch_pm(monkeypatch)
+    code, payload = get_economics({"scope": ["window30"]}, _svc())
+    assert code == 200
+    assert payload["scope"] == "window30"
+    assert payload["window_days"] == 30.0
+    assert reports[0]["window_days"] == 30.0
+    assert payload["all_projects"] is False
+
+
+def test_get_economics_all_projects_opens_extra_dirs(tmp_path, monkeypatch):
+    extra = tmp_path / "other-project"
+    extra.mkdir()
+    opened = []
+    reports, opened = _patch_pm(monkeypatch, extra_dirs=[extra], opened=opened)
+    code, payload = get_economics({"scope": ["all_projects"]}, _svc())
+    assert code == 200
+    assert payload["all_projects"] is True
+    assert payload["window_days"] is None
+    assert reports[0]["window_days"] is None
+    opened_paths = [path for _backend, path in opened]
+    assert "/tmp/pm-primary" in opened_paths
+    assert str(extra) in opened_paths
+    assert len(opened_paths) == 2
+
+
+def test_visibility_only_job_listed_but_omitted_from_owned_totals(monkeypatch):
+    jobs = [
+        {
+            "id": "owned-1",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "created_at": "2026-08-20T00:00:00+00:00",
+        },
+        {
+            "id": "vis-1",
+            "status": "complete",
+            "source": "cli",
+            "accounting_owned": False,
+            "accounting_scope": "visibility_only",
+            "created_at": "2026-08-20T00:01:00+00:00",
+        },
+    ]
+    costs = {
+        "owned-1": _JobCost(usd=1.25, model="owned-model"),
+        "vis-1": _JobCost(usd=9.99, model="foreign-model"),
+    }
+
+    class _IdStore(_Store):
+        def __init__(self):
+            self.last = None
+
+        def list_artifacts(self, job_id):
+            self.last = job_id
+            return [{"_job_id": job_id}]
+
+    id_store = _IdStore()
+
+    def price_by_art(arts, reg):
+        jid = None
+        if arts and isinstance(arts[0], dict):
+            jid = arts[0].get("_job_id")
+        return costs.get(jid, _JobCost(usd=1.25))
+
+    def cf_by_cost(job_cost, reg):
+        usd = float(getattr(job_cost, "total_marginal_cost_usd", 0) or 0)
+        return SimpleNamespace(
+            reference_model_id="anthropic/claude-opus-4",
+            reference_priced=True,
+            naive_cost_usd=usd + 2.0,
+            actual_cost_usd=usd,
+            avoided_usd=2.0 if usd < 5 else 8.0,
+            tasks=1,
+        )
+
+    _patch_pm(monkeypatch)
+    monkeypatch.setattr("puppetmaster.cost.price_job", price_by_art)
+    monkeypatch.setattr("puppetmaster.cost.job_counterfactual", cf_by_cost)
+
+    svc = EconomicsServices(
+        cfg=SimpleNamespace(repo="/workspace"),
+        scoped_jobs_with_stores=lambda repo_root=None: (list(jobs), id_store, id_store),
+        diag=lambda *a, **k: None,
+        active_session_id=lambda: "sess-1",
+    )
+    code, payload = get_economics({"scope": ["repo"]}, svc)
+    assert code == 200
+    rows = {row["job_id"]: row for row in payload["recent_jobs"]}
+    assert "vis-1" in rows
+    assert rows["vis-1"]["accounting_owned"] is False
+    assert rows["vis-1"]["actual_marginal_usd"] is None
+    assert rows["vis-1"]["measured_cost_usd"] is None
+    assert rows["owned-1"]["actual_marginal_usd"] == 1.25
+    assert payload["owned_jobs_considered"] == 1
+    assert payload["owned_actual_marginal_usd"] == 1.25
+    assert payload["owned_avoided_usd"] == 2.0
+    assert payload["owned_actual_marginal_usd"] != 1.25 + 9.99
+
+
+def test_reference_model_id_passed_through(monkeypatch):
+    kept = "kept/reference-model-id"
+    _patch_pm(
+        monkeypatch,
+        build_report=lambda stores, window_days=None: _report(
+            window_days=window_days, reference_model_id=kept
+        ),
+    )
+    code, payload = get_economics({}, _svc())
+    assert code == 200
+    assert payload["counterfactual"]["reference_model_id"] == kept
+    assert payload["savings"]["counterfactual"]["reference_model_id"] == kept
+
+
+def test_pm_failure_returns_available_false(monkeypatch):
+    _patch_pm(monkeypatch)
+    monkeypatch.setattr(
+        "puppetmaster.savings.build_report",
+        lambda stores, window_days=None: (_ for _ in ()).throw(
+            RuntimeError("store is locked")
+        ),
+    )
+    code, payload = get_economics({}, _svc())
+    assert code == 200
+    assert payload["available"] is False
+    assert "locked" in payload["error"]
+    assert payload["savings"] is None
+    assert payload["recent_jobs"] == []
+
+
+def test_conversation_scope_filters_to_owned_active_session(monkeypatch):
+    jobs = [
+        {
+            "id": "here",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "session_id": "sess-1",
+            "created_at": "2026-08-20T00:02:00+00:00",
+        },
+        {
+            "id": "other-session",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "session_id": "sess-2",
+            "created_at": "2026-08-20T00:03:00+00:00",
+        },
+        {
+            "id": "vis-1",
+            "status": "complete",
+            "source": "cli",
+            "accounting_owned": False,
+            "accounting_scope": "visibility_only",
+            "session_id": "sess-1",
+            "created_at": "2026-08-20T00:04:00+00:00",
+        },
+    ]
+    reports, _opened = _patch_pm(monkeypatch)
+    code, payload = get_economics({"scope": ["conversation"]}, _svc(jobs=jobs))
+    assert code == 200
+    assert payload["scope"] == "conversation"
+    assert payload["all_projects"] is False
+    assert reports[0]["window_days"] is None
+    assert [row["job_id"] for row in payload["recent_jobs"]] == ["here"]
+    assert payload["owned_jobs_considered"] == 1
+
+
+def test_invalid_scope_returns_400():
+    code, payload = get_economics({"scope": ["nope"]}, _svc())
+    assert code == 400
+    assert "error" in payload

--- a/tests/test_http_routes_table.py
+++ b/tests/test_http_routes_table.py
@@ -31,6 +31,7 @@ _SAMPLE_GUARDED_GET = (
     "/api/session/state",
     "/api/session/performance",
     "/api/jobs",
+    "/api/economics",
     "/api/sessions",
     "/api/providers",
     "/api/chat/events",

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -6,6 +6,7 @@ import { api } from "../lib/api";
 vi.mock("../lib/api", () => ({
   api: {
     getUsage: vi.fn(),
+    getEconomics: vi.fn(),
     compactSession: vi.fn(),
   },
 }));
@@ -17,23 +18,45 @@ vi.mock("../lib/usePolling", () => ({
 }));
 
 const mockGetUsage = vi.mocked(api.getUsage);
+const mockGetEconomics = vi.mocked(api.getEconomics);
+
+const usageSession = {
+  tokens_used: 8000,
+  est_cost_usd: 0.12,
+  driver: "anthropic:claude-sonnet",
+  price_in: 3,
+  price_out: 15,
+  cache_savings_usd: 0.04,
+  tool_output_savings_usd: 0.02,
+};
+
+const durablePayload = {
+  available: true,
+  scope: "repo",
+  window_days: null,
+  all_projects: false,
+  savings: {
+    routing: { saved_usd: 1.5, plan_routed_tasks: 1 },
+    codegraph: { dollars_saved_est: 0.4 },
+    counterfactual: { reference_model_id: "anthropic/claude-opus-4" },
+  },
+  counterfactual: {
+    reference_model_id: "anthropic/claude-opus-4",
+    avoided_usd: 3.2,
+    label: "list-price vs the named reference model, not a cash refund",
+  },
+  recent_jobs: [] as Array<Record<string, unknown>>,
+};
 
 describe("EconomicsPane", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetEconomics.mockResolvedValue(durablePayload);
   });
 
   it("shows spend and list-price value from getUsage", async () => {
     mockGetUsage.mockResolvedValue({
-      session: {
-        tokens_used: 8000,
-        est_cost_usd: 0.12,
-        driver: "anthropic:claude-sonnet",
-        price_in: 3,
-        price_out: 15,
-        cache_savings_usd: 0.04,
-        tool_output_savings_usd: 0.02,
-      },
+      session: usageSession,
       jobs: [],
     });
 
@@ -45,6 +68,66 @@ describe("EconomicsPane", () => {
     expect(screen.getByText("Prompt-cache value")).toBeInTheDocument();
     expect(screen.getByText("List-price value (est.)")).toBeInTheDocument();
     expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+  });
+
+  it("shows durable heading, reference model, and scope control", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: usageSession,
+      jobs: [],
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("Durable")).toBeInTheDocument();
+    expect(screen.getAllByText(/anthropic\/claude-opus-4/).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Economics scope")).toBeInTheDocument();
+    expect(screen.getByText("This repo")).toBeInTheDocument();
+    expect(screen.getByText("Routing saved (measured)")).toBeInTheDocument();
+    expect(screen.getByText("CodeGraph (estimated)")).toBeInTheDocument();
+    expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+  });
+
+  it("labels visibility-only jobs without treating their dollars as owned spend", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: usageSession,
+      jobs: [],
+    });
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      owned_jobs_considered: 1,
+      owned_actual_marginal_usd: 1.25,
+      recent_jobs: [
+        {
+          job_id: "owned-1",
+          accounting_owned: true,
+          accounting_scope: "marionette",
+          models: [{ model_id: "composer-2" }],
+          tokens: 800,
+          typed_artifacts: 2,
+          tokens_per_typed_artifact: 400,
+          degraded_rate: 0,
+          actual_marginal_usd: 1.25,
+          counterfactual: { avoided_usd: 2.0 },
+        },
+        {
+          job_id: "vis-1",
+          accounting_owned: false,
+          accounting_scope: "visibility_only",
+          models: [{ model_id: "foreign-model" }],
+          tokens: 9000,
+          typed_artifacts: 1,
+          actual_marginal_usd: null,
+          counterfactual: null,
+        },
+      ],
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("vis-1")).toBeInTheDocument();
+    expect(screen.getByText(/visible only/)).toBeInTheDocument();
+    expect(screen.queryByText("$9.99")).not.toBeInTheDocument();
+    expect(screen.queryByText("~$9.99")).not.toBeInTheDocument();
   });
 
   it("refetches on harness-usage-refresh", async () => {

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -1,0 +1,171 @@
+import type { EconomicsData, EconomicsJobRow, EconomicsScope } from "../lib/api";
+
+const SCOPES: Array<{ value: EconomicsScope; label: string }> = [
+  { value: "repo", label: "This repo" },
+  { value: "window30", label: "Last 30 days" },
+  { value: "all_projects", label: "All projects" },
+  { value: "conversation", label: "This conversation" },
+];
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/** Unknown stays em-dash — never a measured $0. */
+function fmtUnknownMoney(value: number | null | undefined): string {
+  if (!isFiniteNumber(value)) return "—";
+  if (value < 0.001 && value !== 0) return `$${value.toFixed(4)}`;
+  if (value < 0.01 && value !== 0) return `$${value.toFixed(3)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+function fmtTokens(value: number | null | undefined): string {
+  if (!isFiniteNumber(value)) return "—";
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  if (value >= 1000) return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return String(value);
+}
+
+function fmtRate(value: number | null | undefined): string {
+  if (!isFiniteNumber(value)) return "—";
+  return `${Math.round(value * 100)}%`;
+}
+
+function shortModel(model: string | undefined): string {
+  const text = (model || "").trim();
+  if (!text) return "unknown";
+  const afterColon = text.includes(":") ? text.slice(text.lastIndexOf(":") + 1) : text;
+  const slash = afterColon.lastIndexOf("/");
+  return slash >= 0 ? afterColon.slice(slash + 1) : afterColon;
+}
+
+function jobModel(row: EconomicsJobRow): string {
+  const id = row.models?.[0]?.model_id;
+  return shortModel(id);
+}
+
+export default function EconomicsDurable({
+  data,
+  scope,
+  onScopeChange,
+}: {
+  data: EconomicsData | null;
+  scope: EconomicsScope;
+  onScopeChange: (scope: EconomicsScope) => void;
+}) {
+  const referenceId = data?.counterfactual?.reference_model_id
+    || data?.savings?.counterfactual?.reference_model_id
+    || "";
+  const routingSaved = data?.savings?.routing?.saved_usd;
+  const codegraphEst = data?.savings?.codegraph?.dollars_saved_est;
+  const avoided = data?.counterfactual?.avoided_usd;
+  const planRouted = data?.savings?.routing?.plan_routed_tasks ?? 0;
+  const jobs = Array.isArray(data?.recent_jobs) ? data.recent_jobs : [];
+
+  return (
+    <div className="w-full px-3 pb-3 text-[11px] text-txt">
+      <div className="text-[10px] uppercase tracking-wide text-faint">Durable</div>
+      <p className="text-[10px] text-muted mb-2 leading-snug">
+        Puppetmaster savings and job receipts for the selected scope. App-run spend stays above.
+      </p>
+
+      <label className="flex items-center justify-between mb-2 text-faint">
+        <span className="text-[10px] uppercase tracking-wide">Scope</span>
+        <select
+          className="bg-transparent text-[11px] text-txt"
+          value={scope}
+          onChange={(event) => onScopeChange(event.target.value as EconomicsScope)}
+          aria-label="Economics scope"
+        >
+          {SCOPES.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {data && data.available === false ? (
+        <p className="text-[10px] text-muted mb-2 leading-snug">
+          {data.error || "Durable economics unavailable."}
+        </p>
+      ) : null}
+
+      {referenceId ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>Reference model</span>
+          <span className="tabular-nums text-right truncate pl-2">{referenceId}</span>
+        </div>
+      ) : null}
+
+      {isFiniteNumber(routingSaved) && routingSaved > 0 ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>Routing saved (measured)</span>
+          <span className="tabular-nums">{fmtUnknownMoney(routingSaved)}</span>
+        </div>
+      ) : data?.available !== false && data?.savings && !isFiniteNumber(routingSaved) ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>Routing saved (measured)</span>
+          <span className="tabular-nums">unknown basis</span>
+        </div>
+      ) : null}
+
+      {isFiniteNumber(codegraphEst) ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>CodeGraph (estimated)</span>
+          <span className="tabular-nums">{fmtUnknownMoney(codegraphEst)}</span>
+        </div>
+      ) : null}
+
+      {isFiniteNumber(avoided) ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>
+            {referenceId
+              ? `list-price vs ${referenceId}, not a refund`
+              : "list-price vs reference, not a refund"}
+          </span>
+          <span className="tabular-nums">{fmtUnknownMoney(avoided)}</span>
+        </div>
+      ) : null}
+
+      {planRouted > 0 ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>Plan-routed / $0-marginal</span>
+          <span className="tabular-nums">{planRouted} tasks, not measured cash</span>
+        </div>
+      ) : null}
+
+      {jobs.length > 0 ? (
+        <div className="mt-3">
+          <div className="text-[10px] uppercase tracking-wide text-faint mb-2">Recent jobs</div>
+          {jobs.map((job) => {
+            const owned = Boolean(job.accounting_owned);
+            const actual = owned ? job.actual_marginal_usd : null;
+            const jobAvoided = owned ? job.counterfactual?.avoided_usd : null;
+            return (
+              <div key={job.job_id || `${job.source}-${job.status}`} className="mb-2">
+                <div className="flex items-center justify-between text-faint">
+                  <span className="truncate pr-2">{job.job_id || "job"}</span>
+                  <span className="tabular-nums shrink-0">
+                    {owned ? `${fmtUnknownMoney(actual)} vs ${fmtUnknownMoney(jobAvoided)}` : "—"}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-faint">
+                  <span className="truncate pr-2">
+                    {jobModel(job)}
+                    {!owned ? " · visible only" : ""}
+                  </span>
+                  <span className="tabular-nums shrink-0">
+                    {fmtTokens(job.tokens)} · {isFiniteNumber(job.typed_artifacts) ? job.typed_artifacts : "—"} typed
+                    {isFiniteNumber(job.tokens_per_typed_artifact) ? ` · ${fmtTokens(job.tokens_per_typed_artifact)}/typed` : ""}
+                    {` · ${fmtRate(job.degraded_rate)} degraded`}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useState } from "react";
-import { api, type UsageData } from "../lib/api";
+import { api, type EconomicsData, type EconomicsScope, type UsageData } from "../lib/api";
 import { usePolling } from "../lib/usePolling";
 import CostBreakdown, { usageToCostBreakdownData } from "./CostBreakdown";
+import EconomicsDurable from "./EconomicsDurable";
 
-/** Right-pane Economics card: live process / this-app-run spend and list-price value. */
+function isEconomicsPayload(data: unknown): data is EconomicsData {
+  return Boolean(data && typeof data === "object" && "available" in (data as object));
+}
+
+/** Right-pane Economics card: live process spend plus durable PM projection. */
 export default function EconomicsPane() {
   const [session, setSession] = useState<UsageData["session"] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [scope, setScope] = useState<EconomicsScope>("repo");
+  const [economics, setEconomics] = useState<EconomicsData | null>(null);
 
   const loadUsage = () =>
     api.getUsage()
@@ -21,17 +28,37 @@ export default function EconomicsPane() {
         setError("Couldn't load this app run's spend.");
       });
 
-  usePolling(loadUsage, 10000);
+  const loadEconomics = () =>
+    Promise.resolve(api.getEconomics(scope))
+      .then((data) => {
+        if (isEconomicsPayload(data)) {
+          setEconomics(data);
+        }
+      })
+      .catch(() => {
+        // Older harnesses omit GET /api/economics; keep CostBreakdown up.
+      });
+
+  const loadAll = () => {
+    void loadUsage();
+    void loadEconomics();
+  };
+
+  usePolling(loadAll, 10000);
 
   useEffect(() => {
-    const onRefresh = () => { void loadUsage(); };
+    const onRefresh = () => { void loadAll(); };
     window.addEventListener("harness-usage-refresh", onRefresh);
     window.addEventListener("harness-session-changed", onRefresh);
     return () => {
       window.removeEventListener("harness-usage-refresh", onRefresh);
       window.removeEventListener("harness-session-changed", onRefresh);
     };
-  }, []);
+  }, [scope]);
+
+  useEffect(() => {
+    void loadEconomics();
+  }, [scope]);
 
   if (!session && error) {
     return <p className="px-3 py-3 text-[11px] text-muted">{error}</p>;
@@ -39,5 +66,10 @@ export default function EconomicsPane() {
   if (!session) {
     return <p className="px-3 py-3 text-[11px] text-muted">Loading this app run…</p>;
   }
-  return <CostBreakdown data={usageToCostBreakdownData(session)} />;
+  return (
+    <div className="w-full min-h-0 overflow-auto">
+      <CostBreakdown data={usageToCostBreakdownData(session)} />
+      <EconomicsDurable data={economics} scope={scope} onScopeChange={setScope} />
+    </div>
+  );
 }

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -779,6 +779,76 @@ export type UsageData = {
   }[];
 };
 
+export type EconomicsScope = "repo" | "window30" | "all_projects" | "conversation";
+
+export type EconomicsJobRow = {
+  job_id?: string;
+  status?: string;
+  source?: string;
+  accounting_owned?: boolean;
+  accounting_scope?: "marionette" | "visibility_only" | string;
+  models?: Array<{
+    model_id?: string;
+    billing?: string;
+    calls?: number;
+    tokens_in?: number;
+    tokens_out?: number;
+  }>;
+  billing?: string[];
+  tokens?: number | null;
+  actual_marginal_usd?: number | null;
+  measured_cost_usd?: number | null;
+  estimated_cost_usd?: number | null;
+  cost_basis?: string | null;
+  counterfactual?: {
+    reference_model_id?: string;
+    reference_priced?: boolean;
+    naive_cost_usd?: number | null;
+    actual_cost_usd?: number | null;
+    avoided_usd?: number | null;
+  } | null;
+  typed_artifacts?: number | null;
+  tokens_per_typed_artifact?: number | null;
+  degraded_rate?: number | null;
+  degraded_tasks?: number | null;
+};
+
+export type EconomicsData = {
+  scope?: EconomicsScope | string;
+  window_days?: number | null;
+  all_projects?: boolean;
+  available?: boolean;
+  error?: string;
+  savings?: {
+    routing?: {
+      saved_usd?: number;
+      baseline_usd?: number;
+      plan_routed_tasks?: number;
+    };
+    routing_pct_cheaper?: number;
+    codegraph?: {
+      dollars_saved_est?: number;
+    };
+    counterfactual?: {
+      reference_model_id?: string;
+      avoided_usd?: number | null;
+    } | null;
+  } | null;
+  counterfactual?: {
+    reference_model_id?: string;
+    reference_priced?: boolean;
+    naive_cost_usd?: number | null;
+    actual_cost_usd?: number | null;
+    avoided_usd?: number | null;
+    label?: string;
+  } | null;
+  recent_jobs?: EconomicsJobRow[];
+  owned_jobs_considered?: number;
+  owned_actual_marginal_usd?: number | null;
+  owned_avoided_usd?: number | null;
+  labels?: Record<string, string>;
+};
+
 export type Checkpoint = {
   id: string;
   label: string;
@@ -1028,6 +1098,8 @@ export const api = {
 
   config: () => getJSON<Config>("/api/config"),
   getUsage: () => getJSON<UsageData>("/api/usage"),
+  getEconomics: (scope: EconomicsScope | string = "repo") =>
+    getJSONSoft<EconomicsData>(`/api/economics?scope=${encodeURIComponent(scope)}`),
   settings: () => getJSON<Settings>("/api/settings"),
   updateSettings: (partial: Partial<Settings> & { api_key?: string; clear_api_key?: boolean }) => postJSON<Settings>("/api/settings", partial),
   jobs: (repoRoot?: string) => {


### PR DESCRIPTION
## Summary
- Adds `GET /api/economics` as a read-only projection of existing Puppetmaster `savings` / `cost` / `receipt` (no new accounting engine).
- Economics pane keeps Slice 1 **This app run** and adds a Durable section with repo / 30-day / all-projects / conversation scope, named counterfactual reference, and job rows that show typed artifacts and degraded rate.
- Visibility-only / external CLI jobs stay listed but cannot enter owned dollar totals.

Continues [issue #78](https://github.com/professorpalmer/marionette/issues/78) Slice 2 (Slice 1 landed in #82). Credit: @kbentonferguson.

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/test_api_economics_peel.py tests/test_http_routes_table.py tests/test_api_usage_peel.py` (18 passed)
- [x] `npm --prefix webapp test -- --run src/__tests__/EconomicsPane.test.tsx src/__tests__/StatusBar.test.tsx src/__tests__/CostBreakdown.test.tsx` (77 passed)
- [ ] Open Economics from either StatusBar pill; confirm This app run is unchanged
- [ ] Change Durable scope; confirm reference model is named and visibility-only jobs show as visible only with em-dash dollars
