### PR TITLE
Release v0.9.259

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.13
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.15
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.13"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.15"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.13"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.15"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -57,7 +57,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.13"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.15"
 
       - name: Run the offline test suite (shard)
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.13"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.15"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.13` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.15` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.13` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.15` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.258, deliberately pre-1.0. Rides puppetmaster-ai==1.22.13, including the Windows foreground-dashboard shutdown fix. Cursor CLI pilots verify requested-versus-served identity; macOS glass uses a crash-safe transparent vibrancy surface shared by the shell panels. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
+> Status: v0.9.259, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15 (dashboard per-project isolation plus hermetic test-suite credential isolation). Economics is one right-pane surface: process spend for this app run, plus a Durable projection of Puppetmaster savings/cost/receipt that names the counterfactual reference and keeps visibility-only jobs out of owned totals. Compact residual factory default remains catalog; summary and hybrid stay Settings opt-ins.
 
 ## Documentation
 
@@ -93,7 +93,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.13` (swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.15` (dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.258"
+__version__ = "0.9.259"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/economics.py
+++ b/harness/api/economics.py
@@ -90,6 +90,7 @@ def _unavailable_payload(scope: str, exc: BaseException) -> dict:
         "scope": scope,
         "window_days": _scope_window_days(scope),
         "all_projects": scope == "all_projects",
+        "savings_scope": "repo" if scope == "conversation" else scope,
         "available": False,
         "error": _short_error(exc),
         "savings": None,
@@ -230,9 +231,9 @@ def _open_savings_stores(dirs: list) -> list:
     for state_dir in dirs:
         try:
             stores.append(create_store("sqlite", state_dir))
-        except Exception as exc:
-            if "locked" in str(exc).lower():
-                raise
+        except Exception:
+            # Skip a locked or unreadable extra store. A total miss still
+            # yields an empty report rather than failing the pane.
             continue
     return stores
 
@@ -274,16 +275,20 @@ def _owning_store(job: dict, harness_store: Any, cli_store: Any) -> Any:
 
 
 def _conversation_jobs(jobs: list, active_session_id: str) -> list:
+    """Keep only Marionette-owned jobs stamped for the active session.
+
+    Fail closed when the session id is missing: unstamped owned jobs must not
+    leak other conversations into this scope.
+    """
     active = (active_session_id or "").strip()
-    owned = filter_accountable_jobs(jobs)
     if not active:
-        return owned
+        return []
+    owned = filter_accountable_jobs(jobs)
     out = []
     for job in owned:
         sid = str(job.get("session_id") or "").strip()
-        if sid and sid != active:
-            continue
-        out.append(job)
+        if sid == active:
+            out.append(job)
     return out
 
 
@@ -502,8 +507,12 @@ def _project_economics(scope: str, svc: EconomicsServices) -> dict:
     )
     recent_jobs = _recent_job_rows(scope, svc)
     totals = _owned_totals(recent_jobs)
+    # Conversation owns job rows only. PM savings is still this-repo
+    # lifetime — name that so the pane cannot present it as conversation spend.
+    savings_scope = "repo" if scope == "conversation" else scope
     return {
         "scope": scope,
+        "savings_scope": savings_scope,
         "window_days": _scope_window_days(scope),
         "all_projects": scope == "all_projects",
         "available": True,

--- a/harness/api/economics.py
+++ b/harness/api/economics.py
@@ -1,0 +1,515 @@
+"""Read-only Economics projection of Puppetmaster savings / cost / receipt.
+
+Owns ``GET /api/economics``. Auth stays on ``server.Handler``; this module
+never imports ``harness.server``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional, Union
+
+from harness.job_scoping import apply_job_economics_policy, filter_accountable_jobs
+
+
+SCOPES = ("repo", "window30", "all_projects", "conversation")
+RECENT_JOB_LIMIT = 12
+COST_BASIS = "measured_usage_x_registry_price"
+COUNTERFACTUAL_LABEL = (
+    "list-price vs the named reference model, not a cash refund"
+)
+LABELS = {
+    "routing_saved_usd": "measured when the router snapshotted a baseline",
+    "codegraph_dollars_saved_est": "estimated",
+    "plan_routed": "$0 marginal, not measured cash",
+    "counterfactual": COUNTERFACTUAL_LABEL,
+    "unknown": "unknown stays unknown; never measured $0",
+}
+
+
+@dataclass
+class EconomicsServices:
+    """Explicit deps for the economics HTTP handler (injected by ``server.py``)."""
+
+    cfg: Any
+    scoped_jobs_with_stores: Callable[..., tuple]
+    diag: Callable[..., Any]
+    active_session_id: Callable[[], str]
+
+
+JsonPayload = Union[dict, list]
+
+
+def get_economics(qs: dict, svc: EconomicsServices) -> tuple[int, JsonPayload]:
+    """GET /api/economics?scope=repo|window30|all_projects|conversation."""
+    scope = _qs_scope(qs)
+    if scope not in SCOPES:
+        return 400, {
+            "error": "scope must be repo, window30, all_projects, or conversation",
+        }
+    try:
+        return 200, _project_economics(scope, svc)
+    except Exception as exc:
+        try:
+            svc.diag("server.economics", exc)
+        except Exception:
+            pass
+        return 200, _unavailable_payload(scope, exc)
+
+
+def _qs_scope(qs: Optional[dict]) -> str:
+    if not qs:
+        return "repo"
+    values = qs.get("scope") or [""]
+    raw = (values[0] if values else "") or ""
+    return str(raw).strip() or "repo"
+
+
+def _workspace_root(svc: EconomicsServices) -> str:
+    repo = str(getattr(svc.cfg, "repo", None) or "").strip()
+    return repo or os.getcwd()
+
+
+def _short_error(exc: BaseException) -> str:
+    text = str(exc).strip() or type(exc).__name__
+    if len(text) > 200:
+        return text[:197] + "..."
+    return text
+
+
+def _scope_window_days(scope: str) -> Optional[float]:
+    if scope == "window30":
+        return 30.0
+    return None
+
+
+def _unavailable_payload(scope: str, exc: BaseException) -> dict:
+    return {
+        "scope": scope,
+        "window_days": _scope_window_days(scope),
+        "all_projects": scope == "all_projects",
+        "available": False,
+        "error": _short_error(exc),
+        "savings": None,
+        "counterfactual": None,
+        "recent_jobs": [],
+        "owned_jobs_considered": 0,
+        "owned_actual_marginal_usd": None,
+        "owned_avoided_usd": None,
+        "labels": dict(LABELS),
+    }
+
+
+def _as_dict(value: Any) -> Optional[dict]:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return dict(value)
+    try:
+        return asdict(value)
+    except TypeError:
+        raw = getattr(value, "__dict__", None)
+        if isinstance(raw, dict):
+            return {k: v for k, v in raw.items() if not str(k).startswith("_")}
+        return None
+
+
+def _routing_pct_cheaper(routing: Any) -> float:
+    if routing is None:
+        return 0.0
+    pct = getattr(routing, "pct_cheaper", None)
+    if pct is not None:
+        try:
+            return round(float(pct), 1)
+        except (TypeError, ValueError):
+            return 0.0
+    if isinstance(routing, dict):
+        if routing.get("pct_cheaper") is not None:
+            try:
+                return round(float(routing.get("pct_cheaper") or 0.0), 1)
+            except (TypeError, ValueError):
+                return 0.0
+        try:
+            baseline = float(routing.get("baseline_usd") or 0.0)
+            saved = float(routing.get("saved_usd") or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+        return round((saved / baseline * 100.0) if baseline else 0.0, 1)
+    return 0.0
+
+
+def _serialize_savings(report: Optional[dict]) -> Optional[dict]:
+    if not report:
+        return None
+    routing = report.get("routing")
+    heal = report.get("self_heal")
+    cf = report.get("counterfactual")
+    return {
+        "window_days": report.get("window_days"),
+        "jobs_considered": report.get("jobs_considered"),
+        "routing": _as_dict(routing) or {},
+        "routing_pct_cheaper": _routing_pct_cheaper(routing),
+        "self_heal": _as_dict(heal) or {},
+        "codegraph": report.get("codegraph"),
+        "reads": report.get("reads"),
+        "memory_cost": report.get("memory_cost"),
+        "tool_offload": report.get("tool_offload")
+        or {"offloads": 0, "tokens_saved": 0, "chars_saved": 0},
+        "metrics": report.get("metrics"),
+        "counterfactual": _as_dict(cf),
+    }
+
+
+def _with_counterfactual_label(cf: Optional[dict]) -> Optional[dict]:
+    if not cf:
+        return None
+    out = dict(cf)
+    out["label"] = COUNTERFACTUAL_LABEL
+    return out
+
+
+def _path_exists(path: Any) -> bool:
+    try:
+        exists = getattr(path, "exists", None)
+        if callable(exists):
+            return bool(exists())
+        return os.path.isdir(str(path))
+    except Exception:
+        return False
+
+
+def _path_resolved(path: Any) -> str:
+    try:
+        resolve = getattr(path, "resolve", None)
+        if callable(resolve):
+            return str(resolve())
+        return os.path.abspath(os.path.expanduser(str(path)))
+    except Exception:
+        return str(path)
+
+
+def _savings_state_dirs(scope: str, workspace: str) -> list:
+    from harness.cli_job_merge import (
+        is_marionette_host_scratch_dir,
+        resolve_cli_state_dir,
+    )
+
+    dirs: list = []
+    seen: set = set()
+
+    primary = resolve_cli_state_dir(workspace)
+    if primary and not is_marionette_host_scratch_dir(primary):
+        key = _path_resolved(primary)
+        seen.add(key)
+        dirs.append(primary)
+
+    if scope == "all_projects":
+        from puppetmaster.state import list_project_state_dirs
+
+        for extra in list_project_state_dirs() or []:
+            if extra is None:
+                continue
+            if not _path_exists(extra):
+                continue
+            if is_marionette_host_scratch_dir(extra):
+                continue
+            key = _path_resolved(extra)
+            if key in seen:
+                continue
+            seen.add(key)
+            dirs.append(extra)
+    return dirs
+
+
+def _open_savings_stores(dirs: list) -> list:
+    from puppetmaster.store_factory import create_store
+
+    stores = []
+    for state_dir in dirs:
+        try:
+            stores.append(create_store("sqlite", state_dir))
+        except Exception as exc:
+            if "locked" in str(exc).lower():
+                raise
+            continue
+    return stores
+
+
+def _build_savings(scope: str, workspace: str) -> Optional[dict]:
+    from puppetmaster.savings import build_report
+
+    dirs = _savings_state_dirs(scope, workspace)
+    stores = _open_savings_stores(dirs)
+    return build_report(stores, window_days=_scope_window_days(scope))
+
+
+def _created_at_key(job: dict) -> float:
+    raw = job.get("created_at") if isinstance(job, dict) else None
+    if raw is None:
+        return 0.0
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    text = str(raw).strip()
+    if not text:
+        return 0.0
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    try:
+        ts = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return ts.timestamp()
+    except Exception:
+        return 0.0
+
+
+def _owning_store(job: dict, harness_store: Any, cli_store: Any) -> Any:
+    if str(job.get("source") or "").strip().lower() == "cli":
+        return cli_store or harness_store
+    return harness_store or cli_store
+
+
+def _conversation_jobs(jobs: list, active_session_id: str) -> list:
+    active = (active_session_id or "").strip()
+    owned = filter_accountable_jobs(jobs)
+    if not active:
+        return owned
+    out = []
+    for job in owned:
+        sid = str(job.get("session_id") or "").strip()
+        if sid and sid != active:
+            continue
+        out.append(job)
+    return out
+
+
+def _serialize_job_counterfactual(cf: Any) -> Optional[dict]:
+    data = _as_dict(cf)
+    if not data:
+        return None
+    return {
+        "reference_model_id": data.get("reference_model_id"),
+        "reference_priced": data.get("reference_priced"),
+        "naive_cost_usd": data.get("naive_cost_usd"),
+        "actual_cost_usd": data.get("actual_cost_usd"),
+        "avoided_usd": data.get("avoided_usd"),
+    }
+
+
+def _models_from_job_cost(job_cost: Any) -> list:
+    by_model = getattr(job_cost, "by_model", None) or {}
+    rows = []
+    for model_id, bucket in by_model.items():
+        info = bucket if isinstance(bucket, dict) else {}
+        rows.append({
+            "model_id": model_id,
+            "billing": info.get("billing"),
+            "calls": info.get("calls"),
+            "tokens_in": info.get("tokens_in"),
+            "tokens_out": info.get("tokens_out"),
+        })
+    return rows
+
+
+def _receipt_tokens(receipt: dict) -> Optional[int]:
+    tokens = receipt.get("tokens") if isinstance(receipt, dict) else None
+    if isinstance(tokens, dict) and tokens.get("total_tokens") is not None:
+        try:
+            return int(tokens.get("total_tokens") or 0)
+        except (TypeError, ValueError):
+            return None
+    if isinstance(tokens, dict):
+        parts = (
+            tokens.get("measured_tokens_in"),
+            tokens.get("measured_tokens_out"),
+            tokens.get("estimated_tokens_in"),
+            tokens.get("estimated_tokens_out"),
+        )
+        if any(p is not None for p in parts):
+            try:
+                return int(sum(int(p or 0) for p in parts))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _project_job_row(
+    job: dict,
+    store: Any,
+    registry: list,
+) -> dict:
+    from puppetmaster.cost import job_counterfactual, price_job
+    from puppetmaster.receipt import build_job_receipt
+
+    jid = job.get("id")
+    gated = apply_job_economics_policy(job)
+    owned = bool(gated.get("accounting_owned"))
+    artifacts: list = []
+    receipt: dict = {}
+    job_cost = None
+    cf = None
+    if store is not None and jid:
+        try:
+            artifacts = store.list_artifacts(jid) or []
+        except Exception:
+            artifacts = []
+        try:
+            receipt = build_job_receipt(store, jid) or {}
+        except Exception:
+            receipt = {}
+        try:
+            job_cost = price_job(artifacts, registry)
+            cf = job_counterfactual(job_cost, registry)
+        except Exception:
+            job_cost = None
+            cf = None
+
+    models = _models_from_job_cost(job_cost) if job_cost is not None else []
+    arts = receipt.get("artifacts") if isinstance(receipt, dict) else None
+    efficiency = receipt.get("efficiency") if isinstance(receipt, dict) else None
+    tasks = receipt.get("tasks") if isinstance(receipt, dict) else None
+    typed = arts.get("typed_total") if isinstance(arts, dict) else None
+    tokens_per = (
+        efficiency.get("tokens_per_typed_artifact")
+        if isinstance(efficiency, dict)
+        else None
+    )
+    degraded_rate = (
+        efficiency.get("degraded_rate") if isinstance(efficiency, dict) else None
+    )
+    degraded_tasks = tasks.get("degraded") if isinstance(tasks, dict) else None
+
+    row = {
+        "job_id": jid,
+        "status": job.get("status"),
+        "source": job.get("source"),
+        "accounting_owned": owned,
+        "accounting_scope": job.get("accounting_scope"),
+        "models": models,
+        "billing": [m.get("billing") for m in models if m.get("billing") is not None],
+        "tokens": _receipt_tokens(receipt),
+        "actual_marginal_usd": None,
+        "measured_cost_usd": None,
+        "estimated_cost_usd": None,
+        "cost_basis": None,
+        "counterfactual": None,
+        "typed_artifacts": typed,
+        "tokens_per_typed_artifact": tokens_per,
+        "degraded_rate": degraded_rate,
+        "degraded_tasks": degraded_tasks,
+    }
+    # Visibility-only / unstamped CLI jobs stay listed but cannot be summed.
+    if owned and job_cost is not None:
+        row["actual_marginal_usd"] = getattr(job_cost, "total_marginal_cost_usd", None)
+        row["measured_cost_usd"] = getattr(job_cost, "measured_cost_usd", None)
+        row["estimated_cost_usd"] = getattr(job_cost, "estimated_cost_usd", None)
+        row["cost_basis"] = COST_BASIS
+        row["counterfactual"] = _serialize_job_counterfactual(cf)
+    return row
+
+
+def _sum_known(values: list) -> Optional[float]:
+    known = []
+    for value in values:
+        if value is None:
+            continue
+        try:
+            known.append(float(value))
+        except (TypeError, ValueError):
+            continue
+    if not known:
+        return None
+    return round(sum(known), 6)
+
+
+def _owned_totals(recent_jobs: list) -> dict:
+    owned = filter_accountable_jobs(recent_jobs)
+    actuals = [row.get("actual_marginal_usd") for row in owned]
+    avoided = []
+    for row in owned:
+        cf = row.get("counterfactual") or {}
+        if isinstance(cf, dict):
+            avoided.append(cf.get("avoided_usd"))
+        else:
+            avoided.append(None)
+    return {
+        "owned_jobs_considered": len(owned),
+        "owned_actual_marginal_usd": _sum_known(actuals),
+        "owned_avoided_usd": _sum_known(avoided),
+    }
+
+
+def _recent_job_rows(scope: str, svc: EconomicsServices) -> list:
+    repo = str(getattr(svc.cfg, "repo", None) or "").strip()
+    jobs, harness_store, cli_store = svc.scoped_jobs_with_stores(
+        repo_root=repo or None
+    )
+    jobs = list(jobs or [])
+    if scope == "conversation":
+        jobs = _conversation_jobs(jobs, svc.active_session_id())
+    jobs.sort(key=_created_at_key, reverse=True)
+    jobs = jobs[:RECENT_JOB_LIMIT]
+    registry: list = []
+    if jobs:
+        from puppetmaster.model_registry import load_registry
+
+        try:
+            registry = load_registry() or []
+        except Exception:
+            registry = []
+    rows = []
+    for job in jobs:
+        store = _owning_store(job, harness_store, cli_store)
+        try:
+            rows.append(_project_job_row(job, store, registry))
+        except Exception as exc:
+            try:
+                svc.diag("server.economics_job", exc, msg="job=%s" % job.get("id"))
+            except Exception:
+                pass
+            rows.append({
+                "job_id": job.get("id"),
+                "status": job.get("status"),
+                "source": job.get("source"),
+                "accounting_owned": bool(job.get("accounting_owned")),
+                "accounting_scope": job.get("accounting_scope"),
+                "models": [],
+                "billing": [],
+                "tokens": None,
+                "actual_marginal_usd": None,
+                "measured_cost_usd": None,
+                "estimated_cost_usd": None,
+                "cost_basis": None,
+                "counterfactual": None,
+                "typed_artifacts": None,
+                "tokens_per_typed_artifact": None,
+                "degraded_rate": None,
+                "degraded_tasks": None,
+            })
+    return rows
+
+
+def _project_economics(scope: str, svc: EconomicsServices) -> dict:
+    workspace = _workspace_root(svc)
+    report = _build_savings(scope, workspace)
+    savings = _serialize_savings(report)
+    counterfactual = _with_counterfactual_label(
+        (savings or {}).get("counterfactual") if savings else None
+    )
+    recent_jobs = _recent_job_rows(scope, svc)
+    totals = _owned_totals(recent_jobs)
+    return {
+        "scope": scope,
+        "window_days": _scope_window_days(scope),
+        "all_projects": scope == "all_projects",
+        "available": True,
+        "savings": savings,
+        "counterfactual": counterfactual,
+        "recent_jobs": recent_jobs,
+        "labels": dict(LABELS),
+        **totals,
+    }

--- a/harness/api/economics.py
+++ b/harness/api/economics.py
@@ -11,11 +11,16 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Optional, Union
 
-from harness.job_scoping import apply_job_economics_policy, filter_accountable_jobs
+from harness.job_scoping import (
+    apply_job_economics_policy,
+    filter_accountable_jobs,
+    parse_job_session_id,
+)
 
 
 SCOPES = ("repo", "window30", "all_projects", "conversation")
 RECENT_JOB_LIMIT = 12
+ALL_PROJECTS_DIR_CAP = 32
 COST_BASIS = "measured_usage_x_registry_price"
 COUNTERFACTUAL_LABEL = (
     "list-price vs the named reference model, not a cash refund"
@@ -221,6 +226,8 @@ def _savings_state_dirs(scope: str, workspace: str) -> list:
                 continue
             seen.add(key)
             dirs.append(extra)
+            if len(dirs) >= ALL_PROJECTS_DIR_CAP:
+                break
     return dirs
 
 
@@ -286,7 +293,9 @@ def _conversation_jobs(jobs: list, active_session_id: str) -> list:
     owned = filter_accountable_jobs(jobs)
     out = []
     for job in owned:
-        sid = str(job.get("session_id") or "").strip()
+        sid = parse_job_session_id(
+            job.get("label"), job.get("tasks") or []
+        ) or str(job.get("session_id") or "").strip()
         if sid == active:
             out.append(job)
     return out
@@ -328,18 +337,62 @@ def _receipt_tokens(receipt: dict) -> Optional[int]:
         except (TypeError, ValueError):
             return None
     if isinstance(tokens, dict):
-        parts = (
-            tokens.get("measured_tokens_in"),
-            tokens.get("measured_tokens_out"),
-            tokens.get("estimated_tokens_in"),
-            tokens.get("estimated_tokens_out"),
-        )
-        if any(p is not None for p in parts):
-            try:
-                return int(sum(int(p or 0) for p in parts))
-            except (TypeError, ValueError):
-                return None
+        measured = (tokens.get("measured_tokens_in"), tokens.get("measured_tokens_out"))
+        estimated = (tokens.get("estimated_tokens_in"), tokens.get("estimated_tokens_out"))
+        try:
+            if any(p is not None for p in measured):
+                return int(sum(int(p or 0) for p in measured))
+            if any(p is not None for p in estimated):
+                return int(sum(int(p or 0) for p in estimated))
+        except (TypeError, ValueError):
+            return None
     return None
+
+
+def _job_in_window(job: dict, window_days: Optional[float]) -> bool:
+    if not window_days:
+        return True
+    created = _created_at_key(job)
+    if created <= 0:
+        return False
+    cutoff = datetime.now(timezone.utc).timestamp() - float(window_days) * 86400.0
+    return created >= cutoff
+
+
+def _int_attr(obj: Any, name: str) -> Optional[int]:
+    raw = getattr(obj, name, None)
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _cost_basis_for_job(job_cost: Any) -> Optional[str]:
+    """Unknown / empty / unpriced ledgers must not claim measured cash."""
+    priced = _int_attr(job_cost, "priced_tasks")
+    unpriced = _int_attr(job_cost, "unpriced_tasks")
+    if priced is None and unpriced is None:
+        return COST_BASIS
+    if not priced:
+        return None
+    measured_runs = _int_attr(job_cost, "measured_runs") or 0
+    estimated_runs = _int_attr(job_cost, "estimated_runs") or 0
+    billings = []
+    by_model = getattr(job_cost, "by_model", None) or {}
+    for bucket in by_model.values():
+        if isinstance(bucket, dict) and bucket.get("billing"):
+            billings.append(str(bucket.get("billing") or "").strip().lower())
+    if billings and all(item == "plan" for item in billings):
+        return "plan"
+    if estimated_runs and not measured_runs:
+        return "estimated"
+    if estimated_runs and measured_runs:
+        return "mixed"
+    if unpriced:
+        return "mixed"
+    return COST_BASIS
 
 
 def _project_job_row(
@@ -408,12 +461,17 @@ def _project_job_row(
         "degraded_tasks": degraded_tasks,
     }
     # Visibility-only / unstamped CLI jobs stay listed but cannot be summed.
+    # Empty or unpriced JobCost objects are 0.0 — that is not measured cash.
     if owned and job_cost is not None:
-        row["actual_marginal_usd"] = getattr(job_cost, "total_marginal_cost_usd", None)
-        row["measured_cost_usd"] = getattr(job_cost, "measured_cost_usd", None)
-        row["estimated_cost_usd"] = getattr(job_cost, "estimated_cost_usd", None)
-        row["cost_basis"] = COST_BASIS
-        row["counterfactual"] = _serialize_job_counterfactual(cf)
+        basis = _cost_basis_for_job(job_cost)
+        if basis is None:
+            row["cost_basis"] = "unknown"
+        else:
+            row["actual_marginal_usd"] = getattr(job_cost, "total_marginal_cost_usd", None)
+            row["measured_cost_usd"] = getattr(job_cost, "measured_cost_usd", None)
+            row["estimated_cost_usd"] = getattr(job_cost, "estimated_cost_usd", None)
+            row["cost_basis"] = basis
+            row["counterfactual"] = _serialize_job_counterfactual(cf)
     return row
 
 
@@ -456,6 +514,8 @@ def _recent_job_rows(scope: str, svc: EconomicsServices) -> list:
     jobs = list(jobs or [])
     if scope == "conversation":
         jobs = _conversation_jobs(jobs, svc.active_session_id())
+    elif scope == "window30":
+        jobs = [job for job in jobs if _job_in_window(job, 30.0)]
     jobs.sort(key=_created_at_key, reverse=True)
     jobs = jobs[:RECENT_JOB_LIMIT]
     registry: list = []
@@ -500,16 +560,20 @@ def _recent_job_rows(scope: str, svc: EconomicsServices) -> list:
 
 def _project_economics(scope: str, svc: EconomicsServices) -> dict:
     workspace = _workspace_root(svc)
-    report = _build_savings(scope, workspace)
-    savings = _serialize_savings(report)
-    counterfactual = _with_counterfactual_label(
-        (savings or {}).get("counterfactual") if savings else None
-    )
+    # Conversation is jobs-only. Do not open repo-lifetime savings stores.
+    if scope == "conversation":
+        savings = None
+        counterfactual = None
+        savings_scope = "repo"
+    else:
+        report = _build_savings(scope, workspace)
+        savings = _serialize_savings(report)
+        counterfactual = _with_counterfactual_label(
+            (savings or {}).get("counterfactual") if savings else None
+        )
+        savings_scope = scope
     recent_jobs = _recent_job_rows(scope, svc)
     totals = _owned_totals(recent_jobs)
-    # Conversation owns job rows only. PM savings is still this-repo
-    # lifetime — name that so the pane cannot present it as conversation spend.
-    savings_scope = "repo" if scope == "conversation" else scope
     return {
         "scope": scope,
         "savings_scope": savings_scope,

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -405,6 +405,7 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
     from .api import checkpoints as _ckpt_api
     from .api import codegraph as _cg_api
     from .api import commands as _cmd_api
+    from .api import economics as _econ_api
     from .api import environment as _env_api
     from .api import files as _files_api
     from .api import git as _git_api
@@ -671,6 +672,8 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         "/api/jobs": _get_jobs,
         "/api/usage": get_json(
             _usage_api.get_usage, services=svc.usage_services, qs_arg="repo"),
+        "/api/economics": get_json(
+            _econ_api.get_economics, services=svc.economics_services, pass_qs=True),
         "/api/artifacts": get_json(
             _jobs_api.get_artifacts, services=svc.job_services, qs_arg="job_id"),
         "/api/swarm/live": _get_swarm_live,

--- a/harness/server.py
+++ b/harness/server.py
@@ -1868,6 +1868,30 @@ def _usage_services():
     )
 
 
+def _economics_services():
+    """Build EconomicsServices from live server module globals (call-time lookup)."""
+    from .api.economics import EconomicsServices
+
+    def _active_session_id():
+        try:
+            sid = (_sessions.active or "") if _sessions is not None else ""
+        except Exception:
+            sid = ""
+        if not sid:
+            try:
+                sid = getattr(_pilot, "harness_session_id", "") or ""
+            except Exception:
+                sid = ""
+        return sid or ""
+
+    return EconomicsServices(
+        cfg=_cfg,
+        scoped_jobs_with_stores=_scoped_jobs_with_stores,
+        diag=_diag,
+        active_session_id=_active_session_id,
+    )
+
+
 def _provider_services():
     """Build ProviderServices from live server module globals (call-time lookup)."""
     from .api.providers import ProviderServices
@@ -2465,6 +2489,7 @@ def _route_services():
         hooks_services=_hooks_services,
         git_services=_git_services,
         usage_services=_usage_services,
+        economics_services=_economics_services,
         sse_services=_sse_services,
         handle_session_relocate=_handle_session_relocate,
         host_ok=_host_ok,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.258"
+version = "0.9.259"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.13" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.15" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.13"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.15"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.13" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.15" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.13}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.15}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/tests/test_accounting_isolation.py
+++ b/tests/test_accounting_isolation.py
@@ -237,6 +237,8 @@ def test_api_swarm_live_cli_job_visible_zero_economics(tmp_path, monkeypatch):
     _cli_store, cli_dir, cli_job_id = _seed_cli_store(tmp_path, str(repo))
 
     httpd, port, srv = _api_server(str(harness_dir))
+    saved_driver = srv._cfg.driver
+    saved_repo = srv._cfg.repo
     try:
         monkeypatch.setenv("HARNESS_APP_RUN_ID", "epoch-test")
         monkeypatch.delenv("HARNESS_CLI_COST_MERGE", raising=False)
@@ -295,6 +297,8 @@ def test_api_swarm_live_cli_job_visible_zero_economics(tmp_path, monkeypatch):
         assert data["session"]["tokens_cached"] >= 4_000
         assert data["session"]["tokens_used"] >= 12_000
     finally:
+        srv._cfg.driver = saved_driver
+        srv._cfg.repo = saved_repo
         httpd.shutdown()
 
 

--- a/tests/test_api_economics_peel.py
+++ b/tests/test_api_economics_peel.py
@@ -306,10 +306,29 @@ def test_conversation_scope_filters_to_owned_active_session(monkeypatch):
     code, payload = get_economics({"scope": ["conversation"]}, _svc(jobs=jobs))
     assert code == 200
     assert payload["scope"] == "conversation"
+    assert payload["savings_scope"] == "repo"
     assert payload["all_projects"] is False
     assert reports[0]["window_days"] is None
     assert [row["job_id"] for row in payload["recent_jobs"]] == ["here"]
     assert payload["owned_jobs_considered"] == 1
+
+
+def test_conversation_excludes_owned_jobs_without_session(monkeypatch):
+    jobs = [
+        {
+            "id": "unstamped",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "created_at": "2026-08-20T00:05:00+00:00",
+        },
+    ]
+    _patch_pm(monkeypatch)
+    code, payload = get_economics({"scope": ["conversation"]}, _svc(jobs=jobs))
+    assert code == 200
+    assert payload["recent_jobs"] == []
+    assert payload["owned_jobs_considered"] == 0
 
 
 def test_invalid_scope_returns_400():

--- a/tests/test_api_economics_peel.py
+++ b/tests/test_api_economics_peel.py
@@ -1,0 +1,318 @@
+"""Characterization tests for the economics API peel."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from harness.api.economics import EconomicsServices, get_economics
+
+
+def _svc(*, repo="/workspace", jobs=None, session_id="sess-1"):
+    jobs = list(jobs or [])
+
+    return EconomicsServices(
+        cfg=SimpleNamespace(repo=repo),
+        scoped_jobs_with_stores=lambda repo_root=None: (list(jobs), _Store(), _Store()),
+        diag=lambda *a, **k: None,
+        active_session_id=lambda: session_id,
+    )
+
+
+class _Store:
+    def list_artifacts(self, job_id):
+        return []
+
+    def get_job(self, job_id):
+        return SimpleNamespace(status="complete", created_at="", completed_at=None)
+
+    def list_tasks(self, job_id):
+        return []
+
+
+class _JobCost:
+    def __init__(self, usd=1.25, avoided=2.5, model="composer-2"):
+        self.total_marginal_cost_usd = usd
+        self.measured_cost_usd = usd
+        self.estimated_cost_usd = 0.0
+        self.by_model = {
+            model: {
+                "calls": 1,
+                "tokens_in": 100,
+                "tokens_out": 50,
+                "marginal_cost_usd": usd,
+                "billing": "metered",
+            }
+        }
+        self.tasks = []
+
+
+def _report(*, window_days=None, reference_model_id="anthropic/claude-opus-4"):
+    return {
+        "window_days": window_days,
+        "jobs_considered": 1,
+        "routing": SimpleNamespace(
+            saved_usd=1.5,
+            baseline_usd=3.0,
+            chosen_usd=1.5,
+            pct_cheaper=50.0,
+            plan_routed_tasks=1,
+            tasks_total=2,
+            tasks_without_baseline=0,
+            cost_optimizing_tasks=1,
+            deliberate_spend_usd=0.0,
+            deliberate_tasks=0,
+        ),
+        "self_heal": SimpleNamespace(fallbacks=0, escalations=0),
+        "codegraph": {"dollars_saved_est": 0.4, "queries": 2, "context_tokens_fed": 1000},
+        "reads": {},
+        "memory_cost": {},
+        "tool_offload": {"offloads": 0, "tokens_saved": 0, "chars_saved": 0},
+        "metrics": {},
+        "counterfactual": SimpleNamespace(
+            reference_model_id=reference_model_id,
+            reference_priced=True,
+            naive_cost_usd=9.0,
+            actual_cost_usd=2.0,
+            avoided_usd=7.0,
+            tasks=2,
+        ),
+    }
+
+
+def _patch_pm(monkeypatch, *, build_report=None, extra_dirs=None, opened=None):
+    opened = opened if opened is not None else []
+    reports = []
+
+    def fake_build_report(stores, window_days=None):
+        reports.append({"stores": list(stores), "window_days": window_days})
+        if build_report is not None:
+            return build_report(stores, window_days=window_days)
+        return _report(window_days=window_days)
+
+    monkeypatch.setattr("harness.cli_job_merge.resolve_cli_state_dir", lambda ws: "/tmp/pm-primary")
+    monkeypatch.setattr(
+        "harness.cli_job_merge.is_marionette_host_scratch_dir",
+        lambda path: False,
+    )
+    monkeypatch.setattr(
+        "puppetmaster.store_factory.create_store",
+        lambda backend, path: opened.append((backend, str(path))) or object(),
+    )
+    monkeypatch.setattr("puppetmaster.savings.build_report", fake_build_report)
+    monkeypatch.setattr(
+        "puppetmaster.state.list_project_state_dirs",
+        lambda: list(extra_dirs or []),
+    )
+    monkeypatch.setattr("puppetmaster.model_registry.load_registry", lambda: [])
+    monkeypatch.setattr("puppetmaster.cost.price_job", lambda arts, reg: _JobCost())
+    monkeypatch.setattr(
+        "puppetmaster.cost.job_counterfactual",
+        lambda job_cost, reg: SimpleNamespace(
+            reference_model_id="anthropic/claude-opus-4",
+            reference_priced=True,
+            naive_cost_usd=4.0,
+            actual_cost_usd=1.25,
+            avoided_usd=2.75,
+            tasks=1,
+        ),
+    )
+    monkeypatch.setattr(
+        "puppetmaster.receipt.build_job_receipt",
+        lambda store, job_id: {
+            "tokens": {"total_tokens": 800},
+            "artifacts": {"typed_total": 2},
+            "efficiency": {"tokens_per_typed_artifact": 400.0, "degraded_rate": 0.0},
+            "tasks": {"degraded": 0},
+        },
+    )
+    return reports, opened
+
+
+def test_get_economics_default_scope_repo(monkeypatch):
+    reports, opened = _patch_pm(monkeypatch)
+    code, payload = get_economics({}, _svc())
+    assert code == 200
+    assert payload["available"] is True
+    assert payload["scope"] == "repo"
+    assert payload["all_projects"] is False
+    assert payload["window_days"] is None
+    assert reports == [{"stores": reports[0]["stores"], "window_days": None}]
+    assert reports[0]["window_days"] is None
+    assert len(opened) == 1
+    assert opened[0] == ("sqlite", "/tmp/pm-primary")
+
+
+def test_get_economics_window30_passes_window_days(monkeypatch):
+    reports, _opened = _patch_pm(monkeypatch)
+    code, payload = get_economics({"scope": ["window30"]}, _svc())
+    assert code == 200
+    assert payload["scope"] == "window30"
+    assert payload["window_days"] == 30.0
+    assert reports[0]["window_days"] == 30.0
+    assert payload["all_projects"] is False
+
+
+def test_get_economics_all_projects_opens_extra_dirs(tmp_path, monkeypatch):
+    extra = tmp_path / "other-project"
+    extra.mkdir()
+    opened = []
+    reports, opened = _patch_pm(monkeypatch, extra_dirs=[extra], opened=opened)
+    code, payload = get_economics({"scope": ["all_projects"]}, _svc())
+    assert code == 200
+    assert payload["all_projects"] is True
+    assert payload["window_days"] is None
+    assert reports[0]["window_days"] is None
+    opened_paths = [path for _backend, path in opened]
+    assert "/tmp/pm-primary" in opened_paths
+    assert str(extra) in opened_paths
+    assert len(opened_paths) == 2
+
+
+def test_visibility_only_job_listed_but_omitted_from_owned_totals(monkeypatch):
+    jobs = [
+        {
+            "id": "owned-1",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "created_at": "2026-08-20T00:00:00+00:00",
+        },
+        {
+            "id": "vis-1",
+            "status": "complete",
+            "source": "cli",
+            "accounting_owned": False,
+            "accounting_scope": "visibility_only",
+            "created_at": "2026-08-20T00:01:00+00:00",
+        },
+    ]
+    costs = {
+        "owned-1": _JobCost(usd=1.25, model="owned-model"),
+        "vis-1": _JobCost(usd=9.99, model="foreign-model"),
+    }
+
+    class _IdStore(_Store):
+        def __init__(self):
+            self.last = None
+
+        def list_artifacts(self, job_id):
+            self.last = job_id
+            return [{"_job_id": job_id}]
+
+    id_store = _IdStore()
+
+    def price_by_art(arts, reg):
+        jid = None
+        if arts and isinstance(arts[0], dict):
+            jid = arts[0].get("_job_id")
+        return costs.get(jid, _JobCost(usd=1.25))
+
+    def cf_by_cost(job_cost, reg):
+        usd = float(getattr(job_cost, "total_marginal_cost_usd", 0) or 0)
+        return SimpleNamespace(
+            reference_model_id="anthropic/claude-opus-4",
+            reference_priced=True,
+            naive_cost_usd=usd + 2.0,
+            actual_cost_usd=usd,
+            avoided_usd=2.0 if usd < 5 else 8.0,
+            tasks=1,
+        )
+
+    _patch_pm(monkeypatch)
+    monkeypatch.setattr("puppetmaster.cost.price_job", price_by_art)
+    monkeypatch.setattr("puppetmaster.cost.job_counterfactual", cf_by_cost)
+
+    svc = EconomicsServices(
+        cfg=SimpleNamespace(repo="/workspace"),
+        scoped_jobs_with_stores=lambda repo_root=None: (list(jobs), id_store, id_store),
+        diag=lambda *a, **k: None,
+        active_session_id=lambda: "sess-1",
+    )
+    code, payload = get_economics({"scope": ["repo"]}, svc)
+    assert code == 200
+    rows = {row["job_id"]: row for row in payload["recent_jobs"]}
+    assert "vis-1" in rows
+    assert rows["vis-1"]["accounting_owned"] is False
+    assert rows["vis-1"]["actual_marginal_usd"] is None
+    assert rows["vis-1"]["measured_cost_usd"] is None
+    assert rows["owned-1"]["actual_marginal_usd"] == 1.25
+    assert payload["owned_jobs_considered"] == 1
+    assert payload["owned_actual_marginal_usd"] == 1.25
+    assert payload["owned_avoided_usd"] == 2.0
+    assert payload["owned_actual_marginal_usd"] != 1.25 + 9.99
+
+
+def test_reference_model_id_passed_through(monkeypatch):
+    kept = "kept/reference-model-id"
+    _patch_pm(
+        monkeypatch,
+        build_report=lambda stores, window_days=None: _report(
+            window_days=window_days, reference_model_id=kept
+        ),
+    )
+    code, payload = get_economics({}, _svc())
+    assert code == 200
+    assert payload["counterfactual"]["reference_model_id"] == kept
+    assert payload["savings"]["counterfactual"]["reference_model_id"] == kept
+
+
+def test_pm_failure_returns_available_false(monkeypatch):
+    _patch_pm(monkeypatch)
+    monkeypatch.setattr(
+        "puppetmaster.savings.build_report",
+        lambda stores, window_days=None: (_ for _ in ()).throw(
+            RuntimeError("store is locked")
+        ),
+    )
+    code, payload = get_economics({}, _svc())
+    assert code == 200
+    assert payload["available"] is False
+    assert "locked" in payload["error"]
+    assert payload["savings"] is None
+    assert payload["recent_jobs"] == []
+
+
+def test_conversation_scope_filters_to_owned_active_session(monkeypatch):
+    jobs = [
+        {
+            "id": "here",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "session_id": "sess-1",
+            "created_at": "2026-08-20T00:02:00+00:00",
+        },
+        {
+            "id": "other-session",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "session_id": "sess-2",
+            "created_at": "2026-08-20T00:03:00+00:00",
+        },
+        {
+            "id": "vis-1",
+            "status": "complete",
+            "source": "cli",
+            "accounting_owned": False,
+            "accounting_scope": "visibility_only",
+            "session_id": "sess-1",
+            "created_at": "2026-08-20T00:04:00+00:00",
+        },
+    ]
+    reports, _opened = _patch_pm(monkeypatch)
+    code, payload = get_economics({"scope": ["conversation"]}, _svc(jobs=jobs))
+    assert code == 200
+    assert payload["scope"] == "conversation"
+    assert payload["all_projects"] is False
+    assert reports[0]["window_days"] is None
+    assert [row["job_id"] for row in payload["recent_jobs"]] == ["here"]
+    assert payload["owned_jobs_considered"] == 1
+
+
+def test_invalid_scope_returns_400():
+    code, payload = get_economics({"scope": ["nope"]}, _svc())
+    assert code == 400
+    assert "error" in payload

--- a/tests/test_api_economics_peel.py
+++ b/tests/test_api_economics_peel.py
@@ -29,17 +29,33 @@ class _Store:
 
 
 class _JobCost:
-    def __init__(self, usd=1.25, avoided=2.5, model="composer-2"):
+    def __init__(
+        self,
+        usd=1.25,
+        avoided=2.5,
+        model="composer-2",
+        *,
+        priced_tasks=1,
+        unpriced_tasks=0,
+        measured_runs=1,
+        estimated_runs=0,
+        estimated_usd=0.0,
+        billing="metered",
+    ):
         self.total_marginal_cost_usd = usd
         self.measured_cost_usd = usd
-        self.estimated_cost_usd = 0.0
+        self.estimated_cost_usd = estimated_usd
+        self.priced_tasks = priced_tasks
+        self.unpriced_tasks = unpriced_tasks
+        self.measured_runs = measured_runs
+        self.estimated_runs = estimated_runs
         self.by_model = {
             model: {
                 "calls": 1,
                 "tokens_in": 100,
                 "tokens_out": 50,
                 "marginal_cost_usd": usd,
-                "billing": "metered",
+                "billing": billing,
             }
         }
         self.tasks = []
@@ -307,8 +323,10 @@ def test_conversation_scope_filters_to_owned_active_session(monkeypatch):
     assert code == 200
     assert payload["scope"] == "conversation"
     assert payload["savings_scope"] == "repo"
+    assert payload["savings"] is None
+    assert payload["counterfactual"] is None
     assert payload["all_projects"] is False
-    assert reports[0]["window_days"] is None
+    assert reports == []
     assert [row["job_id"] for row in payload["recent_jobs"]] == ["here"]
     assert payload["owned_jobs_considered"] == 1
 
@@ -335,3 +353,93 @@ def test_invalid_scope_returns_400():
     code, payload = get_economics({"scope": ["nope"]}, _svc())
     assert code == 400
     assert "error" in payload
+
+
+def test_conversation_reads_session_id_from_label(monkeypatch):
+    jobs = [
+        {
+            "id": "from-label",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "label": '{"session_id": "sess-1"}',
+            "created_at": "2026-08-20T00:06:00+00:00",
+        },
+    ]
+    _patch_pm(monkeypatch)
+    code, payload = get_economics({"scope": ["conversation"]}, _svc(jobs=jobs))
+    assert code == 200
+    assert [row["job_id"] for row in payload["recent_jobs"]] == ["from-label"]
+
+
+def test_window30_drops_jobs_older_than_thirty_days(monkeypatch):
+    jobs = [
+        {
+            "id": "fresh",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "created_at": "2026-08-19T00:00:00+00:00",
+        },
+        {
+            "id": "stale",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "created_at": "2026-06-01T00:00:00+00:00",
+        },
+    ]
+    _patch_pm(monkeypatch)
+    code, payload = get_economics({"scope": ["window30"]}, _svc(jobs=jobs))
+    assert code == 200
+    assert [row["job_id"] for row in payload["recent_jobs"]] == ["fresh"]
+
+
+def test_all_projects_caps_extra_store_opens(tmp_path, monkeypatch):
+    extras = []
+    for idx in range(40):
+        path = tmp_path / f"proj-{idx}"
+        path.mkdir()
+        extras.append(path)
+    opened = []
+    reports, opened = _patch_pm(monkeypatch, extra_dirs=extras, opened=opened)
+    code, payload = get_economics({"scope": ["all_projects"]}, _svc())
+    assert code == 200
+    assert payload["all_projects"] is True
+    assert len(opened) == 32
+    assert opened[0] == ("sqlite", "/tmp/pm-primary")
+    assert reports[0]["window_days"] is None
+
+
+def test_unpriced_job_cost_is_unknown_not_measured_zero(monkeypatch):
+    jobs = [
+        {
+            "id": "empty-price",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "created_at": "2026-08-20T00:00:00+00:00",
+        },
+    ]
+    _patch_pm(monkeypatch)
+    monkeypatch.setattr(
+        "puppetmaster.cost.price_job",
+        lambda arts, reg: _JobCost(
+            usd=0.0,
+            priced_tasks=0,
+            unpriced_tasks=1,
+            measured_runs=0,
+            estimated_runs=0,
+        ),
+    )
+    code, payload = get_economics({"scope": ["repo"]}, _svc(jobs=jobs))
+    assert code == 200
+    row = payload["recent_jobs"][0]
+    assert row["actual_marginal_usd"] is None
+    assert row["measured_cost_usd"] is None
+    assert row["cost_basis"] == "unknown"
+    assert payload["owned_actual_marginal_usd"] is None

--- a/tests/test_http_routes_table.py
+++ b/tests/test_http_routes_table.py
@@ -31,6 +31,7 @@ _SAMPLE_GUARDED_GET = (
     "/api/session/state",
     "/api/session/performance",
     "/api/jobs",
+    "/api/economics",
     "/api/sessions",
     "/api/providers",
     "/api/chat/events",

--- a/tests/test_session_runners_server.py
+++ b/tests/test_session_runners_server.py
@@ -356,6 +356,8 @@ def test_pilot_config_repo_frozen_when_workspace_view_mutates(tmp_path):
     old_repo = srv._cfg.repo
     old_env = os.environ.get("HARNESS_REPO")
     old_pilot = srv._pilot
+    old_driver = srv._cfg.driver
+    srv._cfg.driver = "stub-oracle-v2"
     try:
         repo_a = tmp_path / "frozen-a"
         repo_b = tmp_path / "view-b"
@@ -376,6 +378,7 @@ def test_pilot_config_repo_frozen_when_workspace_view_mutates(tmp_path):
         assert srv._cfg.repo == str(repo_b)
     finally:
         srv._pilot = old_pilot
+        srv._cfg.driver = old_driver
         srv._cfg.repo = old_repo
         if old_env is None:
             os.environ.pop("HARNESS_REPO", None)

--- a/tests/test_usage_meters_survive_rebuild.py
+++ b/tests/test_usage_meters_survive_rebuild.py
@@ -47,46 +47,11 @@ def _restore_meters(pilot, snap):
         setattr(pilot, attr, val)
 
 
-def _stub_rebuild_constructors(monkeypatch, srv):
-    """Keep meter-carry tests off the live catalog (xdist / keyed-health)."""
-
-    class _FreshPilot:
-        def __init__(self, cfg):
-            self.config = cfg
-            self.state_dir = getattr(srv._pilot, "state_dir", "")
-            self._history = []
-            self._auto_distill = False
-            self._busy = None
-            for attr in _METER_ATTRS:
-                setattr(self, attr, 0.0 if "usd" in attr or "cost" in attr else 0)
-
-    class _FreshSession:
-        def __init__(self, cfg):
-            self.state_dir = getattr(srv._pilot, "state_dir", "")
-
-    monkeypatch.setattr("harness.api.attach.ConversationalSession", _FreshPilot)
-    monkeypatch.setattr("harness.api.attach.Session", _FreshSession)
-    monkeypatch.setattr("harness.server.ConversationalSession", _FreshPilot)
-    monkeypatch.setattr(srv, "_apply_model_context_window", lambda: None)
-
-
-def _restore_boot_singletons(srv, saved_pilot, saved_session):
-    srv._pilot = saved_pilot
-    srv._session = saved_session
-    active_id = getattr(srv._sessions, "active", None) or getattr(
-        srv._runners, "active_view_id", None
-    )
-    if not active_id:
-        return
-    try:
-        srv._runners.drop(active_id, notify=False)
-    except Exception:
-        pass
-    try:
-        srv._runners.get_or_create(active_id, lambda: saved_pilot)
-        srv._runners.set_active_view(active_id)
-    except Exception:
-        pass
+def _pin_offline_driver(srv):
+    """Rebuild/attach must not inherit a leaked catalog-unknown driver."""
+    previous = srv._cfg.driver
+    srv._cfg.driver = "stub-oracle-v2"
+    return previous
 
 
 def _zero_boot_carry(srv):
@@ -99,13 +64,12 @@ def _zero_boot_carry(srv):
         pass
 
 
-def test_rebuild_pilot_preserves_usage_meters(monkeypatch):
+def test_rebuild_pilot_preserves_usage_meters():
     srv, httpd, port = _spin_server()
-    saved_pilot = srv._pilot
-    saved_session = srv._session
-    saved = _snapshot_meters(saved_pilot)
+    saved = _snapshot_meters(srv._pilot)
     saved_carry = dict(srv._BOOT_METER_CARRY)
     saved_cost = float(getattr(srv, "_BOOT_CARRY_COST_USD", 0.0) or 0.0)
+    saved_driver = _pin_offline_driver(srv)
     try:
         _zero_boot_carry(srv)
         srv._pilot._tokens_used = 12_000
@@ -124,7 +88,6 @@ def test_rebuild_pilot_preserves_usage_meters(monkeypatch):
         assert before["session"]["est_cost_usd"] > 0
         before_cost = before["session"]["est_cost_usd"]
 
-        _stub_rebuild_constructors(monkeypatch, srv)
         srv._rebuild_pilot_and_session()
 
         after = _get_usage(port, srv._TOKEN)
@@ -148,9 +111,9 @@ def test_rebuild_pilot_preserves_usage_meters(monkeypatch):
         assert after["session"]["est_cost_usd"] > 0
         assert abs(after["session"]["est_cost_usd"] - before_cost) < 1e-9
     finally:
-        # Global singleton -- restore the real boot pilot, not the stub.
-        _restore_boot_singletons(srv, saved_pilot, saved_session)
+        # Global singleton -- restore so later /api/usage tests see a clean pilot.
         _restore_meters(srv._pilot, saved)
+        srv._cfg.driver = saved_driver
         srv._BOOT_METER_CARRY.clear()
         srv._BOOT_METER_CARRY.update(saved_carry)
         srv._BOOT_CARRY_COST_USD = saved_cost
@@ -166,6 +129,7 @@ def test_usage_sums_across_sessions_and_survives_reattach(tmp_path):
     saved_carry = dict(srv._BOOT_METER_CARRY)
     saved_cost = float(getattr(srv, "_BOOT_CARRY_COST_USD", 0.0) or 0.0)
     saved_repos = set(srv._BOOT_REPOS)
+    saved_driver = _pin_offline_driver(srv)
     try:
         _zero_boot_carry(srv)
         srv._BOOT_REPOS.clear()
@@ -238,6 +202,7 @@ def test_usage_sums_across_sessions_and_survives_reattach(tmp_path):
     finally:
         srv._runners = old_runners
         srv._pilot = old_pilot
+        srv._cfg.driver = saved_driver
         srv._cfg.repo = old_repo
         if old_env is None:
             os.environ.pop("HARNESS_REPO", None)
@@ -263,6 +228,7 @@ def test_tool_output_savings_survive_attach_to_other_session(tmp_path):
     saved_carry = dict(srv._BOOT_METER_CARRY)
     saved_cost = float(getattr(srv, "_BOOT_CARRY_COST_USD", 0.0) or 0.0)
     saved_repos = set(srv._BOOT_REPOS)
+    saved_driver = _pin_offline_driver(srv)
     try:
         _zero_boot_carry(srv)
         srv._BOOT_REPOS.clear()
@@ -336,6 +302,7 @@ def test_tool_output_savings_survive_attach_to_other_session(tmp_path):
             srv._pilot.harness_session_id = old_sid
         except Exception:
             pass
+        srv._cfg.driver = saved_driver
         srv._cfg.repo = old_repo
         if old_env is None:
             os.environ.pop("HARNESS_REPO", None)
@@ -356,6 +323,7 @@ def test_drop_folds_meters_into_boot_carry():
     old_pilot = srv._pilot
     saved_carry = dict(srv._BOOT_METER_CARRY)
     saved_cost = float(getattr(srv, "_BOOT_CARRY_COST_USD", 0.0) or 0.0)
+    saved_driver = _pin_offline_driver(srv)
     try:
         _zero_boot_carry(srv)
         reg = SessionRunnerRegistry(
@@ -385,6 +353,7 @@ def test_drop_folds_meters_into_boot_carry():
     finally:
         srv._runners = old_runners
         srv._pilot = old_pilot
+        srv._cfg.driver = saved_driver
         srv._BOOT_METER_CARRY.clear()
         srv._BOOT_METER_CARRY.update(saved_carry)
         srv._BOOT_CARRY_COST_USD = saved_cost
@@ -452,16 +421,15 @@ def test_fold_snapshots_cost_survives_model_reprice():
         httpd.shutdown()
 
 
-def test_idle_swap_snapshots_cost_survives_model_reprice(monkeypatch):
+def test_idle_swap_snapshots_cost_survives_model_reprice():
     """Idle pilot rebuild must freeze USD at old rates (not reprice live meters)."""
     srv, httpd, port = _spin_server()
-    saved_pilot = srv._pilot
-    saved_session = srv._session
-    saved = _snapshot_meters(saved_pilot)
+    saved = _snapshot_meters(srv._pilot)
     saved_carry = dict(srv._BOOT_METER_CARRY)
     saved_cost = float(getattr(srv, "_BOOT_CARRY_COST_USD", 0.0) or 0.0)
-    saved_history = getattr(saved_pilot, "_history", None)
-    saved_auto = getattr(saved_pilot, "_auto_distill", False)
+    saved_history = getattr(srv._pilot, "_history", None)
+    saved_auto = getattr(srv._pilot, "_auto_distill", False)
+    saved_driver = _pin_offline_driver(srv)
     try:
         _zero_boot_carry(srv)
         expensive_in, expensive_out = 5.0, 25.0
@@ -487,7 +455,6 @@ def test_idle_swap_snapshots_cost_survives_model_reprice(monkeypatch):
         orig_runner_prices = srv._resolve_prices_for_runner
         srv._resolve_prices_for_runner = _expensive_for_runner
         try:
-            _stub_rebuild_constructors(monkeypatch, srv)
             srv._rebuild_pilot_and_session()
         finally:
             srv._resolve_prices_for_runner = orig_runner_prices
@@ -505,28 +472,26 @@ def test_idle_swap_snapshots_cost_survives_model_reprice(monkeypatch):
         assert abs(legacy - 0.1) < 1e-12
         assert abs(cost_after_swap - legacy) > 1.0
     finally:
-        _restore_boot_singletons(srv, saved_pilot, saved_session)
         _restore_meters(srv._pilot, saved)
         try:
             srv._pilot._history = saved_history
             srv._pilot._auto_distill = saved_auto
         except Exception:
             pass
+        srv._cfg.driver = saved_driver
         srv._BOOT_METER_CARRY.clear()
         srv._BOOT_METER_CARRY.update(saved_carry)
         srv._BOOT_CARRY_COST_USD = saved_cost
         httpd.shutdown()
 
 
-def test_idle_perform_pilot_swap_freezes_meters(monkeypatch):
+def test_idle_perform_pilot_swap_freezes_meters():
     """``_perform_pilot_swap`` freezes meters into carry (idle path, not deferred)."""
     srv, httpd, port = _spin_server()
-    saved_pilot = srv._pilot
-    saved_session = srv._session
-    saved = _snapshot_meters(saved_pilot)
+    saved = _snapshot_meters(srv._pilot)
     saved_carry = dict(srv._BOOT_METER_CARRY)
     saved_cost = float(getattr(srv, "_BOOT_CARRY_COST_USD", 0.0) or 0.0)
-    saved_driver = srv._cfg.driver
+    saved_driver = _pin_offline_driver(srv)
     try:
         _zero_boot_carry(srv)
         expensive_in, expensive_out = 5.0, 25.0
@@ -550,7 +515,6 @@ def test_idle_perform_pilot_swap_freezes_meters(monkeypatch):
         try:
             # Same driver rebuild exercises the freeze path without needing a
             # second catalog model; mirrors idle swap when the pilot is not busy.
-            _stub_rebuild_constructors(monkeypatch, srv)
             srv._perform_pilot_swap(srv._cfg.driver)
         finally:
             srv._resolve_prices_for_runner = orig_runner_prices
@@ -559,7 +523,6 @@ def test_idle_perform_pilot_swap_freezes_meters(monkeypatch):
         assert getattr(srv._pilot, "_tokens_in") == 0
         assert abs(srv._boot_session_cost(cheap_in, cheap_out) - expected) < 1e-12
     finally:
-        _restore_boot_singletons(srv, saved_pilot, saved_session)
         _restore_meters(srv._pilot, saved)
         srv._cfg.driver = saved_driver
         srv._BOOT_METER_CARRY.clear()

--- a/tests/test_usage_meters_survive_rebuild.py
+++ b/tests/test_usage_meters_survive_rebuild.py
@@ -70,6 +70,25 @@ def _stub_rebuild_constructors(monkeypatch, srv):
     monkeypatch.setattr(srv, "_apply_model_context_window", lambda: None)
 
 
+def _restore_boot_singletons(srv, saved_pilot, saved_session):
+    srv._pilot = saved_pilot
+    srv._session = saved_session
+    active_id = getattr(srv._sessions, "active", None) or getattr(
+        srv._runners, "active_view_id", None
+    )
+    if not active_id:
+        return
+    try:
+        srv._runners.drop(active_id, notify=False)
+    except Exception:
+        pass
+    try:
+        srv._runners.get_or_create(active_id, lambda: saved_pilot)
+        srv._runners.set_active_view(active_id)
+    except Exception:
+        pass
+
+
 def _zero_boot_carry(srv):
     for attr in _METER_ATTRS:
         srv._BOOT_METER_CARRY[attr] = 0.0
@@ -82,7 +101,9 @@ def _zero_boot_carry(srv):
 
 def test_rebuild_pilot_preserves_usage_meters(monkeypatch):
     srv, httpd, port = _spin_server()
-    saved = _snapshot_meters(srv._pilot)
+    saved_pilot = srv._pilot
+    saved_session = srv._session
+    saved = _snapshot_meters(saved_pilot)
     saved_carry = dict(srv._BOOT_METER_CARRY)
     saved_cost = float(getattr(srv, "_BOOT_CARRY_COST_USD", 0.0) or 0.0)
     try:
@@ -127,7 +148,8 @@ def test_rebuild_pilot_preserves_usage_meters(monkeypatch):
         assert after["session"]["est_cost_usd"] > 0
         assert abs(after["session"]["est_cost_usd"] - before_cost) < 1e-9
     finally:
-        # Global singleton -- restore so later /api/usage tests see a clean pilot.
+        # Global singleton -- restore the real boot pilot, not the stub.
+        _restore_boot_singletons(srv, saved_pilot, saved_session)
         _restore_meters(srv._pilot, saved)
         srv._BOOT_METER_CARRY.clear()
         srv._BOOT_METER_CARRY.update(saved_carry)
@@ -433,11 +455,13 @@ def test_fold_snapshots_cost_survives_model_reprice():
 def test_idle_swap_snapshots_cost_survives_model_reprice(monkeypatch):
     """Idle pilot rebuild must freeze USD at old rates (not reprice live meters)."""
     srv, httpd, port = _spin_server()
-    saved = _snapshot_meters(srv._pilot)
+    saved_pilot = srv._pilot
+    saved_session = srv._session
+    saved = _snapshot_meters(saved_pilot)
     saved_carry = dict(srv._BOOT_METER_CARRY)
     saved_cost = float(getattr(srv, "_BOOT_CARRY_COST_USD", 0.0) or 0.0)
-    saved_history = getattr(srv._pilot, "_history", None)
-    saved_auto = getattr(srv._pilot, "_auto_distill", False)
+    saved_history = getattr(saved_pilot, "_history", None)
+    saved_auto = getattr(saved_pilot, "_auto_distill", False)
     try:
         _zero_boot_carry(srv)
         expensive_in, expensive_out = 5.0, 25.0
@@ -481,6 +505,7 @@ def test_idle_swap_snapshots_cost_survives_model_reprice(monkeypatch):
         assert abs(legacy - 0.1) < 1e-12
         assert abs(cost_after_swap - legacy) > 1.0
     finally:
+        _restore_boot_singletons(srv, saved_pilot, saved_session)
         _restore_meters(srv._pilot, saved)
         try:
             srv._pilot._history = saved_history
@@ -496,7 +521,9 @@ def test_idle_swap_snapshots_cost_survives_model_reprice(monkeypatch):
 def test_idle_perform_pilot_swap_freezes_meters(monkeypatch):
     """``_perform_pilot_swap`` freezes meters into carry (idle path, not deferred)."""
     srv, httpd, port = _spin_server()
-    saved = _snapshot_meters(srv._pilot)
+    saved_pilot = srv._pilot
+    saved_session = srv._session
+    saved = _snapshot_meters(saved_pilot)
     saved_carry = dict(srv._BOOT_METER_CARRY)
     saved_cost = float(getattr(srv, "_BOOT_CARRY_COST_USD", 0.0) or 0.0)
     saved_driver = srv._cfg.driver
@@ -532,6 +559,7 @@ def test_idle_perform_pilot_swap_freezes_meters(monkeypatch):
         assert getattr(srv._pilot, "_tokens_in") == 0
         assert abs(srv._boot_session_cost(cheap_in, cheap_out) - expected) < 1e-12
     finally:
+        _restore_boot_singletons(srv, saved_pilot, saved_session)
         _restore_meters(srv._pilot, saved)
         srv._cfg.driver = saved_driver
         srv._BOOT_METER_CARRY.clear()

--- a/tests/test_usage_meters_survive_rebuild.py
+++ b/tests/test_usage_meters_survive_rebuild.py
@@ -47,6 +47,29 @@ def _restore_meters(pilot, snap):
         setattr(pilot, attr, val)
 
 
+def _stub_rebuild_constructors(monkeypatch, srv):
+    """Keep meter-carry tests off the live catalog (xdist / keyed-health)."""
+
+    class _FreshPilot:
+        def __init__(self, cfg):
+            self.config = cfg
+            self.state_dir = getattr(srv._pilot, "state_dir", "")
+            self._history = []
+            self._auto_distill = False
+            self._busy = None
+            for attr in _METER_ATTRS:
+                setattr(self, attr, 0.0 if "usd" in attr or "cost" in attr else 0)
+
+    class _FreshSession:
+        def __init__(self, cfg):
+            self.state_dir = getattr(srv._pilot, "state_dir", "")
+
+    monkeypatch.setattr("harness.api.attach.ConversationalSession", _FreshPilot)
+    monkeypatch.setattr("harness.api.attach.Session", _FreshSession)
+    monkeypatch.setattr("harness.server.ConversationalSession", _FreshPilot)
+    monkeypatch.setattr(srv, "_apply_model_context_window", lambda: None)
+
+
 def _zero_boot_carry(srv):
     for attr in _METER_ATTRS:
         srv._BOOT_METER_CARRY[attr] = 0.0
@@ -57,7 +80,7 @@ def _zero_boot_carry(srv):
         pass
 
 
-def test_rebuild_pilot_preserves_usage_meters():
+def test_rebuild_pilot_preserves_usage_meters(monkeypatch):
     srv, httpd, port = _spin_server()
     saved = _snapshot_meters(srv._pilot)
     saved_carry = dict(srv._BOOT_METER_CARRY)
@@ -80,6 +103,7 @@ def test_rebuild_pilot_preserves_usage_meters():
         assert before["session"]["est_cost_usd"] > 0
         before_cost = before["session"]["est_cost_usd"]
 
+        _stub_rebuild_constructors(monkeypatch, srv)
         srv._rebuild_pilot_and_session()
 
         after = _get_usage(port, srv._TOKEN)
@@ -406,7 +430,7 @@ def test_fold_snapshots_cost_survives_model_reprice():
         httpd.shutdown()
 
 
-def test_idle_swap_snapshots_cost_survives_model_reprice():
+def test_idle_swap_snapshots_cost_survives_model_reprice(monkeypatch):
     """Idle pilot rebuild must freeze USD at old rates (not reprice live meters)."""
     srv, httpd, port = _spin_server()
     saved = _snapshot_meters(srv._pilot)
@@ -439,6 +463,7 @@ def test_idle_swap_snapshots_cost_survives_model_reprice():
         orig_runner_prices = srv._resolve_prices_for_runner
         srv._resolve_prices_for_runner = _expensive_for_runner
         try:
+            _stub_rebuild_constructors(monkeypatch, srv)
             srv._rebuild_pilot_and_session()
         finally:
             srv._resolve_prices_for_runner = orig_runner_prices
@@ -468,7 +493,7 @@ def test_idle_swap_snapshots_cost_survives_model_reprice():
         httpd.shutdown()
 
 
-def test_idle_perform_pilot_swap_freezes_meters():
+def test_idle_perform_pilot_swap_freezes_meters(monkeypatch):
     """``_perform_pilot_swap`` freezes meters into carry (idle path, not deferred)."""
     srv, httpd, port = _spin_server()
     saved = _snapshot_meters(srv._pilot)
@@ -498,6 +523,7 @@ def test_idle_perform_pilot_swap_freezes_meters():
         try:
             # Same driver rebuild exercises the freeze path without needing a
             # second catalog model; mirrors idle swap when the pilot is not busy.
+            _stub_rebuild_constructors(monkeypatch, srv)
             srv._perform_pilot_swap(srv._cfg.driver)
         finally:
             srv._resolve_prices_for_runner = orig_runner_prices

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.258"
+version = "0.9.259"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.13";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.15";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.13";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.15";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 
 // True when `pip show` / `uv pip show` output describes an editable install
@@ -43,7 +43,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.13" }    -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.15" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -65,7 +65,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.13).
+ * to 1.22.15).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.258",
+  "version": "0.9.259",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.258",
+      "version": "0.9.259",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.258",
+  "version": "0.9.259",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -444,7 +444,8 @@ export default function App() {
       <div className="shrink-0 px-px py-px">
         <StatusBar config={config} update={availableUpdate}
           leftOpen={leftOpen} rightOpen={rightOpen}
-          onToggleLeft={() => setLeftOpen((v) => !v)} onToggleRight={() => setRightOpen((v) => !v)} />
+          onToggleLeft={() => setLeftOpen((v) => !v)} onToggleRight={() => setRightOpen((v) => !v)}
+          onOpenEconomics={() => openRightTo("economics")} />
       </div>
 
       {showWizard && <RegistryWizard onClose={() => { localStorage.setItem("pmharness.wizardSeen", "1"); setShowWizard(false); }} />}

--- a/webapp/src/__tests__/CostBreakdown.test.tsx
+++ b/webapp/src/__tests__/CostBreakdown.test.tsx
@@ -5,7 +5,9 @@ import CostBreakdown, {
   compactionAdvicePresentation,
   delegationSavingsCredited,
   formatCacheHitPercent,
+  listPriceValueHeading,
   listPriceValueTotal,
+  listPriceValueWeakestBasis,
   routingSavingsCredited,
   shortPilotModel,
   spendIsEstimated,
@@ -102,7 +104,9 @@ describe("CostBreakdown", () => {
   it("renders the session cost fields it is given", () => {
     render(<CostBreakdown data={baseData} />);
 
-    expect(screen.getByText("Session cost")).toBeInTheDocument();
+    expect(screen.getByText("This app run")).toBeInTheDocument();
+    expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+    expect(screen.getByText(/Resets on full quit/i)).toBeInTheDocument();
     expect(screen.getByText("Estimated spend")).toBeInTheDocument();
     expect(screen.getByText("~$0.04")).toBeInTheDocument();
     expect(screen.getByText("Prompt-cache value")).toBeInTheDocument();
@@ -139,13 +143,55 @@ describe("CostBreakdown", () => {
       tool_output_savings_usd: 0.76,
     };
     expect(listPriceValueTotal(data)).toBeCloseTo(4.58, 8);
+    expect(listPriceValueWeakestBasis(data)).toBe("estimated");
     render(<CostBreakdown data={data} />);
-    const totalRow = screen.getByText("Total value saved").closest("div");
+    const totalRow = screen.getByText("List-price value (est.)").closest("div");
     expect(within(totalRow!).getByText("~$4.58")).toBeInTheDocument();
     expect(totalRow).toHaveAttribute(
       "title",
       expect.stringMatching(/not a cash refund/i),
     );
+    expect(screen.queryByText("Total value saved")).not.toBeInTheDocument();
+    expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+  });
+
+  it("labels the combined list-price total with the weakest included basis", () => {
+    const estimated: CostBreakdownData = {
+      tokens_used: 1000,
+      est_cost_usd: 0.10,
+      cache_savings_usd: 0.20,
+      cache_savings_basis: "catalog",
+      routing_saved_usd: 0.40,
+      routing_savings_basis: "estimated",
+    };
+    expect(listPriceValueWeakestBasis(estimated)).toBe("estimated");
+    expect(listPriceValueHeading("estimated")).toBe("List-price value (est.)");
+    const { rerender } = render(<CostBreakdown data={estimated} />);
+    expect(screen.getByText("List-price value (est.)")).toBeInTheDocument();
+
+    const partial: CostBreakdownData = {
+      tokens_used: 1000,
+      est_cost_usd: 0.10,
+      cache_saved_usd_swarm: 0.22,
+      swarm_cache_savings_basis: "unknown",
+      swarm_cache_unpriced_tokens: 12_500,
+    };
+    expect(listPriceValueWeakestBasis(partial)).toBe("partial");
+    rerender(<CostBreakdown data={partial} />);
+    expect(screen.getByText("List-price value (partial)")).toBeInTheDocument();
+
+    const unknown: CostBreakdownData = {
+      tokens_used: 1000,
+      est_cost_usd: 0.01,
+      routing_saved_usd: 1.25,
+      routing_savings_basis: "unknown",
+    };
+    expect(listPriceValueTotal(unknown)).toBe(0);
+    expect(listPriceValueWeakestBasis(unknown)).toBeNull();
+    rerender(<CostBreakdown data={unknown} />);
+    expect(screen.getByText("unknown basis")).toBeInTheDocument();
+    expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
+    expect(screen.queryByText("List-price value")).not.toBeInTheDocument();
   });
 
   it("labels swarm cache value as partial when some tokens are unpriced", () => {
@@ -578,7 +624,7 @@ describe("CostBreakdown", () => {
     );
     expect(screen.getByText("Standing context floor (est.)")).toBeInTheDocument();
     expect(screen.getByText("Prompt-cache TTL (est.)")).toBeInTheDocument();
-    expect(screen.getByText(/warm/)).toBeInTheDocument();
+    expect(screen.getByText(/warm ·/)).toBeInTheDocument();
   });
 
   it("hides standing economics when flag-off omits fields", () => {

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -1,0 +1,87 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import EconomicsPane from "../components/EconomicsPane";
+import { api } from "../lib/api";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    getUsage: vi.fn(),
+    compactSession: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/usePolling", () => ({
+  usePolling: (fn: () => unknown) => {
+    void fn();
+  },
+}));
+
+const mockGetUsage = vi.mocked(api.getUsage);
+
+describe("EconomicsPane", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows spend and list-price value from getUsage", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: {
+        tokens_used: 8000,
+        est_cost_usd: 0.12,
+        driver: "anthropic:claude-sonnet",
+        price_in: 3,
+        price_out: 15,
+        cache_savings_usd: 0.04,
+        tool_output_savings_usd: 0.02,
+      },
+      jobs: [],
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("This app run")).toBeInTheDocument();
+    expect(screen.getByText("Estimated spend")).toBeInTheDocument();
+    expect(screen.getByText("~$0.12")).toBeInTheDocument();
+    expect(screen.getByText("Prompt-cache value")).toBeInTheDocument();
+    expect(screen.getByText("List-price value (est.)")).toBeInTheDocument();
+    expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+  });
+
+  it("refetches on harness-usage-refresh", async () => {
+    mockGetUsage
+      .mockResolvedValueOnce({
+        session: {
+          tokens_used: 1000,
+          est_cost_usd: 0.05,
+          driver: "anthropic:claude-sonnet",
+          price_in: 3,
+          price_out: 15,
+        },
+        jobs: [],
+      })
+      .mockResolvedValue({
+        session: {
+          tokens_used: 4000,
+          est_cost_usd: 0.22,
+          driver: "anthropic:claude-sonnet",
+          price_in: 3,
+          price_out: 15,
+          cache_savings_usd: 0.10,
+        },
+        jobs: [],
+      });
+
+    render(<EconomicsPane />);
+    expect(await screen.findByText("~$0.05")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new Event("harness-usage-refresh"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("~$0.22")).toBeInTheDocument();
+    });
+    expect(screen.getByText("List-price value")).toBeInTheDocument();
+    expect(mockGetUsage.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -107,6 +107,7 @@ describe("EconomicsPane", () => {
           tokens_per_typed_artifact: 400,
           degraded_rate: 0,
           actual_marginal_usd: 1.25,
+          cost_basis: "measured_usage_x_registry_price",
           counterfactual: { avoided_usd: 2.0 },
         },
         {
@@ -128,6 +129,30 @@ describe("EconomicsPane", () => {
     expect(screen.getByText(/visible only/)).toBeInTheDocument();
     expect(screen.queryByText("$9.99")).not.toBeInTheDocument();
     expect(screen.queryByText("~$9.99")).not.toBeInTheDocument();
+    expect(screen.getByText("$1.25 vs $2.00 · measured")).toBeInTheDocument();
+  });
+
+  it("clears durable state when getEconomics returns a soft 400", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: usageSession,
+      jobs: [],
+    });
+    mockGetEconomics.mockImplementation(async (nextScope?: string) => {
+      if (nextScope === "conversation") {
+        return { ok: false, error: "scope must be repo, window30, all_projects, or conversation" };
+      }
+      return durablePayload;
+    });
+
+    render(<EconomicsPane />);
+    expect(await screen.findByText("Routing saved (measured)")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Economics scope"), {
+      target: { value: "conversation" },
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Routing saved (measured)")).not.toBeInTheDocument();
+    });
   });
 
   it("does not present repo savings as conversation spend", async () => {

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import EconomicsPane from "../components/EconomicsPane";
 import { api } from "../lib/api";
@@ -128,6 +128,30 @@ describe("EconomicsPane", () => {
     expect(screen.getByText(/visible only/)).toBeInTheDocument();
     expect(screen.queryByText("$9.99")).not.toBeInTheDocument();
     expect(screen.queryByText("~$9.99")).not.toBeInTheDocument();
+  });
+
+  it("does not present repo savings as conversation spend", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: usageSession,
+      jobs: [],
+    });
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      scope: "conversation",
+      savings_scope: "repo",
+    });
+
+    render(<EconomicsPane />);
+    expect(await screen.findByText("Durable")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Economics scope"), {
+      target: { value: "conversation" },
+    });
+    expect(
+      await screen.findByText(/Owned jobs for this conversation/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Routing saved (measured)")).not.toBeInTheDocument();
+    expect(screen.queryByText("CodeGraph (estimated)")).not.toBeInTheDocument();
   });
 
   it("refetches on harness-usage-refresh", async () => {

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -6,6 +6,7 @@ import { api } from "../lib/api";
 vi.mock("../lib/api", () => ({
   api: {
     getUsage: vi.fn(),
+    getEconomics: vi.fn(),
     compactSession: vi.fn(),
   },
 }));
@@ -17,23 +18,45 @@ vi.mock("../lib/usePolling", () => ({
 }));
 
 const mockGetUsage = vi.mocked(api.getUsage);
+const mockGetEconomics = vi.mocked(api.getEconomics);
+
+const usageSession = {
+  tokens_used: 8000,
+  est_cost_usd: 0.12,
+  driver: "anthropic:claude-sonnet",
+  price_in: 3,
+  price_out: 15,
+  cache_savings_usd: 0.04,
+  tool_output_savings_usd: 0.02,
+};
+
+const durablePayload = {
+  available: true,
+  scope: "repo",
+  window_days: null,
+  all_projects: false,
+  savings: {
+    routing: { saved_usd: 1.5, plan_routed_tasks: 1 },
+    codegraph: { dollars_saved_est: 0.4 },
+    counterfactual: { reference_model_id: "anthropic/claude-opus-4" },
+  },
+  counterfactual: {
+    reference_model_id: "anthropic/claude-opus-4",
+    avoided_usd: 3.2,
+    label: "list-price vs the named reference model, not a cash refund",
+  },
+  recent_jobs: [] as Array<Record<string, unknown>>,
+};
 
 describe("EconomicsPane", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetEconomics.mockResolvedValue(durablePayload);
   });
 
   it("shows spend and list-price value from getUsage", async () => {
     mockGetUsage.mockResolvedValue({
-      session: {
-        tokens_used: 8000,
-        est_cost_usd: 0.12,
-        driver: "anthropic:claude-sonnet",
-        price_in: 3,
-        price_out: 15,
-        cache_savings_usd: 0.04,
-        tool_output_savings_usd: 0.02,
-      },
+      session: usageSession,
       jobs: [],
     });
 
@@ -45,6 +68,66 @@ describe("EconomicsPane", () => {
     expect(screen.getByText("Prompt-cache value")).toBeInTheDocument();
     expect(screen.getByText("List-price value (est.)")).toBeInTheDocument();
     expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+  });
+
+  it("shows durable heading, reference model, and scope control", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: usageSession,
+      jobs: [],
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("Durable")).toBeInTheDocument();
+    expect(screen.getAllByText(/anthropic\/claude-opus-4/).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Economics scope")).toBeInTheDocument();
+    expect(screen.getByText("This repo")).toBeInTheDocument();
+    expect(screen.getByText("Routing saved (measured)")).toBeInTheDocument();
+    expect(screen.getByText("CodeGraph (estimated)")).toBeInTheDocument();
+    expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+  });
+
+  it("labels visibility-only jobs without treating their dollars as owned spend", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: usageSession,
+      jobs: [],
+    });
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      owned_jobs_considered: 1,
+      owned_actual_marginal_usd: 1.25,
+      recent_jobs: [
+        {
+          job_id: "owned-1",
+          accounting_owned: true,
+          accounting_scope: "marionette",
+          models: [{ model_id: "composer-2" }],
+          tokens: 800,
+          typed_artifacts: 2,
+          tokens_per_typed_artifact: 400,
+          degraded_rate: 0,
+          actual_marginal_usd: 1.25,
+          counterfactual: { avoided_usd: 2.0 },
+        },
+        {
+          job_id: "vis-1",
+          accounting_owned: false,
+          accounting_scope: "visibility_only",
+          models: [{ model_id: "foreign-model" }],
+          tokens: 9000,
+          typed_artifacts: 1,
+          actual_marginal_usd: null,
+          counterfactual: null,
+        },
+      ],
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("vis-1")).toBeInTheDocument();
+    expect(screen.getByText(/visible only/)).toBeInTheDocument();
+    expect(screen.queryByText("$9.99")).not.toBeInTheDocument();
+    expect(screen.queryByText("~$9.99")).not.toBeInTheDocument();
   });
 
   it("refetches on harness-usage-refresh", async () => {

--- a/webapp/src/__tests__/RightPane.collapse.test.tsx
+++ b/webapp/src/__tests__/RightPane.collapse.test.tsx
@@ -42,6 +42,9 @@ vi.mock("../components/DiffReviewPane", () => ({
       : <div data-testid="diff-review-pane" />,
 }));
 vi.mock("../components/SwarmPane", () => ({ default: () => <div /> }));
+vi.mock("../components/EconomicsPane", () => ({
+  default: () => <div data-testid="economics-pane" />,
+}));
 vi.mock("../components/ErrorBoundary", () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -656,6 +659,16 @@ describe("RightPane add-panel menu", () => {
     localStorage.setItem("pmharness.tabOrder.mcpMerged", "1");
   });
 
+  it("opens the Economics panel from harness-focus-tab", async () => {
+    render(<RightPane {...baseProps} />);
+    expect(screen.queryByRole("region", { name: "Economics panel" })).toBeNull();
+
+    window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: "economics" }));
+
+    expect(await screen.findByRole("region", { name: "Economics panel" })).toBeInTheDocument();
+    expect(screen.getByTestId("economics-pane")).toBeInTheDocument();
+  });
+
   it("adds a closed panel from the menu without an optional-panels gate", () => {
     const onOpenTab = (tab: string) => {
       window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: tab }));
@@ -665,6 +678,7 @@ describe("RightPane add-panel menu", () => {
     expect(screen.queryByRole("region", { name: "Worktrees panel" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Add panel" }));
     expect(screen.getByRole("menu", { name: "Add panel" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Economics" })).toBeInTheDocument();
     expect(screen.queryByText("Optional panels")).toBeNull();
     expect(screen.queryByRole("checkbox", { name: "Worktrees" })).toBeNull();
 

--- a/webapp/src/__tests__/StatusBar.test.tsx
+++ b/webapp/src/__tests__/StatusBar.test.tsx
@@ -44,6 +44,7 @@ const statusBarProps = {
   rightOpen: false,
   onToggleLeft: vi.fn(),
   onToggleRight: vi.fn(),
+  onOpenEconomics: vi.fn(),
 };
 
 function AppUpdateChromeHarness() {
@@ -196,8 +197,8 @@ describe("StatusBar usage pills", () => {
 
     render(<StatusBar {...statusBarProps} />);
 
-    const saved = await screen.findByText("~$0.05 saved");
-    expect(saved.closest("span")).toHaveAttribute(
+    const saved = await screen.findByRole("button", { name: /~\$0\.05 saved/ });
+    expect(saved).toHaveAttribute(
       "title",
       expect.stringMatching(/8k tokens unpriced/i),
     );
@@ -240,6 +241,32 @@ describe("StatusBar usage pills", () => {
     await waitFor(() => {
       expect(screen.getByText("~$0.05")).toBeInTheDocument();
     });
+  });
+
+  it("opens Economics from both the spend and savings pills", async () => {
+    const onOpenEconomics = vi.fn();
+    mockGetUsage.mockResolvedValue({
+      session: {
+        tokens_used: 8000,
+        est_cost_usd: 0.12,
+        driver: "anthropic:claude-sonnet",
+        price_in: 3,
+        price_out: 15,
+        tokens_cached: 2000,
+        cache_savings_usd: 0.04,
+        tool_output_savings_usd: 0.02,
+      },
+      jobs: [],
+    });
+
+    render(<StatusBar {...statusBarProps} onOpenEconomics={onOpenEconomics} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "~$0.12" }));
+    expect(onOpenEconomics).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "$0.06 saved" }));
+    expect(onOpenEconomics).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+    expect(screen.queryByText(/click for the full cost breakdown/i)).not.toBeInTheDocument();
   });
 
   it("labels process-wide spend to distinguish from Swarm pane session spend", async () => {

--- a/webapp/src/__tests__/rightPaneTabVisibility.test.ts
+++ b/webapp/src/__tests__/rightPaneTabVisibility.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_RIGHT_PANE_TAB_VISIBILITY,
   loadRightPaneTabVisibility,
   normalizeRightPaneTabVisibility,
+  RIGHT_PANE_OPTIONAL_TAB_IDS,
   RIGHT_PANE_TAB_VISIBILITY_KEY,
   saveRightPaneTabVisibility,
   toggleRightPaneTabVisibility,
@@ -15,6 +16,7 @@ describe("rightPaneTabVisibility", () => {
     expect(DEFAULT_RIGHT_PANE_TAB_VISIBILITY).toMatchObject({
       state: true,
       swarm: true,
+      economics: true,
       files: true,
       git: true,
       terminal: true,
@@ -25,6 +27,7 @@ describe("rightPaneTabVisibility", () => {
       checkpoints: false,
     });
     expect(loadRightPaneTabVisibility()).toEqual(DEFAULT_RIGHT_PANE_TAB_VISIBILITY);
+    expect(RIGHT_PANE_OPTIONAL_TAB_IDS).not.toContain("economics");
   });
 
   it("persists optional tab choices under the versioned key", () => {

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -1,4 +1,4 @@
-// CostBreakdown -- a compact, presentational cost popover for the StatusBar.
+// CostBreakdown -- the Economics pane body (process / this-app-run meters).
 //
 // It turns Marionette's per-task model routing into a visible value prop:
 // "why this model / what it saved". It consumes ONLY fields already served by
@@ -7,7 +7,7 @@
 // absent or zero simply renders nothing rather than "$0.000000" noise or NaN.
 
 import { useState } from "react";
-import { api } from "../lib/api";
+import { api, type UsageData } from "../lib/api";
 
 export type CostBreakdownData = {
   tokens_used: number;
@@ -90,6 +90,68 @@ export type CostBreakdownData = {
     tokens_cached?: number;
   }>;
 };
+
+/** Map GET /api/usage session meters into the Economics panel body. */
+export function usageToCostBreakdownData(
+  session: UsageData["session"],
+): CostBreakdownData {
+  return {
+    tokens_used: session.tokens_used,
+    est_cost_usd: session.est_cost_usd,
+    cost_source: session.cost_source,
+    price_source: session.price_source,
+    estimated: session.estimated,
+    tokens_cached: session.tokens_cached,
+    pilot_input_tokens: session.pilot_input_tokens,
+    pilot_cache_read_tokens: session.pilot_cache_read_tokens,
+    pilot_cache_hit_ratio: session.pilot_cache_hit_ratio,
+    swarm_input_tokens: session.swarm_input_tokens,
+    swarm_cache_read_tokens: session.swarm_cache_read_tokens,
+    swarm_cache_hit_ratio: session.swarm_cache_hit_ratio,
+    prompt_input_tokens: session.prompt_input_tokens,
+    prompt_cache_read_tokens: session.prompt_cache_read_tokens,
+    prompt_cache_hit_ratio: session.prompt_cache_hit_ratio,
+    cache_savings_usd: session.cache_savings_usd,
+    cache_savings_gross_usd: session.cache_savings_gross_usd,
+    cache_savings_basis: session.cache_savings_basis,
+    routing_saved_usd: session.routing_saved_usd,
+    routing_savings_basis: session.routing_savings_basis,
+    routing_tokens_compared: session.routing_tokens_compared,
+    delegation_saved_usd: session.delegation_saved_usd,
+    delegation_savings_basis: session.delegation_savings_basis,
+    delegation_tokens_compared: session.delegation_tokens_compared,
+    cache_saved_usd_swarm: session.cache_saved_usd_swarm,
+    swarm_cache_savings_basis: session.swarm_cache_savings_basis,
+    swarm_cache_unpriced_tokens: session.swarm_cache_unpriced_tokens,
+    tool_output_tokens_saved: session.tool_output_tokens_saved,
+    tool_output_savings_usd: session.tool_output_savings_usd,
+    history_compactions: session.history_compactions,
+    history_tokens_saved: session.history_tokens_saved,
+    history_cache_bust_tokens: session.history_cache_bust_tokens,
+    history_thrash_events: session.history_thrash_events,
+    history_compaction_cost_usd: session.history_compaction_cost_usd,
+    spill_count: session.spill_count,
+    spill_chars: session.spill_chars,
+    evals_recorded: session.evals_recorded,
+    evals_failed: session.evals_failed,
+    memory_layers: session.memory_layers,
+    compaction_advice: session.compaction_advice,
+    history_compaction_ran: session.history_compaction_ran,
+    standing_economics_basis: session.standing_economics_basis,
+    standing_system_tokens: session.standing_system_tokens,
+    standing_tool_tokens: session.standing_tool_tokens,
+    standing_floor_tokens: session.standing_floor_tokens,
+    standing_floor_cost_usd: session.standing_floor_cost_usd,
+    standing_floor_cost_cached_usd: session.standing_floor_cost_cached_usd,
+    prompt_cache_ttl_ms: session.prompt_cache_ttl_ms,
+    prompt_cache_age_ms: session.prompt_cache_age_ms,
+    prompt_cache_expires_in_ms: session.prompt_cache_expires_in_ms,
+    prompt_cache_state: session.prompt_cache_state,
+    price_in: session.price_in,
+    price_out: session.price_out,
+    pilot_by_model: session.pilot_by_model,
+  };
+}
 
 /** Credit routing USD only when basis is actual or estimated — never unknown. */
 export function routingSavingsCredited(
@@ -269,6 +331,112 @@ export function listPriceValueTotal(
   );
 }
 
+export type ListPriceEvidenceBasis = "measured" | "estimated" | "partial" | "unknown";
+
+const EVIDENCE_RANK: Record<ListPriceEvidenceBasis, number> = {
+  measured: 0,
+  estimated: 1,
+  partial: 2,
+  unknown: 3,
+};
+
+function weakerEvidence(
+  current: ListPriceEvidenceBasis | null,
+  next: ListPriceEvidenceBasis,
+): ListPriceEvidenceBasis {
+  if (!current) return next;
+  return EVIDENCE_RANK[next] > EVIDENCE_RANK[current] ? next : current;
+}
+
+/** Weakest evidence basis among lines credited into listPriceValueTotal.
+ *
+ * Unknown / partial / estimated beat measured. Does not change the dollar math.
+ */
+export function listPriceValueWeakestBasis(
+  data: Pick<
+    CostBreakdownData,
+    | "cache_savings_gross_usd"
+    | "cache_savings_usd"
+    | "cache_savings_basis"
+    | "cache_saved_usd_swarm"
+    | "swarm_cache_savings_basis"
+    | "swarm_cache_unpriced_tokens"
+    | "delegation_saved_usd"
+    | "delegation_savings_basis"
+    | "routing_saved_usd"
+    | "routing_savings_basis"
+    | "tool_output_savings_usd"
+  >,
+): ListPriceEvidenceBasis | null {
+  const positive = (value: unknown) =>
+    typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+  const pilotCache =
+    typeof data.cache_savings_gross_usd === "number" &&
+    Number.isFinite(data.cache_savings_gross_usd)
+      ? positive(data.cache_savings_gross_usd)
+      : positive(data.cache_savings_usd);
+  const swarm = positive(data.cache_saved_usd_swarm);
+  const delegationMeasured = data.delegation_savings_basis === "actual_usage";
+  const delegation = delegationSavingsCredited(
+    data.delegation_savings_basis,
+    data.delegation_saved_usd,
+  );
+  const routing = routingSavingsCredited(
+    data.routing_savings_basis,
+    data.routing_saved_usd,
+  );
+  const modelSelection = delegationMeasured
+    ? delegation
+    : (delegation > 0 ? delegation : routing);
+  const compact = positive(data.tool_output_savings_usd);
+
+  let weakest: ListPriceEvidenceBasis | null = null;
+  if (pilotCache > 0) {
+    weakest = weakerEvidence(
+      weakest,
+      data.cache_savings_basis === "unknown"
+        ? "unknown"
+        : data.cache_savings_basis === "capped"
+          ? "estimated"
+          : "measured",
+    );
+  }
+  if (swarm > 0) {
+    const unpriced =
+      typeof data.swarm_cache_unpriced_tokens === "number"
+      && Number.isFinite(data.swarm_cache_unpriced_tokens)
+      && data.swarm_cache_unpriced_tokens > 0;
+    weakest = weakerEvidence(
+      weakest,
+      data.swarm_cache_savings_basis === "unknown" || unpriced
+        ? "partial"
+        : data.swarm_cache_savings_basis === "estimated"
+          ? "estimated"
+          : "measured",
+    );
+  }
+  if (modelSelection > 0) {
+    const modelBasis: ListPriceEvidenceBasis =
+      delegationMeasured || (delegation > 0 && data.delegation_savings_basis !== "estimated")
+        ? "measured"
+        : data.routing_savings_basis === "estimated" || data.routing_savings_basis == null
+          ? "estimated"
+          : "measured";
+    weakest = weakerEvidence(weakest, modelBasis);
+  }
+  if (compact > 0) weakest = weakerEvidence(weakest, "estimated");
+  return weakest;
+}
+
+export function listPriceValueHeading(
+  basis: ListPriceEvidenceBasis | null,
+): string {
+  if (basis === "unknown") return "List-price value (unknown basis)";
+  if (basis === "partial") return "List-price value (partial)";
+  if (basis === "estimated") return "List-price value (est.)";
+  return "List-price value";
+}
+
 function fmtDurationMs(ms: number): string {
   if (ms > 0 && ms < 60_000) return "<1m";
   const mins = Math.max(0, Math.round(ms / 60_000));
@@ -407,6 +575,8 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       ? data.tool_output_savings_usd
       : 0;
   const valueTotal = listPriceValueTotal(data);
+  const valueBasis = listPriceValueWeakestBasis(data);
+  const valueHeading = listPriceValueHeading(valueBasis);
   const compactTokens =
     typeof data.tool_output_tokens_saved === "number" && isFinite(data.tool_output_tokens_saved) && data.tool_output_tokens_saved > 0
       ? data.tool_output_tokens_saved
@@ -508,6 +678,14 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
           (data.history_compaction_ran ? "history compaction ran under context pressure" : ""))
       : "";
   const adviceCopy = compactionAdvicePresentation(compactionAdviceLevel);
+  const showContextHealth =
+    historyCompactions > 0
+    || standingFloorCost > 0
+    || (cacheTtlMs > 0 && Boolean(cacheState))
+    || spillCount > 0
+    || evalsRecorded > 0
+    || l1Bytes > 0
+    || showCompactionAdvice;
 
   const layerLabel = (id: string) => {
     const layer = data.memory_layers?.[id];
@@ -555,10 +733,13 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
   };
 
   return (
-    <div className="w-[260px] rounded-md border border-edge bg-panel shadow-lg p-3 text-[11px] text-txt">
-      <div className="text-[10px] uppercase tracking-wide text-faint mb-2">Session cost</div>
+    <div className="w-full min-h-0 overflow-auto px-3 py-3 text-[11px] text-txt">
+      <div className="text-[10px] uppercase tracking-wide text-faint">This app run</div>
+      <p className="text-[10px] text-muted mb-2 leading-snug">
+        Process spend since launch. Resets on full quit — not Swarm pane repo-session spend, not conversation lifetime.
+      </p>
 
-      {/* (a) Session spend. Provider-billed when OpenRouter (etc.) returned usage.cost. */}
+      {/* (a) App-run spend. Provider-billed when OpenRouter (etc.) returned usage.cost. */}
       {est > 0 ? (
         <div className="flex items-center justify-between mb-1">
           <span className="text-muted">{spendLabel}</span>
@@ -666,13 +847,15 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
         </div>
       ) : null}
 
-      {valueTotal > 0 ? (
+      {valueTotal > 0 || valueBasis === "unknown" ? (
         <div
           className="mt-1.5 pt-1.5 border-t border-edge/50 flex items-center justify-between font-medium"
-          title="Prompt-cache value + model-selection value + compact-output value. Additive list-price value, not a cash refund or billed-spend subtraction."
+          title="Prompt-cache value + model-selection value + compact-output value. Additive list-price value, not a cash refund or billed-spend subtraction. Label follows the weakest included evidence basis."
         >
-          <span className="text-txt">Total value saved</span>
-          <span className="text-good tabular-nums">~{fmtCost(valueTotal)}</span>
+          <span className="text-txt">{valueHeading}</span>
+          <span className="text-good tabular-nums">
+            {valueTotal > 0 ? `~${fmtCost(valueTotal)}` : (valueBasis === "unknown" ? "unknown basis" : "—")}
+          </span>
         </div>
       ) : null}
 
@@ -683,6 +866,9 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
         </div>
       ) : null}
 
+      {showContextHealth ? (
+      <div className="mt-3 pt-2 border-t border-edge/60">
+        <div className="text-[10px] uppercase tracking-wide text-faint mb-2">Context health</div>
       {historyCompactions > 0 ? (
         <div
           className="flex items-center justify-between mb-1 text-faint"
@@ -701,7 +887,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       {standingFloorCost > 0 ? (
         <div
           className="flex items-center justify-between mb-1 text-faint"
-          title="Estimated per-turn cost of the standing system+tools prefix at current list rates. Not billed spend and not part of Total value saved."
+          title="Estimated per-turn cost of the standing system+tools prefix at current list rates. Not billed spend and not part of list-price value."
         >
           <span>Standing context floor (est.)</span>
           <span className="tabular-nums">
@@ -788,6 +974,8 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
               : adviceCopy.message}
           </p>
         </div>
+      ) : null}
+      </div>
       ) : null}
 
       {/* (c) Additive value framing — routing list-price + cache + compact

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -44,6 +44,16 @@ function jobModel(row: EconomicsJobRow): string {
   return shortModel(id);
 }
 
+function costBasisLabel(basis: string | null | undefined): string {
+  const value = (basis || "").trim().toLowerCase();
+  if (value === "plan") return " · plan $0-marginal";
+  if (value === "estimated") return " · estimated";
+  if (value === "mixed") return " · mixed basis";
+  if (value === "unknown") return " · unknown basis";
+  if (value.includes("measured")) return " · measured";
+  return "";
+}
+
 export default function EconomicsDurable({
   data,
   scope,
@@ -68,7 +78,7 @@ export default function EconomicsDurable({
       <p className="text-[10px] text-muted mb-2 leading-snug">
         {scope === "conversation"
           ? "Owned jobs for this conversation. Puppetmaster savings stay on This repo / Last 30 days / All projects."
-          : "Puppetmaster savings and job receipts for the selected scope. App-run spend stays above."}
+          : "Puppetmaster savings for the selected scope. Recent jobs are this workspace tracker; Last 30 days keeps jobs created in that window. App-run spend stays above."}
       </p>
 
       <label className="flex items-center justify-between mb-2 text-faint">
@@ -159,7 +169,9 @@ export default function EconomicsDurable({
                 <div className="flex items-center justify-between text-faint">
                   <span className="truncate pr-2">{job.job_id || "job"}</span>
                   <span className="tabular-nums shrink-0">
-                    {owned ? `${fmtUnknownMoney(actual)} vs ${fmtUnknownMoney(jobAvoided)}` : "—"}
+                    {owned
+                      ? `${fmtUnknownMoney(actual)} vs ${fmtUnknownMoney(jobAvoided)}${costBasisLabel(job.cost_basis)}`
+                      : "—"}
                   </span>
                 </div>
                 <div className="flex items-center justify-between text-faint">

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -1,0 +1,171 @@
+import type { EconomicsData, EconomicsJobRow, EconomicsScope } from "../lib/api";
+
+const SCOPES: Array<{ value: EconomicsScope; label: string }> = [
+  { value: "repo", label: "This repo" },
+  { value: "window30", label: "Last 30 days" },
+  { value: "all_projects", label: "All projects" },
+  { value: "conversation", label: "This conversation" },
+];
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/** Unknown stays em-dash — never a measured $0. */
+function fmtUnknownMoney(value: number | null | undefined): string {
+  if (!isFiniteNumber(value)) return "—";
+  if (value < 0.001 && value !== 0) return `$${value.toFixed(4)}`;
+  if (value < 0.01 && value !== 0) return `$${value.toFixed(3)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+function fmtTokens(value: number | null | undefined): string {
+  if (!isFiniteNumber(value)) return "—";
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  if (value >= 1000) return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return String(value);
+}
+
+function fmtRate(value: number | null | undefined): string {
+  if (!isFiniteNumber(value)) return "—";
+  return `${Math.round(value * 100)}%`;
+}
+
+function shortModel(model: string | undefined): string {
+  const text = (model || "").trim();
+  if (!text) return "unknown";
+  const afterColon = text.includes(":") ? text.slice(text.lastIndexOf(":") + 1) : text;
+  const slash = afterColon.lastIndexOf("/");
+  return slash >= 0 ? afterColon.slice(slash + 1) : afterColon;
+}
+
+function jobModel(row: EconomicsJobRow): string {
+  const id = row.models?.[0]?.model_id;
+  return shortModel(id);
+}
+
+export default function EconomicsDurable({
+  data,
+  scope,
+  onScopeChange,
+}: {
+  data: EconomicsData | null;
+  scope: EconomicsScope;
+  onScopeChange: (scope: EconomicsScope) => void;
+}) {
+  const referenceId = data?.counterfactual?.reference_model_id
+    || data?.savings?.counterfactual?.reference_model_id
+    || "";
+  const routingSaved = data?.savings?.routing?.saved_usd;
+  const codegraphEst = data?.savings?.codegraph?.dollars_saved_est;
+  const avoided = data?.counterfactual?.avoided_usd;
+  const planRouted = data?.savings?.routing?.plan_routed_tasks ?? 0;
+  const jobs = Array.isArray(data?.recent_jobs) ? data.recent_jobs : [];
+
+  return (
+    <div className="w-full px-3 pb-3 text-[11px] text-txt">
+      <div className="text-[10px] uppercase tracking-wide text-faint">Durable</div>
+      <p className="text-[10px] text-muted mb-2 leading-snug">
+        Puppetmaster savings and job receipts for the selected scope. App-run spend stays above.
+      </p>
+
+      <label className="flex items-center justify-between mb-2 text-faint">
+        <span className="text-[10px] uppercase tracking-wide">Scope</span>
+        <select
+          className="bg-transparent text-[11px] text-txt"
+          value={scope}
+          onChange={(event) => onScopeChange(event.target.value as EconomicsScope)}
+          aria-label="Economics scope"
+        >
+          {SCOPES.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {data && data.available === false ? (
+        <p className="text-[10px] text-muted mb-2 leading-snug">
+          {data.error || "Durable economics unavailable."}
+        </p>
+      ) : null}
+
+      {referenceId ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>Reference model</span>
+          <span className="tabular-nums text-right truncate pl-2">{referenceId}</span>
+        </div>
+      ) : null}
+
+      {isFiniteNumber(routingSaved) && routingSaved > 0 ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>Routing saved (measured)</span>
+          <span className="tabular-nums">{fmtUnknownMoney(routingSaved)}</span>
+        </div>
+      ) : data?.available !== false && data?.savings && !isFiniteNumber(routingSaved) ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>Routing saved (measured)</span>
+          <span className="tabular-nums">unknown basis</span>
+        </div>
+      ) : null}
+
+      {isFiniteNumber(codegraphEst) ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>CodeGraph (estimated)</span>
+          <span className="tabular-nums">{fmtUnknownMoney(codegraphEst)}</span>
+        </div>
+      ) : null}
+
+      {isFiniteNumber(avoided) ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>
+            {referenceId
+              ? `list-price vs ${referenceId}, not a refund`
+              : "list-price vs reference, not a refund"}
+          </span>
+          <span className="tabular-nums">{fmtUnknownMoney(avoided)}</span>
+        </div>
+      ) : null}
+
+      {planRouted > 0 ? (
+        <div className="flex items-center justify-between mb-1 text-faint">
+          <span>Plan-routed / $0-marginal</span>
+          <span className="tabular-nums">{planRouted} tasks, not measured cash</span>
+        </div>
+      ) : null}
+
+      {jobs.length > 0 ? (
+        <div className="mt-3">
+          <div className="text-[10px] uppercase tracking-wide text-faint mb-2">Recent jobs</div>
+          {jobs.map((job) => {
+            const owned = Boolean(job.accounting_owned);
+            const actual = owned ? job.actual_marginal_usd : null;
+            const jobAvoided = owned ? job.counterfactual?.avoided_usd : null;
+            return (
+              <div key={job.job_id || `${job.source}-${job.status}`} className="mb-2">
+                <div className="flex items-center justify-between text-faint">
+                  <span className="truncate pr-2">{job.job_id || "job"}</span>
+                  <span className="tabular-nums shrink-0">
+                    {owned ? `${fmtUnknownMoney(actual)} vs ${fmtUnknownMoney(jobAvoided)}` : "—"}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-faint">
+                  <span className="truncate pr-2">
+                    {jobModel(job)}
+                    {!owned ? " · visible only" : ""}
+                  </span>
+                  <span className="tabular-nums shrink-0">
+                    {fmtTokens(job.tokens)} · {isFiniteNumber(job.typed_artifacts) ? job.typed_artifacts : "—"} typed
+                    {isFiniteNumber(job.tokens_per_typed_artifact) ? ` · ${fmtTokens(job.tokens_per_typed_artifact)}/typed` : ""}
+                    {` · ${fmtRate(job.degraded_rate)} degraded`}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -66,7 +66,9 @@ export default function EconomicsDurable({
     <div className="w-full px-3 pb-3 text-[11px] text-txt">
       <div className="text-[10px] uppercase tracking-wide text-faint">Durable</div>
       <p className="text-[10px] text-muted mb-2 leading-snug">
-        Puppetmaster savings and job receipts for the selected scope. App-run spend stays above.
+        {scope === "conversation"
+          ? "Owned jobs for this conversation. Puppetmaster savings stay on This repo / Last 30 days / All projects."
+          : "Puppetmaster savings and job receipts for the selected scope. App-run spend stays above."}
       </p>
 
       <label className="flex items-center justify-between mb-2 text-faint">
@@ -91,6 +93,14 @@ export default function EconomicsDurable({
         </p>
       ) : null}
 
+      {scope === "conversation" ? (
+        jobs.length === 0 && data?.available !== false ? (
+          <p className="text-[10px] text-muted mb-2 leading-snug">
+            No owned jobs stamped for this conversation.
+          </p>
+        ) : null
+      ) : (
+      <>
       {referenceId ? (
         <div className="flex items-center justify-between mb-1 text-faint">
           <span>Reference model</span>
@@ -134,6 +144,8 @@ export default function EconomicsDurable({
           <span className="tabular-nums">{planRouted} tasks, not measured cash</span>
         </div>
       ) : null}
+      </>
+      )}
 
       {jobs.length > 0 ? (
         <div className="mt-3">

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useState } from "react";
-import { api, type UsageData } from "../lib/api";
+import { api, type EconomicsData, type EconomicsScope, type UsageData } from "../lib/api";
 import { usePolling } from "../lib/usePolling";
 import CostBreakdown, { usageToCostBreakdownData } from "./CostBreakdown";
+import EconomicsDurable from "./EconomicsDurable";
 
-/** Right-pane Economics card: live process / this-app-run spend and list-price value. */
+function isEconomicsPayload(data: unknown): data is EconomicsData {
+  return Boolean(data && typeof data === "object" && "available" in (data as object));
+}
+
+/** Right-pane Economics card: live process spend plus durable PM projection. */
 export default function EconomicsPane() {
   const [session, setSession] = useState<UsageData["session"] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [scope, setScope] = useState<EconomicsScope>("repo");
+  const [economics, setEconomics] = useState<EconomicsData | null>(null);
 
   const loadUsage = () =>
     api.getUsage()
@@ -21,17 +28,37 @@ export default function EconomicsPane() {
         setError("Couldn't load this app run's spend.");
       });
 
-  usePolling(loadUsage, 10000);
+  const loadEconomics = () =>
+    Promise.resolve(api.getEconomics(scope))
+      .then((data) => {
+        if (isEconomicsPayload(data)) {
+          setEconomics(data);
+        }
+      })
+      .catch(() => {
+        // Older harnesses omit GET /api/economics; keep CostBreakdown up.
+      });
+
+  const loadAll = () => {
+    void loadUsage();
+    void loadEconomics();
+  };
+
+  usePolling(loadAll, 10000);
 
   useEffect(() => {
-    const onRefresh = () => { void loadUsage(); };
+    const onRefresh = () => { void loadAll(); };
     window.addEventListener("harness-usage-refresh", onRefresh);
     window.addEventListener("harness-session-changed", onRefresh);
     return () => {
       window.removeEventListener("harness-usage-refresh", onRefresh);
       window.removeEventListener("harness-session-changed", onRefresh);
     };
-  }, []);
+  }, [scope]);
+
+  useEffect(() => {
+    void loadEconomics();
+  }, [scope]);
 
   if (!session && error) {
     return <p className="px-3 py-3 text-[11px] text-muted">{error}</p>;
@@ -39,5 +66,10 @@ export default function EconomicsPane() {
   if (!session) {
     return <p className="px-3 py-3 text-[11px] text-muted">Loading this app run…</p>;
   }
-  return <CostBreakdown data={usageToCostBreakdownData(session)} />;
+  return (
+    <div className="w-full min-h-0 overflow-auto">
+      <CostBreakdown data={usageToCostBreakdownData(session)} />
+      <EconomicsDurable data={economics} scope={scope} onScopeChange={setScope} />
+    </div>
+  );
 }

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -31,8 +31,13 @@ export default function EconomicsPane() {
   const loadEconomics = () =>
     Promise.resolve(api.getEconomics(scope))
       .then((data) => {
-        if (isEconomicsPayload(data)) {
+        if (isEconomicsPayload(data) && (!data.scope || data.scope === scope)) {
           setEconomics(data);
+          return;
+        }
+        // getJSONSoft turns HTTP 400 into {ok:false} without `available`.
+        if (data && typeof data === "object" && (data as { ok?: boolean }).ok === false) {
+          setEconomics(null);
         }
       })
       .catch(() => {

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { api, type UsageData } from "../lib/api";
+import { usePolling } from "../lib/usePolling";
+import CostBreakdown, { usageToCostBreakdownData } from "./CostBreakdown";
+
+/** Right-pane Economics card: live process / this-app-run spend and list-price value. */
+export default function EconomicsPane() {
+  const [session, setSession] = useState<UsageData["session"] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadUsage = () =>
+    api.getUsage()
+      .then((data) => {
+        if (data?.session) {
+          setSession(data.session);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to load usage in EconomicsPane", err);
+        setError("Couldn't load this app run's spend.");
+      });
+
+  usePolling(loadUsage, 10000);
+
+  useEffect(() => {
+    const onRefresh = () => { void loadUsage(); };
+    window.addEventListener("harness-usage-refresh", onRefresh);
+    window.addEventListener("harness-session-changed", onRefresh);
+    return () => {
+      window.removeEventListener("harness-usage-refresh", onRefresh);
+      window.removeEventListener("harness-session-changed", onRefresh);
+    };
+  }, []);
+
+  if (!session && error) {
+    return <p className="px-3 py-3 text-[11px] text-muted">{error}</p>;
+  }
+  if (!session) {
+    return <p className="px-3 py-3 text-[11px] text-muted">Loading this app run…</p>;
+  }
+  return <CostBreakdown data={usageToCostBreakdownData(session)} />;
+}

--- a/webapp/src/components/RightDock.tsx
+++ b/webapp/src/components/RightDock.tsx
@@ -7,6 +7,7 @@ import {
   GitPullRequest,
   Globe,
   History,
+  Coins,
   Network,
   PanelRight,
   PanelRightClose,
@@ -56,6 +57,7 @@ const DOCK_LINKS: { id: string; tab: string; icon: ReactNode; title: string }[] 
 const PANEL_OPTIONS = [
   { tab: "state", label: "State", icon: <Database size={12} /> },
   { tab: "swarm", label: "Swarm", icon: <Network size={12} /> },
+  { tab: "economics", label: "Economics", icon: <Coins size={12} /> },
   { tab: "files", label: "Files", icon: <FolderTree size={12} /> },
   { tab: "git", label: "Git", icon: <GitBranch size={12} /> },
   { tab: "worktrees", label: "Worktrees", icon: <GitFork size={12} /> },
@@ -194,10 +196,13 @@ export default function RightDock({
           {addMenuOpen && (
             <div key={menuVersion} role="menu" aria-label="Add panel" className="right-pane-add-menu right-[calc(100%+8px)] left-auto top-0">
               <div className="px-2 py-1 text-[9px] uppercase tracking-wider text-faint">Add panel</div>
-              {(readStoredList("pmharness.tabOrder").length > 0
-                ? readStoredList("pmharness.tabOrder")
-                : PANEL_OPTIONS.map(option => option.tab)
-              ).filter(tab => tab !== "settings").map(tab => {
+              {(() => {
+                const stored = readStoredList("pmharness.tabOrder");
+                const fallback = PANEL_OPTIONS.map(option => option.tab);
+                return stored.length > 0
+                  ? [...stored, ...fallback.filter(tab => !stored.includes(tab))]
+                  : fallback;
+              })().filter(tab => tab !== "settings").map(tab => {
                 const option = PANEL_OPTIONS.find(item => item.tab === tab);
                 if (!option || readStoredList("pmharness.board.openCards").includes(tab)) return null;
                 return (

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -10,6 +10,7 @@ import TerminalPane from "./TerminalPane";
 import CheckpointsPane from "./CheckpointsPane";
 import DiffReviewPane from "./DiffReviewPane";
 import SwarmPane from "./SwarmPane";
+import EconomicsPane from "./EconomicsPane";
 import ErrorBoundary from "./ErrorBoundary";
 import { api, type PendingReview } from "../lib/api";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
@@ -59,7 +60,7 @@ import {
   stackRowTemplateN,
 } from "../lib/stackSplit";
 
-type Tab = "state" | "files" | "git" | "worktrees" | "terminal" | "browser" | "settings" | "checkpoints" | "review" | "swarm";
+type Tab = "state" | "files" | "git" | "worktrees" | "terminal" | "browser" | "settings" | "checkpoints" | "review" | "swarm" | "economics";
 
 const TAB_CONFIG: Record<Tab, { label: string }> = {
   state: { label: "State" },
@@ -72,10 +73,11 @@ const TAB_CONFIG: Record<Tab, { label: string }> = {
   checkpoints: { label: "History" },
   review: { label: "Review" },
   swarm: { label: "Swarm" },
+  economics: { label: "Economics" },
 };
 
 const TAB_GROUPS: { group: string; tabs: Tab[] }[] = [
-  { group: "workspace", tabs: ["state", "swarm", "files", "git", "worktrees", "terminal"] },
+  { group: "workspace", tabs: ["state", "swarm", "economics", "files", "git", "worktrees", "terminal"] },
   { group: "changes", tabs: ["review", "checkpoints"] },
   { group: "tools", tabs: ["browser"] },
 ];
@@ -570,7 +572,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
           return;
         }
         const targetTab = e.detail as Tab;
-        const validTabs: Tab[] = ["state", "files", "git", "worktrees", "terminal", "browser", "settings", "swarm", "checkpoints", "review"];
+        const validTabs: Tab[] = ["state", "files", "git", "worktrees", "terminal", "browser", "settings", "swarm", "economics", "checkpoints", "review"];
         if (validTabs.includes(targetTab)) {
           if (targetTab === "settings") {
             openSettings();
@@ -608,6 +610,8 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
         return <CheckpointsPane />;
       case "swarm":
         return <SwarmPane />;
+      case "economics":
+        return <EconomicsPane />;
       case "review":
         return (
           <DiffReviewPane

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -2384,11 +2384,19 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
             <div className="space-y-2.5 bg-panel2 border border-edge/50 rounded p-2.5">
               <div className="space-y-1">
                 <div className="flex items-center justify-between text-[11px]">
-                  <span className="text-faint">Session Tokens:</span>
+                  <span className="text-faint">This app run tokens:</span>
                   <span className="text-txt font-mono font-medium">{usage.session.tokens_used.toLocaleString()}</span>
                 </div>
                 <div className="flex items-center justify-between text-[11px]">
-                  <span className="text-faint">Session Cost (estimated):</span>
+                  <span className="text-faint">
+                    {usage.session.cost_source === "provider" && usage.session.estimated !== true
+                      ? "This app run (provider-billed):"
+                      : usage.session.cost_source === "mixed"
+                        ? "This app run (mixed):"
+                        : usage.session.cost_source === "plan_estimated"
+                          ? "This app run (plan):"
+                          : "This app run (estimated):"}
+                  </span>
                   <span className="text-good font-mono font-medium">${usage.session.est_cost_usd.toFixed(6)}</span>
                 </div>
                 <div className="flex flex-wrap items-center justify-between gap-1 text-[11px] border-t border-edge/30 pt-1 mt-1">
@@ -2422,7 +2430,8 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
             <p className="text-[10px] text-muted">Loading usage statistics...</p>
           )}
           <p className="text-[9px] text-muted font-mono">
-            All costs are estimated locally based on catalog rates. No live billing APIs are called.
+            This app run resets on full quit — not Swarm pane repo-session spend or conversation lifetime.
+            Spend basis may be provider-billed, mixed, estimated from catalog rates, or a plan-credit estimate.
           </p>
         </div>
 

--- a/webapp/src/components/StatusBar.tsx
+++ b/webapp/src/components/StatusBar.tsx
@@ -23,7 +23,7 @@ import {
 } from "../lib/taskProfileChrome";
 import { isDesktop } from "../lib/transport";
 import { usePolling } from "../lib/usePolling";
-import CostBreakdown, {
+import {
   cacheHitDisplay,
   delegationSavingsCredited,
   listPriceValueTotal,
@@ -79,16 +79,15 @@ function truncateGoalText(text: string, max = 36): string {
 // in LeftRail SESSION JOBS -- a footer total was stale across dir swaps and
 // disagreed with the scoped list, so it was removed. Narrow widths hide
 // secondary labels via container queries instead of overlapping the clusters.
-export default function StatusBar({ config, update, leftOpen, rightOpen, onToggleLeft, onToggleRight }: {
+export default function StatusBar({ config, update, leftOpen, rightOpen, onToggleLeft, onToggleRight, onOpenEconomics }: {
   config: Config | null;
   update: UpdateAvailability | null;
   leftOpen: boolean; rightOpen: boolean;
   onToggleLeft: () => void; onToggleRight: () => void;
+  onOpenEconomics: () => void;
 }) {
   const [branch, setBranch] = useState("");
   const [usage, setUsage] = useState<UsageData["session"] | null>(null);
-  const [costOpen, setCostOpen] = useState(false);
-  const costRef = useRef<HTMLDivElement | null>(null);
   const [apply, setApply] = useState<{ stage: string; message: string; percent: number | null } | null>(null);
   const [toast, setToast] = useState<{
     message: string;
@@ -278,22 +277,6 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
     };
   }, [usageBusy]);
 
-  // Dismiss the cost breakdown popover on outside click or Escape, matching the
-  // PilotPicker dropdown behavior so the status bar has one consistent pattern.
-  useEffect(() => {
-    if (!costOpen) return;
-    const onDown = (e: MouseEvent) => {
-      if (costRef.current && !costRef.current.contains(e.target as Node)) setCostOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setCostOpen(false); };
-    document.addEventListener("mousedown", onDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [costOpen]);
-
   const formatTokens = (num: number) => {
     if (num >= 1000000) {
       return (num / 1000000).toFixed(1).replace(/\.0$/, "") + "M";
@@ -482,7 +465,9 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
                   : "",
               ].filter(Boolean).join("  ·  ");
               return (
-                <span
+                <button
+                  type="button"
+                  onClick={onOpenEconomics}
                   className="status-bar-optional-sm inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-good/10 border border-good/20 text-good/90"
                   title={`${hit.title} List-price value from model selection, prompt-cache, and compaction (additive, not overlapping cash refunds): ${detail}`}
                 >
@@ -498,95 +483,30 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
                     : (cached > 0 || compacted > 0)
                       ? `${formatTokens(cached + compacted)} saved`
                       : null}
-                </span>
+                </button>
               );
             })()}
-            {/* The estimated cost is now a click/hover trigger for a compact
-                routing-value breakdown (why this model / what it saved). It
-                stays a plain figure when there is nothing meaningful to expand. */}
-            <span className="relative inline-flex items-center gap-1 shrink-0" ref={costRef}>
+            <span className="relative inline-flex items-center gap-1 shrink-0">
               <button
                 type="button"
-                onClick={() => setCostOpen((v) => !v)}
+                onClick={onOpenEconomics}
                 title={
                   !spendIsEstimated(usage)
-                    ? "Process-wide billed spend since app launch (provider usage.cost) -- click for the full cost breakdown"
+                    ? "Process-wide billed spend since app launch (provider usage.cost) -- click to open Economics"
                     : usage.cost_source === "plan_estimated"
-                      ? "Process-wide plan-credit estimate since app launch (subscription pilots; not an API receipt) -- click for the full cost breakdown"
+                      ? "Process-wide plan-credit estimate since app launch (subscription pilots; not an API receipt) -- click to open Economics"
                       : usage.price_source === "default"
-                        ? "Process-wide estimated spend using default rates (live/catalog pricing unavailable) -- click for the full cost breakdown"
+                        ? "Process-wide estimated spend using default rates (live/catalog pricing unavailable) -- click to open Economics"
                         : usage.price_source === "unknown"
-                          ? "Process-wide spend with unavailable model rates (no fabricated dollars) -- click for the full cost breakdown"
-                          : "Process-wide estimated spend since app launch -- click for the full cost breakdown (Swarm pane shows per-repo session spend)"
+                          ? "Process-wide spend with unavailable model rates (no fabricated dollars) -- click to open Economics"
+                          : "Process-wide estimated spend since app launch -- click to open Economics (Swarm pane shows per-repo session spend)"
                 }
-                className="inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-panel2 border border-edge text-txt/90 font-medium hover:border-good/40 hover:text-good transition cursor-pointer"
+                className="inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-panel2 border border-edge text-txt/90 font-medium hover:border-edge hover:text-txt transition cursor-pointer"
               >
                 {spendIsEstimated(usage) ? "~" : ""}
                 {formatCost(usage.est_cost_usd)}
               </button>
               <span className="text-faint/70 normal-case font-sans tracking-normal status-bar-optional-lg">process</span>
-              {costOpen && (
-                <div className="absolute bottom-full right-0 mb-1.5 z-50">
-                  <CostBreakdown
-                    data={{
-                      tokens_used: usage.tokens_used,
-                      est_cost_usd: usage.est_cost_usd,
-                      cost_source: usage.cost_source,
-                      price_source: usage.price_source,
-                      estimated: usage.estimated,
-                      tokens_cached: usage.tokens_cached,
-                      pilot_input_tokens: usage.pilot_input_tokens,
-                      pilot_cache_read_tokens: usage.pilot_cache_read_tokens,
-                      pilot_cache_hit_ratio: usage.pilot_cache_hit_ratio,
-                      swarm_input_tokens: usage.swarm_input_tokens,
-                      swarm_cache_read_tokens: usage.swarm_cache_read_tokens,
-                      swarm_cache_hit_ratio: usage.swarm_cache_hit_ratio,
-                      prompt_input_tokens: usage.prompt_input_tokens,
-                      prompt_cache_read_tokens: usage.prompt_cache_read_tokens,
-                      prompt_cache_hit_ratio: usage.prompt_cache_hit_ratio,
-                      cache_savings_usd: usage.cache_savings_usd,
-                      cache_savings_gross_usd: usage.cache_savings_gross_usd,
-                      cache_savings_basis: usage.cache_savings_basis,
-                      routing_saved_usd: usage.routing_saved_usd,
-                      routing_savings_basis: usage.routing_savings_basis,
-                      routing_tokens_compared: usage.routing_tokens_compared,
-                      delegation_saved_usd: usage.delegation_saved_usd,
-                      delegation_savings_basis: usage.delegation_savings_basis,
-                      delegation_tokens_compared: usage.delegation_tokens_compared,
-                      cache_saved_usd_swarm: usage.cache_saved_usd_swarm,
-                      swarm_cache_savings_basis: usage.swarm_cache_savings_basis,
-                      swarm_cache_unpriced_tokens: usage.swarm_cache_unpriced_tokens,
-                      tool_output_tokens_saved: usage.tool_output_tokens_saved,
-                      tool_output_savings_usd: usage.tool_output_savings_usd,
-                      history_compactions: usage.history_compactions,
-                      history_tokens_saved: usage.history_tokens_saved,
-                      history_cache_bust_tokens: usage.history_cache_bust_tokens,
-                      history_thrash_events: usage.history_thrash_events,
-                      history_compaction_cost_usd: usage.history_compaction_cost_usd,
-                      spill_count: usage.spill_count,
-                      spill_chars: usage.spill_chars,
-                      evals_recorded: usage.evals_recorded,
-                      evals_failed: usage.evals_failed,
-                      memory_layers: usage.memory_layers,
-                      compaction_advice: usage.compaction_advice,
-                      history_compaction_ran: usage.history_compaction_ran,
-                      standing_economics_basis: usage.standing_economics_basis,
-                      standing_system_tokens: usage.standing_system_tokens,
-                      standing_tool_tokens: usage.standing_tool_tokens,
-                      standing_floor_tokens: usage.standing_floor_tokens,
-                      standing_floor_cost_usd: usage.standing_floor_cost_usd,
-                      standing_floor_cost_cached_usd: usage.standing_floor_cost_cached_usd,
-                      prompt_cache_ttl_ms: usage.prompt_cache_ttl_ms,
-                      prompt_cache_age_ms: usage.prompt_cache_age_ms,
-                      prompt_cache_expires_in_ms: usage.prompt_cache_expires_in_ms,
-                      prompt_cache_state: usage.prompt_cache_state,
-                      price_in: usage.price_in,
-                      price_out: usage.price_out,
-                      pilot_by_model: usage.pilot_by_model,
-                    }}
-                  />
-                </div>
-              )}
             </span>
           </span>
         </>

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -779,6 +779,76 @@ export type UsageData = {
   }[];
 };
 
+export type EconomicsScope = "repo" | "window30" | "all_projects" | "conversation";
+
+export type EconomicsJobRow = {
+  job_id?: string;
+  status?: string;
+  source?: string;
+  accounting_owned?: boolean;
+  accounting_scope?: "marionette" | "visibility_only" | string;
+  models?: Array<{
+    model_id?: string;
+    billing?: string;
+    calls?: number;
+    tokens_in?: number;
+    tokens_out?: number;
+  }>;
+  billing?: string[];
+  tokens?: number | null;
+  actual_marginal_usd?: number | null;
+  measured_cost_usd?: number | null;
+  estimated_cost_usd?: number | null;
+  cost_basis?: string | null;
+  counterfactual?: {
+    reference_model_id?: string;
+    reference_priced?: boolean;
+    naive_cost_usd?: number | null;
+    actual_cost_usd?: number | null;
+    avoided_usd?: number | null;
+  } | null;
+  typed_artifacts?: number | null;
+  tokens_per_typed_artifact?: number | null;
+  degraded_rate?: number | null;
+  degraded_tasks?: number | null;
+};
+
+export type EconomicsData = {
+  scope?: EconomicsScope | string;
+  window_days?: number | null;
+  all_projects?: boolean;
+  available?: boolean;
+  error?: string;
+  savings?: {
+    routing?: {
+      saved_usd?: number;
+      baseline_usd?: number;
+      plan_routed_tasks?: number;
+    };
+    routing_pct_cheaper?: number;
+    codegraph?: {
+      dollars_saved_est?: number;
+    };
+    counterfactual?: {
+      reference_model_id?: string;
+      avoided_usd?: number | null;
+    } | null;
+  } | null;
+  counterfactual?: {
+    reference_model_id?: string;
+    reference_priced?: boolean;
+    naive_cost_usd?: number | null;
+    actual_cost_usd?: number | null;
+    avoided_usd?: number | null;
+    label?: string;
+  } | null;
+  recent_jobs?: EconomicsJobRow[];
+  owned_jobs_considered?: number;
+  owned_actual_marginal_usd?: number | null;
+  owned_avoided_usd?: number | null;
+  labels?: Record<string, string>;
+};
+
 export type Checkpoint = {
   id: string;
   label: string;
@@ -1028,6 +1098,8 @@ export const api = {
 
   config: () => getJSON<Config>("/api/config"),
   getUsage: () => getJSON<UsageData>("/api/usage"),
+  getEconomics: (scope: EconomicsScope | string = "repo") =>
+    getJSONSoft<EconomicsData>(`/api/economics?scope=${encodeURIComponent(scope)}`),
   settings: () => getJSON<Settings>("/api/settings"),
   updateSettings: (partial: Partial<Settings> & { api_key?: string; clear_api_key?: boolean }) => postJSON<Settings>("/api/settings", partial),
   jobs: (repoRoot?: string) => {

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -815,6 +815,8 @@ export type EconomicsJobRow = {
 
 export type EconomicsData = {
   scope?: EconomicsScope | string;
+  /** Where PM savings were aggregated. Conversation jobs use repo-lifetime savings. */
+  savings_scope?: EconomicsScope | string;
   window_days?: number | null;
   all_projects?: boolean;
   available?: boolean;

--- a/webapp/src/lib/rightPaneTabVisibility.ts
+++ b/webapp/src/lib/rightPaneTabVisibility.ts
@@ -3,6 +3,7 @@
 export type RightPaneTabId =
   | "state"
   | "swarm"
+  | "economics"
   | "files"
   | "git"
   | "worktrees"
@@ -26,6 +27,7 @@ export type RightPaneTabVisibility = Record<RightPaneTabId, boolean>;
 export const DEFAULT_RIGHT_PANE_TAB_VISIBILITY: RightPaneTabVisibility = {
   state: true,
   swarm: true,
+  economics: true,
   files: true,
   git: true,
   worktrees: false,


### PR DESCRIPTION
## Summary
- Absorb #78 Economics: one right-pane surface. This app run stays process spend; Durable projects Puppetmaster savings/cost/receipt with named counterfactual reference.
- Conversation scope lists session-stamped owned jobs only and does not present repo-lifetime savings as this-chat spend. Visibility-only jobs cannot enter owned totals.
- Pins `puppetmaster-ai==1.22.15` across desktop bootstrap, install/doctor, CI, and README. Version 0.9.259.

## Test plan
- [x] Live peel vs `python -m puppetmaster savings --json` (repo + window30 fields matched)
- [x] `pytest` economics peel + version consistency
- [x] vitest EconomicsPane / StatusBar / CostBreakdown
- [x] electron update-pm pin copies match DEFAULT_PUPPETMASTER_SPEC
- [ ] dest→main `tests` matrix: 3.9, 3.11, Windows, frontend-build
