### PR TITLE
Release v0.9.263

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.15` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.262, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Composer uses the same `--shell-panel` glass as the left rail. Chat command tokens open the live agent terminal only when a run_command card is registered. Cmd+J no longer flash-closes an empty right board; column resize is pairwise, not a 12-col snap.
+> Status: v0.9.263, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Composer is again a solid `panel2` island. Chat command tokens open the live agent terminal only when a run_command card is registered. Cmd+J no longer flash-closes an empty right board; column resize is pairwise, not a 12-col snap.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.262"
+__version__ = "0.9.263"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.262"
+version = "0.9.263"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.262",
+  "version": "0.9.263",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.262",
+      "version": "0.9.263",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.262",
+  "version": "0.9.263",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/ComposerDock.busyChrome.test.tsx
+++ b/webapp/src/__tests__/ComposerDock.busyChrome.test.tsx
@@ -126,11 +126,11 @@ describe("ComposerDock busy chrome", () => {
     expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
   });
 
-  it("uses side-panel glass, not an opaque chat island", () => {
+  it("keeps the composer as a solid panel island", () => {
     const { container } = renderBusyDock("");
     const dock = container.querySelector(".composer-dock");
-    expect(dock).toHaveClass("shell-inset-glass");
-    expect(dock?.className).not.toMatch(/bg-panel2/);
+    expect(dock).toHaveClass("bg-panel2/80");
+    expect(dock?.className).not.toMatch(/shell-inset-glass/);
   });
 
   it("keeps send actions in a non-shrinking cluster so the picker can truncate", () => {

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -550,12 +550,12 @@ export default function ComposerDock({
           onDragOver={handleComposerDragOver}
           onDragLeave={handleComposerDragLeave}
           onDrop={handleComposerDrop}
-          className={`composer-dock shell-inset-glass relative rounded-2xl focus-within:border-edge2 transition ${
-            isDragOver ? "border-accent ring-1 ring-accent" : ""
+          className={`composer-dock relative bg-panel2/80 border rounded-2xl focus-within:border-edge2 shadow-lg shadow-black/20 transition ${
+            isDragOver ? "border-accent ring-1 ring-accent" : "border-edge"
           }`}
         >
           {(editingIndex !== null || canRevertEdit || editNotice) && (
-            <div className="flex items-center justify-between gap-2 px-3.5 py-1.5 border-b border-[var(--shell-panel-border)] text-[11.5px] text-accent select-none rounded-t-2xl">
+            <div className="flex items-center justify-between gap-2 px-3.5 py-1.5 bg-panel border-b border-edge text-[11.5px] text-accent select-none rounded-t-2xl">
               <span className="flex items-center gap-1.5 min-w-0">
                 <Pencil size={11} className="shrink-0" />
                 <span className="truncate">
@@ -623,7 +623,7 @@ export default function ComposerDock({
           )}
 
           {showContextPanel && !contextUsage && (
-            <div className="flex items-center justify-between p-3.5 border-b border-[var(--shell-panel-border)] text-[11.5px] select-none rounded-t-2xl animate-in slide-in-from-bottom duration-150">
+            <div className="flex items-center justify-between p-3.5 bg-panel border-b border-edge text-[11.5px] select-none rounded-t-2xl animate-in slide-in-from-bottom duration-150">
               <div className="flex items-center gap-2 text-faint">
                 <Loader2 className="w-3.5 h-3.5 animate-spin" />
                 <span className="font-semibold text-txt">Context Usage</span>
@@ -635,7 +635,7 @@ export default function ComposerDock({
             </div>
           )}
           {showContextPanel && contextUsage && (
-            <div className="flex flex-col p-3.5 border-b border-[var(--shell-panel-border)] text-[11.5px] select-none rounded-t-2xl animate-in slide-in-from-bottom duration-150">
+            <div className="flex flex-col p-3.5 bg-panel border-b border-edge text-[11.5px] select-none rounded-t-2xl animate-in slide-in-from-bottom duration-150">
               <div className="flex items-center justify-between font-medium mb-2.5">
                 <div className="flex items-center gap-1.5">
                   <span className="font-semibold text-txt">Context Usage</span>


### PR DESCRIPTION
## Summary
- Restore the solid `bg-panel2/80` composer island. The v0.9.262 `--shell-panel` glass read worse.
- Keep fail-closed chat linking, Cmd+J seed, rail-width clamp, and pairwise column resize from v0.9.262.

## Test plan
- [ ] `tests` workflow green (3.9, Windows, frontend-build)
- [ ] Composer looks like the pre-262 island, not left-rail glass
- [ ] Cmd+J still stays open; registered command tokens still bind
