### PR TITLE
fix: make synchronous swarm delivery complete and inspectable

### DIFF
--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -2717,9 +2717,10 @@ class ConversationalSession(
 
     def _append_action_result(
         self, act: Any, aid: str, content: str, is_native: bool, *, ok: bool = True,
+        force_inline: bool = False,
     ) -> None:
         tc_id = getattr(act, "tool_call_id", None) or aid
-        clamped_content = self._turn_economy.persist_tool_result(
+        clamped_content = content if force_inline else self._turn_economy.persist_tool_result(
             content, tc_id, tool_name=getattr(act, "kind", None),
         )
         # Tag full-file reads with their path so the pre-send pass can elide an

--- a/harness/pilot.py
+++ b/harness/pilot.py
@@ -1306,14 +1306,6 @@ def build_tools_schema(
                                 "the open session workspace."
                             ),
                         },
-                        "full_digest": {
-                            "type": "boolean",
-                            "description": (
-                                "When true, inline the verbose per-artifact digest in the "
-                                "action_result. Default is handle-first (job_id + headlines + "
-                                "artifact:// URIs); FETCH bodies with peek_artifact/read_file."
-                            ),
-                        },
                     },
                     "required": ["goal"]
                 }

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -87,17 +87,20 @@ from .tool_dispatch import _strip_ansi, is_safe_path
 
 POST_SWARM_SYNTHESIS_NUDGE = (
     "(system) The synchronous swarm has completed. "
-    "Summarize its completed findings for the user now from the handle-first "
-    "swarm result (job_id + headlines + artifact:// URIs). "
-    "If you need full bodies, FETCH via peek_artifact or read_file — do not "
-    "assume digests were inlined. "
+    "Summarize its completed findings from the complete PM swarm artifact "
+    "manifest already pushed into the result. Preserve any partial-delivery warning. "
     "Do not call tools, make plans, or emit progress updates; "
     "return only a concise user-facing synthesis."
 )
 POST_SWARM_SYNTHESIS_FALLBACK = (
     "The completed swarm did not return a user-facing synthesis. "
-    "Its findings are available via the job_id / artifact:// handles in the "
-    "swarm result above (peek_artifact or read_file to FETCH)."
+    "Its machine-owned PM artifact receipt and inspectable artifact links remain "
+    "available in the swarm result above."
+)
+
+_ACTION_RESULT_DISPLAY_FIELDS = (
+    "job_id", "num", "types", "adapter", "artifacts",
+    "error", "duration_ms", "chars", "status", "message",
 )
 
 
@@ -601,10 +604,7 @@ class SendLoopMixin:
                     if aid and aid in pending_cards:
                         card = pending_cards[aid]
                         res_data = {}
-                        for key in [
-                            "job_id", "num", "types", "adapter", "artifacts",
-                            "error", "duration_ms", "chars", "status", "message",
-                        ]:
+                        for key in _ACTION_RESULT_DISPLAY_FIELDS:
                             if key in ev.data:
                                 res_data[key] = ev.data[key]
                         # In-place update of the action_start row (already in display).
@@ -613,10 +613,7 @@ class SendLoopMixin:
                     elif aid:
                         # Result without a tracked start -- still persist a card.
                         res_data = {}
-                        for key in [
-                            "job_id", "num", "types", "adapter", "artifacts",
-                            "error", "duration_ms", "chars", "status", "message",
-                        ]:
+                        for key in _ACTION_RESULT_DISPLAY_FIELDS:
                             if key in ev.data:
                                 res_data[key] = ev.data[key]
                         card = {

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -77,6 +77,101 @@ def _stamp_local_job_agentic_pin(session, job_id: str, pin) -> None:
         return
 
 
+def _artifact_ref(row: Any) -> dict[str, str]:
+    if isinstance(row, dict):
+        get = row.get
+    else:
+        get = lambda key, default="": getattr(row, key, default)
+    return {
+        "id": str(get("id", "") or "").strip(),
+        "task_id": str(get("task_id", "") or "").strip(),
+        "sha256": str(get("sha256", "") or "").strip(),
+    }
+
+
+def _swarm_artifact_delivery(session, job_id: str, result_rows: list[dict]) -> tuple[list[dict], dict]:
+    """Reconcile the PM store with the result projection; never model-pull evidence."""
+
+    expected_refs = [_artifact_ref(row) for row in result_rows]
+    canonical_rows: list[dict] = []
+    try:
+        state = session.state()
+        raw_rows = list(state.store.list_artifacts(job_id))
+        if raw_rows:
+            expected_refs = [_artifact_ref(row) for row in raw_rows]
+            canonical_rows = list(state.format_artifacts(raw_rows))
+    except Exception:
+        canonical_rows = []
+
+    by_id: dict[str, dict] = {}
+    anonymous_rows: list[dict] = []
+    for row in [*result_rows, *canonical_rows]:
+        artifact_id = str(row.get("id") or "").strip()
+        if not artifact_id:
+            if row not in anonymous_rows:
+                anonymous_rows.append(row)
+            continue
+        prior = by_id.get(artifact_id)
+        by_id[artifact_id] = {**(prior or {}), **row}
+
+    ordered: list[dict] = []
+    missing: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for ref in expected_refs:
+        artifact_id = ref["id"]
+        if artifact_id and artifact_id in by_id:
+            row = dict(by_id[artifact_id])
+            row.setdefault("task_id", ref["task_id"] or None)
+            row.setdefault("sha256", ref["sha256"])
+            ordered.append(row)
+            seen.add(artifact_id)
+        else:
+            missing.append({"id": artifact_id or "unknown", "task_id": ref["task_id"]})
+    for artifact_id, row in by_id.items():
+        if artifact_id not in seen:
+            ordered.append(row)
+    ordered.extend(anonymous_rows)
+
+    pm_artifacts = len(expected_refs)
+    available = pm_artifacts - len(missing)
+    return ordered, {
+        "pm_artifacts": pm_artifacts,
+        "available_to_inspect": available,
+        "complete": not missing,
+        "missing": missing,
+    }
+
+
+def _render_swarm_delivery_manifest(job_id: str, rows: list[dict], delivery: dict) -> str:
+    expected = int(delivery.get("pm_artifacts") or 0)
+    available = int(delivery.get("available_to_inspect") or 0)
+    lines = [
+        "PM SWARM ARTIFACT MANIFEST:",
+        f"- PM artifacts: {expected}",
+        f"- Available to inspect: {available}/{expected}",
+    ]
+    missing = list(delivery.get("missing") or [])
+    if missing:
+        lines.append("- WARNING: Synthesis continued with incomplete PM evidence.")
+        for row in missing:
+            lines.append(
+                f"  - missing {row.get('id') or 'unknown'} task={row.get('task_id') or 'unknown'}"
+            )
+    for row in rows:
+        artifact_id = str(row.get("id") or "").strip()
+        lines.append(digest_line(row, job_id))
+        if not artifact_id:
+            continue
+        lines.append(
+            "    "
+            f"id={artifact_id} "
+            f"task={row.get('task_id') or 'unknown'} "
+            f"sha256={row.get('sha256') or 'unknown'} "
+            f"artifact://{job_id}/{artifact_id}"
+        )
+    return "\n".join(lines)
+
+
 def _non_git_workspace_error(repo: str) -> Optional[str]:
     """Calm refuse when the resolved workspace is not a git work tree.
 
@@ -655,14 +750,35 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         except Exception:
             pass
     ordered = _signal + _plumbing
-    digest_arts = _signal[:20] + _plumbing[:3] if _signal else _plumbing[:8]
     # Every user-visible count/label below describes the SURFACED artifacts, not
     # the raw bridge result. A refused demo surfaces nothing, so it must not
     # report a nonzero count or claim it ran "via demo".
     _ui_adapter = 'refused-demo' if _demo_refused else result.adapter
     _ui_num = len(_all_arts)
     _ui_types = sorted({str(a.get('type')) for a in _all_arts if a.get('type')})
-    yield ConvEvent('action_result', {'id': aid, 'job_id': result.job_id, 'num': _ui_num, 'types': _ui_types, 'artifacts': ordered[:12], 'adapter': _ui_adapter, 'mode': result.mode, 'auth_failure': auth_failure, 'error': ('demo substrate -- not real codebase analysis' if _demo_refused else None)})
+    if _demo_refused:
+        delivered_arts = []
+        artifact_delivery = {
+            "pm_artifacts": 0,
+            "available_to_inspect": 0,
+            "complete": True,
+            "missing": [],
+        }
+    else:
+        delivered_arts, artifact_delivery = _swarm_artifact_delivery(
+            session, _job_id_text, ordered,
+        )
+    yield ConvEvent('action_result', {
+        'id': aid,
+        'job_id': result.job_id,
+        'num': _ui_num,
+        'types': _ui_types,
+        'artifacts': ordered[:12],
+        'adapter': _ui_adapter,
+        'mode': result.mode,
+        'auth_failure': auth_failure,
+        'error': ('demo substrate -- not real codebase analysis' if _demo_refused else None),
+    })
     _has_signal = bool(_signal)
     # Quality gate: a "finding" with no substance (a one-liner with no file
     # reference) must not turn the badge green -- a swarm whose workers choked
@@ -690,7 +806,18 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             else 'swarm produced no FINDING/RISK/DECISION artifacts' if _ui_num
             else 'swarm produced no artifacts'))
     _store_jid = (result.job_id or '').strip() or _sync_local_id
-    _badge = {'job_id': _store_jid, 'applied': _swarm_ok, 'files': [], 'summary': _badge_summary, 'error': _badge_error, 'objective': act.goal, 'adapter': _ui_adapter}
+    _badge = {
+        'job_id': _store_jid,
+        'applied': _swarm_ok,
+        'files': [],
+        'summary': _badge_summary,
+        'error': _badge_error,
+        'objective': act.goal,
+        'cwd': _swarm_repo,
+        'adapter': _ui_adapter,
+        'artifacts': delivered_arts,
+        'artifact_delivery': artifact_delivery,
+    }
     _job_engine = _ui_adapter if _demo_refused else (result.adapter or 'agentic')
     # Best-effort routed model so finish cannot clobber a preview ROUTING stamp
     # with bare agentic/native.
@@ -827,24 +954,9 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         pass
     # Only surfaced artifacts become turn findings; a refused demo contributes none.
     turn_findings.extend((a for a in _all_arts if a.get('type') != 'verification'))
-    full_digest_raw = (getattr(act, 'arguments', None) or {}).get('full_digest')
-    if isinstance(full_digest_raw, bool):
-        want_full_digest = full_digest_raw
-    else:
-        want_full_digest = str(full_digest_raw or '').strip().lower() in (
-            '1', 'true', 'yes', 'on',
-        )
-    digest = '\n'.join(
-        digest_line(a, _job_id_text) for a in digest_arts
-    ) or '  (no artifacts)'
-    if auth_failure and not _has_signal and auth_failure not in digest:
-        digest = f"  - [auth] {auth_failure}\n{digest}"
-    from .worker_handles import format_handle_first_result
-    handle_body = format_handle_first_result(
-        _job_id_text,
-        digest_arts or _signal or _all_arts,
+    body = _render_swarm_delivery_manifest(
+        _job_id_text, delivered_arts, artifact_delivery,
     )
-    body = digest if want_full_digest else handle_body
     stall = ''
     if _demo_refused or counters['demo_swarms'] >= 1:
         stall = '\n(NOTE: swarm hit the DEMO substrate and was refused -- Marionette never treats demo findings as real analysis. Do NOT retry or cite those findings. Tell the user analysis needs HARNESS_SWARM_ADAPTER=agentic and a provider key, then stop.)'
@@ -871,19 +983,15 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         acceptance_criteria=_finish_criteria,
     ))
     _follow = (
-        'Explain these findings to the user and either run a narrowed follow-up '
-        'swarm or finish with no actions. FETCH full bodies with peek_artifact '
-        'or read_file on artifact:// URIs when needed.'
-        if not want_full_digest
-        else
-        'Explain these findings to the user and either run a narrowed follow-up '
-        'swarm or finish with no actions.'
+        'Synthesize the available PM evidence. Artifact discovery is complete '
+        'above; do not gather the result set with additional tools or rerun the swarm.'
     )
     session._append_action_result(
         act, aid,
         f"(swarm {aid} '{act.goal}' returned {_ui_num} artifacts {_pilot_via}:"
         f"{evidence_boundary}\n{body}\n{_follow}){stall}",
         is_native,
+        force_inline=True,
     )
     return None
 

--- a/harness/state.py
+++ b/harness/state.py
@@ -248,6 +248,7 @@ class DurableState:
                     detail = redact_secret_text(str(source_reason).strip())[:500] or None
             row = {
                 "id": getattr(a, "id", ""),
+                "sha256": getattr(a, "sha256", ""),
                 "type": art_type,
                 "headline": str(headline)[:300],
                 "confidence": getattr(a, "confidence", None),

--- a/harness/worker_handles.py
+++ b/harness/worker_handles.py
@@ -46,8 +46,7 @@ def format_handle_first_result(
     """Compact handle-first swarm/worker result for model-visible history.
 
     Always includes ``job_id`` and (when ``fetch_hint``) a FETCH reminder.
-    Headlines cite ``artifact://`` URIs; full digest lines stay available via
-    ``full_digest=true`` on run_swarm.
+    Headlines cite ``artifact://`` URIs so full bodies remain directly addressable.
     """
     jid = str(job_id or "").strip() or "unknown"
     lines = [f"job_id={jid}"]

--- a/pmharness/bridge.py
+++ b/pmharness/bridge.py
@@ -674,6 +674,7 @@ def _artifact_provenance(a: Any, payload: dict) -> dict:
         "id": str(getattr(a, "id", "") or "").strip()[:_MAX_ID_CHARS],
         "job_id": job_id,
         "task_id": task_id,
+        "sha256": str(getattr(a, "sha256", "") or "").strip(),
     }
     evidence = _bounded_text_list(
         getattr(a, "evidence", None),

--- a/tests/test_post_swarm_synthesis.py
+++ b/tests/test_post_swarm_synthesis.py
@@ -99,6 +99,38 @@ def _fake_failed_execute_turn_actions(
     return (None, [])
 
 
+def _fake_partial_delivery_execute_turn_actions(
+    session: ConversationalSession,
+    *,
+    turn: Any,
+    counters: dict[str, int],
+    turn_findings: list,
+    **_: Any,
+):
+    """A delivery warning is evidence for synthesis, never a completion block."""
+    assert [action.kind for action in turn.actions] == ["run_swarm"]
+    counters["swarms"] += 1
+    counters["synchronous_swarms"] = counters.get("synchronous_swarms", 0) + 1
+    turn_findings.append({"kind": "finding", "headline": "delivered finding"})
+    session._history.append({
+        "role": "user",
+        "content": (
+            "PM artifacts: 17\nAvailable to inspect: 16/17\n"
+            "WARNING: Synthesis continued with incomplete PM evidence.\n"
+            "missing artifact-16 task=task-4"
+        ),
+    })
+    yield ConvEvent("action_result", {
+        "artifact_delivery": {
+            "pm_artifacts": 17,
+            "available_to_inspect": 16,
+            "complete": False,
+            "missing": [{"id": "artifact-16", "task_id": "task-4"}],
+        },
+    })
+    return (None, [])
+
+
 def _fake_drain_idle_turn(
     _session: ConversationalSession,
     *,
@@ -177,6 +209,28 @@ def test_failed_post_swarm_action_still_gets_a_user_facing_fallback(monkeypatch)
     messages = [event for event in events if event.kind == "message"]
     assert [event.data["text"] for event in messages] == [POST_SWARM_SYNTHESIS_FALLBACK]
     assert len(pilot.calls) == 3
+
+
+def test_partial_delivery_warning_does_not_block_synthesis(monkeypatch):
+    pilot = _SequencePilot([
+        _pilot_envelope(actions=[{"kind": "run_swarm", "goal": "audit findings"}]),
+        _pilot_envelope(say="Synthesis from the 16 available artifacts."),
+    ])
+
+    session, events = _run_post_swarm_turn(
+        monkeypatch,
+        pilot,
+        execute_actions=_fake_partial_delivery_execute_turn_actions,
+    )
+
+    assert [
+        event.data["text"] for event in events if event.kind == "message"
+    ] == ["Synthesis from the 16 available artifacts."]
+    assert any(
+        "Available to inspect: 16/17" in str(message.get("content") or "")
+        for message in session._history
+    )
+    assert events[-1].kind == "assistant_done"
 
 
 def test_synthesis_nudge_never_dispatches_hallucinated_tools(monkeypatch):

--- a/tests/test_swarm_run_facts.py
+++ b/tests/test_swarm_run_facts.py
@@ -939,7 +939,7 @@ class TestSynchronousBoundary:
             PilotAction(
                 kind="run_swarm", goal="audit routing",
                 acceptance_criteria=list(criteria or []),
-                arguments={"full_digest": True},
+                arguments={},
             ),
             "a-1", True,
             counters={"swarms": 0, "demo_swarms": 0},

--- a/tests/test_worker_handles.py
+++ b/tests/test_worker_handles.py
@@ -29,7 +29,7 @@ def test_format_handle_first_empty_arts():
     assert "FETCH" in text
 
 
-def test_sync_swarm_default_is_handle_first(monkeypatch):
+def test_sync_swarm_pushes_every_artifact_into_receipt_and_synthesis(monkeypatch):
     from types import SimpleNamespace
     from unittest.mock import MagicMock
 
@@ -42,11 +42,15 @@ def test_sync_swarm_default_is_handle_first(monkeypatch):
     findings = [
         {
             "type": "finding",
+            "id": f"artifact-{i}",
+            "job_id": "job_hf",
+            "task_id": f"task-{i % 5}",
+            "sha256": f"sha-{i}",
             "headline": f"Finding number {i} with evidence in harness/foo.py:{i}",
             "body": ("DETAIL " * 80) + f" #{i}",
             "evidence": [{"path": f"harness/foo.py", "line": i}],
         }
-        for i in range(6)
+        for i in range(17)
     ]
     result = SimpleNamespace(
         job_id="job_hf",
@@ -71,42 +75,93 @@ def test_sync_swarm_default_is_handle_first(monkeypatch):
         _append_action_result=MagicMock(),
         _display_transcript=[],
     )
-    list(dispatch_swarm_action(
+    events = list(dispatch_swarm_action(
         session,
-        PilotAction(kind="run_swarm", goal="audit", roles=["explore"], arguments={}),
+        PilotAction(
+            kind="run_swarm",
+            goal="audit",
+            roles=[
+                "explore",
+                "pipeline-mapper",
+                "decision-explainer",
+                "conflict-auditor",
+                "test-coverage-reviewer",
+            ],
+            arguments={},
+        ),
         "a-1",
         True,
         counters={"swarms": 0, "demo_swarms": 0},
         turn_findings=[],
     ))
-    text = session._append_action_result.call_args.args[2]
-    assert "job_id=" in text
-    assert "FETCH" in text
-    assert "peek_artifact" in text
-    # Default must be much shorter than a full digest paste of all bodies.
-    assert len(text) < 2500
-    assert "DETAIL DETAIL" not in text
 
-    # full_digest=true restores verbose digest lines.
+    action_result = next(event.data for event in events if event.kind == "action_result")
+    assert len(action_result["artifacts"]) == 12
+    assert "artifact_delivery" not in action_result
+    swarm_result = next(event.data["result"] for event in events if event.kind == "swarm_result")
+    assert [row["id"] for row in swarm_result["artifacts"]] == [
+        f"artifact-{i}" for i in range(17)
+    ]
+    assert swarm_result["artifact_delivery"] == {
+        "pm_artifacts": 17,
+        "available_to_inspect": 17,
+        "complete": True,
+        "missing": [],
+    }
+    assert swarm_result["cwd"] == "/repo"
+
+    text = session._append_action_result.call_args.args[2]
+    assert "PM artifacts: 17" in text
+    assert "Available to inspect: 17/17" in text
+    assert "peek_artifact" not in text
+    for i in range(17):
+        assert f"artifact://job_hf/artifact-{i}" in text
+        assert f"sha-{i}" in text
+    assert "DETAIL DETAIL" not in text
+    raw_rows = [
+        SimpleNamespace(
+            id=f"artifact-{i}",
+            task_id=f"task-{i % 5}",
+            sha256=f"sha-{i}",
+            type="finding",
+        )
+        for i in range(17)
+    ]
+    state = SimpleNamespace(
+        store=SimpleNamespace(list_artifacts=lambda _job_id: raw_rows),
+        # Simulate one PM row that could not be projected into Mari's inspectable ledger.
+        format_artifacts=lambda _rows: findings[:16],
+    )
+    session.state = lambda: state
+    result.artifacts = findings[:16]
+    result.num_artifacts = 16
     session._append_action_result.reset_mock()
-    list(dispatch_swarm_action(
+
+    partial_events = list(dispatch_swarm_action(
         session,
-        PilotAction(
-            kind="run_swarm",
-            goal="audit",
-            roles=["explore"],
-            arguments={"full_digest": True},
-        ),
+        PilotAction(kind="run_swarm", goal="partial audit", roles=["explore"], arguments={}),
         "a-2",
         True,
         counters={"swarms": 0, "demo_swarms": 0},
         turn_findings=[],
     ))
-    full = session._append_action_result.call_args.args[2]
-    assert "[finding]" in full
-    assert "job_id=" in full or "job=" in full
-    # Verbose path still keeps safety notes available; body includes digest rows.
-    assert len(full) > len(text)
+    partial_action_result = next(event.data for event in partial_events if event.kind == "action_result")
+    assert len(partial_action_result["artifacts"]) == 12
+    assert "artifact_delivery" not in partial_action_result
+    partial_result = next(
+        event.data["result"] for event in partial_events if event.kind == "swarm_result"
+    )
+    assert len(partial_result["artifacts"]) == 16
+    assert partial_result["artifact_delivery"] == {
+        "pm_artifacts": 17,
+        "available_to_inspect": 16,
+        "complete": False,
+        "missing": [{"id": "artifact-16", "task_id": "task-1"}],
+    }
+    partial_manifest = session._append_action_result.call_args.args[2]
+    assert "Synthesis continued with incomplete PM evidence" in partial_manifest
+    assert "missing artifact-16 task=task-1" in partial_manifest
+    assert session._append_action_result.call_args.kwargs["force_inline"] is True
 
 
 def test_drain_swarm_results_history_is_handle_first(monkeypatch, tmp_path):

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -2332,6 +2332,39 @@ describe("SwarmPane harness-open-swarm-job deep-link", () => {
     });
   });
 
+  it("opens and scrolls to an exact artifact target", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job_abcdef012345", "Artifact deep-link target", {
+        artifacts_complete: true,
+        artifacts: [{
+          id: "artifact-target",
+          type: "finding",
+          headline: "Exact target finding",
+          confidence: 0.99,
+        }],
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+
+    window.dispatchEvent(
+      new CustomEvent("harness-open-swarm-job", {
+        detail: { jobId: "job_abcdef012345", artifactId: "artifact-target" },
+      }),
+    );
+
+    const finding = await waitFor(() => {
+      const row = document.querySelector('[data-artifact-ids~="artifact-target"]');
+      expect(row).toBeTruthy();
+      return row as HTMLElement;
+    });
+    expect(finding.dataset.findingId).toBe("artifact-target");
+    await waitFor(() => {
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    });
+  });
+
   it("clears filters that hide a deep-link target", async () => {
     mockSwarmLive.mockResolvedValue(
       finishedJob("job_abcdef012345", "Deep-link target behind filter"),
@@ -2376,11 +2409,11 @@ describe("SwarmPane harness-open-swarm-job deep-link", () => {
     await waitFor(() => {
       expect(screen.getByText("Late-mount deep-link target")).toBeInTheDocument();
     });
-    expect(peekPendingSwarmOpenJob()).toBeNull();
     const row = document.querySelector('[data-job-id="job_abcdef012345"]');
     expect(row).toBeTruthy();
     await waitFor(() => {
       expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+      expect(peekPendingSwarmOpenJob()).toBeNull();
     });
   });
 });

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -355,6 +355,48 @@ describe("transcriptItems module", () => {
     expect(items[1]).toMatchObject({ kind: "msg", msg: { role: "assistant", text: "hi" } });
   });
 
+  it("drops run_swarm ActionCards and hydrates the SwarmResult owner", () => {
+    const items = transcriptResponseToItems({
+      display: [
+        {
+          type: "card",
+          id: "call-swarm",
+          kind: "run_swarm",
+          goal: "audit",
+          cwd: "/repo",
+          result: { job_id: "job_abcdef012345", status: "complete" },
+        },
+        {
+          type: "swarm_result",
+          job_id: "job_abcdef012345",
+          applied: true,
+          files: [],
+          summary: "one finding",
+          error: null,
+          objective: "audit",
+          cwd: "/repo",
+          artifacts: [{ id: "artifact-a", type: "finding", headline: "Evidence" }],
+          artifact_delivery: {
+            pm_artifacts: 1,
+            available_to_inspect: 1,
+            complete: true,
+            missing: [],
+          },
+        },
+      ],
+    });
+
+    expect(items.filter((item) => item.kind === "card")).toHaveLength(0);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: "swarm_result",
+      job_id: "job_abcdef012345",
+      objective: "audit",
+      cwd: "/repo",
+      artifact_delivery: { pm_artifacts: 1, available_to_inspect: 1, complete: true },
+    });
+  });
+
   it("transcriptResponseToItems restores pending command_approval display rows", () => {
     const hash = "a".repeat(64);
     const items = transcriptResponseToItems({
@@ -1577,6 +1619,19 @@ describe("streamApply module", () => {
         source_job_id: "local-src",
         reuse_reason: "subset_invalidated",
         invalidated_paths: ["harness/auth.py"],
+        artifacts: [{
+          id: "artifact-a",
+          task_id: "task-a",
+          sha256: "sha-a",
+          type: "finding",
+          headline: "Evidence A",
+        }],
+        artifact_delivery: {
+          pm_artifacts: 1,
+          available_to_inspect: 1,
+          complete: true,
+          missing: [],
+        },
       },
     });
     expect(enriched.filter((it) => it.kind === "swarm_result")).toHaveLength(1);
@@ -1584,6 +1639,7 @@ describe("streamApply module", () => {
       reuse_status: "partial",
       source_job_id: "local-src",
       invalidated_paths: ["harness/auth.py"],
+      artifact_delivery: { pm_artifacts: 1, available_to_inspect: 1, complete: true },
     });
 
     // Later SSE correction: explicit false / fresh / [] must replace prior fields.
@@ -1624,6 +1680,7 @@ describe("streamApply module", () => {
       reuse_status: "fresh",
       source_job_id: "",
       files: ["a.ts"],
+      artifact_delivery: { pm_artifacts: 1, available_to_inspect: 1, complete: true },
     });
 
     // Files-only SSE correction; explicit [] clears, omitted files inherit.

--- a/webapp/src/__tests__/pendingSwarmOpenJob.test.ts
+++ b/webapp/src/__tests__/pendingSwarmOpenJob.test.ts
@@ -6,6 +6,7 @@ import {
   clearPendingSwarmOpenJob,
   peekPendingSwarmOpenJob,
   queuePendingSwarmOpenJob,
+  takePendingSwarmOpenArtifact,
   takePendingSwarmOpenJob,
 } from "../lib/pendingSwarmOpenJob";
 import { openAgentSwarmJob } from "../lib/agentLinks";
@@ -31,6 +32,12 @@ describe("pendingSwarmOpenJob queue", () => {
     queuePendingSwarmOpenJob("local-bf1b30f4");
     queuePendingSwarmOpenJob("job_abcdef012345");
     expect(takePendingSwarmOpenJob()).toBe("job_abcdef012345");
+  });
+
+  it("carries an exact artifact target through a late mount", () => {
+    openAgentSwarmJob("job_abcdef012345", "artifact-target");
+    expect(takePendingSwarmOpenJob()).toBe("job_abcdef012345");
+    expect(takePendingSwarmOpenArtifact()).toBe("artifact-target");
   });
 
   it("ignores blank ids", () => {

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -456,14 +456,12 @@ describe("transcript presentation contract", () => {
     });
 
     render(<TranscriptList {...listProps(items)} />);
-    fireEvent.click(screen.getByRole("button", { name: /Explored|Swarm/i }));
 
-    expect(screen.getByText(/swarm failed ×5/i)).toBeTruthy();
     expect(screen.getByText(/worker timed out after 30s/i)).toBeTruthy();
-    // Routing failure once; distinct timeout remains a second failed row.
+    // ActionCards are no longer terminal owners; each durable job result remains distinct.
     const failedLabels = screen.getAllByText(/swarm failed/i);
-    expect(failedLabels).toHaveLength(2);
-    expect(screen.getAllByText(/No model in registry has all required tags/i)).toHaveLength(1);
+    expect(failedLabels).toHaveLength(3);
+    expect(screen.getAllByText(/No model in registry has all required tags/i)).toHaveLength(2);
   });
 
   it("paints held_for_review and analysis_ok badges without applied/failed chrome", () => {
@@ -507,8 +505,6 @@ describe("transcript presentation contract", () => {
         ])}
       />,
     );
-
-    fireEvent.click(screen.getByRole("button", { name: /Swarm/i }));
 
     const cards = screen.getAllByTestId("swarm-result-card");
     const byOutcome = Object.fromEntries(
@@ -575,7 +571,6 @@ describe("transcript presentation contract", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Swarm/i }));
     const heldCard = screen.getByTestId("swarm-result-card");
     expect(heldCard).toHaveAttribute("data-outcome", "held");
     fireEvent.click(within(heldCard).getByRole("button", { name: /held for review/i }));
@@ -822,7 +817,7 @@ describe("job_id → Swarm Tracker deep-link chrome", () => {
         ])}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Explored|Swarm/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Explored/i }));
 
     const kvLink = screen.getByTestId("job-id-link");
     expect(kvLink).toHaveTextContent("job_abcdef012345");
@@ -844,6 +839,90 @@ describe("job_id → Swarm Tracker deep-link chrome", () => {
         .map((c) => c[0] as CustomEvent)
         .some((e) => e.type === "harness-open-swarm-job" && e.detail?.jobId === "local-bf1b30f4"),
     ).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("renders complete and partial machine-owned swarm delivery receipts", () => {
+    const spy = vi.spyOn(window, "dispatchEvent");
+    const completeArtifacts = Array.from({ length: 17 }, (_, i) => ({
+      id: `artifact-${i}`,
+      task_id: `task-${i % 5}`,
+      sha256: `sha-${i}`,
+      type: i % 2 ? "risk" : "finding",
+      headline: `Evidence ${i}`,
+    }));
+    const missing = [{ id: "artifact-16", task_id: "task-4" }];
+    const persistedItems: Item[] = [
+      {
+        kind: "swarm_result",
+        job_id: "job_111111111111",
+        applied: true,
+        files: [],
+        summary: "17 findings via agentic (17 artifacts)",
+        error: null,
+        objective: "complete audit",
+        cwd: "/repo/complete",
+        reuse_status: "fresh",
+        reuse_reason: "first_pass",
+        artifacts: completeArtifacts,
+        artifact_delivery: {
+          pm_artifacts: 17,
+          available_to_inspect: 17,
+          complete: true,
+          missing: [],
+        },
+      },
+      {
+        kind: "swarm_result",
+        job_id: "job_222222222222",
+        applied: true,
+        files: [],
+        summary: "16 findings via agentic (17 PM artifacts)",
+        error: null,
+        objective: "partial audit",
+        cwd: "/repo/partial",
+        reuse_status: "fresh",
+        artifacts: completeArtifacts.slice(0, 16),
+        artifact_delivery: {
+          pm_artifacts: 17,
+          available_to_inspect: 16,
+          complete: false,
+          missing,
+        },
+      },
+    ];
+    // Hydration/reload must retain the machine-owned receipt and warning.
+    const hydratedItems = JSON.parse(JSON.stringify(persistedItems)) as Item[];
+
+    render(<TranscriptList {...listProps(hydratedItems)} />);
+
+    screen.getAllByText("swarm done").forEach((label) => {
+      fireEvent.click(label.closest("button")!);
+    });
+    screen.getAllByTestId("swarm-delivery-toggle").forEach((toggle) => {
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+      fireEvent.click(toggle);
+    });
+    expect(screen.getAllByText("Artifacts").map((el) => el.parentElement?.textContent)).toEqual([
+      expect.stringContaining("17"),
+      expect.stringContaining("17"),
+    ]);
+    expect(screen.getByText("17/17")).toBeInTheDocument();
+    expect(screen.getByText("16/17")).toBeInTheDocument();
+    expect(screen.queryByText(/Delivered to Mari/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("fresh")).not.toBeInTheDocument();
+    expect(screen.queryByText(/first_pass/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Synthesis continued with incomplete PM evidence/i)).toBeInTheDocument();
+    expect(screen.getByText(/artifact-16.*task-4/i)).toBeInTheDocument();
+    const artifactLinks = screen.getAllByTestId("swarm-artifact-link");
+    expect(artifactLinks).toHaveLength(33);
+    expect(screen.getAllByText("complete audit").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("/repo/complete")).toBeInTheDocument();
+    fireEvent.click(artifactLinks[0]);
+    const openEvent = spy.mock.calls
+      .map((call) => call[0] as CustomEvent)
+      .find((event) => event.type === "harness-open-swarm-job");
+    expect(openEvent?.detail).toEqual({ jobId: "job_111111111111", artifactId: "artifact-0" });
     spy.mockRestore();
   });
 });

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -5,8 +5,9 @@ import { api, jobArtifactList, type SwarmLive, type Job, type Artifact, type Tas
 import { displayModelId, isEngineOnlyModelId, modelIdsEqual } from "../lib/modelIdentity";
 import { lastSelectedProjectRoot, panelOpacityClass, useProjectSwitching } from "../lib/panelTransition";
 import {
+  clearPendingSwarmOpenJob,
+  peekPendingSwarmOpenArtifact,
   peekPendingSwarmOpenJob,
-  takePendingSwarmOpenJob,
 } from "../lib/pendingSwarmOpenJob";
 import { useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
 
@@ -280,6 +281,7 @@ function swarmSignature(res: SwarmLive | null): string {
       `:${j.swarm_cache_savings_basis ?? ""}:${j.swarm_cache_unpriced_tokens ?? 0}` +
       `:${(j.tool_output_savings_usd ?? 0).toFixed(4)}` +
       `:${j.source ?? "harness"}` +
+      `:${j.artifacts_complete ?? ""}` +
       `:${j.outcome?.quality ?? ""}:${j.outcome?.trustworthy ?? ""}` +
       `:${(j.outcome?.reasons || []).join("|")}:${j.updated_at ?? ""}`,
     );
@@ -298,7 +300,8 @@ function swarmSignature(res: SwarmLive | null): string {
       } else {
         const detail = typeof a.detail === "string" ? a.detail.slice(0, 500) : "";
         parts.push(
-          `A:${(a.type || "").slice(0, 8)}:${(a.headline || "").slice(0, 120)}:${a.result ?? ""}` +
+          `A:${a.id ?? ""}:${a.task_id ?? ""}:${(a.type || "").slice(0, 8)}` +
+          `:${(a.headline || "").slice(0, 120)}:${a.result ?? ""}` +
           `:${a.failure ?? ""}:${detail}`,
         );
       }
@@ -324,14 +327,18 @@ function swarmSignature(res: SwarmLive | null): string {
 // shows the identical line 5x. Collapse exact (type + headline) duplicates into a
 // single row with an xN badge, and sort real signal (RISK/BUG/DECISION) above
 // process noise (VERIFICATION) so substance reads first.
-type FindingRow = { art: Artifact; count: number };
+type FindingRow = { art: Artifact; count: number; artifactIds: string[] };
 function dedupeFindings(arts: Artifact[]): FindingRow[] {
   const rows = new Map<string, FindingRow>();
   for (const art of arts) {
     const key = `${(art.type || "").toUpperCase()}::${(art.headline || "").trim().toLowerCase()}`;
     const hit = rows.get(key);
-    if (hit) hit.count += 1;
-    else rows.set(key, { art, count: 1 });
+    if (hit) {
+      hit.count += 1;
+      if (art.id) hit.artifactIds.push(art.id);
+    } else {
+      rows.set(key, { art, count: 1, artifactIds: art.id ? [art.id] : [] });
+    }
   }
   const rank = (t?: string) => {
     const u = (t || "").toUpperCase();
@@ -1037,6 +1044,7 @@ export default function SwarmPane() {
   // Holds latest live payload so the SWR fetcher / poll can merge without
   // wiping artifacts hydrated via /api/artifacts on expand.
   const dataRef = useRef<SwarmLive | null | undefined>(undefined);
+  const pendingOpenRef = useRef<{ jobId: string; artifactId?: string } | null>(null);
 
   const {
     data,
@@ -1093,9 +1101,11 @@ export default function SwarmPane() {
   // Transcript chrome (job_id chips / ActionCard KV) deep-links here: undismiss,
   // expand, hydrate artifacts, scroll the row into view. Also drains any job id
   // queued before this pane mounted (openAgentSwarmJob races focus-tab mount).
-  const openSwarmJobById = useCallback((jobId: string) => {
+  const openSwarmJobById = useCallback((jobId: string, artifactId?: string) => {
     const id = (jobId || "").trim();
+    const artifact = (artifactId || "").trim();
     if (!id) return;
+    pendingOpenRef.current = { jobId: id, ...(artifact ? { artifactId: artifact } : {}) };
     setDismissed((prev) => {
       if (!prev.has(id)) return prev;
       const next = new Set(prev);
@@ -1109,33 +1119,68 @@ export default function SwarmPane() {
     });
     setFinishedOpen(true);
     setJobFilter("all");
+    if (artifact) {
+      setFindingsOpen((prev) => ({ ...prev, [id]: true }));
+    }
     const job = dataRef.current?.jobs?.find((j) => j.id === id);
     if (job) ensureFullArtifacts(job);
-    const scrollToJob = () => {
+    const scrollToTarget = () => {
       const escape =
         typeof CSS !== "undefined" && typeof CSS.escape === "function"
           ? CSS.escape
           : (s: string) => s.replace(/["\\]/g, "\\$&");
       const el = document.querySelector(`[data-job-id="${escape(id)}"]`);
+      if (artifact && el) {
+        const finding = el.querySelector<HTMLElement>(
+          `[data-artifact-ids~="${escape(artifact)}"]`,
+        );
+        if (finding) {
+          const findingId = finding.dataset.findingId;
+          if (findingId) {
+            setExpandedFindings((prev) => ({ ...prev, [findingId]: true }));
+          }
+          finding.scrollIntoView({ block: "center" });
+          pendingOpenRef.current = null;
+          clearPendingSwarmOpenJob();
+          return;
+        }
+      }
       el?.scrollIntoView({ block: "nearest" });
+      if (el && !artifact) {
+        pendingOpenRef.current = null;
+        clearPendingSwarmOpenJob();
+      }
     };
     requestAnimationFrame(() => {
-      requestAnimationFrame(scrollToJob);
+      requestAnimationFrame(scrollToTarget);
     });
-    window.setTimeout(scrollToJob, 80);
+    window.setTimeout(scrollToTarget, 80);
+    if (artifact) {
+      window.setTimeout(scrollToTarget, 250);
+      window.setTimeout(scrollToTarget, 600);
+    }
   }, [ensureFullArtifacts]);
 
   useEffect(() => {
-    const pending = takePendingSwarmOpenJob();
-    if (pending) openSwarmJobById(pending);
+    const pending = pendingOpenRef.current;
+    if (!pending) return;
+    if (!(data?.jobs || []).some((job) => job.id === pending.jobId)) return;
+    openSwarmJobById(pending.jobId, pending.artifactId);
+  }, [data, openSwarmJobById]);
+
+  useEffect(() => {
+    const pending = peekPendingSwarmOpenJob();
+    const pendingArtifact = peekPendingSwarmOpenArtifact();
+    if (pending) openSwarmJobById(pending, pendingArtifact || undefined);
 
     const onOpenSwarmJob = (e: Event) => {
-      const jobId = String((e as CustomEvent<{ jobId?: string }>).detail?.jobId || "").trim();
+      const detail = (e as CustomEvent<{ jobId?: string; artifactId?: string }>).detail;
+      const jobId = String(detail?.jobId || "").trim();
+      const artifactId = String(detail?.artifactId || "").trim();
       if (!jobId) return;
-      // Live listener won the race — drop the matching queued id so a later
-      // remount does not expand/scroll twice.
-      if (peekPendingSwarmOpenJob() === jobId) takePendingSwarmOpenJob();
-      openSwarmJobById(jobId);
+      // Keep the queue until the target DOM exists; the pane can remount while
+      // the right rail opens or before the scoped live payload arrives.
+      openSwarmJobById(jobId, artifactId || undefined);
     };
     window.addEventListener("harness-open-swarm-job", onOpenSwarmJob as EventListener);
     return () => {
@@ -1824,7 +1869,7 @@ export default function SwarmPane() {
                 </button>
                 {sectionOpen && (
                 <div className="pr-1 flex flex-col gap-1 border border-edge/40 rounded p-1.5 bg-panel2/20">
-                  {findingRows.map(({ art, count }, idx: number) => {
+                  {findingRows.map(({ art, count, artifactIds }, idx: number) => {
                     const fid = art.id || `f${idx}`;
                     const fExpanded = !!expandedFindings[fid];
                     const echoWarn = (art.type || "").toUpperCase() === "FINDING"
@@ -1835,7 +1880,12 @@ export default function SwarmPane() {
                           ? art.detail
                           : (() => { try { return JSON.stringify(art.detail, null, 2); } catch { return String(art.detail); } })());
                     return (
-                    <div key={fid} className="text-[9.5px] border-b border-edge/10 pb-1 last:border-0 last:pb-0 flex flex-col gap-0.5">
+                    <div
+                      key={fid}
+                      data-finding-id={fid}
+                      data-artifact-ids={artifactIds.join(" ")}
+                      className="text-[9.5px] border-b border-edge/10 pb-1 last:border-0 last:pb-0 flex flex-col gap-0.5"
+                    >
                       <div className="flex items-center justify-between gap-2">
                         <span className="font-bold text-accent uppercase tracking-wider text-[8px] flex items-center gap-1">
                           {art.type}

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -156,6 +156,43 @@ export type SwarmPendingItem = {
   terminal_job_ids?: string[];
 };
 
+type SwarmArtifact = {
+  id?: string;
+  task_id?: string;
+  sha256?: string;
+  type: string;
+  headline: string;
+};
+
+type SwarmArtifactDelivery = {
+  pm_artifacts: number;
+  available_to_inspect: number;
+  complete: boolean;
+  missing: { id: string; task_id?: string }[];
+};
+
+type SwarmResultItem = {
+  kind: "swarm_result";
+  job_id: string;
+  applied: boolean;
+  files: string[];
+  summary: string;
+  error: string | null;
+  objective?: string;
+  cwd?: string;
+  held_for_review?: boolean;
+  analysis_ok?: boolean;
+  reuse_status?: string;
+  source_job_id?: string;
+  reuse_reason?: string;
+  invalidated_paths?: string[];
+  validation_fingerprint?: string;
+  environment_fingerprint?: string;
+  acceptance_criteria?: string[];
+  artifacts?: SwarmArtifact[];
+  artifact_delivery?: SwarmArtifactDelivery;
+};
+
 export type CommandApprovalItem = {
   kind: "command_approval";
   id: string;
@@ -176,7 +213,7 @@ export type Item =
   | { kind: "thinking"; text: string; streaming?: boolean; id?: string; stream_id?: string }
   | { kind: "tool_prep"; name: string }
   | SwarmPendingItem
-  | { kind: "swarm_result"; job_id: string; applied: boolean; files: string[]; summary: string; error: string | null; objective?: string; held_for_review?: boolean; analysis_ok?: boolean; reuse_status?: string; source_job_id?: string; reuse_reason?: string; invalidated_paths?: string[]; validation_fingerprint?: string; environment_fingerprint?: string; acceptance_criteria?: string[] }
+  | SwarmResultItem
   | { kind: "checkpoint"; id: string; label: string; trigger: string }
   | { kind: "pending_review"; id: string; summary: string }
   | {
@@ -223,7 +260,7 @@ export type GroupedItem =
   | { kind: "msg"; msg: Msg }
   | { kind: "thinking"; text: string; streaming?: boolean; id?: string; stream_id?: string }
   | SwarmPendingItem
-  | { kind: "swarm_result"; job_id: string; applied: boolean; files: string[]; summary: string; error: string | null; objective?: string; held_for_review?: boolean; analysis_ok?: boolean; reuse_status?: string; source_job_id?: string; reuse_reason?: string; invalidated_paths?: string[]; validation_fingerprint?: string; environment_fingerprint?: string; acceptance_criteria?: string[] }
+  | SwarmResultItem
   | { kind: "checkpoint"; id: string; label: string; trigger: string }
   | { kind: "pending_review"; id: string; summary: string }
   | {
@@ -274,7 +311,7 @@ type ActivityItem =
   | { kind: "vault_cite"; route: string; snippets: string[]; query?: string }
   | { kind: "checkpoint"; id: string; label: string; trigger: string }
   | SwarmPendingItem
-  | { kind: "swarm_result"; job_id: string; applied: boolean; files: string[]; summary: string; error: string | null; objective?: string; held_for_review?: boolean; analysis_ok?: boolean; reuse_status?: string; source_job_id?: string; reuse_reason?: string; invalidated_paths?: string[]; validation_fingerprint?: string; environment_fingerprint?: string; acceptance_criteria?: string[] }
+  | SwarmResultItem
   | { kind: "msg"; msg: Msg }
   | Extract<
       Item,
@@ -612,11 +649,10 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
       flush();
       grouped.push(item);
     } else if (item.kind === "swarm_result") {
-      // These are emitted by tool execution, so they belong inside the same
-      // collapsed investigation as the action card that produced them. Rendering
-      // them as standalone chips made the transcript vertically noisy.
-      // Keep terminal detail after any later tool rows in this investigation.
-      terminalSwarmItems.push(item);
+      // The durable swarm receipt is the terminal owner; never bury it under an
+      // activity fold now that run_swarm ActionCards are intentionally absent.
+      flush();
+      grouped.push(item);
     } else if (item.kind === "checkpoint") {
       currentGroup.push(item);
     } else if (item.kind === "pending_review") {
@@ -1192,12 +1228,15 @@ export const TranscriptList = memo(function TranscriptList({
           summary={it.summary}
           error={it.error}
           objective={it.objective}
+          cwd={it.cwd}
           heldForReview={it.held_for_review}
           analysisOk={it.analysis_ok}
           reuseStatus={it.reuse_status}
           sourceJobId={it.source_job_id}
           reuseReason={it.reuse_reason}
           invalidatedPaths={it.invalidated_paths}
+          artifacts={it.artifacts}
+          artifactDelivery={it.artifact_delivery}
         />
       );
     } else if (it.kind === "checkpoint") {
@@ -1622,6 +1661,7 @@ function getCardMeta(card: Card): string | null {
     parts.push(`${duration}ms`);
   }
 
+
   if (isGateSuppressed(card)) {
     // Swarm/delegate gate blocked this call -- not a tool failure. Label it
     // honestly so a broad-ask turn doesn't look like a wall of red errors.
@@ -1756,7 +1796,7 @@ function ActivityGroup({
   const cards = items.filter((it) => it.kind === "card") as { kind: "card"; card: Card }[];
   const cgItems = items.filter((it) => it.kind === "codegraph_context") as { kind: "codegraph_context"; symbols: number; query: string }[];
   const checkpointItems = items.filter((it) => it.kind === "checkpoint") as { kind: "checkpoint"; id: string; label: string; trigger: string }[];
-  const swarmResults = items.filter((it) => it.kind === "swarm_result") as { kind: "swarm_result"; job_id: string; applied: boolean; files: string[]; summary: string; error: string | null; objective?: string }[];
+  const swarmResults = items.filter((it) => it.kind === "swarm_result") as SwarmResultItem[];
   // Recount incrementally from visible top-level cards AND nested worker rows
   // so Explored / Investigating tracks the investigation timeline the user sees.
   const nestedRows = cards.flatMap((c) => c.card.actions || []);
@@ -1909,12 +1949,15 @@ function ActivityGroup({
           summary={it.summary}
           error={it.error}
           objective={it.objective}
+          cwd={it.cwd}
           heldForReview={it.held_for_review}
           analysisOk={it.analysis_ok}
           reuseStatus={it.reuse_status}
           sourceJobId={it.source_job_id}
           reuseReason={it.reuse_reason}
           invalidatedPaths={it.invalidated_paths}
+          artifacts={it.artifacts}
+          artifactDelivery={it.artifact_delivery}
           duplicateCount={dupCount}
         />
       );
@@ -3309,11 +3352,15 @@ function SwarmPendingPill({
 // label, and border so the body text stays readable instead of tinted.
 function reuseStatusLabel(status?: string): string | null {
   const s = (status || "").trim().toLowerCase();
-  if (s === "reused") return "reused";
-  if (s === "partial") return "partially reverified";
-  if (s === "invalidated") return "invalidated";
-  if (s === "fresh") return "fresh";
+  if (s === "reused") return "prior validation reused";
+  if (s === "partial") return "partially revalidated";
+  if (s === "invalidated") return "prior validation invalidated";
   return null;
+}
+
+function visibleReuseReason(reason?: string): string {
+  const value = (reason || "").trim();
+  return value === "first_pass" || value === "no_reusable_candidate" ? "" : value;
 }
 
 /** Bounded relative-path summary for partial reuse honesty (no secrets). */
@@ -3356,24 +3403,29 @@ function SwarmJobIdButton({
   );
 }
 
-function SwarmResultCard({ jobId, applied, files, summary, error, objective, heldForReview, analysisOk, reuseStatus, sourceJobId, reuseReason, invalidatedPaths, duplicateCount = 1 }: {
+function SwarmResultCard({ jobId, applied, files, summary, error, objective, cwd, heldForReview, analysisOk, reuseStatus, sourceJobId, reuseReason, invalidatedPaths, artifacts, artifactDelivery, duplicateCount = 1 }: {
   jobId?: string;
   applied: boolean;
   files: string[];
   summary: string;
   error: string | null;
   objective?: string;
+  cwd?: string;
   heldForReview?: boolean;
   analysisOk?: boolean;
   reuseStatus?: string;
   sourceJobId?: string;
   reuseReason?: string;
   invalidatedPaths?: string[];
+  artifacts?: SwarmArtifact[];
+  artifactDelivery?: SwarmArtifactDelivery;
   duplicateCount?: number;
 }) {
   const [open, setOpen] = useState(false);
+  const [artifactsOpen, setArtifactsOpen] = useState(false);
   const obj = objective ? (objective.length > 70 ? objective.slice(0, 70) + "..." : objective) : "swarm";
   const reuseLabel = reuseStatusLabel(reuseStatus);
+  const reuseReasonLabel = visibleReuseReason(reuseReason);
   const pathSummary = formatInvalidatedPaths(invalidatedPaths);
   const primaryJobId = (jobId || "").trim();
   // Operator honesty: held_for_review / analysis_ok are successful non-applies —
@@ -3421,9 +3473,10 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, hel
     || tone === "analysis"
     || primaryJobId
     || sourceJobId
-    || reuseReason
+    || reuseReasonLabel
     || pathSummary
     || reuseLabel
+    || artifactDelivery
   );
 
   return (
@@ -3457,7 +3510,7 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, hel
         {reuseLabel && (
           <span
             className="text-[9px] font-mono text-muted bg-panel2/70 border border-edge/50 px-1.5 py-0.5 rounded shrink-0"
-            title={pathSummary || reuseReason || sourceJobId || reuseLabel}
+            title={pathSummary || reuseReasonLabel || sourceJobId || reuseLabel}
           >
             {reuseLabel}
           </span>
@@ -3486,18 +3539,92 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, hel
               <SwarmJobIdButton jobId={primaryJobId} />
             </div>
           ) : null}
-          {(reuseLabel || reuseReason || sourceJobId) && (
+          {objective ? (
+            <div className="text-[10px] leading-relaxed text-muted whitespace-normal break-words">
+              <span className="text-faint">goal </span>{objective}
+            </div>
+          ) : null}
+          {cwd ? (
+            <div className="text-[10px] leading-relaxed text-muted font-mono whitespace-normal break-words">
+              <span className="text-faint font-sans">cwd </span>{cwd}
+            </div>
+          ) : null}
+          {(reuseLabel || reuseReasonLabel || sourceJobId) && (
             <div className="text-[10px] text-muted font-mono leading-relaxed break-words inline-flex items-center gap-1 flex-wrap">
-              <span>{reuseLabel ? `validation ${reuseLabel}` : "validation"}</span>
+              <span>{reuseLabel || "validation"}</span>
               {sourceJobId ? (
                 <>
                   <span>from</span>
                   <SwarmJobIdButton jobId={sourceJobId} />
                 </>
               ) : null}
-              {reuseReason ? <span>({reuseReason})</span> : null}
+              {reuseReasonLabel ? <span>({reuseReasonLabel})</span> : null}
             </div>
           )}
+          {artifactDelivery ? (
+            <div
+              className={`rounded border p-2 space-y-2 ${
+                artifactDelivery.complete
+                  ? "border-edge/40 bg-panel2/20"
+                  : "border-warn/40 bg-warn/5"
+              }`}
+              data-testid="swarm-delivery-receipt"
+            >
+              <button
+                type="button"
+                data-testid="swarm-delivery-toggle"
+                aria-expanded={artifactsOpen}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setArtifactsOpen((value) => !value);
+                }}
+                className="flex w-full flex-wrap items-center gap-x-4 gap-y-1 text-left text-[10px] text-muted hover:text-txt"
+              >
+                {artifactsOpen ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+                <span>Artifacts <strong className="text-txt font-medium">{artifactDelivery.pm_artifacts}</strong></span>
+                <span>
+                  Available to inspect{" "}
+                  <strong className="text-txt font-medium">
+                    {artifactDelivery.available_to_inspect}/{artifactDelivery.pm_artifacts}
+                  </strong>
+                </span>
+              </button>
+              {!artifactDelivery.complete ? (
+                <div className="text-[10px] text-warn space-y-0.5" data-testid="swarm-delivery-warning">
+                  <div>Synthesis continued with incomplete PM evidence.</div>
+                  {(artifactDelivery.missing || []).map((row) => (
+                    <div key={`${row.id}:${row.task_id || ""}`} className="font-mono break-words">
+                      {row.id} · {row.task_id || "unknown task"}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              {artifactsOpen && Array.isArray(artifacts) && artifacts.length > 0 ? (
+                <div className="max-h-72 overflow-auto space-y-1">
+                  {artifacts.map((artifact, index) => (
+                    <button
+                      key={artifact.id || index}
+                      type="button"
+                      data-testid="swarm-artifact-link"
+                      data-artifact-id={artifact.id || ""}
+                      data-artifact-sha256={artifact.sha256 || ""}
+                      onClick={() => primaryJobId && openAgentSwarmJob(primaryJobId, artifact.id)}
+                      className="block w-full rounded border border-edge/30 bg-panel/30 px-2 py-1.5 text-left hover:bg-panel2/35 transition-colors"
+                      title={artifact.id ? `Inspect ${artifact.id} in Swarm Tracker` : "Inspect swarm artifacts"}
+                    >
+                      <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[9px]">
+                        <span className="uppercase text-faint">{artifact.type}</span>
+                        {artifact.id ? <span className="font-mono text-accent/80 break-all">{artifact.id}</span> : null}
+                      </span>
+                      <span className="mt-1 block text-[10.5px] leading-relaxed text-muted whitespace-normal break-words">
+                        {artifact.headline}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
           {Array.isArray(invalidatedPaths) && invalidatedPaths.length > 0 && (
             <div className="flex flex-col gap-1">
               <div className="text-[10px] text-muted font-mono">invalidated paths</div>

--- a/webapp/src/components/conversation/streamApply.ts
+++ b/webapp/src/components/conversation/streamApply.ts
@@ -1917,6 +1917,7 @@ function swarmResultItemFromPayload(
     summary: resObj?.summary || "",
     error: hasError ? (resObj.error ?? null) : (undefined as unknown as null),
     objective,
+    cwd: resObj?.cwd !== undefined && resObj?.cwd !== null ? String(resObj.cwd) : undefined,
     held_for_review: hasHeld ? Boolean(resObj.held_for_review) : undefined,
     analysis_ok: hasAnalysisOk ? Boolean(resObj.analysis_ok) : undefined,
     // Preserve explicit empty-string / present fields so corrections can clear
@@ -1942,6 +1943,11 @@ function swarmResultItemFromPayload(
     acceptance_criteria: Array.isArray(resObj?.acceptance_criteria)
       ? resObj.acceptance_criteria.map((c: unknown) => String(c || "").trim()).filter(Boolean)
       : undefined,
+    artifacts: Array.isArray(resObj?.artifacts) ? resObj.artifacts : undefined,
+    artifact_delivery:
+      resObj?.artifact_delivery && typeof resObj.artifact_delivery === "object"
+        ? resObj.artifact_delivery
+        : undefined,
   };
 }
 
@@ -1959,6 +1965,17 @@ export function applySwarmResultToItems(
 ): Item[] {
   const jobId = String(d.job_id || "").trim();
   if (!jobId) return items;
+  if (items.some((it) => (
+    it.kind === "card"
+    && it.card.kind === "run_swarm"
+    && String(it.card.result?.job_id || "").trim() === jobId
+  ))) {
+    items = items.filter((it) => !(
+      it.kind === "card"
+      && it.card.kind === "run_swarm"
+      && String(it.card.result?.job_id || "").trim() === jobId
+    ));
+  }
 
   const resObj = d.result || d;
   const resultFailed = swarmResultLooksFailed(resObj);
@@ -1987,6 +2004,7 @@ export function applySwarmResultToItems(
         && merged.validation_fingerprint === it.validation_fingerprint
         && merged.environment_fingerprint === it.environment_fingerprint
         && merged.summary === it.summary
+        && merged.cwd === it.cwd
         && merged.applied === it.applied
         && merged.error === it.error
         && merged.held_for_review === it.held_for_review
@@ -1996,7 +2014,10 @@ export function applySwarmResultToItems(
         && JSON.stringify(merged.invalidated_paths || [])
           === JSON.stringify(it.invalidated_paths || [])
         && JSON.stringify(merged.acceptance_criteria || [])
-          === JSON.stringify(it.acceptance_criteria || []);
+          === JSON.stringify(it.acceptance_criteria || [])
+        && JSON.stringify(merged.artifacts || []) === JSON.stringify(it.artifacts || [])
+        && JSON.stringify(merged.artifact_delivery || null)
+          === JSON.stringify(it.artifact_delivery || null);
       if (same) return it;
       changed = true;
       return merged;

--- a/webapp/src/components/conversation/streamEventHandler.ts
+++ b/webapp/src/components/conversation/streamEventHandler.ts
@@ -455,7 +455,9 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
       // stack another card (session-switch SSE race → infinite Investigated).
       // Default tool cards to collapsed always: they used to mount open while
       // running and snap shut on action_result, which read as a flicker.
-      setItems((p) => appendActionStartCard(p, d));
+      if (d.kind !== "run_swarm") {
+        setItems((p) => appendActionStartCard(p, d));
+      }
     } else if (ev.kind === "action_result") {
       clearWaitHintOnProgress();
       setCompactingStatus(null);
@@ -469,7 +471,7 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
       // narration) is still finalized in place.
       flushTypewriter();
       setItems((p) => {
-        let next = applyActionResultCard(p, d);
+        let next = d.kind === "run_swarm" ? p : applyActionResultCard(p, d);
         // Sync run_swarm early failures emit action_result(error) without a
         // swarm_result — flip the matching local-swarm pill off the spinner.
         if (d.error) next = failSwarmPendingForActionError(next, d.id);

--- a/webapp/src/components/conversation/transcriptItems.ts
+++ b/webapp/src/components/conversation/transcriptItems.ts
@@ -42,6 +42,7 @@ export function mergeSwarmResultReuse(
     summary: next.summary || prev.summary,
     error: next.error !== undefined ? next.error : prev.error,
     objective: next.objective || prev.objective,
+    cwd: next.cwd !== undefined ? next.cwd : prev.cwd,
     held_for_review: next.held_for_review !== undefined
       ? next.held_for_review
       : prev.held_for_review,
@@ -61,6 +62,10 @@ export function mergeSwarmResultReuse(
     acceptance_criteria: next.acceptance_criteria !== undefined
       ? next.acceptance_criteria
       : prev.acceptance_criteria,
+    artifacts: next.artifacts !== undefined ? next.artifacts : prev.artifacts,
+    artifact_delivery: next.artifact_delivery !== undefined
+      ? next.artifact_delivery
+      : prev.artifact_delivery,
   };
 }
 
@@ -298,6 +303,7 @@ export function transcriptResponseToItems(res: {
   if (res.display && res.display.length > 0) {
     loadedItems = res.display.flatMap((m: any): Item[] => {
       if (m.type === "card") {
+        if (m.kind === "run_swarm") return [];
         // result == null means still in flight (persisted at action_start).
         const pending = m.result == null;
         const goals = Array.isArray(m.goals)
@@ -368,6 +374,7 @@ export function transcriptResponseToItems(res: {
           summary: m.summary || "",
           error: m.error || null,
           objective: m.objective || "",
+          cwd: m.cwd !== undefined && m.cwd !== null ? String(m.cwd) : undefined,
           held_for_review: m.held_for_review !== undefined && m.held_for_review !== null
             ? Boolean(m.held_for_review)
             : undefined,
@@ -398,6 +405,10 @@ export function transcriptResponseToItems(res: {
             : undefined,
           acceptance_criteria: Array.isArray(m.acceptance_criteria)
             ? m.acceptance_criteria.map((c: unknown) => String(c || "").trim()).filter(Boolean)
+            : undefined,
+          artifacts: Array.isArray(m.artifacts) ? m.artifacts : undefined,
+          artifact_delivery: m.artifact_delivery && typeof m.artifact_delivery === "object"
+            ? m.artifact_delivery
             : undefined,
         }];
       } else if (m.type === "command_approval") {

--- a/webapp/src/lib/agentLinks.ts
+++ b/webapp/src/lib/agentLinks.ts
@@ -478,14 +478,17 @@ export function openAgentWorkspace(path: string): void {
  * expands/scrolls (harness-open-swarm-job is easy to miss when the pane
  * mounts only after harness-focus-tab opens the right rail).
  */
-export function openAgentSwarmJob(jobId: string): void {
+export function openAgentSwarmJob(jobId: string, artifactId?: string): void {
   const id = (jobId || "").trim();
+  const artifact = (artifactId || "").trim();
   if (!id || !looksLikeJobId(id)) return;
   try {
-    queuePendingSwarmOpenJob(id);
+    queuePendingSwarmOpenJob(id, artifact);
     window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: "swarm" }));
     window.dispatchEvent(
-      new CustomEvent("harness-open-swarm-job", { detail: { jobId: id } }),
+      new CustomEvent("harness-open-swarm-job", {
+        detail: { jobId: id, ...(artifact ? { artifactId: artifact } : {}) },
+      }),
     );
   } catch {
     /* ignore */

--- a/webapp/src/lib/pendingSwarmOpenJob.ts
+++ b/webapp/src/lib/pendingSwarmOpenJob.ts
@@ -3,16 +3,18 @@
  *
  * openAgentSwarmJob fires harness-focus-tab then harness-open-swarm-job
  * synchronously. SwarmPane may mount only after the right pane opens / the
- * swarm tab activates, so the event can be missed — stash the job id until
+ * swarm tab activates, so the event can be missed — stash the target until
  * SwarmPane consumes it on mount (same idea as App.pendingRightTab).
  */
 
 let pendingOpenJobId: string | null = null;
+let pendingOpenArtifactId: string | null = null;
 
-/** Stash a job id for a late-mounted SwarmPane to consume. */
-export function queuePendingSwarmOpenJob(jobId: string): void {
+/** Stash a job and optional artifact for a late-mounted SwarmPane to consume. */
+export function queuePendingSwarmOpenJob(jobId: string, artifactId?: string): void {
   const id = (jobId || "").trim();
   pendingOpenJobId = id || null;
+  pendingOpenArtifactId = id ? (artifactId || "").trim() || null : null;
 }
 
 /** Peek without clearing (tests / race guards). */
@@ -27,7 +29,20 @@ export function takePendingSwarmOpenJob(): string | null {
   return id;
 }
 
+/** Peek the optional artifact target without clearing it. */
+export function peekPendingSwarmOpenArtifact(): string | null {
+  return pendingOpenArtifactId;
+}
+
+/** Take and clear the optional artifact target paired with the pending job. */
+export function takePendingSwarmOpenArtifact(): string | null {
+  const id = pendingOpenArtifactId;
+  pendingOpenArtifactId = null;
+  return id;
+}
+
 /** Test helper: drop any stashed deep-link. */
 export function clearPendingSwarmOpenJob(): void {
   pendingOpenJobId = null;
+  pendingOpenArtifactId = null;
 }


### PR DESCRIPTION
## Core Problem
Marionette can run and bill for every swarm worker, then silently feed only a truncated subset of the artifacts into the final synthesis, leaving the user with a fraction of the knowledge they paid to produce.

## Problem reproduced

A real five-worker swarm produced 73 durable PM artifacts, but Marionette exposed only:

- 12 artifacts in the chat action result;
- 20 signal + 3 plumbing rows in the pilot digest/spill;
- zero successfully fetched full artifacts before synthesis.

The pilot then described that bounded spill as the complete persisted delivery. One omitted risk directly contradicted the final answer and was retrievable in 5 ms once its ID was known. The model did not adjudicate the disagreement; it never received it.

The ownership error is narrower than model correctness:

```text
artifact durability != artifact delivery
```

## Proposed synchronous `run_swarm` contract

- Reconcile the terminal job against PM's canonical durable artifact set.
- Preserve exact artifact ID, task ID, SHA-256, type, compact claim, evidence locus, and `artifact://` URI.
- Push a complete compact manifest into synthesis without model-directed gathering or arbitrary artifact cutoffs.
- Persist a machine-owned receipt on the existing `SwarmResultCard`:
  - `Artifacts N`
  - `Available to inspect M/N`
- Continue synthesis when delivery is partial, but show a durable warning with missing artifact/task identities.
- Keep full bodies in PM storage; the pushed representation is compact, not raw worker bytes.

## UI ownership

`SwarmResultCard` is now the singular terminal owner:

- job ID;
- goal and cwd as plain text;
- meaningful validation/reuse state;
- artifact delivery receipt and dropdown;
- exact artifact deep-links into the matching Swarm Tracker finding.
<img width="720" height="773" alt="Screenshot 2026-08-21 at 1 41 56 PM" src="https://github.com/user-attachments/assets/3eb25419-739e-4c6d-b594-bd608d231a69" />



The duplicate `run_swarm` ActionCard is not rendered. Routine internal copy such as `fresh (first_pass)` is hidden; meaningful reuse states remain in plain language.

The ActionCard seems obsolete in it's current state. Clickable text opens empty terminal shells with no clear indication of what a user is supposed to do, and now that the canonical SwarmResultCard exists, ActionCard has no business carrying swarm details.

## Mounted evidence

Real feature-branch run:

```text
PM artifact refs:        61
chat artifact refs:      61
synthesis manifest refs: 61
PM == chat:              true
PM == synthesis:         true
missing / extra:         0 / 0
```

First click from a non-Swarm pane:

```text
clicked:         true
job visible:     true
finding visible: true
finding ID:      exact requested artifact
```

## Focused verification

- synchronous delivery complete and partial fixtures;
- synthesis continues under partial delivery;
- transcript hydration and sparse-result merge;
- exact artifact deep-link and late-mount race;
- `run_swarm` ActionCard removal;
- focused `run_implement` / `run_parallel` compatibility suites;
- frontend production build;
- `git diff --check`.

No broad local suite was run; CI owns broad regression coverage.

## Deferred Follow-up

Background completion still uses the legacy handle-first path in `conversation_jobs.py` for `run_implement` and `run_parallel`. Focused compatibility tests pass, so this PR should not break those lanes, but the complete-delivery guarantee does **not** yet cover them.

## Review questions

1. Is the complete compact manifest the right boundary, or should PM expose a smaller canonical receipt primitive first?
2. Should background implement/parallel parity land here before merge?
3. Is `SwarmResultCard` the right singular UI owner?
4. Are there context-cost concerns not addressed by compact IDs/hashes/headlines rather than full bodies?
