### PR TITLE
Release v0.9.267

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.15` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.266, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Provider/tool protocol hardening makes swarms reliable across OpenRouter and OpenCode, live catalogs surface OpenCode Zen and Ox Alpha, and stable bottom anchoring plus remembered Swarm Tracker cards remove chat/sidebar jumps.
+> Status: v0.9.267, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Strict agentic model pins now carry through implement and parallel work without silently falling back to another adapter, with truthful provider/model receipts and fail-closed routing.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.266"
+__version__ = "0.9.267"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -3546,6 +3546,7 @@ class ConversationalSession(
     def _run_edit_worker_bounded(self, objective: str, requested_adapter: str,
                                  job_id: str = "", target_repo: str = "",
                                  expects_diff: bool = True, on_event=None,
+                                 agentic_pin=None, strict_adapter: bool = False,
                                  lifecycle_budget=None,
                                  deadline_seconds: Optional[float] = None):
         """Run the edit worker under a hard wall-clock deadline. The work runs in
@@ -3614,6 +3615,8 @@ class ConversationalSession(
                         session_id=self.harness_session_id or "",
                         cwd=effective_cwd,
                         expects_diff=expects_diff,
+                        agentic_pin=agentic_pin,
+                        strict_adapter=strict_adapter,
                         on_event=on_event,
                     )
             except Exception as exc:  # surfaced to the caller after join

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -601,6 +601,7 @@ class ConversationJobsMixin:
     def _run_provider_worker_background(
         self, job_id: str, objective: str, requested_adapter: str = "",
         target_repo: str = "", expects_diff: bool = True,
+        agentic_pin=None, strict_adapter: bool = False,
     ) -> None:
         from .conversation import append_failed_declarative_checks_summary
 
@@ -652,6 +653,8 @@ class ConversationJobsMixin:
                 objective, requested_adapter, job_id=job_id,
                 target_repo=target_repo, expects_diff=expects_diff,
                 on_event=_on_worker_event,
+                agentic_pin=agentic_pin,
+                strict_adapter=strict_adapter,
                 lifecycle_budget=lifecycle_budget,
                 deadline_seconds=deadline_s if deadline_s > 0 else None,
             )
@@ -739,6 +742,8 @@ class ConversationJobsMixin:
                             recovery_objective, requested_adapter, job_id=job_id,
                             target_repo=target_repo, expects_diff=expects_diff,
                             on_event=_on_worker_event,
+                            agentic_pin=agentic_pin,
+                            strict_adapter=strict_adapter,
                             lifecycle_budget=lifecycle_budget,
                             deadline_seconds=remaining,
                         )
@@ -1123,6 +1128,16 @@ class ConversationJobsMixin:
                 }
 
             res_dict["worker_provenance"] = provenance
+            for routing_key, routing_value in (
+                ("adapter", getattr(res, "engine", "")),
+                ("model", getattr(res, "model", "")),
+                ("requested_model", getattr(res, "requested_model", "")),
+                ("provider", getattr(res, "provider", "")),
+                ("routing_policy", getattr(res, "routing_policy", "")),
+            ):
+                normalized_value = str(routing_value or "").strip()
+                if normalized_value:
+                    res_dict[routing_key] = normalized_value
 
             # Always fold completed WorkerResult.events into job['actions']
             # (progressive callback may have already recorded most of them).

--- a/harness/edit_engines.py
+++ b/harness/edit_engines.py
@@ -34,6 +34,7 @@ from harness.diag import note as _diag
 
 if TYPE_CHECKING:
     from harness.config import HarnessConfig
+    from harness.swarm_model_pin import AgenticModelPin
     from harness.worker import WorkerResult
 
 
@@ -189,6 +190,19 @@ def cursor_platform_available() -> bool:
         return bool(os.environ.get("CURSOR_API_KEY", "").strip())
 
 
+def agentic_platform_enabled() -> bool:
+    """Whether the Puppetmaster platform lock permits agentic execution."""
+
+    try:
+        from puppetmaster.platform_lock import is_adapter_enabled
+
+        return bool(is_adapter_enabled("agentic"))
+    except Exception:
+        # Older Puppetmaster versions had no lock helper. Preserve the historical
+        # key-aware behavior rather than disabling agentic on an import mismatch.
+        return True
+
+
 def _provider_has_usable_key(provider) -> bool:
     """Stored / env / OAuth key present and not disconnected (``has_key`` truth)."""
     from harness.registry_wizard import get_provider_key
@@ -312,13 +326,51 @@ def run_edit_worker(
     config: "HarnessConfig", goal: str, requested_adapter: str = "",
     job_id: str = "", session_id: str = "", cwd: str = "",
     expects_diff: bool = True,
+    agentic_pin: Optional["AgenticModelPin"] = None,
+    strict_adapter: bool = False,
     on_event=None,
 ) -> "WorkerResult":
     """Run the selected in-process edit engine and return a normalized result.
 
     Falls back from agentic/cursor to native only when those could not run.
     """
-    engine = select_edit_engine(config, requested_adapter)
+    from harness.worker import WorkerResult
+
+    requested = (requested_adapter or "").strip().lower()
+    strict_agentic = bool(
+        strict_adapter or agentic_pin is not None or requested == "agentic"
+    )
+    if strict_agentic and requested not in ("", "agentic"):
+        return _stamp_agentic(
+            WorkerResult(
+                ok=False,
+                error=AGENTIC_ROUTE_FAILED,
+                summary=(
+                    f"Agentic model pin cannot run through adapter "
+                    f"{requested_adapter!r}; use adapter='agentic'."
+                ),
+            ),
+            execution_pin=agentic_pin,
+        )
+    if strict_agentic and (
+        not agentic_platform_enabled() or not agentic_available()
+    ):
+        reason = (
+            "Agentic adapter is disabled by the platform lock."
+            if not agentic_platform_enabled()
+            else "No usable provider key is available for the agentic adapter."
+        )
+        return _stamp_agentic(
+            WorkerResult(
+                ok=False,
+                error=AGENTIC_UNAVAILABLE,
+                summary=reason,
+            ),
+            execution_pin=agentic_pin,
+        )
+
+    effective_adapter = "agentic" if strict_agentic else requested_adapter
+    engine = select_edit_engine(config, effective_adapter)
     target_cwd = cwd or config.repo
     if engine == "cursor":
         result = run_cursor_edit(
@@ -337,7 +389,10 @@ def run_edit_worker(
         result = run_agentic_edit(
             config, goal, session_id=session_id, cwd=target_cwd,
             expects_diff=expects_diff, job_id=job_id,
+            agentic_pin=agentic_pin,
         )
+        if strict_agentic:
+            return result
         if result.error in _FALLBACK_REASONS:
             if cursor_platform_available():
                 _diag("edit_engines.run_edit_worker",
@@ -365,12 +420,16 @@ def run_implement(
     config: "HarnessConfig", goal: str, requested_adapter: str = "",
     job_id: str = "", session_id: str = "", cwd: str = "",
     expects_diff: bool = True,
+    agentic_pin: Optional["AgenticModelPin"] = None,
+    strict_adapter: bool = False,
 ) -> "WorkerResult":
     """Dispatch a single implement worker (agentic or native)."""
     return run_edit_worker(
         config, goal, requested_adapter=requested_adapter,
         job_id=job_id, session_id=session_id, cwd=cwd,
         expects_diff=expects_diff,
+        agentic_pin=agentic_pin,
+        strict_adapter=strict_adapter,
     )
 
 
@@ -378,6 +437,8 @@ def run_parallel(
     config: "HarnessConfig", goals: list[str], requested_adapter: str = "",
     session_id: str = "", cwd: str = "",
     expects_diff: bool = True,
+    agentic_pin: Optional["AgenticModelPin"] = None,
+    strict_adapter: bool = False,
 ) -> list["WorkerResult"]:
     """Run several implement workers sequentially (caller fans out concurrency)."""
     results = []
@@ -388,6 +449,8 @@ def run_parallel(
             config, goal, requested_adapter=requested_adapter,
             session_id=session_id, cwd=cwd,
             expects_diff=expects_diff,
+            agentic_pin=agentic_pin,
+            strict_adapter=strict_adapter,
         ))
     return results
 
@@ -557,6 +620,7 @@ def run_cursor_edit(
 def run_agentic_edit(
     config: "HarnessConfig", goal: str, *, session_id: str = "", cwd: str = "",
     expects_diff: bool = True, job_id: str = "",
+    agentic_pin: Optional["AgenticModelPin"] = None,
 ) -> "WorkerResult":
     """Puppetmaster agentic adapter in a managed worktree.
 
@@ -580,7 +644,7 @@ def run_agentic_edit(
         return _stamp_agentic(WorkerResult(
             ok=False, error=AGENTIC_UNAVAILABLE,
             summary="No provider key visible for the agentic engine.",
-        ))
+        ), execution_pin=agentic_pin)
 
     try:
         from puppetmaster.orchestrator import Orchestrator
@@ -591,10 +655,18 @@ def run_agentic_edit(
         return _stamp_agentic(WorkerResult(
             ok=False, error=AGENTIC_UNAVAILABLE,
             summary=f"Puppetmaster unavailable: {exc}",
-        ))
+        ), execution_pin=agentic_pin)
 
-    provider = (os.environ.get("HARNESS_IMPLEMENT_PROVIDER", "") or "").strip().lower()
-    model = (os.environ.get("HARNESS_IMPLEMENT_MODEL", "") or "").strip()
+    provider = (
+        agentic_pin.provider
+        if agentic_pin is not None
+        else (os.environ.get("HARNESS_IMPLEMENT_PROVIDER", "") or "").strip().lower()
+    )
+    model = (
+        agentic_pin.model
+        if agentic_pin is not None
+        else (os.environ.get("HARNESS_IMPLEMENT_MODEL", "") or "").strip()
+    )
 
     try:
         repo_root = cwd or config.repo
@@ -627,6 +699,8 @@ def run_agentic_edit(
                     "routing_policy": "balanced",
                     **_analysis_capability_payload(),
                 }
+                if agentic_pin is not None:
+                    base_payload.update(agentic_pin.payload_fields())
                 payload = stamp_task_payload(
                     base_payload, session_id=session_id, cwd=wt_path,
                 )
@@ -645,6 +719,7 @@ def run_agentic_edit(
                     "cwd": wt_path,
                     "prompt": goal,
                     "auto_route": not (provider and model),
+                    "allowed_adapters": ["agentic"],
                     "token_budget": worker_token_budget(),
                 }, session_id=session_id, cwd=wt_path)
                 if not (provider and model):
@@ -671,6 +746,8 @@ def run_agentic_edit(
                     payload["provider"] = provider
                 if model:
                     payload["model"] = model
+                if agentic_pin is not None:
+                    payload.update(agentic_pin.payload_fields())
 
                 spec = WorkerSpec(
                     role="implement",
@@ -702,6 +779,28 @@ def run_agentic_edit(
             worktree_diff_empty = not bool(patch.strip())
             tokens_out, tokens_in, failure, final_text = _summarize_agentic_result(result)
             routed_model = _routed_model_id(result)
+            if agentic_pin is not None:
+                from harness.swarm_model_pin import agentic_pin_matches_routed_model
+
+                if not agentic_pin_matches_routed_model(
+                    agentic_pin,
+                    routed_model,
+                ):
+                    return _stamp_agentic(WorkerResult(
+                        ok=False,
+                        error=AGENTIC_ROUTE_FAILED,
+                        summary=(
+                            f"Agentic model mismatch: requested "
+                            f"{agentic_pin.router_model_id!r}, routed "
+                            f"{routed_model!r}."
+                        ),
+                        model=routed_model,
+                        worktree=wt_path,
+                        managed_worktree_path=wt_path,
+                        managed_worktree_mode="managed",
+                        worktree_diff_empty=worktree_diff_empty,
+                        events=list(mapped_events),
+                    ), result, execution_pin=agentic_pin)
 
             # Analysis/review: never report seed leftovers as applied edits.
             if not expects_diff:
@@ -721,7 +820,7 @@ def run_agentic_edit(
                         managed_worktree_mode="managed",
                         worktree_diff_empty=worktree_diff_empty,
                         events=list(mapped_events),
-                    ), result)
+                    ), result, execution_pin=agentic_pin)
                 if not expects_diff:
                     # Gate on structured findings — never green unlabeled prose.
                     # Same rescue order as swarm/bridge: promote verification-
@@ -773,7 +872,7 @@ def run_agentic_edit(
                             worktree_diff_empty=worktree_diff_empty,
                             events=list(mapped_events),
                             findings=signal_rows,
-                        ), result)
+                        ), result, execution_pin=agentic_pin)
                     label = degrade_reason or "no structured findings"
                     summary_parts = [label]
                     if final_text:
@@ -790,7 +889,7 @@ def run_agentic_edit(
                         managed_worktree_mode="managed",
                         worktree_diff_empty=worktree_diff_empty,
                         events=list(mapped_events),
-                    ), result)
+                    ), result, execution_pin=agentic_pin)
                 return _stamp_agentic(WorkerResult(
                     ok=False, tokens_out=tokens_out, tokens_in=tokens_in,
                     summary=final_text or "no changes produced",
@@ -800,7 +899,7 @@ def run_agentic_edit(
                     managed_worktree_mode="managed",
                     worktree_diff_empty=worktree_diff_empty,
                     events=list(mapped_events),
-                ), result)
+                ), result, execution_pin=agentic_pin)
 
             return _stamp_agentic(WorkerResult(
                 ok=True, patch=patch, files_changed=files_changed,
@@ -812,12 +911,12 @@ def run_agentic_edit(
                 managed_worktree_mode="managed",
                 worktree_diff_empty=worktree_diff_empty,
                 events=list(mapped_events),
-            ), result)
+            ), result, execution_pin=agentic_pin)
     except Exception as exc:
         _diag("edit_engines.run_agentic_edit", exc)
         return _stamp_agentic(WorkerResult(
             ok=False, error=AGENTIC_ERROR, summary=f"Agentic engine error: {exc}",
-        ))
+        ), execution_pin=agentic_pin)
 
 
 # Store event names that already mean a tool/action boundary (not lifecycle).
@@ -1007,11 +1106,20 @@ def _routed_model_id(result) -> str:
     return model_id
 
 
-def _stamp_agentic(result: "WorkerResult", pm_result=None) -> "WorkerResult":
+def _stamp_agentic(
+    result: "WorkerResult",
+    pm_result=None,
+    *,
+    execution_pin: Optional["AgenticModelPin"] = None,
+) -> "WorkerResult":
     """Label a WorkerResult as the agentic engine + routed model (best-effort)."""
     result.engine = "agentic"
     if not (result.model or "").strip() and pm_result is not None:
         routed = _routed_model_id(pm_result)
         if routed:
             result.model = routed
+    if execution_pin is not None:
+        result.requested_model = execution_pin.requested
+        result.provider = execution_pin.provider
+        result.routing_policy = execution_pin.policy
     return result

--- a/harness/pilot.py
+++ b/harness/pilot.py
@@ -249,9 +249,10 @@ class PilotAction:
     # copy; run_swarm uses it as the read-only audit subject, never as a write
     # surface for the pilot's own tools.
     repo: str = ""
-    # run_swarm: optional registry id or adapter model name pin. Empty means
-    # auto-route. Unknown/pilot-session pins demote to auto-route at execute
-    # time against the keyed agentic catalog. Prompt text alone never pins.
+    # run_swarm / run_implement / run_parallel: optional registry id or adapter
+    # model name pin. Implement/parallel pins are strict agentic constraints;
+    # swarm retains its compatibility demotion for unknown pilot-session ids.
+    # Prompt text alone never pins.
     model: str = ""
     # Optional explicit acceptance criteria for swarm/parallel analysis.
     # Never inferred from goal prose — only an explicit list/string field.
@@ -661,7 +662,13 @@ def from_wire(
     if mode_note and kind in ("run_implement", "run_parallel"):
         coercion_notes.append(f"mode {mode_note}")
     _log_arg_coercion(kind, coercion_notes)
-    model = (raw.get("model") or "").strip() if kind == "run_swarm" else ""
+    model = ""
+    if kind in ("run_swarm", "run_implement", "run_parallel"):
+        model = str(
+            raw.get("model")
+            or arguments.get("model")
+            or ""
+        ).strip()
 
     memory_action = ""
     memory_content = ""
@@ -1460,6 +1467,7 @@ def build_tools_schema(
                     "properties": {
                         "goal": {"type": "string", "description": "The coding objective / task description to implement"},
                         "adapter": {"type": "string", "description": "Optional edit engine. Default is 'agentic' -- Puppetmaster's standalone keys-only worker (routes directly through your provider API, no external CLI). 'native' forces Marionette's own richer pilot loop. 'cursor'/'codex'/'claude-code' use those external agent CLIs when installed."},
+                        "model": {"type": "string", "description": "Optional strict agentic worker model pin (registry id or provider/model, for example openrouter/stealth/ox-alpha). A model pin implies adapter=agentic, never falls back, and must be omitted for normal auto-routing."},
                         "mode": {"type": "string", "enum": ["implement", "analysis", "review"], "description": "Worker execution mode: 'implement' (expects a patch; default) or 'analysis'/'review' (read-only report; empty diff is success)."},
                         "repo": {"type": "string", "description": "Optional absolute path to a DIFFERENT git repository to run this implementation in (defaults to the open workspace). Use when the task edits a repo other than the current one. Must be a git work tree."}
                     },
@@ -1494,6 +1502,7 @@ def build_tools_schema(
                             ),
                         },
                         "adapter": {"type": "string", "description": "Optional edit engine (default 'agentic' -- standalone keys-only; 'native' for the richer pilot; 'cursor'/'codex'/'claude-code' for external CLIs when installed)"},
+                        "model": {"type": "string", "description": "Optional strict agentic model pin shared by every child goal (registry id or provider/model). Implies adapter=agentic and disables fallback/auto-substitution."},
                         "mode": {"type": "string", "enum": ["implement", "analysis", "review"], "description": "Worker execution mode: 'implement' (can edit) or 'analysis'/'review' (read-only)"},
                         "repo": {"type": "string", "description": "Optional absolute path to a DIFFERENT git repository to run this implementation in (defaults to the open workspace). Use when the task edits a repo other than the current one. Must be a git work tree."},
                         "acceptance_criteria": {

--- a/harness/pilot_guards.py
+++ b/harness/pilot_guards.py
@@ -1122,6 +1122,7 @@ def _parse_cli_goal_and_model(tokens: list[str]) -> tuple[str, str]:
     """Extract --goal / --model / first positional from launch argv."""
     goal = ""
     model = ""
+    provider = ""
     positionals: list[str] = []
     i = 0
     n = len(tokens)
@@ -1149,6 +1150,16 @@ def _parse_cli_goal_and_model(tokens: list[str]) -> tuple[str, str]:
                 model = tokens[i].strip()
                 i += 1
             continue
+        if tok.startswith("--provider="):
+            provider = tok.split("=", 1)[1].strip()
+            i += 1
+            continue
+        if tok == "--provider":
+            i += 1
+            if i < n:
+                provider = tokens[i].strip()
+                i += 1
+            continue
         if tok.startswith("-"):
             i += 1
             if i < n and not tokens[i].startswith("-"):
@@ -1158,6 +1169,11 @@ def _parse_cli_goal_and_model(tokens: list[str]) -> tuple[str, str]:
         i += 1
     if not goal and positionals:
         goal = positionals[0].strip()
+    if provider and model:
+        lower_model = model.lower()
+        provider_prefix = provider.lower() + "/"
+        if not lower_model.startswith(provider_prefix):
+            model = f"{provider}/{model}"
     return goal, model
 
 
@@ -1179,7 +1195,7 @@ def translate_puppetmaster_cli_action(
     parsed = parse_puppetmaster_cli_launch(command)
     if parsed is None:
         return None
-    _subcmd, parsed_goal, parsed_model = parsed
+    subcmd, parsed_goal, parsed_model = parsed
     native_kind, _example = puppetmaster_cli_native_mapping(command, state)
     if native_kind not in ("run_swarm", "run_implement"):
         return None
@@ -1196,6 +1212,7 @@ def translate_puppetmaster_cli_action(
         kind=native_kind,
         goal=goal,
         model=model,
+        adapter="agentic" if subcmd == "agentic" else "",
         tool_call_id=tool_call_id,
     )
 

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -32,6 +32,51 @@ DISPATCH_ACTION_KINDS: frozenset[str] = frozenset({
 })
 
 
+def _strict_agentic_dispatch(act) -> tuple[object, bool, str]:
+    """Resolve an explicit action model/agentic adapter before any fallback."""
+
+    requested_model = str(getattr(act, "model", "") or "").strip()
+    requested_adapter = str(getattr(act, "adapter", "") or "").strip().lower()
+    strict_agentic = bool(
+        requested_model or requested_adapter == "agentic"
+    )
+    if not strict_agentic:
+        return None, False, ""
+    if requested_model and requested_adapter not in ("", "agentic"):
+        return (
+            None,
+            True,
+            (
+                f"model={requested_model!r} is an agentic worker pin and "
+                f"cannot be combined with adapter={requested_adapter!r}"
+            ),
+        )
+    if not requested_model:
+        return None, True, ""
+    from harness.swarm_model_pin import resolve_agentic_model_pin
+
+    pin, error = resolve_agentic_model_pin(requested_model)
+    return pin, True, error
+
+
+def _stamp_local_job_agentic_pin(session, job_id: str, pin) -> None:
+    """Persist immutable requested identity alongside the selected model."""
+
+    if pin is None:
+        return
+    try:
+        with session._local_jobs_lock:
+            row = session._local_jobs.get(job_id)
+            if not isinstance(row, dict):
+                return
+            row["requested_model"] = pin.requested
+            row["provider"] = pin.provider
+            row["routing_policy"] = pin.policy
+            session._persist_local_jobs_locked()
+    except Exception:
+        return
+
+
 def _non_git_workspace_error(repo: str) -> Optional[str]:
     """Calm refuse when the resolved workspace is not a git work tree.
 
@@ -904,8 +949,23 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         return None
     claimed = True
     dispatched = False
+    agentic_pin, strict_adapter, pin_error = _strict_agentic_dispatch(act)
+    if pin_error:
+        session._release_objective(act.goal)
+        yield ConvEvent('action_start', {
+            'id': aid, 'kind': 'run_implement', 'goal': act.goal,
+            'cwd': effective_repo,
+        })
+        yield ConvEvent('action_result', {'id': aid, 'error': pin_error})
+        session._append_action_result(
+            act, aid, f'(run_implement {aid} failed: {pin_error})', is_native,
+        )
+        return None
     external_adapters = {'cursor', 'claude-code', 'codex', 'openai', 'hermes'}
     requested_adapter, adapter_remap_note = session._resolve_requested_implement_adapter(act.adapter or '')
+    if strict_adapter:
+        requested_adapter = 'agentic'
+        adapter_remap_note = ''
     use_external = requested_adapter in external_adapters and _puppetmaster_available() and session._external_adapter_available(requested_adapter)
     if requested_adapter in external_adapters and (not use_external):
         if not adapter_remap_note:
@@ -1005,7 +1065,11 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         return None
     else:
         from harness.edit_engines import select_edit_engine
-        engine = select_edit_engine(session.config, requested_adapter)
+        engine = (
+            'agentic'
+            if strict_adapter
+            else select_edit_engine(session.config, requested_adapter)
+        )
         _mode = _requested_mode
         if _force_analysis:
             _mode = 'analysis'
@@ -1018,8 +1082,22 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             try:
                 session._register_local_job(
                     job_id, act.goal, role=_mode, cwd=effective_repo, engine=engine,
-                    model=session.config.driver or '' if engine == 'native' else '',
+                    model=(
+                        agentic_pin.router_model_id
+                        if agentic_pin is not None
+                        else (
+                            session.config.driver or ''
+                            if engine == 'native'
+                            else ''
+                        )
+                    ),
+                    **(
+                        {"skip_routing_preview": True}
+                        if agentic_pin is not None
+                        else {}
+                    ),
                 )
+                _stamp_local_job_agentic_pin(session, job_id, agentic_pin)
             except Exception as e:
                 session._release_objective(act.goal)
                 err = f'tracker register failed: {e}'
@@ -1028,7 +1106,16 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                 return None
             session._session_job_ids.append(job_id)
             _prewarm_worker_imports()
-            if not session._submit_swarm(session._run_provider_worker_background, job_id, act.goal, requested_adapter, effective_repo, expects_diff):
+            if not session._submit_swarm(
+                session._run_provider_worker_background,
+                job_id,
+                act.goal,
+                requested_adapter,
+                effective_repo,
+                expects_diff,
+                agentic_pin,
+                strict_adapter,
+            ):
                 cap_msg = session._swarm_submit_reject_message()
                 session._release_objective(act.goal)
                 yield ConvEvent('action_result', {'id': aid, 'status': 'deferred', 'message': cap_msg})
@@ -1127,8 +1214,22 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             return None
     except Exception:
         pass
+    agentic_pin, strict_adapter, pin_error = _strict_agentic_dispatch(act)
+    if pin_error:
+        yield ConvEvent('action_start', {
+            'id': aid, 'kind': 'run_parallel', 'goals': goals,
+            'cwd': effective_repo,
+        })
+        yield ConvEvent('action_result', {'id': aid, 'error': pin_error})
+        session._append_action_result(
+            act, aid, f'(run_parallel {aid} failed: {pin_error})', is_native,
+        )
+        return None
     external_adapters = {'cursor', 'claude-code', 'codex', 'openai', 'hermes'}
     requested_adapter, adapter_remap_note = session._resolve_requested_implement_adapter(act.adapter or '')
+    if strict_adapter:
+        requested_adapter = 'agentic'
+        adapter_remap_note = ''
     use_external = requested_adapter in external_adapters and _puppetmaster_available() and session._external_adapter_available(requested_adapter)
     if requested_adapter in external_adapters and (not use_external):
         if not adapter_remap_note:
@@ -1298,7 +1399,11 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             return None
     else:
         from harness.edit_engines import select_edit_engine
-        engine = select_edit_engine(session.config, requested_adapter)
+        engine = (
+            'agentic'
+            if strict_adapter
+            else select_edit_engine(session.config, requested_adapter)
+        )
         try:
             _mode = (getattr(act, 'mode', None) or 'implement').strip().lower()
         except Exception:
@@ -1320,7 +1425,7 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             buffered_reuse_events = []
             _parallel_admission = f"parallel-{aid}"
             _reuse_mod = None
-            if _mode in ('analysis', 'review'):
+            if _mode in ('analysis', 'review') and agentic_pin is None:
                 try:
                     from harness import validation_reuse as _reuse_mod
                 except Exception:
@@ -1359,8 +1464,19 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                             session._register_local_job(
                                 job_id, sub_goal, role=_mode, cwd=effective_repo,
                                 engine=engine,
-                                model=session.config.driver or '' if engine == 'native' else '',
+                                model=(
+                                    agentic_pin.router_model_id
+                                    if agentic_pin is not None
+                                    else (
+                                        session.config.driver or ''
+                                        if engine == 'native'
+                                        else ''
+                                    )
+                                ),
                                 skip_routing_preview=True,
+                            )
+                            _stamp_local_job_agentic_pin(
+                                session, job_id, agentic_pin,
                             )
                             _reuse_registered = True
                             session._finish_local_job(
@@ -1464,7 +1580,23 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                             session._register_local_job(
                                 job_id, sub_goal, role=narrow_role,
                                 cwd=effective_repo, engine=engine,
-                                model=session.config.driver or '' if engine == 'native' else '',
+                                model=(
+                                    agentic_pin.router_model_id
+                                    if agentic_pin is not None
+                                    else (
+                                        session.config.driver or ''
+                                        if engine == 'native'
+                                        else ''
+                                    )
+                                ),
+                                **(
+                                    {"skip_routing_preview": True}
+                                    if agentic_pin is not None
+                                    else {}
+                                ),
+                            )
+                            _stamp_local_job_agentic_pin(
+                                session, job_id, agentic_pin,
                             )
                             # Pre-stamp partial reuse so background finish/drain
                             # keep invalidated_paths + source lineage.
@@ -1500,6 +1632,8 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                                 requested_adapter,
                                 effective_repo,
                                 expects_diff,
+                                agentic_pin,
+                                strict_adapter,
                                 admission_group=_parallel_admission,
                                 admission_size=len(goals),
                             )
@@ -1545,7 +1679,23 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                             session._register_local_job(
                                 job_id, sub_goal, role=_mode,
                                 cwd=effective_repo, engine=engine,
-                                model=session.config.driver or '' if engine == 'native' else '',
+                                model=(
+                                    agentic_pin.router_model_id
+                                    if agentic_pin is not None
+                                    else (
+                                        session.config.driver or ''
+                                        if engine == 'native'
+                                        else ''
+                                    )
+                                ),
+                                **(
+                                    {"skip_routing_preview": True}
+                                    if agentic_pin is not None
+                                    else {}
+                                ),
+                            )
+                            _stamp_local_job_agentic_pin(
+                                session, job_id, agentic_pin,
                             )
                             try:
                                 with session._local_jobs_lock:
@@ -1579,6 +1729,8 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                                 requested_adapter,
                                 effective_repo,
                                 expects_diff,
+                                agentic_pin,
+                                strict_adapter,
                                 admission_group=_parallel_admission,
                                 admission_size=len(goals),
                             )
@@ -1611,7 +1763,23 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                     session._register_local_job(
                         job_id, sub_goal, role=_mode, cwd=effective_repo,
                         engine=engine,
-                        model=session.config.driver or '' if engine == 'native' else '',
+                        model=(
+                            agentic_pin.router_model_id
+                            if agentic_pin is not None
+                            else (
+                                session.config.driver or ''
+                                if engine == 'native'
+                                else ''
+                            )
+                        ),
+                        **(
+                            {"skip_routing_preview": True}
+                            if agentic_pin is not None
+                            else {}
+                        ),
+                    )
+                    _stamp_local_job_agentic_pin(
+                        session, job_id, agentic_pin,
                     )
                     if _parallel_criteria and _mode in ('analysis', 'review'):
                         try:
@@ -1628,6 +1796,8 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                         requested_adapter,
                         effective_repo,
                         expects_diff,
+                        agentic_pin,
+                        strict_adapter,
                         admission_group=_parallel_admission,
                         admission_size=len(goals),
                     )

--- a/harness/swarm_model_pin.py
+++ b/harness/swarm_model_pin.py
@@ -10,12 +10,73 @@ auto-route across the live union catalog instead of failing.
 """
 
 import re
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from .diag import note as _diag
 
 # Prefer agentic (API-billed) remaps before platform cursor when both match.
 _PIN_ADAPTER_ORDER = ("agentic", "cursor", "openai")
+
+
+@dataclass(frozen=True)
+class AgenticModelPin:
+    """Immutable provider/model constraint for one agentic dispatch."""
+
+    requested: str
+    provider: str
+    model: str
+    router_model_id: str
+    reason: str = "exact"
+    policy: str = "explicit_pin"
+
+    def payload_fields(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "auto_route": False,
+            "allowed_adapters": ["agentic"],
+            "pinned_adapter": "agentic",
+            "pinned_model": self.router_model_id,
+            "pinned_adapter_model_name": self.model,
+            "pin_policy": self.policy,
+            "requested_model": self.requested,
+        }
+
+
+def _direct_agentic_provider_model(pin: str) -> Optional[AgenticModelPin]:
+    """Resolve ``provider/model`` when a keyed live model is not in the registry."""
+
+    requested = (pin or "").strip()
+    body = requested
+    if body.lower().startswith("agentic/"):
+        body = body.split("/", 1)[1].strip()
+    if ":" in body:
+        provider, model = body.split(":", 1)
+    elif "/" in body:
+        provider, model = body.split("/", 1)
+    else:
+        return None
+    provider = provider.strip().lower()
+    model = model.strip()
+    if not provider or not model:
+        return None
+    try:
+        from .auto_registry import keyed_agentic_providers
+
+        keyed = {str(item).strip().lower() for item in keyed_agentic_providers()}
+    except Exception as exc:
+        _diag("swarm_model_pin.direct_keyed", exc)
+        keyed = set()
+    if provider not in keyed:
+        return None
+    return AgenticModelPin(
+        requested=requested,
+        provider=provider,
+        model=model,
+        router_model_id=f"agentic/{provider}/{model}",
+        reason="direct_provider_model",
+    )
 
 
 def _registry_rows(*, adapters: Optional[set[str]] = None) -> list[dict]:
@@ -323,3 +384,70 @@ def resolve_swarm_model_pin(
         "reason": reason,
         "adapter": "",
     }
+
+
+def resolve_agentic_model_pin(pin: str) -> tuple[Optional[AgenticModelPin], str]:
+    """Resolve an explicit agentic pin without swarm's auto-route demotion."""
+
+    requested = (pin or "").strip()
+    if not requested:
+        return None, ""
+
+    resolved = resolve_swarm_model_pin(
+        requested,
+        allowed_adapters=["agentic"],
+    )
+    if not resolved.get("demoted") and resolved.get("adapter") == "agentic":
+        fields = dict(resolved.get("pin_fields") or {})
+        provider = str(fields.get("provider") or "").strip().lower()
+        model = str(
+            fields.get("pinned_adapter_model_name")
+            or fields.get("model")
+            or ""
+        ).strip()
+        router_model_id = str(
+            fields.get("pinned_model") or resolved.get("resolved") or ""
+        ).strip()
+        if provider and model and router_model_id:
+            return AgenticModelPin(
+                requested=requested,
+                provider=provider,
+                model=model,
+                router_model_id=router_model_id,
+                reason=str(resolved.get("reason") or "exact"),
+            ), ""
+
+    direct = _direct_agentic_provider_model(requested)
+    if direct is not None:
+        return direct, ""
+
+    available = list_available_agentic_worker_models(limit=8)
+    reason = str(resolved.get("reason") or "").strip()
+    if not reason:
+        reason = f"pin {requested!r} is not available to the agentic adapter"
+    hints = ", ".join(available) if available else "(none keyed)"
+    return None, f"{reason}. Available agentic models: {hints}"
+
+
+def agentic_pin_matches_routed_model(
+    pin: Optional[AgenticModelPin],
+    routed_model: str,
+) -> bool:
+    """Fail closed only when the provider reports a different known model."""
+
+    if pin is None or not (routed_model or "").strip():
+        return True
+
+    def _normalized(value: str) -> str:
+        text = (value or "").strip().lower()
+        if text.startswith("agentic/"):
+            text = text.split("/", 1)[1]
+        return text
+
+    served = _normalized(routed_model)
+    accepted = {
+        _normalized(pin.router_model_id),
+        _normalized(f"{pin.provider}/{pin.model}"),
+        _normalized(pin.model),
+    }
+    return served in accepted

--- a/harness/worker.py
+++ b/harness/worker.py
@@ -100,6 +100,11 @@ class WorkerResult:
     # panel never stamps the pilot slug as the worker when the engine is agentic.
     engine: str = ""
     model: str = ""
+    # Explicit agentic routing truth. ``model`` is the actually routed/served
+    # model; these fields preserve the immutable request for tracker receipts.
+    requested_model: str = ""
+    provider: str = ""
+    routing_policy: str = ""
     # Measured worker provenance. These are populated from git/worktree state,
     # never from provider prose, and remain optional for legacy callers.
     managed_worktree_path: str = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.266"
+version = "0.9.267"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_edit_engines.py
+++ b/tests/test_edit_engines.py
@@ -26,6 +26,7 @@ from harness.edit_engines import (
     run_agentic_edit,
     run_edit_worker,
     run_native_edit,
+    run_parallel,
     select_edit_engine,
     _summarize_agentic_result,
 )
@@ -627,6 +628,82 @@ def test_agentic_payload_explicit_provider_and_model(monkeypatch):
         shutil.rmtree(repo_dir, ignore_errors=True)
 
 
+def test_agentic_payload_uses_immutable_per_action_pin(monkeypatch):
+    from harness.swarm_model_pin import AgenticModelPin
+
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        captured: list[dict] = []
+        _install_agentic_mocks(
+            monkeypatch,
+            capture_payload=captured,
+            orchestrator_result=_fake_pm_result([
+                _fake_artifact(model="stealth/ox-alpha", stdout="ok"),
+            ]),
+        )
+        monkeypatch.setenv("HARNESS_IMPLEMENT_PROVIDER", "openai")
+        monkeypatch.setenv("HARNESS_IMPLEMENT_MODEL", "wrong-model")
+        monkeypatch.setattr(
+            "harness.edit_engines.finalize_worktree_patch",
+            lambda _wt: ("patch", ["a.txt"]),
+        )
+        pin = AgenticModelPin(
+            requested="openrouter/stealth/ox-alpha",
+            provider="openrouter",
+            model="stealth/ox-alpha",
+            router_model_id="agentic/openrouter/stealth/ox-alpha",
+        )
+
+        result = run_agentic_edit(cfg, "goal", agentic_pin=pin)
+
+        assert result.ok is True
+        assert result.requested_model == pin.requested
+        assert result.provider == "openrouter"
+        assert result.routing_policy == "explicit_pin"
+        payload = captured[0]
+        assert payload["provider"] == "openrouter"
+        assert payload["model"] == "stealth/ox-alpha"
+        assert payload["auto_route"] is False
+        assert payload["allowed_adapters"] == ["agentic"]
+        assert payload["pinned_model"] == pin.router_model_id
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_payload_fails_closed_on_routed_model_mismatch(monkeypatch):
+    from harness.swarm_model_pin import AgenticModelPin
+
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        routed = _fake_artifact(model="other/model", stdout="wrong model")
+        routed.type = ""
+        _install_agentic_mocks(
+            monkeypatch,
+            orchestrator_result=_fake_pm_result([routed]),
+        )
+        monkeypatch.setattr(
+            "harness.edit_engines.finalize_worktree_patch",
+            lambda _wt: ("patch", ["a.txt"]),
+        )
+        pin = AgenticModelPin(
+            requested="openrouter/stealth/ox-alpha",
+            provider="openrouter",
+            model="stealth/ox-alpha",
+            router_model_id="agentic/openrouter/stealth/ox-alpha",
+        )
+
+        result = run_agentic_edit(cfg, "goal", agentic_pin=pin)
+
+        assert result.ok is False
+        assert result.error == AGENTIC_ROUTE_FAILED
+        assert "model mismatch" in result.summary.lower()
+        assert result.requested_model == pin.requested
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
 def test_agentic_analysis_uses_analyze_payload_not_implement(monkeypatch):
     """expects_diff=False must not stamp mode=implement (avoids 900s edit loop)."""
     repo_dir = create_temp_git_repo()
@@ -1212,6 +1289,104 @@ def test_run_edit_worker_falls_back_on_agentic_unavailable(monkeypatch):
         assert result is native_sentinel
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_run_edit_worker_explicit_agentic_never_falls_back(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr(
+            "harness.edit_engines.agentic_available", lambda: True,
+        )
+        monkeypatch.setattr(
+            "harness.edit_engines.agentic_platform_enabled", lambda: True,
+        )
+        agentic_failure = WorkerResult(
+            ok=False,
+            error=AGENTIC_ROUTE_FAILED,
+            summary="route failed",
+        )
+        monkeypatch.setattr(
+            "harness.edit_engines.run_agentic_edit",
+            lambda *args, **kwargs: agentic_failure,
+        )
+        fallback_calls = []
+        monkeypatch.setattr(
+            "harness.edit_engines.run_cursor_edit",
+            lambda *args, **kwargs: fallback_calls.append("cursor"),
+        )
+        monkeypatch.setattr(
+            "harness.edit_engines.run_native_edit",
+            lambda *args, **kwargs: fallback_calls.append("native"),
+        )
+
+        result = run_edit_worker(
+            cfg,
+            "goal",
+            requested_adapter="agentic",
+        )
+
+        assert result is agentic_failure
+        assert fallback_calls == []
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_run_edit_worker_explicit_agentic_unavailable_fails_closed(monkeypatch):
+    cfg = HarnessConfig()
+    monkeypatch.setattr(
+        "harness.edit_engines.agentic_platform_enabled", lambda: True,
+    )
+    monkeypatch.setattr(
+        "harness.edit_engines.agentic_available", lambda: False,
+    )
+    fallback_calls = []
+    monkeypatch.setattr(
+        "harness.edit_engines.run_native_edit",
+        lambda *args, **kwargs: fallback_calls.append("native"),
+    )
+
+    result = run_edit_worker(
+        cfg,
+        "goal",
+        requested_adapter="agentic",
+    )
+
+    assert result.ok is False
+    assert result.error == AGENTIC_UNAVAILABLE
+    assert result.engine == "agentic"
+    assert fallback_calls == []
+
+
+def test_run_parallel_forwards_same_agentic_pin_to_every_child(monkeypatch):
+    from harness.swarm_model_pin import AgenticModelPin
+
+    pin = AgenticModelPin(
+        requested="openrouter/stealth/ox-alpha",
+        provider="openrouter",
+        model="stealth/ox-alpha",
+        router_model_id="agentic/openrouter/stealth/ox-alpha",
+    )
+    seen = []
+
+    def fake_implement(config, goal, **kwargs):
+        seen.append((goal, kwargs))
+        return WorkerResult(ok=True, patch="patch")
+
+    monkeypatch.setattr("harness.edit_engines.run_implement", fake_implement)
+
+    results = run_parallel(
+        HarnessConfig(),
+        ["one", "two"],
+        requested_adapter="agentic",
+        agentic_pin=pin,
+        strict_adapter=True,
+    )
+
+    assert len(results) == 2
+    assert [goal for goal, _kwargs in seen] == ["one", "two"]
+    assert all(kwargs["agentic_pin"] is pin for _goal, kwargs in seen)
+    assert all(kwargs["strict_adapter"] is True for _goal, kwargs in seen)
 
 
 def test_run_edit_worker_no_fallback_on_empty_agentic_result(monkeypatch):

--- a/tests/test_pilot_guards.py
+++ b/tests/test_pilot_guards.py
@@ -64,6 +64,7 @@ from harness.pilot_guards import (
     swarm_gate_enabled,
     tiny_workspace_tool_budget,
     turn_tool_budget_cap,
+    translate_puppetmaster_cli_action,
     user_requests_browser_qa,
     workspace_source_stats,
 )
@@ -944,7 +945,7 @@ def test_parse_screenshot_agentic_cli_goal_and_model():
     subcmd, goal, model = parsed
     assert subcmd == "agentic"
     assert goal == "Add token-level streaming"
-    assert model == "deepseek/deepseek-v4-pro"
+    assert model == "opencode-go/deepseek/deepseek-v4-pro"
 
 
 def test_parse_wrapped_screenshot_agentic_cli_goal_and_model():
@@ -953,7 +954,17 @@ def test_parse_wrapped_screenshot_agentic_cli_goal_and_model():
     subcmd, goal, model = parsed
     assert subcmd == "agentic"
     assert goal == _SCREENSHOT_WRAPPED_GOAL
-    assert model == "deepseek/deepseek-v4-pro"
+    assert model == "opencode-go/deepseek/deepseek-v4-pro"
+
+
+def test_translate_agentic_cli_preserves_provider_model_and_adapter():
+    translated = translate_puppetmaster_cli_action(
+        _Act(kind="run_command", command=_SCREENSHOT_AGENTIC_CLI),
+    )
+    assert translated is not None
+    assert translated.kind == "run_implement"
+    assert translated.adapter == "agentic"
+    assert translated.model == "opencode-go/deepseek/deepseek-v4-pro"
 
 
 def test_parse_preserves_quoted_goal_containing_workers_flag_text():

--- a/tests/test_run_parallel_provider.py
+++ b/tests/test_run_parallel_provider.py
@@ -144,6 +144,7 @@ def test_run_parallel_analysis_empty_diff_applied(monkeypatch):
         cfg.repo = repo_dir
         session = ConversationalSession(cfg)
         monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
+        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
 
         expects_seen = []
         substantive = (
@@ -243,6 +244,7 @@ def test_run_parallel_analysis_discards_seed_patch_persists_findings(monkeypatch
         cfg.repo = repo_dir
         session = ConversationalSession(cfg)
         monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
+        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
 
         finding_line = (
             "FINDING: harness/auth.py:42 token refresh never validates expiry"
@@ -350,6 +352,7 @@ def test_run_parallel_analysis_verification_only_degraded(monkeypatch):
         cfg.repo = repo_dir
         session = ConversationalSession(cfg)
         monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
+        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
 
         def mock_worker_run(self):
             return WorkerResult(
@@ -414,6 +417,7 @@ def test_run_parallel_implement_empty_diff_not_applied(monkeypatch):
         cfg.repo = repo_dir
         session = ConversationalSession(cfg)
         monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
+        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
 
         def mock_worker_run(self):
             assert getattr(self, "expects_diff", True) is True

--- a/tests/test_send_loop_actions.py
+++ b/tests/test_send_loop_actions.py
@@ -380,7 +380,8 @@ def test_execute_translates_screenshot_agentic_cli_to_run_swarm(monkeypatch):
     translated, aid, _native = captured[0]
     assert translated.kind == "run_swarm"
     assert translated.goal == "Add token-level streaming"
-    assert translated.model == "deepseek/deepseek-v4-pro"
+    assert translated.model == "opencode-go/deepseek/deepseek-v4-pro"
+    assert translated.adapter == "agentic"
     assert translated.tool_call_id == "call_screenshot"
     assert aid == "call_screenshot"
     starts = [e for e in events if e.kind == "action_start"]
@@ -426,7 +427,8 @@ def test_execute_translates_wrapped_screenshot_agentic_cli_to_run_swarm(monkeypa
     translated, aid, _native = captured[0]
     assert translated.kind == "run_swarm"
     assert translated.goal == _SCREENSHOT_WRAPPED_GOAL
-    assert translated.model == "deepseek/deepseek-v4-pro"
+    assert translated.model == "opencode-go/deepseek/deepseek-v4-pro"
+    assert translated.adapter == "agentic"
     assert translated.tool_call_id == "call_wrapped_screenshot"
     assert aid == "call_wrapped_screenshot"
     starts = [e for e in events if e.kind == "action_start"]
@@ -479,7 +481,8 @@ def test_execute_translates_agentic_cli_to_run_implement_off_swarm(monkeypatch):
     translated, aid = captured[0]
     assert translated.kind == "run_implement"
     assert translated.goal == "Add token-level streaming"
-    assert translated.model == "deepseek/deepseek-v4-pro"
+    assert translated.model == "opencode-go/deepseek/deepseek-v4-pro"
+    assert translated.adapter == "agentic"
     assert translated.tool_call_id == "call_impl"
     assert aid == "call_impl"
     session._do_run_command.assert_not_called()

--- a/tests/test_send_loop_dispatch.py
+++ b/tests/test_send_loop_dispatch.py
@@ -522,6 +522,48 @@ def test_dispatch_parallel_uses_resolved_git_child_cwd(tmp_path, monkeypatch):
     )
 
 
+def test_model_pin_implies_strict_agentic_dispatch(monkeypatch):
+    from harness.send_loop_dispatch import _strict_agentic_dispatch
+    from harness.swarm_model_pin import AgenticModelPin
+
+    expected = AgenticModelPin(
+        requested="openrouter/stealth/ox-alpha",
+        provider="openrouter",
+        model="stealth/ox-alpha",
+        router_model_id="agentic/openrouter/stealth/ox-alpha",
+    )
+    monkeypatch.setattr(
+        "harness.swarm_model_pin.resolve_agentic_model_pin",
+        lambda _model: (expected, ""),
+    )
+
+    pin, strict, error = _strict_agentic_dispatch(
+        SimpleNamespace(
+            model="openrouter/stealth/ox-alpha",
+            adapter="",
+        ),
+    )
+
+    assert pin is expected
+    assert strict is True
+    assert error == ""
+
+
+def test_model_pin_rejects_conflicting_adapter():
+    from harness.send_loop_dispatch import _strict_agentic_dispatch
+
+    pin, strict, error = _strict_agentic_dispatch(
+        SimpleNamespace(
+            model="openrouter/stealth/ox-alpha",
+            adapter="cursor",
+        ),
+    )
+
+    assert pin is None
+    assert strict is True
+    assert "cannot be combined" in error
+
+
 # ---------------------------------------------------------------------------
 # Swarm quality gate: thin/generic findings must not read as a green success.
 

--- a/tests/test_swarm_model_pin.py
+++ b/tests/test_swarm_model_pin.py
@@ -113,6 +113,65 @@ def test_resolve_unknown_pin_demotes_instead_of_raising(monkeypatch, tmp_path):
     assert out["resolved"] == ""
 
 
+def test_resolve_direct_openrouter_agentic_pin_strict(monkeypatch, tmp_path):
+    models_path = tmp_path / "models.json"
+    models_path.write_text(json.dumps({"models": []}), encoding="utf-8")
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setattr(
+        "harness.auto_registry.ensure_keyed_provider_registry_health",
+        lambda: {"ready": True},
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: {"openrouter"},
+    )
+    monkeypatch.setattr(
+        "puppetmaster.model_registry.apply_model_pin",
+        lambda payload, model, *, adapter, registry=None: {
+            **(payload or {}),
+            "model": model,
+        },
+    )
+
+    from harness.swarm_model_pin import resolve_agentic_model_pin
+
+    pin, error = resolve_agentic_model_pin("openrouter/stealth/ox-alpha")
+    assert error == ""
+    assert pin is not None
+    assert pin.provider == "openrouter"
+    assert pin.model == "stealth/ox-alpha"
+    assert pin.router_model_id == "agentic/openrouter/stealth/ox-alpha"
+    assert pin.payload_fields()["auto_route"] is False
+    assert pin.payload_fields()["allowed_adapters"] == ["agentic"]
+
+
+def test_resolve_direct_agentic_pin_requires_keyed_provider(monkeypatch, tmp_path):
+    models_path = tmp_path / "models.json"
+    models_path.write_text(json.dumps({"models": []}), encoding="utf-8")
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setattr(
+        "harness.auto_registry.ensure_keyed_provider_registry_health",
+        lambda: {"ready": False},
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: set(),
+    )
+    monkeypatch.setattr(
+        "puppetmaster.model_registry.apply_model_pin",
+        lambda payload, model, *, adapter, registry=None: {
+            **(payload or {}),
+            "model": model,
+        },
+    )
+
+    from harness.swarm_model_pin import resolve_agentic_model_pin
+
+    pin, error = resolve_agentic_model_pin("openrouter/stealth/ox-alpha")
+    assert pin is None
+    assert "not in keyed worker registry" in error
+
+
 def test_run_swarm_model_description_mentions_live_catalog(monkeypatch):
     monkeypatch.setattr(
         "harness.swarm_worker_allowlist.resolve_swarm_worker_allowlist",
@@ -133,6 +192,42 @@ def test_run_swarm_model_description_mentions_live_catalog(monkeypatch):
     text = _run_swarm_model_pin_description()
     assert "agentic/gpt-5.6-luna" in text
     assert "remap" in text.lower()
+
+
+def test_implement_and_parallel_tool_schemas_expose_model_pin():
+    from harness.pilot import build_tools_schema
+
+    tools = {
+        row["function"]["name"]: row["function"]
+        for row in build_tools_schema()
+    }
+    assert "model" in tools["run_implement"]["parameters"]["properties"]
+    assert "model" in tools["run_parallel"]["parameters"]["properties"]
+
+
+def test_implement_and_parallel_wire_model_pin_accept_nested_arguments():
+    from harness.pilot import from_wire
+
+    implement = from_wire(
+        "run_implement",
+        {
+            "arguments": {
+                "goal": "fix it",
+                "model": "openrouter/stealth/ox-alpha",
+            },
+        },
+    )
+    parallel = from_wire(
+        "run_parallel",
+        {
+            "arguments": {
+                "goals": ["one", "two"],
+                "model": "openrouter/stealth/ox-alpha",
+            },
+        },
+    )
+    assert implement.model == "openrouter/stealth/ox-alpha"
+    assert parallel.model == "openrouter/stealth/ox-alpha"
 
 
 def test_pin_candidates_include_openai_codex_colon_form():

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.266"
+version = "0.9.267"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.266",
+  "version": "0.9.267",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.266",
+      "version": "0.9.267",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.266",
+  "version": "0.9.267",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- make explicit agentic model pins immutable across implement and parallel dispatch
- fail closed on unavailable adapters, conflicting routes, or routed-model mismatches instead of falling back
- preserve provider/model routing identity in CLI translation, tracker rows, and result artifacts

## Test plan
- [x] `.venv/bin/python -m pytest -q` (4,827 passed, 76 skipped)
- [x] focused agentic/parallel regressions (300 passed)
- [x] `tests/test_version_consistency.py`
- [x] `git diff --check`
- [ ] GitHub `tests` matrix: Python 3.9, Python 3.11, Windows, frontend-build