### PR TITLE
Release v0.9.268

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.15` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.267, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Strict agentic model pins now carry through implement and parallel work without silently falling back to another adapter, with truthful provider/model receipts and fail-closed routing.
+> Status: v0.9.268, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Provider streams now preserve partial output and report authoritative terminal causes end to end, while incomplete turns expose isolated Continue/Retry recovery and stable activity grouping instead of silently stopping.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.267"
+__version__ = "0.9.268"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -54,12 +54,25 @@ from .send_loop_actions import execute_turn_actions
 from .repeat_tool_reminder import reset_repeat_chain
 from .send_loop_phases import (
     account_provider_attempt,
+    apply_provider_terminal,
+    classified_finish_kwargs,
     dispatch_pilot_provider_call,
+    emit_classified_provider_error,
     drain_idle_turn,
+    emit_loop_exit_close,
+    emit_stagnation_halt,
     finalize_assistant_turn,
+    native_tools_blocked,
     promote_trailing_reasoning_to_say,
     record_provider_dispatch_error_receipt,
     run_auto_verify,
+)
+from .terminal_cause import (
+    TERMINAL_DRIVER_SWAP,
+    TERMINAL_EMPTY_LOOP,
+    TERMINAL_INVALID_TOOL,
+    TERMINAL_TURN_BUDGET,
+    finalize_stop_cause,
 )
 from .stream_performance import (
     make_stream_timing_accumulator,
@@ -1003,6 +1016,8 @@ class SendLoopMixin:
         post_swarm_nudge_active = False
 
         consecutive_non_productive = 0
+        loop_exit_cause = None
+        last_classified = None
         # AUTO-VERIFY LOOP: after a turn that edited files, run a fast, scoped
         # project check and feed a FAILURE back as a tool observation IN THE SAME
         # user message so the pilot can self-correct. Bounded per user message so
@@ -1243,7 +1258,11 @@ class SendLoopMixin:
                 break
 
             if resp and resp.error:
-                yield ConvEvent("error", {"error": self._humanize_pilot_error(resp.error)})
+                yield from emit_classified_provider_error(self, resp)
+                return
+
+            last_classified, blocked = yield from apply_provider_terminal(self, resp)
+            if blocked:
                 return
 
             is_native = False
@@ -1374,6 +1393,8 @@ class SendLoopMixin:
                     self, user_message=user_message, step=step, swarms=swarms,
                     turn_prose=turn_prose, turn_findings=turn_findings,
                     extra={"turn_budget_exhausted": True},
+                    stop_cause=TERMINAL_TURN_BUDGET,
+                    **classified_finish_kwargs(last_classified),
                 )
                 return
 
@@ -1387,6 +1408,7 @@ class SendLoopMixin:
                 consecutive_non_productive += 1
 
             if consecutive_non_productive >= 3:
+                loop_exit_cause = TERMINAL_EMPTY_LOOP
                 break
 
             # Stagnation governor: repeated normalized assistant prose plus the
@@ -1425,32 +1447,14 @@ class SendLoopMixin:
                         self._stagnation_last_prose = prose_key
                         self._stagnation_last_actions = action_key
                         if self._stagnation_streak >= stagnation_streak_cap():
-                            halt_msg = (
-                                "Stopped: repeated the same response and actions "
-                                "with no new progress (auto-halt). Tell me how to "
-                                "continue, or try a narrower ask."
-                            )
                             # Heal any tool_call pairing from this assistant turn
                             # before exiting so history stays valid for the next send.
                             self._sanitize_tool_pairs()
-                            yield ConvEvent("notice", {
-                                "message": halt_msg,
-                                "kind": "stagnation",
-                            })
-                            yield ConvEvent("message", {
-                                "role": "assistant",
-                                "text": halt_msg,
-                            })
-                            self._display_transcript.append({
-                                "type": "message",
-                                "role": "assistant",
-                                "text": halt_msg,
-                            })
-                            yield from finalize_assistant_turn(
-                                self, user_message=user_message, step=step,
+                            yield from emit_stagnation_halt(
+                                self, last_classified=last_classified,
+                                user_message=user_message, step=step,
                                 swarms=swarms, turn_prose=turn_prose,
                                 turn_findings=turn_findings,
-                                extra={"stagnation_halt": True},
                             )
                             return
                 except Exception:
@@ -1498,14 +1502,22 @@ class SendLoopMixin:
                     swarms=swarms,
                     turn_prose=turn_prose,
                     turn_findings=turn_findings,
+                    stop_cause=finalize_stop_cause(last_classified),
+                    **classified_finish_kwargs(last_classified),
                 )
                 if disposition == "continue":
                     continue
                 if disposition == "break":
+                    loop_exit_cause = TERMINAL_DRIVER_SWAP
                     break
                 return
 
             # 4. Execute each action as a collapsible tool-call.
+            if native_tools_blocked(last_classified, resp, tool_calls, is_native=is_native, has_actions=turn.has_actions):
+                yield ConvEvent("error", {
+                    "error": "Incomplete tool arguments cannot be executed.",
+                })
+                return
             _action_counters = {
                 "action_seq": action_seq,
                 "swarms": swarms,
@@ -1542,6 +1554,8 @@ class SendLoopMixin:
                     swarms=swarms, turn_prose=turn_prose,
                     turn_findings=turn_findings,
                     extra={"invalid_tool_halt": True},
+                    stop_cause=TERMINAL_INVALID_TOOL,
+                    **classified_finish_kwargs(last_classified),
                 )
                 return
 
@@ -1562,12 +1576,15 @@ class SendLoopMixin:
             if _verify_again:
                 continue
 
-        # Hit the step cap -- close the turn gracefully.
-        limit_msg = "(Reached the investigation step limit for this message.)"
-        yield ConvEvent("message", {"role": "assistant", "text": limit_msg})
-        self._display_transcript.append({"type": "message", "role": "assistant", "text": limit_msg})
-        yield from finalize_assistant_turn(
-            self, user_message=user_message, step=step, swarms=swarms,
-            turn_prose=turn_prose, turn_findings=turn_findings,
+        # Distinct post-loop closes: empty-loop, driver-swap, or true step cap.
+        yield from emit_loop_exit_close(
+            self,
+            loop_exit_cause=loop_exit_cause,
+            last_classified=last_classified,
+            user_message=user_message,
+            step=step,
+            swarms=swarms,
+            turn_prose=turn_prose,
+            turn_findings=turn_findings,
         )
 

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -40,6 +40,25 @@ from .stream_performance_store import (
     build_receipt,
     copy_stream_performance,
 )
+from .terminal_cause import (
+    TERMINAL_CONTENT_FILTER,
+    TERMINAL_DRIVER_SWAP,
+    TERMINAL_EMPTY_LOOP,
+    TERMINAL_INCOMPLETE,
+    TERMINAL_LENGTH,
+    TERMINAL_NATURAL,
+    TERMINAL_PROVIDER_EOF,
+    TERMINAL_STAGNATION,
+    TERMINAL_STEP_CAP,
+    TERMINAL_TRANSPORT_ERROR,
+    TERMINAL_UNSPECIFIED,
+    blocking_terminal_message,
+    canonicalize_terminal_cause,
+    classify_provider_terminal,
+    finalize_stop_cause,
+    loop_exit_message,
+    provider_tools_are_executable,
+)
 from .tool_timeout import invoke_do, run_with_tool_deadline
 from .workspace_rules_refresh import maybe_refresh_workspace_rules
 from .url_safety import sanitize_url_for_display
@@ -230,18 +249,294 @@ def finalize_assistant_turn(
     turn_prose: list,
     turn_findings: list,
     extra: Optional[dict] = None,
+    stop_cause: str = "",
+    finish_reason: str = "",
+    incomplete_reason: str = "",
 ) -> Iterator[Any]:
     """Persist a compact receipt, emit assistant_done, then housekeeping."""
     from .conversation import ConvEvent
 
     persist_turn_receipt(session, user_message)
-    payload: Dict[str, Any] = {"turns": step + 1, "swarms": swarms}
+    cause = finalize_stop_cause(None, loop_cause=stop_cause)
+    payload: Dict[str, Any] = {
+        "turns": step + 1,
+        "swarms": swarms,
+        "stop_cause": cause,
+    }
+    raw_finish = str(finish_reason or "").strip()
+    if raw_finish:
+        payload["finish_reason"] = raw_finish
+    raw_incomplete = str(incomplete_reason or "").strip()
+    if raw_incomplete:
+        payload["incomplete_reason"] = raw_incomplete
     if extra:
         payload.update(extra)
+    try:
+        session._last_stop_cause = cause
+    except Exception:
+        pass
+    mark_latest_receipt_assistant_done(
+        session,
+        stop_cause=cause,
+        finish_reason=raw_finish,
+        incomplete_reason=raw_incomplete,
+    )
     yield ConvEvent("assistant_done", payload)
     session._submit_housekeeping(
         session._maybe_ingest,
         user_message, list(turn_prose), list(turn_findings),
+    )
+
+
+def classified_finish_kwargs(classified: Any) -> Dict[str, str]:
+    """``finish_reason`` / ``incomplete_reason`` for finalize helpers."""
+    if classified is None:
+        return {"finish_reason": "", "incomplete_reason": ""}
+    try:
+        return {
+            "finish_reason": classified.finish_reason or "",
+            "incomplete_reason": classified.incomplete_reason or "",
+        }
+    except Exception:
+        return {"finish_reason": "", "incomplete_reason": ""}
+
+
+def is_structurally_complete_envelope(resp: Any) -> bool:
+    """True when the body is a native JSON envelope (``say`` / ``actions``).
+
+    Bounded compatibility seam for synthetic / native pilots that return a
+    complete JSON envelope without provider finish metadata. Production
+    network drivers set ``requires_explicit_terminal = True`` and must not
+    use this implicit-natural upgrade — they stay fail-closed until the
+    driver stamps an explicit finish / stream terminal. Do not infer the
+    flag from class names.
+    """
+    try:
+        text = getattr(resp, "text", None) or ""
+    except Exception:
+        return False
+    if not isinstance(text, str) or not text.strip():
+        return False
+    try:
+        from .pilot import _extract_json_object
+        obj = _extract_json_object(text)
+    except Exception:
+        return False
+    return isinstance(obj, dict) and (
+        "say" in obj or "actions" in obj or "thinking" in obj
+    )
+
+
+def pilot_requires_explicit_terminal(session: Any) -> bool:
+    """True when the active pilot must stamp an explicit provider terminal."""
+    try:
+        return getattr(
+            getattr(session, "pilot", None),
+            "requires_explicit_terminal",
+            False,
+        ) is True
+    except Exception:
+        return False
+
+
+_NAMED_MODEL_ERROR_CAUSES = frozenset({
+    TERMINAL_LENGTH,
+    TERMINAL_INCOMPLETE,
+    TERMINAL_CONTENT_FILTER,
+    TERMINAL_PROVIDER_EOF,
+})
+
+
+def classified_terminal_error_payload(
+    session: Any,
+    resp: Any,
+    classified: Any,
+) -> Dict[str, Any]:
+    """Structured error ConvEvent data so the frontend maps the cause exactly."""
+    raw_error = _response_error_text(resp)
+    cause = ""
+    try:
+        cause = str(getattr(classified, "cause", "") or "")
+    except Exception:
+        cause = ""
+    try:
+        if cause in _NAMED_MODEL_ERROR_CAUSES:
+            msg = blocking_terminal_message(classified)
+        else:
+            msg = session._humanize_pilot_error(
+                raw_error or blocking_terminal_message(classified)
+            )
+    except Exception:
+        msg = (
+            blocking_terminal_message(classified)
+            if classified is not None
+            else "Provider transport failed before a clean stop."
+        )
+    payload: Dict[str, Any] = {"error": msg}
+    if classified is None:
+        return payload
+    try:
+        if classified.cause:
+            payload["terminal_cause"] = classified.cause
+        if classified.finish_reason:
+            payload["finish_reason"] = classified.finish_reason
+        if classified.incomplete_reason:
+            payload["incomplete_reason"] = classified.incomplete_reason
+        if classified.stream_terminal:
+            payload["stream_terminal"] = classified.stream_terminal
+    except Exception:
+        pass
+    return payload
+
+
+def emit_classified_provider_error(session: Any, resp: Any) -> Iterator[Any]:
+    """Classify ``resp.error`` before the generic send-loop early return."""
+    from .conversation import ConvEvent
+
+    classified = classify_provider_terminal(resp)
+    try:
+        session._last_provider_terminal = classified
+    except Exception:
+        pass
+    yield ConvEvent("error", classified_terminal_error_payload(
+        session, resp, classified,
+    ))
+
+
+def _response_error_text(resp: Any) -> str:
+    try:
+        error = getattr(resp, "error", None)
+    except Exception:
+        return ""
+    if isinstance(error, bool) or error is None:
+        return ""
+    if isinstance(error, str):
+        return error.strip()
+    try:
+        return str(error).strip()
+    except Exception:
+        return ""
+
+
+def native_tools_blocked(
+    classified: Any,
+    resp: Any,
+    tool_calls: Any,
+    *,
+    is_native: bool,
+    has_actions: bool,
+) -> bool:
+    """True only for an intermediate tool close whose args cannot execute."""
+    if not is_native or not has_actions:
+        return False
+    if classified is None or not classified.is_intermediate:
+        return False
+    return not provider_tools_are_executable(resp, tool_calls=tool_calls)
+
+
+def apply_provider_terminal(session: Any, resp: Any) -> Iterator[Any]:
+    """Classify the latest provider close and yield an error when blocked.
+
+    Generator return is ``(classified, blocked)``. Intermediate tool-call
+    closes are not blocked so parsed actions can still run.
+    """
+    from .conversation import ConvEvent
+
+    classified = classify_provider_terminal(resp)
+    if (
+        classified.cause == TERMINAL_UNSPECIFIED
+        and not classified.has_provider_signal
+        and not _response_error_text(resp)
+    ):
+        if (
+            is_structurally_complete_envelope(resp)
+            and not pilot_requires_explicit_terminal(session)
+        ):
+            classified = classified._replace(
+                cause=TERMINAL_NATURAL,
+                is_affirmative_natural=True,
+                blocks_clean_finalize=False,
+            )
+        else:
+            try:
+                text = getattr(resp, "text", None) or ""
+            except Exception:
+                text = ""
+            if not str(text).strip():
+                # Empty synthetic/stream body is not a provider close.
+                try:
+                    session._last_provider_terminal = classified
+                except Exception:
+                    pass
+                return classified, False
+    try:
+        session._last_provider_terminal = classified
+    except Exception:
+        pass
+    if not classified.blocks_clean_finalize or classified.is_intermediate:
+        return classified, False
+    yield ConvEvent(
+        "error",
+        classified_terminal_error_payload(session, resp, classified),
+    )
+    return classified, True
+
+
+def emit_stagnation_halt(
+    session: Any,
+    *,
+    last_classified: Any,
+    user_message: str,
+    step: int,
+    swarms: Any,
+    turn_prose: list,
+    turn_findings: list,
+) -> Iterator[Any]:
+    """Emit the stagnation auto-halt notice and close the turn."""
+    from .conversation import ConvEvent
+
+    halt_msg = loop_exit_message(TERMINAL_STAGNATION)
+    yield ConvEvent("notice", {"message": halt_msg, "kind": "stagnation"})
+    yield ConvEvent("message", {"role": "assistant", "text": halt_msg})
+    session._display_transcript.append({
+        "type": "message", "role": "assistant", "text": halt_msg,
+    })
+    yield from finalize_assistant_turn(
+        session, user_message=user_message, step=step,
+        swarms=swarms, turn_prose=turn_prose,
+        turn_findings=turn_findings,
+        extra={"stagnation_halt": True},
+        stop_cause=TERMINAL_STAGNATION,
+        **classified_finish_kwargs(last_classified),
+    )
+
+
+def emit_loop_exit_close(
+    session: Any,
+    *,
+    loop_exit_cause: Any,
+    last_classified: Any,
+    user_message: str,
+    step: int,
+    swarms: Any,
+    turn_prose: list,
+    turn_findings: list,
+) -> Iterator[Any]:
+    """Post-loop close: empty-loop, driver-swap, or true step cap."""
+    from .conversation import ConvEvent
+
+    if loop_exit_cause not in (TERMINAL_EMPTY_LOOP, TERMINAL_DRIVER_SWAP):
+        loop_exit_cause = TERMINAL_STEP_CAP
+    limit_msg = loop_exit_message(loop_exit_cause)
+    yield ConvEvent("message", {"role": "assistant", "text": limit_msg})
+    session._display_transcript.append({
+        "type": "message", "role": "assistant", "text": limit_msg,
+    })
+    yield from finalize_assistant_turn(
+        session, user_message=user_message, step=step, swarms=swarms,
+        turn_prose=turn_prose, turn_findings=turn_findings,
+        stop_cause=loop_exit_cause,
+        **classified_finish_kwargs(last_classified),
     )
 
 
@@ -550,6 +845,64 @@ def run_stream(
         q.put(("error", ex))
 
 
+SYNC_COMPLETE_WIRE_MODE = "sync_complete"
+SYNC_COMPLETE_FINISH_REASON = "completed"
+
+_EXPLICIT_COMPLETE_FINISH_KEYS = (
+    "finish_reason",
+    "stop_reason",
+    "finishReason",
+    "stream_terminal",
+    "incomplete_reason",
+)
+
+
+def stamp_sync_complete_terminal(resp: Any) -> Any:
+    """Authoritative application terminal for a successful ``complete()`` return.
+
+    Used only at the synchronous ``complete()`` dispatch seam. Never invents a
+    natural close when ``resp.error`` is set or explicit finish metadata is
+    already present. ``chat`` / ``chat_stream`` must keep fail-closed provider
+    rules unchanged.
+    """
+    if resp is None:
+        return resp
+    try:
+        error = getattr(resp, "error", None)
+    except Exception:
+        return resp
+    if isinstance(error, bool):
+        error = None
+    if isinstance(error, str) and not error.strip():
+        error = None
+    if error:
+        return resp
+    try:
+        meta = getattr(resp, "meta", None)
+    except Exception:
+        meta = None
+    if not isinstance(meta, dict):
+        meta = {}
+        try:
+            resp.meta = meta
+        except Exception:
+            return resp
+    has_explicit = False
+    for key in _EXPLICIT_COMPLETE_FINISH_KEYS:
+        raw = meta.get(key)
+        if isinstance(raw, str) and raw.strip():
+            has_explicit = True
+            break
+        if raw is not None and not isinstance(raw, (str, bool)) and str(raw).strip():
+            has_explicit = True
+            break
+    if not _receipt_meta_label(meta, "wire_mode"):
+        meta["wire_mode"] = SYNC_COMPLETE_WIRE_MODE
+    if not has_explicit:
+        meta["finish_reason"] = SYNC_COMPLETE_FINISH_REASON
+    return resp
+
+
 def dispatch_pilot_provider_call(
     session: Any,
     *,
@@ -645,6 +998,7 @@ def dispatch_pilot_provider_call(
             pass
     _mark_provider_dispatch_invoked(session)
     resp = session.pilot.complete(prompt, **complete_kwargs)
+    stamp_sync_complete_terminal(resp)
     _finish_and_attach_timing(accumulator, resp)
     return "", resp
 
@@ -1230,17 +1584,51 @@ def drain_stream_queue(q: Any, accumulator: Any = None) -> Iterator[Any]:
             raise val
 
 
+# Receipts stay success only for a clean natural / executable-tool close.
+# Incomplete, length, filter, EOF, unspecified, and transport closes are errors
+# even when DriverResponse.error is left unset.
+_RECEIPT_ERROR_CAUSES = frozenset({
+    TERMINAL_INCOMPLETE,
+    TERMINAL_LENGTH,
+    TERMINAL_CONTENT_FILTER,
+    TERMINAL_PROVIDER_EOF,
+    TERMINAL_UNSPECIFIED,
+    TERMINAL_TRANSPORT_ERROR,
+})
+
+
 def classify_provider_receipt_status(resp: Any) -> str:
-    """Map a driver response to a receipt terminal status. Never raises."""
+    """Map a driver response to a receipt terminal status. Never raises.
+
+    Status follows the normalized terminal cause, not only ``resp.error``.
+    Old v1 receipts that omit ``terminal_cause`` still read via
+    ``sanitize_receipt``.
+    """
     try:
         error = getattr(resp, "error", None) if resp is not None else None
-        if not error:
-            return "success"
-        from pmharness.drivers import error_classifier
-        err_cls = error_classifier.classify(None, error)
-        if err_cls == error_classifier.ErrorClass.CONTEXT_OVERFLOW:
-            return "context_overflow"
-        return "error"
+        if error:
+            from pmharness.drivers import error_classifier
+            err_cls = error_classifier.classify(None, error)
+            if err_cls == error_classifier.ErrorClass.CONTEXT_OVERFLOW:
+                return "context_overflow"
+        classified = classify_provider_terminal(resp)
+        if classified.cause in _RECEIPT_ERROR_CAUSES:
+            return "error"
+        if classified.cause == TERMINAL_INCOMPLETE:
+            return "error"
+        meta = getattr(resp, "meta", None) if resp is not None else None
+        if isinstance(meta, dict):
+            incomplete_tools = meta.get("incomplete_tool_calls")
+            if isinstance(incomplete_tools, list) and incomplete_tools:
+                return "error"
+            raw_tools = meta.get("tool_calls")
+            if isinstance(raw_tools, list) and raw_tools and not classified.allows_tool_execution:
+                return "error"
+        if error:
+            return "error"
+        if classified.blocks_clean_finalize and not classified.is_intermediate:
+            return "error"
+        return "success"
     except Exception:
         return "error"
 
@@ -1268,6 +1656,101 @@ def _receipt_meta_label(meta: Any, key: str) -> str:
     if not text or "\n" in text or "\x00" in text or len(text) > 128:
         return ""
     return text
+
+
+def _receipt_requested_output_cap(session: Any, meta: Dict[str, Any]) -> Any:
+    for key in (
+        "requested_output_cap", "max_output_tokens", "max_tokens",
+        "maxOutputTokens",
+    ):
+        if key in meta:
+            value = meta.get(key)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                return value
+    try:
+        cap = getattr(getattr(session, "pilot", None), "max_tokens", None)
+        if isinstance(cap, int) and not isinstance(cap, bool) and cap >= 0:
+            return cap
+    except Exception:
+        pass
+    return None
+
+
+def _receipt_terminal_kwargs(session: Any, resp: Any, status: Any = None) -> Dict[str, Any]:
+    """Sanitized provider-terminal fields for a stream receipt. Never raises."""
+    try:
+        classified = classify_provider_terminal(resp)
+        if resp is None and str(status or "").strip().lower() == "error":
+            classified = classify_provider_terminal(error="transport failed")
+        meta = getattr(resp, "meta", None) if resp is not None else None
+        if not isinstance(meta, dict):
+            meta = {}
+        out: Dict[str, Any] = {}
+        if classified.cause:
+            out["terminal_cause"] = classified.cause
+        if classified.finish_reason:
+            out["finish_reason"] = classified.finish_reason
+        if classified.incomplete_reason:
+            out["incomplete_reason"] = classified.incomplete_reason
+        api_mode = _receipt_meta_label(meta, "api_mode") or _receipt_meta_label(
+            meta, "wire_mode",
+        )
+        if api_mode:
+            out["api_mode"] = api_mode
+        if classified.stream_terminal:
+            out["stream_terminal"] = classified.stream_terminal
+            out["last_provider_event"] = classified.stream_terminal
+        last_event = _receipt_meta_label(meta, "last_provider_event")
+        if last_event:
+            out["last_provider_event"] = last_event
+        if "stream_started" in meta and isinstance(meta.get("stream_started"), bool):
+            out["stream_started"] = meta["stream_started"]
+        elif classified.has_provider_signal and classified.stream_terminal:
+            out["stream_started"] = True
+        malformed = meta.get("malformed_sse_chunks")
+        if isinstance(malformed, int) and not isinstance(malformed, bool) and malformed >= 0:
+            out["malformed_chunk_count"] = malformed
+        cap = _receipt_requested_output_cap(session, meta)
+        if cap is not None:
+            out["requested_output_cap"] = cap
+        wire = _receipt_meta_label(meta, "wire_mode")
+        if not wire:
+            if classified.stream_terminal or meta.get("stream_started") is True:
+                wire = "stream"
+            elif classified.has_provider_signal:
+                wire = "sync"
+        if wire:
+            out["wire_mode"] = wire
+        out["assistant_done_emitted"] = False
+        return out
+    except Exception:
+        return {}
+
+
+def mark_latest_receipt_assistant_done(
+    session: Any,
+    *,
+    stop_cause: str = "",
+    finish_reason: str = "",
+    incomplete_reason: str = "",
+) -> None:
+    """Patch the newest sidecar receipt after assistant_done. Never raises."""
+    try:
+        sid = str(getattr(session, "harness_session_id", "") or "").strip()
+        state_dir = str(getattr(session, "state_dir", "") or "").strip()
+        if not sid or not state_dir:
+            return
+        fields: Dict[str, Any] = {"assistant_done_emitted": True}
+        cause = canonicalize_terminal_cause(stop_cause)
+        if cause:
+            fields["terminal_cause"] = cause
+        if finish_reason:
+            fields["finish_reason"] = finish_reason
+        if incomplete_reason:
+            fields["incomplete_reason"] = incomplete_reason
+        StreamPerformanceReceiptStore(state_dir).patch_latest_receipt(sid, **fields)
+    except Exception:
+        return
 
 
 def _receipt_identity_kwargs(resp: Any, driver: str) -> Dict[str, Any]:
@@ -1371,6 +1854,7 @@ def record_provider_stream_receipt(
             model=_receipt_model_label(session, resp, driver),
             status=status,
             **_receipt_identity_kwargs(resp, driver),
+            **_receipt_terminal_kwargs(session, resp, status),
         )
         StreamPerformanceReceiptStore(state_dir).record(sid, receipt)
     except Exception:
@@ -1649,6 +2133,9 @@ def drain_idle_turn(
     swarms: Any,
     turn_prose: list,
     turn_findings: list,
+    stop_cause: str = "",
+    finish_reason: str = "",
+    incomplete_reason: str = "",
 ) -> Iterator[Any]:
     """No-actions path: deliver pending steers / queued prompts, or finalize.
 
@@ -1795,6 +2282,9 @@ def drain_idle_turn(
         swarms=swarms,
         turn_prose=turn_prose,
         turn_findings=turn_findings,
+        stop_cause=finalize_stop_cause(None, loop_cause=stop_cause),
+        finish_reason=finish_reason,
+        incomplete_reason=incomplete_reason,
     )
     return ("return", user_message)
 

--- a/harness/stream_performance_store.py
+++ b/harness/stream_performance_store.py
@@ -28,6 +28,8 @@ import threading
 import time
 from typing import Any, Dict, Iterator, List, Optional
 
+from .terminal_cause import TERMINAL_CAUSES, canonicalize_terminal_cause
+
 from .paths import _resolve, path_within
 from .stream_performance import (
     BACKEND_READY_TOTAL_MS,
@@ -42,13 +44,19 @@ from .stream_performance import (
     THROUGHPUT_BASIS_KEY,
 )
 
-RECEIPT_SCHEMA_VERSION = 1
+RECEIPT_SCHEMA_VERSION = 2
+RECEIPT_SCHEMA_VERSION_V1 = 1
 MAX_RECEIPTS_PER_SESSION = 200
 RECEIPT_STATUSES = frozenset({"success", "error", "context_overflow"})
 RECEIPT_IDENTITY_STATUSES = frozenset({
     "verified", "mismatch", "unreported", "auto",
 })
 RECEIPT_TOKEN_BASES = frozenset({"provider", "unknown"})
+RECEIPT_WIRE_MODES = frozenset({
+    "chat_completions", "responses", "codex_responses",
+    "messages", "generate_content", "converse", "stream", "sync",
+    "sync_complete",
+})
 PERFORMANCE_SUBDIR = "stream_performance"
 _LOAD_MAX_BYTES = 2 * 1024 * 1024
 _MAX_LABEL_CHARS = 128
@@ -434,6 +442,23 @@ def _model_from_driver(driver: str) -> str:
     return text
 
 
+def _safe_bool(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _receipt_schema_version(value: Any) -> int:
+    """Accept v1 reads; new writes use the current schema."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return RECEIPT_SCHEMA_VERSION
+    if number == RECEIPT_SCHEMA_VERSION_V1:
+        return RECEIPT_SCHEMA_VERSION_V1
+    return RECEIPT_SCHEMA_VERSION
+
+
 def build_receipt(
     *,
     session_id: str,
@@ -454,6 +479,18 @@ def build_receipt(
     cache_read_tokens: Any = None,
     cache_write_tokens: Any = None,
     token_basis: Any = "",
+    terminal_cause: Any = "",
+    finish_reason: Any = "",
+    incomplete_reason: Any = "",
+    api_mode: Any = "",
+    wire_mode: Any = "",
+    requested_output_cap: Any = None,
+    stream_started: Any = None,
+    stream_terminal: Any = "",
+    last_provider_event: Any = "",
+    malformed_chunk_count: Any = None,
+    assistant_done_emitted: Any = None,
+    schema_version: Any = None,
 ) -> Dict[str, Any]:
     """Fixed JSON-safe receipt. Unknown / unsafe fields are dropped."""
     sid = safe_session_id(str(session_id or ""))
@@ -466,7 +503,7 @@ def build_receipt(
     driver_s = _safe_label(driver)
     model_s = _safe_label(model) or _model_from_driver(driver_s)
     receipt: Dict[str, Any] = {
-        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "schema_version": _receipt_schema_version(schema_version),
         "session_id": sid,
         "turn_index": _safe_int(
             turn_index, default=0, minimum=0, maximum=_MAX_NONNEG_INT,
@@ -514,6 +551,39 @@ def build_receipt(
     basis = str(token_basis or "").strip().lower()
     if basis in RECEIPT_TOKEN_BASES:
         receipt["token_basis"] = basis
+    cause = canonicalize_terminal_cause(terminal_cause)
+    if cause and cause in TERMINAL_CAUSES:
+        receipt["terminal_cause"] = cause
+    finish_s = _safe_label(finish_reason)
+    if finish_s:
+        receipt["finish_reason"] = finish_s
+    incomplete_s = _safe_label(incomplete_reason)
+    if incomplete_s:
+        receipt["incomplete_reason"] = incomplete_s
+    api_s = _safe_label(api_mode)
+    if api_s:
+        receipt["api_mode"] = api_s
+    wire_s = _safe_label(wire_mode)
+    if wire_s and (wire_s in RECEIPT_WIRE_MODES or len(wire_s) <= _MAX_LABEL_CHARS):
+        receipt["wire_mode"] = wire_s
+    cap = _bounded_nonneg_int(requested_output_cap)
+    if cap is not None:
+        receipt["requested_output_cap"] = cap
+    started = _safe_bool(stream_started)
+    if started is not None:
+        receipt["stream_started"] = started
+    stream_term = _safe_label(stream_terminal)
+    if stream_term:
+        receipt["stream_terminal"] = stream_term
+    last_event = _safe_label(last_provider_event)
+    if last_event:
+        receipt["last_provider_event"] = last_event
+    malformed = _bounded_nonneg_int(malformed_chunk_count)
+    if malformed is not None:
+        receipt["malformed_chunk_count"] = malformed
+    done_flag = _safe_bool(assistant_done_emitted)
+    if done_flag is not None:
+        receipt["assistant_done_emitted"] = done_flag
     return receipt
 
 
@@ -542,6 +612,18 @@ def sanitize_receipt(raw: Any) -> Optional[Dict[str, Any]]:
         cache_read_tokens=raw.get("cache_read_tokens"),
         cache_write_tokens=raw.get("cache_write_tokens"),
         token_basis=raw.get("token_basis", ""),
+        terminal_cause=raw.get("terminal_cause", ""),
+        finish_reason=raw.get("finish_reason", ""),
+        incomplete_reason=raw.get("incomplete_reason", ""),
+        api_mode=raw.get("api_mode", ""),
+        wire_mode=raw.get("wire_mode", ""),
+        requested_output_cap=raw.get("requested_output_cap"),
+        stream_started=raw.get("stream_started"),
+        stream_terminal=raw.get("stream_terminal", ""),
+        last_provider_event=raw.get("last_provider_event", ""),
+        malformed_chunk_count=raw.get("malformed_chunk_count"),
+        assistant_done_emitted=raw.get("assistant_done_emitted"),
+        schema_version=raw.get("schema_version"),
     )
 
 
@@ -742,6 +824,34 @@ class StreamPerformanceReceiptStore:
         except Exception:
             return
 
+    def patch_latest_receipt(self, session_id: str, **fields: Any) -> None:
+        """Best-effort in-place update of the newest receipt. Never raises."""
+        try:
+            path = _usable_receipt_path(self.state_dir, session_id, create_dir=False)
+            if not path:
+                return
+            with _receipt_lock(path):
+                if _is_symlink(path) or _is_symlink(os.path.dirname(path)):
+                    return
+                rows = _load_document(path)
+                if not rows:
+                    return
+                latest = dict(rows[-1])
+                latest.update(fields)
+                cleaned = sanitize_receipt(latest)
+                if cleaned is None:
+                    return
+                cleaned["session_id"] = safe_session_id(session_id) or cleaned["session_id"]
+                rows[-1] = cleaned
+                payload = {
+                    "schema_version": RECEIPT_SCHEMA_VERSION,
+                    "session_id": cleaned["session_id"],
+                    "receipts": rows,
+                }
+                _atomic_write_json(path, payload)
+        except Exception:
+            return
+
     def delete_session(self, session_id: str) -> None:
         try:
             path = _usable_receipt_path(self.state_dir, session_id)
@@ -764,6 +874,7 @@ def remove_session_performance_receipts(state_dir: str, session_id: str) -> None
 __all__ = (
     "MAX_RECEIPTS_PER_SESSION",
     "RECEIPT_SCHEMA_VERSION",
+    "RECEIPT_SCHEMA_VERSION_V1",
     "RECEIPT_STATUSES",
     "RECEIPT_IDENTITY_STATUSES",
     "RECEIPT_TOKEN_BASES",

--- a/harness/terminal_cause.py
+++ b/harness/terminal_cause.py
@@ -1,0 +1,605 @@
+"""Typed provider / send-loop terminal causes.
+
+Python 3.9-compatible vocabulary plus a pure classifier. Unknown or missing
+provider reasons never become ``natural``. Loop-level closes (step cap,
+turn budget, stagnation, …) are named here so finalize/receipts share one
+allowlist. Stdlib only; never raises on the hot path.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, FrozenSet, List, NamedTuple, Optional
+
+# Canonical vocabulary. ``tool_calls`` is the intermediate/tool-use close;
+# ``invalid_tool`` is the auto-halt invalid-tool close.
+TERMINAL_NATURAL = "natural"
+TERMINAL_TOOL_CALLS = "tool_calls"
+TERMINAL_LENGTH = "length"
+TERMINAL_INCOMPLETE = "incomplete"
+TERMINAL_CONTENT_FILTER = "content_filter"
+TERMINAL_PROVIDER_EOF = "provider_eof"
+TERMINAL_TRANSPORT_ERROR = "transport_error"
+TERMINAL_CANCELLED = "cancelled"
+TERMINAL_STEP_CAP = "step_cap"
+TERMINAL_TURN_BUDGET = "turn_budget"
+TERMINAL_STAGNATION = "stagnation"
+TERMINAL_INVALID_TOOL = "invalid_tool"
+TERMINAL_EMPTY_LOOP = "empty_loop"
+TERMINAL_DRIVER_SWAP = "driver_swap"
+
+# Fail-closed label when a provider reason is missing or unrecognized.
+TERMINAL_UNSPECIFIED = "unspecified"
+
+TERMINAL_CAUSES: FrozenSet[str] = frozenset({
+    TERMINAL_NATURAL,
+    TERMINAL_TOOL_CALLS,
+    TERMINAL_LENGTH,
+    TERMINAL_INCOMPLETE,
+    TERMINAL_CONTENT_FILTER,
+    TERMINAL_PROVIDER_EOF,
+    TERMINAL_TRANSPORT_ERROR,
+    TERMINAL_CANCELLED,
+    TERMINAL_STEP_CAP,
+    TERMINAL_TURN_BUDGET,
+    TERMINAL_STAGNATION,
+    TERMINAL_INVALID_TOOL,
+    TERMINAL_EMPTY_LOOP,
+    TERMINAL_DRIVER_SWAP,
+    TERMINAL_UNSPECIFIED,
+})
+
+# Aliases accepted when reading provider / Wave 1 labels.
+_CAUSE_ALIASES = {
+    "intermediate": TERMINAL_TOOL_CALLS,
+    "tool_use": TERMINAL_TOOL_CALLS,
+    "tool-calls": TERMINAL_TOOL_CALLS,
+    "auto_halt": TERMINAL_INVALID_TOOL,
+    "invalid-tool": TERMINAL_INVALID_TOOL,
+    "eof": TERMINAL_PROVIDER_EOF,
+    "error": TERMINAL_TRANSPORT_ERROR,
+    "transport": TERMINAL_TRANSPORT_ERROR,
+}
+
+# Provider dialects that mean an affirmative natural stop (no tools).
+_NATURAL_REASONS = frozenset({
+    "stop",
+    "end_turn",
+    "end-turn",
+    "completed",
+    "complete",
+    "stop_sequence",
+    "stop-sequence",
+})
+
+# Gemini uses uppercase STOP for a clean end (or for function calls).
+_GEMINI_NATURAL = frozenset({"STOP", "stop"})
+
+_LENGTH_REASONS = frozenset({
+    "length",
+    "max_tokens",
+    "max-tokens",
+    "max_output_tokens",
+    "max-output-tokens",
+    "MAX_TOKENS",
+})
+
+_TOOL_REASONS = frozenset({
+    "tool_calls",
+    "tool_use",
+    "tool-use",
+    "FUNCTION_CALL",
+    "function_call",
+})
+
+_FILTER_REASONS = frozenset({
+    "content_filter",
+    "content_filtered",
+    "content-filter",
+    "SAFETY",
+    "RECITATION",
+    "BLOCKLIST",
+    "PROHIBITED_CONTENT",
+    "SPII",
+    "IMAGE_SAFETY",
+    "LANGUAGE",
+    "refusal",
+    "guardrail_intervened",
+    "guardrail",
+})
+
+_CANCEL_REASONS = frozenset({
+    "cancelled",
+    "canceled",
+    "user_cancelled",
+    "user_canceled",
+    "interrupted",
+})
+
+_FAILED_REASONS = frozenset({
+    "failed",
+    "error",
+    "MALFORMED_FUNCTION_CALL",
+    "OTHER",
+    "FINISH_REASON_UNSPECIFIED",
+})
+
+_INCOMPLETE_REASONS = frozenset({
+    "incomplete",
+    "empty",
+})
+
+# Missing framing / terminal-less close only. ``incomplete`` is a named
+# model terminal, not an EOF synonym.
+_EOF_REASONS = frozenset({
+    "provider_eof",
+    "eof",
+})
+
+# Causes that must never emit a clean assistant_done success.
+# ``unspecified`` is fail-closed: missing/unknown provider reasons are never
+# coerced to a natural stop.
+BLOCK_CLEAN_FINALIZE: FrozenSet[str] = frozenset({
+    TERMINAL_LENGTH,
+    TERMINAL_INCOMPLETE,
+    TERMINAL_CONTENT_FILTER,
+    TERMINAL_PROVIDER_EOF,
+    TERMINAL_TRANSPORT_ERROR,
+    TERMINAL_CANCELLED,
+    TERMINAL_UNSPECIFIED,
+})
+
+# Wave 1 stream_terminal values that already mean a classified close.
+# ``incomplete`` is the named model terminal; only a missing framing /
+# terminal-less close maps to provider_eof.
+_STREAM_TERMINAL_MAP = {
+    "stop": TERMINAL_NATURAL,
+    "tool_calls": TERMINAL_TOOL_CALLS,
+    "length": TERMINAL_LENGTH,
+    "incomplete": TERMINAL_INCOMPLETE,
+    "empty": TERMINAL_INCOMPLETE,
+    "error": TERMINAL_TRANSPORT_ERROR,
+    "content_filter": TERMINAL_CONTENT_FILTER,
+    "cancelled": TERMINAL_CANCELLED,
+    "canceled": TERMINAL_CANCELLED,
+}
+
+
+class TerminalClassification(NamedTuple):
+    """Pure result of classifying a DriverResponse / error / meta blob."""
+
+    cause: str
+    finish_reason: str
+    incomplete_reason: str
+    stream_terminal: str
+    has_provider_signal: bool
+    is_affirmative_natural: bool
+    is_intermediate: bool
+    blocks_clean_finalize: bool
+    allows_tool_execution: bool
+
+
+def _as_text(value: Any) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    try:
+        return str(value).strip()
+    except Exception:
+        return ""
+
+
+def _norm_reason(value: Any) -> str:
+    return _as_text(value)
+
+
+def canonicalize_terminal_cause(value: Any) -> str:
+    """Map a label onto the vocabulary, or ``\"\"`` when it is not allowlisted."""
+    raw = _as_text(value)
+    if not raw:
+        return ""
+    if raw in TERMINAL_CAUSES:
+        return raw
+    aliased = _CAUSE_ALIASES.get(raw) or _CAUSE_ALIASES.get(raw.lower())
+    if aliased:
+        return aliased
+    lower = raw.lower()
+    if lower in TERMINAL_CAUSES:
+        return lower
+    return ""
+
+
+def _meta_of(resp: Any, meta: Any) -> Dict[str, Any]:
+    if isinstance(meta, dict):
+        return meta
+    if resp is None:
+        return {}
+    try:
+        raw = getattr(resp, "meta", None)
+    except Exception:
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _error_of(resp: Any, error: Any) -> str:
+    if error is not None and not isinstance(error, bool):
+        text = _as_text(error)
+        if text:
+            return text
+    if resp is None:
+        return ""
+    try:
+        return _as_text(getattr(resp, "error", None))
+    except Exception:
+        return ""
+
+
+def _tool_arguments_are_complete(arguments: Any) -> bool:
+    raw = arguments if isinstance(arguments, str) else ""
+    if not raw.strip():
+        return True
+    try:
+        import json
+        json.loads(raw)
+    except Exception:
+        return False
+    return True
+
+
+def _executable_tool_calls(meta: Dict[str, Any]) -> List[Any]:
+    raw = meta.get("tool_calls")
+    if not isinstance(raw, list):
+        return []
+    out = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        fn = item.get("function") if isinstance(item.get("function"), dict) else {}
+        name = _as_text(fn.get("name") or item.get("name"))
+        if not name:
+            continue
+        args = fn.get("arguments") if fn else item.get("arguments")
+        if not _tool_arguments_are_complete(args):
+            continue
+        out.append(item)
+    return out
+
+
+def _has_incomplete_tools(meta: Dict[str, Any], executable: List[Any]) -> bool:
+    incomplete = meta.get("incomplete_tool_calls")
+    if isinstance(incomplete, list) and incomplete:
+        return True
+    raw = meta.get("tool_calls")
+    if not isinstance(raw, list) or not raw:
+        return False
+    return len(executable) < len([
+        item for item in raw if isinstance(item, dict)
+    ])
+
+
+def _looks_like_transport_error(error: str) -> bool:
+    if not error:
+        return False
+    lowered = error.lower()
+    needles = (
+        "http ",
+        "timeout",
+        "timed out",
+        "connection",
+        "reset",
+        "broken pipe",
+        "urlopen",
+        "ssl",
+        "network",
+        "502",
+        "503",
+        "504",
+        "429",
+    )
+    return any(n in lowered for n in needles)
+
+
+def _map_finish_reason(
+    finish: str,
+    *,
+    incomplete_reason: str,
+    executable_tools: List[Any],
+) -> Optional[str]:
+    """Map a raw provider finish/stop reason. None = unrecognized / missing."""
+    if not finish:
+        return None
+    if finish in _LENGTH_REASONS or finish.lower() in {r.lower() for r in _LENGTH_REASONS}:
+        return TERMINAL_LENGTH
+    if finish in _FILTER_REASONS or finish.lower() in {r.lower() for r in _FILTER_REASONS}:
+        return TERMINAL_CONTENT_FILTER
+    if finish in _CANCEL_REASONS or finish.lower() in {r.lower() for r in _CANCEL_REASONS}:
+        return TERMINAL_CANCELLED
+    if finish in _TOOL_REASONS or finish.lower() in {r.lower() for r in _TOOL_REASONS}:
+        return TERMINAL_TOOL_CALLS
+    if finish in _FAILED_REASONS or finish.lower() in {r.lower() for r in _FAILED_REASONS}:
+        if finish.lower() == "failed":
+            return TERMINAL_TRANSPORT_ERROR
+        return TERMINAL_INCOMPLETE
+    if finish.lower() in _INCOMPLETE_REASONS:
+        inc = incomplete_reason.lower()
+        if inc in ("max_output_tokens", "length", "max_tokens"):
+            return TERMINAL_LENGTH
+        if inc == "content_filter":
+            return TERMINAL_CONTENT_FILTER
+        return TERMINAL_INCOMPLETE
+    if finish.lower() in _EOF_REASONS and finish.lower() != "incomplete":
+        return TERMINAL_PROVIDER_EOF
+    if finish in _NATURAL_REASONS or finish.lower() in _NATURAL_REASONS:
+        if executable_tools:
+            return TERMINAL_TOOL_CALLS
+        return TERMINAL_NATURAL
+    if finish in _GEMINI_NATURAL:
+        if executable_tools:
+            return TERMINAL_TOOL_CALLS
+        return TERMINAL_NATURAL
+    return None
+
+
+def _map_stream_terminal(stream_terminal: str) -> Optional[str]:
+    if not stream_terminal:
+        return None
+    mapped = _STREAM_TERMINAL_MAP.get(stream_terminal) or _STREAM_TERMINAL_MAP.get(
+        stream_terminal.lower()
+    )
+    return mapped
+
+
+def classify_provider_terminal(
+    resp: Any = None,
+    *,
+    error: Any = None,
+    meta: Any = None,
+) -> TerminalClassification:
+    """Normalize DriverResponse / error / meta into one terminal cause.
+
+    Never raises. Input usage, cache hits, and context-percent fields are
+    ignored — only finish/stream/error/tool evidence counts. Missing or
+    unknown provider reasons are ``unspecified`` / ``incomplete``, never
+    ``natural``.
+    """
+    try:
+        blob = _meta_of(resp, meta)
+        err = _error_of(resp, error)
+        finish = _norm_reason(
+            blob.get("finish_reason")
+            or blob.get("stop_reason")
+            or blob.get("finishReason")
+        )
+        incomplete_reason = _norm_reason(blob.get("incomplete_reason"))
+        stream_terminal = _norm_reason(blob.get("stream_terminal"))
+        executable = _executable_tool_calls(blob)
+        incomplete_tools = _has_incomplete_tools(blob, executable)
+        stream_started = blob.get("stream_started")
+        has_signal = bool(
+            finish
+            or stream_terminal
+            or incomplete_reason
+            or err
+            or stream_started is True
+            or executable
+            or incomplete_tools
+        )
+
+        cause: Optional[str] = None
+
+        # Wave 1 stream_terminal is already fail-closed; prefer it when present.
+        mapped_stream = _map_stream_terminal(stream_terminal)
+        mapped_finish = _map_finish_reason(
+            finish,
+            incomplete_reason=incomplete_reason,
+            executable_tools=executable,
+        )
+
+        if mapped_stream is not None:
+            cause = mapped_stream
+            # Length / transport / filter from stream_terminal win over a
+            # contradictory success finish. Tool-call finish can refine stop.
+            if cause == TERMINAL_NATURAL and mapped_finish == TERMINAL_TOOL_CALLS:
+                cause = TERMINAL_TOOL_CALLS
+            if cause == TERMINAL_NATURAL and executable:
+                cause = TERMINAL_TOOL_CALLS
+            if cause in (TERMINAL_PROVIDER_EOF, TERMINAL_INCOMPLETE):
+                if mapped_finish == TERMINAL_LENGTH:
+                    cause = TERMINAL_LENGTH
+                elif mapped_finish == TERMINAL_CONTENT_FILTER:
+                    cause = TERMINAL_CONTENT_FILTER
+                else:
+                    inc = incomplete_reason.lower()
+                    if inc in ("max_output_tokens", "length", "max_tokens"):
+                        cause = TERMINAL_LENGTH
+                    elif inc == "content_filter":
+                        cause = TERMINAL_CONTENT_FILTER
+        elif mapped_finish is not None:
+            cause = mapped_finish
+        elif err:
+            lowered = err.lower()
+            if "content_filter" in lowered or "content filter" in lowered:
+                cause = TERMINAL_CONTENT_FILTER
+            elif "finish_reason=length" in lowered or "max_tokens" in lowered:
+                cause = TERMINAL_LENGTH
+            elif "cancelled" in lowered or "canceled" in lowered or "interrupted" in lowered:
+                cause = TERMINAL_CANCELLED
+            elif _looks_like_transport_error(err):
+                cause = TERMINAL_TRANSPORT_ERROR
+            elif stream_started is True:
+                cause = TERMINAL_PROVIDER_EOF
+            else:
+                cause = TERMINAL_TRANSPORT_ERROR if err else TERMINAL_UNSPECIFIED
+
+        if cause is None and incomplete_reason:
+            inc = incomplete_reason.lower()
+            if inc in ("max_output_tokens", "length", "max_tokens"):
+                cause = TERMINAL_LENGTH
+            elif inc == "content_filter":
+                cause = TERMINAL_CONTENT_FILTER
+            else:
+                cause = TERMINAL_INCOMPLETE
+
+        if cause is None and incomplete_tools and not executable:
+            cause = TERMINAL_INCOMPLETE
+
+        if cause is None and executable and not err:
+            # Tools without a recognized finish are intermediate, not natural.
+            cause = TERMINAL_TOOL_CALLS
+
+        if cause is None:
+            # Missing / unknown provider reason: fail closed.
+            if stream_started is True and not finish and not stream_terminal:
+                cause = TERMINAL_PROVIDER_EOF
+            elif has_signal and finish and mapped_finish is None:
+                cause = TERMINAL_UNSPECIFIED
+            elif has_signal and not finish and not stream_terminal and err:
+                cause = TERMINAL_TRANSPORT_ERROR
+            else:
+                cause = TERMINAL_UNSPECIFIED
+
+        if cause == TERMINAL_TOOL_CALLS and incomplete_tools and not executable:
+            cause = TERMINAL_INCOMPLETE
+
+        if cause in (TERMINAL_LENGTH, TERMINAL_INCOMPLETE, TERMINAL_PROVIDER_EOF):
+            allows_tools = False
+        elif cause == TERMINAL_TOOL_CALLS and executable:
+            allows_tools = True
+        else:
+            allows_tools = False
+
+        is_natural = cause == TERMINAL_NATURAL
+        blocks = cause in BLOCK_CLEAN_FINALIZE or cause == TERMINAL_UNSPECIFIED
+        return TerminalClassification(
+            cause=cause,
+            finish_reason=finish,
+            incomplete_reason=incomplete_reason,
+            stream_terminal=stream_terminal,
+            has_provider_signal=has_signal,
+            is_affirmative_natural=is_natural,
+            is_intermediate=cause == TERMINAL_TOOL_CALLS,
+            blocks_clean_finalize=blocks,
+            allows_tool_execution=allows_tools,
+        )
+    except Exception:
+        return TerminalClassification(
+            cause=TERMINAL_UNSPECIFIED,
+            finish_reason="",
+            incomplete_reason="",
+            stream_terminal="",
+            has_provider_signal=False,
+            is_affirmative_natural=False,
+            is_intermediate=False,
+            blocks_clean_finalize=True,
+            allows_tool_execution=False,
+        )
+
+
+def provider_tools_are_executable(
+    resp: Any = None,
+    *,
+    meta: Any = None,
+    tool_calls: Any = None,
+) -> bool:
+    """True only when classified tools may reach ``execute_turn_actions``."""
+    try:
+        classified = classify_provider_terminal(resp, meta=meta)
+        if not classified.allows_tool_execution:
+            return False
+        blob = _meta_of(resp, meta)
+        if tool_calls is None:
+            tool_calls = blob.get("tool_calls")
+        if not isinstance(tool_calls, list) or not tool_calls:
+            return False
+        for item in tool_calls:
+            if not isinstance(item, dict):
+                return False
+            fn = item.get("function") if isinstance(item.get("function"), dict) else {}
+            args = fn.get("arguments") if fn else item.get("arguments")
+            if not _tool_arguments_are_complete(args):
+                return False
+        return True
+    except Exception:
+        return False
+
+
+def blocking_terminal_message(classified: TerminalClassification) -> str:
+    """Short, truthful user-facing line for a blocked provider close."""
+    cause = classified.cause
+    if cause == TERMINAL_LENGTH:
+        return "Provider stopped: output length limit (finish_reason=length)."
+    if cause == TERMINAL_CONTENT_FILTER:
+        return "Provider refused the response (content filter)."
+    if cause == TERMINAL_PROVIDER_EOF:
+        return "Provider stream ended without a finish_reason (incomplete)."
+    if cause == TERMINAL_TRANSPORT_ERROR:
+        return "Provider transport failed before a clean stop."
+    if cause == TERMINAL_CANCELLED:
+        return "Provider call was cancelled."
+    if cause == TERMINAL_INCOMPLETE:
+        return "Provider returned an incomplete response."
+    return "Provider stopped without an affirmative natural finish."
+
+
+def loop_exit_message(cause: str) -> str:
+    """User-facing line for send-loop closes that are not provider terminals."""
+    if cause == TERMINAL_EMPTY_LOOP:
+        return "(No productive reply this turn — stopping.)"
+    if cause == TERMINAL_DRIVER_SWAP:
+        return "(Queued prompt needs a different driver — ending this turn.)"
+    if cause == TERMINAL_STEP_CAP:
+        return "(Reached the investigation step limit for this message.)"
+    if cause == TERMINAL_TURN_BUDGET:
+        return "(Reached the output token budget for this turn.)"
+    if cause == TERMINAL_STAGNATION:
+        return (
+            "Stopped: repeated the same response and actions "
+            "with no new progress (auto-halt). Tell me how to "
+            "continue, or try a narrower ask."
+        )
+    return "(Turn ended.)"
+
+
+def finalize_stop_cause(
+    classified: Optional[TerminalClassification],
+    *,
+    loop_cause: str = "",
+) -> str:
+    """Pick the assistant_done stop_cause. Loop causes win when provided."""
+    named = canonicalize_terminal_cause(loop_cause)
+    if named:
+        return named
+    if classified is None:
+        return TERMINAL_UNSPECIFIED
+    if classified.is_affirmative_natural:
+        return TERMINAL_NATURAL
+    if classified.cause in TERMINAL_CAUSES:
+        return classified.cause
+    return TERMINAL_UNSPECIFIED
+
+
+__all__ = (
+    "BLOCK_CLEAN_FINALIZE",
+    "TERMINAL_CAUSES",
+    "TERMINAL_CANCELLED",
+    "TERMINAL_CONTENT_FILTER",
+    "TERMINAL_DRIVER_SWAP",
+    "TERMINAL_EMPTY_LOOP",
+    "TERMINAL_INCOMPLETE",
+    "TERMINAL_INVALID_TOOL",
+    "TERMINAL_LENGTH",
+    "TERMINAL_NATURAL",
+    "TERMINAL_PROVIDER_EOF",
+    "TERMINAL_STAGNATION",
+    "TERMINAL_STEP_CAP",
+    "TERMINAL_TOOL_CALLS",
+    "TERMINAL_TRANSPORT_ERROR",
+    "TERMINAL_TURN_BUDGET",
+    "TERMINAL_UNSPECIFIED",
+    "TerminalClassification",
+    "blocking_terminal_message",
+    "canonicalize_terminal_cause",
+    "classify_provider_terminal",
+    "finalize_stop_cause",
+    "loop_exit_message",
+    "provider_tools_are_executable",
+)

--- a/pmharness/drivers/anthropic.py
+++ b/pmharness/drivers/anthropic.py
@@ -136,6 +136,7 @@ def _anthropic_cache_meta(usage_fields: dict) -> dict:
 
 class AnthropicDriver:
     supports_streaming = True
+    requires_explicit_terminal = True
 
     def __init__(self, name: str, model: str, *,
                  base_url: str = "https://api.anthropic.com/v1",

--- a/pmharness/drivers/bedrock.py
+++ b/pmharness/drivers/bedrock.py
@@ -189,6 +189,7 @@ def _safe_callback(cb: Optional[Callable], *args) -> None:
 class BedrockDriver:
     # Real mid-invoke deltas via ConverseStream (or bedrock_chat_stream).
     supports_streaming = True
+    requires_explicit_terminal = True
 
     def __init__(
         self,

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -48,10 +48,12 @@ _CODEX_LENGTH_CONTINUE = (
     "prior text. Finish the answer directly.]"
 )
 _CODEX_MAX_INCOMPLETE_RETRIES = 3
-# After a visible final_answer with no tools, do not wait forever for
-# response.completed. Codex keepalives reset a long socket timeout, which
-# left Electron on Still working until Stop sealed the already-buffered
-# summary. Drain a short idle for in-flight summary tokens, then finish.
+# ChatGPT Codex only: after a visible final_answer with no tools, do not
+# wait forever for response.completed. Codex keepalives reset a long socket
+# timeout, which left Electron on Still working until Stop sealed the
+# already-buffered summary. Drain a short idle for in-flight summary tokens,
+# then finish. Non-ChatGPT Responses hosts (OpenCode Go Muse, etc.) must
+# wait for an authoritative terminal instead of forging completed.
 _POST_ANSWER_SLICE_SECONDS = 0.25
 _POST_ANSWER_IDLE_SECONDS = 0.5
 _POST_ANSWER_MAX_SECONDS = 2.0
@@ -244,6 +246,34 @@ def _tools_to_responses(tools: Optional[list]) -> Optional[List[dict]]:
                 "parameters": t.get("parameters") or {"type": "object", "properties": {}},
             })
     return out or None
+
+
+def _codex_stream_terminal_fields(raw: dict, finish: str, err_msg: Optional[str]) -> dict:
+    """Authoritative stream stamps so receipts do not infer wire_mode=sync."""
+    status = str(raw.get("status") or "")
+    last_event = str(raw.get("last_provider_event") or "").strip()
+    if finish == "content_filter":
+        terminal = "content_filter"
+        last_event = last_event or "response.incomplete"
+    elif err_msg or status == "failed" or finish == "failed":
+        terminal = "error"
+        last_event = last_event or "response.failed"
+    elif status == "incomplete" or finish == "incomplete":
+        terminal = "incomplete"
+        last_event = last_event or "response.incomplete"
+    elif status == "completed" or finish in ("completed", "stop"):
+        terminal = "stop"
+        last_event = last_event or "response.completed"
+    else:
+        terminal = "incomplete"
+        last_event = last_event or "response.incomplete"
+    out = {
+        "stream_started": True,
+        "stream_terminal": terminal,
+    }
+    if last_event:
+        out["last_provider_event"] = last_event
+    return out
 
 
 def _incomplete_reason(raw: dict) -> str:
@@ -490,6 +520,7 @@ def _consume_codex_sse(
     on_delta: Optional[Callable[..., None]] = None,
     on_reasoning_delta: Optional[Callable[..., None]] = None,
     on_stream_item_done: Optional[Callable[..., None]] = None,
+    chatgpt_backend: bool = True,
 ) -> dict:
     """Consume Codex Responses SSE; return a synthetic Responses-shaped dict.
 
@@ -499,6 +530,11 @@ def _consume_codex_sse(
     Channel ownership is keyed by ``item_id`` / ``output_index`` — never by the
     most-recently-added item. Commentary is visible progress; analysis/reasoning
     stay on the reasoning stream; final_answer is the answer stream.
+
+    The post-answer idle drain (forge ``completed`` after 0.5s idle / 2.0s
+    total) is ChatGPT-only. Non-ChatGPT Responses hosts wait for
+    ``response.completed`` / ``incomplete`` / ``failed``; EOF or ``[DONE]``
+    without that terminal is incomplete/error and keeps partial text.
     """
     collected_items: List[dict] = []
     text_deltas: List[str] = []
@@ -519,6 +555,7 @@ def _consume_codex_sse(
     saw_terminal = False
     stream_error: Optional[str] = None
     answer_item_done = False
+    last_provider_event = ""
 
     def _remember_item(
         item: dict,
@@ -586,6 +623,8 @@ def _consume_codex_sse(
 
     def _finish_tool_free_answer():
         nonlocal saw_terminal, terminal_status
+        if not chatgpt_backend:
+            return
         saw_terminal = True
         terminal_status = "completed"
         _seal_open_channels(("progress", "reasoning", "answer"), "")
@@ -597,7 +636,7 @@ def _consume_codex_sse(
         keepalive_streak = 0
 
     def _should_finish_drain():
-        if not post_answer_drain or has_tool_calls:
+        if not chatgpt_backend or not post_answer_drain or has_tool_calls:
             return False
         now = time.monotonic()
         if now - last_meaningful >= _POST_ANSWER_IDLE_SECONDS:
@@ -616,6 +655,8 @@ def _consume_codex_sse(
         """Start the short post-answer drain. False means caller should stop."""
         nonlocal post_answer_drain, drain_started, last_meaningful
         nonlocal keepalive_streak
+        if not chatgpt_backend:
+            return True
         if has_tool_calls:
             return True
         if post_answer_drain:
@@ -639,7 +680,8 @@ def _consume_codex_sse(
             break
         except (TimeoutError, socket.timeout):
             if (
-                not has_tool_calls
+                chatgpt_backend
+                and not has_tool_calls
                 and (answer_item_done or text_deltas or collected_items)
             ):
                 _finish_tool_free_answer()
@@ -679,6 +721,8 @@ def _consume_codex_sse(
         if not isinstance(event, dict):
             continue
         event_type = str(event.get("type") or "")
+        if event_type:
+            last_provider_event = event_type
 
         if event_type == "error":
             stream_error = str(
@@ -850,6 +894,7 @@ def _consume_codex_sse(
             "output_text": "",
             "usage": {},
             "error": stream_error,
+            "last_provider_event": last_provider_event or "error",
         }
 
     if collected_items:
@@ -871,6 +916,7 @@ def _consume_codex_sse(
             "output_text": "",
             "usage": {},
             "error": "Codex Responses stream did not emit a terminal response",
+            "last_provider_event": last_provider_event,
         }
 
     assembled_text = "".join(text_deltas)
@@ -886,6 +932,10 @@ def _consume_codex_sse(
             err_msg = str(terminal_error)[:800]
         else:
             err_msg = "Codex response failed"
+    if not saw_terminal and not chatgpt_backend:
+        terminal_status = "incomplete"
+        if not err_msg:
+            err_msg = "Codex Responses stream ended without a terminal response"
 
     out = {
         "status": terminal_status,
@@ -895,6 +945,7 @@ def _consume_codex_sse(
         "usage": terminal_usage if isinstance(terminal_usage, dict) else {},
         "error": err_msg,
         "model": terminal_model,
+        "last_provider_event": last_provider_event,
     }
     if terminal_incomplete_details is not None:
         out["incomplete_details"] = terminal_incomplete_details
@@ -904,6 +955,8 @@ def _consume_codex_sse(
 class CodexResponsesDriver:
     # ChatGPT Codex backend requires stream=true; expose real SSE to the pilot.
     supports_streaming = True
+    # Network driver: never accept implicit JSON-envelope natural.
+    requires_explicit_terminal = True
 
     def __init__(
         self,
@@ -998,6 +1051,7 @@ class CodexResponsesDriver:
             payload_messages = payload_messages[1:]
         # ChatGPT Codex backend rejects max_output_tokens (HTTP 400
         # "Unsupported parameter"); Hermes omits it when is_codex_backend.
+        # Non-ChatGPT Responses hosts (OpenCode Go) honor the stored cap.
         #
         # Request a reasoning summary so the pilot UI can leave
         # "Waiting on provider…" and paint Thought while gpt-5.x thinks.
@@ -1013,6 +1067,12 @@ class CodexResponsesDriver:
             "store": False,
             "stream": True,  # required by chatgpt.com/backend-api/codex
         }
+        if (
+            not self.chatgpt_backend
+            and isinstance(self.max_tokens, int)
+            and self.max_tokens > 0
+        ):
+            body["max_output_tokens"] = int(self.max_tokens)
         if api_effort:
             body["reasoning"] = {"effort": api_effort, "summary": "auto"}
         resp_tools = _tools_to_responses(tools)
@@ -1092,6 +1152,7 @@ class CodexResponsesDriver:
                         on_delta=on_delta,
                         on_reasoning_delta=on_reasoning_delta,
                         on_stream_item_done=on_stream_item_done,
+                        chatgpt_backend=self.chatgpt_backend,
                     )
                 return raw, None, data
             except urllib.error.HTTPError as e:
@@ -1158,30 +1219,23 @@ class CodexResponsesDriver:
         t0: float,
         incomplete_retries: int = 0,
     ) -> DriverResponse:
-        if raw.get("error"):
-            return DriverResponse(
-                text="", model=self.name, error=str(raw["error"]),
-                latency_ms=(time.time() - t0) * 1000.0,
-                meta={
-                    "api_mode": "codex_responses",
-                    "finish_reason": raw.get("status"),
-                },
-            )
         text, tool_calls, finish = _extract_text_and_tools(raw)
         if not text and isinstance(raw.get("output_text"), str):
             text = raw["output_text"]
         if finish == "content_filter":
+            meta = {
+                "api_mode": "codex_responses",
+                "finish_reason": "content_filter",
+                "billing": "plan",
+                "requested_model": self.model,
+            }
+            meta.update(_codex_stream_terminal_fields(raw, finish, _CONTENT_FILTER_MSG))
             return DriverResponse(
                 text="",
                 model=self.name,
                 error=_CONTENT_FILTER_MSG,
                 latency_ms=(time.time() - t0) * 1000.0,
-                meta={
-                    "api_mode": "codex_responses",
-                    "finish_reason": "content_filter",
-                    "billing": "plan",
-                    "requested_model": self.model,
-                },
+                meta=meta,
             )
         usage = raw.get("usage") or {}
         tin, tout = _usage_ints(usage)
@@ -1217,12 +1271,16 @@ class CodexResponsesDriver:
         served = raw.get("model")
         if isinstance(served, str) and served.strip():
             meta["served_model"] = served.strip()
+        raw_error = raw.get("error")
+        err_msg = str(raw_error) if raw_error else None
+        meta.update(_codex_stream_terminal_fields(raw, finish, err_msg))
         return DriverResponse(
             text=text,
             tokens_in=tin,
             tokens_out=tout,
             latency_ms=(time.time() - t0) * 1000.0,
             model=self.name,
+            error=err_msg,
             meta=meta,
         )
 
@@ -1427,6 +1485,30 @@ class CodexResponsesDriver:
                 tool_calls = (resp.meta or {}).get("tool_calls") or []
                 finish = str((resp.meta or {}).get("finish_reason") or "")
                 kind = _codex_continuation_kind(finish, text, tool_calls)
+                # ChatGPT-only: incomplete continuation re-POSTs a nudge.
+                # Non-ChatGPT Muse (and other Responses hosts) must return the
+                # first preserved partial and never auto-POST a second stream.
+                if kind is not None and not self.chatgpt_backend:
+                    meta = _final_meta(resp.meta or {})
+                    reason = str(meta.get("incomplete_reason") or finish or "incomplete")
+                    err = resp.error or (
+                        f"Codex response incomplete ({reason})"
+                    )
+                    if "stream_started" not in meta:
+                        meta["stream_started"] = True
+                    if "stream_terminal" not in meta:
+                        meta["stream_terminal"] = "incomplete"
+                    return _attach_request_cache_diagnostics(
+                        DriverResponse(
+                            text=text,
+                            tokens_in=acc_tin,
+                            tokens_out=acc_tout,
+                            latency_ms=resp.latency_ms,
+                            model=self.name,
+                            error=err,
+                            meta=meta,
+                        )
+                    )
                 if kind is None:
                     final_text = "".join(length_parts) + text if length_parts else text
                     if incomplete_retries == 0 and final_text == text:

--- a/pmharness/drivers/cursor_acp.py
+++ b/pmharness/drivers/cursor_acp.py
@@ -18,7 +18,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from .base import SYSTEM_PROMPT, DriverResponse
 from .cursor_cli import (
@@ -905,10 +905,135 @@ class WarmAcpSession:
         return out
 
 
+# session/prompt JSON-RPC success is the ACP completed event. Known stopReason
+# variants map onto the shared terminal vocabulary; missing stopReason stamps
+# completed from that event (not text shape). Unrecognized reasons fail closed.
+_ACP_API_MODE = "cursor_acp"
+_ACP_WIRE_MODE = "cursor_acp"
+_ACP_LAST_PROVIDER_EVENT = "session/prompt"
+
+_ACP_NATURAL_STOPS = frozenset({
+    "end_turn",
+    "stop",
+    "completed",
+    "complete",
+    "stop_sequence",
+})
+_ACP_LENGTH_STOPS = frozenset({
+    "max_tokens",
+    "length",
+    "max_output_tokens",
+})
+_ACP_INCOMPLETE_STOPS = frozenset({
+    "incomplete",
+    "empty",
+    "max_turn_requests",
+})
+_ACP_FILTER_STOPS = frozenset({
+    "refusal",
+    "content_filter",
+    "content_filtered",
+})
+_ACP_CANCEL_STOPS = frozenset({
+    "cancelled",
+    "canceled",
+    "user_cancelled",
+    "user_canceled",
+    "interrupted",
+})
+_ACP_ERROR_STOPS = frozenset({
+    "error",
+    "failed",
+})
+
+
+def _as_acp_stop_text(value: Any) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    try:
+        return str(value).strip()
+    except Exception:
+        return ""
+
+
+def _acp_stop_key(value: Any) -> str:
+    return _as_acp_stop_text(value).lower().replace("-", "_")
+
+
+def _cursor_acp_terminal_fields(
+    stop_reason: Any,
+    *,
+    result: Any = None,
+    stream_started: bool = True,
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Authoritative stamps for a successful ACP ``session/prompt`` close.
+
+    Returns ``(meta, error)``. Natural stops and a missing ``stopReason`` on
+    the JSON-RPC completed event stamp ``completed`` + ``stop``. Length,
+    incomplete, filter, cancel, and error stay truthful and never look like
+    a clean finish. Unrecognized ``stopReason`` fails closed. Never infers
+    completion from assistant text shape.
+    """
+    raw = _as_acp_stop_text(stop_reason)
+    if not raw and isinstance(result, dict):
+        raw = _as_acp_stop_text(
+            result.get("stopReason") or result.get("stop_reason")
+        )
+    key = _acp_stop_key(raw)
+    finish = ""
+    terminal = "incomplete"
+    err: Optional[str] = None
+    if not key:
+        # JSON-RPC success of session/prompt is the completed event.
+        finish = "completed"
+        terminal = "stop"
+    elif key in _ACP_NATURAL_STOPS:
+        finish = "completed"
+        terminal = "stop"
+    elif key in _ACP_LENGTH_STOPS:
+        finish = "length"
+        terminal = "length"
+        err = f"ACP prompt finished with stopReason={raw}"
+    elif key in _ACP_INCOMPLETE_STOPS:
+        finish = "incomplete"
+        terminal = "incomplete"
+        err = f"ACP prompt finished with stopReason={raw}"
+    elif key in _ACP_FILTER_STOPS:
+        finish = "content_filter"
+        terminal = "content_filter"
+        err = f"ACP prompt finished with stopReason={raw}"
+    elif key in _ACP_CANCEL_STOPS:
+        finish = "cancelled"
+        terminal = "cancelled"
+        err = f"ACP prompt finished with stopReason={raw}"
+    elif key in _ACP_ERROR_STOPS:
+        finish = "failed"
+        terminal = "error"
+        err = f"ACP prompt finished with stopReason={raw}"
+    else:
+        finish = raw
+        terminal = "incomplete"
+        err = f"ACP prompt finished with unrecognized stopReason={raw}"
+    meta = {
+        "finish_reason": finish,
+        "stream_terminal": terminal,
+        "stream_started": bool(stream_started),
+        "api_mode": _ACP_API_MODE,
+        "wire_mode": _ACP_WIRE_MODE,
+        "last_provider_event": _ACP_LAST_PROVIDER_EVENT,
+        "stop_reason": raw,
+    }
+    return meta, err
+
+
 class CursorAcpDriver:
     """Warm ACP pilot with automatic --print fallback."""
 
     supports_streaming = True
+    # Production Cursor path: fail closed without an explicit provider terminal.
+    requires_explicit_terminal = True
 
     def __init__(
         self,
@@ -1051,6 +1176,13 @@ class CursorAcpDriver:
         tin = int(out.get("tokens_in") or 0)
         tout = int(out.get("tokens_out") or 0)
         requested = (self.model or "").strip()
+        # session/prompt JSON-RPC success is the stream close. Host tools stay
+        # empty so incomplete/error terminals cannot execute truncated calls.
+        terminal_meta, terminal_error = _cursor_acp_terminal_fields(
+            out.get("stop_reason"),
+            result=out.get("result"),
+            stream_started=True,
+        )
         meta = {
             "tool_calls": [],
             "session_id": out.get("session_id") or "",
@@ -1058,7 +1190,6 @@ class CursorAcpDriver:
             "cursor_acp": True,
             "cursor_cli_internal_tools": [],
             "host_tools_ignored": True,
-            "stop_reason": out.get("stop_reason"),
             # Plan credits — $ meter is estimate-only unless agent returns cost.
             "billing": "plan",
             "reasoning": str(out.get("reasoning") or ""),
@@ -1068,6 +1199,7 @@ class CursorAcpDriver:
             "identity_status": IDENTITY_AUTO,
             "token_basis": "provider" if (tin or tout) else "unknown",
         }
+        meta.update(terminal_meta)
         cost = out.get("provider_cost_usd")
         if cost is not None:
             try:
@@ -1086,6 +1218,7 @@ class CursorAcpDriver:
             tokens_out=tout,
             latency_ms=(time.time() - t0) * 1000.0,
             model=self.name,
+            error=terminal_error,
             meta=meta,
         )
 

--- a/pmharness/drivers/cursor_cli.py
+++ b/pmharness/drivers/cursor_cli.py
@@ -534,6 +534,8 @@ def consume_stream_json(
     final_result_text = ""
     usage: dict = {}
     saw_partial = False
+    last_event_type = ""
+    stream_started = False
 
     for raw in lines:
         if isinstance(raw, bytes):
@@ -558,6 +560,9 @@ def consume_stream_json(
             usage = usage_blob
 
         etype = event.get("type")
+        if etype:
+            last_event_type = str(etype)
+            stream_started = True
         if etype == "system" and event.get("subtype") == "init":
             session_id = str(event.get("session_id") or session_id)
             model = str(event.get("model") or model)
@@ -651,6 +656,8 @@ def consume_stream_json(
         "session_id": session_id,
         "model": model,
         "raw_result": final_result_text,
+        "last_event_type": last_event_type,
+        "stream_started": stream_started,
     }
 
 
@@ -880,10 +887,46 @@ def _looks_like_resume_failure(text: str) -> bool:
     return any(marker in lower for marker in _RESUME_FAILURE_MARKERS)
 
 
+def _cursor_cli_success_terminal_meta(parsed: dict) -> dict:
+    """Authoritative terminal stamps for a successful Cursor Agent process close.
+
+    chat / chat_stream share ``_run_stream``. Do not invent a natural close
+    on cancelled, nonzero, error, or partial process failure — callers must
+    only merge this after a clean wait + exit 0 and no ``err``.
+    """
+    last = ""
+    try:
+        last = str(parsed.get("last_event_type") or "").strip()
+    except Exception:
+        last = ""
+    started = False
+    try:
+        started = bool(
+            parsed.get("stream_started")
+            or parsed.get("text")
+            or last
+        )
+    except Exception:
+        started = bool(last)
+    out = {
+        "finish_reason": "completed",
+        "stream_terminal": "stop",
+        "stream_started": started,
+        "api_mode": "cursor_cli",
+        "wire_mode": "cursor_cli_stream",
+    }
+    if last:
+        out["last_provider_event"] = last
+    return out
+
+
 class CursorCliDriver:
     """Pilot driver backed by the Cursor Agent CLI subprocess."""
 
     supports_streaming = True
+    # Local subprocess, but still a production chat path: never accept an
+    # implicit JSON-envelope natural. Stamp finish/stream_terminal on success.
+    requires_explicit_terminal = True
 
     def __init__(
         self,
@@ -1220,6 +1263,11 @@ class CursorCliDriver:
             if _cursor_usage_reports_cache_write(usage_blob):
                 meta["cache_write_tokens"] = int(cache_write)
             attach_modality_fields(meta, usage_detail)
+
+            # Successful process close only. Timeout / nonzero / identity /
+            # resume / parsed-error paths keep fail-closed (no natural stamp).
+            if not err and proc.returncode in (0, None):
+                meta.update(_cursor_cli_success_terminal_meta(parsed))
 
             # Verified exact requested model keeps the picker label. A true
             # mismatch must not stamp that label as the served fact.

--- a/pmharness/drivers/gemini.py
+++ b/pmharness/drivers/gemini.py
@@ -17,6 +17,7 @@ from .retry import with_retry
 
 class GeminiDriver:
     supports_streaming = True
+    requires_explicit_terminal = True
 
     def __init__(self, name: str, model: str, *,
                  base_url: str = "https://generativelanguage.googleapis.com/v1beta",

--- a/pmharness/drivers/openai_compat.py
+++ b/pmharness/drivers/openai_compat.py
@@ -25,11 +25,381 @@ from .retry import with_retry
 from pmharness.reasoning import extract_reasoning, strip_think_blocks
 from pmharness.think_scrubber import StreamingThinkScrubber
 
+_SUCCESS_CHAT_FINISH = frozenset({"stop", "stop_sequence", "end_turn"})
+_TOOL_CHAT_FINISH = frozenset({"tool_calls", "function_call"})
+_LENGTH_CHAT_FINISH = frozenset({"length", "max_tokens", "max_output_tokens"})
+_FILTER_CHAT_FINISH = frozenset({"content_filter"})
+_INCOMPLETE_CHAT_FINISH = frozenset({"incomplete", "empty"})
+
+
+def _norm_chat_finish(finish) -> str:
+    """Case-insensitive provider finish token. Empty stays empty."""
+    if finish is None or isinstance(finish, bool):
+        return ""
+    try:
+        return str(finish).strip().lower()
+    except Exception:
+        return ""
+
+
+def _tool_arguments_are_complete(arguments) -> bool:
+    """True when tool arguments are empty or parse as JSON.
+
+    Empty arguments are valid for no-arg tools. Nonempty text that does
+    not parse is truncated mid-stream and must not dispatch.
+    """
+    raw = arguments if isinstance(arguments, str) else ""
+    if not raw.strip():
+        return True
+    try:
+        json.loads(raw)
+    except Exception:
+        return False
+    return True
+
+
+def _executable_stream_tool_calls(assembled: dict, finish_reason: str) -> list:
+    """Return only tool calls that are safe to dispatch.
+
+    Missing ids stay empty so the conversation layer can canonicalize them.
+    Truncated arguments and length-capped / filtered streams never become
+    executable ``tool_calls``. A tool close is executable only when the
+    finish is ``tool_calls`` / ``function_call`` and arguments parse.
+    """
+    finish = _norm_chat_finish(finish_reason)
+    if finish not in _TOOL_CHAT_FINISH:
+        return []
+    out = []
+    for idx in sorted(assembled.keys(), key=lambda k: (isinstance(k, int), k)):
+        tc = assembled[idx]
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function") or {}
+        name = str(fn.get("name") or "").strip()
+        if not name:
+            continue
+        if not _tool_arguments_are_complete(fn.get("arguments") or ""):
+            continue
+        out.append(tc)
+    return out
+
+
+def _split_chat_tool_calls(raw_calls) -> tuple[list, list]:
+    """Split provider tool_calls into executable vs truncated/incomplete."""
+    assembled: dict = {}
+    if isinstance(raw_calls, list):
+        for idx, tc in enumerate(raw_calls):
+            if isinstance(tc, dict):
+                assembled[idx] = tc
+    elif isinstance(raw_calls, dict):
+        assembled = raw_calls
+    executable = _executable_stream_tool_calls(assembled, "tool_calls")
+    return executable, _incomplete_stream_tool_calls(assembled, executable)
+
+
+def _openai_chat_terminal(
+    finish: str,
+    *,
+    executable: list | None = None,
+    incomplete_tools: list | None = None,
+    stream_started: bool = False,
+    malformed_sse_chunks: int = 0,
+    transport_error: str | None = None,
+) -> tuple[str, str | None]:
+    """Classify a chat Completions finish. Never invents a natural stop.
+
+    Returns ``(stream_terminal, error)``. Known reasons are named truthfully.
+    Truncated tool JSON is incomplete even when finish_reason is tool_calls.
+    """
+    if transport_error:
+        return "error", transport_error
+    finish_raw = "" if finish is None or isinstance(finish, bool) else str(finish).strip()
+    finish = _norm_chat_finish(finish_raw)
+    executable = executable or []
+    incomplete_tools = incomplete_tools or []
+    if finish in _LENGTH_CHAT_FINISH:
+        return "length", f"OpenAI chat finished with finish_reason={finish_raw}"
+    if finish in _FILTER_CHAT_FINISH:
+        return "content_filter", f"OpenAI chat finished with finish_reason={finish_raw}"
+    if finish in _INCOMPLETE_CHAT_FINISH:
+        return "incomplete", f"OpenAI chat finished with finish_reason={finish_raw}"
+    if finish in _TOOL_CHAT_FINISH:
+        if incomplete_tools and not executable:
+            return (
+                "incomplete",
+                f"OpenAI chat finished with finish_reason={finish_raw} "
+                "but tool arguments were truncated",
+            )
+        if executable:
+            return "tool_calls", None
+        return (
+            "incomplete",
+            f"OpenAI chat finished with finish_reason={finish_raw} "
+            "but no executable tool calls",
+        )
+    if finish in _SUCCESS_CHAT_FINISH:
+        return "stop", None
+    if finish_raw:
+        return (
+            "incomplete",
+            f"OpenAI chat finished with unrecognized finish_reason={finish_raw}",
+        )
+    if not stream_started:
+        if malformed_sse_chunks:
+            return "empty", "OpenAI chat stream had no valid chunks"
+        return "empty", "OpenAI chat ended without a finish_reason"
+    return "incomplete", "OpenAI chat stream ended without a finish_reason"
+
+
+def _incomplete_stream_tool_calls(assembled: dict, executable: list) -> list:
+    executable_ids = {id(tc) for tc in executable}
+    return [
+        assembled[idx]
+        for idx in sorted(assembled.keys(), key=lambda k: (isinstance(k, int), k))
+        if isinstance(assembled[idx], dict) and id(assembled[idx]) not in executable_ids
+    ]
+
+
+class _OpenAIChatSseAccumulator:
+    """Host-agnostic OpenAI chat Completions SSE parser.
+
+    Ox Alpha, OpenRouter, and OpenCode Go share this contract. Request-body
+    host overlays (stream_options / parallel_tool_calls) stay outside.
+    """
+
+    def __init__(
+        self,
+        *,
+        on_delta=None,
+        on_reasoning_delta=None,
+        on_tool_hint=None,
+    ) -> None:
+        self.on_delta = on_delta
+        self.on_reasoning_delta = on_reasoning_delta
+        self.on_tool_hint = on_tool_hint
+        self.full_text = ""
+        self.reasoning_pieces: list = []
+        self.assembled_tool_calls: dict = {}
+        self.last_tool_call_index = None
+        self.finish_reason = ""
+        self.tokens_in = 0
+        self.tokens_out = 0
+        self.cached_tokens = 0
+        self.cache_write_tokens = 0
+        self.stream_has_cache_read = False
+        self.stream_has_cache_write = False
+        self.provider_cost_usd = None
+        self.stream_raw_usage = None
+        self.served_model = None
+        self.stream_started = False
+        self.saw_done = False
+        self.malformed_sse_chunks = 0
+        self.think_scrubber = StreamingThinkScrubber()
+
+    def feed(self, line) -> bool:
+        """Consume one SSE line. Return False after ``[DONE]``."""
+        line_str = (
+            line.decode("utf-8", "replace").strip()
+            if isinstance(line, bytes)
+            else str(line).strip()
+        )
+        if not line_str:
+            return True
+        if not line_str.startswith("data:"):
+            return True
+        data_str = line_str[5:].strip()
+        if not data_str:
+            return True
+        if data_str == "[DONE]":
+            self.saw_done = True
+            return False
+        try:
+            chunk = json.loads(data_str)
+        except Exception:
+            self.malformed_sse_chunks += 1
+            return True
+        if not isinstance(chunk, dict):
+            self.malformed_sse_chunks += 1
+            return True
+
+        chunk_served = OpenAICompatDriver._served_model_from_payload(chunk)
+        if chunk_served:
+            self.served_model = chunk_served
+
+        chunk_usage = chunk.get("usage")
+        if chunk_usage:
+            from .token_usage import coerce_token_usage_record
+
+            usage_detail = coerce_token_usage_record(chunk_usage)
+            self.tokens_in = int(usage_detail.tokens_in)
+            self.tokens_out = int(usage_detail.tokens_out)
+            if OpenAICompatDriver._usage_reports_cache_read(chunk_usage):
+                self.stream_has_cache_read = True
+                self.cached_tokens = int(usage_detail.cache_read)
+            if OpenAICompatDriver._usage_reports_cache_write(chunk_usage):
+                self.stream_has_cache_write = True
+                self.cache_write_tokens = int(usage_detail.cache_write)
+            self.stream_raw_usage = chunk_usage
+            step_cost = OpenAICompatDriver._cost_from_usage(chunk_usage)
+            if step_cost is not None:
+                self.provider_cost_usd = step_cost
+
+        choices = chunk.get("choices") or []
+        if not choices:
+            return True
+        choice = choices[0]
+        if not isinstance(choice, dict):
+            return True
+        delta = choice.get("delta") or {}
+        if not isinstance(delta, dict):
+            delta = {}
+
+        content_delta = delta.get("content") or ""
+        if content_delta:
+            self.stream_started = True
+            self.full_text += content_delta
+            visible = self.think_scrubber.feed(content_delta)
+            if visible and self.on_delta is not None:
+                self.on_delta(visible)
+
+        reasoning_delta = (
+            delta.get("reasoning")
+            or delta.get("reasoning_content")
+            or ""
+        )
+        if reasoning_delta:
+            self.stream_started = True
+            self.reasoning_pieces.append(reasoning_delta)
+            if self.on_reasoning_delta is not None:
+                self.on_reasoning_delta(reasoning_delta)
+
+        delta_tool_calls = delta.get("tool_calls") or []
+        if delta_tool_calls:
+            self.stream_started = True
+        for chunk_pos, tc in enumerate(delta_tool_calls):
+            if not isinstance(tc, dict):
+                continue
+            idx = OpenAICompatDriver._resolve_stream_tool_call_index(
+                tc,
+                self.assembled_tool_calls,
+                chunk_pos=chunk_pos,
+                chunk_count=len(delta_tool_calls),
+                last_index=self.last_tool_call_index,
+            )
+            self.last_tool_call_index = idx
+            tc_func = tc.get("function") or {}
+            name_piece = tc_func.get("name") or ""
+            if idx not in self.assembled_tool_calls:
+                self.assembled_tool_calls[idx] = {
+                    "id": tc.get("id") or "",
+                    "type": tc.get("type") or "function",
+                    "function": {
+                        "name": name_piece,
+                        "arguments": tc_func.get("arguments") or "",
+                    },
+                }
+            else:
+                existing = self.assembled_tool_calls[idx]
+                if tc.get("id"):
+                    existing["id"] = tc.get("id")
+                if tc.get("type"):
+                    existing["type"] = tc.get("type")
+                if name_piece:
+                    existing["function"]["name"] += name_piece
+                if tc_func.get("arguments"):
+                    existing["function"]["arguments"] += tc_func["arguments"]
+            hint = self.assembled_tool_calls[idx]["function"]["name"]
+            if name_piece and hint and self.on_tool_hint is not None:
+                self.on_tool_hint(hint)
+
+        chunk_finish_reason = choice.get("finish_reason")
+        if chunk_finish_reason:
+            self.finish_reason = chunk_finish_reason
+        return True
+
+    def flush_scrubber(self) -> None:
+        try:
+            scrub_tail = self.think_scrubber.flush()
+        except Exception:
+            scrub_tail = ""
+        if scrub_tail and self.on_delta is not None:
+            self.on_delta(scrub_tail)
+
+    def finalize(self, *, transport_error: str | None = None) -> dict:
+        """Apply fail-closed terminal rules. Never drops accumulated progress."""
+        self.flush_scrubber()
+        message_obj = {"content": self.full_text}
+        accumulated_reasoning = "".join(self.reasoning_pieces)
+        if accumulated_reasoning:
+            message_obj["reasoning"] = accumulated_reasoning
+            message_obj["reasoning_content"] = accumulated_reasoning
+        reasoning = extract_reasoning(message_obj)
+        pure_text = strip_think_blocks(self.full_text)
+        executable = _executable_stream_tool_calls(
+            self.assembled_tool_calls, self.finish_reason,
+        )
+        incomplete_tools = _incomplete_stream_tool_calls(
+            self.assembled_tool_calls, executable,
+        )
+        finish = str(self.finish_reason or "")
+        stream_terminal, error = _openai_chat_terminal(
+            finish,
+            executable=executable,
+            incomplete_tools=incomplete_tools,
+            stream_started=self.stream_started,
+            malformed_sse_chunks=self.malformed_sse_chunks,
+            transport_error=transport_error,
+        )
+        return {
+            "text": pure_text,
+            "reasoning": reasoning,
+            "tool_calls": executable,
+            "incomplete_tool_calls": incomplete_tools,
+            "finish_reason": finish,
+            "tokens_in": self.tokens_in,
+            "tokens_out": self.tokens_out,
+            "stream_started": self.stream_started,
+            "saw_done": self.saw_done,
+            "malformed_sse_chunks": self.malformed_sse_chunks,
+            "stream_terminal": stream_terminal,
+            "error": error,
+            "served_model": self.served_model,
+            "stream_raw_usage": self.stream_raw_usage,
+            "stream_has_cache_read": self.stream_has_cache_read,
+            "stream_has_cache_write": self.stream_has_cache_write,
+            "cached_tokens": self.cached_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
+            "provider_cost_usd": self.provider_cost_usd,
+        }
+
+
+def _consume_openai_chat_sse(
+    lines,
+    *,
+    on_delta=None,
+    on_reasoning_delta=None,
+    on_tool_hint=None,
+    transport_error: str | None = None,
+) -> dict:
+    """Shared OpenAI chat Completions SSE parser used by every host."""
+    acc = _OpenAIChatSseAccumulator(
+        on_delta=on_delta,
+        on_reasoning_delta=on_reasoning_delta,
+        on_tool_hint=on_tool_hint,
+    )
+    for line in lines:
+        if not acc.feed(line):
+            break
+    return acc.finalize(transport_error=transport_error)
+
 
 class OpenAICompatDriver:
     # Explicit capability flag the conversation loop checks (is True) before using the
     # streaming path -- prevents MagicMock test doubles from accidentally streaming.
     supports_streaming = True
+    # Network driver: never accept implicit JSON-envelope natural. Stamp an
+    # explicit finish / stream_terminal or fail closed.
+    requires_explicit_terminal = True
 
     def __init__(
         self,
@@ -692,23 +1062,47 @@ class OpenAICompatDriver:
                 message_obj = choice["message"]
                 text = message_obj.get("content") or ""
                 tool_calls = message_obj.get("tool_calls") or []
-                finish_reason = choice.get("finish_reason") or ""
+                finish_reason = str(choice.get("finish_reason") or "")
             except (KeyError, IndexError, TypeError):
                 return DriverResponse(
                     text="", model=self.name, error=f"unexpected response shape: {str(raw)[:300]}",
                     latency_ms=latency,
                 )
 
+            if not tool_calls:
+                legacy = message_obj.get("function_call")
+                if isinstance(legacy, dict) and str(legacy.get("name") or "").strip():
+                    tool_calls = [{
+                        "id": str(message_obj.get("function_call_id") or ""),
+                        "type": "function",
+                        "function": legacy,
+                    }]
+                    if not finish_reason:
+                        finish_reason = "function_call"
+
             reasoning = extract_reasoning(message_obj)
             pure_text = strip_think_blocks(text)
+            executable, incomplete_tools = _split_chat_tool_calls(tool_calls)
+            if _norm_chat_finish(finish_reason) not in _TOOL_CHAT_FINISH:
+                executable, withheld = [], list(executable) + list(incomplete_tools)
+                incomplete_tools = withheld
+            stream_terminal, chat_error = _openai_chat_terminal(
+                finish_reason,
+                executable=executable,
+                incomplete_tools=incomplete_tools,
+                stream_started=bool(pure_text or executable or incomplete_tools or reasoning),
+            )
 
             usage = raw.get("usage", {}) or {}
             meta = self._usage_meta(usage)
             meta.update({
-                "tool_calls": tool_calls,
+                "tool_calls": executable,
                 "reasoning": reasoning,
                 "finish_reason": finish_reason,
+                "stream_terminal": stream_terminal,
             })
+            if incomplete_tools:
+                meta["incomplete_tool_calls"] = incomplete_tools
             served = self._served_model_from_payload(raw if isinstance(raw, dict) else {})
             if served:
                 meta["served_model"] = served
@@ -721,6 +1115,7 @@ class OpenAICompatDriver:
                 tokens_out=int(usage_detail.tokens_out),
                 latency_ms=latency,
                 model=self.name,
+                error=chat_error,
                 meta=meta,
             )
 
@@ -772,6 +1167,44 @@ class OpenAICompatDriver:
 
         data = json.dumps(body).encode("utf-8")
 
+        def _response_from_acc(
+            acc: _OpenAIChatSseAccumulator,
+            *,
+            t0: float,
+            transport_error: str | None = None,
+        ) -> DriverResponse:
+            parsed = acc.finalize(transport_error=transport_error)
+            meta = {
+                "tool_calls": parsed["tool_calls"],
+                "reasoning": parsed["reasoning"],
+                "finish_reason": parsed["finish_reason"],
+                "stream_started": parsed["stream_started"],
+                "stream_terminal": parsed["stream_terminal"],
+                "malformed_sse_chunks": parsed["malformed_sse_chunks"],
+                "saw_done": parsed["saw_done"],
+            }
+            if parsed["incomplete_tool_calls"]:
+                meta["incomplete_tool_calls"] = parsed["incomplete_tool_calls"]
+            if parsed["stream_has_cache_read"]:
+                meta["cache_read_tokens"] = parsed["cached_tokens"]
+            if parsed["stream_has_cache_write"]:
+                meta["cache_write_tokens"] = parsed["cache_write_tokens"]
+            if parsed["stream_raw_usage"] is not None:
+                meta["raw_usage"] = parsed["stream_raw_usage"]
+            if parsed["provider_cost_usd"] is not None:
+                meta["provider_cost_usd"] = parsed["provider_cost_usd"]
+            if parsed["served_model"]:
+                meta["served_model"] = parsed["served_model"]
+            return DriverResponse(
+                text=parsed["text"],
+                tokens_in=parsed["tokens_in"],
+                tokens_out=parsed["tokens_out"],
+                latency_ms=(time.time() - t0) * 1000.0,
+                model=self.name,
+                error=parsed["error"],
+                meta=meta,
+            )
+
         def _call() -> DriverResponse:
             headers = {
                 "Content-Type": "application/json",
@@ -779,147 +1212,25 @@ class OpenAICompatDriver:
             }
             headers.update(self.extra_headers)
             t0 = time.time()
-            full_text = ""
-            reasoning_pieces = []
-            assembled_tool_calls = {}
-            last_tool_call_index = None
-            finish_reason = ""
-            tokens_in = 0
-            tokens_out = 0
-            cached_tokens = 0
-            cache_write_tokens = 0
-            stream_has_cache_read = False
-            stream_has_cache_write = False
-            provider_cost_usd = None
-            stream_raw_usage = None
-            served_model = None
-            stream_started = False
-            # Hermes-style: suppress <think>/<reasoning> tags that split across
-            # SSE deltas so visible on_delta never leaks mid-stream reasoning.
-            think_scrubber = StreamingThinkScrubber()
+            acc = _OpenAIChatSseAccumulator(
+                on_delta=on_delta,
+                on_reasoning_delta=on_reasoning_delta,
+                on_tool_hint=on_tool_hint,
+            )
 
             req = urllib.request.Request(url, data=data, headers=headers, method="POST")
             try:
                 with urllib.request.urlopen(req, timeout=self.timeout) as resp:
                     for line in resp:
-                        line_str = line.decode("utf-8", "replace").strip()
-                        if not line_str:
-                            continue
-                        if line_str.startswith("data: "):
-                            data_str = line_str[6:].strip()
-                            if data_str == "[DONE]":
-                                break
-                            try:
-                                chunk = json.loads(data_str)
-                            except Exception:
-                                continue
-
-                            chunk_served = self._served_model_from_payload(chunk)
-                            if chunk_served:
-                                served_model = chunk_served
-
-                            # Process token usage if present
-                            chunk_usage = chunk.get("usage")
-                            if chunk_usage:
-                                from .token_usage import coerce_token_usage_record
-
-                                usage_detail = coerce_token_usage_record(chunk_usage)
-                                tokens_in = int(usage_detail.tokens_in)
-                                tokens_out = int(usage_detail.tokens_out)
-                                if self._usage_reports_cache_read(chunk_usage):
-                                    stream_has_cache_read = True
-                                    cached_tokens = int(usage_detail.cache_read)
-                                if self._usage_reports_cache_write(chunk_usage):
-                                    stream_has_cache_write = True
-                                    cache_write_tokens = int(usage_detail.cache_write)
-                                stream_raw_usage = chunk_usage
-                                step_cost = self._cost_from_usage(chunk_usage)
-                                if step_cost is not None:
-                                    provider_cost_usd = step_cost
-
-                            choices = chunk.get("choices") or []
-                            if choices:
-                                choice = choices[0]
-                                delta = choice.get("delta") or {}
-
-                                # Content text delta
-                                content_delta = delta.get("content") or ""
-                                if content_delta:
-                                    stream_started = True
-                                    full_text += content_delta
-                                    visible = think_scrubber.feed(content_delta)
-                                    if visible:
-                                        on_delta(visible)
-
-                                # Reasoning delta -- forward live so the UI can
-                                # paint Thought while tokens climb (GLM/OR
-                                # often stream reasoning before content).
-                                reasoning_delta = (
-                                    delta.get("reasoning")
-                                    or delta.get("reasoning_content")
-                                    or ""
-                                )
-                                if reasoning_delta:
-                                    stream_started = True
-                                    reasoning_pieces.append(reasoning_delta)
-                                    if on_reasoning_delta is not None:
-                                        on_reasoning_delta(reasoning_delta)
-
-                                # Tool calls delta. Receipt itself is stream
-                                # activity, even when a later HTTP error arrives.
-                                delta_tool_calls = delta.get("tool_calls") or []
-                                if delta_tool_calls:
-                                    stream_started = True
-                                for chunk_pos, tc in enumerate(delta_tool_calls):
-                                    if not isinstance(tc, dict):
-                                        continue
-                                    idx = self._resolve_stream_tool_call_index(
-                                        tc,
-                                        assembled_tool_calls,
-                                        chunk_pos=chunk_pos,
-                                        chunk_count=len(delta_tool_calls),
-                                        last_index=last_tool_call_index,
-                                    )
-                                    last_tool_call_index = idx
-                                    tc_func = tc.get("function") or {}
-                                    name_piece = tc_func.get("name") or ""
-                                    if idx not in assembled_tool_calls:
-                                        assembled_tool_calls[idx] = {
-                                            "id": tc.get("id") or "",
-                                            "type": tc.get("type") or "function",
-                                            "function": {
-                                                "name": name_piece,
-                                                "arguments": tc_func.get("arguments") or ""
-                                            }
-                                        }
-                                    else:
-                                        existing = assembled_tool_calls[idx]
-                                        if tc.get("id"):
-                                            existing["id"] = tc.get("id")
-                                        if tc.get("type"):
-                                            existing["type"] = tc.get("type")
-                                        if name_piece:
-                                            existing["function"]["name"] += name_piece
-                                        if tc_func.get("arguments"):
-                                            existing["function"]["arguments"] += tc_func["arguments"]
-
-                                    # Hint only when the name advanced this chunk
-                                    # (arguments-only deltas would otherwise spam).
-                                    _hint = assembled_tool_calls[idx]["function"]["name"]
-                                    if name_piece and _hint and on_tool_hint is not None:
-                                        on_tool_hint(_hint)
-
-                                chunk_finish_reason = choice.get("finish_reason")
-                                if chunk_finish_reason:
-                                    finish_reason = chunk_finish_reason
-
+                        if not acc.feed(line):
+                            break
             except urllib.error.HTTPError as e:
                 detail = e.read().decode("utf-8", "replace")[:500]
                 # Endpoint rejected the `reasoning` field: disable it for the
                 # session and fall back to the non-streaming chat() (which shares
                 # the retry path) so the turn still succeeds. Only safe before any
                 # tokens streamed -- otherwise a partial stream would double-emit.
-                if (not stream_started and self._reasoning_unsupported(e.code, detail)
+                if (not acc.stream_started and self._reasoning_unsupported(e.code, detail)
                         and body.get("reasoning") is not None):
                     self.enable_reasoning = False
                     return self.chat(
@@ -930,14 +1241,14 @@ class OpenAICompatDriver:
                 # non-streaming chat() (drops stream-only fields) before any
                 # content/reasoning/tool delta. Never after stream activity;
                 # never for an actionable 400; never via chat_stream.
-                if not stream_started and self._is_empty_chat_completion_400_stub(
+                if not acc.stream_started and self._is_empty_chat_completion_400_stub(
                     e.code, detail,
                 ):
                     return self.chat(
                         messages, tools=tools, system=system, session_id=session_id,
                     )
                 # Pool rotate only before any tokens streamed (same safety rule).
-                if not stream_started:
+                if not acc.stream_started:
                     nxt = self._pool_rotate_on_http_error(e.code, detail)
                     if nxt:
                         return self.chat_stream(
@@ -949,64 +1260,13 @@ class OpenAICompatDriver:
                             on_reasoning_delta=on_reasoning_delta,
                             on_tool_hint=on_tool_hint,
                         )
-                return DriverResponse(
-                    text="", model=self.name, error=f"HTTP {e.code}: {detail}",
-                    latency_ms=(time.time() - t0) * 1000.0,
-                    meta={"stream_started": stream_started},
+                return _response_from_acc(
+                    acc, t0=t0, transport_error=f"HTTP {e.code}: {detail}",
                 )
             except Exception as e:
-                return DriverResponse(
-                    text="", model=self.name, error=repr(e),
-                    latency_ms=(time.time() - t0) * 1000.0,
-                    meta={"stream_started": stream_started},
-                )
+                return _response_from_acc(acc, t0=t0, transport_error=repr(e))
 
-            latency = (time.time() - t0) * 1000.0
-
-            # Emit any held-back partial-tag tail that was not a real tag.
-            try:
-                scrub_tail = think_scrubber.flush()
-            except Exception:
-                scrub_tail = ""
-            if scrub_tail:
-                on_delta(scrub_tail)
-
-            # Build message_obj to pass to extract_reasoning
-            message_obj = {"content": full_text}
-            accumulated_reasoning = "".join(reasoning_pieces)
-            if accumulated_reasoning:
-                message_obj["reasoning"] = accumulated_reasoning
-                message_obj["reasoning_content"] = accumulated_reasoning
-
-            reasoning = extract_reasoning(message_obj)
-            pure_text = strip_think_blocks(full_text)
-
-            tool_calls = [assembled_tool_calls[i] for i in sorted(assembled_tool_calls.keys())]
-
-            meta = {
-                "tool_calls": tool_calls,
-                "reasoning": reasoning,
-                "finish_reason": finish_reason,
-                "stream_started": stream_started,
-            }
-            if stream_has_cache_read:
-                meta["cache_read_tokens"] = cached_tokens
-            if stream_has_cache_write:
-                meta["cache_write_tokens"] = cache_write_tokens
-            if stream_raw_usage is not None:
-                meta["raw_usage"] = stream_raw_usage
-            if provider_cost_usd is not None:
-                meta["provider_cost_usd"] = provider_cost_usd
-            if served_model:
-                meta["served_model"] = served_model
-            return DriverResponse(
-                text=pure_text,
-                tokens_in=tokens_in,
-                tokens_out=tokens_out,
-                latency_ms=latency,
-                model=self.name,
-                meta=meta,
-            )
+            return _response_from_acc(acc, t0=t0)
 
         return with_retry(_call)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.267"
+version = "0.9.268"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_adaptive_steps.py
+++ b/tests/test_adaptive_steps.py
@@ -22,7 +22,12 @@ class FakePilot:
             self.current_turn += 1
         else:
             txt = '{"say": "Done.", "actions": []}'
-        return DriverResponse(text=txt, tokens_out=10, latency_ms=1.0)
+        return DriverResponse(
+            text=txt,
+            tokens_out=10,
+            latency_ms=1.0,
+            meta={"finish_reason": "stop"},
+        )
 
 
 def test_adaptive_steps_productive_runs_past_10():
@@ -83,12 +88,15 @@ def test_adaptive_steps_stalls_halts_at_threshold(monkeypatch):
         
         events = list(session.send("Let's go!"))
         
-        # The loop should halt at consecutive_non_productive >= 3, which is exactly step 3 (0-indexed 0, 1, 2)
-        # It will yield "Reached the investigation step limit for this message." and assistant_done with turns=3.
+        # Empty non-productive turns must not be labeled as the investigation step cap.
         messages = [e.data.get("text") for e in events if e.kind == "message" and e.data.get("role") == "assistant"]
-        assert any("Reached the investigation step limit for this message" in m for m in messages if m)
+        assert any("No productive reply this turn" in m for m in messages if m)
+        assert not any(
+            m and "investigation step limit" in m for m in messages
+        )
         
         done_event = next(e for e in events if e.kind == "assistant_done")
         assert done_event.data["turns"] == 3
+        assert done_event.data.get("stop_cause") == "empty_loop"
     finally:
         shutil.rmtree(temp_dir)

--- a/tests/test_codex_responses_driver.py
+++ b/tests/test_codex_responses_driver.py
@@ -552,3 +552,210 @@ def test_driver_none_omits_reasoning_block(pool_dir, monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
     d.complete("ping")
     assert "reasoning" not in captured["body"]
+
+
+def test_chatgpt_build_body_omits_max_output_tokens():
+    d = CodexResponsesDriver(name="codex", model="gpt-5.5", max_tokens=2048)
+    body = d._build_body([{"role": "user", "content": "hi"}])
+    assert "max_output_tokens" not in body
+
+
+def test_non_chatgpt_build_body_sends_max_output_tokens():
+    d = CodexResponsesDriver(
+        name="muse",
+        model="muse-spark-1.2-contributor",
+        base_url="https://opencode.ai/zen/go/v1",
+        api_key_env="OPENCODE_GO_API_KEY",
+        max_tokens=2048,
+        chatgpt_backend=False,
+    )
+    body = d._build_body([{"role": "user", "content": "hi"}])
+    assert body["max_output_tokens"] == 2048
+
+
+def test_non_chatgpt_build_body_omits_nonpositive_max_output_tokens():
+    d = CodexResponsesDriver(
+        name="muse",
+        model="muse-spark-1.2-contributor",
+        chatgpt_backend=False,
+        max_tokens=0,
+    )
+    body = d._build_body([{"role": "user", "content": "hi"}])
+    assert "max_output_tokens" not in body
+
+
+def test_consume_sse_non_chatgpt_eof_without_terminal_is_incomplete():
+    lines = [
+        b'data: {"type":"response.output_text.delta","delta":"partial"}\n',
+        b"data: [DONE]\n",
+    ]
+    raw = _consume_codex_sse(lines, chatgpt_backend=False)
+    assert raw["status"] != "completed"
+    assert raw["status"] == "incomplete"
+    assert raw["output_text"] == "partial"
+    assert raw.get("error")
+    text, _, finish = _extract_text_and_tools(raw)
+    assert text == "partial"
+    assert finish == "incomplete"
+
+
+def test_consume_sse_chatgpt_still_seals_after_answer_timeout():
+    """ChatGPT anti-hang drain must not regress when chatgpt_backend defaults."""
+
+    def lines():
+        yield b'data: {"type":"response.output_item.added","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"Test received."}\n'
+        yield b'data: {"type":"response.output_item.done","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        raise TimeoutError("timed out")
+
+    raw = _consume_codex_sse(lines())
+    assert raw["status"] == "completed"
+    assert raw["output_text"] == "Test received."
+    assert not raw.get("error")
+
+
+class _IterResp:
+    def __init__(self, lines):
+        self._lines = lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+
+def _muse_responses_driver():
+    d = CodexResponsesDriver(
+        name="opencode-go:muse-spark-1.2-contributor",
+        model="muse-spark-1.2-contributor",
+        base_url="https://opencode.ai/zen/go/v1",
+        api_key_env="OPENCODE_GO_API_KEY",
+        max_tokens=4096,
+        chatgpt_backend=False,
+    )
+    d._key = lambda: "sk-go-test"
+    return d
+
+
+def test_muse_production_driver_is_non_chatgpt_responses():
+    from pmharness.drivers.openai_compat import OpenAICompatDriver
+
+    d = _muse_responses_driver()
+    assert isinstance(d, CodexResponsesDriver)
+    assert not isinstance(d, OpenAICompatDriver)
+    assert d.chatgpt_backend is False
+
+
+def test_muse_slow_answer_deltas_reach_completed(monkeypatch):
+    """Slow Muse tokens spanning >2s plus a 400ms pause must not seal early."""
+    d = _muse_responses_driver()
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(
+        "pmharness.drivers.codex_responses.time.monotonic",
+        lambda: clock["now"],
+    )
+
+    def lines():
+        yield b'data: {"type":"response.output_item.added","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"Hel"}\n'
+        clock["now"] += 2.2
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"lo"}\n'
+        clock["now"] += 0.4
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"!"}\n'
+        yield b'data: {"type":"response.output_item.done","item":{"type":"message","phase":"final_answer","id":"msg_f","content":[{"type":"output_text","text":"Hello!"}]}}\n'
+        yield b'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":4,"output_tokens":3}}}\n'
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _IterResp(lines()))
+    deltas = []
+    resp = d.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        on_delta=deltas.append,
+    )
+    assert resp.error is None
+    answer = "".join(
+        (p["text"] if isinstance(p, dict) else p) for p in deltas
+    )
+    assert answer == "Hello!"
+    assert resp.text == "Hello!"
+    assert resp.meta["finish_reason"] == "completed"
+    assert resp.tokens_out == 3
+    assert resp.meta.get("stream_started") is True
+    assert resp.meta.get("stream_terminal")
+    assert resp.meta.get("last_provider_event") == "response.completed"
+
+
+def test_muse_eof_without_terminal_preserves_partial_text(monkeypatch):
+    d = _muse_responses_driver()
+
+    def lines():
+        yield b'data: {"type":"response.output_text.delta","delta":"partial answer"}\n'
+        yield b'data: {"usage":{"input_tokens":2,"output_tokens":1}}\n'
+        yield b"data: [DONE]\n"
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _IterResp(lines()))
+    resp = d.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        on_delta=lambda _t: None,
+    )
+    assert resp.error
+    assert "terminal" in resp.error.lower()
+    assert resp.text == "partial answer"
+    assert resp.meta["finish_reason"] != "completed"
+    assert resp.meta.get("stream_started") is True
+    assert resp.meta.get("stream_terminal")
+    assert resp.meta.get("last_provider_event")
+
+
+def test_muse_incomplete_max_output_tokens_does_not_continue(monkeypatch):
+    """Production-shaped Muse cap: one incomplete stream, no second POST."""
+    d = _muse_responses_driver()
+    posts = {"n": 0}
+    item = {
+        "type": "message",
+        "id": "msg_cap",
+        "phase": "final_answer",
+        "content": [{"type": "output_text", "text": "partial muse answer"}],
+    }
+    terminal = {
+        "type": "response.incomplete",
+        "response": {
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "usage": {
+                "input_tokens": 40,
+                "output_tokens": 12,
+                "cost": 0.02,
+            },
+            "model": "muse-spark-1.2-contributor",
+        },
+    }
+
+    def lines():
+        yield f'data: {json.dumps({"type":"response.output_item.done","item":item})}\n'.encode()
+        yield f'data: {json.dumps(terminal)}\n'.encode()
+
+    def fake_urlopen(*_a, **_k):
+        posts["n"] += 1
+        return _IterResp(lines())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    resp = d.chat_stream(
+        [{"role": "user", "content": "write a long essay"}],
+        on_delta=lambda _t: None,
+    )
+    assert posts["n"] == 1
+    assert resp.error
+    assert "incomplete" in (resp.error or "").lower()
+    assert resp.text == "partial muse answer"
+    assert resp.meta["finish_reason"] == "incomplete"
+    assert resp.meta["incomplete_reason"] == "max_output_tokens"
+    assert resp.meta.get("stream_started") is True
+    assert resp.meta.get("stream_terminal")
+    assert resp.meta.get("last_provider_event") == "response.incomplete"
+    assert resp.tokens_in == 40
+    assert resp.tokens_out == 12
+    assert resp.meta.get("incomplete_retries") == 0

--- a/tests/test_cursor_acp_driver.py
+++ b/tests/test_cursor_acp_driver.py
@@ -13,6 +13,7 @@ from pmharness.drivers.cursor_acp import (
     AcpTransport,
     CursorAcpDriver,
     WarmAcpSession,
+    _cursor_acp_terminal_fields,
     _extract_tool_event,
     _extract_tool_hint,
     _extract_update_text,
@@ -77,6 +78,8 @@ class _FakeProc:
         self.set_mode_calls: list[str] = []
         # When set, session/set_mode replies with this JSON-RPC error payload.
         self.set_mode_error: Optional[dict] = None
+        # session/prompt result. None omits stopReason (protocol close only).
+        self.stop_reason: Optional[str] = "end_turn"
         self._agent.start()
 
     def poll(self) -> Optional[int]:
@@ -144,13 +147,12 @@ class _FakeProc:
                         },
                     },
                 )
-                self._reply(
-                    mid,
-                    {
-                        "stopReason": "end_turn",
-                        "usage": {"inputTokens": 120, "outputTokens": 8},
-                    },
-                )
+                result = {
+                    "usage": {"inputTokens": 120, "outputTokens": 8},
+                }
+                if self.stop_reason is not None:
+                    result["stopReason"] = self.stop_reason
+                self._reply(mid, result)
             elif method == "initialized":
                 continue
             elif mid is not None:
@@ -362,14 +364,23 @@ def test_driver_uses_acp_when_session_works(monkeypatch):
         on_delta=deltas.append,
     )
     assert resp.text == "pong-ok"
+    assert resp.error is None
     assert resp.meta.get("cursor_acp") is True
     assert resp.meta.get("billing") == "plan"
     assert resp.meta.get("requested_model") == "auto"
     assert resp.meta.get("identity_status") == "auto"
     assert resp.meta.get("tool_calls") == []
+    assert resp.meta.get("finish_reason") == "completed"
+    assert resp.meta.get("stream_terminal") == "stop"
+    assert resp.meta.get("stream_started") is True
+    assert resp.meta.get("api_mode") == "cursor_acp"
+    assert resp.meta.get("wire_mode") == "cursor_acp"
+    assert resp.meta.get("last_provider_event") == "session/prompt"
+    assert resp.meta.get("stop_reason") == "end_turn"
     assert resp.tokens_in == 120
     assert resp.tokens_out == 8
     assert deltas == ["pong", "-ok"]
+    assert drv.requires_explicit_terminal is True
     drv.close()
 
 
@@ -699,3 +710,218 @@ def test_acp_live_set_mode_failure_invalidates_session(monkeypatch):
     assert session.session_id is None
     assert session.transport is None
     assert fallback.mode == "ask"
+
+
+def _acp_driver(monkeypatch, *, stop_reason="end_turn"):
+    """Production-shaped warm ACP driver with a mocked stdio agent."""
+    proc = _FakeProc()
+    proc.stop_reason = stop_reason
+    transport = AcpTransport(proc)
+    session = WarmAcpSession(
+        model="auto",
+        cwd="C:\\ws",
+        transport_factory=lambda: transport,
+    )
+
+    class NoFallback:
+        def _run_stream(self, *a, **k):
+            raise AssertionError("must not fall back")
+
+    monkeypatch.setenv("HARNESS_CURSOR_ACP", "1")
+    drv = CursorAcpDriver(
+        name="cursor-cli:auto",
+        model="auto",
+        session=session,
+        fallback=NoFallback(),  # type: ignore[arg-type]
+    )
+    return drv
+
+
+@pytest.mark.parametrize(
+    "stop, finish, terminal, has_error",
+    [
+        ("end_turn", "completed", "stop", False),
+        ("end-turn", "completed", "stop", False),
+        ("stop", "completed", "stop", False),
+        ("completed", "completed", "stop", False),
+        ("", "completed", "stop", False),
+        (None, "completed", "stop", False),
+        ("max_tokens", "length", "length", True),
+        ("max-tokens", "length", "length", True),
+        ("length", "length", "length", True),
+        ("max_turn_requests", "incomplete", "incomplete", True),
+        ("incomplete", "incomplete", "incomplete", True),
+        ("refusal", "content_filter", "content_filter", True),
+        ("content_filter", "content_filter", "content_filter", True),
+        ("cancelled", "cancelled", "cancelled", True),
+        ("canceled", "cancelled", "cancelled", True),
+        ("error", "failed", "error", True),
+        ("failed", "failed", "error", True),
+        ("mystery_code", "mystery_code", "incomplete", True),
+    ],
+)
+def test_cursor_acp_terminal_fields_map_stop_reasons(stop, finish, terminal, has_error):
+    meta, err = _cursor_acp_terminal_fields(stop, stream_started=True)
+    assert meta["finish_reason"] == finish
+    assert meta["stream_terminal"] == terminal
+    assert meta["stream_started"] is True
+    assert meta["api_mode"] == "cursor_acp"
+    assert meta["wire_mode"] == "cursor_acp"
+    assert meta["last_provider_event"] == "session/prompt"
+    if has_error:
+        assert err
+        assert meta["finish_reason"] not in ("completed", "stop")
+        assert meta["stream_terminal"] != "stop"
+    else:
+        assert err is None
+        assert meta["finish_reason"] == "completed"
+        assert meta["stream_terminal"] == "stop"
+
+
+def test_cursor_acp_terminal_fields_reads_result_stop_reason():
+    meta, err = _cursor_acp_terminal_fields(
+        None, result={"stopReason": "end_turn"}, stream_started=True,
+    )
+    assert err is None
+    assert meta["finish_reason"] == "completed"
+    assert meta["stop_reason"] == "end_turn"
+
+
+def test_cursor_acp_missing_stop_reason_stamps_completed_not_text(monkeypatch):
+    """Successful session/prompt with no stopReason uses the protocol event."""
+    drv = _acp_driver(monkeypatch, stop_reason=None)
+    resp = drv.chat([{"role": "user", "content": "who are you?"}])
+    assert resp.error is None
+    assert resp.text == "pong-ok"
+    assert resp.meta["finish_reason"] == "completed"
+    assert resp.meta["stream_terminal"] == "stop"
+    assert resp.meta["stream_started"] is True
+    assert resp.meta["api_mode"] == "cursor_acp"
+    assert resp.meta["wire_mode"] == "cursor_acp"
+    assert resp.meta["last_provider_event"] == "session/prompt"
+    assert resp.meta["tool_calls"] == []
+    drv.close()
+
+
+def test_cursor_acp_max_tokens_is_length_not_natural(monkeypatch):
+    drv = _acp_driver(monkeypatch, stop_reason="max_tokens")
+    resp = drv.chat_stream(
+        [{"role": "user", "content": "write a lot"}],
+        on_delta=lambda _t: None,
+    )
+    assert resp.error
+    assert "max_tokens" in resp.error
+    assert resp.text == "pong-ok"
+    assert resp.meta["finish_reason"] == "length"
+    assert resp.meta["stream_terminal"] == "length"
+    assert resp.meta["stop_reason"] == "max_tokens"
+    assert resp.meta["wire_mode"] == "cursor_acp"
+    assert resp.meta["tool_calls"] == []
+    drv.close()
+
+
+def test_cursor_acp_cancelled_and_error_are_not_natural(monkeypatch):
+    cancelled = _acp_driver(monkeypatch, stop_reason="cancelled")
+    c_resp = cancelled.chat([{"role": "user", "content": "hi"}])
+    assert c_resp.error
+    assert c_resp.meta["finish_reason"] == "cancelled"
+    assert c_resp.meta["stream_terminal"] == "cancelled"
+    assert c_resp.meta["finish_reason"] not in ("completed", "stop")
+    assert c_resp.meta["tool_calls"] == []
+    cancelled.close()
+
+    failed = _acp_driver(monkeypatch, stop_reason="error")
+    e_resp = failed.chat([{"role": "user", "content": "hi"}])
+    assert e_resp.error
+    assert e_resp.meta["finish_reason"] == "failed"
+    assert e_resp.meta["stream_terminal"] == "error"
+    assert e_resp.meta["stream_terminal"] != "stop"
+    assert e_resp.meta["tool_calls"] == []
+    failed.close()
+
+
+def test_cursor_acp_unrecognized_stop_reason_fails_closed(monkeypatch):
+    drv = _acp_driver(monkeypatch, stop_reason="mystery_code")
+    resp = drv.chat([{"role": "user", "content": "hi"}])
+    assert resp.error
+    assert "unrecognized" in resp.error
+    assert resp.meta["finish_reason"] == "mystery_code"
+    assert resp.meta["stream_terminal"] == "incomplete"
+    assert resp.meta["finish_reason"] not in ("completed", "stop")
+    assert resp.meta["stream_terminal"] != "stop"
+    assert resp.meta["tool_calls"] == []
+    drv.close()
+
+
+def test_cursor_acp_prose_send_emits_natural_and_records_stream_wire(
+    tmp_path, monkeypatch,
+):
+    """Successful ACP prose finalizes and receipts record streamed ACP wire."""
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+    from harness.stream_performance_store import StreamPerformanceReceiptStore
+
+    monkeypatch.setattr(
+        "harness.send_loop.profile_skips_auto_inject",
+        lambda session: (True, True),
+    )
+    drv = _acp_driver(monkeypatch)
+    cfg = HarnessConfig(
+        driver="cursor-cli:auto",
+        state_dir=str(tmp_path),
+        repo=str(tmp_path),
+    )
+    session = ConversationalSession(cfg)
+    session.harness_session_id = "sess-acp"
+    session.pilot = drv
+    monkeypatch.setattr(session, "_resolve_append_only", lambda: False)
+    monkeypatch.setattr(session, "_get_codegraph_context", lambda msg: "")
+    monkeypatch.setattr(session, "_maybe_compact_history", lambda **k: iter(()))
+    events = list(session.send("who are you?"))
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "natural"
+    assert done.data.get("finish_reason") == "completed"
+    assert not any(e.kind == "error" for e in events)
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-acp")
+    assert rows
+    assert rows[0]["wire_mode"] == "cursor_acp"
+    assert rows[0]["api_mode"] == "cursor_acp"
+    assert rows[0]["stream_started"] is True
+    assert rows[0]["terminal_cause"] == "natural"
+    drv.close()
+
+
+def test_cursor_acp_incomplete_send_does_not_finalize_or_run_tools(
+    tmp_path, monkeypatch,
+):
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+
+    monkeypatch.setattr(
+        "harness.send_loop.profile_skips_auto_inject",
+        lambda session: (True, True),
+    )
+
+    def boom(*_a, **_k):
+        raise AssertionError("execute_turn_actions must not run")
+
+    monkeypatch.setattr("harness.send_loop.execute_turn_actions", boom)
+    drv = _acp_driver(monkeypatch, stop_reason="max_tokens")
+    cfg = HarnessConfig(
+        driver="cursor-cli:auto",
+        state_dir=str(tmp_path),
+        repo=str(tmp_path),
+    )
+    session = ConversationalSession(cfg)
+    session.harness_session_id = "sess-acp-len"
+    session.pilot = drv
+    monkeypatch.setattr(session, "_resolve_append_only", lambda: False)
+    monkeypatch.setattr(session, "_get_codegraph_context", lambda msg: "")
+    monkeypatch.setattr(session, "_maybe_compact_history", lambda **k: iter(()))
+    events = list(session.send("write a long essay"))
+    kinds = [e.kind for e in events]
+    assert "assistant_done" not in kinds
+    err = next(e for e in events if e.kind == "error")
+    assert err.data.get("terminal_cause") == "length"
+    assert err.data.get("finish_reason") == "length"
+    drv.close()

--- a/tests/test_cursor_acp_driver.py
+++ b/tests/test_cursor_acp_driver.py
@@ -867,7 +867,7 @@ def test_cursor_acp_prose_send_emits_natural_and_records_stream_wire(
     )
     drv = _acp_driver(monkeypatch)
     cfg = HarnessConfig(
-        driver="cursor-cli:auto",
+        driver="gemini-3.5-flash",
         state_dir=str(tmp_path),
         repo=str(tmp_path),
     )
@@ -908,7 +908,7 @@ def test_cursor_acp_incomplete_send_does_not_finalize_or_run_tools(
     monkeypatch.setattr("harness.send_loop.execute_turn_actions", boom)
     drv = _acp_driver(monkeypatch, stop_reason="max_tokens")
     cfg = HarnessConfig(
-        driver="cursor-cli:auto",
+        driver="gemini-3.5-flash",
         state_dir=str(tmp_path),
         repo=str(tmp_path),
     )

--- a/tests/test_cursor_cli_driver.py
+++ b/tests/test_cursor_cli_driver.py
@@ -312,6 +312,13 @@ def test_driver_chat_stream_mocked_subprocess(monkeypatch, tmp_path):
     # Kernel system — not Marionette's skills dump.
     assert "CodeGraph" in joined or "puppetmaster codegraph" in joined
     assert "HOST MODE CONTRACT" in joined
+    assert resp.meta.get("finish_reason") == "completed"
+    assert resp.meta.get("stream_terminal") == "stop"
+    assert resp.meta.get("stream_started") is True
+    assert resp.meta.get("api_mode") == "cursor_cli"
+    assert resp.meta.get("wire_mode") == "cursor_cli_stream"
+    assert resp.meta.get("last_provider_event") == "result"
+    assert d.requires_explicit_terminal is True
 
 
 def test_agent_child_env_puts_harness_python_first(monkeypatch, tmp_path):
@@ -1318,3 +1325,153 @@ def test_print_path_fails_closed_on_fable_vs_luna(monkeypatch, tmp_path):
     assert resp.meta["served_model"] == "gpt-5.6-luna-medium"
     assert resp.meta["identity_status"] == "mismatch"
     assert d._native_chat_id is None
+    assert resp.meta.get("finish_reason") not in ("completed", "stop")
+    assert resp.meta.get("stream_terminal") != "stop"
+
+
+def _fake_cursor_proc(stream, *, returncode=0):
+    class FakeProc:
+        def __init__(self):
+            self.returncode = returncode
+            self.stdout = io.StringIO(stream)
+            self.stderr = io.StringIO("")
+
+        def wait(self, timeout=None):
+            if returncode != 0:
+                self.returncode = returncode
+            return returncode
+
+        def kill(self):
+            pass
+
+    return FakeProc()
+
+
+def test_driver_chat_stamps_natural_terminal_on_success(monkeypatch, tmp_path):
+    fake_bin = tmp_path / "agent"
+    fake_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    stream = "\n".join([
+        json.dumps({
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+            "timestamp_ms": 1,
+        }),
+        json.dumps({
+            "type": "result",
+            "is_error": False,
+            "result": "ok",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }),
+        "",
+    ])
+    monkeypatch.setattr(
+        "pmharness.drivers.cursor_cli.subprocess.Popen",
+        lambda *a, **k: _fake_cursor_proc(stream),
+    )
+    d = CursorCliDriver(
+        name="cursor-cli:m", model="composer-2.5", agent_binary=str(fake_bin),
+    )
+    resp = d.chat([{"role": "user", "content": "hi"}])
+    assert resp.error is None
+    assert resp.text == "ok"
+    assert resp.meta["finish_reason"] == "completed"
+    assert resp.meta["stream_terminal"] == "stop"
+    assert resp.meta["stream_started"] is True
+    assert resp.meta["api_mode"] == "cursor_cli"
+    assert resp.meta["wire_mode"] == "cursor_cli_stream"
+    assert resp.meta["last_provider_event"] == "result"
+
+
+def test_driver_nonzero_exit_does_not_stamp_natural(monkeypatch, tmp_path):
+    fake_bin = tmp_path / "agent"
+    fake_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    stream = "\n".join([
+        json.dumps({
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "partial"}]},
+            "timestamp_ms": 1,
+        }),
+        "",
+    ])
+    monkeypatch.setattr(
+        "pmharness.drivers.cursor_cli.subprocess.Popen",
+        lambda *a, **k: _fake_cursor_proc(stream, returncode=1),
+    )
+    d = CursorCliDriver(
+        name="cursor-cli:m", model="composer-2.5", agent_binary=str(fake_bin),
+    )
+    resp = d.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        on_delta=lambda _t: None,
+    )
+    assert resp.meta.get("finish_reason") not in ("completed", "stop")
+    assert resp.meta.get("stream_terminal") != "stop"
+
+
+def test_driver_result_error_does_not_stamp_natural(monkeypatch, tmp_path):
+    fake_bin = tmp_path / "agent"
+    fake_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    stream = "\n".join([
+        json.dumps({
+            "type": "result",
+            "is_error": True,
+            "result": "agent exploded",
+        }),
+        "",
+    ])
+    monkeypatch.setattr(
+        "pmharness.drivers.cursor_cli.subprocess.Popen",
+        lambda *a, **k: _fake_cursor_proc(stream),
+    )
+    d = CursorCliDriver(
+        name="cursor-cli:m", model="composer-2.5", agent_binary=str(fake_bin),
+    )
+    resp = d.chat([{"role": "user", "content": "hi"}])
+    assert resp.error
+    assert resp.meta.get("finish_reason") not in ("completed", "stop")
+    assert resp.meta.get("stream_terminal") != "stop"
+
+
+def test_driver_timeout_does_not_stamp_natural(monkeypatch, tmp_path):
+    import subprocess
+
+    fake_bin = tmp_path / "agent"
+    fake_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    stream = "\n".join([
+        json.dumps({
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "partial"}]},
+            "timestamp_ms": 1,
+        }),
+        "",
+    ])
+
+    class TimeoutProc:
+        returncode = None
+        stdout = io.StringIO(stream)
+        stderr = io.StringIO("")
+
+        def wait(self, timeout=None):
+            raise subprocess.TimeoutExpired(cmd="agent", timeout=timeout or 1)
+
+        def kill(self):
+            self.returncode = -9
+
+    monkeypatch.setattr(
+        "pmharness.drivers.cursor_cli.subprocess.Popen",
+        lambda *a, **k: TimeoutProc(),
+    )
+    d = CursorCliDriver(
+        name="cursor-cli:m",
+        model="composer-2.5",
+        agent_binary=str(fake_bin),
+        timeout=1,
+    )
+    resp = d.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        on_delta=lambda _t: None,
+    )
+    assert resp.error
+    assert "timed out" in resp.error
+    assert resp.meta.get("finish_reason") not in ("completed", "stop")
+    assert resp.meta.get("stream_terminal") != "stop"

--- a/tests/test_driver_retry.py
+++ b/tests/test_driver_retry.py
@@ -174,9 +174,11 @@ def test_openai_driver_chat_stream_no_retry_after_delta(monkeypatch):
 
     assert calls_to_urlopen == 1
     assert deltas == ["Hello"]
+    assert resp.text == "Hello"
     assert resp.error is not None
     assert "HTTP 503" in resp.error
     assert resp.meta.get("retry_attempts") == 1
+    assert resp.meta.get("stream_started") is True
 
 
 def test_pool_rotate_backoff_honors_retry_after_and_classifier():

--- a/tests/test_midturn_context.py
+++ b/tests/test_midturn_context.py
@@ -17,7 +17,7 @@ class MockDriverResponse:
         self.error = error
         self.tokens_out = tokens_out
         self.tokens_in = tokens_in
-        self.meta = {}
+        self.meta = {} if error else {"finish_reason": "stop"}
 
 
 class MockPilotWithOverflow:

--- a/tests/test_no_progress_loop.py
+++ b/tests/test_no_progress_loop.py
@@ -153,7 +153,7 @@ def test_stagnation_governor_halts_on_repeated_prose_and_actions(monkeypatch):
         call_count["n"] += 1
         resp = MagicMock()
         resp.text = payload
-        resp.meta = {}
+        resp.meta = {"finish_reason": "stop"}
         resp.error = None
         return resp
 
@@ -180,6 +180,7 @@ def test_stagnation_governor_halts_on_repeated_prose_and_actions(monkeypatch):
     assert "no new progress" in (notice.data.get("message") or "").lower()
     done = [e for e in events if e.kind == "assistant_done"]
     assert done and done[-1].data.get("stagnation_halt") is True
+    assert done[-1].data.get("stop_cause") == "stagnation"
     # Cap=3 means three identical fingerprints; model asked at most a few times.
     assert call_count["n"] <= 5
 

--- a/tests/test_openai_compat_stream_terminals.py
+++ b/tests/test_openai_compat_stream_terminals.py
@@ -1,0 +1,629 @@
+"""Fail-closed OpenAI chat Completions stream terminals.
+
+Shared parser contract for Ox Alpha / OpenRouter / OpenCode Go hosts.
+Hermetic: no network.
+"""
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from pmharness.drivers.openai_compat import (
+    OpenAICompatDriver,
+    _consume_openai_chat_sse,
+)
+
+
+def _driver(base_url="https://api.openai.com/v1", model="gpt-4o"):
+    d = OpenAICompatDriver(
+        name="t",
+        model=model,
+        base_url=base_url,
+        api_key_env="TEST_OAI_KEY",
+    )
+    d._key = lambda: "fake-key"
+    return d
+
+
+class _SseResp:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+
+def _data(payload) -> bytes:
+    return ("data: " + json.dumps(payload) + "\n").encode("utf-8")
+
+
+def _run_stream(monkeypatch, driver, lines, **kwargs):
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _SseResp(lines),
+    )
+    return driver.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        on_delta=kwargs.get("on_delta") or (lambda _t: None),
+        on_reasoning_delta=kwargs.get("on_reasoning_delta"),
+        on_tool_hint=kwargs.get("on_tool_hint"),
+        tools=kwargs.get("tools"),
+    )
+
+
+def test_clean_stop_succeeds(monkeypatch):
+    lines = [
+        _data({"choices": [{"delta": {"content": "ok"}, "finish_reason": "stop"}]}),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.error is None
+    assert resp.text == "ok"
+    assert resp.meta["finish_reason"] == "stop"
+    assert resp.meta["stream_terminal"] == "stop"
+    assert resp.meta["malformed_sse_chunks"] == 0
+
+
+def test_finish_reason_length_is_explicit_incomplete(monkeypatch):
+    lines = [
+        _data({"choices": [{"delta": {"content": "partial "}}]}),
+        _data({
+            "choices": [{"delta": {"content": "cut"}, "finish_reason": "length"}],
+            "usage": {"prompt_tokens": 8, "completion_tokens": 4},
+        }),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.error
+    assert "length" in resp.error
+    assert resp.text == "partial cut"
+    assert resp.meta["finish_reason"] == "length"
+    assert resp.meta["stream_terminal"] == "length"
+    assert resp.meta["stream_started"] is True
+    assert resp.tokens_in == 8
+    assert resp.tokens_out == 4
+    assert resp.meta["tool_calls"] == []
+
+
+def test_partial_eof_without_done_or_finish_is_incomplete(monkeypatch):
+    lines = [
+        _data({"choices": [{"delta": {"content": "partial"}}]}),
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.error
+    assert resp.text == "partial"
+    assert resp.meta["stream_terminal"] == "incomplete"
+    assert resp.meta["finish_reason"] == ""
+    assert resp.meta["stream_started"] is True
+
+
+def test_empty_stream_is_not_success(monkeypatch):
+    resp = _run_stream(monkeypatch, _driver(), [b"data: [DONE]\n"])
+    assert resp.error
+    assert resp.text == ""
+    assert resp.meta["stream_terminal"] == "empty"
+    assert resp.meta["stream_started"] is False
+
+
+def test_malformed_sse_is_not_silent_success(monkeypatch):
+    lines = [
+        b"data: not-json{{{{\n",
+        b"data: [1, 2, 3]\n",
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.error
+    assert resp.text == ""
+    assert resp.meta["malformed_sse_chunks"] == 2
+    assert resp.meta["stream_terminal"] == "empty"
+
+
+def test_partial_text_then_http_failure_preserves_progress(monkeypatch):
+    class _PartialThenHttp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def __iter__(self):
+            yield _data({
+                "choices": [{"delta": {"content": "hello"}}],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+            })
+            raise urllib.error.HTTPError(
+                "https://api.openai.com/v1", 502, "bad", {},
+                io.BytesIO(b'{"error":{"message":"upstream"}}'),
+            )
+
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _PartialThenHttp(),
+    )
+    resp = _driver().chat_stream(
+        [{"role": "user", "content": "hi"}],
+        on_delta=lambda _t: None,
+    )
+    assert resp.error and "502" in resp.error
+    assert resp.text == "hello"
+    assert resp.tokens_in == 3
+    assert resp.tokens_out == 1
+    assert resp.meta["raw_usage"] == {"prompt_tokens": 3, "completion_tokens": 1}
+    assert resp.meta["stream_started"] is True
+    assert resp.meta["stream_terminal"] == "error"
+    assert resp.meta["tool_calls"] == []
+
+
+def test_truncated_tool_arguments_cannot_dispatch(monkeypatch):
+    lines = [
+        _data({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":',
+                        },
+                    }],
+                },
+            }],
+        }),
+        _data({"choices": [{"delta": {}, "finish_reason": "length"}]}),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.meta["tool_calls"] == []
+    assert resp.meta.get("incomplete_tool_calls")
+    assert resp.meta["incomplete_tool_calls"][0]["function"]["arguments"] == '{"path":'
+    assert resp.meta["finish_reason"] == "length"
+    assert resp.error
+
+
+def test_truncated_args_with_tool_calls_finish_still_withheld(monkeypatch):
+    lines = [
+        _data({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "x',
+                        },
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+        }),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.error
+    assert "truncated" in resp.error.lower() or "tool" in resp.error.lower()
+    assert resp.meta["finish_reason"] == "tool_calls"
+    assert resp.meta["stream_terminal"] == "incomplete"
+    assert resp.meta["tool_calls"] == []
+    assert resp.meta["incomplete_tool_calls"][0]["function"]["name"] == "read_file"
+
+
+def test_duplicate_and_out_of_order_index_assembly(monkeypatch):
+    lines = [
+        _data({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 1,
+                        "id": "call_b",
+                        "function": {"name": "beta", "arguments": ""},
+                    }],
+                },
+            }],
+        }),
+        _data({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_a",
+                        "function": {"name": "alpha", "arguments": ""},
+                    }],
+                },
+            }],
+        }),
+        _data({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 1,
+                        "function": {"arguments": '{"b":2}'},
+                    }],
+                },
+            }],
+        }),
+        _data({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "function": {"arguments": '{"a":1}'},
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+        }),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.error is None
+    tool_calls = resp.meta["tool_calls"]
+    assert [tc["id"] for tc in tool_calls] == ["call_a", "call_b"]
+    assert tool_calls[0]["function"]["arguments"] == '{"a":1}'
+    assert tool_calls[1]["function"]["arguments"] == '{"b":2}'
+
+
+def test_missing_tool_call_ids_stay_empty_for_canonicalization(monkeypatch):
+    lines = [
+        _data({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"a"}',
+                        },
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+        }),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.error is None
+    assert resp.meta["tool_calls"][0]["id"] == ""
+    assert resp.meta["tool_calls"][0]["function"]["name"] == "read_file"
+
+
+@pytest.mark.parametrize("base_url,model", [
+    ("https://openrouter.ai/api/v1", "stealth/ox-alpha"),
+    ("https://opencode.ai/zen/go/v1", "ox-alpha-free"),
+    ("https://opencode.ai/zen/v1", "x-preview-f-free"),
+])
+def test_host_cases_use_shared_parser_contract(base_url, model):
+    lines = [
+        _data({"choices": [{"delta": {"content": "ok"}, "finish_reason": "stop"}]}),
+        b"data: [DONE]\n",
+    ]
+    parsed = _consume_openai_chat_sse(lines)
+    assert parsed["error"] is None
+    assert parsed["text"] == "ok"
+    assert parsed["stream_terminal"] == "stop"
+    assert parsed["finish_reason"] == "stop"
+    assert parsed["malformed_sse_chunks"] == 0
+    assert parsed["tool_calls"] == []
+
+    length_lines = [
+        _data({"choices": [{"delta": {"content": "cut"}, "finish_reason": "length"}]}),
+        b"data: [DONE]\n",
+    ]
+    length = _consume_openai_chat_sse(length_lines)
+    assert length["stream_terminal"] == "length"
+    assert length["error"]
+    assert length["text"] == "cut"
+    # Host overlays stay on the request; the parser is host-agnostic.
+    d = _driver(base_url=base_url, model=model)
+    if d._is_opencode_go_host():
+        assert d._is_openrouter_host() is False
+    if d._is_openrouter_host():
+        assert d._is_opencode_go_host() is False
+
+
+def test_content_filter_is_classified_truthfully(monkeypatch):
+    lines = [
+        _data({"choices": [{"delta": {"content": "nope"}, "finish_reason": "content_filter"}]}),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.error
+    assert "content_filter" in resp.error
+    assert "without a finish_reason" not in resp.error
+    assert resp.meta["finish_reason"] == "content_filter"
+    assert resp.meta["stream_terminal"] == "content_filter"
+    assert resp.text == "nope"
+    assert resp.meta["tool_calls"] == []
+
+
+def test_legacy_function_call_is_executable_when_complete(monkeypatch):
+    lines = [
+        _data({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"a"}',
+                        },
+                    }],
+                },
+                "finish_reason": "function_call",
+            }],
+        }),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.error is None
+    assert resp.meta["stream_terminal"] == "tool_calls"
+    assert resp.meta["finish_reason"] == "function_call"
+    assert resp.meta["tool_calls"][0]["function"]["name"] == "read_file"
+
+
+def test_unknown_finish_reason_fails_closed_and_names_the_reason(monkeypatch):
+    lines = [
+        _data({"choices": [{"delta": {"content": "ok"}, "finish_reason": "mystery_code"}]}),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.error
+    assert "mystery_code" in resp.error
+    assert "without a finish_reason" not in resp.error
+    assert resp.meta["stream_terminal"] == "incomplete"
+    assert resp.text == "ok"
+
+
+def _run_chat(monkeypatch, driver, payload):
+    class _JsonResp:
+        def __init__(self, body):
+            self._data = json.dumps(body).encode("utf-8")
+
+        def read(self):
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _JsonResp(payload),
+    )
+    return driver.chat([{"role": "user", "content": "hi"}])
+
+
+def test_chat_finish_reason_stop_succeeds(monkeypatch):
+    resp = _run_chat(monkeypatch, _driver(), {
+        "choices": [{
+            "message": {"content": "hello", "tool_calls": []},
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+    })
+    assert resp.error is None
+    assert resp.text == "hello"
+    assert resp.meta["finish_reason"] == "stop"
+    assert resp.meta["stream_terminal"] == "stop"
+    assert resp.tokens_in == 2
+
+
+def test_chat_finish_reason_length_fails_closed(monkeypatch):
+    resp = _run_chat(monkeypatch, _driver(), {
+        "choices": [{
+            "message": {"content": "partial cut"},
+            "finish_reason": "length",
+        }],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 3},
+    })
+    assert resp.error
+    assert "length" in resp.error
+    assert resp.text == "partial cut"
+    assert resp.meta["finish_reason"] == "length"
+    assert resp.meta["stream_terminal"] == "length"
+    assert resp.tokens_out == 3
+
+
+def test_chat_blank_finish_fails_closed(monkeypatch):
+    resp = _run_chat(monkeypatch, _driver(), {
+        "choices": [{
+            "message": {"content": "sync text"},
+            "finish_reason": None,
+        }],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+    })
+    assert resp.error
+    assert resp.meta["stream_terminal"] in ("incomplete", "empty")
+    assert resp.text == "sync text"
+
+
+def test_chat_unknown_finish_fails_closed(monkeypatch):
+    resp = _run_chat(monkeypatch, _driver(), {
+        "choices": [{
+            "message": {"content": "x"},
+            "finish_reason": "mystery_code",
+        }],
+        "usage": {},
+    })
+    assert resp.error
+    assert "mystery_code" in resp.error
+    assert "without a finish_reason" not in resp.error
+
+
+def test_chat_content_filter_fails_closed(monkeypatch):
+    resp = _run_chat(monkeypatch, _driver(), {
+        "choices": [{
+            "message": {"content": "blocked"},
+            "finish_reason": "content_filter",
+        }],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+    })
+    assert resp.error
+    assert resp.meta["stream_terminal"] == "content_filter"
+    assert resp.text == "blocked"
+
+
+def test_chat_tool_calls_truncated_is_error(monkeypatch):
+    resp = _run_chat(monkeypatch, _driver(), {
+        "choices": [{
+            "message": {
+                "content": "",
+                "tool_calls": [{
+                    "id": "c1",
+                    "function": {"name": "read_file", "arguments": '{"path":'},
+                }],
+            },
+            "finish_reason": "tool_calls",
+        }],
+        "usage": {},
+    })
+    assert resp.error
+    assert resp.meta["tool_calls"] == []
+    assert resp.meta["incomplete_tool_calls"]
+    assert resp.meta["stream_terminal"] == "incomplete"
+
+
+def test_chat_legacy_function_call_is_executable(monkeypatch):
+    resp = _run_chat(monkeypatch, _driver(), {
+        "choices": [{
+            "message": {
+                "content": "",
+                "function_call": {"name": "read_file", "arguments": "{}"},
+            },
+            "finish_reason": "function_call",
+        }],
+        "usage": {},
+    })
+    assert resp.error is None
+    assert resp.meta["stream_terminal"] == "tool_calls"
+    assert resp.meta["tool_calls"][0]["function"]["name"] == "read_file"
+
+
+def test_host_overlays_remain_on_the_request(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured[req.full_url] = json.loads(req.data.decode("utf-8"))
+        return _SseResp([
+            _data({"choices": [{"delta": {"content": "ok"}, "finish_reason": "stop"}]}),
+            b"data: [DONE]\n",
+        ])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    tools = [{"type": "function", "function": {"name": "run_command", "parameters": {}}}]
+
+    go = _driver("https://opencode.ai/zen/go/v1", "ox-alpha-free")
+    go.chat_stream([{"role": "user", "content": "hi"}], tools=tools, on_delta=lambda _t: None)
+    go_body = captured[f"{go.base_url}/chat/completions"]
+    assert "stream_options" not in go_body
+    assert "parallel_tool_calls" not in go_body
+
+    router = _driver("https://openrouter.ai/api/v1", "stealth/ox-alpha")
+    router.chat_stream(
+        [{"role": "user", "content": "hi"}], tools=tools, on_delta=lambda _t: None,
+    )
+    or_body = captured[f"{router.base_url}/chat/completions"]
+    assert or_body["parallel_tool_calls"] is True
+    assert or_body["stream_options"] == {"include_usage": True}
+
+
+@pytest.mark.parametrize(
+    "finish,terminal",
+    [
+        ("STOP", "stop"),
+        ("end_turn", "stop"),
+        ("stop_sequence", "stop"),
+        ("MAX_TOKENS", "length"),
+        ("max_output_tokens", "length"),
+        ("length", "length"),
+        ("CONTENT_FILTER", "content_filter"),
+    ],
+)
+def test_chat_finish_aliases_are_case_insensitive(monkeypatch, finish, terminal):
+    resp = _run_chat(monkeypatch, _driver(), {
+        "choices": [{
+            "message": {"content": "alias text", "tool_calls": []},
+            "finish_reason": finish,
+        }],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+    })
+    assert resp.meta["finish_reason"] == finish
+    assert resp.meta["stream_terminal"] == terminal
+    assert "without a finish_reason" not in str(resp.error or "")
+    if terminal == "stop":
+        assert resp.error is None
+    else:
+        assert resp.error
+        assert finish in resp.error
+
+
+def test_chat_tool_calls_alias_validates_json(monkeypatch):
+    ok = _run_chat(monkeypatch, _driver(), {
+        "choices": [{
+            "message": {
+                "content": "",
+                "tool_calls": [{
+                    "id": "c1",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }],
+            },
+            "finish_reason": "TOOL_CALLS",
+        }],
+        "usage": {},
+    })
+    assert ok.error is None
+    assert ok.meta["stream_terminal"] == "tool_calls"
+    assert ok.meta["finish_reason"] == "TOOL_CALLS"
+
+    truncated = _run_chat(monkeypatch, _driver(), {
+        "choices": [{
+            "message": {
+                "content": "",
+                "tool_calls": [{
+                    "id": "c1",
+                    "function": {"name": "read_file", "arguments": '{"path":'},
+                }],
+            },
+            "finish_reason": "function_call",
+        }],
+        "usage": {},
+    })
+    assert truncated.error
+    assert truncated.meta["stream_terminal"] == "incomplete"
+    assert "without a finish_reason" not in truncated.error
+
+
+def test_openai_compat_requires_explicit_terminal():
+    assert _driver().requires_explicit_terminal is True
+
+
+@pytest.mark.parametrize(
+    "finish,terminal",
+    [
+        ("STOP", "stop"),
+        ("MAX_TOKENS", "length"),
+        ("CONTENT_FILTER", "content_filter"),
+        ("end_turn", "stop"),
+    ],
+)
+def test_stream_finish_aliases_are_case_insensitive(monkeypatch, finish, terminal):
+    lines = [
+        _data({"choices": [{"delta": {"content": "ok"}, "finish_reason": finish}]}),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines)
+    assert resp.meta["finish_reason"] == finish
+    assert resp.meta["stream_terminal"] == terminal
+    assert "without a finish_reason" not in str(resp.error or "")

--- a/tests/test_opencode_go.py
+++ b/tests/test_opencode_go.py
@@ -272,11 +272,65 @@ def test_build_pilot_routes_openai_responses_models():
 @pytest.mark.parametrize("model", ["grok-4.5", "muse-spark-1.2-contributor"])
 def test_build_pilot_routes_grok_and_muse_through_responses(model):
     from pmharness.drivers.codex_responses import CodexResponsesDriver
+    from pmharness.drivers.openai_compat import OpenAICompatDriver
 
     driver = prov.build_pilot(f"opencode-go:{model}")
     assert isinstance(driver, CodexResponsesDriver)
+    assert not isinstance(driver, OpenAICompatDriver)
     assert driver.model == model
     assert driver.chatgpt_backend is False
+
+
+def test_muse_build_pilot_stream_waits_for_completed(monkeypatch):
+    """Production-shaped Muse Spark 1.2: CodexResponses, not OpenAI chat."""
+    import urllib.request
+
+    from pmharness.drivers.codex_responses import CodexResponsesDriver
+    from pmharness.drivers.openai_compat import OpenAICompatDriver
+
+    driver = prov.build_pilot("opencode-go:muse-spark-1.2-contributor")
+    assert isinstance(driver, CodexResponsesDriver)
+    assert not isinstance(driver, OpenAICompatDriver)
+    assert driver.chatgpt_backend is False
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(
+        "pmharness.drivers.codex_responses.time.monotonic",
+        lambda: clock["now"],
+    )
+
+    def lines():
+        yield b'data: {"type":"response.output_item.added","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"Hel"}\n'
+        clock["now"] += 2.2
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"lo"}\n'
+        clock["now"] += 0.4
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"!"}\n'
+        yield b'data: {"type":"response.completed","response":{"status":"completed","usage":{}}}\n'
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def __iter__(self):
+            return iter(lines())
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _Resp())
+    deltas = []
+    resp = driver.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        on_delta=deltas.append,
+    )
+    assert resp.error is None
+    answer = "".join(
+        (p["text"] if isinstance(p, dict) else p) for p in deltas
+    )
+    assert answer == "Hello!"
+    assert resp.text == "Hello!"
+    assert resp.meta["finish_reason"] == "completed"
 
 
 def test_build_pilot_strips_a_namespaced_model_before_the_wire():
@@ -437,6 +491,7 @@ def test_codex_responses_drops_chatgpt_only_wire_bits_for_other_hosts():
         [{"role": "user", "content": "hi"}], session_id="chat-1",
     )
     assert "client_metadata" not in body
+    assert body["max_output_tokens"] == driver.max_tokens
 
 
 def test_codex_responses_keeps_chatgpt_headers_by_default():

--- a/tests/test_prompt_caching.py
+++ b/tests/test_prompt_caching.py
@@ -234,7 +234,7 @@ def test_openai_compat_chat_stream_prompt_caching(monkeypatch):
     def mock_urlopen(req, timeout=None):
         chunks = [
             {"choices": [{"delta": {"content": "Hello "}}]},
-            {"choices": [{"delta": {"content": "world!"}}]},
+            {"choices": [{"delta": {"content": "world!"}, "finish_reason": "stop"}]},
             {
                 "choices": [],
                 "usage": {

--- a/tests/test_provider_cache_usage_normalization.py
+++ b/tests/test_provider_cache_usage_normalization.py
@@ -171,7 +171,7 @@ def _capturing_openai_response(monkeypatch, captured):
 
 def _capturing_openai_stream(monkeypatch, captured):
     sse = (
-        'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}\n\n'
+        'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n\n'
         'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1}}\n\n'
         "data: [DONE]\n\n"
     )
@@ -680,7 +680,7 @@ def test_openai_compat_chat_stream_omits_absent_cache_and_captures_served(
 
     sse = (
         'data: {"id":"1","model":"gpt-4o-mini","choices":[{"delta":{"content":"hi"},'
-        '"finish_reason":null}]}\n\n'
+        '"finish_reason":"stop"}]}\n\n'
         'data: {"id":"1","model":"gpt-4o-mini","choices":[],'
         '"usage":{"prompt_tokens":12,"completion_tokens":1}}\n\n'
         "data: [DONE]\n\n"

--- a/tests/test_send_loop_phases.py
+++ b/tests/test_send_loop_phases.py
@@ -61,6 +61,13 @@ PHASE_HELPERS = (
     "dispatch_readonly_action",
     "dispatch_local_action",
     "run_auto_verify",
+    "apply_provider_terminal",
+    "classified_finish_kwargs",
+    "emit_classified_provider_error",
+    "emit_loop_exit_close",
+    "emit_stagnation_halt",
+    "stamp_sync_complete_terminal",
+    "native_tools_blocked",
 )
 
 
@@ -111,6 +118,15 @@ def test_mixin_calls_new_phase_helpers():
     assert "account_provider_attempt(" in src
     assert "record_provider_dispatch_error_receipt(" in src
     assert "drain_idle_turn(" in src
+    assert "apply_provider_terminal(" in src
+    assert "emit_classified_provider_error(" in src
+    assert "emit_loop_exit_close(" in src
+    assert "emit_stagnation_halt(" in src
+    assert "classified_finish_kwargs(" in src
+    assert "native_tools_blocked(" in src
+    assert "classify_provider_terminal(" not in src
+    assert "blocking_terminal_message(" not in src
+    assert "loop_exit_message(" not in src
     assert "run_auto_verify(" in src
     assert "execute_turn_actions(" in src
     assert "reset_timing_before_step(" in src
@@ -1340,6 +1356,7 @@ def test_drain_idle_turn_finalizes_when_idle():
         swarms=1,
         turn_prose=["p"],
         turn_findings=["f"],
+        stop_cause="natural",
     )
     try:
         while True:
@@ -1349,8 +1366,38 @@ def test_drain_idle_turn_finalizes_when_idle():
     assert disposition == "return"
     assert user_message == "hi"
     assert events[0].kind == "assistant_done"
-    assert events[0].data == {"turns": 3, "swarms": 1}
+    assert events[0].data["turns"] == 3
+    assert events[0].data["swarms"] == 1
+    assert events[0].data["stop_cause"] == "natural"
     assert submitted == [("ingest", ("hi", ["p"], ["f"]))]
+
+
+def test_drain_idle_turn_blank_stop_cause_is_unspecified():
+    session = SimpleNamespace(
+        drain_steer=lambda: [],
+        _history=[],
+        _steer_pending=False,
+        _next_queued_needs_driver_swap=lambda: False,
+        _pop_next_prompt=lambda: None,
+        _submit_housekeeping=lambda *_a: None,
+        _maybe_ingest="ingest",
+    )
+    events = []
+    gen = drain_idle_turn(
+        session,
+        user_message="hi",
+        step=0,
+        swarms=0,
+        turn_prose=[],
+        turn_findings=[],
+    )
+    try:
+        while True:
+            events.append(next(gen))
+    except StopIteration:
+        pass
+    assert events[0].kind == "assistant_done"
+    assert events[0].data["stop_cause"] == "unspecified"
 
 
 def test_drain_idle_turn_breaks_on_driver_swap():

--- a/tests/test_send_loop_terminals.py
+++ b/tests/test_send_loop_terminals.py
@@ -1,0 +1,802 @@
+"""Send-loop consults the terminal classifier; close paths stay truthful."""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from harness.config import HarnessConfig
+from harness.conversation import ConversationalSession
+from harness.send_loop_phases import (
+    dispatch_pilot_provider_call,
+    stamp_sync_complete_terminal,
+)
+from pmharness.drivers.base import DriverResponse
+
+
+def _session(tmp_path, monkeypatch, pilot, *, sid="sess-term"):
+    monkeypatch.setattr(
+        "harness.send_loop.profile_skips_auto_inject",
+        lambda session: (True, True),
+    )
+    cfg = HarnessConfig(
+        driver="stub-oracle-v2",
+        state_dir=str(tmp_path),
+        repo=str(tmp_path),
+    )
+    session = ConversationalSession(cfg)
+    session.harness_session_id = sid
+    session.pilot = pilot
+    monkeypatch.setattr(session, "_resolve_append_only", lambda: False)
+    monkeypatch.setattr(session, "_get_codegraph_context", lambda msg: "")
+    monkeypatch.setattr(session, "_maybe_compact_history", lambda **k: iter(()))
+    return session
+
+
+class _Scripted:
+    name = "scripted-terminal"
+
+    def __init__(self, replies):
+        self.replies = list(replies)
+        self.calls = 0
+
+    def chat(self, messages, tools=None, system=None):
+        self.calls += 1
+        if self.replies:
+            return self.replies.pop(0)
+        return DriverResponse(
+            text='{"say": "fallback", "actions": []}',
+            tokens_out=1,
+            latency_ms=1.0,
+            meta={"finish_reason": "stop"},
+        )
+
+    def complete(self, prompt, system=None):
+        return self.chat([])
+
+
+class _CompleteOnly:
+    """Legacy/synthetic pilot: synchronous complete() only, no chat."""
+
+    name = "complete-only"
+
+    def __init__(self, replies):
+        self.replies = list(replies)
+
+    def complete(self, prompt, system=None):
+        if self.replies:
+            return self.replies.pop(0)
+        return DriverResponse(
+            text='{"say": "done", "actions": []}',
+            tokens_out=1,
+            latency_ms=1.0,
+        )
+
+
+def _done(**meta):
+    payload = {"finish_reason": "stop"}
+    payload.update(meta)
+    return DriverResponse(
+        text='{"say": "all done", "actions": []}',
+        tokens_out=4,
+        latency_ms=1.0,
+        meta=payload,
+    )
+
+
+def test_length_after_visible_text_never_emits_assistant_done(tmp_path, monkeypatch):
+    executed = {"n": 0}
+
+    def boom(*_a, **_k):
+        executed["n"] += 1
+        raise AssertionError("execute_turn_actions must not run")
+
+    monkeypatch.setattr("harness.send_loop.execute_turn_actions", boom)
+    session = _session(tmp_path, monkeypatch, _Scripted([
+        DriverResponse(
+            text="partial answer cut off",
+            tokens_out=8,
+            tokens_in=20,
+            latency_ms=1.0,
+            meta={
+                "finish_reason": "length",
+                "stream_terminal": "length",
+                "stream_started": True,
+            },
+        ),
+    ]))
+    events = list(session.send("write a long essay"))
+    kinds = [e.kind for e in events]
+    assert "assistant_done" not in kinds
+    assert "error" in kinds
+    err = next(e for e in events if e.kind == "error")
+    assert err.data.get("terminal_cause") == "length"
+    assert err.data.get("finish_reason") == "length"
+    assert executed["n"] == 0
+
+
+def test_provider_eof_after_visible_text_never_emits_assistant_done(tmp_path, monkeypatch):
+    session = _session(tmp_path, monkeypatch, _Scripted([
+        DriverResponse(
+            text="visible then drop",
+            tokens_out=3,
+            latency_ms=1.0,
+            meta={
+                "finish_reason": "",
+                "stream_started": True,
+            },
+        ),
+    ]))
+    events = list(session.send("hello"))
+    kinds = [e.kind for e in events]
+    assert "assistant_done" not in kinds
+    assert "error" in kinds
+    err = next(e for e in events if e.kind == "error")
+    assert err.data.get("terminal_cause") == "provider_eof"
+
+
+def test_named_incomplete_stream_terminal_is_not_provider_eof(tmp_path, monkeypatch):
+    session = _session(tmp_path, monkeypatch, _Scripted([
+        DriverResponse(
+            text="visible then incomplete",
+            tokens_out=3,
+            latency_ms=1.0,
+            meta={
+                "finish_reason": "incomplete",
+                "stream_terminal": "incomplete",
+                "stream_started": True,
+            },
+        ),
+    ]))
+    events = list(session.send("hello"))
+    err = next(e for e in events if e.kind == "error")
+    assert err.data.get("terminal_cause") == "incomplete"
+    assert "assistant_done" not in [e.kind for e in events]
+
+
+def test_text_only_missing_finish_is_unspecified_error(tmp_path, monkeypatch):
+    session = _session(tmp_path, monkeypatch, _Scripted([
+        DriverResponse(
+            text="sync text with no finish",
+            tokens_out=3,
+            latency_ms=1.0,
+            meta={},
+        ),
+    ]))
+    events = list(session.send("hello"))
+    kinds = [e.kind for e in events]
+    assert "assistant_done" not in kinds
+    assert "error" in kinds
+
+
+def test_natural_stop_emits_assistant_done_with_cause(tmp_path, monkeypatch):
+    session = _session(tmp_path, monkeypatch, _Scripted([
+        _done(finish_reason="stop", stream_terminal="stop"),
+    ]))
+    events = list(session.send("hi"))
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "natural"
+    assert done.data.get("finish_reason") == "stop"
+    assert not any(e.kind == "error" for e in events)
+
+
+def test_hard_turn_budget_stop_cause(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_TURN_BUDGET", "1")
+    session = _session(tmp_path, monkeypatch, _Scripted([
+        DriverResponse(
+            text=json.dumps({
+                "say": "step 1",
+                "actions": [{"kind": "run_command", "command": "echo 1"}],
+            }),
+            tokens_out=60,
+            latency_ms=1.0,
+            meta={"finish_reason": "stop"},
+        ),
+        DriverResponse(
+            text=json.dumps({"say": "step 2", "actions": []}),
+            tokens_out=60,
+            latency_ms=1.0,
+            meta={"finish_reason": "stop"},
+        ),
+    ]))
+    events = list(session.send("Work on this +100!"))
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("turn_budget_exhausted") is True
+    assert done.data.get("stop_cause") == "turn_budget"
+
+
+def test_stagnation_stop_cause(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STAGNATION_STREAK_CAP", "3")
+    monkeypatch.setenv("HARNESS_MAX_PILOT_STEPS", "0")
+    payload = json.dumps({
+        "say": "I will keep checking the same thing.",
+        "actions": [{"kind": "list_dir", "path": "."}],
+    })
+    replies = [
+        DriverResponse(
+            text=payload, tokens_out=5, latency_ms=1.0,
+            meta={"finish_reason": "stop"},
+        )
+        for _ in range(6)
+    ]
+    session = _session(tmp_path, monkeypatch, _Scripted(replies))
+    monkeypatch.setattr(
+        "harness.send_loop_actions.dispatch_readonly_action",
+        lambda *a, **k: iter(()),
+    )
+    monkeypatch.setattr(
+        "harness.send_loop_actions.run_parallel_prefetch",
+        lambda *a, **k: {},
+    )
+    events = list(session.send("look around"))
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stagnation_halt") is True
+    assert done.data.get("stop_cause") == "stagnation"
+
+
+def test_invalid_tool_stop_cause(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_MAX_PILOT_STEPS", "8")
+
+    def _tc(name, args=None, tc_id="tc1"):
+        return {
+            "id": tc_id,
+            "type": "function",
+            "function": {
+                "name": name,
+                "arguments": json.dumps(args if args is not None else {}),
+            },
+        }
+
+    class _Native:
+        name = "invalid-tool-native"
+
+        def __init__(self, replies):
+            self.replies = list(replies)
+
+        def chat(self, messages, tools=None, system=None, **kwargs):
+            reply = self.replies.pop(0) if self.replies else {"text": "Done."}
+            return DriverResponse(
+                text=reply.get("text") or "",
+                tokens_out=5,
+                latency_ms=1.0,
+                meta={
+                    "tool_calls": reply.get("tool_calls") or [],
+                    "reasoning": "",
+                    "finish_reason": (
+                        "tool_calls" if reply.get("tool_calls") else "stop"
+                    ),
+                },
+            )
+
+    cfg = HarnessConfig(
+        driver="stub-oracle-v2",
+        state_dir=str(tmp_path / "state"),
+        repo=str(tmp_path / "repo"),
+    )
+    (tmp_path / "repo").mkdir(exist_ok=True)
+    (tmp_path / "state").mkdir(exist_ok=True)
+    session = ConversationalSession(cfg)
+    session.config.no_delegation = True
+    session.pilot = _Native([
+        {"tool_calls": [_tc("frobnicate_xyz", {}, tc_id="tc_a")]},
+        {"tool_calls": [_tc("frobnicate_xyz", {}, tc_id="tc_b")]},
+        {"tool_calls": [_tc("frobnicate_xyz", {}, tc_id="tc_c")]},
+    ])
+    hidden = ["read_file", "run_command"]
+    session._build_visible_tools_schema = lambda: [
+        {"type": "function", "function": {"name": name, "parameters": {
+            "type": "object", "properties": {},
+        }}}
+        for name in hidden
+    ]
+    events = list(session.send("degenerate"))
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("invalid_tool_halt") is True
+    assert done.data.get("stop_cause") == "invalid_tool"
+
+
+def test_true_step_cap_is_not_empty_loop(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_MAX_PILOT_STEPS", "1")
+    replies = [
+        DriverResponse(
+            text=json.dumps({
+                "say": f"step {i}",
+                "actions": [{"kind": "run_command", "command": f"echo {i}"}],
+            }),
+            tokens_out=4,
+            latency_ms=1.0,
+            meta={"finish_reason": "stop"},
+        )
+        for i in range(4)
+    ]
+    session = _session(tmp_path, monkeypatch, _Scripted(replies))
+    events = list(session.send("keep going"))
+    messages = [
+        e.data.get("text") for e in events
+        if e.kind == "message" and e.data.get("role") == "assistant"
+    ]
+    assert any("investigation step limit" in (m or "") for m in messages)
+    assert not any("No productive reply" in (m or "") for m in messages)
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "step_cap"
+
+
+def test_empty_loop_is_not_step_cap(tmp_path, monkeypatch):
+    from harness.pilot import PilotTurn
+    monkeypatch.setattr(PilotTurn, "has_actions", True)
+    replies = [
+        DriverResponse(
+            text='{"say": "", "actions": []}',
+            tokens_out=1,
+            latency_ms=1.0,
+            meta={"finish_reason": "stop"},
+        )
+        for _ in range(5)
+    ]
+    session = _session(tmp_path, monkeypatch, _Scripted(replies))
+    events = list(session.send("go"))
+    messages = [
+        e.data.get("text") for e in events
+        if e.kind == "message" and e.data.get("role") == "assistant"
+    ]
+    assert any("No productive reply this turn" in (m or "") for m in messages)
+    assert not any("investigation step limit" in (m or "") for m in messages)
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "empty_loop"
+
+
+def test_driver_swap_is_not_step_cap(tmp_path, monkeypatch):
+    session = _session(tmp_path, monkeypatch, _Scripted([_done()]))
+    session.enqueue_prompt("next job", model="deepseek/deepseek-v4-flash")
+    events = list(session.send("finish this first"))
+    messages = [
+        e.data.get("text") for e in events
+        if e.kind == "message" and e.data.get("role") == "assistant"
+    ]
+    assert any("different driver" in (m or "") for m in messages)
+    assert not any("investigation step limit" in (m or "") for m in messages)
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "driver_swap"
+
+
+def test_incomplete_tool_args_never_reach_execute(tmp_path, monkeypatch):
+    called = {"n": 0}
+
+    def tracked(*_a, **_k):
+        called["n"] += 1
+        if False:
+            yield None
+        return "return", []
+
+    monkeypatch.setattr("harness.send_loop.execute_turn_actions", tracked)
+    session = _session(tmp_path, monkeypatch, _Scripted([
+        DriverResponse(
+            text="",
+            tokens_out=2,
+            latency_ms=1.0,
+            meta={
+                "finish_reason": "tool_calls",
+                "stream_terminal": "tool_calls",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":',
+                    },
+                }],
+                "incomplete_tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "read_file", "arguments": '{"path":'},
+                }],
+            },
+        ),
+    ]))
+    events = list(session.send("read it"))
+    assert called["n"] == 0
+    assert "assistant_done" not in [e.kind for e in events]
+    assert any(e.kind == "error" for e in events)
+
+
+def test_context_usage_cannot_be_confused_with_output_terminal(tmp_path, monkeypatch):
+    session = _session(tmp_path, monkeypatch, _Scripted([
+        DriverResponse(
+            text='{"say": "ok", "actions": []}',
+            tokens_in=14000,
+            tokens_out=20,
+            latency_ms=1.0,
+            meta={
+                "finish_reason": "stop",
+                "stream_terminal": "stop",
+                "raw_usage": {"prompt_tokens": 14000, "completion_tokens": 20},
+                "context_used_pct": 14,
+            },
+        ),
+    ]))
+    events = list(session.send("status?"))
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "natural"
+    assert done.data.get("finish_reason") == "stop"
+    assert not any(e.kind == "error" for e in events)
+
+
+def test_stamp_sync_complete_skips_errors_and_preserves_finish():
+    errored = DriverResponse(text="nope", error="boom", meta={})
+    stamp_sync_complete_terminal(errored)
+    assert errored.meta == {}
+
+    explicit = DriverResponse(text="cut", meta={"finish_reason": "length"})
+    stamp_sync_complete_terminal(explicit)
+    assert explicit.meta["finish_reason"] == "length"
+    assert explicit.meta["wire_mode"] == "sync_complete"
+
+    blank = DriverResponse(text='{"say": "ok", "actions": []}', meta={})
+    stamp_sync_complete_terminal(blank)
+    assert blank.meta["wire_mode"] == "sync_complete"
+    assert blank.meta["finish_reason"] == "completed"
+
+
+def _exhaust_dispatch(gen):
+    try:
+        while True:
+            next(gen)
+    except StopIteration as stop:
+        return stop.value
+
+
+def test_dispatch_complete_stamps_sync_complete_marker():
+    resp = DriverResponse(text='{"say": "hi", "actions": []}', meta={})
+
+    def complete(prompt, **kwargs):
+        return resp
+
+    session = SimpleNamespace(
+        pilot=SimpleNamespace(complete=complete),
+        config=SimpleNamespace(no_delegation=False),
+        harness_session_id=None,
+    )
+    streamed, out = _exhaust_dispatch(dispatch_pilot_provider_call(
+        session,
+        plan=False,
+        sys_prompt="sys",
+        prompt="ping",
+        synthesis_nudge_active=False,
+    ))
+    assert streamed == ""
+    assert out is resp
+    assert out.meta["wire_mode"] == "sync_complete"
+    assert out.meta["finish_reason"] == "completed"
+
+
+def test_dispatch_chat_does_not_stamp_sync_complete():
+    resp = DriverResponse(text="sync text with no finish", meta={})
+
+    def chat(messages, **kwargs):
+        return resp
+
+    history = [{"role": "system", "content": "sys"}]
+    session = SimpleNamespace(
+        pilot=SimpleNamespace(chat=chat, supports_streaming=False),
+        config=SimpleNamespace(no_delegation=False),
+        harness_session_id=None,
+        _history=history,
+        _messages_for_provider=lambda: list(history),
+        _build_visible_tools_schema=lambda: [],
+    )
+    streamed, out = _exhaust_dispatch(dispatch_pilot_provider_call(
+        session,
+        plan=False,
+        sys_prompt="sys",
+        prompt="ping",
+        synthesis_nudge_active=False,
+    ))
+    assert streamed == ""
+    assert out is resp
+    assert out.meta.get("wire_mode") != "sync_complete"
+    assert out.meta.get("finish_reason") not in ("completed", "natural")
+
+
+def test_sync_complete_envelope_actions_execute(tmp_path, monkeypatch):
+    executed = {"n": 0}
+
+    def track(*_a, **_k):
+        executed["n"] += 1
+        if False:
+            yield None
+        return "continue", []
+
+    monkeypatch.setattr("harness.send_loop.execute_turn_actions", track)
+    session = _session(tmp_path, monkeypatch, _CompleteOnly([
+        DriverResponse(
+            text=json.dumps({
+                "say": "running a command",
+                "actions": [{"kind": "run_command", "command": "echo 1"}],
+            }),
+            tokens_out=4,
+            latency_ms=1.0,
+        ),
+        DriverResponse(
+            text=json.dumps({"say": "all done", "actions": []}),
+            tokens_out=2,
+            latency_ms=1.0,
+        ),
+    ]))
+    events = list(session.send("go"))
+    assert executed["n"] == 1
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "natural"
+    assert done.data.get("finish_reason") == "completed"
+    assert not any(e.kind == "error" for e in events)
+
+
+def test_sync_complete_final_envelope_is_natural(tmp_path, monkeypatch):
+    session = _session(tmp_path, monkeypatch, _CompleteOnly([
+        DriverResponse(
+            text='{"say": "all done", "actions": []}',
+            tokens_out=2,
+            latency_ms=1.0,
+        ),
+    ]))
+    events = list(session.send("hi"))
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "natural"
+    assert done.data.get("finish_reason") == "completed"
+    assert not any(e.kind == "error" for e in events)
+
+
+def test_sync_chat_json_envelope_without_finish_executes(tmp_path, monkeypatch):
+    executed = {"n": 0}
+
+    def track(*_a, **_k):
+        executed["n"] += 1
+        if False:
+            yield None
+        return "continue", []
+
+    monkeypatch.setattr("harness.send_loop.execute_turn_actions", track)
+    session = _session(tmp_path, monkeypatch, _Scripted([
+        DriverResponse(
+            text=json.dumps({
+                "say": "running a command",
+                "actions": [{"kind": "run_command", "command": "echo 1"}],
+            }),
+            tokens_out=4,
+            latency_ms=1.0,
+            meta={},
+        ),
+        DriverResponse(
+            text=json.dumps({"say": "all done", "actions": []}),
+            tokens_out=2,
+            latency_ms=1.0,
+            meta={},
+        ),
+    ]))
+    events = list(session.send("go"))
+    assert executed["n"] == 1
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "natural"
+    assert not any(e.kind == "error" for e in events)
+
+
+def test_sync_complete_preserves_explicit_length(tmp_path, monkeypatch):
+    session = _session(tmp_path, monkeypatch, _CompleteOnly([
+        DriverResponse(
+            text="partial cut off",
+            tokens_out=2,
+            latency_ms=1.0,
+            meta={"finish_reason": "length"},
+        ),
+    ]))
+    events = list(session.send("hi"))
+    assert "assistant_done" not in [e.kind for e in events]
+    assert any(e.kind == "error" for e in events)
+
+
+class _CursorLike:
+    """Production-shaped Cursor CLI chat path: explicit terminal, native prose."""
+
+    name = "cursor-cli:auto"
+    requires_explicit_terminal = True
+
+    def __init__(self, replies):
+        self.replies = list(replies)
+
+    def chat(self, messages, tools=None, system=None):
+        if self.replies:
+            return self.replies.pop(0)
+        return DriverResponse(text="", error="empty script")
+
+
+def test_cursor_cli_stamped_success_emits_assistant_done(tmp_path, monkeypatch):
+    session = _session(tmp_path, monkeypatch, _CursorLike([
+        DriverResponse(
+            text="The handler should land here.",
+            tokens_out=8,
+            latency_ms=12.0,
+            meta={
+                "finish_reason": "completed",
+                "stream_terminal": "stop",
+                "stream_started": True,
+                "api_mode": "cursor_cli",
+                "wire_mode": "cursor_cli_stream",
+                "last_provider_event": "result",
+                "cursor_cli": True,
+                "tool_calls": [],
+            },
+        ),
+    ]))
+    events = list(session.send("summarize"))
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "natural"
+    assert done.data.get("finish_reason") == "completed"
+    assert not any(e.kind == "error" for e in events)
+    assert session._last_provider_terminal.cause == "natural"
+
+
+class _CursorAcpLike:
+    """Production-shaped Cursor ACP chat path: explicit terminal, native prose."""
+
+    name = "cursor-cli:auto"
+    requires_explicit_terminal = True
+
+    def __init__(self, replies):
+        self.replies = list(replies)
+
+    def chat(self, messages, tools=None, system=None):
+        if self.replies:
+            return self.replies.pop(0)
+        return DriverResponse(text="", error="empty script")
+
+
+def test_cursor_acp_stamped_success_emits_assistant_done_and_records_wire(
+    tmp_path, monkeypatch,
+):
+    from harness.stream_performance_store import StreamPerformanceReceiptStore
+
+    session = _session(tmp_path, monkeypatch, _CursorAcpLike([
+        DriverResponse(
+            text="The handler should land here.",
+            tokens_out=8,
+            latency_ms=12.0,
+            meta={
+                "finish_reason": "completed",
+                "stream_terminal": "stop",
+                "stream_started": True,
+                "api_mode": "cursor_acp",
+                "wire_mode": "cursor_acp",
+                "last_provider_event": "session/prompt",
+                "stop_reason": "end_turn",
+                "cursor_acp": True,
+                "tool_calls": [],
+            },
+        ),
+    ]))
+    events = list(session.send("summarize"))
+    done = next(e for e in events if e.kind == "assistant_done")
+    assert done.data.get("stop_cause") == "natural"
+    assert done.data.get("finish_reason") == "completed"
+    assert not any(e.kind == "error" for e in events)
+    assert session._last_provider_terminal.cause == "natural"
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-term")
+    assert rows
+    assert rows[0]["wire_mode"] == "cursor_acp"
+    assert rows[0]["api_mode"] == "cursor_acp"
+    assert rows[0]["stream_started"] is True
+    assert rows[0]["terminal_cause"] == "natural"
+
+
+def test_cursor_acp_incomplete_and_error_do_not_emit_assistant_done(
+    tmp_path, monkeypatch,
+):
+    executed = {"n": 0}
+
+    def boom(*_a, **_k):
+        executed["n"] += 1
+        raise AssertionError("execute_turn_actions must not run")
+
+    monkeypatch.setattr("harness.send_loop.execute_turn_actions", boom)
+    length = _session(tmp_path, monkeypatch, _CursorAcpLike([
+        DriverResponse(
+            text="partial ACP cut off",
+            error="ACP prompt finished with stopReason=max_tokens",
+            tokens_out=8,
+            latency_ms=12.0,
+            meta={
+                "finish_reason": "length",
+                "stream_terminal": "length",
+                "stream_started": True,
+                "api_mode": "cursor_acp",
+                "wire_mode": "cursor_acp",
+                "last_provider_event": "session/prompt",
+                "stop_reason": "max_tokens",
+                "cursor_acp": True,
+                "tool_calls": [],
+            },
+        ),
+    ]), sid="sess-acp-len")
+    length_events = list(length.send("write a long essay"))
+    assert "assistant_done" not in [e.kind for e in length_events]
+    length_err = next(e for e in length_events if e.kind == "error")
+    assert length_err.data.get("terminal_cause") == "length"
+    assert executed["n"] == 0
+
+    failed = _session(tmp_path, monkeypatch, _CursorAcpLike([
+        DriverResponse(
+            text="agent died mid-turn",
+            error="ACP prompt finished with stopReason=error",
+            tokens_out=3,
+            latency_ms=8.0,
+            meta={
+                "finish_reason": "failed",
+                "stream_terminal": "error",
+                "stream_started": True,
+                "api_mode": "cursor_acp",
+                "wire_mode": "cursor_acp",
+                "last_provider_event": "session/prompt",
+                "stop_reason": "error",
+                "cursor_acp": True,
+                "tool_calls": [],
+            },
+        ),
+    ]), sid="sess-acp-err")
+    fail_events = list(failed.send("continue"))
+    assert "assistant_done" not in [e.kind for e in fail_events]
+    fail_err = next(e for e in fail_events if e.kind == "error")
+    assert fail_err.data.get("terminal_cause") == "transport_error"
+    assert executed["n"] == 0
+
+
+def test_requires_explicit_terminal_rejects_implicit_envelope_natural(tmp_path, monkeypatch):
+    class _NetworkPilot:
+        name = "openai-compat:test"
+        requires_explicit_terminal = True
+
+        def chat(self, messages, tools=None, system=None):
+            return DriverResponse(
+                text='{"say": "implicit close", "actions": []}',
+                tokens_out=3,
+                latency_ms=1.0,
+                meta={},
+            )
+
+    session = _session(tmp_path, monkeypatch, _NetworkPilot())
+    events = list(session.send("hi"))
+    kinds = [e.kind for e in events]
+    assert "assistant_done" not in kinds
+    err = next(e for e in events if e.kind == "error")
+    assert err.data.get("terminal_cause") == "unspecified"
+
+
+def test_named_model_error_carries_terminal_cause_not_generic(tmp_path, monkeypatch):
+    session = _session(tmp_path, monkeypatch, _Scripted([
+        DriverResponse(
+            text="partial answer cut off",
+            error="OpenAI chat finished with finish_reason=length",
+            tokens_out=8,
+            latency_ms=1.0,
+            meta={
+                "finish_reason": "length",
+                "stream_terminal": "length",
+                "stream_started": True,
+            },
+        ),
+    ]))
+    events = list(session.send("write a long essay"))
+    err = next(e for e in events if e.kind == "error")
+    assert err.data.get("terminal_cause") == "length"
+    assert err.data.get("finish_reason") == "length"
+    assert "connection" not in str(err.data.get("error") or "").lower()
+    assert "assistant_done" not in [e.kind for e in events]
+
+
+def test_production_drivers_use_explicit_terminal_flag_not_class_names():
+    from pmharness.drivers.codex_responses import CodexResponsesDriver
+    from pmharness.drivers.cursor_acp import CursorAcpDriver
+    from pmharness.drivers.cursor_cli import CursorCliDriver
+    from pmharness.drivers.openai_compat import OpenAICompatDriver
+
+    assert OpenAICompatDriver.requires_explicit_terminal is True
+    assert CodexResponsesDriver.requires_explicit_terminal is True
+    assert CursorCliDriver.requires_explicit_terminal is True
+    assert CursorAcpDriver.requires_explicit_terminal is True
+    assert getattr(_Scripted([]), "requires_explicit_terminal", False) is not True
+    assert getattr(_CompleteOnly([]), "requires_explicit_terminal", False) is not True

--- a/tests/test_stream_performance_store.py
+++ b/tests/test_stream_performance_store.py
@@ -384,6 +384,7 @@ def test_send_records_one_receipt_per_provider_call(monkeypatch, tmp_path):
                 text='{"say": "hi", "actions": []}',
                 tokens_out=2,
                 latency_ms=1.0,
+                meta={"finish_reason": "stop"},
             )
 
         def complete(self, prompt, system=None):
@@ -444,6 +445,7 @@ def test_overflow_failed_and_retry_are_separate_attempts(monkeypatch, tmp_path):
                 text='{"say": "recovered", "actions": []}',
                 tokens_out=2,
                 latency_ms=2.0,
+                meta={"finish_reason": "stop"},
             )
 
         def complete(self, prompt, system=None):
@@ -543,6 +545,7 @@ def test_sink_failure_does_not_change_send_hot_path(monkeypatch, tmp_path):
                 text='{"say": "still works", "actions": []}',
                 tokens_out=2,
                 latency_ms=1.0,
+                meta={"finish_reason": "stop"},
             )
 
         def complete(self, prompt, system=None):
@@ -567,6 +570,7 @@ def test_receipts_never_enter_history_display_or_transcript(monkeypatch, tmp_pat
                 text='{"say": "visible", "actions": []}',
                 tokens_out=2,
                 latency_ms=1.0,
+                meta={"finish_reason": "stop"},
             )
 
         def complete(self, prompt, system=None):
@@ -619,6 +623,7 @@ def test_malformed_tokens_out_records_one_receipt_and_hot_path_survives(monkeypa
                 text='{"say": "still honest", "actions": []}',
                 tokens_out="nope",
                 latency_ms=1.0,
+                meta={"finish_reason": "stop"},
             )
 
         def complete(self, prompt, system=None):
@@ -648,7 +653,10 @@ def test_account_provider_attempt_records_before_meter_raise(tmp_path, monkeypat
         text="ok",
         tokens_out="nope",
         latency_ms=1.0,
-        meta={STREAM_PERFORMANCE_KEY: {PROVIDER_CALL_TOTAL_MS: 9.0}},
+        meta={
+            STREAM_PERFORMANCE_KEY: {PROVIDER_CALL_TOTAL_MS: 9.0},
+            "finish_reason": "stop",
+        },
     )
     session = SimpleNamespace(
         harness_session_id="sess-order",
@@ -827,6 +835,7 @@ def test_stream_success_records_one_receipt(monkeypatch, tmp_path):
                 text='{"say": "streamed hi", "actions": []}',
                 tokens_out=4,
                 latency_ms=2.0,
+                meta={"finish_reason": "stop", "stream_started": True, "stream_terminal": "stop"},
             )
 
         def complete(self, prompt, system=None):
@@ -855,6 +864,7 @@ def test_complete_success_records_one_receipt(monkeypatch, tmp_path):
                 text='{"say": "from complete", "actions": []}',
                 tokens_out=2,
                 latency_ms=1.0,
+                meta={"finish_reason": "stop"},
             )
 
     session = _send_session(tmp_path, monkeypatch, CompleteOnly(), sid="sess-complete-ok")
@@ -880,6 +890,7 @@ def test_receipt_turn_index_and_user_ordinal(monkeypatch, tmp_path):
                 text='{"say": "turn", "actions": []}',
                 tokens_out=2,
                 latency_ms=1.0,
+                meta={"finish_reason": "stop"},
             )
 
         def complete(self, prompt, system=None):
@@ -921,6 +932,7 @@ def test_missing_session_id_skips_receipt_write(monkeypatch, tmp_path):
                 text='{"say": "ok", "actions": []}',
                 tokens_out=2,
                 latency_ms=1.0,
+                meta={"finish_reason": "stop"},
             )
 
         def complete(self, prompt, system=None):
@@ -1355,3 +1367,169 @@ def test_api_workspace_cross_session_denied(tmp_path):
     code, payload = get_session_performance({"session_id": ["sess-b"]}, current)
     assert code == 200
     assert payload["count"] == 1
+
+
+def test_receipt_schema_v2_fields_persist_and_old_v1_reads(tmp_path):
+    from harness.send_loop_phases import record_provider_stream_receipt
+    from harness.stream_performance_store import RECEIPT_SCHEMA_VERSION_V1
+
+    meta = {
+        STREAM_PERFORMANCE_KEY: {PROVIDER_CALL_TOTAL_MS: 9.0},
+        "finish_reason": "stop",
+        "stream_terminal": "stop",
+        "stream_started": True,
+        "incomplete_reason": "",
+        "api_mode": "chat_completions",
+        "malformed_sse_chunks": 2,
+        "max_tokens": 1500,
+        "requested_model": "gpt-test",
+        "served_model": "gpt-test",
+    }
+    resp = DriverResponse(
+        text="ok", tokens_in=14, tokens_out=3, latency_ms=1.0, meta=meta,
+    )
+    session = SimpleNamespace(
+        harness_session_id="sess-v2",
+        state_dir=str(tmp_path),
+        config=SimpleNamespace(driver="openai/gpt-test"),
+        _current_user_ordinal=lambda: 0,
+        pilot=SimpleNamespace(max_tokens=1500),
+    )
+    record_provider_stream_receipt(session, resp, provider_step=3, provider_attempt=1)
+    rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-v2")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["schema_version"] == RECEIPT_SCHEMA_VERSION
+    assert row["terminal_cause"] == "natural"
+    assert row["finish_reason"] == "stop"
+    assert row["stream_terminal"] == "stop"
+    assert row["stream_started"] is True
+    assert row["malformed_chunk_count"] == 2
+    assert row["requested_output_cap"] == 1500
+    assert row["api_mode"] == "chat_completions"
+    assert row["provider_step"] == 3
+    assert row["provider_attempt"] == 1
+    assert row["requested_model"] == "gpt-test"
+    assert row["served_model"] == "gpt-test"
+    assert row["assistant_done_emitted"] is False
+
+    StreamPerformanceReceiptStore(str(tmp_path)).patch_latest_receipt(
+        "sess-v2", assistant_done_emitted=True, terminal_cause="natural",
+    )
+    patched = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-v2")[0]
+    assert patched["assistant_done_emitted"] is True
+
+    old_path = Path(receipt_file_path(str(tmp_path), "sess-old"))
+    old_path.parent.mkdir(parents=True, exist_ok=True)
+    old_path.write_text(json.dumps({
+        "schema_version": RECEIPT_SCHEMA_VERSION_V1,
+        "session_id": "sess-old",
+        "receipts": [{
+            "schema_version": RECEIPT_SCHEMA_VERSION_V1,
+            "session_id": "sess-old",
+            "turn_index": 1,
+            "provider_step": 4,
+            "provider_attempt": 0,
+            "driver": "openai/gpt-test",
+            "model": "gpt-test",
+            "status": "success",
+            "captured_at": 1000.0,
+            "stream_performance": {"content_delta_count": 1},
+        }],
+    }), encoding="utf-8")
+    old_rows = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-old")
+    assert len(old_rows) == 1
+    assert old_rows[0]["session_id"] == "sess-old"
+    assert old_rows[0]["provider_step"] == 4
+    assert old_rows[0]["status"] == "success"
+    assert old_rows[0]["stream_performance"]["content_delta_count"] == 1
+    assert "terminal_cause" not in old_rows[0] or old_rows[0].get("terminal_cause") in (
+        None, "",
+    )
+
+
+def test_usage_percent_does_not_become_receipt_terminal_cause(tmp_path):
+    from harness.send_loop_phases import record_provider_stream_receipt
+
+    resp = DriverResponse(
+        text="ok",
+        tokens_in=14000,
+        tokens_out=20,
+        latency_ms=1.0,
+        meta={
+            STREAM_PERFORMANCE_KEY: {PROVIDER_CALL_TOTAL_MS: 4.0},
+            "finish_reason": "stop",
+            "raw_usage": {"prompt_tokens": 14000, "completion_tokens": 20},
+            "context_used_pct": 14,
+        },
+    )
+    session = SimpleNamespace(
+        harness_session_id="sess-ctx",
+        state_dir=str(tmp_path),
+        config=SimpleNamespace(driver="openai/gpt-test"),
+        _current_user_ordinal=lambda: 0,
+    )
+    record_provider_stream_receipt(session, resp, provider_step=0, provider_attempt=0)
+    row = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-ctx")[0]
+    assert row["terminal_cause"] == "natural"
+    assert row["finish_reason"] == "stop"
+    assert row["tokens_in"] == 14000
+
+
+def test_receipt_status_follows_terminal_cause_not_only_error(tmp_path):
+    from harness.send_loop_phases import (
+        classify_provider_receipt_status,
+        record_provider_stream_receipt,
+    )
+
+    length = DriverResponse(
+        text="cut",
+        tokens_out=4,
+        latency_ms=1.0,
+        meta={"finish_reason": "length", "stream_terminal": "length"},
+    )
+    assert classify_provider_receipt_status(length) == "error"
+    session = SimpleNamespace(
+        harness_session_id="sess-status",
+        state_dir=str(tmp_path),
+        config=SimpleNamespace(driver="openai/gpt-test"),
+        _current_user_ordinal=lambda: 0,
+    )
+    record_provider_stream_receipt(session, length, provider_step=0, provider_attempt=0)
+    row = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-status")[0]
+    assert row["status"] == "error"
+    assert row["terminal_cause"] == "length"
+    assert row["finish_reason"] == "length"
+
+    truncated = DriverResponse(
+        text="",
+        tokens_out=2,
+        latency_ms=1.0,
+        meta={
+            "finish_reason": "tool_calls",
+            "stream_terminal": "tool_calls",
+            "tool_calls": [],
+            "incomplete_tool_calls": [{
+                "id": "c1",
+                "function": {"name": "read_file", "arguments": '{"path":'},
+            }],
+        },
+    )
+    assert classify_provider_receipt_status(truncated) == "error"
+    record_provider_stream_receipt(
+        SimpleNamespace(
+            harness_session_id="sess-trunc",
+            state_dir=str(tmp_path),
+            config=SimpleNamespace(driver="openai/gpt-test"),
+            _current_user_ordinal=lambda: 0,
+        ),
+        truncated,
+        provider_step=0,
+        provider_attempt=0,
+    )
+    trunc_row = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts("sess-trunc")[0]
+    assert trunc_row["status"] == "error"
+    assert trunc_row["terminal_cause"] == "incomplete"
+
+    unspecified = DriverResponse(text="sync only", tokens_out=1, latency_ms=1.0, meta={})
+    assert classify_provider_receipt_status(unspecified) == "error"

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -35,14 +35,19 @@ class FakeStreamingDriver:
                             }
                         }
                     ],
-                    "reasoning": "Let me read the file first."
+                    "reasoning": "Let me read the file first.",
+                    "finish_reason": "tool_calls",
+                    "stream_terminal": "tool_calls",
                 }
                 return DriverResponse(text="Reading...", meta=meta)
             else:
                 text = '{"say":"Reading...","actions":[{"kind":"read_file","path":"test.txt"}]}'
-                return DriverResponse(text=text)
+                return DriverResponse(text=text, meta={"finish_reason": "stop"})
         else:
-            return DriverResponse(text="Done.", meta={"tool_calls": [], "reasoning": ""})
+            return DriverResponse(
+                text="Done.",
+                meta={"tool_calls": [], "reasoning": "", "finish_reason": "stop"},
+            )
 
     def chat_stream(self, messages, *, tools=None, system=None, on_delta,
                     on_reasoning_delta=None, on_tool_hint=None):
@@ -67,14 +72,29 @@ class FakeStreamingDriver:
                             }
                         }
                     ],
-                    "reasoning": "Let me read the file first."
+                    "reasoning": "Let me read the file first.",
+                    "finish_reason": "tool_calls",
+                    "stream_terminal": "tool_calls",
+                    "stream_started": True,
                 }
                 return DriverResponse(text="Reading...", meta=meta)
             else:
                 text = '{"say":"Reading...","actions":[{"kind":"read_file","path":"test.txt"}]}'
-                return DriverResponse(text=text)
+                return DriverResponse(
+                    text=text,
+                    meta={"finish_reason": "stop", "stream_started": True, "stream_terminal": "stop"},
+                )
         else:
-            return DriverResponse(text="Done.", meta={"tool_calls": [], "reasoning": ""})
+            return DriverResponse(
+                text="Done.",
+                meta={
+                    "tool_calls": [],
+                    "reasoning": "",
+                    "finish_reason": "stop",
+                    "stream_started": True,
+                    "stream_terminal": "stop",
+                },
+            )
 
 
 def test_driver_chat_stream_assembly():
@@ -126,7 +146,8 @@ def test_driver_chat_stream_assembly():
                             "arguments": 'th": "foo"}'
                         }
                     }]
-                }
+                },
+                "finish_reason": "tool_calls",
             }]
         }).encode("utf-8") + b"\n",
         b"data: " + json.dumps({
@@ -192,6 +213,8 @@ def test_driver_chat_stream_assembly():
         assert tool_calls[0]["id"] == "call_99"
         assert tool_calls[0]["function"]["name"] == "read_file"
         assert tool_calls[0]["function"]["arguments"] == '{"path": "foo"}'
+        assert resp.error is None
+        assert resp.meta["finish_reason"] == "tool_calls"
 
     finally:
         urllib.request.urlopen = original_urlopen
@@ -210,6 +233,9 @@ def _sse_stream_driver(monkeypatch, sse_payloads):
         b"data: " + json.dumps(payload).encode("utf-8") + b"\n"
         for payload in sse_payloads
     ]
+    lines.append(
+        b'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n'
+    )
     lines.append(b"data: [DONE]\n")
 
     class FakeResponse:
@@ -397,7 +423,13 @@ class _MissingIdStreamingPilot:
             return DriverResponse(
                 text="",
                 tokens_out=4,
-                meta={"tool_calls": payload, "reasoning": "read both"},
+                meta={
+                    "tool_calls": payload,
+                    "reasoning": "read both",
+                    "finish_reason": "tool_calls",
+                    "stream_terminal": "tool_calls",
+                    "stream_started": True,
+                },
             )
         if self.calls == 2:
             payload = [
@@ -414,12 +446,24 @@ class _MissingIdStreamingPilot:
             return DriverResponse(
                 text="",
                 tokens_out=3,
-                meta={"tool_calls": payload, "reasoning": "read third"},
+                meta={
+                    "tool_calls": payload,
+                    "reasoning": "read third",
+                    "finish_reason": "tool_calls",
+                    "stream_terminal": "tool_calls",
+                    "stream_started": True,
+                },
             )
         return DriverResponse(
             text="Done.",
             tokens_out=2,
-            meta={"tool_calls": [], "reasoning": ""},
+            meta={
+                "tool_calls": [],
+                "reasoning": "",
+                "finish_reason": "stop",
+                "stream_terminal": "stop",
+                "stream_started": True,
+            },
         )
 
 
@@ -483,7 +527,13 @@ class _LiveReasoningPilot:
         return DriverResponse(
             text="Here is the summary.",
             tokens_out=12,
-            meta={"tool_calls": [], "reasoning": "Let me pull the latest from GitHub and check the wiki."},
+            meta={
+                "tool_calls": [],
+                "reasoning": "Let me pull the latest from GitHub and check the wiki.",
+                "finish_reason": "stop",
+                "stream_terminal": "stop",
+                "stream_started": True,
+            },
         )
 
 

--- a/tests/test_task_kernel_wire.py
+++ b/tests/test_task_kernel_wire.py
@@ -172,10 +172,12 @@ def test_finalize_assistant_turn_emits_done_and_persists(tmp_path: Path):
         turn_prose=["p"],
         turn_findings=[],
         extra={"stagnation_halt": True},
+        stop_cause="stagnation",
     ))
     assert events[0].kind == "assistant_done"
     assert events[0].data["turns"] == 2
     assert events[0].data["stagnation_halt"] is True
+    assert events[0].data["stop_cause"] == "stagnation"
     assert submitted == [("ingest", ("hi", ["p"], []))]
     rows = load_receipts(str(tmp_path), limit=1)
     assert rows[0]["task_id"] == "s"

--- a/tests/test_terminal_cause.py
+++ b/tests/test_terminal_cause.py
@@ -1,0 +1,181 @@
+"""Pure classifier table for provider / send-loop terminal causes."""
+from __future__ import annotations
+
+import pytest
+
+from harness.terminal_cause import (
+    TERMINAL_CONTENT_FILTER,
+    TERMINAL_INCOMPLETE,
+    TERMINAL_LENGTH,
+    TERMINAL_NATURAL,
+    TERMINAL_PROVIDER_EOF,
+    TERMINAL_TOOL_CALLS,
+    TERMINAL_TRANSPORT_ERROR,
+    TERMINAL_UNSPECIFIED,
+    classify_provider_terminal,
+    finalize_stop_cause,
+    provider_tools_are_executable,
+)
+from pmharness.drivers.base import DriverResponse
+
+
+def _resp(text="", error=None, **meta):
+    return DriverResponse(text=text, error=error, meta=meta)
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"finish_reason": "stop"}, TERMINAL_NATURAL),
+        ({"finish_reason": "tool_calls", "tool_calls": [
+            {"id": "c1", "function": {"name": "read_file", "arguments": "{}"}},
+        ]}, TERMINAL_TOOL_CALLS),
+        ({"finish_reason": "length"}, TERMINAL_LENGTH),
+        ({"finish_reason": "content_filter"}, TERMINAL_CONTENT_FILTER),
+        ({"finish_reason": "end_turn"}, TERMINAL_NATURAL),
+        ({"finish_reason": "max_tokens"}, TERMINAL_LENGTH),
+        ({"finish_reason": "tool_use", "tool_calls": [
+            {"id": "c1", "function": {"name": "read_file", "arguments": "{}"}},
+        ]}, TERMINAL_TOOL_CALLS),
+        ({"finish_reason": "completed"}, TERMINAL_NATURAL),
+        ({"finish_reason": "incomplete", "incomplete_reason": "max_output_tokens"},
+         TERMINAL_LENGTH),
+        ({"finish_reason": "incomplete", "incomplete_reason": "content_filter"},
+         TERMINAL_CONTENT_FILTER),
+        ({"finish_reason": "incomplete"}, TERMINAL_INCOMPLETE),
+        ({"finish_reason": "failed"}, TERMINAL_TRANSPORT_ERROR),
+        ({"finish_reason": "STOP"}, TERMINAL_NATURAL),
+        ({"finish_reason": "MAX_TOKENS"}, TERMINAL_LENGTH),
+        ({"finish_reason": "SAFETY"}, TERMINAL_CONTENT_FILTER),
+        ({"finish_reason": "RECITATION"}, TERMINAL_CONTENT_FILTER),
+        ({"stream_terminal": "stop"}, TERMINAL_NATURAL),
+        ({"stream_terminal": "tool_calls", "tool_calls": [
+            {"id": "c1", "function": {"name": "x", "arguments": ""}},
+        ]}, TERMINAL_TOOL_CALLS),
+        ({"stream_terminal": "length", "finish_reason": "length"}, TERMINAL_LENGTH),
+        ({"stream_terminal": "incomplete", "stream_started": True},
+         TERMINAL_INCOMPLETE),
+        ({"stream_terminal": "incomplete", "incomplete_reason": "max_output_tokens"},
+         TERMINAL_LENGTH),
+        ({"stream_terminal": "incomplete", "incomplete_reason": "length"},
+         TERMINAL_LENGTH),
+        ({"stream_terminal": "empty"}, TERMINAL_INCOMPLETE),
+        ({"stream_terminal": "error"}, TERMINAL_TRANSPORT_ERROR),
+        ({"finish_reason": "stop_sequence"}, TERMINAL_NATURAL),
+        ({"finish_reason": "end_turn", "stop_reason": "end_turn"}, TERMINAL_NATURAL),
+    ],
+)
+def test_classifier_table_known_dialects(kwargs, expected):
+    classified = classify_provider_terminal(_resp("hello", **kwargs))
+    assert classified.cause == expected
+    if expected == TERMINAL_NATURAL:
+        assert classified.is_affirmative_natural is True
+        assert classified.blocks_clean_finalize is False
+    else:
+        assert classified.is_affirmative_natural is False
+
+
+def test_missing_and_unknown_never_default_to_natural():
+    missing = classify_provider_terminal(_resp("partial", stream_started=True))
+    assert missing.cause == TERMINAL_PROVIDER_EOF
+    assert missing.is_affirmative_natural is False
+    assert missing.blocks_clean_finalize is True
+
+    unknown = classify_provider_terminal(_resp("x", finish_reason="mystery_code"))
+    assert unknown.cause == TERMINAL_UNSPECIFIED
+    assert unknown.is_affirmative_natural is False
+    assert unknown.blocks_clean_finalize is True
+
+    empty = classify_provider_terminal(_resp(""))
+    assert empty.cause == TERMINAL_UNSPECIFIED
+    assert empty.is_affirmative_natural is False
+    assert empty.blocks_clean_finalize is True
+
+    text_only = classify_provider_terminal(_resp("hello there"))
+    assert text_only.cause == TERMINAL_UNSPECIFIED
+    assert text_only.is_affirmative_natural is False
+    assert text_only.blocks_clean_finalize is True
+    assert finalize_stop_cause(text_only) == TERMINAL_UNSPECIFIED
+    assert finalize_stop_cause(empty) != TERMINAL_NATURAL
+    assert finalize_stop_cause(None) == TERMINAL_UNSPECIFIED
+
+
+def test_input_usage_and_context_percent_are_not_output_terminals():
+    classified = classify_provider_terminal(_resp(
+        "ok",
+        finish_reason="stop",
+        tokens_in=14000,
+        context_used_pct=14,
+        raw_usage={"prompt_tokens": 14000, "completion_tokens": 20},
+        cache_read_tokens=9000,
+    ))
+    assert classified.cause == TERMINAL_NATURAL
+    assert classified.is_affirmative_natural is True
+
+    usage_only = classify_provider_terminal(_resp(
+        "",
+        tokens_in=14000,
+        raw_usage={"prompt_tokens": 14000, "completion_tokens": 0},
+        context_used_pct=14,
+    ))
+    assert usage_only.cause == TERMINAL_UNSPECIFIED
+    assert usage_only.cause != TERMINAL_LENGTH
+    assert usage_only.is_affirmative_natural is False
+    assert usage_only.blocks_clean_finalize is True
+    assert finalize_stop_cause(usage_only) == TERMINAL_UNSPECIFIED
+
+
+def test_incomplete_tools_are_not_executable():
+    resp = _resp(
+        "",
+        finish_reason="tool_calls",
+        tool_calls=[],
+        incomplete_tool_calls=[{
+            "id": "c1",
+            "function": {"name": "read_file", "arguments": '{"path":'},
+        }],
+    )
+    classified = classify_provider_terminal(resp)
+    assert classified.cause == TERMINAL_INCOMPLETE
+    assert classified.allows_tool_execution is False
+    assert provider_tools_are_executable(resp) is False
+
+
+def test_truncated_args_in_tool_calls_cannot_execute():
+    resp = _resp(
+        "",
+        finish_reason="tool_calls",
+        tool_calls=[{
+            "id": "c1",
+            "function": {"name": "read_file", "arguments": '{"path":'},
+        }],
+    )
+    assert provider_tools_are_executable(resp) is False
+    assert classify_provider_terminal(resp).allows_tool_execution is False
+
+
+def test_transport_error_string_and_wave1_error_terminal():
+    http = classify_provider_terminal(_resp("hello", error="HTTP 502: upstream"))
+    assert http.cause == TERMINAL_TRANSPORT_ERROR
+    assert http.blocks_clean_finalize is True
+
+    stream_err = classify_provider_terminal(_resp(
+        "hello", error="HTTP 502: upstream", stream_terminal="error",
+        stream_started=True,
+    ))
+    assert stream_err.cause == TERMINAL_TRANSPORT_ERROR
+
+
+def test_classifier_never_raises():
+    class Boom:
+        @property
+        def meta(self):
+            raise RuntimeError("nope")
+
+        @property
+        def error(self):
+            raise RuntimeError("nope")
+
+    classified = classify_provider_terminal(Boom())
+    assert classified.cause == TERMINAL_UNSPECIFIED
+    assert classified.is_affirmative_natural is False

--- a/tests/test_tool_name_repair.py
+++ b/tests/test_tool_name_repair.py
@@ -363,6 +363,7 @@ def test_g_three_invalid_only_steps_halt_after_results(tmp_path, monkeypatch):
     assert "invalid tool" in (halt.data.get("reason") or "").lower()
     done = next(e for e in events if e.kind == "assistant_done")
     assert done.data.get("invalid_tool_halt") is True
+    assert done.data.get("stop_cause") == "invalid_tool"
     tool_msgs = [m for m in session._history if m.get("role") == "tool"]
     assert len(tool_msgs) == 3
     assert {m.get("tool_call_id") for m in tool_msgs} == {"tc_a", "tc_b", "tc_c"}

--- a/tests/test_turn_budget.py
+++ b/tests/test_turn_budget.py
@@ -72,7 +72,12 @@ class _BudgetPilot:
                 self.user_contents.append(str(m.get("content") or ""))
         txt = self.turns[min(self.step, len(self.turns) - 1)]
         self.step += 1
-        return DriverResponse(text=txt, tokens_out=self.tokens_out, latency_ms=1.0)
+        return DriverResponse(
+            text=txt,
+            tokens_out=self.tokens_out,
+            latency_ms=1.0,
+            meta={"finish_reason": "stop"},
+        )
 
     def complete(self, prompt, *, system=None):
         from pmharness.drivers.openai_compat import DriverResponse
@@ -80,7 +85,12 @@ class _BudgetPilot:
         self.system_prompts.append(system or "")
         txt = self.turns[min(self.step, len(self.turns) - 1)]
         self.step += 1
-        return DriverResponse(text=txt, tokens_out=self.tokens_out, latency_ms=1.0)
+        return DriverResponse(
+            text=txt,
+            tokens_out=self.tokens_out,
+            latency_ms=1.0,
+            meta={"finish_reason": "stop"},
+        )
 
 
 def test_hard_turn_budget_stops_loop_early():
@@ -98,6 +108,7 @@ def test_hard_turn_budget_stops_loop_early():
         events = list(session.send("Work on this +100!"))
         done = next(e for e in events if e.kind == "assistant_done")
         assert done.data.get("turn_budget_exhausted") is True
+        assert done.data.get("stop_cause") == "turn_budget"
         assert done.data["turns"] == 2
         usage = session.get_context_usage()
         assert usage.get("turn_budget_exhausted") is True

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.267"
+version = "0.9.268"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/electron/stream-bridge.test.cjs
+++ b/webapp/electron/stream-bridge.test.cjs
@@ -90,6 +90,19 @@ test("2xx stream end without a done frame still emits :done", () => {
   assert.equal(calls.errors.length, 0);
 });
 
+test("2xx body end after partial frames without assistant_done is one :done, not :error", () => {
+  const res = fakeResponse(200);
+  const calls = wireWithRecorder(res);
+  res.emit("data", 'data: {"kind":"message_delta","data":{"text":"The handler should "}}\n\n');
+  res.emit("data", 'data: {"kind":"stream_item_done","data":{"stream_id":"a1"}}\n\n');
+  res.emit("end");
+  assert.equal(calls.done, 1, "raw 2xx body end must settle exactly once via onDone");
+  assert.equal(calls.errors.length, 0, "2xx body end is not onError-success");
+  assert.equal(calls.events.length, 2);
+  assert.equal(calls.events[0].kind, "message_delta");
+  assert.ok(!calls.events.some((ev) => ev.kind === "assistant_done"));
+});
+
 test("2xx response error maps to a sanitized connection :error", () => {
   const res = fakeResponse(200);
   const calls = wireWithRecorder(res);

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.267",
+  "version": "0.9.268",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.267",
+      "version": "0.9.268",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.267",
+  "version": "0.9.268",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/ComposerDock.recovery.test.tsx
+++ b/webapp/src/__tests__/ComposerDock.recovery.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Continue / Retry: disabled while busy, one dispatch, honest visible send.
+ */
+import { createRef } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ComposerDock from "../components/conversation/ComposerDock";
+
+vi.mock("../lib/api", () => ({
+  api: {},
+}));
+vi.mock("../components/PilotPicker", () => ({
+  default: () => <div data-testid="pilot-picker" />,
+}));
+vi.mock("../components/conversation/WorkspaceChip", () => ({
+  default: () => <div data-testid="workspace-chip" />,
+}));
+
+const noop = () => {};
+
+function renderDock(opts: {
+  composerBusy: boolean;
+  recoveryAvailable?: boolean;
+  recoveryRetryAvailable?: boolean;
+  onContinue?: () => void;
+  onRetry?: () => void;
+}) {
+  return render(
+    <ComposerDock
+      config={null}
+      taRef={createRef<HTMLTextAreaElement>()}
+      input=""
+      auto={false}
+      plan={false}
+      composerBusy={opts.composerBusy}
+      transcriptStale={false}
+      wikiPrepared={null}
+      memoryProposals={[]}
+      distillNotice={null}
+      msgQueue={[]}
+      dragIndex={null}
+      dragOverIndex={null}
+      queueItems={[]}
+      queueDragIndex={null}
+      queueDragOverIndex={null}
+      editingIndex={null}
+      canRevertEdit={false}
+      editNotice={null}
+      editBusy={false}
+      showContextPanel={false}
+      contextUsage={null}
+      mentionSearch={null}
+      filteredFiles={[]}
+      filteredFolders={[]}
+      symbolResults={[]}
+      mentionListingCap={null}
+      selectedFileIndex={0}
+      codegraphStatus={null}
+      slashSearch={null}
+      selectedSlashIndex={0}
+      allSlashCommands={[]}
+      attachedImages={[]}
+      isDragOver={false}
+      uploadError={null}
+      onSetWikiPrepared={noop}
+      onSetMemoryProposals={noop}
+      onSetDistillNotice={noop}
+      onSetMsgQueue={noop}
+      onSetInput={noop}
+      onSetAuto={noop}
+      onSetPlan={noop}
+      onSetCanRevertEdit={noop}
+      onSetEditNotice={noop}
+      onSetShowContextPanel={noop}
+      onSetSelectedFileIndex={noop}
+      onSetSelectedSlashIndex={noop}
+      onSetAttachedImages={noop}
+      onSetUploadError={noop}
+      onSetLightboxUrl={noop}
+      setSafeTimeout={noop}
+      fetchContextUsage={noop}
+      handleDragStart={noop}
+      handleDragOver={noop}
+      handleDragLeave={noop}
+      handleDrop={noop}
+      handleDragEnd={noop}
+      moveQueueItem={noop}
+      handleQueueClearAll={noop}
+      handleQueueDragStart={noop}
+      handleQueueDragOver={noop}
+      handleQueueDragLeave={noop}
+      handleQueueDrop={noop}
+      handleQueueDragEnd={noop}
+      handleQueueEdit={noop}
+      handleQueueRemove={noop}
+      handleComposerDragOver={noop}
+      handleComposerDragLeave={noop}
+      handleComposerDrop={noop}
+      handleRevertEdit={noop}
+      handleCancelEdit={noop}
+      handleInputChange={noop}
+      handleKeyDown={noop}
+      handlePaste={noop}
+      insertMention={noop}
+      insertFolder={noop}
+      insertSymbol={noop}
+      insertCodebase={noop}
+      showCodebaseMention={false}
+      insertSlashCommand={noop}
+      handleQueueAdd={noop}
+      stop={noop}
+      send={noop}
+      recoveryAvailable={opts.recoveryAvailable}
+      recoveryRetryAvailable={opts.recoveryRetryAvailable}
+      recoveryCause="provider_eof"
+      onContinue={opts.onContinue}
+      onRetry={opts.onRetry}
+    />,
+  );
+}
+
+describe("ComposerDock recovery chrome", () => {
+  it("hides Continue/Retry while the mouth is busy", () => {
+    renderDock({ composerBusy: true, recoveryAvailable: true });
+    expect(screen.queryByRole("button", { name: /continue/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /retry/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
+  });
+
+  it("dispatches Continue and Retry exactly once from an incomplete turn", () => {
+    const onContinue = vi.fn();
+    const onRetry = vi.fn();
+    renderDock({
+      composerBusy: false,
+      recoveryAvailable: true,
+      recoveryRetryAvailable: true,
+      onContinue,
+      onRetry,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Retry when there is no latest user ask", () => {
+    const onRetry = vi.fn();
+    renderDock({
+      composerBusy: false,
+      recoveryAvailable: true,
+      recoveryRetryAvailable: false,
+      onRetry,
+    });
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+});

--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -810,7 +810,7 @@ describe("Wave 4 command-job reattach fences", () => {
           {
             id: 4,
             kind: "stream",
-            data: { cursor: 4, kind: "assistant_done", data: {}, generation: 1 },
+            data: { cursor: 4, kind: "assistant_done", data: { stop_cause: "natural" }, generation: 1 },
           },
         ],
       } as any;
@@ -1081,7 +1081,7 @@ describe("mid-turn store-event cursor reattach", () => {
       events: [{
         id: 5,
         kind: "stream",
-        data: { cursor: 5, kind: "assistant_done", data: {}, generation: 1 },
+        data: { cursor: 5, kind: "assistant_done", data: { stop_cause: "natural" }, generation: 1 },
       }],
     } as any);
 

--- a/webapp/src/__tests__/chatLoopResilience.wave5.test.ts
+++ b/webapp/src/__tests__/chatLoopResilience.wave5.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   STREAM_ABORT_MESSAGE,
   resetCrossSessionLatchesOnSwitch,
+  resetTurnLifecycleOnSessionSwitch,
   resetTurnSettledOnSessionSwitch,
   shouldRefreshBusyChrome,
   streamOnDoneDecision,
@@ -220,14 +221,13 @@ describe("Wave 5: stream EOF without assistant_done stays honest", () => {
     expect(shouldRefreshBusyChrome({ turnSettled: true })).toBe(false);
   });
 
-  it("silently settles when the answer is already complete (no false abort)", () => {
+  it("does not silently settle from a sealed answer without assistant_done", () => {
     expect(
       streamOnDoneDecision({
         turnSettled: false,
         userStopped: false,
-        answerComplete: true,
       }).kind,
-    ).toBe("done");
+    ).toBe("abort_error");
   });
 });
 
@@ -262,7 +262,26 @@ describe("Wave 5: interrupted / done framing settle turn chrome", () => {
     apply({ kind: "done", data: {} });
     expect(state.turnSettledRef.current).toBe(true);
     expect(state.turnOpen).toBe(false);
-    expect(state.status).toBe("done");
+    expect(state.status).not.toBe("thinking");
+    expect(state.status).not.toBe("streaming");
+    expect(state.status).not.toBe("done");
+  });
+
+  it("resets recovery lifecycle so Continue from A cannot dispatch into B", () => {
+    const recoveryDispatchingRef = { current: true };
+    const recoveryContextRef = {
+      current: { sessionId: "sess-a", generation: 9 },
+    };
+    const lifecycle: { current: string } = { current: "settled_incomplete" };
+    resetTurnLifecycleOnSessionSwitch({
+      setTurnLifecycle: (next) => { lifecycle.current = next; },
+      setTerminalCause: () => {},
+      recoveryDispatchingRef,
+      recoveryContextRef,
+    });
+    expect(lifecycle.current).toBe("settled_complete");
+    expect(recoveryDispatchingRef.current).toBe(false);
+    expect(recoveryContextRef.current).toBeNull();
   });
 
   it("clears turnSettled on session switch so mid-turn B can refresh busy chrome", () => {
@@ -339,7 +358,7 @@ describe("Wave 5: command timeout settles the card and chrome", () => {
     expect(cardEffectivelyRunning(cardItem.card)).toBe(false);
     expect(state.status).toBe("thinking");
 
-    apply({ kind: "assistant_done", data: {} });
+    apply({ kind: "assistant_done", data: { stop_cause: "natural" } });
     expect(state.turnOpen).toBe(false);
     expect(state.status).toBe("done");
     expect(state.waitHint).toBeNull();

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -1072,6 +1072,7 @@ describe("pillStatus + workspaceDisplay + StatusPill chrome", () => {
     expect(isPilotMouthBusy(false, "thinking")).toBe(true);
     expect(isPilotMouthBusy(false, "streaming")).toBe(true);
     expect(isPilotMouthBusy(false, "idle")).toBe(false);
+    expect(isPilotMouthBusy(false, "idle", true)).toBe(true);
   });
 
   it("workspaceLeafName and StatusPill helpers stay calm Cursor chrome", () => {

--- a/webapp/src/__tests__/feedScroll.test.ts
+++ b/webapp/src/__tests__/feedScroll.test.ts
@@ -141,6 +141,32 @@ describe("scrollTopAfterFeedHeightChange", () => {
     ).toBeNull();
   });
 
+  it("does not follow fold or tool-shelf expansion while unpinned", () => {
+    expect(
+      scrollTopAfterFeedHeightChange({
+        scrollHeight: 2400,
+        scrollTop: 200,
+        clientHeight: client,
+        pinned: false,
+        settling: false,
+        releasedByGesture: false,
+      }),
+    ).toBeNull();
+    expect(
+      feedResizeScrollFollowDecision({
+        scrollHeight: 2400,
+        scrollTop: 200,
+        clientHeight: client,
+        offsetHeight: client,
+        snapshotPinned: false,
+        snapshotSettling: false,
+        snapshotScrollTop: 200,
+        snapshotScrollHeight: 2000,
+        releasedByGesture: false,
+      }),
+    ).toEqual({ kind: "noop" });
+  });
+
   it("follows during settling when the user has not released", () => {
     expect(
       scrollTopAfterFeedHeightChange({

--- a/webapp/src/__tests__/streamTerminal.error.test.ts
+++ b/webapp/src/__tests__/streamTerminal.error.test.ts
@@ -8,7 +8,9 @@
 import { describe, expect, it } from "vitest";
 import {
   STREAM_ABORT_MESSAGE,
+  alreadySettledOnDoneStatus,
   resetCrossSessionLatchesOnSwitch,
+  resetTurnLifecycleOnSessionSwitch,
   resetTurnSettledOnSessionSwitch,
   shouldRefreshBusyChrome,
   streamErrorText,
@@ -59,6 +61,18 @@ describe("streamErrorText", () => {
     expect(streamErrorText("something odd")).toBe(STREAM_ABORT_MESSAGE);
   });
 
+  it("named model terminals are not connection-lost chrome", () => {
+    expect(streamErrorText({ message: "boom" }, "length")).toMatch(/length/i);
+    expect(streamErrorText({ message: "boom" }, "length")).not.toMatch(
+      /connection|closed before/i,
+    );
+    expect(streamErrorText({ message: "boom" }, "content_filter")).toMatch(/refused/i);
+    expect(streamErrorText({ message: "boom" }, "incomplete")).toMatch(/incomplete/i);
+    expect(streamErrorText({ message: "boom" }, "provider_eof")).not.toMatch(
+      /connection lost/i,
+    );
+  });
+
   it("never echoes raw error payload text (no token/body leakage)", () => {
     for (const err of [
       { status: 403, code: "auth", message: `rejected token ${SECRET}` },
@@ -79,14 +93,13 @@ describe("Wave 5 stream terminal chrome gates", () => {
     expect(streamOnDoneDecision({ turnSettled: true, userStopped: false }).kind).toBe("done");
   });
 
-  it("does not paint abort when the answer is already complete", () => {
+  it("does not treat a sealed answer as authority for stream EOF", () => {
     expect(
       streamOnDoneDecision({
         turnSettled: false,
         userStopped: false,
-        answerComplete: true,
       }).kind,
-    ).toBe("done");
+    ).toBe("abort_error");
   });
 
   it("blocks busy-chrome refresh after settle or Stop", () => {
@@ -99,6 +112,38 @@ describe("Wave 5 stream terminal chrome gates", () => {
     const ref = { current: true };
     resetTurnSettledOnSessionSwitch(ref);
     expect(ref.current).toBe(false);
+  });
+
+  it("resets turn lifecycle and recovery context on session switch", () => {
+    const lifecycle: { current: string } = { current: "settled_incomplete" };
+    const cause: { current: string | null } = { current: "provider_eof" };
+    const recoveryDispatchingRef = { current: true };
+    const recoveryContextRef = {
+      current: { sessionId: "sess-a", generation: 2 },
+    };
+    resetTurnLifecycleOnSessionSwitch({
+      setTurnLifecycle: (next) => { lifecycle.current = next; },
+      setTerminalCause: (next) => { cause.current = next; },
+      recoveryDispatchingRef,
+      recoveryContextRef,
+    });
+    expect(lifecycle.current).toBe("settled_complete");
+    expect(cause.current).toBeNull();
+    expect(recoveryDispatchingRef.current).toBe(false);
+    expect(recoveryContextRef.current).toBeNull();
+  });
+
+  it("already-settled onDone never upgrades error/idle to done", () => {
+    expect(alreadySettledOnDoneStatus({
+      prev: "error",
+      liveJobs: false,
+      userStopped: false,
+    })).toBe("error");
+    expect(alreadySettledOnDoneStatus({
+      prev: "idle",
+      liveJobs: false,
+      userStopped: true,
+    })).toBe("idle");
   });
 
   it("clears userStopped / resume / approved-retry latches on session switch", () => {

--- a/webapp/src/__tests__/thinkingStreamUx.test.ts
+++ b/webapp/src/__tests__/thinkingStreamUx.test.ts
@@ -1372,7 +1372,7 @@ describe("createApplyStreamEvent waitHint lifecycle", () => {
   it("clears waitHint on terminal assistant_done with no live jobs", () => {
     const { state, apply } = makeWaitHintDeps();
     apply({ kind: "notice", data: { kind: "wait", message: "Provider still working — stream idle" } });
-    apply({ kind: "assistant_done", data: {} });
+    apply({ kind: "assistant_done", data: { stop_cause: "natural" } });
     expect(state.waitHint).toBeNull();
   });
 
@@ -1389,7 +1389,7 @@ describe("createApplyStreamEvent waitHint lifecycle", () => {
     deps.setStatus = ((value: any) => {
       hintState.status = typeof value === "function" ? value(hintState.status) : value;
     }) as typeof deps.setStatus;
-    createApplyStreamEvent(deps)({ kind: "assistant_done", data: {} });
+    createApplyStreamEvent(deps)({ kind: "assistant_done", data: { stop_cause: "natural" } });
     expect(hintState.waitHint).toBe("Still working…");
     expect(hintState.status).toBe("awaiting_swarm");
   });

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -922,4 +922,102 @@ describe("live command token clicks", () => {
     expect(clearance).toHaveClass("feed-bottom-clearance");
     expect(clearance.style.height).toBe("clamp(72px, 12vh, 144px)");
   });
+
+  it("keeps a tool-free live answer outside the collapsed ActivityGroup", () => {
+    const live: Item = {
+      kind: "msg",
+      msg: { role: "assistant", text: "I will patch auth next.", streaming: true },
+    };
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "fix auth" } },
+      live,
+    ];
+    expect(collectIntermediateAssistantItems(items, true).has(live)).toBe(false);
+    render(
+      <TranscriptList
+        {...listProps(items)}
+        status="streaming"
+        turnOpen
+      />,
+    );
+    expect(screen.getByText(/I will patch auth next/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Investigating|Explored/i })).toBeNull();
+  });
+
+  it("groups consecutive read/search cards into one exploration shelf", () => {
+    render(
+      <TranscriptList
+        {...listProps([
+          { kind: "msg", msg: { role: "user", text: "look around" } },
+          {
+            kind: "card",
+            card: {
+              id: "r1",
+              goal: "auth.ts",
+              cwd: null,
+              kind: "read_file",
+              running: false,
+              open: false,
+              result: { status: "ok" },
+            },
+          },
+          {
+            kind: "card",
+            card: {
+              id: "g1",
+              goal: "login",
+              cwd: null,
+              kind: "grep",
+              running: false,
+              open: false,
+              result: { status: "ok" },
+            },
+          },
+        ])}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Explored/i }));
+    expect(screen.getByTestId("exploration-shelf")).toBeTruthy();
+    expect(screen.getByTestId("exploration-shelf")).toHaveAttribute("data-count", "2");
+  });
+
+  it("does not remount the exploration shelf when a consecutive card appends", () => {
+    const card = (id: string, running = false): Item => ({
+      kind: "card",
+      card: {
+        id,
+        goal: `${id}.ts`,
+        cwd: null,
+        kind: "read_file",
+        running,
+        open: false,
+        result: running ? undefined : { status: "ok" },
+      },
+    });
+    const user: Item = { kind: "msg", msg: { role: "user", text: "look around" } };
+    const { rerender } = render(
+      <TranscriptList
+        {...listProps([user, card("r1", true), card("g1", true)])}
+        status="executing"
+        turnOpen
+      />,
+    );
+    if (!screen.queryByRole("button", { name: /^Exploration /i })) {
+      fireEvent.click(screen.getByRole("button", { name: /Investigating|Explored/i }));
+    }
+    const shelfToggle = screen.getByRole("button", { name: /^Exploration /i });
+    expect(shelfToggle).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(shelfToggle);
+    expect(shelfToggle).toHaveAttribute("aria-expanded", "false");
+    rerender(
+      <TranscriptList
+        {...listProps([user, card("r1", true), card("g1", true), card("r2", true)])}
+        status="executing"
+        turnOpen
+      />,
+    );
+    const shelfAfter = screen.getByRole("button", { name: /^Exploration /i });
+    expect(screen.getByTestId("exploration-shelf")).toHaveAttribute("data-count", "3");
+    expect(shelfAfter).toHaveAttribute("aria-expanded", "false");
+  });
 });

--- a/webapp/src/__tests__/transcriptSurfaceStability.test.ts
+++ b/webapp/src/__tests__/transcriptSurfaceStability.test.ts
@@ -259,10 +259,9 @@ describe("transcript surface stability (no mid-turn reclassification)", () => {
     ];
 
     const whileOpen = collectIntermediateAssistantItems(items, true);
-    // While open, fold mid-turn narration once investigation activity exists
-    // (avoids outside-stream → absorb blink). Pre-tool sealed text folds too.
-    expect(whileOpen.has(preTool)).toBe(true);
-    expect(whileOpen.has(postTool)).toBe(true);
+    // Live answer stays a top-level Bubble (no absorb → peel remount).
+    expect(whileOpen.has(preTool)).toBe(false);
+    expect(whileOpen.has(postTool)).toBe(false);
 
     const whenDone = collectIntermediateAssistantItems(items, false);
     expect(whenDone.has(preTool)).toBe(false);
@@ -430,8 +429,8 @@ describe("transcript surface stability (no mid-turn reclassification)", () => {
     // absorbing it shrinks the render window and makes Explored/swarm-done
     // rows vanish when the loop seals and finales peel back out.
     expect(whileOpen.has(priorFinale)).toBe(false);
-    // Current-turn streaming narration still folds (blink-free).
-    expect(whileOpen.has(liveStream)).toBe(true);
+    // Tool-free live answer stays outside the collapsed ActivityGroup.
+    expect(whileOpen.has(liveStream)).toBe(false);
 
     const whenDone = collectIntermediateAssistantItems(items, false);
     expect(whenDone.has(priorFinale)).toBe(false);
@@ -469,7 +468,7 @@ describe("transcript surface stability (no mid-turn reclassification)", () => {
       worker,
     ];
     const absorbed = collectIntermediateAssistantItems(items, true);
-    expect(absorbed.has(narration)).toBe(true);
+    expect(absorbed.has(narration)).toBe(false);
     // Absorbed into the fold; ActivityGroup renders via Bubble, not muted <pre>.
     expect(absorbed.has(worker)).toBe(true);
   });
@@ -968,7 +967,7 @@ describe("transcript surface stability (no mid-turn reclassification)", () => {
     state.itemsRef.current = state.items;
     const apply = createApplyStreamEvent(makeApplyDeps(state));
 
-    apply({ kind: "assistant_done", data: {} });
+    apply({ kind: "assistant_done", data: { stop_cause: "natural" } });
     expect(surfaceKinds(state.items)).toEqual(["msg:user", "msg:assistant"]);
     expect(assistantTexts(state.items)).toEqual(["almost done"]);
   });

--- a/webapp/src/__tests__/transportConn.test.ts
+++ b/webapp/src/__tests__/transportConn.test.ts
@@ -124,7 +124,7 @@ describe("web fetch SSE stream terminal settle", () => {
       "fetch",
       vi.fn(async () =>
         sseResponse([
-          'data: {"kind":"assistant_done","data":{}}\n\n',
+          'data: {"kind":"assistant_done","data":{"stop_cause":"natural"}}\n\n',
           'data: {"kind":"done"}\n\n',
         ]),
       ),

--- a/webapp/src/__tests__/turnProgress.test.ts
+++ b/webapp/src/__tests__/turnProgress.test.ts
@@ -18,6 +18,9 @@ import {
   turnHasVisibleBusySurface,
   turnHasLiveInvestigation,
   turnLooksAnswerComplete,
+  explorationShelfAnchorId,
+  isExplorationShelfKind,
+  partitionExplorationShelf,
 } from "../lib/turnProgress";
 import {
   clearToolPrepPlaceholders,
@@ -982,5 +985,26 @@ describe("tool card CLI input + stale running", () => {
     const p = deriveBusyProgress(items, "executing", 5_000);
     // Answer not complete, but no effectively-running card — not "running read file".
     expect(p.label.toLowerCase()).not.toContain("read file");
+  });
+});
+
+describe("exploration shelf grouping", () => {
+  it("groups consecutive read/search cards and leaves commands alone", () => {
+    expect(isExplorationShelfKind("read_file")).toBe(true);
+    expect(isExplorationShelfKind("grep")).toBe(true);
+    expect(isExplorationShelfKind("run_command")).toBe(false);
+    const rows = partitionExplorationShelf(
+      ["read_file", "grep", "run_command", "read_file"],
+      (k) => k,
+    );
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({ kind: "shelf", items: ["read_file", "grep"] });
+    expect(rows[1]).toMatchObject({ kind: "item", item: "run_command" });
+    expect(rows[2]).toMatchObject({ kind: "item", item: "read_file" });
+  });
+
+  it("anchors shelf identity on the first card so appends do not remount", () => {
+    expect(explorationShelfAnchorId(["r1", "g1"])).toBe("expl-shelf-r1");
+    expect(explorationShelfAnchorId(["r1", "g1", "r2"])).toBe("expl-shelf-r1");
   });
 });

--- a/webapp/src/__tests__/turnTerminal.wave3.test.ts
+++ b/webapp/src/__tests__/turnTerminal.wave3.test.ts
@@ -1,0 +1,660 @@
+/**
+ * Wave 3 — authoritative turn terminals, recovery, and live-answer chrome.
+ */
+import { describe, expect, it } from "vitest";
+import type { Item } from "../components/TranscriptList";
+import {
+  collectIntermediateAssistantItems,
+  isLiveAnswerAssistant,
+  stableItemKey,
+} from "../components/TranscriptList";
+import { createApplyStreamEvent } from "../components/conversation/streamEventHandler";
+import {
+  alreadySettledOnDoneStatus,
+  resetTurnLifecycleOnSessionSwitch,
+  streamOnDoneDecision,
+} from "../components/conversation/streamTerminal";
+import {
+  mergeLocalTurnTerminals,
+  mergeTranscriptItems,
+  transcriptResponseToItems,
+} from "../components/conversation/transcriptItems";
+import { appendTurnTerminal } from "../components/conversation/streamApply";
+import { explorationShelfAnchorId } from "../lib/turnProgress";
+import { isPilotMouthBusy } from "../components/conversation/runnersBusy";
+import { appendStreamingTextToItems } from "../components/conversation/streamBubbles";
+import { flushTypewriterBuffer } from "../components/conversation/streamTypewriter";
+import { staleLocalStreamTickDecision } from "../components/conversation/runnersBusy";
+import { isTerminalStreamKind } from "../components/conversation/chatEvents";
+import {
+  CONTINUE_PROMPT,
+  canonicalizeTerminalCause,
+  composerBusyDuringSwitch,
+  hasPartialAssistantAnswer,
+  latestUserAsk,
+  recoveryControlsAvailable,
+  recoveryDispatchAllowed,
+  settleFromAssistantDone,
+  settleFromAutoHalt,
+  settleFromFramingDone,
+  settleFromRingReplayDone,
+  settleFromStaleLocalAbandon,
+  settleFromStreamError,
+  settleFromTransportEof,
+  terminalCauseCopy,
+  type TerminalCause,
+  type TurnSettle,
+} from "../lib/turnTerminal";
+
+function msg(role: "user" | "assistant", text: string, streaming = false): Item {
+  return { kind: "msg", msg: { role, text, streaming } };
+}
+
+function makeApplyDeps(opts?: { turnSettled?: boolean }) {
+  const state = {
+    items: [msg("user", "go")] as Item[],
+    itemsRef: { current: [] as Item[] },
+    typeBufRef: { current: "" },
+    waitHint: null as string | null,
+    status: "thinking" as
+      | "idle"
+      | "thinking"
+      | "executing"
+      | "done"
+      | "error"
+      | "streaming"
+      | "awaiting_swarm",
+    turnOpen: true,
+    turnSettledRef: { current: Boolean(opts?.turnSettled) },
+    settle: null as TurnSettle | null,
+  };
+  state.itemsRef.current = state.items;
+
+  const setItems = (updater: Item[] | ((prev: Item[]) => Item[])) => {
+    const next = typeof updater === "function" ? updater(state.items) : updater;
+    state.items = next;
+    state.itemsRef.current = next;
+  };
+  const appendStreamingText = (chunk: string) => {
+    if (!chunk) return;
+    setItems((p: Item[]) => appendStreamingTextToItems(p, chunk));
+  };
+  const flushTypewriter = () => {
+    flushTypewriterBuffer(
+      {
+        typeBufRef: state.typeBufRef,
+        typeRafRef: { current: null },
+        typeDoneRef: { current: false },
+      },
+      appendStreamingText,
+      () => {},
+    );
+  };
+
+  const apply = createApplyStreamEvent({
+    setCompactingStatus: () => {},
+    setItems,
+    setDistillNotice: () => {},
+    setWikiPrepared: () => {},
+    setMemoryProposals: () => {},
+    setWaitHint: (value: string | null | ((prev: string | null) => string | null)) => {
+      state.waitHint = typeof value === "function" ? value(state.waitHint) : value;
+    },
+    setStatus: (
+      value:
+        | typeof state.status
+        | ((prev: typeof state.status) => typeof state.status),
+    ) => {
+      state.status = typeof value === "function" ? value(state.status) : value;
+    },
+    setTurnOpen: (value: boolean | ((prev: boolean) => boolean)) => {
+      state.turnOpen = typeof value === "function" ? value(state.turnOpen) : value;
+    },
+    setPendingJobIds: () => {},
+    pendingJobIdsRef: { current: [] as string[] },
+    setSafeTimeout: () => {},
+    itemsRef: state.itemsRef,
+    planTurnRef: { current: false },
+    turnSettledRef: state.turnSettledRef,
+    resumeQueuedRef: { current: false },
+    typeBufRef: state.typeBufRef,
+    flushTypewriter,
+    startTypewriter: () => {},
+    appendStreamingText,
+    setCard: () => {},
+    onArtifacts: () => {},
+    onJobChange: () => {},
+    handleSwarmResult: () => {},
+    refreshQueue: () => {},
+    fetchContextUsage: () => {},
+    recordTurnSettle: (settle) => {
+      state.settle = settle;
+    },
+  });
+
+  return { state, apply };
+}
+
+function terminalChip(items: Item[]): Extract<Item, { kind: "turn_terminal" }> | undefined {
+  return items.find((it) => it.kind === "turn_terminal") as
+    | Extract<Item, { kind: "turn_terminal" }>
+    | undefined;
+}
+
+describe("Wave 3: transport EOF is never a silent success", () => {
+  it("message_delta mid-sentence + stream_item_done + EOF is incomplete, never done", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({ kind: "message_delta", data: { text: "The handler should " } });
+    apply({ kind: "stream_item_done", data: { stream_id: "a1" } });
+    expect(hasPartialAssistantAnswer(state.items)).toBe(true);
+    expect(streamOnDoneDecision({
+      turnSettled: state.turnSettledRef.current,
+      userStopped: false,
+    }).kind).toBe("abort_error");
+    apply({ kind: "done", data: {} });
+    expect(state.turnSettledRef.current).toBe(true);
+    expect(state.turnOpen).toBe(false);
+    expect(state.status).toBe("error");
+    expect(state.settle?.lifecycle).toBe("settled_incomplete");
+    expect(state.settle?.lifecycle).not.toBe("settled_complete");
+    const chip = terminalChip(state.items);
+    expect(chip?.cause).toBe("provider_eof");
+    expect(chip?.text).not.toMatch(/context\s*%/i);
+  });
+
+  it("empty stream_id stream_item_done + EOF is also incomplete", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({ kind: "message_delta", data: { text: "Halfway through a senten" } });
+    apply({ kind: "stream_item_done", data: { stream_id: "" } });
+    apply({ kind: "done", data: {} });
+    expect(state.settle?.lifecycle).toBe("settled_incomplete");
+    expect(state.status).toBe("error");
+    expect(terminalChip(state.items)?.cause).toBe("provider_eof");
+  });
+
+  it("framing kind=done while the stream is active is incomplete", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({ kind: "message_delta", data: { text: "Still writing" } });
+    expect(state.turnOpen).toBe(true);
+    apply({ kind: "done", data: {} });
+    expect(state.settle?.lifecycle).toBe("settled_incomplete");
+    expect(state.status).not.toBe("done");
+  });
+
+  it("assistant_done natural is complete; non-natural shows the cause", () => {
+    const natural = makeApplyDeps();
+    natural.apply({ kind: "message_delta", data: { text: "All set." } });
+    natural.apply({ kind: "assistant_done", data: { stop_cause: "natural", finish_reason: "stop" } });
+    expect(natural.state.settle?.lifecycle).toBe("settled_complete");
+    expect(natural.state.status).toBe("done");
+    expect(terminalChip(natural.state.items)).toBeUndefined();
+
+    const length = makeApplyDeps();
+    length.apply({ kind: "message_delta", data: { text: "Cut off mid" } });
+    length.apply({
+      kind: "assistant_done",
+      data: { stop_cause: "length", finish_reason: "length" },
+    });
+    expect(length.state.settle?.lifecycle).toBe("settled_incomplete");
+    expect(terminalChip(length.state.items)?.cause).toBe("length");
+    expect(terminalChip(length.state.items)?.text).toMatch(/length/i);
+    expect(terminalChip(length.state.items)?.text).not.toMatch(/context\s*%/i);
+  });
+});
+
+describe("Wave 3: abandon / ring replay cannot paint success", () => {
+  it("stale-local abandon without assistant_done is incomplete", () => {
+    const settle = settleFromStaleLocalAbandon({
+      turnSettled: false,
+      userStopped: false,
+      hasPartialAnswer: true,
+    });
+    expect(settle.kind).toBe("settle");
+    if (settle.kind !== "settle") return;
+    expect(settle.lifecycle).toBe("settled_incomplete");
+    expect(settle.status).not.toBe("done");
+  });
+
+  it("ring replay done without an authoritative terminal is incomplete", () => {
+    expect(isTerminalStreamKind("done")).toBe(true);
+    const settle = settleFromRingReplayDone({
+      turnSettled: false,
+      hasPartialAnswer: true,
+    });
+    expect(settle.kind).toBe("settle");
+    if (settle.kind !== "settle") return;
+    expect(settle.lifecycle).toBe("settled_incomplete");
+  });
+
+  it("already-settled abandon / framing done stay put", () => {
+    expect(settleFromStaleLocalAbandon({
+      turnSettled: true,
+      userStopped: false,
+      hasPartialAnswer: true,
+    })).toEqual({ kind: "already_settled" });
+    expect(settleFromFramingDone({
+      turnSettled: true,
+      hasPartialAnswer: true,
+    })).toEqual({ kind: "already_settled" });
+  });
+
+  it("staleLocalStreamTickDecision still abandons a zombie stream", () => {
+    expect(staleLocalStreamTickDecision({
+      localStreamActive: true,
+      userStopped: false,
+      runnerBusy: false,
+      awaitingSwarm: false,
+      turnSettled: false,
+      sawRunnerBusyThisStream: true,
+      consecutiveIdlePolls: 2,
+    }).kind).toBe("abandon");
+  });
+});
+
+describe("Wave 3: session switch onto running B never flashes Send", () => {
+  it("keeps the mouth busy while the target runner is unknown", () => {
+    expect(composerBusyDuringSwitch({
+      switchPending: true,
+      turnOpen: false,
+      status: "idle",
+      mouthBusy: isPilotMouthBusy(false, "idle"),
+    })).toBe(true);
+    expect(isPilotMouthBusy(false, "idle", true)).toBe(true);
+    expect(isPilotMouthBusy(true, "thinking", false)).toBe(true);
+    expect(isPilotMouthBusy(false, "idle", false)).toBe(false);
+  });
+});
+
+describe("Wave 3: live answer stays outside the investigation fold", () => {
+  it("does not absorb a tool-free streaming answer", () => {
+    const live: Item = {
+      kind: "msg",
+      msg: { role: "assistant", text: "Starting the fix…", streaming: true },
+    };
+    const items: Item[] = [msg("user", "do it"), live];
+    expect(isLiveAnswerAssistant(live.msg)).toBe(true);
+    const absorbed = collectIntermediateAssistantItems(items, true);
+    expect(absorbed.has(live)).toBe(false);
+    expect(collectIntermediateAssistantItems(items, false).has(live)).toBe(false);
+  });
+
+  it("does not remount a live answer when the turn settles", () => {
+    const answer: Item = {
+      kind: "msg",
+      msg: { role: "assistant", text: "Here is the patch.", streaming: true, channel: "answer" },
+    };
+    const items: Item[] = [
+      msg("user", "patch it"),
+      {
+        kind: "thinking",
+        text: "inspect",
+        id: "th-1",
+      },
+      {
+        kind: "card",
+        card: {
+          id: "c1",
+          goal: "a.ts",
+          cwd: null,
+          kind: "read_file",
+          running: false,
+          open: false,
+          result: { status: "ok" },
+        },
+      },
+      answer,
+    ];
+    expect(collectIntermediateAssistantItems(items, true).has(answer)).toBe(false);
+    const sealed: Item = {
+      kind: "msg",
+      msg: { ...answer.msg, streaming: false },
+    };
+    const after: Item[] = [...items.slice(0, -1), sealed];
+    expect(collectIntermediateAssistantItems(after, false).has(sealed)).toBe(false);
+  });
+});
+
+describe("Wave 3: Continue / Retry", () => {
+  it("disables recovery while busy and requires exactly one dispatch", () => {
+    expect(recoveryControlsAvailable("settled_incomplete")).toBe(true);
+    expect(recoveryControlsAvailable("aborted")).toBe(true);
+    expect(recoveryControlsAvailable("running")).toBe(false);
+    expect(recoveryDispatchAllowed({
+      composerBusy: true,
+      dispatching: false,
+      lifecycle: "settled_incomplete",
+    })).toBe(false);
+    expect(recoveryDispatchAllowed({
+      composerBusy: false,
+      dispatching: true,
+      lifecycle: "settled_incomplete",
+    })).toBe(false);
+    expect(recoveryDispatchAllowed({
+      composerBusy: false,
+      dispatching: false,
+      lifecycle: "settled_incomplete",
+    })).toBe(true);
+  });
+
+  it("preserves the latest user ask and continue prompt", () => {
+    const items: Item[] = [
+      msg("user", "first"),
+      msg("assistant", "partial answer that got cut"),
+      msg("user", "please finish the auth patch"),
+      msg("assistant", "I started by reading"),
+    ];
+    expect(latestUserAsk(items)).toBe("please finish the auth patch");
+    expect(CONTINUE_PROMPT).toMatch(/continue/i);
+  });
+
+  it("Retry skips the internal Continue prompt and uses the real ask", () => {
+    const items: Item[] = [
+      msg("user", "please finish the auth patch"),
+      msg("assistant", "I started by reading"),
+      msg("user", CONTINUE_PROMPT),
+    ];
+    expect(latestUserAsk(items)).toBe("please finish the auth patch");
+    expect(latestUserAsk(items)).not.toBe(CONTINUE_PROMPT);
+  });
+});
+
+describe("Wave 3: truthful cause copy", () => {
+  const cases: Array<[TerminalCause, RegExp]> = [
+    ["length", /length/i],
+    ["incomplete", /incomplete/i],
+    ["provider_eof", /stream ended|provider/i],
+    ["transport_error", /connection lost/i],
+    ["turn_budget", /token budget/i],
+    ["step_cap", /step limit/i],
+    ["stagnation", /no new progress/i],
+    ["invalid_tool", /invalid tool/i],
+    ["interrupted", /interrupted/i],
+  ];
+  it("names the real stop cause and never invents context %", () => {
+    for (const [cause, re] of cases) {
+      const copy = terminalCauseCopy(cause);
+      expect(copy).toMatch(re);
+      expect(copy).not.toMatch(/context\s*%/i);
+    }
+    expect(terminalCauseCopy("context_overflow")).toMatch(/context overflow/i);
+  });
+
+  it("maps assistant_done causes onto the lifecycle", () => {
+    expect(settleFromAssistantDone({ stopCause: "natural" }).lifecycle).toBe("settled_complete");
+    expect(settleFromAssistantDone({ stopCause: "turn_budget" }).lifecycle).toBe("settled_incomplete");
+    expect(settleFromTransportEof({
+      turnSettled: false,
+      userStopped: false,
+      hasPartialAnswer: false,
+    })).toMatchObject({ lifecycle: "aborted" });
+  });
+});
+
+describe("Wave 3: transport EOF decision ignores transcript shape", () => {
+  it("streamOnDoneDecision has no answerComplete authority", () => {
+    expect(streamOnDoneDecision({ turnSettled: false, userStopped: false }).kind).toBe(
+      "abort_error",
+    );
+    expect(streamOnDoneDecision({ turnSettled: true, userStopped: false }).kind).toBe("done");
+  });
+});
+
+describe("Wave 3 last-mile: fail-closed empty assistant_done", () => {
+  it("blank stop_cause stays unspecified / incomplete, never natural", () => {
+    expect(canonicalizeTerminalCause("")).toBe("unspecified");
+    expect(canonicalizeTerminalCause(null)).toBe("unspecified");
+    expect(canonicalizeTerminalCause(undefined)).toBe("unspecified");
+    expect(settleFromAssistantDone({ stopCause: "" }).lifecycle).toBe("settled_incomplete");
+    expect(settleFromAssistantDone({ stopCause: "" }).cause).toBe("unspecified");
+    expect(settleFromAssistantDone({}).lifecycle).toBe("settled_incomplete");
+  });
+
+  it("legacy empty assistant_done event stays incomplete", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({ kind: "message_delta", data: { text: "Halfway" } });
+    apply({ kind: "assistant_done", data: {} });
+    expect(state.settle?.lifecycle).toBe("settled_incomplete");
+    expect(state.settle?.cause).toBe("unspecified");
+    expect(state.settle?.lifecycle).not.toBe("settled_complete");
+    expect(terminalChip(state.items)?.cause).toBe("unspecified");
+  });
+});
+
+describe("Wave 3 last-mile: one terminal explanation", () => {
+  it("stream error paints a chip and no assistant error bubble", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({ kind: "message_delta", data: { text: "cut off" } });
+    apply({ kind: "error", data: { error: "backend dropped" } });
+    const chips = state.items.filter((it) => it.kind === "turn_terminal");
+    const errorBubbles = state.items.filter(
+      (it) => it.kind === "msg" && /\[error\]|\[aborted\]/.test(it.msg.text || ""),
+    );
+    expect(chips).toHaveLength(1);
+    expect(errorBubbles).toHaveLength(0);
+    expect(chips[0]?.text).toMatch(/backend dropped/);
+  });
+
+  it("settleFromStreamError is a single explanation path", () => {
+    const settle = settleFromStreamError("backend dropped");
+    expect(settle.explanation).toMatch(/backend dropped/);
+    expect(settle.lifecycle).toBe("error");
+  });
+
+  it("named model terminals are not relabeled as connection lost", () => {
+    for (const cause of ["length", "content_filter", "incomplete"] as const) {
+      const settle = settleFromStreamError(
+        "OpenAI chat finished with finish_reason=" + cause,
+        cause,
+      );
+      expect(settle.cause).toBe(cause);
+      expect(settle.lifecycle).toBe("settled_incomplete");
+      expect(settle.explanation).not.toMatch(/connection lost|closed before/i);
+      expect(recoveryControlsAvailable(settle.lifecycle)).toBe(true);
+    }
+    const eof = settleFromStreamError("stream ended", "provider_eof");
+    expect(eof.cause).toBe("provider_eof");
+    expect(eof.explanation).not.toMatch(/connection lost/i);
+    expect(recoveryControlsAvailable(eof.lifecycle)).toBe(true);
+  });
+
+  it("error event with terminal_cause paints one truthful chip", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({ kind: "message_delta", data: { text: "partial cut" } });
+    apply({
+      kind: "error",
+      data: {
+        error: "Provider stopped: output length limit (finish_reason=length).",
+        terminal_cause: "length",
+        finish_reason: "length",
+      },
+    });
+    const chips = state.items.filter((it) => it.kind === "turn_terminal");
+    const errorBubbles = state.items.filter(
+      (it) => it.kind === "msg" && /\[error\]|\[aborted\]/.test(it.msg.text || ""),
+    );
+    expect(chips).toHaveLength(1);
+    expect(errorBubbles).toHaveLength(0);
+    expect(chips[0]?.cause).toBe("length");
+    expect(chips[0]?.text).toMatch(/length/i);
+    expect(chips[0]?.text).not.toMatch(/connection lost|closed before/i);
+    expect(state.settle?.cause).toBe("length");
+  });
+});
+
+describe("Wave 3 last-mile: session switch isolates recovery", () => {
+  it("resets lifecycle, cause, and recovery context on switch", () => {
+    const lifecycle: { current: string } = { current: "settled_incomplete" };
+    const cause: { current: string | null } = { current: "provider_eof" };
+    const recoveryDispatchingRef = { current: true };
+    const recoveryContextRef = {
+      current: { sessionId: "sess-a", generation: 4 },
+    };
+    resetTurnLifecycleOnSessionSwitch({
+      setTurnLifecycle: (next) => { lifecycle.current = next as typeof lifecycle.current; },
+      setTerminalCause: (next) => { cause.current = next as typeof cause.current; },
+      recoveryDispatchingRef,
+      recoveryContextRef,
+    });
+    expect(lifecycle.current).toBe("settled_complete");
+    expect(cause.current).toBeNull();
+    expect(recoveryDispatchingRef.current).toBe(false);
+    expect(recoveryContextRef.current).toBeNull();
+  });
+
+  it("refuses Continue/Retry after a session switch", () => {
+    expect(recoveryDispatchAllowed({
+      composerBusy: false,
+      dispatching: false,
+      lifecycle: "settled_incomplete",
+      boundSessionId: "sess-a",
+      activeSessionId: "sess-b",
+      boundGeneration: 3,
+      activeGeneration: 3,
+    })).toBe(false);
+    expect(recoveryDispatchAllowed({
+      composerBusy: false,
+      dispatching: false,
+      lifecycle: "settled_incomplete",
+      boundSessionId: "sess-a",
+      activeSessionId: "sess-a",
+      boundGeneration: 3,
+      activeGeneration: 7,
+    })).toBe(false);
+    expect(recoveryDispatchAllowed({
+      composerBusy: false,
+      dispatching: false,
+      lifecycle: "settled_incomplete",
+      boundSessionId: "sess-a",
+      activeSessionId: "sess-a",
+      boundGeneration: 3,
+      activeGeneration: 3,
+    })).toBe(true);
+  });
+});
+
+describe("Wave 3 last-mile: turn_terminal hydrate / merge", () => {
+  it("maps turn_terminal display rows and does not coerce them to messages", () => {
+    const items = transcriptResponseToItems({
+      display: [
+        { type: "message", role: "user", text: "go" },
+        {
+          type: "turn_terminal",
+          id: "term-hydrate-1",
+          cause: "provider_eof",
+          state: "settled_incomplete",
+          text: "Provider stream ended before a clean finish.",
+        },
+      ],
+    });
+    const chip = terminalChip(items);
+    expect(chip?.kind).toBe("turn_terminal");
+    expect(chip?.id).toBe("term-hydrate-1");
+    expect(items.some((it) => it.kind === "msg" && /Provider stream ended/.test(it.msg.text || ""))).toBe(false);
+  });
+
+  it("preserves a local chip when remote hydrate omits it", () => {
+    const local: Item[] = [
+      msg("user", "go"),
+      msg("assistant", "Halfway"),
+      {
+        kind: "turn_terminal",
+        id: "term-local",
+        cause: "provider_eof",
+        state: "settled_incomplete",
+        text: "Provider stream ended before a clean finish.",
+      },
+    ];
+    const remote: Item[] = [
+      msg("user", "go"),
+      msg("assistant", "Halfway"),
+    ];
+    const merged = mergeTranscriptItems(local, remote);
+    expect(terminalChip(merged)?.id).toBe("term-local");
+    expect(mergeLocalTurnTerminals(remote, local)).toHaveLength(3);
+  });
+});
+
+describe("Wave 3 last-mile: unique keys and shelf identity", () => {
+  it("gives each turn_terminal a unique id, not cause+state", () => {
+    const first = appendTurnTerminal([], {
+      cause: "provider_eof",
+      state: "settled_incomplete",
+      text: "first",
+    });
+    const second = appendTurnTerminal(
+      [...first, msg("user", "again")],
+      { cause: "provider_eof", state: "settled_incomplete", text: "second" },
+    );
+    const chips = second.filter((it) => it.kind === "turn_terminal") as Array<
+      Extract<Item, { kind: "turn_terminal" }>
+    >;
+    expect(chips).toHaveLength(2);
+    expect(chips[0]?.id).toBeTruthy();
+    expect(chips[1]?.id).toBeTruthy();
+    expect(chips[0]?.id).not.toBe(chips[1]?.id);
+    expect(stableItemKey(chips[0]!, 0)).not.toBe(stableItemKey(chips[1]!, 1));
+    expect(stableItemKey(chips[0]!, 0)).not.toMatch(/^turn-term-provider_eof-settled_incomplete$/);
+  });
+
+  it("keeps the exploration shelf anchored as cards append", () => {
+    expect(explorationShelfAnchorId(["r1", "g1"])).toBe(
+      explorationShelfAnchorId(["r1", "g1", "r2"]),
+    );
+    expect(explorationShelfAnchorId(["r1", "g1"])).toBe("expl-shelf-r1");
+  });
+});
+
+describe("Wave 3 last-mile: auto_halt and onDone-after-error", () => {
+  it("auto_halt settles through the typed incomplete lifecycle", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({ kind: "message_delta", data: { text: "working" } });
+    apply({ kind: "auto_halt", data: { reason: "swarm ceiling reached (2/20)", snapshot: {} } });
+    expect(state.turnSettledRef.current).toBe(true);
+    expect(state.turnOpen).toBe(false);
+    expect(state.settle?.lifecycle).toBe("settled_incomplete");
+    expect(state.settle?.lifecycle).not.toBe("running");
+    expect(state.settle?.cause).not.toBe("natural");
+    expect(settleFromAutoHalt("swarm ceiling reached").lifecycle).toBe("settled_incomplete");
+    expect(settleFromAutoHalt("natural").cause).not.toBe("natural");
+  });
+
+  it("already-settled onDone preserves error and idle chrome", () => {
+    expect(alreadySettledOnDoneStatus({
+      prev: "error",
+      liveJobs: false,
+      userStopped: false,
+    })).toBe("error");
+    expect(alreadySettledOnDoneStatus({
+      prev: "idle",
+      liveJobs: false,
+      userStopped: true,
+    })).toBe("idle");
+    expect(alreadySettledOnDoneStatus({
+      prev: "error",
+      liveJobs: true,
+      userStopped: false,
+    })).toBe("error");
+    expect(alreadySettledOnDoneStatus({
+      prev: "done",
+      liveJobs: false,
+      userStopped: false,
+    })).toBe("done");
+    expect(alreadySettledOnDoneStatus({
+      prev: "awaiting_swarm",
+      liveJobs: true,
+      userStopped: false,
+    })).toBe("awaiting_swarm");
+  });
+
+  it("error then framing done does not reseal as success", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({ kind: "error", data: { error: "backend dropped" } });
+    expect(state.status).toBe("error");
+    expect(state.settle?.lifecycle).toBe("error");
+    apply({ kind: "done", data: {} });
+    expect(state.status).toBe("error");
+    expect(state.settle?.lifecycle).toBe("error");
+    expect(state.items.filter((it) => it.kind === "turn_terminal")).toHaveLength(1);
+  });
+});
+

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -10,8 +10,22 @@ import {
 import {
   deriveBusyProgress,
   turnHasLiveInvestigation,
-  turnLooksAnswerComplete,
 } from "../lib/turnProgress";
+import {
+  CONTINUE_PROMPT,
+  hasPartialAssistantAnswer,
+  latestUserAsk,
+  recoveryControlsAvailable,
+  recoveryDispatchAllowed,
+  settleFromStaleLocalAbandon,
+  settleFromStreamError,
+  settleFromTransportEof,
+  settleFromUserStop,
+  type RecoveryContext,
+  type TerminalCause,
+  type TurnLifecycle,
+  type TurnSettle,
+} from "../lib/turnTerminal";
 import { renameDefaultSessionIfNeeded } from "../lib/sessionTitle";
 import { notifyWorkspaceMutated } from "../lib/workspaceMutationEvents";
 
@@ -45,6 +59,7 @@ import { isAgentLoopOpen, isPilotMouthBusy } from "./conversation/runnersBusy";
 import {
   appendPendingReview,
   appendStopHonestyNotice,
+  appendTurnTerminal,
   applySwarmResultToItems,
   finalizeOrphanSwarmPills,
   focusReviewTabAndRefresh,
@@ -112,7 +127,7 @@ import {
   restoreFeedScrollAfterFocus,
 } from "./conversation/transcriptVirtualWindow";
 import {
-  STREAM_ABORT_MESSAGE,
+  alreadySettledOnDoneStatus,
   streamErrorText,
   streamOnDoneDecision,
   streamOnErrorDecision,
@@ -437,6 +452,12 @@ export default function Conversation({
   // awaiting_swarm: model turn closed after background dispatch, but workers
   // still fly — Cursor-style "Still working…" until keep-alive resume.
   const [turnOpen, setTurnOpen] = useState(false);
+  const [turnLifecycle, setTurnLifecycle] = useState<TurnLifecycle>("settled_complete");
+  const [terminalCause, setTerminalCause] = useState<TerminalCause | null>(null);
+  const [sessionSwitchPending, setSessionSwitchPending] = useState(false);
+  const recoveryDispatchingRef = useRef(false);
+  const recoveryContextRef = useRef<RecoveryContext | null>(null);
+  const lastSettleRef = useRef<TurnSettle | null>(null);
   const [waitHint, setWaitHint] = useState<string | null>(null);
   // True while visible items belong to a prior session (or are awaiting hydrate).
   // Dims the feed and blocks send so stale A is never treated as B.
@@ -545,7 +566,7 @@ export default function Conversation({
     turnOpen,
   });
   // Mouth ≠ runner. awaiting_swarm / holdSwarmAwait keep the fold, not Stop.
-  const composerBusy = isPilotMouthBusy(turnOpen, status);
+  const composerBusy = isPilotMouthBusy(turnOpen, status, sessionSwitchPending);
   const derivedPillStatus: string = derivePillStatus({
     transcriptStale,
     answerChromeIdle: false,
@@ -1436,7 +1457,12 @@ export default function Conversation({
     setWaitHint,
     setPendingJobIds,
     setBackendPendingSwarms,
+    setSessionSwitchPending,
     clearSafeTimeouts,
+    setTurnLifecycle,
+    setTerminalCause,
+    recoveryDispatchingRef,
+    recoveryContextRef,
   });
 
 
@@ -2455,8 +2481,40 @@ export default function Conversation({
       liveIds,
     );
 
+  const applyLocalTurnSettle = (settle: TurnSettle, items: Item[], liveIds: string[]) => {
+    const sealed = sealTurnItems(items, liveIds);
+    if (!settle.explanation) return sealed;
+    return appendTurnTerminal(sealed, {
+      id: `turn-term-${streamGenRef.current}`,
+      cause: settle.cause,
+      state: settle.lifecycle,
+      text: settle.explanation,
+    });
+  };
+
+  const recordTurnSettle = (settle: TurnSettle) => {
+    lastSettleRef.current = settle;
+    setTurnLifecycle(settle.lifecycle);
+    setTerminalCause(settle.cause === "natural" ? null : settle.cause);
+    recoveryDispatchingRef.current = false;
+    if (recoveryControlsAvailable(settle.lifecycle)) {
+      const sessionId = cachedSessionIdRef.current || activeSessionId || "";
+      recoveryContextRef.current = sessionId
+        ? { sessionId, generation: streamGenRef.current }
+        : null;
+    } else {
+      recoveryContextRef.current = null;
+    }
+  };
+
   abandonStaleLocalStreamRef.current = () => {
     if (userStoppedRef.current) return;
+    const settle = settleFromStaleLocalAbandon({
+      turnSettled: turnSettledRef.current,
+      userStopped: userStoppedRef.current,
+      hasPartialAnswer: hasPartialAssistantAnswer(itemsRef.current),
+    });
+    if (settle.kind === "already_settled") return;
     turnSettledRef.current = true;
     resumeQueuedRef.current = false;
     detachedBusyRef.current = false;
@@ -2468,11 +2526,12 @@ export default function Conversation({
     flushTypewriter();
     setTurnOpen(false);
     setWaitHint(null);
-    setStatus("done");
+    setStatus(settle.status);
     setCompactingStatus(null);
+    recordTurnSettle(settle);
     const liveIds = liveNonLocalSwarmJobIds();
     setPendingJobIds(liveIds);
-    setItems((p) => sealTurnItems(p, liveIds));
+    setItems((p) => applyLocalTurnSettle(settle, p, liveIds));
     const sid = cachedSessionIdRef.current;
     if (!sid) return;
     void api.sessionTranscript(sid).then((tres) => {
@@ -2480,7 +2539,11 @@ export default function Conversation({
       const loadedItems = transcriptResponseToItems(tres);
       setItems((prev) => {
         if (cachedSessionIdRef.current !== sid) return prev;
-        const next = sealTurnItems(mergeTranscriptItems(prev, loadedItems), liveIds);
+        const next = applyLocalTurnSettle(
+          settle,
+          mergeTranscriptItems(prev, loadedItems),
+          liveIds,
+        );
         const fp = transcriptFingerprint(next);
         if (fp === transcriptFpRef.current) return prev;
         transcriptFpRef.current = fp;
@@ -2525,6 +2588,7 @@ export default function Conversation({
     handleSwarmResult,
     refreshQueue,
     fetchContextUsage,
+    recordTurnSettle,
   });
   applyStreamEventRef.current = applyStreamEvent;
 
@@ -2537,10 +2601,14 @@ export default function Conversation({
       resume,
       userStopped: userStoppedRef.current,
     });
-    if (gate === "stale") return;
+    if (gate === "stale") {
+      recoveryDispatchingRef.current = false;
+      return;
+    }
     if (gate === "stopped_resume") {
       // Keep-alive after Stop must not re-arm the turn.
       resumeQueuedRef.current = false;
+      recoveryDispatchingRef.current = false;
       return;
     }
     if (!resume) {
@@ -2549,6 +2617,10 @@ export default function Conversation({
     }
     planTurnRef.current = usePlan;
     turnSettledRef.current = false;
+    lastSettleRef.current = null;
+    recoveryContextRef.current = null;
+    setTurnLifecycle("running");
+    setTerminalCause(null);
     // imagesOverride lets the idle queue-drain path (maybeDrainQueue) carry a
     // queued prompt's image attachments even though they were never placed in
     // the live attachedImages composer state.
@@ -2603,39 +2675,54 @@ export default function Conversation({
          const doneDec = streamOnDoneDecision({
            turnSettled: turnSettledRef.current,
            userStopped: userStoppedRef.current,
-           answerComplete: turnLooksAnswerComplete(itemsRef.current),
          });
          if (doneDec.kind === "abort_error") {
+           const settle = settleFromTransportEof({
+             turnSettled: false,
+             userStopped: false,
+             hasPartialAnswer: hasPartialAssistantAnswer(itemsRef.current),
+           });
+           if (settle.kind === "already_settled") return;
            turnSettledRef.current = true;
            setTurnOpen(false);
            setWaitHint(null);
-           setStatus("error");
+           setStatus(settle.status);
+           recordTurnSettle(settle);
            const liveIds = liveNonLocalSwarmJobIds();
            setPendingJobIds(liveIds);
-           setItems((p) => [...sealTurnItems(p, liveIds), {
-             kind: "msg",
-             msg: {
-               role: "assistant",
-               text: STREAM_ABORT_MESSAGE,
-             },
-           }]);
+           setItems((p) => applyLocalTurnSettle(settle, p, liveIds));
          } else {
-           // Silent settle when assistant_done / Stop / sealed answer already won.
+           // Authoritative settle already won — preserve error/interrupted
+           // chrome and the terminal chip. Never reseal as success.
            turnSettledRef.current = true;
            setTurnOpen(false);
-           // Do not clobber awaiting_swarm / Still working… set by assistant_done
-           // when background jobs are still flying (Cursor-style pause point).
            const liveIds = liveNonLocalSwarmJobIds();
            const liveJobs = liveIds.some((id) => Boolean(id));
            setPendingJobIds(liveIds);
-           if (liveJobs && !userStoppedRef.current) {
-             setStatus("awaiting_swarm");
-             setWaitHint(SWARM_AWAIT_HINT);
+           const lastSettle = lastSettleRef.current;
+           const preserveInterrupt = lastSettle?.lifecycle === "error"
+             || lastSettle?.lifecycle === "interrupted"
+             || lastSettle?.lifecycle === "aborted";
+           setStatus((prev) => alreadySettledOnDoneStatus({
+             prev,
+             liveJobs,
+             userStopped: userStoppedRef.current,
+           }));
+           if (liveJobs && !userStoppedRef.current && !preserveInterrupt) {
+             setWaitHint((prev) => prev || SWARM_AWAIT_HINT);
            } else {
              setWaitHint(null);
-             setStatus("done");
            }
-           setItems((p) => sealTurnItems(p, liveIds));
+           setItems((p) => {
+             const sealed = sealTurnItems(p, liveIds);
+             if (!lastSettle?.explanation) return sealed;
+             return appendTurnTerminal(sealed, {
+               id: `turn-term-${streamGenRef.current}`,
+               cause: lastSettle.cause,
+               state: lastSettle.lifecycle,
+               text: lastSettle.explanation,
+             });
+           });
          }
          cancelRef.current = null;
          localStreamActiveRef.current = false;
@@ -2652,20 +2739,18 @@ export default function Conversation({
            userStopped: userStoppedRef.current,
          });
          if (errDec.kind === "abort_error") {
+           const namedCause = (streamErr as { terminal_cause?: unknown } | null)?.terminal_cause;
+           const settle = settleFromStreamError(
+             streamErrorText(streamErr, namedCause),
+             namedCause,
+           );
            turnSettledRef.current = true;
            setTurnOpen(false);
            setWaitHint(null);
+           recordTurnSettle(settle);
            const liveIds = liveNonLocalSwarmJobIds();
            setPendingJobIds(liveIds);
-           setItems((p) => [...sealTurnItems(p, liveIds), {
-             kind: "msg",
-             msg: {
-               role: "assistant",
-               // A real error (403 auth skew, backend down) renders its own
-               // meaningful text instead of the generic abort chrome.
-               text: streamErrorText(streamErr),
-             },
-           }]);
+           setItems((p) => applyLocalTurnSettle(settle, p, liveIds));
            setStatus("error");
          } else if (errDec.kind === "preserve_error_or_done") {
            // EventSource often fires onerror when the stream closes after a
@@ -2674,13 +2759,21 @@ export default function Conversation({
            const liveJobs = pendingJobIdsRef.current.some(
              (id) => id && !id.startsWith("local-swarm-"),
            );
-           if (liveJobs && !userStoppedRef.current) {
-             setStatus("awaiting_swarm");
-             setWaitHint(SWARM_AWAIT_HINT);
-           } else {
-             setWaitHint(null);
-             setStatus((prev) => (prev === "error" ? prev : "done"));
-           }
+          if (liveJobs && !userStoppedRef.current) {
+            setStatus((prev) => alreadySettledOnDoneStatus({
+              prev,
+              liveJobs: true,
+              userStopped: false,
+            }));
+            setWaitHint((prev) => prev || SWARM_AWAIT_HINT);
+          } else {
+            setWaitHint(null);
+            setStatus((prev) => alreadySettledOnDoneStatus({
+              prev,
+              liveJobs: false,
+              userStopped: userStoppedRef.current,
+            }));
+          }
          }
          cancelRef.current = null;
          localStreamActiveRef.current = false;
@@ -3052,15 +3145,17 @@ export default function Conversation({
     cancelRef.current = null;
     localStreamActiveRef.current = false;
     flushTypewriter();
+    const settle = settleFromUserStop();
     setTurnOpen(false);
     setWaitHint(null);
     setStatus("idle");
     setCompactingStatus(null);
+    recordTurnSettle(settle);
     const liveIds = liveNonLocalSwarmJobIds();
     setPendingJobIds(liveIds);
     // Same seal → orphan settle order as assistant_done: close any open
     // pilot/reasoning surface before folding orphan swarm/investigation cards.
-    setItems((p) => sealTurnItems(p, liveIds));
+    setItems((p) => applyLocalTurnSettle(settle, p, liveIds));
   };
 
   const stop = () => {
@@ -3072,8 +3167,13 @@ export default function Conversation({
         ? async () => {
             const tres = await api.sessionTranscript(sid);
             const loadedItems = transcriptResponseToItems(tres);
+            const settle = lastSettleRef.current;
+            const liveIds = liveNonLocalSwarmJobIds();
             setItems((prev) => {
-              const next = mergeTranscriptItems(prev, loadedItems);
+              const merged = mergeTranscriptItems(prev, loadedItems);
+              const next = settle
+                ? applyLocalTurnSettle(settle, merged, liveIds)
+                : merged;
               const fp = transcriptFingerprint(next);
               if (fp === transcriptFpRef.current) return prev;
               transcriptFpRef.current = fp;
@@ -3155,6 +3255,38 @@ export default function Conversation({
     [],
   );
   const handleTranscriptImageClick = useCallback((url: string) => setLightboxUrl(url), []);
+  const recoveryBound = recoveryContextRef.current;
+  const handleRecoveryContinue = () => {
+    if (!recoveryBound) return;
+    if (!recoveryDispatchAllowed({
+      composerBusy,
+      dispatching: recoveryDispatchingRef.current,
+      lifecycle: turnLifecycle,
+      boundSessionId: recoveryBound.sessionId,
+      activeSessionId,
+      boundGeneration: recoveryBound.generation,
+      activeGeneration: streamGenRef.current,
+    })) return;
+    recoveryDispatchingRef.current = true;
+    executeSendRef.current(CONTINUE_PROMPT, auto, plan);
+  };
+  const handleRecoveryRetry = () => {
+    if (!recoveryBound) return;
+    if (!recoveryDispatchAllowed({
+      composerBusy,
+      dispatching: recoveryDispatchingRef.current,
+      lifecycle: turnLifecycle,
+      boundSessionId: recoveryBound.sessionId,
+      activeSessionId,
+      boundGeneration: recoveryBound.generation,
+      activeGeneration: streamGenRef.current,
+    })) return;
+    const ask = latestUserAsk(itemsRef.current);
+    if (!ask) return;
+    recoveryDispatchingRef.current = true;
+    executeSendRef.current(ask, auto, plan);
+  };
+
   const handleTranscriptExecutePlan = useCallback((planText: string) => {
     setAuto(true);
     setPlan(false);
@@ -3327,6 +3459,19 @@ export default function Conversation({
         handleQueueAdd={handleQueueAdd}
         stop={stop}
         send={send}
+        recoveryAvailable={Boolean(recoveryBound) && recoveryDispatchAllowed({
+          composerBusy,
+          dispatching: recoveryDispatchingRef.current,
+          lifecycle: turnLifecycle,
+          boundSessionId: recoveryBound?.sessionId,
+          activeSessionId,
+          boundGeneration: recoveryBound?.generation,
+          activeGeneration: streamGenRef.current,
+        })}
+        recoveryRetryAvailable={Boolean(latestUserAsk(items))}
+        recoveryCause={terminalCause}
+        onContinue={handleRecoveryContinue}
+        onRetry={handleRecoveryRetry}
       />
       )}
         />

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -40,7 +40,9 @@ import {
   cardEffectivelyRunning,
   cardHasDurableJob,
   deriveBusyProgress,
+  explorationShelfAnchorId,
   investigatingHeadline,
+  partitionExplorationShelf,
   resolveCardCliInput,
   shortenGoal,
   quietWorkingCueVisible,
@@ -214,7 +216,8 @@ export type Item =
       command?: string;
       output_excerpt?: string;
     }
-  | { kind: "verification"; passed: boolean; output?: string; cmd?: string };
+  | { kind: "verification"; passed: boolean; output?: string; cmd?: string }
+  | { kind: "turn_terminal"; id?: string; cause: string; state: string; text: string };
 
 export type GroupedItem =
   | { kind: "msg"; msg: Msg }
@@ -261,6 +264,7 @@ export type GroupedItem =
       output_excerpt?: string;
     }
   | { kind: "verification"; passed: boolean; output?: string; cmd?: string }
+  | { kind: "turn_terminal"; id?: string; cause: string; state: string; text: string }
   | { kind: "activity_group"; items: ActivityItem[] };
 
 type ActivityItem =
@@ -437,12 +441,20 @@ function VaultCiteChip({
  * every historical finale into its Explored group, then peel those finales
  * back out on seal (row remount churn / flicker in the virtualized feed).
  *
- * Current turn while open: fold streaming + sealed narration once there is
- * investigation activity (or while streaming before the first tool).
+ * Current turn while open: fold worker/progress/plan narration and sealed
+ * mid-turn text that still has later tools. Live answers stay top-level.
  * Current turn when closed / any prior turn: trailing final stands alone.
  */
 function isPlanOrProgressAssistant(msg: Msg): boolean {
   return Boolean(msg.isPlan) || msg.channel === "progress";
+}
+
+/** Live/final answer stays a top-level Bubble — never absorbed into ActivityGroup. */
+export function isLiveAnswerAssistant(msg: Msg): boolean {
+  if (msg.workerStream) return false;
+  if (isPlanOrProgressAssistant(msg)) return false;
+  if (msg.channel === "answer") return true;
+  return msg.streaming === true;
 }
 
 function turnHasInvestigationActivity(items: Item[], turnStart: number): boolean {
@@ -515,14 +527,20 @@ export function collectIntermediateAssistantItems(
     // Open-loop absorption is current-turn only (see docstring).
     const openAbsorb = agentLoopOpen && i >= currentTurnStart;
     if (openAbsorb) {
-      // Mid-turn: keep streaming + sealed narration inside the fold from the
-      // first token once the turn is investigative, and while streaming even
-      // before the first tool (avoids outside→absorb blink). Pure chat still
-      // peels to a standalone finale when the loop closes (no card after).
-      if (foldActivity || item.msg.streaming === true) {
+      if (item.msg.workerStream) {
         intermediateItems.add(item);
+        continue;
       }
-      continue;
+      // Live answer / unmarked streaming stays a top-level Bubble so it
+      // cannot hide behind a collapsed fold or remount on terminal peel.
+      if (isLiveAnswerAssistant(item.msg)) {
+        continue;
+      }
+      if (isPlanOrProgressAssistant(item.msg) && (foldActivity || item.msg.streaming === true)) {
+        intermediateItems.add(item);
+        continue;
+      }
+      // Sealed mid-turn narration still uses the sealed rule below.
     }
 
     const later = laterInvestigationActivity(items, i);
@@ -590,6 +608,9 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
         flush();
         grouped.push(item);
       }
+    } else if (item.kind === "turn_terminal") {
+      flush();
+      grouped.push(item);
     } else if (item.kind === "swarm_result") {
       // These are emitted by tool execution, so they belong inside the same
       // collapsed investigation as the action card that produced them. Rendering
@@ -847,7 +868,7 @@ export function activityGroupStableId(items: ActivityItem[], fallbackIndex: numb
   return canon;
 }
 
-function stableItemKey(it: GroupedItem, i: number): string {
+export function stableItemKey(it: GroupedItem, i: number): string {
   switch (it.kind) {
     case "msg":
       return `msg-${objKey(it.msg)}`;
@@ -881,6 +902,8 @@ function stableItemKey(it: GroupedItem, i: number): string {
       return `auth-${it.id || i}`;
     case "steer":
       return `steer-${i}`;
+    case "turn_terminal":
+      return it.id ? `turn-term-${it.id}` : `turn-term-${i}-${it.cause}-${it.state}`;
     case "quality_gate":
       return `qg-${i}-${it.outcome}-${it.passed ? "ok" : "fail"}`;
     case "verifying":
@@ -1416,6 +1439,19 @@ export const TranscriptList = memo(function TranscriptList({
           live={Boolean(it.streaming)}
         />
       );
+    } else if (it.kind === "turn_terminal") {
+      return (
+        <div
+          key={key}
+          role="status"
+          data-testid="turn-terminal-chip"
+          data-cause={it.cause}
+          data-state={it.state}
+          className="flex items-center gap-1.5 py-1 px-3 rounded-md border border-edge/50 text-[10.5px] w-fit my-1 select-none font-mono text-muted"
+        >
+          <span>{it.text}</span>
+        </div>
+      );
     } else if (it.kind === "activity_group") {
       const openId = activityGroupStableId(it.items, i);
       return (
@@ -1616,6 +1652,65 @@ function getCardMeta(card: Card): string | null {
   }
 
   return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+function ExplorationShelf({
+  items,
+  duplicateCounts,
+  onToggleCard,
+  activityGroupOpen,
+}: {
+  items: Array<{ kind: "card"; card: Card }>;
+  duplicateCounts: number[];
+  onToggleCard: (card: Card) => void;
+  activityGroupOpen: boolean;
+}) {
+  const anyRunning = items.some((it) => cardEffectivelyRunning(it.card));
+  const [open, setOpen] = useState(anyRunning);
+  const userCollapsedRef = useRef(false);
+  useEffect(() => {
+    if (anyRunning && !userCollapsedRef.current) {
+      setOpen(true);
+    }
+  }, [anyRunning]);
+  const kinds = items.map((it) => it.card.kind || "action");
+  const summary = aggregateExplorationSummary(kinds) || `${items.length} steps`;
+  const headline = anyRunning ? `Exploring · ${summary}` : summary;
+  const shelfId = explorationShelfAnchorId(items.map((it) => it.card.id));
+  return (
+    <div className="w-full" data-testid="exploration-shelf" data-count={items.length}>
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-label={`Exploration ${summary}`}
+        onClick={() => {
+          setOpen((v) => {
+            const next = !v;
+            userCollapsedRef.current = !next;
+            return next;
+          });
+        }}
+        className="flex items-center gap-1.5 py-0.5 text-[11px] font-sans font-normal text-faint/80 hover:text-muted transition w-fit max-w-full select-none bg-transparent border-0 p-0 cursor-pointer text-left"
+      >
+        {open ? <ChevronDown size={10} className="text-faint/55 shrink-0" /> : <ChevronRight size={10} className="text-faint/55 shrink-0" />}
+        {anyRunning ? <Loader2 size={10} className="animate-spin text-faint/60 shrink-0" /> : null}
+        <span className="truncate">{headline}</span>
+      </button>
+      {open && (
+        <div className="flex flex-col gap-0.5 pl-2 mt-0.5">
+          {items.map((it, idx) => (
+            <ActionCard
+              key={it.card.id || `${shelfId}-${idx}`}
+              card={it.card}
+              onToggle={() => onToggleCard(it.card)}
+              duplicateCount={duplicateCounts[idx] || 1}
+              activityGroupOpen={activityGroupOpen}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 function ActivityGroup({
@@ -1964,7 +2059,25 @@ function ActivityGroup({
       </button>
       {open && (
         <div className="flex flex-col gap-0.5 pl-3 mt-1 border-l border-edge/30 w-full">
-          {displayItems.map(renderInner)}
+          {partitionExplorationShelf(displayItems, (row) => (
+            row.kind === "card" ? String(row.card.kind || "") : null
+          )).map((row) => {
+            if (row.kind === "shelf") {
+              const cards = row.items.filter(
+                (it): it is { kind: "card"; card: Card } => it.kind === "card",
+              );
+              return (
+                <ExplorationShelf
+                  key={explorationShelfAnchorId(cards.map((c) => c.card.id))}
+                  items={cards}
+                  duplicateCounts={row.indexes.map((idx) => duplicateCounts[idx] || 1)}
+                  onToggleCard={onToggleCard}
+                  activityGroupOpen={open}
+                />
+              );
+            }
+            return renderInner(row.item, row.index);
+          })}
         </div>
       )}
     </div>

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -23,6 +23,7 @@ import {
   X,
   Zap,
   Brain,
+  RefreshCw,
 } from "lucide-react";
 import { api, type Config, type ContextUsageResponse } from "../../lib/api";
 import PilotPicker from "../PilotPicker";
@@ -135,6 +136,11 @@ export default function ComposerDock({
   handleQueueAdd,
   stop,
   send,
+  recoveryAvailable = false,
+  recoveryRetryAvailable = false,
+  recoveryCause = null,
+  onContinue,
+  onRetry,
 }: {
   config: Config | null;
   taRef: RefObject<HTMLTextAreaElement | null>;
@@ -228,6 +234,11 @@ export default function ComposerDock({
   handleQueueAdd: () => void;
   stop: () => void;
   send: (mode?: "interrupt") => void;
+  recoveryAvailable?: boolean;
+  recoveryRetryAvailable?: boolean;
+  recoveryCause?: string | null;
+  onContinue?: () => void;
+  onRetry?: () => void;
 }) {
   const queueNotice = usePanelNotice(queueLoadError);
   const matchingSlash =
@@ -1022,6 +1033,30 @@ export default function ComposerDock({
               >
                 <span className="composer-toolbar-send-label">Interrupt</span>
               </button>
+            )}
+            {!composerBusy && recoveryAvailable && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => onContinue?.()}
+                  disabled={editBusy || transcriptStale || !onContinue}
+                  title={recoveryCause ? `Continue the incomplete reply (${recoveryCause})` : "Continue from the preserved partial answer"}
+                  aria-label="Continue"
+                  className="px-2 h-[20px] rounded-md bg-panel2/60 border border-edge/60 text-faint hover:text-muted hover:border-edge2 text-[10.5px] font-medium flex items-center gap-1 transition disabled:opacity-40 disabled:cursor-default"
+                >
+                  <span className="composer-toolbar-send-label">Continue</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onRetry?.()}
+                  disabled={editBusy || transcriptStale || !recoveryRetryAvailable || !onRetry}
+                  title="Retry the latest user ask"
+                  aria-label="Retry"
+                  className="px-2 h-[20px] rounded-md bg-panel2/60 border border-edge/60 text-faint hover:text-muted hover:border-edge2 text-[10.5px] font-medium flex items-center gap-1 transition disabled:opacity-40 disabled:cursor-default"
+                >
+                  <RefreshCw size={9} /><span className="composer-toolbar-send-label">Retry</span>
+                </button>
+              </>
             )}
             {composerBusy
               ? <>

--- a/webapp/src/components/conversation/reexports.ts
+++ b/webapp/src/components/conversation/reexports.ts
@@ -13,6 +13,7 @@ export {
   transcriptResponseToItems,
   shouldPreferLocalTranscript,
   mergeTranscriptItems,
+  mergeLocalTurnTerminals,
   transcriptFingerprint,
   mergeSwarmResultReuse,
 } from "./transcriptItems";
@@ -123,6 +124,7 @@ export {
   appendVerification,
   appendVerifying,
   appendStreamError,
+  appendTurnTerminal,
   appendNonStreamingThinking,
   applySwarmResultToItems,
   failSwarmPendingForActionError,
@@ -309,7 +311,9 @@ export {
   streamOnErrorDecision,
   shouldRefreshBusyChrome,
   resetTurnSettledOnSessionSwitch,
+  resetTurnLifecycleOnSessionSwitch,
   resetCrossSessionLatchesOnSwitch,
+  alreadySettledOnDoneStatus,
 } from "./streamTerminal";
 export { default as TranscriptEmptyState } from "./TranscriptEmptyState";
 export { createChatEventsReattach } from "./chatEventsReattach";

--- a/webapp/src/components/conversation/runnersBusy.ts
+++ b/webapp/src/components/conversation/runnersBusy.ts
@@ -29,11 +29,15 @@ export function isAgentLoopOpen(
 /**
  * Composer mouth: Stop/Steer only while the pilot's short turn is open.
  * A flying PM job (awaiting_swarm) is running, not busy — Send stays Send.
+ * switchPending keeps the mouth busy during A→B so a running target never
+ * flashes Send before getSessionState resolves.
  */
 export function isPilotMouthBusy(
   turnOpen: boolean,
   status: BusyStatus | string,
+  switchPending: boolean = false,
 ): boolean {
+  if (switchPending) return true;
   return (
     turnOpen
     || status === "thinking"

--- a/webapp/src/components/conversation/sessionHydrate.ts
+++ b/webapp/src/components/conversation/sessionHydrate.ts
@@ -107,6 +107,7 @@ export const SESSION_STATE_FAIL_NOTICE =
 /**
  * On activeSessionId change: default idle/turnOpen=false until runners resolve
  * for the target session. Prevents busy A's Stop/thinking chrome sticking on B.
+ * Conversation overlays sessionSwitchPending so running B never flashes Send.
  */
 export function shouldResetBusyChromeOnSwitch(switchedSession: boolean): boolean {
   return switchedSession;

--- a/webapp/src/components/conversation/streamApply.ts
+++ b/webapp/src/components/conversation/streamApply.ts
@@ -1776,6 +1776,44 @@ export function appendStreamError(items: Item[], error: string): Item[] {
   ];
 }
 
+let turnTerminalSeq = 0;
+
+function nextTurnTerminalId(preferred?: string, existing?: string): string {
+  const chosen = String(preferred || existing || "").trim();
+  if (chosen) return chosen;
+  turnTerminalSeq += 1;
+  return `turn-term-${turnTerminalSeq}`;
+}
+
+/** Durable terminal chip. Replaces a trailing chip so EOF + framing cannot stack. */
+export function appendTurnTerminal(
+  items: Item[],
+  data: {
+    id?: string;
+    cause: string;
+    state: string;
+    text: string;
+  },
+): Item[] {
+  const text = String(data.text || "").trim();
+  if (!text) return items;
+  const last = items[items.length - 1];
+  const next: Extract<Item, { kind: "turn_terminal" }> = {
+    kind: "turn_terminal",
+    id: nextTurnTerminalId(
+      data.id,
+      last?.kind === "turn_terminal" ? last.id : undefined,
+    ),
+    cause: String(data.cause || "unspecified"),
+    state: String(data.state || "settled_incomplete"),
+    text,
+  };
+  if (last?.kind === "turn_terminal") {
+    return [...items.slice(0, -1), next];
+  }
+  return [...items, next];
+}
+
 export function appendNonStreamingThinking(items: Item[], text: string): Item[] {
   // Ring/replay often delivers thinking without delta:true — sometimes as
   // cumulative snapshots. Opt into snapshot de-duplication here only; live

--- a/webapp/src/components/conversation/streamEventHandler.ts
+++ b/webapp/src/components/conversation/streamEventHandler.ts
@@ -29,7 +29,7 @@ import {
   appendPendingReview,
   appendQualityGate,
   appendQueuedPromptUserBubble,
-  appendStreamError,
+  appendTurnTerminal,
   appendSwarmPending,
   appendVerification,
   appendVerifying,
@@ -59,6 +59,15 @@ import { turnHasLiveInvestigation } from "../../lib/turnProgress";
 import { notifyWorkspaceMutated } from "../../lib/workspaceMutationEvents";
 import { shouldRefreshBusyChrome } from "./streamTerminal";
 import { waitHintForAssistantDone } from "./swarmPoll";
+import {
+  hasPartialAssistantAnswer,
+  settleFromAssistantDone,
+  settleFromAutoHalt,
+  settleFromFramingDone,
+  settleFromInterrupted,
+  settleFromStreamError,
+  type TurnSettle,
+} from "../../lib/turnTerminal";
 
 export type StreamEvent = { kind: string; data?: any; turn?: number; cursor?: number };
 
@@ -102,6 +111,8 @@ export type ApplyStreamEventDeps = {
   handleSwarmResult: (d: any) => void;
   refreshQueue: () => void;
   fetchContextUsage: () => void;
+  /** Optional Wave 3 lifecycle hook — tests may omit it. */
+  recordTurnSettle?: (settle: TurnSettle) => void;
 };
 
 export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
@@ -132,6 +143,7 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
     handleSwarmResult,
     refreshQueue,
     fetchContextUsage,
+    recordTurnSettle,
   } = deps;
 
   const clearWaitHintOnProgress = () => setWaitHint(null);
@@ -140,6 +152,26 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
       turnSettled: turnSettledRef.current,
       userStopped: userStoppedRef?.current,
     });
+  const paintTurnSettle = (settle: TurnSettle, awaitHint?: string | null) => {
+    turnSettledRef.current = true;
+    setTurnOpen(settle.turnOpen);
+    if (settle.lifecycle === "awaiting_swarm") {
+      setStatus("awaiting_swarm");
+      setWaitHint(awaitHint || "Still working…");
+    } else {
+      setStatus(settle.status);
+      setWaitHint(null);
+    }
+    recordTurnSettle?.(settle);
+  };
+  const withTerminalChip = (items: Item[], settle: TurnSettle): Item[] => {
+    if (!settle.explanation) return items;
+    return appendTurnTerminal(items, {
+      cause: settle.cause,
+      state: settle.lifecycle,
+      text: settle.explanation,
+    });
+  };
 
   return (ev: StreamEvent) => {
     const d = ev.data || {};
@@ -525,11 +557,9 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
         setSafeTimeout(() => setDistillNotice((cur) => (cur === notice ? null : cur)), 8000);
       }
     } else if (ev.kind === "auto_halt") {
-      turnSettledRef.current = true;
-      setTurnOpen(false);
-      setWaitHint(null);
-      setStatus("done");
-      setItems((p) => appendAutoHalt(p, d.reason || "", d.snapshot));
+      const settle = settleFromAutoHalt(d.reason);
+      paintTurnSettle(settle);
+      setItems((p) => withTerminalChip(appendAutoHalt(p, d.reason || "", d.snapshot), settle));
     } else if (ev.kind === "swarm_pending") {
       const job_ids = d.job_ids || [];
       // Set-union — replayed swarm_pending must not grow the tracker forever.
@@ -565,8 +595,6 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
       }
       refreshQueue();
     } else if (ev.kind === "assistant_done") {
-      turnSettledRef.current = true;
-      setTurnOpen(false);
       // Sync local-swarm-* ids finish inside the turn; anything still spinning
       // for those is an orphan. Background job_*/local-* stay live so their
       // pills keep spinning until swarm_result arrives.
@@ -574,29 +602,29 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
         (id) => !id.startsWith("local-swarm-"),
       );
       setPendingJobIds(liveIds);
-      // Cursor-style pause: summary may already be on screen, but hold busy
-      // chrome ("Still working…") while background workers fly. Keep-alive
-      // resume clears this when the next model turn starts.
       const awaitHint = waitHintForAssistantDone(liveIds);
-      if (awaitHint) {
-        setStatus("awaiting_swarm");
-        setWaitHint(awaitHint);
-      } else {
-        setWaitHint(null);
-        setStatus("done");
-      }
+      const settle = settleFromAssistantDone({
+        stopCause: d.stop_cause,
+        finishReason: d.finish_reason,
+        incompleteReason: d.incomplete_reason,
+        liveJobs: Boolean(awaitHint),
+      });
+      paintTurnSettle(settle, awaitHint);
       // Drain + seal any remaining live surfaces so a turn cannot close with an
       // open typewriter / streaming bubble still painted as in-flight.
       flushTypewriter();
       setItems((p) =>
-        reconcileOrphanInvestigationCards(
-          finalizeOrphanSwarmPills(
-            // Cursor CLI often paints the finale before buffered tool_call
-            // events; hoist late cards/thinking under that readout into the fold.
-            hoistCardsBeforeTrailingFinals(sealOpenStreamSurfaces(p)),
+        withTerminalChip(
+          reconcileOrphanInvestigationCards(
+            finalizeOrphanSwarmPills(
+              // Cursor CLI often paints the finale before buffered tool_call
+              // events; hoist late cards/thinking under that readout into the fold.
+              hoistCardsBeforeTrailingFinals(sealOpenStreamSurfaces(p)),
+              liveIds,
+            ),
             liveIds,
           ),
-          liveIds,
+          settle,
         ),
       );
       fetchContextUsage();
@@ -607,73 +635,72 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
       // optimistic first-send rename missed or the server derived a different slug.
       window.dispatchEvent(new Event("harness-config-changed"));
     } else if (ev.kind === "error") {
-      turnSettledRef.current = true;
-      setTurnOpen(false);
+      const settle = settleFromStreamError(d.error, d.terminal_cause);
+      paintTurnSettle(settle);
       setCompactingStatus(null);
-      setWaitHint(null);
-      setStatus("error");
       const liveIds = pendingJobIdsRef.current.filter(
         (id) => !id.startsWith("local-swarm-"),
       );
       setPendingJobIds(liveIds);
       setItems((p) =>
-        reconcileOrphanInvestigationCards(
-          finalizeOrphanSwarmPills(
-            hoistCardsBeforeTrailingFinals(appendStreamError(p, d.error || "")),
+        withTerminalChip(
+          reconcileOrphanInvestigationCards(
+            finalizeOrphanSwarmPills(
+              hoistCardsBeforeTrailingFinals(sealOpenStreamSurfaces(p)),
+              liveIds,
+            ),
             liveIds,
           ),
-          liveIds,
+          settle,
         ),
       );
     } else if (ev.kind === "interrupted") {
       // Harness cancel/steer interrupt — settle like Stop (no false abort bubble).
-      turnSettledRef.current = true;
-      setTurnOpen(false);
+      const settle = settleFromInterrupted();
+      paintTurnSettle(settle);
       setCompactingStatus(null);
-      setWaitHint(null);
-      setStatus("idle");
       const liveIds = pendingJobIdsRef.current.filter(
         (id) => !id.startsWith("local-swarm-"),
       );
       setPendingJobIds(liveIds);
       flushTypewriter();
       setItems((p) =>
-        reconcileOrphanInvestigationCards(
-          finalizeOrphanSwarmPills(
-            hoistCardsBeforeTrailingFinals(sealOpenStreamSurfaces(p)),
+        withTerminalChip(
+          reconcileOrphanInvestigationCards(
+            finalizeOrphanSwarmPills(
+              hoistCardsBeforeTrailingFinals(sealOpenStreamSurfaces(p)),
+              liveIds,
+            ),
             liveIds,
           ),
-          liveIds,
+          settle,
         ),
       );
     } else if (ev.kind === "done") {
-      // Framing-only sentinel (live transport settles via onDone; reattach
-      // applies retained frames). Must settle turn chrome when assistant_done
-      // was dropped so isTerminalStreamKind stop is not dishonest.
+      // Framing-only sentinel: transport, never proof of a completed turn.
       if (turnSettledRef.current) return;
-      turnSettledRef.current = true;
-      setTurnOpen(false);
-      setCompactingStatus(null);
+      flushTypewriter();
       const liveIds = pendingJobIdsRef.current.filter(
         (id) => !id.startsWith("local-swarm-"),
       );
       setPendingJobIds(liveIds);
-      const awaitHint = waitHintForAssistantDone(liveIds);
-      if (awaitHint) {
-        setStatus("awaiting_swarm");
-        setWaitHint(awaitHint);
-      } else {
-        setWaitHint(null);
-        setStatus("done");
-      }
-      flushTypewriter();
+      const settle = settleFromFramingDone({
+        turnSettled: false,
+        hasPartialAnswer: hasPartialAssistantAnswer(itemsRef.current),
+      });
+      if (settle.kind === "already_settled") return;
+      paintTurnSettle(settle);
+      setCompactingStatus(null);
       setItems((p) =>
-        reconcileOrphanInvestigationCards(
-          finalizeOrphanSwarmPills(
-            hoistCardsBeforeTrailingFinals(sealOpenStreamSurfaces(p)),
+        withTerminalChip(
+          reconcileOrphanInvestigationCards(
+            finalizeOrphanSwarmPills(
+              hoistCardsBeforeTrailingFinals(sealOpenStreamSurfaces(p)),
+              liveIds,
+            ),
             liveIds,
           ),
-          liveIds,
+          settle,
         ),
       );
     }

--- a/webapp/src/components/conversation/streamTerminal.ts
+++ b/webapp/src/components/conversation/streamTerminal.ts
@@ -2,6 +2,19 @@
  * Pure helpers for stream onDone / onError terminal chrome.
  */
 
+import {
+  CAUSE_CONTENT_FILTER,
+  CAUSE_INCOMPLETE,
+  CAUSE_LENGTH,
+  CAUSE_PROVIDER_EOF,
+  TURN_SETTLED_COMPLETE,
+  canonicalizeTerminalCause,
+  terminalCauseCopy,
+  type RecoveryContext,
+  type TerminalCause,
+  type TurnLifecycle,
+} from "../../lib/turnTerminal";
+
 export const STREAM_ABORT_MESSAGE =
   "[aborted] Connection closed before the turn finished. Send again to retry.";
 
@@ -30,7 +43,19 @@ function streamErrorHttpStatus(err: StreamErrorLike): number | null {
  * raw error payload (it crossed a process boundary and must stay secret-free);
  * only the HTTP status / connection class picks the message.
  */
-export function streamErrorText(err: StreamErrorLike): string {
+export function streamErrorText(
+  err: StreamErrorLike,
+  terminalCause?: unknown,
+): string {
+  const named = canonicalizeTerminalCause(terminalCause);
+  if (
+    named === CAUSE_LENGTH
+    || named === CAUSE_INCOMPLETE
+    || named === CAUSE_CONTENT_FILTER
+    || named === CAUSE_PROVIDER_EOF
+  ) {
+    return terminalCauseCopy(named);
+  }
   const status = streamErrorHttpStatus(err);
   if (status === 401 || status === 403) {
     return (
@@ -64,18 +89,17 @@ export type StreamTerminalDecision =
   | { kind: "noop" };
 
 /**
- * Live SSE onDone after flush — abort if the turn never settled.
- * When the transcript already shows a sealed answer (SSE lag / missing
- * assistant_done), settle silently instead of painting a false abort bubble.
+ * Live SSE onDone after flush — abort unless an authoritative terminal
+ * already settled the turn (assistant_done / user Stop).
+ *
+ * Transcript shape (`answerComplete` / turnLooksAnswerComplete) is never
+ * authority: a sealed mid-sentence bubble + EOF is incomplete, not done.
  */
 export function streamOnDoneDecision(opts: {
   turnSettled: boolean;
   userStopped: boolean;
-  /** Pure-chat answer already sealed on screen (see turnLooksAnswerComplete). */
-  answerComplete?: boolean;
 }): StreamTerminalDecision {
   if (opts.turnSettled || opts.userStopped) return { kind: "done" };
-  if (opts.answerComplete) return { kind: "done" };
   return { kind: "abort_error" };
 }
 
@@ -84,6 +108,40 @@ export function resetTurnSettledOnSessionSwitch(
   turnSettledRef: { current: boolean },
 ): void {
   turnSettledRef.current = false;
+}
+
+/**
+ * Idle/settled baseline after A→B. Incomplete recovery chrome and Continue/Retry
+ * context from A must not linger on B.
+ */
+export function resetTurnLifecycleOnSessionSwitch(opts: {
+  setTurnLifecycle: (lifecycle: TurnLifecycle) => void;
+  setTerminalCause: (cause: TerminalCause | null) => void;
+  recoveryDispatchingRef: { current: boolean };
+  recoveryContextRef: { current: RecoveryContext | null };
+}): void {
+  opts.setTurnLifecycle(TURN_SETTLED_COMPLETE);
+  opts.setTerminalCause(null);
+  opts.recoveryDispatchingRef.current = false;
+  opts.recoveryContextRef.current = null;
+}
+
+/**
+ * Live SSE onDone after an authoritative settle: never overwrite error /
+ * interrupted / idle chrome with a success pill.
+ */
+export function alreadySettledOnDoneStatus(opts: {
+  prev: "idle" | "thinking" | "executing" | "done" | "error" | "streaming" | "awaiting_swarm";
+  liveJobs: boolean;
+  userStopped: boolean;
+}): typeof opts.prev {
+  if (opts.liveJobs && !opts.userStopped) {
+    if (opts.prev === "error" || opts.prev === "idle") return opts.prev;
+    return "awaiting_swarm";
+  }
+  if (opts.prev === "error" || opts.prev === "idle") return opts.prev;
+  if (opts.prev === "awaiting_swarm") return "idle";
+  return opts.prev;
 }
 
 /**

--- a/webapp/src/components/conversation/transcriptItems.ts
+++ b/webapp/src/components/conversation/transcriptItems.ts
@@ -426,6 +426,17 @@ export function transcriptResponseToItems(res: {
           status,
           ...(typeof m.error === "string" && m.error ? { error: m.error } : {}),
         }];
+      } else if (m.type === "turn_terminal") {
+        const text = String(m.text || "").trim();
+        if (!text) return [];
+        const id = String(m.id || "").trim();
+        return [{
+          kind: "turn_terminal" as const,
+          id: id || `turn-term-${String(m.cause || "unspecified")}-${String(m.state || "settled_incomplete")}-${text.length}`,
+          cause: String(m.cause || "unspecified"),
+          state: String(m.state || "settled_incomplete"),
+          text,
+        }];
       } else {
         const rawText = m.text || "";
         const role = m.role as "user" | "assistant";
@@ -634,11 +645,25 @@ function insertIndexForRemoteCard(
  * path, remote swarm_result / swarm_pending rows still reconcile by stable
  * identity (latest-explicit reuse merge + terminal pending merge).
  */
+/** Keep this session's terminal chip when disk/API hydrate omits client-only rows. */
+export function mergeLocalTurnTerminals(remote: Item[], local: Item[]): Item[] {
+  const remoteHas = remote.some((it) => it.kind === "turn_terminal");
+  if (remoteHas) return remote;
+  const localTerms = local.filter(
+    (it): it is Extract<Item, { kind: "turn_terminal" }> => it.kind === "turn_terminal",
+  );
+  if (localTerms.length === 0) return remote;
+  return [...remote, ...localTerms];
+}
+
 export function mergeTranscriptItems(local: Item[], remote: Item[]): Item[] {
   if (!shouldPreferLocalTranscript(local, remote)) {
     // Equal card counts take remote, but never drop a still-pending approval
     // the SSE stream already painted (ring_miss / cursor_gap hydrate).
-    return dedupeDisplayItems(appendMissingPendingApprovals(remote, local));
+    return dedupeDisplayItems(appendMissingPendingApprovals(
+      mergeLocalTurnTerminals(remote, local),
+      local,
+    ));
   }
   const remoteByCardId = new Map<string, Extract<Item, { kind: "card" }>>();
   for (const it of remote) {
@@ -823,6 +848,8 @@ export function transcriptFingerprint(items: Item[]): string {
       fp += `|t:${(it.text || "").length}:${(it as { streaming?: boolean }).streaming ? 1 : 0}`;
     } else if (it.kind === "tool_prep") {
       fp += `|p:${String((it as { name?: string }).name || "")}`;
+    } else if (it.kind === "turn_terminal") {
+      fp += `|tt:${it.id || ""}:${it.cause}:${it.state}:${(it.text || "").length}`;
     } else {
       fp += `|o:${it.kind}`;
     }

--- a/webapp/src/components/conversation/useSessionSwitch.ts
+++ b/webapp/src/components/conversation/useSessionSwitch.ts
@@ -47,8 +47,10 @@ import {
 } from "./swarmPoll";
 import {
   resetCrossSessionLatchesOnSwitch,
+  resetTurnLifecycleOnSessionSwitch,
   resetTurnSettledOnSessionSwitch,
 } from "./streamTerminal";
+import type { RecoveryContext, TerminalCause, TurnLifecycle } from "../../lib/turnTerminal";
 
 export type SessionStatus =
   | "idle"
@@ -124,8 +126,14 @@ export type UseSessionSwitchDeps = {
    * after idle finalize with no pending swarms.
    */
   setBackendPendingSwarms: Dispatch<SetStateAction<boolean>>;
+  /** Hide Send until B's runner state is known (no flash onto a running session). */
+  setSessionSwitchPending: Dispatch<SetStateAction<boolean>>;
   /** Clear pending setSafeTimeout kicks so A→B cannot executeSend into B. */
   clearSafeTimeouts: () => void;
+  setTurnLifecycle: Dispatch<SetStateAction<TurnLifecycle>>;
+  setTerminalCause: Dispatch<SetStateAction<TerminalCause | null>>;
+  recoveryDispatchingRef: MutableRefObject<boolean>;
+  recoveryContextRef: MutableRefObject<RecoveryContext | null>;
 };
 
 /** Warm-cache switch + chatEvents reattach arming for the active session id. */
@@ -182,7 +190,12 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
     setWaitHint,
     setPendingJobIds,
     setBackendPendingSwarms,
+    setSessionSwitchPending,
     clearSafeTimeouts,
+    setTurnLifecycle,
+    setTerminalCause,
+    recoveryDispatchingRef,
+    recoveryContextRef,
   } = deps;
 
   // Warm-cache session switch: save outgoing transcript, hydrate incoming from
@@ -277,6 +290,12 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
         resumeQueuedRef,
         approvedCommandRetryRef,
       });
+      resetTurnLifecycleOnSessionSwitch({
+        setTurnLifecycle,
+        setTerminalCause,
+        recoveryDispatchingRef,
+        recoveryContextRef,
+      });
     }
     // Reset mid-turn reattach cursor/poll so the next session starts clean.
     clearChatEventsPoll();
@@ -289,7 +308,9 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
       cancelStreamPaint,
     );
     // Default idle until getSessionState / runners poll resolve the target.
+    // Keep the mouth busy via sessionSwitchPending so running B never flashes Send.
     if (shouldResetBusyChromeOnSwitch(switchedSession)) {
+      setSessionSwitchPending(true);
       setTurnOpen(false);
       setStatus("idle");
       setCompactingStatus(null);
@@ -307,6 +328,7 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
         setItems([]);
       }
       setTranscriptStale(emptySwitch.stale);
+      setSessionSwitchPending(false);
       setTurnOpen(false);
       setStatus("idle");
       setCompactingStatus(null);
@@ -337,9 +359,16 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
       sessionState?: string | null,
       pendingSwarms?: boolean,
     ) => {
-      if (cancelled || localStreamActiveRef.current) return;
+      if (cancelled) return;
+      if (localStreamActiveRef.current) {
+        setSessionSwitchPending(false);
+        return;
+      }
       if (!activeSessionId) return;
-      if (userStoppedRef.current) return;
+      if (userStoppedRef.current) {
+        setSessionSwitchPending(false);
+        return;
+      }
       const decision = runnerBusySwitchDecision({
         runnerState: runners?.[activeSessionId],
         localStreamActive: false,
@@ -347,6 +376,7 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
         sessionState,
         pendingSwarms,
       });
+      setSessionSwitchPending(false);
       if (decision.kind === "awaiting") {
         // Pause-point: Still working… with Steer/Stop via awaiting_swarm latch
         // (turnOpen stays false; isAgentLoopOpen covers awaiting_swarm).
@@ -408,6 +438,7 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
         // Idle until useRunnersBusyPoll re-arms; never leave A's chrome stuck.
         const failure = sessionStateFailureSwitchDecision();
         detachedBusyRef.current = false;
+        setSessionSwitchPending(false);
         setTurnOpen(false);
         setStatus("idle");
         setCompactingStatus(null);

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -357,6 +357,63 @@ const BUCKET_ORDER: ExplorationBucket[] = [
   "other",
 ];
 
+/** Read / search / wiki / fetch cards may collapse into one activity shelf. */
+export function isExplorationShelfKind(kind: string): boolean {
+  const b = explorationBucket(kind);
+  return b === "files" || b === "searches" || b === "wiki" || b === "fetches";
+}
+
+export type ExplorationShelfRow<T> =
+  | { kind: "item"; item: T; index: number }
+  | { kind: "shelf"; items: T[]; indexes: number[] };
+
+/**
+ * Collapse consecutive exploration tool cards into one shelf. Commands and
+ * edits stay individual so a Run/Write never hides inside a Read group.
+ */
+/** First card id — appending more exploration cards must not remount the shelf. */
+export function explorationShelfAnchorId(
+  cardIds: Array<string | undefined | null>,
+): string {
+  for (const id of cardIds) {
+    const text = String(id || "").trim();
+    if (text) return `expl-shelf-${text}`;
+  }
+  return "expl-shelf";
+}
+
+export function partitionExplorationShelf<T>(
+  items: T[],
+  cardKind: (item: T) => string | null,
+): ExplorationShelfRow<T>[] {
+  const out: ExplorationShelfRow<T>[] = [];
+  let i = 0;
+  while (i < items.length) {
+    const kind = cardKind(items[i]);
+    if (kind && isExplorationShelfKind(kind)) {
+      const start = i;
+      const group: T[] = [];
+      const indexes: number[] = [];
+      while (i < items.length) {
+        const nextKind = cardKind(items[i]);
+        if (!nextKind || !isExplorationShelfKind(nextKind)) break;
+        group.push(items[i]);
+        indexes.push(i);
+        i += 1;
+      }
+      if (group.length >= 2) {
+        out.push({ kind: "shelf", items: group, indexes });
+      } else {
+        out.push({ kind: "item", item: group[0], index: start });
+      }
+      continue;
+    }
+    out.push({ kind: "item", item: items[i], index: i });
+    i += 1;
+  }
+  return out;
+}
+
 /** Aggregate card kinds into "3 files, 1 search" (Cursor explored summary). */
 export function aggregateExplorationSummary(kinds: string[]): string {
   const counts: Partial<Record<ExplorationBucket, number>> = {};

--- a/webapp/src/lib/turnTerminal.ts
+++ b/webapp/src/lib/turnTerminal.ts
@@ -1,0 +1,461 @@
+/**
+ * Authoritative frontend turn lifecycle + terminal-cause vocabulary.
+ *
+ * Transport signals (framing kind=done, HTTP/SSE EOF, Electron end, ring
+ * replay exhaustion, transcript shape) never prove a completed turn.
+ * Only assistant_done with stop_cause=natural, or an honest user Stop,
+ * may become settled_complete.
+ */
+
+export const TURN_RUNNING = "running";
+export const TURN_AWAITING_SWARM = "awaiting_swarm";
+export const TURN_SETTLED_COMPLETE = "settled_complete";
+export const TURN_SETTLED_INCOMPLETE = "settled_incomplete";
+export const TURN_ABORTED = "aborted";
+export const TURN_ERROR = "error";
+export const TURN_INTERRUPTED = "interrupted";
+
+export type TurnLifecycle =
+  | typeof TURN_RUNNING
+  | typeof TURN_AWAITING_SWARM
+  | typeof TURN_SETTLED_COMPLETE
+  | typeof TURN_SETTLED_INCOMPLETE
+  | typeof TURN_ABORTED
+  | typeof TURN_ERROR
+  | typeof TURN_INTERRUPTED;
+
+export const CAUSE_NATURAL = "natural";
+export const CAUSE_LENGTH = "length";
+export const CAUSE_INCOMPLETE = "incomplete";
+export const CAUSE_PROVIDER_EOF = "provider_eof";
+export const CAUSE_TRANSPORT_ERROR = "transport_error";
+export const CAUSE_TURN_BUDGET = "turn_budget";
+export const CAUSE_STEP_CAP = "step_cap";
+export const CAUSE_STAGNATION = "stagnation";
+export const CAUSE_INVALID_TOOL = "invalid_tool";
+export const CAUSE_INTERRUPTED = "interrupted";
+export const CAUSE_CANCELLED = "cancelled";
+export const CAUSE_CONTENT_FILTER = "content_filter";
+export const CAUSE_EMPTY_LOOP = "empty_loop";
+export const CAUSE_DRIVER_SWAP = "driver_swap";
+export const CAUSE_CONTEXT_OVERFLOW = "context_overflow";
+export const CAUSE_UNSPECIFIED = "unspecified";
+export const CAUSE_TOOL_CALLS = "tool_calls";
+
+export type TerminalCause =
+  | typeof CAUSE_NATURAL
+  | typeof CAUSE_LENGTH
+  | typeof CAUSE_INCOMPLETE
+  | typeof CAUSE_PROVIDER_EOF
+  | typeof CAUSE_TRANSPORT_ERROR
+  | typeof CAUSE_TURN_BUDGET
+  | typeof CAUSE_STEP_CAP
+  | typeof CAUSE_STAGNATION
+  | typeof CAUSE_INVALID_TOOL
+  | typeof CAUSE_INTERRUPTED
+  | typeof CAUSE_CANCELLED
+  | typeof CAUSE_CONTENT_FILTER
+  | typeof CAUSE_EMPTY_LOOP
+  | typeof CAUSE_DRIVER_SWAP
+  | typeof CAUSE_CONTEXT_OVERFLOW
+  | typeof CAUSE_UNSPECIFIED
+  | typeof CAUSE_TOOL_CALLS;
+
+export type BusyChromeStatus =
+  | "idle"
+  | "thinking"
+  | "executing"
+  | "done"
+  | "error"
+  | "streaming"
+  | "awaiting_swarm";
+
+export type TurnSettle = {
+  kind: "settle";
+  lifecycle: TurnLifecycle;
+  cause: TerminalCause;
+  status: BusyChromeStatus;
+  turnOpen: boolean;
+  /** Operator-facing chip / row. Null when nothing extra should paint. */
+  explanation: string | null;
+};
+
+export type TurnSettleResult = TurnSettle | { kind: "already_settled" };
+
+const CAUSE_ALIASES: Record<string, TerminalCause> = {
+  natural: CAUSE_NATURAL,
+  length: CAUSE_LENGTH,
+  incomplete: CAUSE_INCOMPLETE,
+  provider_eof: CAUSE_PROVIDER_EOF,
+  eof: CAUSE_PROVIDER_EOF,
+  transport_error: CAUSE_TRANSPORT_ERROR,
+  transport: CAUSE_TRANSPORT_ERROR,
+  error: CAUSE_TRANSPORT_ERROR,
+  turn_budget: CAUSE_TURN_BUDGET,
+  step_cap: CAUSE_STEP_CAP,
+  stagnation: CAUSE_STAGNATION,
+  invalid_tool: CAUSE_INVALID_TOOL,
+  "invalid-tool": CAUSE_INVALID_TOOL,
+  auto_halt: CAUSE_INCOMPLETE,
+  interrupted: CAUSE_INTERRUPTED,
+  cancelled: CAUSE_CANCELLED,
+  canceled: CAUSE_CANCELLED,
+  user_stop: CAUSE_CANCELLED,
+  content_filter: CAUSE_CONTENT_FILTER,
+  empty_loop: CAUSE_EMPTY_LOOP,
+  driver_swap: CAUSE_DRIVER_SWAP,
+  context_overflow: CAUSE_CONTEXT_OVERFLOW,
+  unspecified: CAUSE_UNSPECIFIED,
+  tool_calls: CAUSE_TOOL_CALLS,
+  intermediate: CAUSE_TOOL_CALLS,
+};
+
+const KNOWN_CAUSES = new Set<string>(Object.values(CAUSE_ALIASES));
+
+/** Map a backend / alias label onto the frontend vocabulary. */
+export function canonicalizeTerminalCause(raw: unknown): TerminalCause {
+  const text = String(raw || "").trim();
+  if (!text) return CAUSE_UNSPECIFIED;
+  if (KNOWN_CAUSES.has(text) && text in CAUSE_ALIASES) {
+    return CAUSE_ALIASES[text] || (text as TerminalCause);
+  }
+  const aliased = CAUSE_ALIASES[text] || CAUSE_ALIASES[text.toLowerCase()];
+  if (aliased) return aliased;
+  return CAUSE_UNSPECIFIED;
+}
+
+/**
+ * Truthful chip copy. Never mentions context % unless the backend named
+ * context overflow as the cause.
+ */
+export function terminalCauseCopy(cause: TerminalCause): string {
+  switch (cause) {
+    case CAUSE_NATURAL:
+      return "";
+    case CAUSE_LENGTH:
+      return "Stopped: output length limit.";
+    case CAUSE_INCOMPLETE:
+      return "Reply incomplete.";
+    case CAUSE_PROVIDER_EOF:
+      return "Provider stream ended before a clean finish.";
+    case CAUSE_TRANSPORT_ERROR:
+      return "Connection lost before the turn finished.";
+    case CAUSE_TURN_BUDGET:
+      return "Reached the output token budget for this turn.";
+    case CAUSE_STEP_CAP:
+      return "Reached the investigation step limit.";
+    case CAUSE_STAGNATION:
+      return "Stopped: no new progress.";
+    case CAUSE_INVALID_TOOL:
+      return "Stopped: invalid tool call.";
+    case CAUSE_INTERRUPTED:
+      return "Interrupted.";
+    case CAUSE_CANCELLED:
+      return "Stopped.";
+    case CAUSE_CONTENT_FILTER:
+      return "Provider refused the response.";
+    case CAUSE_EMPTY_LOOP:
+      return "No productive reply this turn.";
+    case CAUSE_DRIVER_SWAP:
+      return "Turn ended for a driver change.";
+    case CAUSE_CONTEXT_OVERFLOW:
+      return "Stopped: context overflow.";
+    case CAUSE_TOOL_CALLS:
+      return "Turn ended during tool use.";
+    case CAUSE_UNSPECIFIED:
+    default:
+      return "Turn ended without a clean finish.";
+  }
+}
+
+export function isNaturalStopCause(cause: TerminalCause): boolean {
+  return cause === CAUSE_NATURAL;
+}
+
+export function isAuthoritativeComplete(opts: {
+  stopCause?: unknown;
+  userStopped?: boolean;
+}): boolean {
+  if (opts.userStopped) return true;
+  return isNaturalStopCause(canonicalizeTerminalCause(opts.stopCause));
+}
+
+export function recoveryControlsAvailable(lifecycle: TurnLifecycle): boolean {
+  return (
+    lifecycle === TURN_SETTLED_INCOMPLETE
+    || lifecycle === TURN_ABORTED
+    || lifecycle === TURN_ERROR
+    || lifecycle === TURN_INTERRUPTED
+  );
+}
+
+/** Visible Continue prompt — never an invisible continuation. */
+export const CONTINUE_PROMPT = "Continue from where you left off.";
+
+export type TurnItemLike =
+  | { kind: "msg"; msg: { role: string; text?: string; workerStream?: boolean } }
+  | { kind: string; [key: string]: unknown };
+
+function itemsInCurrentTurn(items: TurnItemLike[]): TurnItemLike[] {
+  let lastUser = -1;
+  for (let i = items.length - 1; i >= 0; i--) {
+    const it = items[i];
+    if (it.kind === "msg" && (it as { msg: { role: string } }).msg.role === "user") {
+      lastUser = i;
+      break;
+    }
+  }
+  return lastUser >= 0 ? items.slice(lastUser + 1) : items;
+}
+
+export function latestUserAsk(items: TurnItemLike[]): string {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const it = items[i];
+    if (it.kind !== "msg") continue;
+    const msg = (it as { msg: { role: string; text?: string } }).msg;
+    const text = String(msg.text || "").trim();
+    if (msg.role === "user" && text && text !== CONTINUE_PROMPT) {
+      return text;
+    }
+  }
+  return "";
+}
+
+export function latestPartialAssistant(items: TurnItemLike[]): string {
+  for (const it of [...itemsInCurrentTurn(items)].reverse()) {
+    if (it.kind !== "msg") continue;
+    const msg = (it as { msg: { role: string; text?: string; workerStream?: boolean } }).msg;
+    if (msg.role !== "assistant" || msg.workerStream) continue;
+    const text = String(msg.text || "").trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+export function hasPartialAssistantAnswer(items: TurnItemLike[]): boolean {
+  return Boolean(latestPartialAssistant(items));
+}
+
+export function settleFromAssistantDone(opts: {
+  stopCause?: unknown;
+  finishReason?: unknown;
+  incompleteReason?: unknown;
+  liveJobs?: boolean;
+}): TurnSettle {
+  const cause = canonicalizeTerminalCause(opts.stopCause);
+  if (opts.liveJobs) {
+    return {
+      kind: "settle",
+      lifecycle: TURN_AWAITING_SWARM,
+      cause: isNaturalStopCause(cause) ? CAUSE_NATURAL : cause,
+      status: "awaiting_swarm",
+      turnOpen: false,
+      explanation: isNaturalStopCause(cause) ? null : terminalCauseCopy(cause),
+    };
+  }
+  if (isNaturalStopCause(cause)) {
+    return {
+      kind: "settle",
+      lifecycle: TURN_SETTLED_COMPLETE,
+      cause: CAUSE_NATURAL,
+      status: "done",
+      turnOpen: false,
+      explanation: null,
+    };
+  }
+  return {
+    kind: "settle",
+    lifecycle: TURN_SETTLED_INCOMPLETE,
+    cause,
+    status: "done",
+    turnOpen: false,
+    explanation: terminalCauseCopy(cause),
+  };
+}
+
+export function settleFromTransportEof(opts: {
+  turnSettled: boolean;
+  userStopped: boolean;
+  hasPartialAnswer: boolean;
+}): TurnSettleResult {
+  if (opts.turnSettled || opts.userStopped) {
+    return { kind: "already_settled" };
+  }
+  if (opts.hasPartialAnswer) {
+    return {
+      kind: "settle",
+      lifecycle: TURN_SETTLED_INCOMPLETE,
+      cause: CAUSE_PROVIDER_EOF,
+      status: "error",
+      turnOpen: false,
+      explanation: terminalCauseCopy(CAUSE_PROVIDER_EOF),
+    };
+  }
+  return {
+    kind: "settle",
+    lifecycle: TURN_ABORTED,
+    cause: CAUSE_PROVIDER_EOF,
+    status: "error",
+    turnOpen: false,
+    explanation: terminalCauseCopy(CAUSE_PROVIDER_EOF),
+  };
+}
+
+export function settleFromFramingDone(opts: {
+  turnSettled: boolean;
+  hasPartialAnswer: boolean;
+}): TurnSettleResult {
+  if (opts.turnSettled) return { kind: "already_settled" };
+  return settleFromTransportEof({
+    turnSettled: false,
+    userStopped: false,
+    hasPartialAnswer: opts.hasPartialAnswer,
+  });
+}
+
+export function settleFromUserStop(): TurnSettle {
+  return {
+    kind: "settle",
+    lifecycle: TURN_INTERRUPTED,
+    cause: CAUSE_CANCELLED,
+    status: "idle",
+    turnOpen: false,
+    explanation: terminalCauseCopy(CAUSE_CANCELLED),
+  };
+}
+
+export function settleFromInterrupted(): TurnSettle {
+  return {
+    kind: "settle",
+    lifecycle: TURN_INTERRUPTED,
+    cause: CAUSE_INTERRUPTED,
+    status: "idle",
+    turnOpen: false,
+    explanation: terminalCauseCopy(CAUSE_INTERRUPTED),
+  };
+}
+
+const MODEL_STREAM_ERROR_CAUSES = new Set<TerminalCause>([
+  CAUSE_LENGTH,
+  CAUSE_INCOMPLETE,
+  CAUSE_CONTENT_FILTER,
+]);
+
+export function settleFromStreamError(
+  errorText?: unknown,
+  terminalCause?: unknown,
+): TurnSettle {
+  const named = canonicalizeTerminalCause(terminalCause);
+  if (MODEL_STREAM_ERROR_CAUSES.has(named)) {
+    return {
+      kind: "settle",
+      lifecycle: TURN_SETTLED_INCOMPLETE,
+      cause: named,
+      status: "done",
+      turnOpen: false,
+      explanation: terminalCauseCopy(named),
+    };
+  }
+  if (named === CAUSE_PROVIDER_EOF) {
+    return {
+      kind: "settle",
+      lifecycle: TURN_SETTLED_INCOMPLETE,
+      cause: CAUSE_PROVIDER_EOF,
+      status: "error",
+      turnOpen: false,
+      explanation: terminalCauseCopy(CAUSE_PROVIDER_EOF),
+    };
+  }
+  const raw = String(errorText || "").trim();
+  const explanation = raw
+    ? (raw.startsWith("[error]") || raw.startsWith("[aborted]")
+      ? raw
+      : `[error] ${raw}`)
+    : terminalCauseCopy(named === CAUSE_UNSPECIFIED ? CAUSE_TRANSPORT_ERROR : named);
+  return {
+    kind: "settle",
+    lifecycle: TURN_ERROR,
+    cause: named === CAUSE_UNSPECIFIED ? CAUSE_TRANSPORT_ERROR : named,
+    status: "error",
+    turnOpen: false,
+    explanation,
+  };
+}
+
+/** Full-auto halt is never a silent success; lifecycle must leave `running`. */
+export function settleFromAutoHalt(reason?: unknown): TurnSettle {
+  let cause = canonicalizeTerminalCause(reason);
+  if (isNaturalStopCause(cause) || cause === CAUSE_UNSPECIFIED) {
+    cause = CAUSE_INCOMPLETE;
+  }
+  return {
+    kind: "settle",
+    lifecycle: TURN_SETTLED_INCOMPLETE,
+    cause,
+    status: "done",
+    turnOpen: false,
+    explanation: terminalCauseCopy(cause),
+  };
+}
+
+export function settleFromStaleLocalAbandon(opts: {
+  turnSettled: boolean;
+  userStopped: boolean;
+  hasPartialAnswer: boolean;
+}): TurnSettleResult {
+  if (opts.userStopped || opts.turnSettled) return { kind: "already_settled" };
+  return settleFromTransportEof({
+    turnSettled: false,
+    userStopped: false,
+    hasPartialAnswer: opts.hasPartialAnswer,
+  });
+}
+
+export function settleFromRingReplayDone(opts: {
+  turnSettled: boolean;
+  hasPartialAnswer: boolean;
+}): TurnSettleResult {
+  return settleFromFramingDone(opts);
+}
+
+/** Mouth stays busy while a session switch has not resolved B's runner yet. */
+export function composerBusyDuringSwitch(opts: {
+  switchPending: boolean;
+  turnOpen: boolean;
+  status: string;
+  mouthBusy: boolean;
+}): boolean {
+  if (opts.switchPending) return true;
+  return opts.mouthBusy;
+}
+
+export type RecoveryContext = {
+  sessionId: string;
+  generation: number;
+};
+
+export function recoveryDispatchAllowed(opts: {
+  composerBusy: boolean;
+  dispatching: boolean;
+  lifecycle: TurnLifecycle;
+  boundSessionId?: string | null;
+  activeSessionId?: string | null;
+  boundGeneration?: number | null;
+  activeGeneration?: number | null;
+}): boolean {
+  if (opts.composerBusy || opts.dispatching) return false;
+  if (!recoveryControlsAvailable(opts.lifecycle)) return false;
+  if (opts.boundSessionId) {
+    if (!opts.activeSessionId || opts.boundSessionId !== opts.activeSessionId) {
+      return false;
+    }
+  }
+  if (
+    opts.boundGeneration != null
+    && opts.activeGeneration != null
+    && opts.boundGeneration !== opts.activeGeneration
+  ) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- preserve partial provider output and normalize authoritative terminal causes across OpenAI-compatible, Responses, Cursor CLI, and Cursor ACP transports
- prevent silent completion on EOF, output limits, malformed frames, and truncated tools while persisting truthful stream receipts
- add session-scoped Continue/Retry recovery, stable live-answer presentation, and lower-churn exploration grouping

## Test plan
- [x] `.venv/bin/python -m pytest -q` (4,965 passed, 76 skipped)
- [x] `npm test` (1,215 passed)
- [x] `npm run test:electron`
- [x] `npm run build`
- [x] `tests/test_version_consistency.py`
- [x] `git diff --check`