### PR TITLE
Release v0.9.265

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.15` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.264, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. React Compiler is on for the Vite tree (Hermes-scoped JSX / `from 'react'` filter). Command tokens still light up only after a run_command card registers. Composer stays a solid `panel2` island.
+> Status: v0.9.265, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Live chat paints Codex/Hermes-style (33ms timer, no char drip). Explicit "swarm / multi-worker" asks block git theater until run_swarm fires.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.264"
+__version__ = "0.9.265"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/pilot_guards.py
+++ b/harness/pilot_guards.py
@@ -6,7 +6,9 @@ Per-turn guards wired before native tool dispatch:
 
 1. LOOP BREAKER — suppress repeated (tool, normalized-args) calls within a turn.
 2. SWARM GATE — on broad-intent user messages, block native exploration until
-   run_swarm / run_parallel / run_implement is dispatched. After a healthy
+   run_swarm / run_parallel / run_implement is dispatched. Explicit "swarm" /
+   "multi-worker" asks also block git, launch scripts, and run_implement until
+   run_swarm / run_parallel actually fire. After a healthy
    dispatch, list_dir / search_files / exploration run_command stay blocked on
    broad turns (read_file + search_codegraph remain allowed to validate
    concrete findings); thin swarm results require re-dispatch, not an inline
@@ -213,6 +215,29 @@ _BROAD_INTENT_RE = re.compile(
     r"comprehensive\s+(?:review|audit|analysis)|"
     r"across\s+the\s+(?:codebase|repo|project|directory)|"
     r"whole\s+(?:codebase|repo|project|directory)"
+    r")",
+    re.IGNORECASE,
+)
+
+_EXPLICIT_SWARM_RE = re.compile(
+    r"(?:"
+    r"\brun_swarm\b|"
+    r"\bpuppetmaster\s+swarm\b|"
+    r"\b(?:start|spin\s+up|launch|dispatch|run)\s+(?:a\s+)?swarm\b|"
+    r"\bswarm\s+(?:glm|kimi|qwen|gpt|deepseek|claude|via|with|using|multi)|"
+    r"\bmulti[- ]workers?\b|"
+    r"\bfan-?out\b"
+    r")",
+    re.IGNORECASE,
+)
+
+_EXPLICIT_SWARM_NEG_RE = re.compile(
+    r"(?:"
+    r"don'?t\s+swarm|"
+    r"do\s+not\s+swarm|"
+    r"swarm\s+tracker|"
+    r"where\s+is\s+run_swarm|"
+    r"what\s+is\s+(?:a\s+)?swarm"
     r")",
     re.IGNORECASE,
 )
@@ -536,6 +561,10 @@ class TurnGuardState:
     delegation_seen: bool = False
     user_message: str = ""
     broad_intent: bool = False
+    # User named a swarm (run_swarm / puppetmaster swarm / multi-workers).
+    # Stronger than broad_intent: git/scripts/run_implement stay blocked
+    # until run_swarm / run_parallel actually dispatch.
+    explicit_swarm: bool = False
     swarm_dispatched: bool = False
     read_file_count: int = 0
     # Count of swarm-gate suppressions this turn (full redirect + short replays).
@@ -589,6 +618,18 @@ def is_broad_intent_user_message(message: str) -> bool:
     if _BROAD_INTENT_RE.search(text):
         return True
     return _is_cross_platform_compare(text)
+
+
+def is_explicit_swarm_user_message(message: str) -> bool:
+    """True when the user asked to launch a swarm, not merely mentioned one."""
+    text = _norm_whitespace(message or "")
+    if not text:
+        return False
+    if _NARROW_INTENT_RE.search(text):
+        return False
+    if _EXPLICIT_SWARM_NEG_RE.search(text):
+        return False
+    return bool(_EXPLICIT_SWARM_RE.search(text))
 
 
 def _norm_path(path: str) -> str:
@@ -879,6 +920,20 @@ def _is_durable_recall_read(act: Any) -> bool:
 
 
 def is_swarm_gate_blocked_exploration(state: TurnGuardState, kind: str, act: Any) -> bool:
+    if getattr(state, "explicit_swarm", False):
+        if state.kernel_recovery:
+            return False
+        if not state.swarm_dispatched:
+            if kind in ("run_swarm", "run_parallel"):
+                return False
+            if kind in ("search_codegraph", "search_state", "route_task", "query_wiki"):
+                return False
+            if kind == "read_file" and _is_durable_recall_read(act):
+                return False
+            return True
+        if not state.broad_intent:
+            return False
+
     if not state.broad_intent:
         return False
 
@@ -925,8 +980,20 @@ def _loop_suppress_message(kind: str, repeat_count: int) -> str:
     )
 
 
-def _swarm_gate_suppress_message(kind: str, *, swarm_dispatched: bool = False) -> str:
+def _swarm_gate_suppress_message(
+    kind: str,
+    *,
+    swarm_dispatched: bool = False,
+    explicit_swarm: bool = False,
+) -> str:
     roles = ", ".join(BROAD_SWARM_ROLES)
+    if explicit_swarm and not swarm_dispatched:
+        return (
+            f"(SUPPRESSED: {kind} — this turn asked for a swarm. Do not git, "
+            f"write launch scripts, or shell the Puppetmaster CLI. Call run_swarm "
+            f"now with MULTIPLE roles ({roles}) and auto-routed OpenRouter/"
+            f"agentic models. run_implement is one worker, not a swarm.)"
+        )
     if swarm_dispatched:
         return (
             f"(SUPPRESSED: native exploration {kind} — a swarm already ran this turn and "
@@ -955,8 +1022,19 @@ def _swarm_gate_suppress_message(kind: str, *, swarm_dispatched: bool = False) -
     )
 
 
-def _swarm_gate_replay_message(kind: str, *, swarm_dispatched: bool = False) -> str:
+def _swarm_gate_replay_message(
+    kind: str,
+    *,
+    swarm_dispatched: bool = False,
+    explicit_swarm: bool = False,
+) -> str:
     """Short cached redirect after the first full swarm-gate suppress this turn."""
+    if explicit_swarm and not swarm_dispatched:
+        return (
+            f"[swarm_gate redirect already issued this turn — stop {kind}. "
+            f"Call run_swarm or run_parallel now. Do not git or shell "
+            f"Puppetmaster CLI.]"
+        )
     if swarm_dispatched:
         return (
             f"[swarm_gate redirect already issued this turn — stop broad native "
@@ -1372,7 +1450,9 @@ def check_swarm_gate(state: TurnGuardState, kind: str, act: Any) -> GuardVerdict
         from .task_profile import profile_disables_swarm_gate
 
         profile = getattr(state, "task_profile", "") or ""
-        if profile_disables_swarm_gate(profile):
+        if profile_disables_swarm_gate(profile) and not getattr(
+            state, "explicit_swarm", False
+        ):
             return GuardVerdict(False)
     except Exception:
         pass
@@ -1383,6 +1463,7 @@ def check_swarm_gate(state: TurnGuardState, kind: str, act: Any) -> GuardVerdict
     prior = state.swarm_gate_suppress_count
     state.swarm_gate_suppress_count = prior + 1
     dispatched = bool(state.swarm_dispatched)
+    explicit = bool(getattr(state, "explicit_swarm", False))
 
     # First suppression(s) this turn get the full redirect so the model sees a
     # clear "stop exploring, call run_swarm now" signal. Further identical-class
@@ -1392,13 +1473,17 @@ def check_swarm_gate(state: TurnGuardState, kind: str, act: Any) -> GuardVerdict
         return GuardVerdict(
             suppress=True,
             reason="swarm_gate",
-            message=_swarm_gate_suppress_message(kind, swarm_dispatched=dispatched),
+            message=_swarm_gate_suppress_message(
+                kind, swarm_dispatched=dispatched, explicit_swarm=explicit,
+            ),
         )
 
     return GuardVerdict(
         suppress=True,
         reason="swarm_gate_replay",
-        message=_swarm_gate_replay_message(kind, swarm_dispatched=dispatched),
+        message=_swarm_gate_replay_message(
+            kind, swarm_dispatched=dispatched, explicit_swarm=explicit,
+        ),
         replay=True,
     )
 
@@ -1595,6 +1680,7 @@ def new_turn_guard_state(
     return TurnGuardState(
         user_message=user_message or "",
         broad_intent=is_broad_intent_user_message(user_message or ""),
+        explicit_swarm=is_explicit_swarm_user_message(user_message or ""),
         iteration_budget=IterationBudget(cap) if cap > 0 else None,
         tiny_workspace=tiny,
         nested_implement=bool(nested_implement),

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -880,7 +880,7 @@ def drain_stream_queue(q: Any, accumulator: Any = None) -> Iterator[Any]:
     ``streamed_reasoning`` / ``stream_ended_on_reasoning`` so the send loop
     can promote a thought-only finale into an assistant message.
 
-    Same-(channel, stream_id) deltas are batched (~40ms / 80 chars) before
+    Same-(channel, stream_id) deltas are batched (~16ms / 80 chars) before
     becoming SSE frames so word-sized tokens cannot exhaust the replay ring.
     Each new contentful (channel, stream_id) answer/reasoning identity yields
     its first frame immediately so perceived TTFT is not gated on the batch

--- a/harness/stream_identity.py
+++ b/harness/stream_identity.py
@@ -12,7 +12,10 @@ import time
 from typing import Any, Dict, Optional, Tuple
 
 # Coalesce same-(channel, stream_id) deltas until either threshold trips.
-STREAM_DELTA_BATCH_MS = 40.0
+# 16ms is one paint frame — enough to protect the 512-frame SSE ring from
+# word tokens without stacking a second visible wave on the client's 33ms
+# Hermes-style paint timer. Keep the 80-char cap for bursty providers.
+STREAM_DELTA_BATCH_MS = 16.0
 STREAM_DELTA_BATCH_CHARS = 80
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.264"
+version = "0.9.265"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_pilot_guards.py
+++ b/tests/test_pilot_guards.py
@@ -33,6 +33,7 @@ from harness.pilot_guards import (
     guards_active,
     is_backend_restart_command,
     is_broad_intent_user_message,
+    is_explicit_swarm_user_message,
     is_exploration_command,
     is_headless_chrome_file_smoke_command,
     is_local_handoff_command,
@@ -122,6 +123,76 @@ def test_broad_intent_classification_positives(message):
 )
 def test_broad_intent_classification_negatives(message):
     assert is_broad_intent_user_message(message) is False
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "yeah, puppetmaster swarm glm 5.3 multi-workers via openrouter",
+        "run_swarm on token streaming",
+        "spin up a swarm for the discord cards",
+        "launch a swarm via OpenRouter",
+        "multi-worker fan-out on the backend",
+    ],
+)
+def test_explicit_swarm_classification_positives(message):
+    assert is_explicit_swarm_user_message(message) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "hi",
+        "Where is run_swarm defined?",
+        "what is a swarm",
+        "open the swarm tracker",
+        "don't swarm yet, just read backend.py",
+        "Find the class TurnGuardState",
+    ],
+)
+def test_explicit_swarm_classification_negatives(message):
+    assert is_explicit_swarm_user_message(message) is False
+
+
+def test_explicit_swarm_blocks_git_and_scripts_until_run_swarm():
+    prompt = "yeah, puppetmaster swarm glm 5.3 multi-workers via openrouter"
+    state = new_turn_guard_state(prompt)
+    assert state.explicit_swarm is True
+    assert state.broad_intent is False
+
+    git = check_swarm_gate(
+        state, "run_command", _Act(kind="run_command", command="git status"),
+    )
+    assert git.suppress is True
+    assert git.reason == "swarm_gate"
+    assert "run_implement is one worker" in git.message
+
+    script = check_swarm_gate(
+        state,
+        "run_command",
+        _Act(kind="run_command", command="node ./glm53/script.sh --n 10"),
+    )
+    assert script.suppress is True
+
+    implement = check_swarm_gate(
+        state, "run_implement", _Act(kind="run_implement", goal="wire streaming"),
+    )
+    assert implement.suppress is True
+    assert "run_swarm" in implement.message
+    assert "run_implement" in implement.message
+
+    swarm = check_swarm_gate(
+        state, "run_swarm", _Act(kind="run_swarm", goal="token streaming fan-out"),
+    )
+    assert swarm.suppress is False
+
+    record_action_execution(
+        state, "run_swarm", _Act(kind="run_swarm", goal="token streaming fan-out"),
+    )
+    after = check_swarm_gate(
+        state, "run_command", _Act(kind="run_command", command="git status"),
+    )
+    assert after.suppress is False
 
 
 def test_investigate_shaped_turn_swarm_gate_suppresses_exploration():

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -50,9 +50,9 @@ const configuredDevServerLatch = createDevServerFallbackLatch();
 const isPackaged = app.isPackaged;
 
 // Keep the renderer at full speed while the window is blurred or occluded
-// (pattern lifted from Hermes desktop). The transcript streams to screen
-// through a requestAnimationFrame-gated typewriter pump, and Chromium pauses
-// rAF (and clamps timers) for backgrounded/occluded renderers -- without
+// (pattern lifted from Hermes desktop). The transcript streams through a
+// 33ms paint timer (Hermes STREAM_DELTA_FLUSH_MS; not rAF). Chromium still
+// parks rAF and clamps timers for backgrounded/occluded renderers -- without
 // these, a live answer freezes the moment focus moves to another window and
 // only paints on refocus. `backgroundThrottling: false` on the BrowserWindow
 // covers the blurred case; these process-level switches additionally stop

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.264",
+  "version": "0.9.265",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.264",
+      "version": "0.9.265",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.264",
+  "version": "0.9.265",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/chatLoopResilience.wave5.test.ts
+++ b/webapp/src/__tests__/chatLoopResilience.wave5.test.ts
@@ -146,7 +146,8 @@ describe("Wave 5: long reasoning stays busy without idle blink", () => {
     expect(progress.label.toLowerCase()).toContain("still working");
     expect(progress.pill.toLowerCase()).toContain("still working");
     expect(progress.pill).not.toBe("idle");
-    expect(shouldShowBusyFooter(state.items, state.status)).toBe(true);
+    // Live thinking row already owns the signal — footer under it blinks.
+    expect(shouldShowBusyFooter(state.items, state.status)).toBe(false);
   });
 });
 

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -256,6 +256,7 @@ import {
   classifySwarmPollEvent,
 } from "../components/conversation/swarmPoll";
 import {
+  STREAM_PAINT_MS,
   cancelTypewriterWithoutFlush,
   flushTypewriterBuffer,
   pumpTypewriterFrame,
@@ -807,7 +808,9 @@ describe("streamBubbles module", () => {
     expect(findStreamingBubbleIdx(items, { excludeWorkerStream: true })).toBe(-1);
     expect(typewriterCharsPerFrame(0, false)).toBe(0);
     expect(typewriterCharsPerFrame(3, false)).toBe(3);
-    expect(typewriterCharsPerFrame(40, true)).toBeGreaterThanOrEqual(12);
+    expect(typewriterCharsPerFrame(40, false)).toBe(40);
+    expect(typewriterCharsPerFrame(40, true)).toBe(40);
+    expect(STREAM_PAINT_MS).toBe(33);
   });
 
   it("finds an earlier pilot bubble when a trailing worker preview fails affinity", () => {
@@ -3423,8 +3426,9 @@ describe("streamTypewriter first reveal", () => {
     const chunks: string[] = [];
     let cancelled = 0;
     startTypewriterLoop(refs, (c) => chunks.push(c), () => 3);
-    const remaining = refs.typeBufRef.current;
-    expect(remaining.length).toBeGreaterThan(0);
+    // Codex/Hermes paint: first reveal drains the arrived chunk.
+    expect(refs.typeBufRef.current).toBe("");
+    expect(chunks.join("")).toBe(text);
     flushTypewriterBuffer(refs, (c) => chunks.push(c), () => {
       cancelled += 1;
     });
@@ -3445,24 +3449,16 @@ describe("streamTypewriter first reveal", () => {
     expect(cancelled).toBe(2);
   });
 
-  it("scheduled pump continues the same live cadence on leftover buffer", () => {
+  it("scheduled pump on leftover buffer drains the rest in one take", () => {
     const text = "Hello world, this is buffered prose.";
     const refs = makeRefs(text);
     const chunks: string[] = [];
-    let pump: (() => void) | null = null;
-    startTypewriterLoop(refs, (c) => chunks.push(c), (cb) => {
-      pump = cb;
-      return 11;
-    });
-    const first = text.slice(0, typewriterCharsPerFrame(text.length, false));
-    expect(chunks).toEqual([first]);
-    const leftover = text.slice(first.length);
-    expect(refs.typeBufRef.current).toBe(leftover);
-    expect(pump).not.toBeNull();
+    startTypewriterLoop(refs, (c) => chunks.push(c), () => 11);
+    expect(chunks).toEqual([text]);
+    expect(refs.typeBufRef.current).toBe("");
     pumpTypewriterFrame(refs, (c) => chunks.push(c), () => 12);
-    const second = leftover.slice(0, typewriterCharsPerFrame(leftover.length, false));
-    expect(chunks).toEqual([first, second]);
-    expect(refs.typeBufRef.current).toBe(leftover.slice(second.length));
+    expect(chunks).toEqual([text]);
+    expect(refs.typeBufRef.current).toBe("");
   });
 
   it("empty-buffer pump with typeDone false reschedules without appending", () => {

--- a/webapp/src/__tests__/investigationCollapser.seal.test.tsx
+++ b/webapp/src/__tests__/investigationCollapser.seal.test.tsx
@@ -171,8 +171,9 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
       />,
     );
     expect(screen.getByText(/Investigating/i)).toBeTruthy();
-    // Investigating fold owns the status surface — no flat Still working footer.
-    expect(screen.queryByText(/Still working/i)).toBeNull();
+    // Finished cards + open loop: fold stays Investigating and the footer
+    // keeps Still working… so tool-batch gaps are not a dead log dump.
+    expect(screen.getByText(/Still working/i)).toBeTruthy();
   });
 
   it("holdSwarmAwait with active pilot turn keeps mid-turn Investigating, not sealed Explored", () => {

--- a/webapp/src/__tests__/turnProgress.test.ts
+++ b/webapp/src/__tests__/turnProgress.test.ts
@@ -339,7 +339,7 @@ describe("turnLooksAnswerComplete / shouldShowBusyFooter (T5)", () => {
       msg("assistant", "partial…", true),
     ];
     expect(turnLooksAnswerComplete(items)).toBe(false);
-    expect(shouldShowBusyFooter(items, "streaming")).toBe(true);
+    expect(shouldShowBusyFooter(items, "streaming")).toBe(false);
   });
 
   it("is false while a card is running", () => {
@@ -349,7 +349,7 @@ describe("turnLooksAnswerComplete / shouldShowBusyFooter (T5)", () => {
       card("1", "a.ts", "read_file", true),
     ];
     expect(turnLooksAnswerComplete(items)).toBe(false);
-    expect(shouldShowBusyFooter(items, "executing")).toBe(true);
+    expect(shouldShowBusyFooter(items, "executing")).toBe(false);
   });
 
   it("is false between tool steps after mid-turn narration (no idle blink)", () => {
@@ -375,7 +375,7 @@ describe("turnLooksAnswerComplete / shouldShowBusyFooter (T5)", () => {
       { kind: "thinking", text: "more", streaming: true },
     ];
     expect(turnLooksAnswerComplete(items)).toBe(false);
-    expect(shouldShowBusyFooter(items, "thinking")).toBe(true);
+    expect(shouldShowBusyFooter(items, "thinking")).toBe(false);
   });
 
   it("is false while tool_prep is active", () => {
@@ -385,7 +385,7 @@ describe("turnLooksAnswerComplete / shouldShowBusyFooter (T5)", () => {
       { kind: "tool_prep", name: "grep" },
     ];
     expect(turnLooksAnswerComplete(items)).toBe(false);
-    expect(shouldShowBusyFooter(items, "thinking")).toBe(true);
+    expect(shouldShowBusyFooter(items, "thinking")).toBe(false);
   });
 
   it("is false with no assistant text yet (T3 waiting still shows)", () => {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -184,7 +184,9 @@ import {
 } from "./conversation/swarmPoll";
 import { armResumeKick } from "./conversation/sessionResumeLatch";
 import {
+  cancelStreamPaint,
   flushTypewriterBuffer,
+  scheduleStreamPaint,
   startTypewriterLoop,
 } from "./conversation/streamTypewriter";
 import {
@@ -470,20 +472,18 @@ export default function Conversation({
   // Stable indirection so the always-on swarm-results poll (defined before the
   // trigger) can fire a keep-alive turn without a declaration-order dependency.
   const resumeTriggerRef = useRef<() => void>(() => {});
-  // Typewriter buffer: network deltas arrive in bursts (whole sentences at a
-  // time). To render smoothly like Cursor/Hermes we DON'T paint on arrival --
-  // we queue incoming text here and drain it at a steady per-frame cadence via
-  // requestAnimationFrame, so the user sees an even "typing" effect regardless
-  // of how chunky the underlying stream is.
+  // Typewriter buffer: network deltas arrive in bursts. Codex paints the
+  // arrived chunk (no char drip). Hermes coalesces on a 33ms timer — not rAF
+  // — so a hidden/minimized renderer cannot park the queue until refocus.
   const typeBufRef = useRef<string>("");          // undrained characters
-  const typeRafRef = useRef<number | null>(null); // active rAF handle
-  const typeDoneRef = useRef<boolean>(false);     // stream ended -> drain fast then stop
+  const typeRafRef = useRef<number | null>(null); // active paint-timer handle
+  const typeDoneRef = useRef<boolean>(false);     // stream ended -> drain then stop
 
-  // Cancel any in-flight typewriter rAF on unmount so the loop never leaks.
+  // Cancel any in-flight paint timer on unmount so the loop never leaks.
   useEffect(() => {
     return () => {
       if (typeRafRef.current != null) {
-        cancelAnimationFrame(typeRafRef.current);
+        cancelStreamPaint(typeRafRef.current);
         typeRafRef.current = null;
       }
     };
@@ -2356,14 +2356,12 @@ export default function Conversation({
     });
   };
 
-  // Drain the typewriter buffer at a steady cadence. While the stream is live we
-  // reveal a fixed number of chars per frame (smooths bursty network arrival);
-  // once the stream has ended we accelerate so we never lag behind the model.
+  // Drain the whole arrived chunk on a 33ms Hermes timer (Codex: no drip).
   const startTypewriter = () => {
     startTypewriterLoop(
       { typeBufRef, typeRafRef, typeDoneRef },
       appendStreamingText,
-      requestAnimationFrame,
+      scheduleStreamPaint,
     );
   };
 
@@ -2371,7 +2369,7 @@ export default function Conversation({
     flushTypewriterBuffer(
       { typeBufRef, typeRafRef, typeDoneRef },
       appendStreamingText,
-      cancelAnimationFrame,
+      cancelStreamPaint,
     );
   };
   flushTypewriterRef.current = flushTypewriter;

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -49,6 +49,7 @@ import {
   toolInputFieldKey,
   toolRowLabel,
   turnHasLiveInvestigation,
+  turnHasVisibleBusySurface,
 } from "../lib/turnProgress";
 import { isAgentLoopOpen } from "./conversation/runnersBusy";
 import {
@@ -1479,10 +1480,10 @@ export const TranscriptList = memo(function TranscriptList({
   );
 
   const busyProgress = deriveBusyProgress(items, status, busyElapsedMs);
-  const hideBusyFooter = turnHasLiveInvestigation(
-    items,
-    pausePoint ? false : agentLoopOpen,
-  );
+  // Hide the under-fold line only while a card / prep / stream already
+  // shows work. A sticky Investigating fold of *finished* tools used to
+  // own chrome and swallow "Still working…" between Kimi-style batches.
+  const hideBusyFooter = turnHasVisibleBusySurface(items);
   const showBusyFooter =
     (shouldShowBusyFooter(items, status) || pausePoint) && !hideBusyFooter;
   const showStall = quietWorkingCueVisible(
@@ -2404,16 +2405,12 @@ const PrettyMarkdown = memo(function PrettyMarkdown({ text }: { text: string }) 
 function StreamingMarkdown({ text }: { text: string }) {
   const buf = splitStreamingMarkdown(text || "");
   const deferredFlushed = useDeferredValue(buf.flushed);
-  const lag = deferredFlushed !== buf.flushed
-    ? buf.flushed.slice(deferredFlushed.length)
-    : "";
-  return (
-    <>
-      <PrettyMarkdown text={deferredFlushed} />
-      {lag ? (
-        <span data-md-lag className="whitespace-pre-wrap">{lag}</span>
-      ) : null}
-      {buf.open ? (
+  // Never paint flushed-as-markdown plus a sibling lag <span>. That remounts
+  // the trailing sentence as <p> then <span> then <p> again — the blink.
+  if (buf.open) {
+    return (
+      <>
+        {buf.flushed ? <PrettyMarkdown text={deferredFlushed} /> : null}
         <pre
           data-md-pending
           data-lang={buf.open.lang || undefined}
@@ -2421,7 +2418,13 @@ function StreamingMarkdown({ text }: { text: string }) {
         >
           {buf.open.body + buf.hold}
         </pre>
-      ) : buf.hold ? (
+      </>
+    );
+  }
+  return (
+    <>
+      <PrettyMarkdown text={buf.flushed} />
+      {buf.hold ? (
         <span data-md-hold className="font-mono">{buf.hold}</span>
       ) : null}
     </>

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -48,7 +48,6 @@ import {
   toolFocusPhrase,
   toolInputFieldKey,
   toolRowLabel,
-  turnHasLiveInvestigation,
   turnHasVisibleBusySurface,
 } from "../lib/turnProgress";
 import { isAgentLoopOpen } from "./conversation/runnersBusy";

--- a/webapp/src/components/conversation/reexports.ts
+++ b/webapp/src/components/conversation/reexports.ts
@@ -275,6 +275,9 @@ export {
 } from "./swarmPoll";
 export { armResumeKick, scheduleResumeIfPending } from "./sessionResumeLatch";
 export {
+  STREAM_PAINT_MS,
+  scheduleStreamPaint,
+  cancelStreamPaint,
   pumpTypewriterFrame,
   startTypewriterLoop,
   flushTypewriterBuffer,

--- a/webapp/src/components/conversation/streamBubbles.ts
+++ b/webapp/src/components/conversation/streamBubbles.ts
@@ -234,12 +234,12 @@ export function finalizeOpenPilotBubble(items: Item[]): Item[] {
 }
 
 /**
- * Typewriter drain rate: scale with backlog so live streams never lag
- * arbitrarily far behind; accelerate when the stream has ended.
+ * Paint whatever arrived this tick. Codex and Hermes flush the queued
+ * chunk in one commit — a /8 drip on top of SSE coalescing is what made
+ * Kimi (and every other bursty provider) look like spurts.
+ *
+ * ``done`` stays in the signature so callers and tests keep a stable API.
  */
-export function typewriterCharsPerFrame(bufLen: number, done: boolean): number {
-  if (bufLen <= 0) return 0;
-  return done
-    ? Math.max(12, Math.ceil(bufLen / 4))
-    : Math.max(3, Math.ceil(bufLen / 8));
+export function typewriterCharsPerFrame(bufLen: number, _done: boolean): number {
+  return bufLen > 0 ? bufLen : 0;
 }

--- a/webapp/src/components/conversation/streamTypewriter.ts
+++ b/webapp/src/components/conversation/streamTypewriter.ts
@@ -1,9 +1,26 @@
 /**
  * Typewriter pump helpers for streaming assistant deltas.
- * Conversation owns the rAF refs; this module owns the per-frame math.
+ * Conversation owns the timer handle; this module owns the per-tick math.
+ *
+ * Hermes measured 33ms as the floor that batches ~2 tokens per React
+ * commit at typical 60 tok/s without visible lag (30 fps of text growth).
+ * They use a timer, not rAF: Chromium parks rAF on hidden/minimized
+ * renderers, so a finished answer sits queued until refocus. Codex paints
+ * the arrived chunk — no char drip. We do both.
  */
 
 import { typewriterCharsPerFrame } from "./streamBubbles";
+
+/** Hermes ``STREAM_DELTA_FLUSH_MS`` — coalesce without a fake typewriter. */
+export const STREAM_PAINT_MS = 33;
+
+export function scheduleStreamPaint(cb: () => void): number {
+  return window.setTimeout(cb, STREAM_PAINT_MS);
+}
+
+export function cancelStreamPaint(id: number): void {
+  window.clearTimeout(id);
+}
 
 export type TypewriterRefs = {
   typeBufRef: { current: string };

--- a/webapp/src/components/conversation/useSessionSwitch.ts
+++ b/webapp/src/components/conversation/useSessionSwitch.ts
@@ -33,7 +33,7 @@ import {
 } from "./composerAttachmentCache";
 import type { MemoryProposal } from "./streamEventHandler";
 import { createChatEventsReattach } from "./chatEventsReattach";
-import { cancelTypewriterWithoutFlush } from "./streamTypewriter";
+import { cancelStreamPaint, cancelTypewriterWithoutFlush } from "./streamTypewriter";
 import { gatherSessionArtifacts } from "./sessionArtifacts";
 import { releaseAllTranscriptPreviewBlobs } from "./transcriptImageBlobs";
 import {
@@ -286,7 +286,7 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
     // cache hydrate below). Authoritative text comes back via sessionTranscript.
     cancelTypewriterWithoutFlush(
       { typeBufRef, typeRafRef, typeDoneRef },
-      cancelAnimationFrame,
+      cancelStreamPaint,
     );
     // Default idle until getSessionState / runners poll resolve the target.
     if (shouldResetBusyChromeOnSwitch(switchedSession)) {

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -488,7 +488,9 @@ export function turnLooksAnswerComplete(items: TurnItem[]): boolean {
 
 /**
  * Whether the transcript busy footer should render for this status + items.
- * False when the answer already looks complete despite a lagging busy status.
+ * False when the answer already looks complete despite a lagging busy status,
+ * or when a stream / running card already owns the live signal — stacking
+ * "Still working…" under growing text is the blink in the screenshot.
  */
 export function shouldShowBusyFooter(items: TurnItem[], status: BusyStatus): boolean {
   if (status === "awaiting_swarm") return true;
@@ -496,6 +498,7 @@ export function shouldShowBusyFooter(items: TurnItem[], status: BusyStatus): boo
     status === "thinking" || status === "executing" || status === "streaming";
   if (!busy) return false;
   if (turnLooksAnswerComplete(items)) return false;
+  if (turnHasVisibleBusySurface(items)) return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Codex/Hermes live paint: 33ms timer, no character drip; server coalesce is 16ms / 80 chars.
- Still working stays off growing text and finished-tool folds; returns only in the gap between tools.
- Explicit swarm / multi-worker asks block git, launch scripts, and `run_implement` until `run_swarm` or `run_parallel` dispatches.

## Test plan
- [x] `pytest tests/test_version_consistency.py tests/test_pilot_guards.py tests/test_stream_identity_batch.py`
- [x] vitest stream/chrome helpers
- [ ] dest→main `tests` matrix (3.9, 3.11, Windows, frontend-build)