### PR TITLE
Release v0.9.271

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.15
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.16
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.15"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.16"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.15"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.16"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -57,7 +57,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.15"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.16"
 
       - name: Run the offline test suite (shard)
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.15"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.16"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.15` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.16` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.15` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.16` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.270, deliberately pre-1.0. Rides puppetmaster-ai==1.22.15. Synchronous run_swarm now delivers a complete compact PM artifact manifest into synthesis, with a SwarmResultCard receipt, instead of a truncated handle-first subset.
+> Status: v0.9.271, deliberately pre-1.0. Rides puppetmaster-ai==1.22.16. Google Antigravity CLI (`agy`) is a first-class Puppetmaster worker adapter.
 
 ## Documentation
 
@@ -93,7 +93,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.15` (dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.16` (Google Antigravity `agy` adapter, dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.270"
+__version__ = "0.9.271"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/adapter_resolve.py
+++ b/harness/adapter_resolve.py
@@ -56,6 +56,8 @@ def _probe_external_adapter_available(adapter: str) -> bool:
         return bool(os.environ.get("OPENAI_API_KEY"))
     if a == "hermes":
         return shutil.which("hermes") is not None
+    if a == "antigravity":
+        return shutil.which("agy") is not None
     # Unknown adapter name: let the external path try (it will report its own error).
     return True
 
@@ -164,7 +166,7 @@ class AdapterResolveMixin:
         requested = (requested or "").strip().lower()
         if not requested or requested in ("agentic", "native", "provider"):
             return requested, ""
-        external = {"cursor", "claude-code", "codex", "openai", "hermes"}
+        external = {"cursor", "claude-code", "codex", "openai", "hermes", "antigravity"}
         if requested not in external:
             return requested, ""
         if self._external_adapter_available(requested):

--- a/harness/api/platform.py
+++ b/harness/api/platform.py
@@ -26,6 +26,7 @@ _ALLOWED_ADAPTERS = (
     "hermes",
     "claude-code",
     "codex",
+    "antigravity",
     "openai",
 )
 

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -1096,7 +1096,7 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             act, aid, f'(run_implement {aid} failed: {pin_error})', is_native,
         )
         return None
-    external_adapters = {'cursor', 'claude-code', 'codex', 'openai', 'hermes'}
+    external_adapters = {'cursor', 'claude-code', 'codex', 'openai', 'hermes', 'antigravity'}
     requested_adapter, adapter_remap_note = session._resolve_requested_implement_adapter(act.adapter or '')
     if strict_adapter:
         requested_adapter = 'agentic'
@@ -1360,7 +1360,7 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             act, aid, f'(run_parallel {aid} failed: {pin_error})', is_native,
         )
         return None
-    external_adapters = {'cursor', 'claude-code', 'codex', 'openai', 'hermes'}
+    external_adapters = {'cursor', 'claude-code', 'codex', 'openai', 'hermes', 'antigravity'}
     requested_adapter, adapter_remap_note = session._resolve_requested_implement_adapter(act.adapter or '')
     if strict_adapter:
         requested_adapter = 'agentic'

--- a/harness/server.py
+++ b/harness/server.py
@@ -244,11 +244,13 @@ def _init_platform_lock() -> None:
         # is enabled. It runs its own tool-use loop directly against whatever
         # provider API the user has a key for (Anthropic, OpenAI, Gemini,
         # OpenRouter, ...), so a fresh install needs NOTHING but a provider key --
-        # no external agent CLI (cursor / claude / codex / hermes) installed or
-        # logged in. Every CLI adapter is left OFF so Marionette stays fully
+        # no external agent CLI (cursor / claude / codex / hermes / agy) installed
+        # or logged in. Every CLI adapter is left OFF so Marionette stays fully
         # self-contained and vendor-neutral; any of them can still be re-enabled
         # in Settings > Platform for users who have that tooling.
-        default_disabled = ["cursor", "claude-code", "codex", "openai", "hermes"]
+        default_disabled = [
+            "cursor", "claude-code", "codex", "openai", "hermes", "antigravity",
+        ]
         if "disabled" not in pdata or not isinstance(pdata["disabled"], list):
             pdata["disabled"] = default_disabled
         else:
@@ -348,6 +350,7 @@ def _get_platform_adapters() -> dict:
         {"name": "hermes", "implement_capable": True},
         {"name": "claude-code", "implement_capable": True},
         {"name": "codex", "implement_capable": True},
+        {"name": "antigravity", "implement_capable": True},
         {"name": "openai", "implement_capable": False}
     ]
 
@@ -384,6 +387,9 @@ def _get_platform_adapters() -> dict:
         elif name == "codex":
             available = shutil.which("codex") is not None
             note = "Codex agent CLI. Requires 'codex' command in path."
+        elif name == "antigravity":
+            available = shutil.which("agy") is not None
+            note = "Google Antigravity CLI. Requires 'agy' on PATH."
         else:
             available = True
             note = ""

--- a/pmharness/registry.py
+++ b/pmharness/registry.py
@@ -176,6 +176,7 @@ _NATIVE_SLASH_NAMESPACES = frozenset({
     "cursor-agent",
     "cursor-cli",
     "hermes",
+    "antigravity",
     "openai-codex",
     "unknown",
 })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.270"
+version = "0.9.271"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.15" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.16" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.15"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.16"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.15" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.16" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.15}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.16}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/tests/test_bridge_agentic_credential_boundary.py
+++ b/tests/test_bridge_agentic_credential_boundary.py
@@ -194,6 +194,9 @@ def test_prewalk_syncs_before_orchestrator(monkeypatch, tmp_path):
         sync_seen.append("sync")
 
     monkeypatch.setattr(bridge, "_sync_agentic_credential_env", _track_sync)
+    monkeypatch.setattr(
+        bridge, "_resolve_prewalk_implement_adapter", lambda *_a, **_k: "agentic",
+    )
     monkeypatch.setenv("HARNESS_REPO", str(tmp_path))
     monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _CapturingOrchestrator)
     monkeypatch.setattr(

--- a/tests/test_platform_settings.py
+++ b/tests/test_platform_settings.py
@@ -70,6 +70,7 @@ def test_first_run_sensible_default(temp_platform_json):
     assert "claude-code" in data["disabled"]
     assert "codex" in data["disabled"]
     assert "openai" in data["disabled"]
+    assert "antigravity" in data["disabled"]
 
 
 def test_init_respects_foreign_writer_without_marker(temp_platform_json):
@@ -111,7 +112,7 @@ def test_get_platform_adapters(temp_platform_json):
         data = json.loads(resp.read().decode())
         
         adapters = data["adapters"]
-        assert len(adapters) == 6
+        assert len(adapters) == 7
 
         # The standalone 'agentic' adapter is present and implement-capable.
         agentic = next(a for a in adapters if a["name"] == "agentic")

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.15";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.16";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.15";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.16";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 
 // True when `pip show` / `uv pip show` output describes an editable install
@@ -43,7 +43,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.15" }    -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.16" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -65,7 +65,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.15).
+ * to 1.22.16).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.270",
+  "version": "0.9.271",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.270",
+      "version": "0.9.271",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.270",
+  "version": "0.9.271",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Pin `puppetmaster-ai==1.22.16` across desktop bootstrap, installer, doctor, updater, CI, and README (Antigravity CLI `agy` adapter on PyPI).
- Marionette v0.9.271 pin ride. Cary platform lock is unchanged.

## Test plan
- [ ] `tests` workflow green on this PR: Python 3.9, 3.11, Windows, frontend-build
- [ ] Operational pin test (`DEFAULT_PUPPETMASTER_SPEC` vs install/doctor/CI) still agrees
- [ ] After merge, `python scripts/ci_release_gate.py require-green` then tag `v0.9.271`