### PR TITLE
Release v0.9.261

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.15` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.260, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Cursor CLI accepts `CURSOR_API_KEY` (or a pasted Settings key) and no longer passes the invalid `--mode agent` flag. Window glass factory-flips to Soft 40 on this update; later Settings changes keep. Economics remains one right-pane surface for process spend plus a Durable Puppetmaster projection. Compact residual factory default remains catalog.
+> Status: v0.9.261, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Window glass factory-flips to Soft 40; Windows Settings no longer hide the lever when the OS build is misreported. The floating dock pill uses the same `--shell-panel` glass as the left rail. Cursor CLI accepts `CURSOR_API_KEY`. Compact residual factory default remains catalog.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.260"
+__version__ = "0.9.261"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.260"
+version = "0.9.261"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.260"
+version = "0.9.261"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/electron/translucency.cjs
+++ b/webapp/electron/translucency.cjs
@@ -60,11 +60,42 @@ function translucencySupportedOn(platform) {
   return platform === "darwin" || platform === "win32";
 }
 
-function glassSupportedOn(platform, release) {
+function windowsBuildNumber(release) {
+  const parts = String(release || "").split(".");
+  const raw = parts.length >= 3 ? parts[2] : parts[0];
+  const build = Number.parseInt(raw || "", 10);
+  return Number.isFinite(build) ? build : 0;
+}
+
+function resolveSystemRelease(explicit) {
+  if (explicit) return String(explicit);
+  try {
+    if (typeof process.getSystemVersion === "function") {
+      const version = process.getSystemVersion();
+      if (version) return String(version);
+    }
+  } catch {
+    /* Electron-only */
+  }
+  return os.release();
+}
+
+function readOsVersionName(explicit) {
+  if (explicit != null) return String(explicit);
+  try {
+    return os.version();
+  } catch {
+    return "";
+  }
+}
+
+function glassSupportedOn(platform, release, versionName) {
   if (platform === "darwin") return true;
   if (platform !== "win32") return false;
-  const build = Number.parseInt(String(release || "").split(".")[2] || "", 10);
-  return Number.isFinite(build) && build >= WINDOWS_GLASS_MIN_BUILD;
+  if (windowsBuildNumber(release) >= WINDOWS_GLASS_MIN_BUILD) return true;
+  // Application-manifest compat can make os.release() look like 6.2.9200
+  // on a real Windows 11 box. os.version() still says Windows 11.
+  return /Windows 11/i.test(String(versionName || ""));
 }
 
 function normalizeMode(value, glassSupported, legacyIntensity) {
@@ -176,12 +207,13 @@ function translucencyDiff(previous, next) {
   };
 }
 
-function capabilities(platform, release) {
-  const glassSupported = glassSupportedOn(platform, release);
+function capabilities(platform, release, versionName) {
+  const glassSupported = glassSupportedOn(platform, release, versionName);
   return {
     translucencySupported: translucencySupportedOn(platform),
     glassSupported,
     isWindows: platform === "win32",
+    windowsBuild: platform === "win32" ? windowsBuildNumber(release) : 0,
     materials: glassMaterialsFor(platform === "win32" && glassSupported),
   };
 }
@@ -277,11 +309,20 @@ function applyWindowTranslucency(win, state, changed, opts) {
 
 function createTranslucencyController(opts) {
   const platform = (opts && opts.platform) || process.platform;
-  const release = (opts && opts.release) || os.release();
+  const release = resolveSystemRelease(opts && opts.release);
+  const versionName = readOsVersionName(opts && opts.versionName);
   const homeDir = opts && opts.homeDir;
   const getWindow = opts && opts.getWindow;
   const log = (opts && opts.log) || (() => {});
-  const caps = capabilities(platform, release);
+  const caps = capabilities(platform, release, versionName);
+  try {
+    log(
+      `[translucency] platform=${platform} release=${release} ` +
+        `build=${caps.windowsBuild} glass=${caps.glassSupported}`,
+    );
+  } catch {
+    /* logging must never throw */
+  }
   const loaded = loadPersistedTranslucency({
     homeDir,
     glassSupported: caps.glassSupported,
@@ -378,6 +419,9 @@ module.exports = {
   glassMaterialsFor,
   glassSurfaceKeep,
   glassSupportedOn,
+  readOsVersionName,
+  resolveSystemRelease,
+  windowsBuildNumber,
   normalizeMaterial,
   normalizeMode,
   normalizeState,

--- a/webapp/electron/translucency.test.cjs
+++ b/webapp/electron/translucency.test.cjs
@@ -61,8 +61,13 @@ describe("platform support", () => {
     assert.equal(glassSupportedOn("darwin"), true);
     assert.equal(glassSupportedOn("linux"), false);
     assert.equal(glassSupportedOn("win32", "10.0.22621"), true);
+    assert.equal(glassSupportedOn("win32", "10.0.26100.4652"), true);
     assert.equal(glassSupportedOn("win32", "10.0.19045"), false);
     assert.equal(glassSupportedOn("win32", ""), false);
+    assert.equal(glassSupportedOn("win32", "6.2.9200"), false);
+    assert.equal(glassSupportedOn("win32", "6.2.9200", "Windows 11 Pro"), true);
+    assert.equal(capabilities("win32", "10.0.26100.4652").windowsBuild, 26100);
+    assert.equal(capabilities("win32", "6.2.9200", "Windows 11 Pro").glassSupported, true);
   });
 });
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.260",
+  "version": "0.9.261",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.260",
+      "version": "0.9.261",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.260",
+  "version": "0.9.261",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/RightPane.collapse.test.tsx
+++ b/webapp/src/__tests__/RightPane.collapse.test.tsx
@@ -86,6 +86,11 @@ describe("RightPane collapse placement", () => {
     seedBoardTabOrder();
   });
 
+  it("paints the floating pill with the left-rail panel glass", () => {
+    render(<RightDock onOpenTab={vi.fn()} onExpand={vi.fn()} onCollapse={baseProps.onCollapse} />);
+    expect(screen.getByTestId("floating-dock-pill")).toHaveClass("shell-inset-glass");
+  });
+
   it("places collapse in the dock action cluster and invokes onCollapse", () => {
     render(<RightDock onOpenTab={vi.fn()} onExpand={vi.fn()} onCollapse={baseProps.onCollapse} />);
 

--- a/webapp/src/__tests__/WindowGlassSettings.test.tsx
+++ b/webapp/src/__tests__/WindowGlassSettings.test.tsx
@@ -17,6 +17,35 @@ describe("WindowGlassSettings", () => {
     });
   });
 
+  it("explains when Windows is below the glass floor", async () => {
+    (window as { harnessIPC?: unknown }).harnessIPC = {
+      translucency: {
+        get: async () => ({
+          state: { intensity: 0, fade: 0, mode: "clear", material: "popover" },
+          capabilities: {
+            translucencySupported: true,
+            glassSupported: false,
+            isWindows: true,
+            windowsBuild: 19045,
+            materials: ["under-window", "popover", "titlebar"],
+          },
+        }),
+        capabilities: async () => ({
+          translucencySupported: true,
+          glassSupported: false,
+          isWindows: true,
+          windowsBuild: 19045,
+          materials: ["under-window", "popover", "titlebar"],
+        }),
+      },
+    };
+    render(<WindowGlassSettings />);
+    expect(await screen.findByTestId("window-glass-settings")).toBeInTheDocument();
+    expect(screen.getByText(/Windows 11 22H2/i)).toBeInTheDocument();
+    expect(screen.getByText(/build 19045/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /glass window/i })).toBeNull();
+  });
+
   it("toggles glass on and paints the root attribute", async () => {
     const setCalls: unknown[] = [];
     (window as { harnessIPC?: unknown }).harnessIPC = {

--- a/webapp/src/components/RightDock.tsx
+++ b/webapp/src/components/RightDock.tsx
@@ -159,10 +159,11 @@ export default function RightDock({
       className="pointer-events-none absolute right-4 top-[3.75rem] bottom-10 z-20 flex flex-col items-center select-none"
       aria-label="Floating panel shortcuts"
     >
-      {/* Floating dock — a quiet charcoal surface keeps shortcuts legible. */}
+      {/* Same --shell-panel glass as the left rail: slightly darker keep so
+          icons stay readable, no extra backdrop-blur island. */}
       <div
-        className="pointer-events-auto flex flex-col items-center gap-0.5 rounded-2xl px-1 py-1.5
-          bg-[#13161a]/90 backdrop-blur-md border border-edge/50 shadow-[0_4px_18px_rgba(0,0,0,0.3)]"
+        data-testid="floating-dock-pill"
+        className="pointer-events-auto flex flex-col items-center gap-0.5 rounded-2xl px-1 py-1.5 shell-inset-glass"
       >
         <button
           type="button"

--- a/webapp/src/components/WindowGlassSettings.tsx
+++ b/webapp/src/components/WindowGlassSettings.tsx
@@ -22,7 +22,22 @@ export default function WindowGlassSettings() {
     return () => resetTranslucencyPeek();
   }, []);
 
-  if (!caps?.translucencySupported || !caps.glassSupported) return null;
+  if (!caps?.translucencySupported) return null;
+
+  if (!caps.glassSupported) {
+    const build = caps.windowsBuild && caps.windowsBuild > 0 ? ` (build ${caps.windowsBuild})` : "";
+    return (
+      <div className="space-y-1.5" data-testid="window-glass-settings">
+        <label className="block uppercase tracking-wider text-[10px] text-faint font-semibold">
+          Transparent background
+        </label>
+        <p className="text-[10px] text-muted">
+          Glass needs Windows 11 22H2 or later{build}. This PC is below that
+          floor, so frost is unavailable here.
+        </p>
+      </div>
+    );
+  }
 
   const on = state.mode === "glass" && state.intensity > 0;
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -94,6 +94,14 @@ body {
 
 /* Side rails + footer sit "within" the window: rounded, lightly bordered,
    with gutter from the window edge instead of flush hard dividers. */
+/* Shared fill with the left rail. Callers keep their own radius (the floating
+   pill is a capsule; inset panels are 12px). */
+.shell-inset-glass {
+  border: 1px solid var(--shell-panel-border);
+  background: var(--shell-panel);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+}
+
 .shell-inset-panel {
   border-radius: var(--shell-panel-radius);
   border: 1px solid var(--shell-panel-border);

--- a/webapp/src/lib/windowGlass.ts
+++ b/webapp/src/lib/windowGlass.ts
@@ -17,6 +17,7 @@ export type TranslucencyCapabilities = {
   translucencySupported: boolean;
   glassSupported: boolean;
   isWindows: boolean;
+  windowsBuild?: number;
   materials: GlassMaterial[];
 };
 
@@ -216,6 +217,7 @@ export async function loadTranslucencyCapabilities(): Promise<TranslucencyCapabi
     translucencySupported: false,
     glassSupported: false,
     isWindows: false,
+    windowsBuild: 0,
     materials: ["under-window", "popover", "titlebar", "header"],
   };
 }


### PR DESCRIPTION
## Summary
- Windows General no longer hides glass when `os.release()` lies (`6.2.9200`). Uses Electron `process.getSystemVersion()`, 4-part builds, and a Windows 11 name fallback. Below 22H2, Settings explains why frost is unavailable.
- Floating dock pill uses the same `--shell-panel` glass as the left rail (`shell-inset-glass`) instead of a 90% opaque backdrop-blur island.
- Version stamps 0.9.261. Pin stays `puppetmaster-ai==1.22.15`.

## Test plan
- [ ] `tests` matrix green: Python 3.9, Windows shards, frontend-build
- [ ] Windows 11: General shows Glass window (Soft 40) above Driver
- [ ] Windows 10 / old build: General shows the 22H2 floor note instead of a blank gap
- [ ] Collapsed dock pill matches left-rail glass tint (not a solid charcoal chip)