### PR TITLE
Release v0.9.262

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.15` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.261, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Window glass factory-flips to Soft 40; Windows Settings no longer hide the lever when the OS build is misreported. The floating dock pill uses the same `--shell-panel` glass as the left rail. Cursor CLI accepts `CURSOR_API_KEY`. Compact residual factory default remains catalog.
+> Status: v0.9.262, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Composer uses the same `--shell-panel` glass as the left rail. Chat command tokens open the live agent terminal only when a run_command card is registered. Cmd+J no longer flash-closes an empty right board; column resize is pairwise, not a 12-col snap.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.261"
+__version__ = "0.9.262"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.261"
+version = "0.9.262"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.261",
+  "version": "0.9.262",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.261",
+      "version": "0.9.262",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.261",
+  "version": "0.9.262",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -17,83 +17,14 @@ import {
   resolveDroppedOsPath,
 } from "./components/conversation/composerInput";
 import { openAgentWorkspace } from "./lib/agentLinks";
+import { reclampRailWidths } from "./lib/railLayout";
 
 const LS = {
   left: "pmharness.leftW",
   leftOpen: "pmharness.leftOpen", rightOpen: "pmharness.rightOpen", rightW: "pmharness.rightW",
 };
-const clamp = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n));
 const num = (k: string, d: number) => { const v = Number(localStorage.getItem(k)); return Number.isFinite(v) && v > 0 ? v : d; };
-const bool = (k: string, d: boolean) => { const v = localStorage.getItem(k); return v === null ? d : v === "1"; };
-
-const MIN_CENTER_W = 360;
-const LEFT_MIN_W = 180;
-const LEFT_MAX_W = 420;
-const RIGHT_MIN_W = 320;
-const RIGHT_COMPACT_MIN_W = 220;
-
-/** Flex chrome around the center column: shell padding and rail gutters. */
-const RAIL_GUTTER_W = 6;
-
-function layoutChrome(leftOpen: boolean, rightOpen: boolean): number {
-  let gutters = 0;
-  if (leftOpen) gutters += 1;
-  if (rightOpen) gutters += 1;
-  return 2 + gutters * RAIL_GUTTER_W;
-}
-
-/** Keep open rails within min/window budget while preserving MIN_CENTER_W for the chat column. */
-function reclampRailWidths(
-  leftW: number,
-  rightW: number,
-  leftOpen: boolean,
-  rightOpen: boolean,
-  innerWidth: number,
-): { leftW: number; rightW: number } {
-  const chrome = layoutChrome(leftOpen, rightOpen);
-  const availableWidth = Math.max(0, innerWidth - chrome);
-  const preferredLeft = leftOpen ? clamp(leftW, LEFT_MIN_W, LEFT_MAX_W) : 0;
-  const preferredRight = rightOpen ? Math.max(RIGHT_MIN_W, rightW) : 0;
-  const requiredRails = (leftOpen ? LEFT_MIN_W : 0) + (rightOpen ? RIGHT_MIN_W : 0);
-  const centerWidth = Math.min(MIN_CENTER_W, Math.max(0, availableWidth - requiredRails));
-  const railBudget = Math.max(0, availableWidth - centerWidth);
-
-  if (!leftOpen && !rightOpen) return { leftW, rightW };
-
-  if (leftOpen && rightOpen) {
-    // At normal widths both rails keep their full minimums. If the window
-    // cannot hold those minimums plus the chat column, compact the right board
-    // first so the left rail remains useful and the cards stay inside the shell.
-    const compactRightMin = Math.min(RIGHT_MIN_W, RIGHT_COMPACT_MIN_W, railBudget);
-    const compactLeftMin = Math.min(LEFT_MIN_W, Math.max(0, railBudget - compactRightMin));
-    const leftMax = Math.max(compactLeftMin, railBudget - compactRightMin);
-    const left = clamp(
-      Math.min(preferredLeft, Math.max(compactLeftMin, railBudget - preferredRight)),
-      compactLeftMin,
-      Math.min(LEFT_MAX_W, leftMax),
-    );
-    const right = clamp(
-      Math.min(preferredRight, Math.max(0, railBudget - left)),
-      compactRightMin,
-      Math.max(compactRightMin, railBudget - left),
-    );
-    return { leftW: left, rightW: right };
-  }
-
-  if (leftOpen) {
-    const leftMin = Math.min(LEFT_MIN_W, railBudget);
-    return {
-      leftW: clamp(preferredLeft, leftMin, Math.min(LEFT_MAX_W, railBudget)),
-      rightW,
-    };
-  }
-
-  const rightMin = Math.min(RIGHT_MIN_W, railBudget);
-  return {
-    leftW,
-    rightW: clamp(preferredRight, rightMin, railBudget),
-  };
-}
+const bool = (k: string, d: boolean) => { const v = localStorage.getItem(k); return v === null ? d : v === "1"; }
 
 function lastRightTab(): string {
   try {
@@ -167,6 +98,18 @@ export default function App() {
     });
   };
   const closeEmptyRightPane = useCallback(() => setRightOpen(false), []);
+  const toggleRight = useCallback(() => {
+    setRightOpen((open) => {
+      if (open) return false;
+      // First open (or re-open after every card was closed) must seed a tab.
+      // Bare setRightOpen(true) mounts an empty board that immediately
+      // onEmpty-closes — the Ctrl+J flash.
+      if (!hasStoredRightPaneCards()) {
+        pendingRightTab.current = lastRightTab();
+      }
+      return true;
+    });
+  }, []);
   const requestRightMinWidth = useCallback((minPx: number) => {
     const next = reclampRailWidths(
       leftWRef.current,
@@ -321,7 +264,7 @@ export default function App() {
       }
       switch (k) {
         case "b": e.preventDefault(); setLeftOpen((v) => !v); break;        // toggle sessions panel
-        case "j": e.preventDefault(); setRightOpen((v) => !v); break;       // toggle right pane
+        case "j": e.preventDefault(); toggleRight(); break;       // toggle right pane
         case "i":                                                          // focus chat input (Cursor: toggle sidepanel)
         // Cmd/Ctrl+L focuses the composer. TerminalPane capture steals this
         // when the live xterm has a selection (Add to chat).
@@ -333,7 +276,7 @@ export default function App() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [toggleRight]);
 
   return (
     <div className="h-full flex flex-col bg-[var(--shell-chrome)]">
@@ -444,7 +387,7 @@ export default function App() {
       <div className="shrink-0 px-px py-px">
         <StatusBar config={config} update={availableUpdate}
           leftOpen={leftOpen} rightOpen={rightOpen}
-          onToggleLeft={() => setLeftOpen((v) => !v)} onToggleRight={() => setRightOpen((v) => !v)}
+          onToggleLeft={() => setLeftOpen((v) => !v)} onToggleRight={toggleRight}
           onOpenEconomics={() => openRightTo("economics")} />
       </div>
 
@@ -452,7 +395,7 @@ export default function App() {
 
       <CommandPalette
         onToggleLeft={() => setLeftOpen((v) => !v)}
-        onToggleRight={() => setRightOpen((v) => !v)}
+        onToggleRight={toggleRight}
       />
     </div>
   );

--- a/webapp/src/__tests__/ComposerDock.busyChrome.test.tsx
+++ b/webapp/src/__tests__/ComposerDock.busyChrome.test.tsx
@@ -126,6 +126,13 @@ describe("ComposerDock busy chrome", () => {
     expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
   });
 
+  it("uses side-panel glass, not an opaque chat island", () => {
+    const { container } = renderBusyDock("");
+    const dock = container.querySelector(".composer-dock");
+    expect(dock).toHaveClass("shell-inset-glass");
+    expect(dock?.className).not.toMatch(/bg-panel2/);
+  });
+
   it("keeps send actions in a non-shrinking cluster so the picker can truncate", () => {
     const { container } = renderBusyDock("");
     expect(container.querySelector(".composer-toolbar")).toBeTruthy();

--- a/webapp/src/__tests__/RightPane.collapse.test.tsx
+++ b/webapp/src/__tests__/RightPane.collapse.test.tsx
@@ -123,7 +123,7 @@ describe("RightPane collapse placement", () => {
     expect(stateCard).toHaveClass("right-pane-card");
     expect(stateCard).not.toHaveClass("right-pane-floating-card");
     expect(stateCard.style.position).toBe("");
-    expectCardGridPlacement("State", "1 / span 12", "1");
+    expectCardGridPlacement("State", "1", "1");
     const board = stateCard.closest(".right-pane-board");
     expect(board).toHaveClass("h-full", "w-full");
     expect(board?.querySelector(".right-pane-board-grid")).toContainElement(stateCard);
@@ -153,8 +153,8 @@ describe("RightPane collapse placement", () => {
   it("fills a two-card stack with a height split and no inner width handles", () => {
     render(<><RightDock onOpenTab={vi.fn()} onExpand={vi.fn()} onCollapse={baseProps.onCollapse} /><RightPane {...baseProps} /></>);
 
-    expectCardGridPlacement("State", "1 / span 12", "1");
-    expectCardGridPlacement("Terminal", "1 / span 12", "2");
+    expectCardGridPlacement("State", "1", "1");
+    expectCardGridPlacement("Terminal", "1", "2");
     expect(screen.getByRole("region", { name: "State panel" }).style.width).toBe("");
     expect(screen.getByRole("region", { name: "Terminal panel" }).style.width).toBe("");
     expect(screen.queryByRole("separator", { name: "Resize tool columns" })).toBeNull();
@@ -238,9 +238,9 @@ describe("RightPane Claude-style card packing", () => {
       </>,
     );
 
-    expectCardGridPlacement("State", "1 / span 12", "1");
-    expectCardGridPlacement("Terminal", "1 / span 12", "2");
-    expectCardGridPlacement("Swarm", "1 / span 12", "3");
+    expectCardGridPlacement("State", "1", "1");
+    expectCardGridPlacement("Terminal", "1", "2");
+    expectCardGridPlacement("Swarm", "1", "3");
     expect(screen.queryAllByRole("separator", { name: "Resize stacked panel height" })).toHaveLength(2);
     expect(screen.queryByTestId("right-pane-toolbar")).toBeNull();
   });
@@ -258,10 +258,10 @@ describe("RightPane Claude-style card packing", () => {
       </>,
     );
 
-    expectCardGridPlacement("State", "1 / span 12", "1");
-    expectCardGridPlacement("Terminal", "1 / span 12", "2");
-    expectCardGridPlacement("Swarm", "1 / span 12", "3");
-    expectCardGridPlacement("Files", "1 / span 12", "4");
+    expectCardGridPlacement("State", "1", "1");
+    expectCardGridPlacement("Terminal", "1", "2");
+    expectCardGridPlacement("Swarm", "1", "3");
+    expectCardGridPlacement("Files", "1", "4");
     expect(screen.queryAllByRole("separator", { name: "Resize stacked panel height" })).toHaveLength(3);
     expect(screen.queryByTestId("right-pane-toolbar")).toBeNull();
   });
@@ -271,13 +271,13 @@ describe("RightPane Claude-style card packing", () => {
     { count: 2, cards: ["state", "terminal"] },
     { count: 3, cards: ["state", "terminal", "swarm"] },
     { count: 4, cards: ["state", "terminal", "swarm", "files"] },
-  ])("uses a bounded 12-column grid for $count cards", ({ cards }) => {
+  ])("uses a single flexible track for $count stacked cards", ({ cards }) => {
     localStorage.setItem("pmharness.board.openCards", JSON.stringify(cards));
     render(<RightPane {...baseProps} />);
 
     const grid = document.querySelector(".right-pane-board-grid");
     expect(grid).toHaveStyle({
-      gridTemplateColumns: "repeat(12, minmax(0, 1fr))",
+      gridTemplateColumns: "minmax(0, 1fr)",
       gridTemplateRows: "minmax(0, 1fr)",
     });
     expect(screen.getAllByRole("region")).toHaveLength(cards.length);
@@ -317,9 +317,9 @@ describe("RightPane Claude-style card packing", () => {
       terminal: { columnSpan: 7, customized: true },
       browser: { columnSpan: 5, customized: true },
     });
-    expectCardGridPlacement("State", "6 / span 7", "1");
-    expectCardGridPlacement("Terminal", "6 / span 7", "2");
-    expectCardGridPlacement("Browser", "1 / span 5", "1");
+    expectCardGridPlacement("State", "2", "1");
+    expectCardGridPlacement("Terminal", "2", "2");
+    expectCardGridPlacement("Browser", "1", "1");
   });
 
   it("gives the middle of three columns its own width handle", () => {
@@ -346,9 +346,9 @@ describe("RightPane Claude-style card packing", () => {
     expect(screen.getByTestId("column-resize-1")).toBeInTheDocument();
     expect(screen.queryByTestId("column-resize-2")).toBeNull();
     expect(screen.getAllByRole("separator", { name: "Resize tool columns" })).toHaveLength(2);
-    expectCardGridPlacement("Files", "9 / span 4", "1");
-    expectCardGridPlacement("Browser", "5 / span 4", "1");
-    expectCardGridPlacement("State", "1 / span 4", "1");
+    expectCardGridPlacement("Files", "3", "1");
+    expectCardGridPlacement("Browser", "2", "1");
+    expectCardGridPlacement("State", "1", "1");
   });
 
   it("resizes the middle column against its left neighbor only", () => {
@@ -378,9 +378,9 @@ describe("RightPane Claude-style card packing", () => {
       browser: { columnSpan: 5, customized: true },
       state: { columnSpan: 3, customized: true },
     });
-    expectCardGridPlacement("Files", "9 / span 4", "1");
-    expectCardGridPlacement("Browser", "4 / span 5", "1");
-    expectCardGridPlacement("State", "1 / span 3", "1");
+    expectCardGridPlacement("Files", "3", "1");
+    expectCardGridPlacement("Browser", "2", "1");
+    expectCardGridPlacement("State", "1", "1");
   });
 
   it("shrinks the top stacked card so the bottom card can fill the rest", () => {
@@ -426,9 +426,9 @@ describe("RightPane Claude-style card packing", () => {
     fireEvent.dragStart(screen.getByRole("button", { name: "Drag Browser panel" }), { dataTransfer });
     fireEvent.drop(screen.getByRole("region", { name: "Drop to open a column" }), { dataTransfer });
 
-    expectCardGridPlacement("Review", "7 / span 6", "1");
-    expectCardGridPlacement("Swarm", "7 / span 6", "2");
-    expectCardGridPlacement("Browser", "1 / span 6", "1");
+    expectCardGridPlacement("Review", "2", "1");
+    expectCardGridPlacement("Swarm", "2", "2");
+    expectCardGridPlacement("Browser", "1", "1");
     expect(onRequestMinWidth).toHaveBeenCalledWith(420);
     expect(JSON.parse(localStorage.getItem("pmharness.board.columns.v1") || "[]")).toEqual([
       ["review", "swarm"],
@@ -447,9 +447,9 @@ describe("RightPane Claude-style card packing", () => {
     fireEvent.dragStart(screen.getByRole("button", { name: "Drag Browser panel" }), { dataTransfer });
     fireEvent.drop(screen.getByRole("region", { name: "Review panel" }), { dataTransfer });
 
-    expectCardGridPlacement("Browser", "1 / span 12", "1");
-    expectCardGridPlacement("Review", "1 / span 12", "2");
-    expectCardGridPlacement("Swarm", "1 / span 12", "3");
+    expectCardGridPlacement("Browser", "1", "1");
+    expectCardGridPlacement("Review", "1", "2");
+    expectCardGridPlacement("Swarm", "1", "3");
     expect(JSON.parse(localStorage.getItem("pmharness.board.columns.v1") || "[]")).toEqual([
       ["browser", "review", "swarm"],
     ]);

--- a/webapp/src/__tests__/agentCommandIndex.test.ts
+++ b/webapp/src/__tests__/agentCommandIndex.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  getAgentCommandIndexVersion,
+  lookupAgentCommandSession,
+  lookupAgentCommandSessionById,
+  normalizeCommandKey,
+  registerAgentCommandSession,
+  _resetAgentCommandIndexForTests,
+} from "../lib/agentCommandIndex";
+
+describe("agentCommandIndex", () => {
+  beforeEach(() => {
+    _resetAgentCommandIndexForTests();
+  });
+
+  it("normalizes $ prefix and whitespace", () => {
+    expect(normalizeCommandKey("  $   git   pull  ")).toBe("git pull");
+  });
+
+  it("looks up the latest session for a command", () => {
+    registerAgentCommandSession({ id: "old", command: "git pull", output: "a" });
+    registerAgentCommandSession({ id: "live", command: "$ git pull", output: "b" });
+    const found = lookupAgentCommandSession("git pull");
+    expect(found?.id).toBe("live");
+    expect(found?.output).toBe("b");
+    expect(lookupAgentCommandSessionById("old")?.command).toBe("git pull");
+  });
+
+  it("does not bump version on streaming output for the same id", () => {
+    registerAgentCommandSession({ id: "card-1", command: "pytest -q" });
+    const v = getAgentCommandIndexVersion();
+    registerAgentCommandSession({ id: "card-1", command: "pytest -q", output: "ok\n" });
+    registerAgentCommandSession({ id: "card-1", command: "pytest -q", output: "ok\nmore\n" });
+    expect(getAgentCommandIndexVersion()).toBe(v);
+    expect(lookupAgentCommandSession("pytest -q")?.output).toBe("ok\nmore\n");
+  });
+
+  it("ignores empty and overlong commands", () => {
+    expect(registerAgentCommandSession({ id: "x", command: "   " })).toBeNull();
+    expect(registerAgentCommandSession({ id: "x", command: "n".repeat(501) })).toBeNull();
+    expect(lookupAgentCommandSession("echo hi")).toBeNull();
+  });
+});

--- a/webapp/src/__tests__/agentLinks.test.ts
+++ b/webapp/src/__tests__/agentLinks.test.ts
@@ -8,6 +8,9 @@ import {
   parseFileHref,
   looksLikePathInlineCode,
   classifyActionGoal,
+  classifyTranscriptHref,
+  commandMarkdownHref,
+  fileMarkdownHref,
   autolinkAgentText,
   openAgentLink,
   openAgentFile,
@@ -17,9 +20,12 @@ import {
   openAgentWorkspace,
   openAgentSwarmJob,
   openAgentSpill,
-  stableCommandId,
 } from "../lib/agentLinks";
 import { _resetAgentTerminalStreamForTests } from "../lib/agentTerminalStream";
+import {
+  registerAgentCommandSession,
+  _resetAgentCommandIndexForTests,
+} from "../lib/agentCommandIndex";
 
 describe("agentLinks detection", () => {
   it("classifies urls and paths", () => {
@@ -72,6 +78,11 @@ describe("agentLinks detection", () => {
       line: 10,
       col: 4,
     });
+    expect(parseFileHref("src/main.py:165-210")).toEqual({
+      path: "src/main.py",
+      line: 165,
+      col: undefined,
+    });
     expect(parseFileHref("file:///C:/proj/a.ts")).toEqual({
       path: "C:/proj/a.ts",
       line: undefined,
@@ -81,11 +92,15 @@ describe("agentLinks detection", () => {
 
   it("detects path-like inline code", () => {
     expect(looksLikePathInlineCode("harness/server.py")).toBe(true);
-    expect(looksLikePathInlineCode("foo.py:3")).toBe(true);
+    expect(looksLikePathInlineCode("foo.py:3")).toBe(false);
+    expect(looksLikePathInlineCode("src/foo.py:3")).toBe(true);
     expect(looksLikePathInlineCode("--flag")).toBe(false);
     expect(looksLikePathInlineCode("npm install")).toBe(false);
     expect(looksLikePathInlineCode("/Users/me/My Projects/app.ts")).toBe(true);
     expect(looksLikePathInlineCode("/Users/me/My Projects/app.ts:12")).toBe(true);
+    expect(looksLikePathInlineCode("backend.py")).toBe(false);
+    expect(looksLikePathInlineCode("job_thread_id")).toBe(false);
+    expect(looksLikePathInlineCode("Starting")).toBe(false);
   });
 
   it("does not treat package specs as file editor links", () => {
@@ -107,6 +122,7 @@ describe("agentLinks detection", () => {
     expect(looksLikeFilePath("anysphere/ui")).toBe(false);
     expect(looksLikePathInlineCode("anysphere/ui")).toBe(false);
     expect(looksLikeFilePath("package.json")).toBe(true);
+    expect(looksLikePathInlineCode("package.json")).toBe(false);
     expect(looksLikeFilePath("~/Downloads/security-assessment-report.md")).toBe(true);
     expect(looksLikePathInlineCode("~/Downloads/security-assessment-report.md")).toBe(true);
     expect(looksLikeFilePath("/tmp/@scope/pkg/index.ts")).toBe(true);
@@ -242,16 +258,55 @@ describe("autolinkAgentText", () => {
     expect(out).toContain("[ok](src/a.ts)");
     expect(out).toContain("`keep/me.py`");
   });
+
+  it("does not autolink identifiers or bare filenames", () => {
+    const src = "Starting Plan Steps Done job_thread_id backend.py PROGRESS.";
+    expect(autolinkAgentText(src)).toBe(src);
+  });
+});
+
+describe("classifyTranscriptHref", () => {
+  it("accepts real urls, jobs, spills, and pathed files", () => {
+    expect(classifyTranscriptHref("https://example.com/a")).toBe("url");
+    expect(classifyTranscriptHref("spill://sess1/call_a")).toBe("spill");
+    expect(classifyTranscriptHref("job_abcdef012345")).toBe("job");
+    expect(classifyTranscriptHref("webapp/src/App.tsx")).toBe("file");
+    expect(classifyTranscriptHref("src/main.py:165-210")).toBe("file");
+  });
+
+  it("rejects model-spam identifiers, commands, and bare filenames", () => {
+    expect(classifyTranscriptHref("Starting")).toBe("none");
+    expect(classifyTranscriptHref("Plan")).toBe("none");
+    expect(classifyTranscriptHref("job_thread_id")).toBe("none");
+    expect(classifyTranscriptHref("backend.py")).toBe("none");
+    expect(classifyTranscriptHref("git status")).toBe("none");
+    expect(classifyTranscriptHref("Starting the job")).toBe("none");
+    expect(classifyTranscriptHref("PROGRESS")).toBe("none");
+  });
+
+  it("lights a command href only after a live session is registered", () => {
+    _resetAgentCommandIndexForTests();
+    expect(classifyTranscriptHref("git pull")).toBe("none");
+    expect(classifyTranscriptHref(commandMarkdownHref("card-9"))).toBe("none");
+    registerAgentCommandSession({ id: "card-9", command: "git pull", output: "ok\n" });
+    expect(classifyTranscriptHref("git pull")).toBe("command");
+    expect(classifyTranscriptHref("$ git pull")).toBe("command");
+    expect(classifyTranscriptHref(commandMarkdownHref("card-9"))).toBe("command");
+    expect(classifyTranscriptHref(fileMarkdownHref("webapp/src/App.tsx"))).toBe("file");
+    _resetAgentCommandIndexForTests();
+  });
 });
 
 describe("openAgentLink events", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     _resetAgentTerminalStreamForTests();
+    _resetAgentCommandIndexForTests();
   });
 
   afterEach(() => {
     _resetAgentTerminalStreamForTests();
+    _resetAgentCommandIndexForTests();
   });
 
   it("dispatches browser events for urls", () => {
@@ -298,27 +353,57 @@ describe("openAgentLink events", () => {
     });
   });
 
-  it("hashes command when reveal id is omitted", () => {
+  it("does not mint a blank terminal for speculative command clicks", () => {
     const spy = vi.spyOn(window, "dispatchEvent");
     openAgentCommand("echo hi");
+    openAgentCommand("Starting the job", { run: false });
+    const kinds = spy.mock.calls.map((c) => (c[0] as CustomEvent).type);
+    expect(kinds).not.toContain("harness-open-agent-terminal");
+    expect(kinds).not.toContain("harness-focus-tab");
+  });
+
+  it("opens the registered live session for a later chat command click", () => {
+    registerAgentCommandSession({ id: "card-live", command: "git pull", output: "Already up to date.\n" });
+    const spy = vi.spyOn(window, "dispatchEvent");
+    openAgentCommand("git pull");
     const ev = spy.mock.calls
       .map((c) => c[0] as CustomEvent)
       .find((e) => e.type === "harness-open-agent-terminal");
-    expect(ev?.detail?.id).toBe(stableCommandId("echo hi"));
-    expect(ev?.detail?.command).toBe("echo hi");
+    expect(ev?.detail).toEqual({
+      id: "card-live",
+      command: "git pull",
+      output: "Already up to date.\n",
+    });
   });
 
-  it("openAgentLink routes url vs file vs shell", () => {
+  it("openAgentLink routes a registered command href to that terminal", () => {
+    registerAgentCommandSession({ id: "card-live", command: "git pull", output: "ok\n" });
+    const spy = vi.spyOn(window, "dispatchEvent");
+    const prevent = vi.fn();
+    openAgentLink("git pull", { preventDefault: prevent });
+    expect(prevent).toHaveBeenCalled();
+    const ev = spy.mock.calls
+      .map((c) => c[0] as CustomEvent)
+      .find((e) => e.type === "harness-open-agent-terminal");
+    expect(ev?.detail?.id).toBe("card-live");
+    expect(spy.mock.calls.map((c) => (c[0] as CustomEvent).type)).not.toContain(
+      "harness-run-command",
+    );
+  });
+
+  it("openAgentLink routes url vs file and ignores dead command/file hrefs", () => {
     const spy = vi.spyOn(window, "dispatchEvent");
     const prevent = vi.fn();
     openAgentLink("https://x.com", { preventDefault: prevent });
     expect(prevent).toHaveBeenCalled();
     openAgentLink("foo/bar.ts", { preventDefault: prevent });
     openAgentLink("npm.cmd", { preventDefault: prevent });
+    openAgentLink("backend.py", { preventDefault: prevent });
+    openAgentLink("Starting the job", { preventDefault: prevent });
     const types = spy.mock.calls.map((c) => (c[0] as CustomEvent).type);
     expect(types).toContain("harness-open-url");
     expect(types).toContain("harness-open-file");
-    expect(types).toContain("harness-open-agent-terminal");
+    expect(types).not.toContain("harness-open-agent-terminal");
     expect(types).not.toContain("harness-run-command");
   });
 

--- a/webapp/src/__tests__/boardColumnWidths.test.ts
+++ b/webapp/src/__tests__/boardColumnWidths.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   GRID_COLUMN_COUNT,
+  absorbShellResize,
   applyPairwiseColumnResize,
+  columnSpanFromPointerDelta,
+  columnTrackTemplate,
+  groupGridColumn,
   normalizeGroupWidths,
   showColumnResizeHandle,
 } from "../lib/boardColumnWidths";
@@ -18,6 +22,50 @@ describe("showColumnResizeHandle", () => {
   });
 });
 
+describe("groupGridColumn", () => {
+  it("maps right-indexed groups onto left-to-right tracks", () => {
+    expect(groupGridColumn(0, 1)).toBe("1");
+    expect(groupGridColumn(0, 2)).toBe("2");
+    expect(groupGridColumn(1, 2)).toBe("1");
+    expect(groupGridColumn(0, 3)).toBe("3");
+    expect(groupGridColumn(2, 3)).toBe("1");
+  });
+});
+
+describe("columnTrackTemplate", () => {
+  it("uses a single flexible track for one column", () => {
+    expect(columnTrackTemplate([12])).toBe("minmax(0, 1fr)");
+  });
+
+  it("weights unmeasured columns so the leftmost is first", () => {
+    expect(columnTrackTemplate([7, 5])).toBe("minmax(0, 5fr) minmax(0, 7fr)");
+  });
+
+  it("locks non-leftmost columns to pixels once the board is measured", () => {
+    expect(columnTrackTemplate([7, 5], 1200)).toBe("minmax(0, 1fr) 700px");
+  });
+});
+
+describe("columnSpanFromPointerDelta", () => {
+  it("moves continuously instead of snapping to whole grid columns", () => {
+    expect(columnSpanFromPointerDelta({
+      startSpan: 6,
+      startClientX: 100,
+      clientX: 90,
+      boardWidth: 1200,
+    })).toBeCloseTo(6.1);
+  });
+});
+
+describe("absorbShellResize", () => {
+  it("gives extra board width to the leftmost column only", () => {
+    const next = absorbShellResize([6, 6], 1200, 1400);
+    expect(next[0]).toBeCloseTo((600 / 1400) * GRID_COLUMN_COUNT);
+    expect(next[1]).toBeCloseTo((800 / 1400) * GRID_COLUMN_COUNT);
+    expect(next[0] + next[1]).toBeCloseTo(GRID_COLUMN_COUNT);
+  });
+});
+
 describe("applyPairwiseColumnResize", () => {
   it("resizes a pair of columns without touching a third", () => {
     expect(applyPairwiseColumnResize([4, 4, 4], 1, 6)).toEqual([4, 6, 2]);
@@ -25,6 +73,12 @@ describe("applyPairwiseColumnResize", () => {
 
   it("keeps two-column complementary math", () => {
     expect(applyPairwiseColumnResize([6, 6], 0, 7)).toEqual([7, 5]);
+  });
+
+  it("allows fractional spans so pointer drags do not grid-snap", () => {
+    const next = applyPairwiseColumnResize([6, 6], 0, 6.4);
+    expect(next[0]).toBeCloseTo(6.4);
+    expect(next[1]).toBeCloseTo(5.6);
   });
 
   it("clamps to the pair minimum so a middle column cannot vanish", () => {

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -212,6 +212,7 @@ import {
   soundPrefEnabled,
 } from "../components/conversation/completionNotify";
 import {
+  chooseResolvedFilePath,
   closeTabResult,
   otherTabsHaveDirty,
   setTabDirty,
@@ -3025,6 +3026,18 @@ describe("queueOps / openFileTabs / runnersBusy", () => {
     expect(tabHasDirty([{ path: "a.ts", isDirty: true }], "a.ts")).toBe(true);
     expect(otherTabsHaveDirty([{ path: "a.ts", isDirty: true }, { path: "b.ts", isDirty: false }], "b.ts")).toBe(true);
     expect(setTabDirty([{ path: "a.ts", isDirty: false }], "a.ts", true)[0].isDirty).toBe(true);
+    expect(chooseResolvedFilePath("src/a.ts", { ok: true, path: "src/a.ts" })).toEqual({
+      path: "src/a.ts",
+    });
+    expect(chooseResolvedFilePath("backend.py", { ok: false, error: "File not found" })).toEqual({
+      toast: "Couldn't open backend.py.",
+    });
+    expect(chooseResolvedFilePath("same.py", { candidates: ["one/same.py", "two/same.py"] })).toEqual({
+      toast: "Multiple files match same.py; use a more specific path.",
+    });
+    expect(chooseResolvedFilePath("missing.py", null, { trusted: true })).toEqual({
+      path: "missing.py",
+    });
     expect(userStoppedBusyChrome("thinking")).toBe("idle");
     expect(preserveOrThinking("idle")).toBe("thinking");
     expect(

--- a/webapp/src/__tests__/openRightTo.focus.test.ts
+++ b/webapp/src/__tests__/openRightTo.focus.test.ts
@@ -73,3 +73,51 @@ describe("openRightTo focus when pane already open", () => {
     dispatch.mockRestore();
   });
 });
+
+function toggleRightLikeApp(opts: {
+  rightOpen: boolean;
+  hasStoredCards: boolean;
+  lastTab: string;
+  setRightOpen: (updater: (open: boolean) => boolean) => void;
+  pendingRightTab: { current: string | null };
+}) {
+  opts.setRightOpen((open) => {
+    if (open) return false;
+    if (!opts.hasStoredCards) opts.pendingRightTab.current = opts.lastTab;
+    return true;
+  });
+}
+
+describe("Ctrl+J right pane toggle", () => {
+  it("seeds the last tab when opening an empty board so it cannot flash closed", () => {
+    const pendingRightTab = { current: null as string | null };
+    let rightOpen = false;
+    toggleRightLikeApp({
+      rightOpen,
+      hasStoredCards: false,
+      lastTab: "state",
+      pendingRightTab,
+      setRightOpen: (updater) => {
+        rightOpen = updater(rightOpen);
+      },
+    });
+    expect(rightOpen).toBe(true);
+    expect(pendingRightTab.current).toBe("state");
+  });
+
+  it("does not seed a tab when stored cards already exist", () => {
+    const pendingRightTab = { current: null as string | null };
+    let rightOpen = false;
+    toggleRightLikeApp({
+      rightOpen,
+      hasStoredCards: true,
+      lastTab: "state",
+      pendingRightTab,
+      setRightOpen: (updater) => {
+        rightOpen = updater(rightOpen);
+      },
+    });
+    expect(rightOpen).toBe(true);
+    expect(pendingRightTab.current).toBeNull();
+  });
+});

--- a/webapp/src/__tests__/railLayout.test.ts
+++ b/webapp/src/__tests__/railLayout.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  LEFT_MIN_W,
+  MIN_CENTER_W,
+  RIGHT_COMPACT_MIN_W,
+  RIGHT_MIN_W,
+  layoutChrome,
+  reclampRailWidths,
+} from "../lib/railLayout";
+
+describe("reclampRailWidths", () => {
+  it("keeps the left rail at its current width when the right board opens", () => {
+    const innerWidth = 1100;
+    const leftW = 248;
+    const rightW = 520;
+    const next = reclampRailWidths(leftW, rightW, true, true, innerWidth);
+    expect(next.leftW).toBe(leftW);
+    expect(next.rightW).toBeLessThanOrEqual(rightW);
+    expect(next.leftW + next.rightW + MIN_CENTER_W + layoutChrome(true, true))
+      .toBeLessThanOrEqual(innerWidth);
+  });
+
+  it("does not shrink a fitting left rail on a wide window", () => {
+    const next = reclampRailWidths(320, 520, true, true, 1600);
+    expect(next.leftW).toBe(320);
+    expect(next.rightW).toBe(520);
+  });
+
+  it("compacts the right board before the left rail on a tight window", () => {
+    const next = reclampRailWidths(248, 520, true, true, 900);
+    expect(next.leftW).toBeGreaterThanOrEqual(LEFT_MIN_W);
+    expect(next.rightW).toBeLessThan(520);
+    expect(next.rightW).toBeGreaterThanOrEqual(RIGHT_COMPACT_MIN_W);
+    expect(next.rightW).toBeLessThanOrEqual(RIGHT_MIN_W);
+  });
+});

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -11,6 +11,7 @@ import {
   resolveActivityGroupOpen,
   type Item,
 } from "../components/TranscriptList";
+import { _resetAgentCommandIndexForTests } from "../lib/agentCommandIndex";
 
 afterEach(() => cleanup());
 
@@ -844,5 +845,68 @@ describe("job_id → Swarm Tracker deep-link chrome", () => {
         .some((e) => e.type === "harness-open-swarm-job" && e.detail?.jobId === "local-bf1b30f4"),
     ).toBe(true);
     spy.mockRestore();
+  });
+});
+
+describe("live command token clicks", () => {
+  afterEach(() => {
+    _resetAgentCommandIndexForTests();
+  });
+
+  it("clicks a registered `git pull` token into that agent terminal", () => {
+    const spy = vi.spyOn(window, "dispatchEvent");
+    render(
+      <TranscriptList
+        {...listProps([
+          { kind: "msg", msg: { role: "user", text: "pull latest" } },
+          {
+            kind: "card",
+            card: {
+              id: "card-git-pull",
+              goal: "git pull",
+              cwd: null,
+              kind: "run_command",
+              running: false,
+              open: false,
+              result: { status: "ok", command: "git pull", output: "Already up to date.\n" },
+            },
+          },
+          {
+            kind: "msg",
+            msg: { role: "assistant", text: "Ran `git pull` and it was already up to date." },
+          },
+        ])}
+      />,
+    );
+
+    const token = screen.getByRole("button", { name: "git pull" });
+    expect(token).toHaveAttribute("title", "Reveal running command");
+    fireEvent.click(token);
+
+    const opened = spy.mock.calls
+      .map((c) => c[0] as CustomEvent)
+      .find((e) => e.type === "harness-open-agent-terminal");
+    expect(opened?.detail).toEqual({
+      id: "card-git-pull",
+      command: "git pull",
+      output: "Already up to date.\n",
+    });
+    expect(spy.mock.calls.map((c) => (c[0] as CustomEvent).type)).not.toContain("harness-run-command");
+    spy.mockRestore();
+  });
+
+  it("leaves an unregistered command token as muted code", () => {
+    render(
+      <TranscriptList
+        {...listProps([
+          { kind: "msg", msg: { role: "assistant", text: "You can run `git status` next." } },
+        ])}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "git status" })).toBeNull();
+    const code = screen.getByText("git status");
+    expect(code.tagName).toBe("CODE");
+    expect(code).toHaveClass("text-txt/90");
   });
 });

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -188,6 +188,7 @@ import {
   startTypewriterLoop,
 } from "./conversation/streamTypewriter";
 import {
+  chooseResolvedFilePath,
   closeTabResult,
   otherTabsHaveDirty,
   setTabDirty,
@@ -297,34 +298,33 @@ export default function Conversation({
   };
 
   useEffect(() => {
-    const handleOpenFile = (e: CustomEvent<{ path: string; line?: number; col?: number }>) => {
+    const handleOpenFile = (e: CustomEvent<{ path: string; line?: number; col?: number; trusted?: boolean }>) => {
       const filePath = e.detail.path;
       if (!filePath) return;
       const line = e.detail.line;
       const col = e.detail.col;
+      const trusted = !!e.detail.trusted;
       const openResolved = (resolvedPath: string) => {
         setOpenTabs((prev) => upsertOpenTab(prev, resolvedPath, line, col));
         setActiveTab(resolvedPath);
       };
-      // Agent prose often cites an unqualified basename (`routing_savings.py`).
-      // Resolve read-only hints before opening so a unique nested file works
-      // like Cursor; exact tree paths still return immediately. Older backends
-      // fall back to the original path.
+      const applyChoice = (choice: ReturnType<typeof chooseResolvedFilePath>) => {
+        if (!choice) return;
+        if ("toast" in choice) {
+          window.dispatchEvent(new CustomEvent("harness-toast", { detail: choice.toast }));
+          return;
+        }
+        openResolved(choice.path);
+      };
+      // Transcript clicks fail closed when resolve cannot find a unique file.
+      // File-tree clicks are trusted and may open the given path if resolve is down.
       void api.resolveFile(filePath)
         .then((resolved) => {
-          if (resolved?.ok && resolved.path) {
-            openResolved(resolved.path);
-            return;
-          }
-          if (Array.isArray(resolved?.candidates) && resolved.candidates.length > 1) {
-            window.dispatchEvent(new CustomEvent("harness-toast", {
-              detail: `Multiple files match ${filePath}; use a more specific path.`,
-            }));
-            return;
-          }
-          openResolved(filePath);
+          applyChoice(chooseResolvedFilePath(filePath, resolved, { trusted }));
         })
-        .catch(() => openResolved(filePath));
+        .catch(() => {
+          applyChoice(chooseResolvedFilePath(filePath, null, { trusted }));
+        });
     };
     window.addEventListener("harness-open-file", handleOpenFile as EventListener);
     return () => {

--- a/webapp/src/components/FileTree.tsx
+++ b/webapp/src/components/FileTree.tsx
@@ -340,7 +340,7 @@ export default function FileTree() {
   const handleFileSelect = (path: string) => {
     setSelectedPath(path);
     // Dispatch custom event to let CenterPane/Conversation know we want to open this file
-    window.dispatchEvent(new CustomEvent("harness-open-file", { detail: { path } }));
+    window.dispatchEvent(new CustomEvent("harness-open-file", { detail: { path, trusted: true } }));
   };
 
   const openContextMenu = (e: React.MouseEvent, node: FileNode | null) => {

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useRef } from "react";
+import { useCallback, useState, useEffect, useLayoutEffect, useRef } from "react";
 import { X, GripVertical } from "lucide-react";
 import StatePane from "./StatePane";
 import BrowserPane from "./BrowserPane";
@@ -44,6 +44,10 @@ import {
   MIN_CARD_COLUMN_SPAN,
   applyPairwiseColumnResize,
   clampCardColumnSpan,
+  columnSpanFromPointerDelta,
+  columnTrackTemplate,
+  groupGridColumn,
+  absorbShellResize,
   normalizeGroupWidths,
   showColumnResizeHandle,
 } from "../lib/boardColumnWidths";
@@ -145,16 +149,13 @@ function buildCardPlacements(
   );
   const groupWidths = normalizeGroupWidths(requestedWidths, preferredGroupIndex);
   const placements = new Map<Tab, CardPlacement>();
-  let rightmostColumn = GRID_COLUMN_COUNT;
 
   groups.forEach((group, groupIndex) => {
     const groupWidth = groupWidths[groupIndex];
-    const groupStart = rightmostColumn - groupWidth + 1;
-    rightmostColumn = groupStart - 1;
 
     group.forEach((tab, cardIndex) => {
       placements.set(tab, {
-        gridColumn: `${groupStart} / span ${groupWidth}`,
+        gridColumn: groupGridColumn(groupIndex, groupCount),
         gridRow: String(cardIndex + 1),
         // Left-edge splitter on every column except the leftmost. A single
         // column always fills the board; the shell Resizer owns that width.
@@ -262,6 +263,8 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
   const stackFractionsRef = useRef(stackFractions);
   stackFractionsRef.current = stackFractions;
   const boardRef = useRef<HTMLDivElement | null>(null);
+  const [boardWidth, setBoardWidth] = useState(0);
+  const prevBoardWidthRef = useRef(0);
   const preferredResizeGroupRef = useRef(-1);
   const [draggedTab, setDraggedTab] = useState<Tab | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(isSettingsOverlayOpen);
@@ -339,6 +342,40 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     localStorage.setItem(CARD_LAYOUT_STORAGE_KEY, JSON.stringify(nextLayouts));
   }, []);
 
+  useLayoutEffect(() => {
+    const el = boardRef.current;
+    if (!el) {
+      prevBoardWidthRef.current = 0;
+      setBoardWidth(0);
+      return;
+    }
+    const applyWidth = () => {
+      const nextWidth = el.getBoundingClientRect().width;
+      const prevWidth = prevBoardWidthRef.current;
+      prevBoardWidthRef.current = nextWidth;
+      setBoardWidth(nextWidth);
+      if (!(prevWidth > 0 && nextWidth > 0) || Math.abs(prevWidth - nextWidth) < 0.5) return;
+      const groups = columnsRef.current.filter(group => group.length > 0);
+      if (groups.length <= 1) return;
+      const current = groups.map(group => Math.max(
+        ...group.map(tab => cardColumnSpan(tab, cardLayoutsRef.current, groups.length)),
+      ));
+      const absorbed = absorbShellResize(current, prevWidth, nextWidth);
+      const nextLayouts: CardLayouts = { ...cardLayoutsRef.current };
+      groups.forEach((group, index) => {
+        for (const tab of group) {
+          nextLayouts[tab] = { columnSpan: absorbed[index], customized: true };
+        }
+      });
+      persistCardLayouts(nextLayouts);
+    };
+    applyWidth();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(applyWidth);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [visible, openCards.length, persistCardLayouts]);
+
   const persistStackFractions = useCallback((nextFractions: Record<string, number[]>) => {
     stackFractionsRef.current = nextFractions;
     setStackFractions(nextFractions);
@@ -383,13 +420,19 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     handle.setPointerCapture(event.pointerId);
     const startX = event.clientX;
     const startSpan = placement.columnSpan;
-    const pixelsPerColumn = boardWidth / GRID_COLUMN_COUNT;
     beginColumnResize();
 
     const onMove = (moveEvent: PointerEvent) => {
       if (!handle.hasPointerCapture(moveEvent.pointerId)) return;
-      const deltaColumns = Math.round((startX - moveEvent.clientX) / pixelsPerColumn);
-      setGroupColumnSpan(placement.groupIndex, startSpan + deltaColumns);
+      setGroupColumnSpan(
+        placement.groupIndex,
+        columnSpanFromPointerDelta({
+          startSpan,
+          startClientX: startX,
+          clientX: moveEvent.clientX,
+          boardWidth,
+        }),
+      );
     };
     const onUp = (upEvent: PointerEvent) => {
       if (handle.hasPointerCapture(upEvent.pointerId)) {
@@ -630,6 +673,9 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     preferredResizeGroupRef.current,
   );
   const cardStacks = columns.filter((group) => group.length > 0);
+  const groupWidths = cardStacks.map((stack) => (
+    cardPlacements.get(stack[0])?.columnSpan ?? MIN_CARD_COLUMN_SPAN
+  ));
   const showNewColumnDrop = Boolean(draggedTab && canOpenLeftColumn(columns, draggedTab));
 
   return (
@@ -650,7 +696,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
             <div
               className="right-pane-board-grid"
               style={{
-                gridTemplateColumns: `repeat(${GRID_COLUMN_COUNT}, minmax(0, 1fr))`,
+                gridTemplateColumns: columnTrackTemplate(groupWidths, boardWidth),
                 gridTemplateRows: "minmax(0, 1fr)",
               }}
             >

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, memo } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, useSyncExternalStore, memo } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronRight, Loader2, ChevronDown, ChevronUp, Play, Copy, Check, Pencil, RefreshCw, History, Share2, CheckCircle2, XCircle, Eye } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -19,15 +19,20 @@ import {
   looksLikeJobId,
   looksLikeSpillUri,
   looksLikePathInlineCode,
-  looksLikeShellCommand,
   classifyActionGoal,
+  classifyTranscriptHref,
   autolinkAgentText,
   type AgentLinkKind,
 } from "../lib/agentLinks";
 import {
+  getAgentCommandIndexVersion,
+  lookupAgentCommandSession,
+  registerAgentCommandSession,
+  subscribeAgentCommandIndex,
+} from "../lib/agentCommandIndex";
+import {
   pathTokenInCodeLine,
   tokenizeClickableOutput,
-  isSingleShellCommandFence,
 } from "../lib/clickableOutput";
 import { splitStreamingMarkdown } from "../lib/streamMarkdown";
 import {
@@ -901,6 +906,29 @@ function stableItemKey(it: GroupedItem, i: number): string {
 const FEED_ROW_ESTIMATE_PX = 72;
 const FEED_VIRTUAL_OVERSCAN = 8;
 
+/** Bind run_command cards even when Investigating is collapsed (Hermes procId). */
+function indexCardCommandSession(card: Card): void {
+  const cliInput = resolveCardCliInput(card);
+  const resultCommand = String(card.result?.command || "").trim();
+  const inputKey = toolInputFieldKey(card.kind || "");
+  const commandKv = inputKey === "command" && resultCommand ? resultCommand : cliInput;
+  const rawGoal = commandKv || cliInput;
+  const { linkKind, value } = classifyActionGoal(card.kind || "", rawGoal);
+  const id = String(card.id || card.result?.job_id || "").trim();
+  if (linkKind !== "command" || !id || !value) return;
+  registerAgentCommandSession({
+    id,
+    command: value,
+    output: String(card.result?.output || ""),
+  });
+}
+
+function indexTranscriptCommandSessions(items: Item[]): void {
+  for (const it of items) {
+    if (it.kind === "card") indexCardCommandSession(it.card);
+  }
+}
+
 // PERF: Memoized transcript renderer. Its props are intentionally free of the
 // composer `input` (or any per-keystroke state), so React.memo lets typing skip
 // re-rendering the whole transcript. Only transcript-affecting state (items,
@@ -958,6 +986,10 @@ export const TranscriptList = memo(function TranscriptList({
 }: TranscriptListProps) {
   // Match Conversation's latch — awaiting_swarm plus holdSwarmAwait so
   // Investigating / mid-turn absorption / footer stay armed through idle flaps.
+  useEffect(() => {
+    indexTranscriptCommandSessions(items);
+  }, [items]);
+
   const agentLoopOpen = isAgentLoopOpen(turnOpen, status) || holdSwarmAwait;
   // Pause-point: StatusPill prefers Still working… — seal sticky Investigating
   // and keep the busy footer visible instead of hiding under fold chrome.
@@ -1192,7 +1224,7 @@ export const TranscriptList = memo(function TranscriptList({
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  openAgentCommand(it.command, { run: false });
+                  openAgentCommand(it.command, { id: it.command, run: false });
                 }}
                 title="Reveal command"
                 className="block mt-0.5 max-w-full text-left text-[10px] text-accent/80 hover:underline underline-offset-2 font-mono truncate bg-transparent border-0 p-0 cursor-pointer"
@@ -1225,7 +1257,7 @@ export const TranscriptList = memo(function TranscriptList({
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  openAgentCommand(it.command, { run: false });
+                  openAgentCommand(it.command, { id: it.command, run: false });
                 }}
                 title="Reveal command"
                 className="mt-2 block w-full max-h-28 overflow-auto rounded border border-edge bg-panel/60 p-2 font-mono text-[10.5px] text-accent/85 hover:underline underline-offset-2 whitespace-pre-wrap break-all select-text text-left cursor-pointer"
@@ -2122,7 +2154,9 @@ function FencedCodeBlock({ className, children, ...props }: any) {
   const pathLines = lines.filter((ln) => pathTokenInCodeLine(ln)).length;
   // Directory trees / file lists: make paths open in the editor on click.
   const clickableTree = pathLines >= 2 || (lines.length <= 4 && pathLines >= 1);
-  const shellCommand = !clickableTree && isSingleShellCommandFence(codeText, className);
+  const liveCommand = !clickableTree && lines.length === 1
+    ? lookupAgentCommandSession(codeText)
+    : null;
 
   const handleCopy = () => {
     navigator.clipboard.writeText(codeText);
@@ -2130,9 +2164,29 @@ function FencedCodeBlock({ className, children, ...props }: any) {
     setTimeout(() => setCopied(false), 1200);
   };
 
+  const revealLiveCommand = (e: React.MouseEvent) => {
+    if (!liveCommand) return;
+    e.preventDefault();
+    e.stopPropagation();
+    openAgentCommand(liveCommand.command, {
+      id: liveCommand.id,
+      output: liveCommand.output,
+      run: false,
+    });
+  };
+
   return (
     <div className="relative group/code my-2">
-      {clickableTree ? (
+      {liveCommand ? (
+        <button
+          type="button"
+          onClick={revealLiveCommand}
+          title="Reveal running command"
+          className={`${className || ""} block w-full text-left bg-panel/80 border border-accent/20 rounded-md p-3 pr-10 overflow-x-auto font-mono text-[0.719rem] leading-[1.55] text-accent/90 hover:underline underline-offset-2 cursor-pointer m-0 whitespace-pre`}
+        >
+          {children}
+        </button>
+      ) : clickableTree ? (
         <pre
           className={`${className || ""} block bg-panel/80 border border-accent/20 rounded-md p-3 pr-10 overflow-x-auto font-mono text-[0.719rem] leading-[1.55] text-txt/90 m-0 whitespace-pre`}
           {...props}
@@ -2163,20 +2217,6 @@ function FencedCodeBlock({ className, children, ...props }: any) {
             );
           })}
         </pre>
-      ) : shellCommand ? (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            openAgentCommand(codeText.trim(), { run: false });
-          }}
-          title="Reveal command output"
-          className={`${className || ""} block w-full text-left bg-panel/80 border border-accent/20 rounded-md p-3 pr-10 overflow-x-auto font-mono text-[0.719rem] leading-[1.55] text-accent/90 hover:underline underline-offset-2 cursor-pointer m-0 whitespace-pre`}
-          {...props}
-        >
-          {codeText}
-        </button>
       ) : (
         <code className={`${className || ""} block bg-panel/80 border border-accent/20 rounded-md p-3 pr-10 overflow-x-auto font-mono text-[0.719rem] leading-[1.55] text-txt/90`} {...props}>
           {children}
@@ -2203,6 +2243,11 @@ function openMarkdownHref(href: string, e: React.MouseEvent): void {
 // Pretty tree only. Streaming wrappers pass a deferred `flushed` string so
 // highlight.js never remounts on a fence the next token can still extend.
 const PrettyMarkdown = memo(function PrettyMarkdown({ text }: { text: string }) {
+  useSyncExternalStore(
+    subscribeAgentCommandIndex,
+    getAgentCommandIndexVersion,
+    getAgentCommandIndexVersion,
+  );
   const linked = autolinkAgentText(text || "");
   return (
     <ReactMarkdown
@@ -2223,15 +2268,21 @@ const PrettyMarkdown = memo(function PrettyMarkdown({ text }: { text: string }) 
             {children}
           </blockquote>
         ),
-        a: ({ href, children }: any) => (
-          <a
-            href={href}
-            onClick={(e) => openMarkdownHref(href, e)}
-            className="text-accent/90 no-underline hover:underline underline-offset-2 decoration-accent/40 cursor-pointer break-words"
-          >
-            {children}
-          </a>
-        ),
+        a: ({ href, children }: any) => {
+          const kind = classifyTranscriptHref(href || "");
+          if (kind === "none") {
+            return <span>{children}</span>;
+          }
+          return (
+            <a
+              href={href}
+              onClick={(e) => openMarkdownHref(href, e)}
+              className="text-accent/90 no-underline hover:underline underline-offset-2 decoration-accent/40 cursor-pointer break-words"
+            >
+              {children}
+            </a>
+          );
+        },
         img: ({ src, alt }: any) => (
           <img
             src={src}
@@ -2266,22 +2317,6 @@ const PrettyMarkdown = memo(function PrettyMarkdown({ text }: { text: string }) 
           const isInline = !className;
           if (isInline) {
             const raw = nodeToText(children).trim();
-            if (looksLikeShellCommand(raw)) {
-              return (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    openAgentCommand(raw, { run: false });
-                  }}
-                  title="Reveal command"
-                  className="bg-accent/[0.08] px-1 py-[1px] rounded text-[0.9em] font-mono text-accent/90 hover:underline underline-offset-2 cursor-pointer"
-                >
-                  {children}
-                </button>
-              );
-            }
             if (looksLikePathInlineCode(raw)) {
               return (
                 <button
@@ -2314,8 +2349,29 @@ const PrettyMarkdown = memo(function PrettyMarkdown({ text }: { text: string }) 
                 </button>
               );
             }
+            const liveCommand = lookupAgentCommandSession(raw);
+            if (liveCommand) {
+              return (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    openAgentCommand(liveCommand.command, {
+                      id: liveCommand.id,
+                      output: liveCommand.output,
+                      run: false,
+                    });
+                  }}
+                  title="Reveal running command"
+                  className="bg-accent/[0.08] px-1 py-[1px] rounded text-[0.9em] font-mono text-accent/90 hover:underline underline-offset-2 cursor-pointer"
+                >
+                  {children}
+                </button>
+              );
+            }
             return (
-              <code className="bg-accent/[0.08] px-1 py-[1px] rounded text-[0.9em] font-mono text-accent/90" {...props}>
+              <code className="bg-panel2/60 px-1 py-[1px] rounded text-[0.9em] font-mono text-txt/90" {...props}>
                 {children}
               </code>
             );
@@ -2633,11 +2689,17 @@ function ActionCard({
   const commandRevealId = String(card.id || card.result?.job_id || goalValue || "").trim();
   const commandRevealOutput = String(card.result?.output || "");
 
-  // Keep an open agent-mirror tab in sync as run_command output grows.
+  // Bind this card's process id the way Hermes keys background terminals
+  // by procId, then keep an open mirror in sync as output grows.
   useEffect(() => {
-    if (linkKind !== "command" || !commandRevealId || !commandRevealOutput) return;
-    syncAgentCommandOutput(commandRevealId, commandRevealOutput);
-  }, [linkKind, commandRevealId, commandRevealOutput]);
+    if (linkKind !== "command" || !commandRevealId || !goalValue) return;
+    registerAgentCommandSession({
+      id: commandRevealId,
+      command: goalValue,
+      output: commandRevealOutput,
+    });
+    if (commandRevealOutput) syncAgentCommandOutput(commandRevealId, commandRevealOutput);
+  }, [linkKind, commandRevealId, goalValue, commandRevealOutput]);
 
   const openCommandReveal = (command: string) => {
     const cmd = (command || "").trim();
@@ -2783,7 +2845,7 @@ function ActionCard({
                       const v = nestedLink.value;
                       if (nestedLink.linkKind === "file") openAgentFile(v);
                       else if (nestedLink.linkKind === "url") openAgentUrl(v);
-                      else if (nestedLink.linkKind === "command") openAgentCommand(v, { run: false });
+                      else if (nestedLink.linkKind === "command") openAgentCommand(v, { id: v, run: false });
                       else if (nestedLink.linkKind === "image") openAgentImage(v);
                       else if (nestedLink.linkKind === "workspace") openAgentWorkspace(v);
                       else if (nestedLink.linkKind === "job") openAgentSwarmJob(v);
@@ -3017,7 +3079,7 @@ const KV = ({
             else if (linkKind === "job") openAgentSwarmJob(v);
             else if (linkKind === "spill") openAgentSpill(v);
             else if (onCommandClick) onCommandClick();
-            else openAgentCommand(v, { run: false });
+            else openAgentCommand(v, { id: v, run: false });
           }}
         >
           {v}

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -550,12 +550,12 @@ export default function ComposerDock({
           onDragOver={handleComposerDragOver}
           onDragLeave={handleComposerDragLeave}
           onDrop={handleComposerDrop}
-          className={`composer-dock relative bg-panel2/80 border rounded-2xl focus-within:border-edge2 shadow-lg shadow-black/20 transition ${
-            isDragOver ? "border-accent ring-1 ring-accent" : "border-edge"
+          className={`composer-dock shell-inset-glass relative rounded-2xl focus-within:border-edge2 transition ${
+            isDragOver ? "border-accent ring-1 ring-accent" : ""
           }`}
         >
           {(editingIndex !== null || canRevertEdit || editNotice) && (
-            <div className="flex items-center justify-between gap-2 px-3.5 py-1.5 bg-panel border-b border-edge text-[11.5px] text-accent select-none rounded-t-2xl">
+            <div className="flex items-center justify-between gap-2 px-3.5 py-1.5 border-b border-[var(--shell-panel-border)] text-[11.5px] text-accent select-none rounded-t-2xl">
               <span className="flex items-center gap-1.5 min-w-0">
                 <Pencil size={11} className="shrink-0" />
                 <span className="truncate">
@@ -623,7 +623,7 @@ export default function ComposerDock({
           )}
 
           {showContextPanel && !contextUsage && (
-            <div className="flex items-center justify-between p-3.5 bg-panel border-b border-edge text-[11.5px] select-none rounded-t-2xl animate-in slide-in-from-bottom duration-150">
+            <div className="flex items-center justify-between p-3.5 border-b border-[var(--shell-panel-border)] text-[11.5px] select-none rounded-t-2xl animate-in slide-in-from-bottom duration-150">
               <div className="flex items-center gap-2 text-faint">
                 <Loader2 className="w-3.5 h-3.5 animate-spin" />
                 <span className="font-semibold text-txt">Context Usage</span>
@@ -635,7 +635,7 @@ export default function ComposerDock({
             </div>
           )}
           {showContextPanel && contextUsage && (
-            <div className="flex flex-col p-3.5 bg-panel border-b border-edge text-[11.5px] select-none rounded-t-2xl animate-in slide-in-from-bottom duration-150">
+            <div className="flex flex-col p-3.5 border-b border-[var(--shell-panel-border)] text-[11.5px] select-none rounded-t-2xl animate-in slide-in-from-bottom duration-150">
               <div className="flex items-center justify-between font-medium mb-2.5">
                 <div className="flex items-center gap-1.5">
                   <span className="font-semibold text-txt">Context Usage</span>

--- a/webapp/src/components/conversation/openFileTabs.ts
+++ b/webapp/src/components/conversation/openFileTabs.ts
@@ -55,3 +55,38 @@ export function tabHasDirty(tabs: EditorTab[], path?: string): boolean {
 export function otherTabsHaveDirty(tabs: EditorTab[], keepPath: string): boolean {
   return tabs.some((t) => t.path !== keepPath && t.isDirty);
 }
+
+export type FileResolvePayload = {
+  ok?: boolean;
+  path?: string;
+  exact?: boolean;
+  error?: string;
+  candidates?: string[];
+};
+
+export type FileResolveChoice =
+  | { path: string }
+  | { toast: string };
+
+/**
+ * Map /api/file/resolve onto an editor path. Transcript clicks fail closed
+ * when the file is missing; file-tree clicks may fall back to the given path.
+ */
+export function chooseResolvedFilePath(
+  requested: string,
+  resolved: FileResolvePayload | null | undefined,
+  opts?: { trusted?: boolean },
+): FileResolveChoice | null {
+  const hint = (requested || "").trim();
+  if (!hint) return null;
+  if (resolved?.ok && resolved.path) return { path: resolved.path };
+  const candidates = Array.isArray(resolved?.candidates)
+    ? resolved.candidates.map((c) => String(c || "").trim()).filter(Boolean)
+    : [];
+  if (candidates.length === 1) return { path: candidates[0] };
+  if (candidates.length > 1) {
+    return { toast: `Multiple files match ${hint}; use a more specific path.` };
+  }
+  if (opts?.trusted) return { path: hint };
+  return { toast: `Couldn't open ${hint}.` };
+}

--- a/webapp/src/components/conversation/reexports.ts
+++ b/webapp/src/components/conversation/reexports.ts
@@ -232,6 +232,7 @@ export {
   setTabDirty,
   tabHasDirty,
   otherTabsHaveDirty,
+  chooseResolvedFilePath,
 } from "./openFileTabs";
 export {
   userStoppedBusyChrome,

--- a/webapp/src/lib/agentCommandIndex.ts
+++ b/webapp/src/lib/agentCommandIndex.ts
@@ -1,0 +1,109 @@
+/** Live agent-command sessions, keyed the way Hermes keys `procId`.
+
+Chat tokens become command links only when a real run_command / shell card
+has registered here. Speculative `` `git pull` `` stays prose until that
+process exists; then the click focuses that mirror, not a blank tab.
+*/
+
+export type AgentCommandSession = {
+  id: string;
+  command: string;
+  output: string;
+  updatedAt: number;
+};
+
+const byId = new Map<string, AgentCommandSession>();
+/** Normalized command → session ids, most recently updated last. */
+const idsByCommand = new Map<string, string[]>();
+
+let version = 0;
+const listeners = new Set<() => void>();
+
+function emit(bump: boolean): void {
+  if (bump) version += 1;
+  listeners.forEach((fn) => fn());
+}
+
+/** Collapse whitespace and a leading `$ ` so `$ git pull` matches `git pull`. */
+export function normalizeCommandKey(command: string): string {
+  return (command || "")
+    .trim()
+    .replace(/^\$\s+/, "")
+    .replace(/\s+/g, " ");
+}
+
+function rememberCommandId(key: string, id: string): void {
+  const prev = idsByCommand.get(key) || [];
+  idsByCommand.set(key, [...prev.filter((item) => item !== id), id]);
+}
+
+function forgetCommandId(key: string, id: string): void {
+  const next = (idsByCommand.get(key) || []).filter((item) => item !== id);
+  if (next.length) idsByCommand.set(key, next);
+  else idsByCommand.delete(key);
+}
+
+/**
+ * Record a live or completed agent command. Same id + command updates output
+ * silently (streaming) so chat markdown does not remount every chunk.
+ * A new id or a command change bumps the version so existing tokens light up.
+ */
+export function registerAgentCommandSession(input: {
+  id: string;
+  command: string;
+  output?: string;
+}): AgentCommandSession | null {
+  const id = String(input.id || "").trim();
+  const command = normalizeCommandKey(input.command);
+  if (!id || !command || command.length > 500) return null;
+  const output = String(input.output || "");
+  const existing = byId.get(id);
+  const now = Date.now();
+  if (existing && existing.command === command) {
+    existing.output = output;
+    existing.updatedAt = now;
+    rememberCommandId(command, id);
+    return existing;
+  }
+  if (existing && existing.command !== command) {
+    forgetCommandId(existing.command, id);
+  }
+  const session: AgentCommandSession = { id, command, output, updatedAt: now };
+  byId.set(id, session);
+  rememberCommandId(command, id);
+  emit(true);
+  return session;
+}
+
+export function lookupAgentCommandSession(command: string): AgentCommandSession | null {
+  const key = normalizeCommandKey(command);
+  if (!key) return null;
+  const ids = idsByCommand.get(key);
+  if (!ids || ids.length === 0) return null;
+  return byId.get(ids[ids.length - 1]) ?? null;
+}
+
+export function lookupAgentCommandSessionById(id: string): AgentCommandSession | null {
+  const key = String(id || "").trim();
+  if (!key) return null;
+  return byId.get(key) ?? null;
+}
+
+export function subscribeAgentCommandIndex(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+export function getAgentCommandIndexVersion(): number {
+  return version;
+}
+
+/** Test helper: wipe the index between cases. */
+export function _resetAgentCommandIndexForTests(): void {
+  byId.clear();
+  idsByCommand.clear();
+  version = 0;
+  listeners.clear();
+}

--- a/webapp/src/lib/agentLinks.ts
+++ b/webapp/src/lib/agentLinks.ts
@@ -6,6 +6,11 @@ instead of a raw OS navigation. Never throws.
 
 import { normalizeRepoPath } from "./pathNormalize";
 import {
+  lookupAgentCommandSession,
+  lookupAgentCommandSessionById,
+  registerAgentCommandSession,
+} from "./agentCommandIndex";
+import {
   seedAgentTerminalCommand,
   syncAgentTerminalSnapshot,
 } from "./agentTerminalStream";
@@ -15,6 +20,8 @@ export type OpenFileDetail = {
   path: string;
   line?: number;
   col?: number;
+  /** File-tree / known-good paths may open even if resolve is unavailable. */
+  trusted?: boolean;
 };
 
 export type ParsedFileHref = {
@@ -113,7 +120,7 @@ function hasFilesystemPrefix(clean: string): boolean {
  * Letter-start extensions reject version tails (`.1` in `tar@6.2.1`).
  */
 function hasFilenameExtension(clean: string): boolean {
-  const withoutLine = clean.replace(/(?::\d+){0,2}$/, "");
+  const withoutLine = clean.replace(/(?::\d+(?:-\d+)?)(?::\d+)?$/, "");
   const base = withoutLine.split(/[\\/]/).pop() || "";
   return /\.([A-Za-z][\w]{0,7}|7z)$/.test(base);
 }
@@ -210,7 +217,7 @@ export function parseFileHref(href: string): ParsedFileHref | null {
   let line: number | undefined;
   let col: number | undefined;
   // path.ext:12 or path.ext:12:3 — require a dotted extension before :line
-  const m = raw.match(/^(.+\.\w{1,8}):(\d+)(?::(\d+))?$/);
+  const m = raw.match(/^(.+\.\w{1,8}):(\d+)(?:-\d+)?(?::(\d+))?$/);
   if (m) {
     raw = m[1];
     line = parseInt(m[2], 10);
@@ -224,17 +231,94 @@ export function parseFileHref(href: string): ParsedFileHref | null {
   return { path: raw, line, col };
 }
 
-/** Inline `` `path` `` that should open as a file — not a package or command. */
+/**
+ * Transcript / markdown href that should open as a file.
+ * Bare `` `backend.py` `` is not enough — models backtick identifiers constantly.
+ * Require a filesystem prefix or a directory separator plus a filename extension.
+ */
 export function looksLikePathInlineCode(text: string): boolean {
   const t = (text || "").trim();
   if (!t || t.includes("\n") || t.length > 260) return false;
-  // Reject obvious non-paths (commands, flags, pure identifiers).
   if (/^[-+]/.test(t)) return false;
-  // Whitespace usually means a command — except conservative spaced paths
-  // (`/Users/me/My Projects/app.ts`), matching PATH_IN_TEXT / looksLikeSpacedFilePath.
   if (/\s/.test(t)) return looksLikeSpacedFilePath(t);
   if (looksLikeShellCommand(t)) return false;
-  return looksLikeFilePath(t);
+  if (!looksLikeFilePath(t)) return false;
+  const clean = t
+    .replace(/^file:\/\//i, "")
+    .replace(/^["']|["']$/g, "");
+  return hasFilesystemPrefix(clean) || /[\\/]/.test(clean);
+}
+
+/**
+ * Hermes `#session/` / `#preview/` style: identity-bound destinations that
+ * survive markdown sanitization. Never invent these from prose.
+ */
+export function commandMarkdownHref(id: string): string {
+  return `#command/${encodeURIComponent(id)}`;
+}
+
+export function commandRefFromMarkdownHref(href?: string): string | null {
+  if (!href?.startsWith("#command/")) return null;
+  try {
+    return decodeURIComponent(href.slice("#command/".length)) || null;
+  } catch {
+    return null;
+  }
+}
+
+export function fileMarkdownHref(path: string): string {
+  return `#file/${encodeURIComponent(path)}`;
+}
+
+export function fileRefFromMarkdownHref(href?: string): string | null {
+  if (!href?.startsWith("#file/")) return null;
+  try {
+    return decodeURIComponent(href.slice("#file/".length)) || null;
+  } catch {
+    return null;
+  }
+}
+
+export type TranscriptTarget =
+  | { kind: "url"; href: string }
+  | { kind: "spill"; href: string }
+  | { kind: "job"; href: string }
+  | { kind: "file"; href: string }
+  | { kind: "command"; command: string; id: string; output: string }
+  | { kind: "none" };
+
+/**
+ * Classify a markdown href / autolink target for transcript clicks.
+ * Commands light up only when a live/completed agent session is registered
+ * (Hermes `procId` / Codex trusted-destination rule).
+ */
+export function classifyTranscriptTarget(href: string): TranscriptTarget {
+  const h = (href || "").trim();
+  if (!h) return { kind: "none" };
+  if (isExternalUrl(h)) return { kind: "url", href: h };
+  if (looksLikeSpillUri(h)) return { kind: "spill", href: h };
+  if (looksLikeJobId(h)) return { kind: "job", href: h };
+  const commandId = commandRefFromMarkdownHref(h);
+  if (commandId) {
+    const live = lookupAgentCommandSessionById(commandId);
+    return live
+      ? { kind: "command", command: live.command, id: live.id, output: live.output }
+      : { kind: "none" };
+  }
+  const fileRef = fileRefFromMarkdownHref(h);
+  if (fileRef && looksLikeFilePath(fileRef)) {
+    return { kind: "file", href: fileRef };
+  }
+  if (looksLikePathInlineCode(h)) return { kind: "file", href: h };
+  const live = lookupAgentCommandSession(h);
+  if (live) {
+    return { kind: "command", command: live.command, id: live.id, output: live.output };
+  }
+  return { kind: "none" };
+}
+
+export function classifyTranscriptHref(href: string): AgentLinkKind {
+  return classifyTranscriptTarget(href).kind;
 }
 
 export type AgentLinkKind =
@@ -440,6 +524,13 @@ export type OpenAgentCommandOpts = {
 export function openAgentCommand(command: string, opts?: OpenAgentCommandOpts): void {
   const cmd = (command || "").trim();
   if (!cmd) return;
+  const live = !opts?.id ? lookupAgentCommandSession(cmd) : null;
+  const id = String(opts?.id || live?.id || "").trim();
+  const output = String(opts?.output || live?.output || "");
+  // Speculative transcript clicks used to mint a blank agent-terminal
+  // mirror. Fail closed unless this is an interactive inject or a real
+  // registered / tool-card reveal (Hermes openAgentTerminal(procId)).
+  if (!opts?.run && !id && !output) return;
   try {
     window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: "terminal" }));
     if (opts?.run) {
@@ -448,13 +539,13 @@ export function openAgentCommand(command: string, opts?: OpenAgentCommandOpts): 
       );
       return;
     }
-    const id = String(opts?.id || stableCommandId(cmd)).trim() || stableCommandId(cmd);
-    const output = String(opts?.output || "");
-    seedAgentTerminalCommand(id, cmd);
-    if (output) syncAgentTerminalSnapshot(id, output);
+    const revealId = id || stableCommandId(cmd);
+    registerAgentCommandSession({ id: revealId, command: cmd, output });
+    seedAgentTerminalCommand(revealId, cmd);
+    if (output) syncAgentTerminalSnapshot(revealId, output);
     window.dispatchEvent(
       new CustomEvent("harness-open-agent-terminal", {
-        detail: { id, command: cmd, output },
+        detail: { id: revealId, command: cmd, output },
       })
     );
   } catch {
@@ -467,6 +558,10 @@ export function syncAgentCommandOutput(id: string, output: string): void {
   const procId = String(id || "").trim();
   const snap = String(output || "");
   if (!procId || !snap) return;
+  const known = lookupAgentCommandSessionById(procId);
+  if (known) {
+    registerAgentCommandSession({ id: procId, command: known.command, output: snap });
+  }
   try {
     syncAgentTerminalSnapshot(procId, snap);
     window.dispatchEvent(
@@ -482,32 +577,35 @@ export function syncAgentCommandOutput(id: string, output: string): void {
 /** Route a markdown href click (or synthetic open). */
 export function openAgentLink(href: string, e?: { preventDefault(): void }): void {
   if (!href) return;
-  if (isExternalUrl(href)) {
+  const target = classifyTranscriptTarget(href);
+  if (target.kind === "none") {
     e?.preventDefault();
-    openAgentUrl(href);
-    return;
-  }
-  if (looksLikeSpillUri(href)) {
-    e?.preventDefault();
-    openAgentSpill(href);
-    return;
-  }
-  if (looksLikeJobId(href)) {
-    e?.preventDefault();
-    openAgentSwarmJob(href);
-    return;
-  }
-  if (looksLikeShellCommand(href)) {
-    e?.preventDefault();
-    openAgentCommand(href, { run: false });
-    return;
-  }
-  if (looksLikeFilePath(href)) {
-    e?.preventDefault();
-    openAgentFile(href);
     return;
   }
   e?.preventDefault();
+  if (target.kind === "url") {
+    openAgentUrl(target.href);
+    return;
+  }
+  if (target.kind === "spill") {
+    openAgentSpill(target.href);
+    return;
+  }
+  if (target.kind === "job") {
+    openAgentSwarmJob(target.href);
+    return;
+  }
+  if (target.kind === "file") {
+    openAgentFile(target.href);
+    return;
+  }
+  if (target.kind === "command") {
+    openAgentCommand(target.command, {
+      id: target.id,
+      output: target.output,
+      run: false,
+    });
+  }
 }
 
 /**

--- a/webapp/src/lib/boardColumnWidths.ts
+++ b/webapp/src/lib/boardColumnWidths.ts
@@ -10,12 +10,46 @@ export function minGroupWidth(groupCount: number): number {
 
 export function clampCardColumnSpan(value: number, fallback: number): number {
   if (!Number.isFinite(value)) return fallback;
-  return Math.max(MIN_CARD_COLUMN_SPAN, Math.min(GRID_COLUMN_COUNT, Math.round(value)));
+  return Math.max(MIN_CARD_COLUMN_SPAN, Math.min(GRID_COLUMN_COUNT, value));
 }
 
 /** Left-edge handle on every column except the leftmost (highest index). */
 export function showColumnResizeHandle(groupIndex: number, groupCount: number): boolean {
   return groupCount > 1 && groupIndex >= 0 && groupIndex < groupCount - 1;
+}
+
+/** Visual CSS grid column (1-based, left-to-right) for a right-indexed group. */
+export function groupGridColumn(groupIndex: number, groupCount: number): string {
+  if (groupCount <= 1) return "1";
+  return String(groupCount - groupIndex);
+}
+
+/**
+ * Track list for the board grid, visual left-to-right.
+ * The leftmost column is 1fr so shell-resize grows only that column; neighbors
+ * keep a pixel width once the board has been measured.
+ */
+export function columnTrackTemplate(widths: readonly number[], boardWidth = 0): string {
+  if (widths.length <= 1) return "minmax(0, 1fr)";
+  const total = widths.reduce((sum, width) => sum + width, 0) || 1;
+  const visual = widths.slice().reverse();
+  if (!Number.isFinite(boardWidth) || boardWidth <= 0) {
+    return visual.map(width => `minmax(0, ${width}fr)`).join(" ");
+  }
+  return visual.map((width, visualIndex) => {
+    if (visualIndex === 0) return "minmax(0, 1fr)";
+    return `${(width / total) * boardWidth}px`;
+  }).join(" ");
+}
+
+export function columnSpanFromPointerDelta(opts: {
+  startSpan: number;
+  startClientX: number;
+  clientX: number;
+  boardWidth: number;
+}): number {
+  if (!Number.isFinite(opts.boardWidth) || opts.boardWidth <= 0) return opts.startSpan;
+  return opts.startSpan + (opts.startClientX - opts.clientX) / (opts.boardWidth / GRID_COLUMN_COUNT);
 }
 
 export function normalizeGroupWidths(requested: number[], preferredGroupIndex: number): number[] {
@@ -32,7 +66,7 @@ export function normalizeGroupWidths(requested: number[], preferredGroupIndex: n
       return a - b;
     });
     let cursor = 0;
-    while (remaining > 0) {
+    while (remaining >= 1) {
       widths[order[cursor % order.length]] += 1;
       remaining -= 1;
       cursor += 1;
@@ -72,12 +106,50 @@ export function applyPairwiseColumnResize(
   const minWidth = minGroupWidth(groupCount);
   const neighborIndex = groupIndex + 1;
   if (neighborIndex >= groupCount) return widths.slice();
-  const current = widths.map(width => Math.max(minWidth, Math.min(GRID_COLUMN_COUNT, Math.round(width))));
+  const current = widths.map(width => Math.max(minWidth, Math.min(GRID_COLUMN_COUNT, width)));
   const pairTotal = current[groupIndex] + current[neighborIndex];
-  const span = Number.isFinite(nextSpan) ? Math.round(nextSpan) : current[groupIndex];
+  const span = Number.isFinite(nextSpan) ? nextSpan : current[groupIndex];
   const primary = Math.max(minWidth, Math.min(pairTotal - minWidth, span));
   const next = current.slice();
   next[groupIndex] = primary;
   next[neighborIndex] = pairTotal - primary;
   return next;
+}
+
+/**
+ * When the shell resizer changes board width, keep every column except the
+ * leftmost at its previous pixel size. Extra (or missing) width goes to the
+ * leftmost column so dragging the left edge does not scale the whole board.
+ */
+export function absorbShellResize(
+  widths: readonly number[],
+  oldBoardWidth: number,
+  newBoardWidth: number,
+): number[] {
+  if (widths.length <= 1) return widths.slice();
+  if (!(oldBoardWidth > 0 && newBoardWidth > 0) || oldBoardWidth === newBoardWidth) {
+    return widths.slice();
+  }
+  const minWidth = minGroupWidth(widths.length);
+  const total = widths.reduce((sum, width) => sum + width, 0) || 1;
+  const px = widths.map(width => (width / total) * oldBoardWidth);
+  const leftmost = widths.length - 1;
+  const minPx = (minWidth / GRID_COLUMN_COUNT) * newBoardWidth;
+  let lockedSum = 0;
+  for (let index = 0; index < leftmost; index += 1) lockedSum += px[index];
+  let leftPx = newBoardWidth - lockedSum;
+  if (leftPx < minPx) {
+    let remaining = minPx - leftPx;
+    leftPx = minPx;
+    for (let index = leftmost - 1; index >= 0 && remaining > 0; index -= 1) {
+      const reducible = Math.max(0, px[index] - minPx);
+      const take = Math.min(reducible, remaining);
+      px[index] -= take;
+      remaining -= take;
+    }
+  }
+  px[leftmost] = leftPx;
+  const others = px.slice(0, leftmost).map(value => (value / newBoardWidth) * GRID_COLUMN_COUNT);
+  const othersSum = others.reduce((sum, value) => sum + value, 0);
+  return others.concat(GRID_COLUMN_COUNT - othersSum);
 }

--- a/webapp/src/lib/clickableOutput.ts
+++ b/webapp/src/lib/clickableOutput.ts
@@ -7,7 +7,6 @@ same routing as markdown autolinks — without pulling in react-markdown.
 import {
   isExternalUrl,
   looksLikeFilePath,
-  looksLikePathInlineCode,
   looksLikeShellCommand,
   looksLikeSpillUri,
 } from "./agentLinks";
@@ -73,9 +72,7 @@ export function pathTokenInCodeLine(
   if (!m) return null;
   const path = m[2];
   const bare = path.replace(/(?::\d+){1,2}$/, "");
-  if (!looksLikePathInlineCode(bare) && !looksLikePathInlineCode(bare.split(/[\\/]/).pop() || "")) {
-    return null;
-  }
+  if (!looksLikeFilePath(bare)) return null;
   return { before: m[1], path, after: m[3] || "" };
 }
 
@@ -83,9 +80,8 @@ function pathCandidateValid(raw: string): boolean {
   const unwrapped = unwrapPathToken(raw);
   const bare = unwrapped.replace(/(?::\d+){1,2}$/, "");
   if (!bare || looksLikeShellCommand(bare)) return false;
-  if (looksLikePathInlineCode(bare) || looksLikeFilePath(bare)) return true;
-  // Bare basename.ext[:line] from stack frames.
-  return looksLikePathInlineCode(bare.split(/[\\/]/).pop() || "");
+  if (looksLikeFilePath(bare)) return true;
+  return false;
 }
 
 type Span = {

--- a/webapp/src/lib/railLayout.ts
+++ b/webapp/src/lib/railLayout.ts
@@ -1,0 +1,70 @@
+/** Shell rail widths: keep the left rail put and compact the right board first. */
+
+export const MIN_CENTER_W = 360;
+export const LEFT_MIN_W = 180;
+export const LEFT_MAX_W = 420;
+export const RIGHT_MIN_W = 320;
+export const RIGHT_COMPACT_MIN_W = 220;
+
+/** Flex chrome around the center column: shell padding and rail gutters. */
+export const RAIL_GUTTER_W = 6;
+
+const clamp = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n));
+
+export function layoutChrome(leftOpen: boolean, rightOpen: boolean): number {
+  let gutters = 0;
+  if (leftOpen) gutters += 1;
+  if (rightOpen) gutters += 1;
+  return 2 + gutters * RAIL_GUTTER_W;
+}
+
+/**
+ * Keep open rails within min/window budget while preserving MIN_CENTER_W.
+ * Opening the right board must not steal width from a left rail that still fits.
+ * If the window cannot hold both preferred widths plus the chat column, compact
+ * the right board first so the left rail stays at its current size.
+ */
+export function reclampRailWidths(
+  leftW: number,
+  rightW: number,
+  leftOpen: boolean,
+  rightOpen: boolean,
+  innerWidth: number,
+): { leftW: number; rightW: number } {
+  const chrome = layoutChrome(leftOpen, rightOpen);
+  const availableWidth = Math.max(0, innerWidth - chrome);
+  const preferredLeft = leftOpen ? clamp(leftW, LEFT_MIN_W, LEFT_MAX_W) : 0;
+  const preferredRight = rightOpen ? Math.max(RIGHT_MIN_W, rightW) : 0;
+  const requiredRails = (leftOpen ? LEFT_MIN_W : 0) + (rightOpen ? RIGHT_MIN_W : 0);
+  const centerWidth = Math.min(MIN_CENTER_W, Math.max(0, availableWidth - requiredRails));
+  const railBudget = Math.max(0, availableWidth - centerWidth);
+
+  if (!leftOpen && !rightOpen) return { leftW, rightW };
+
+  if (leftOpen && rightOpen) {
+    const compactRightMin = Math.min(RIGHT_MIN_W, RIGHT_COMPACT_MIN_W, railBudget);
+    const compactLeftMin = Math.min(LEFT_MIN_W, Math.max(0, railBudget - compactRightMin));
+    const leftMax = Math.min(LEFT_MAX_W, Math.max(compactLeftMin, railBudget - compactRightMin));
+    const left = clamp(preferredLeft, compactLeftMin, leftMax);
+    const right = clamp(
+      preferredRight,
+      compactRightMin,
+      Math.max(compactRightMin, railBudget - left),
+    );
+    return { leftW: left, rightW: right };
+  }
+
+  if (leftOpen) {
+    const leftMin = Math.min(LEFT_MIN_W, railBudget);
+    return {
+      leftW: clamp(preferredLeft, leftMin, Math.min(LEFT_MAX_W, railBudget)),
+      rightW,
+    };
+  }
+
+  const rightMin = Math.min(RIGHT_MIN_W, railBudget);
+  return {
+    leftW,
+    rightW: clamp(preferredRight, rightMin, railBudget),
+  };
+}

--- a/webapp/src/lib/terminalPathLinks.ts
+++ b/webapp/src/lib/terminalPathLinks.ts
@@ -10,7 +10,6 @@ import type { IDisposable, ILink, Terminal } from "@xterm/xterm";
 import {
   isExternalUrl,
   looksLikeFilePath,
-  looksLikePathInlineCode,
   looksLikeShellCommand,
   openAgentFile,
   openAgentUrl,
@@ -28,8 +27,8 @@ export type TerminalPathMatch = {
 function pathCandidateValid(raw: string): boolean {
   const bare = unwrapPathToken(raw).replace(/(?::\d+){1,2}$/, "");
   if (!bare || looksLikeShellCommand(bare)) return false;
-  if (looksLikePathInlineCode(bare) || looksLikeFilePath(bare)) return true;
-  return looksLikePathInlineCode(bare.split(/[\\/]/).pop() || "");
+  if (looksLikeFilePath(bare)) return true;
+  return false;
 }
 
 /** Match clickable path tokens on a single terminal line (testable pure helper). */


### PR DESCRIPTION
## Summary
- Composer uses the same `--shell-panel` glass as the left rail instead of a solid `panel2` island.
- Chat command tokens open the live agent terminal only when a `run_command` card is registered; speculative clicks stay dead.
- Cmd+J no longer flash-closes an empty right board. Left rail keeps its width when the board opens. Column resize is pairwise, not a 12-col snap.

## Test plan
- [ ] `tests` workflow green (3.9, 3.11, Windows, frontend-build)
- [ ] Cmd+J opens Swarm Tracker and stays open
- [ ] Click a registered `git pull` in chat and land on that agent terminal
- [ ] Unregistered inline commands stay muted code
- [ ] Two-column board: drag the handle; only that pair moves
