### PR TITLE
Release v0.9.269

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.15` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.268, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Provider streams now preserve partial output and report authoritative terminal causes end to end, while incomplete turns expose isolated Continue/Retry recovery and stable activity grouping instead of silently stopping.
+> Status: v0.9.269, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. OpenCode Go / Muse Responses stream deaths now name the selected host instead of Codex, and still fail-close with Continue/Retry.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.268"
+__version__ = "0.9.269"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -2956,6 +2956,44 @@ class ConversationalSession(
                 "Marionette."
             )
 
+        # Responses SSE died without completed/incomplete/failed. The shared
+        # driver class is CodexResponsesDriver even for OpenCode Go / Muse, so
+        # never leave a raw "Codex Responses" line on a non-Codex picker.
+        if (
+            "stream did not emit a terminal response" in low
+            or "stream ended without a terminal response" in low
+            or "stream timed out" in low
+        ) and (
+            "responses stream" in low
+            or "codex responses" in low
+            or "opencode responses" in low
+            or "openai responses" in low
+        ):
+            driver = str(model or "").lower()
+            if (
+                driver.startswith("opencode-go")
+                or driver.startswith("opencode-zen")
+                or "muse-spark" in driver
+                or "opencode" in low
+            ):
+                host = "OpenCode Go"
+            elif "codex" in driver or driver.startswith("openai-codex"):
+                host = "Codex"
+            else:
+                host = "the Responses host"
+            event_m = _re.search(r"last event:\s*([a-z0-9._-]+)", low)
+            event_bit = (
+                f" (last event: {event_m.group(1)})" if event_m else ""
+            )
+            if "timed out" in low:
+                what = f"{host} timed out waiting for a stream finish{event_bit}"
+            else:
+                what = f"{host} closed the stream before a finish{event_bit}"
+            return (
+                f"pilot: {what}. Press Continue to finish from tools already "
+                "run, or Retry the last step."
+            )
+
         return f"pilot: {s}"
 
     def _accumulate_session_meters(

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -34,6 +34,42 @@ _TERMINAL_EVENT_TYPES = frozenset({
     "response.failed",
 })
 
+
+def responses_stream_label(*, chatgpt_backend: bool, base_url: str = "") -> str:
+    """User-facing host name for Responses SSE errors.
+
+    ChatGPT Codex and OpenCode Go share this driver. The error must name the
+    host the picker selected, not the class that implements the wire.
+    """
+    if chatgpt_backend:
+        return "Codex Responses"
+    host = str(base_url or "").lower()
+    if "opencode.ai" in host:
+        return "OpenCode Responses"
+    return "OpenAI Responses"
+
+
+def responses_stream_error(
+    label: str,
+    kind: str,
+    last_event: str = "",
+) -> str:
+    """Build a stream-death error that names the host, not the driver class."""
+    name = str(label or "").strip() or "OpenAI Responses"
+    if kind == "timeout":
+        msg = f"{name} stream timed out"
+    elif kind == "ended":
+        msg = f"{name} stream ended without a terminal response"
+    elif kind == "failed":
+        head = name[:-10] if name.endswith(" Responses") else name
+        msg = f"{head} response failed"
+    else:
+        msg = f"{name} stream did not emit a terminal response"
+    event = str(last_event or "").strip()
+    if event:
+        msg = f"{msg} (last event: {event})"
+    return msg
+
 # Hermes-aligned: reasoning-only incomplete turns need a distinct user nudge
 # or the retry is byte-identical and fails forever.
 _CODEX_INCOMPLETE_NUDGE = (
@@ -521,6 +557,7 @@ def _consume_codex_sse(
     on_reasoning_delta: Optional[Callable[..., None]] = None,
     on_stream_item_done: Optional[Callable[..., None]] = None,
     chatgpt_backend: bool = True,
+    stream_label: Optional[str] = None,
 ) -> dict:
     """Consume Codex Responses SSE; return a synthetic Responses-shaped dict.
 
@@ -536,6 +573,9 @@ def _consume_codex_sse(
     ``response.completed`` / ``incomplete`` / ``failed``; EOF or ``[DONE]``
     without that terminal is incomplete/error and keeps partial text.
     """
+    label = stream_label or responses_stream_label(
+        chatgpt_backend=chatgpt_backend,
+    )
     collected_items: List[dict] = []
     text_deltas: List[str] = []
     reasoning_deltas: List[str] = []
@@ -692,7 +732,9 @@ def _consume_codex_sse(
                     "output": [],
                     "output_text": "",
                     "usage": {},
-                    "error": "Codex Responses stream timed out",
+                    "error": responses_stream_error(
+                        label, "timeout", last_provider_event,
+                    ),
                 }
             break
 
@@ -915,7 +957,9 @@ def _consume_codex_sse(
             "output": [],
             "output_text": "",
             "usage": {},
-            "error": "Codex Responses stream did not emit a terminal response",
+            "error": responses_stream_error(
+                label, "no_terminal", last_provider_event,
+            ),
             "last_provider_event": last_provider_event,
         }
 
@@ -931,11 +975,13 @@ def _consume_codex_sse(
         elif terminal_error:
             err_msg = str(terminal_error)[:800]
         else:
-            err_msg = "Codex response failed"
+            err_msg = responses_stream_error(label, "failed")
     if not saw_terminal and not chatgpt_backend:
         terminal_status = "incomplete"
         if not err_msg:
-            err_msg = "Codex Responses stream ended without a terminal response"
+            err_msg = responses_stream_error(
+                label, "ended", last_provider_event,
+            )
 
     out = {
         "status": terminal_status,
@@ -1153,6 +1199,10 @@ class CodexResponsesDriver:
                         on_reasoning_delta=on_reasoning_delta,
                         on_stream_item_done=on_stream_item_done,
                         chatgpt_backend=self.chatgpt_backend,
+                        stream_label=responses_stream_label(
+                            chatgpt_backend=self.chatgpt_backend,
+                            base_url=self.base_url,
+                        ),
                     )
                 return raw, None, data
             except urllib.error.HTTPError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.268"
+version = "0.9.269"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_codex_responses_driver.py
+++ b/tests/test_codex_responses_driver.py
@@ -15,6 +15,8 @@ from pmharness.drivers.codex_responses import (
     _consume_codex_sse,
     _extract_text_and_tools,
     _messages_to_responses_input,
+    responses_stream_error,
+    responses_stream_label,
 )
 
 
@@ -584,6 +586,26 @@ def test_non_chatgpt_build_body_omits_nonpositive_max_output_tokens():
     assert "max_output_tokens" not in body
 
 
+def test_responses_stream_label_names_host_not_driver_class():
+    assert responses_stream_label(chatgpt_backend=True) == "Codex Responses"
+    assert responses_stream_label(
+        chatgpt_backend=False,
+        base_url="https://opencode.ai/zen/go/v1",
+    ) == "OpenCode Responses"
+    assert responses_stream_label(
+        chatgpt_backend=False,
+        base_url="https://api.openai.com/v1",
+    ) == "OpenAI Responses"
+    err = responses_stream_error(
+        "OpenCode Responses",
+        "no_terminal",
+        "response.output_item.added",
+    )
+    assert err.startswith("OpenCode Responses")
+    assert "codex" not in err.lower()
+    assert "response.output_item.added" in err
+
+
 def test_consume_sse_non_chatgpt_eof_without_terminal_is_incomplete():
     lines = [
         b'data: {"type":"response.output_text.delta","delta":"partial"}\n',
@@ -594,9 +616,29 @@ def test_consume_sse_non_chatgpt_eof_without_terminal_is_incomplete():
     assert raw["status"] == "incomplete"
     assert raw["output_text"] == "partial"
     assert raw.get("error")
+    assert "openai responses" in str(raw["error"]).lower()
+    assert "codex" not in str(raw["error"]).lower()
     text, _, finish = _extract_text_and_tools(raw)
     assert text == "partial"
     assert finish == "incomplete"
+
+
+def test_consume_sse_opencode_empty_eof_after_item_added_names_host():
+    lines = [
+        b'data: {"type":"response.output_item.added","item":{"type":"message","id":"msg_x"}}\n',
+        b"data: [DONE]\n",
+    ]
+    raw = _consume_codex_sse(
+        lines,
+        chatgpt_backend=False,
+        stream_label="OpenCode Responses",
+    )
+    assert raw["status"] == "failed"
+    err = str(raw.get("error") or "").lower()
+    assert "opencode responses" in err
+    assert "did not emit a terminal response" in err
+    assert "response.output_item.added" in err
+    assert "codex" not in err
 
 
 def test_consume_sse_chatgpt_still_seals_after_answer_timeout():
@@ -703,6 +745,8 @@ def test_muse_eof_without_terminal_preserves_partial_text(monkeypatch):
     )
     assert resp.error
     assert "terminal" in resp.error.lower()
+    assert "opencode" in resp.error.lower()
+    assert "codex" not in resp.error.lower()
     assert resp.text == "partial answer"
     assert resp.meta["finish_reason"] != "completed"
     assert resp.meta.get("stream_started") is True

--- a/tests/test_humanize_pilot_error.py
+++ b/tests/test_humanize_pilot_error.py
@@ -100,6 +100,42 @@ def test_quota_exhaustion_is_explained():
     assert "credit" in out.lower() or "quota" in out.lower()
 
 
+def test_opencode_responses_stream_death_does_not_say_codex():
+    s = _s()
+    s.config.driver = "opencode-go:muse-spark-1.2-contributor"
+    raw = (
+        "OpenCode Responses stream did not emit a terminal response "
+        "(last event: response.output_item.added)"
+    )
+    out = s._humanize_pilot_error(raw)
+    assert out.startswith("pilot:")
+    assert "opencode go" in out.lower()
+    assert "continue" in out.lower()
+    assert "codex" not in out.lower()
+    assert "response.output_item.added" in out
+
+
+def test_legacy_codex_stream_death_on_muse_driver_is_rewritten():
+    s = _s()
+    s.config.driver = "opencode-go:muse-spark-1.2-contributor"
+    out = s._humanize_pilot_error(
+        "Codex Responses stream did not emit a terminal response"
+    )
+    assert "opencode go" in out.lower()
+    assert "continue" in out.lower()
+    assert "codex" not in out.lower()
+
+
+def test_codex_stream_death_on_codex_driver_keeps_codex_host():
+    s = _s()
+    s.config.driver = "openai-codex:gpt-5.5"
+    out = s._humanize_pilot_error(
+        "Codex Responses stream did not emit a terminal response"
+    )
+    assert "codex closed the stream" in out.lower()
+    assert "continue" in out.lower()
+
+
 def test_empty_error_has_message():
     s = _s()
     out = s._humanize_pilot_error("")

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.268",
+  "version": "0.9.269",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.268",
+      "version": "0.9.269",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.268",
+  "version": "0.9.269",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- OpenCode Go / Muse Responses stream deaths now name the selected host (`OpenCode Responses`) instead of Codex.
- Fail-close is unchanged: no `completed`/`incomplete`/`failed` still yields Continue/Retry, not a forged success.
- Version bump to v0.9.269. Pin stays `puppetmaster-ai==1.22.15`.

## Test plan
- [ ] `tests` workflow green on this PR: Python 3.9, 3.11, Windows, frontend-build
- [ ] Local pytest: 4970 passed, 76 skipped
- [ ] After merge, `python scripts/ci_release_gate.py require-green` then tag `v0.9.269`