### PR TITLE
Receipt-first Swarm Tracker spend (#102)

### DIFF
--- a/harness/api/economics.py
+++ b/harness/api/economics.py
@@ -410,6 +410,17 @@ def _project_job_row(
     receipt: dict = {}
     job_cost = None
     cf = None
+    pm_receipt = None
+    if store is not None and jid and str(jid).startswith("job_"):
+        try:
+            from harness.financial_receipt import (
+                load_pm_cost_report,
+                persistable_pm_receipt,
+            )
+            raw_report = load_pm_cost_report(store, jid, registry=registry)
+            pm_receipt = persistable_pm_receipt(raw_report)
+        except Exception:
+            pm_receipt = None
     if store is not None and jid:
         try:
             artifacts = store.list_artifacts(jid) or []
@@ -419,12 +430,13 @@ def _project_job_row(
             receipt = build_job_receipt(store, jid) or {}
         except Exception:
             receipt = {}
-        try:
-            job_cost = price_job(artifacts, registry)
-            cf = job_counterfactual(job_cost, registry)
-        except Exception:
-            job_cost = None
-            cf = None
+        if pm_receipt is None:
+            try:
+                job_cost = price_job(artifacts, registry)
+                cf = job_counterfactual(job_cost, registry)
+            except Exception:
+                job_cost = None
+                cf = None
 
     models = _models_from_job_cost(job_cost) if job_cost is not None else []
     arts = receipt.get("artifacts") if isinstance(receipt, dict) else None
@@ -462,7 +474,17 @@ def _project_job_row(
     }
     # Visibility-only / unstamped CLI jobs stay listed but cannot be summed.
     # Empty or unpriced JobCost objects are 0.0 — that is not measured cash.
-    if owned and job_cost is not None:
+    if owned and pm_receipt is not None:
+        row["financial_receipt"] = pm_receipt
+        row["actual_marginal_usd"] = pm_receipt.get("spend_usd")
+        actual = (pm_receipt.get("pm_report") or {}).get("actual_cost") or {}
+        row["measured_cost_usd"] = actual.get("measured_cost_usd")
+        row["estimated_cost_usd"] = actual.get("estimated_cost_usd")
+        row["cost_basis"] = pm_receipt.get("spend_basis")
+        row["counterfactual"] = _serialize_job_counterfactual(pm_receipt.get("counterfactual"))
+        if row["counterfactual"] is not None:
+            row["counterfactual"]["label"] = "Estimated savings"
+    elif owned and job_cost is not None:
         basis = _cost_basis_for_job(job_cost)
         if basis is None:
             row["cost_basis"] = "unknown"

--- a/harness/api/jobs.py
+++ b/harness/api/jobs.py
@@ -567,6 +567,51 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
             ):
                 if j.get(_rk) not in (None, "", [], {}):
                     row[_rk] = j.get(_rk)
+            if str(jid).startswith("job_"):
+                try:
+                    from harness.financial_receipt import (
+                        load_pm_cost_report,
+                        persistable_pm_receipt,
+                    )
+                    raw_report = load_pm_cost_report(job_store, jid, registry=registry)
+                    receipt = persistable_pm_receipt(raw_report)
+                    row["financial_receipt"] = receipt
+                    if receipt.get("spend_usd") is not None:
+                        row["est_cost_usd"] = receipt["spend_usd"]
+                        row["estimated"] = bool(receipt.get("estimated"))
+                        row["cost_provenance"] = receipt.get("cost_provenance") or row.get("cost_provenance")
+                    elif receipt.get("spend_basis") == "unavailable":
+                        # Do not keep a routing forecast as spend.
+                        row["est_cost_usd"] = 0.0
+                        row["estimated"] = True
+                        row["cost_provenance"] = "unknown"
+                    if receipt.get("route_forecast_usd") is not None:
+                        row["route_forecast_usd"] = receipt.get("route_forecast_usd")
+                    tasks = row.get("tasks") or []
+                    actual_tasks = ((raw_report.get("actual_cost") or {}).get("tasks") or [])
+                    priced_by_id = {
+                        str(t.get("task_id")): t
+                        for t in actual_tasks
+                        if isinstance(t, dict) and t.get("task_id")
+                    }
+                    if len(tasks) == 1 and receipt.get("spend_usd") is not None:
+                        tasks[0]["est_cost_usd"] = receipt["spend_usd"]
+                        tasks[0]["estimated"] = bool(receipt.get("estimated"))
+                        tasks[0]["cost_provenance"] = receipt.get("cost_provenance")
+                    elif priced_by_id:
+                        for task in tasks:
+                            pt = priced_by_id.get(str(task.get("id") or ""))
+                            if not pt:
+                                continue
+                            if pt.get("priced") and pt.get("marginal_cost_usd") is not None:
+                                task["est_cost_usd"] = round(float(pt["marginal_cost_usd"]), 6)
+                                task["estimated"] = bool(pt.get("tokens_estimated"))
+                                task["cost_provenance"] = "static"
+                    elif len(tasks) > 1:
+                        for task in tasks:
+                            task.pop("est_cost_usd", None)
+                except Exception:
+                    pass
             res_jobs.append(apply_job_economics_policy(row))
     except Exception as e:
         svc.diag("server.jobs_list_aggregate", e)

--- a/harness/api/swarm_cost.py
+++ b/harness/api/swarm_cost.py
@@ -216,19 +216,27 @@ def _job_swarm_accounting_detail(raw_arts, registry: list) -> dict:
                 provenance = "static"
                 estimated = True
         else:
-            est_cost_usd = _routing_estimate_cost(raw_arts)
-            provenance = "default"
+            # Usage present but unpriceable: Cost unavailable, not a forecast.
+            est_cost_usd = 0.0
+            provenance = "unknown"
             estimated = True
     except Exception:
-        est_cost_usd = _routing_estimate_cost(raw_arts)
-        provenance = "default"
+        est_cost_usd = 0.0
+        provenance = "unknown"
         estimated = True
 
+    forecast = 0.0
+    try:
+        forecast = float(_routing_estimate_cost(raw_arts) or 0.0)
+    except Exception:
+        forecast = 0.0
     return {
         "tokens": tokens,
         "est_cost_usd": round(float(est_cost_usd or 0.0), 6),
         "cost_provenance": provenance,
         "estimated": bool(estimated),
+        "route_forecast_usd": round(forecast, 6),
+        "spend_is_forecast": False,
     }
 
 
@@ -280,7 +288,11 @@ def _task_swarm_accounting(raw_arts, registry: list) -> dict:
 
     by_task: dict = {}
     for task_id, cost in _routing_estimate_by_task(raw_arts).items():
-        by_task[task_id] = {"tokens": 0, "est_cost_usd": round(float(cost or 0.0), 6)}
+        # Forecast is metadata only — never spend.
+        by_task[task_id] = {
+            "tokens": 0,
+            "route_forecast_usd": round(float(cost or 0.0), 6),
+        }
 
     arts_for_usage = _arts_for_swarm_usage(raw_arts)
     try:
@@ -332,12 +344,12 @@ def _task_swarm_accounting(raw_arts, registry: list) -> dict:
                     "estimated": estimated,
                 }
             else:
-                # Unpriceable usage with tokens: keep routing estimate.
+                # Unpriceable usage: Cost unavailable. Keep forecast separate.
                 by_task[task_id] = {
                     "tokens": tokens,
-                    "est_cost_usd": float(prev.get("est_cost_usd") or 0.0),
-                    "cost_provenance": "default",
+                    "cost_provenance": "unknown",
                     "estimated": True,
+                    "route_forecast_usd": prev.get("route_forecast_usd"),
                 }
     except Exception:
         pass

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -1198,6 +1198,7 @@ class ConversationJobsMixin:
                     "invalidated_paths",
                     "reuse_reason",
                     "acceptance_criteria",
+                    "financial_receipt",
                 ):
                     if stamped.get(_rk) not in (None, "", [], {}):
                         res_dict[_rk] = stamped[_rk]

--- a/harness/financial_receipt.py
+++ b/harness/financial_receipt.py
@@ -1,0 +1,483 @@
+"""Receipt-first spend labels for local jobs and consumed PM cost reports.
+
+Not a master economics object and not a second ledger. Local jobs mint one
+terminal receipt; PM jobs carry the structured report already produced by
+``puppetmaster cost <job_id> --json``. Forecasts never become spend.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+SPEND_PROVIDER = "provider"
+SPEND_MEASURED = "measured"
+SPEND_ESTIMATED = "estimated"
+SPEND_UNAVAILABLE = "unavailable"
+
+LABEL_PROVIDER = "Provider-reported cost"
+LABEL_MEASURED = "Measured usage cost"
+LABEL_ESTIMATED = "Estimated cost"
+LABEL_FORECAST = "Route forecast"
+LABEL_SAVINGS = "Estimated savings"
+LABEL_UNAVAILABLE = "Cost unavailable"
+
+
+def format_job_identifier(job_id: str) -> str:
+    """One copyable identifier: ``Job local-...`` or ``Job job_...``."""
+    jid = str(job_id or "").strip()
+    if not jid:
+        return "Job"
+    return "Job %s" % jid
+
+
+def _money(amount: float, estimated: bool) -> str:
+    body = "$%.4f" % float(amount)
+    return "~%s" % body if estimated else body
+
+
+def format_spend_label(
+    amount: Optional[float],
+    basis: str,
+) -> str:
+    """Named spend string. Unknown never paints as measured $0."""
+    if basis == SPEND_UNAVAILABLE or amount is None:
+        return LABEL_UNAVAILABLE
+    try:
+        value = float(amount)
+    except (TypeError, ValueError):
+        return LABEL_UNAVAILABLE
+    if basis == SPEND_PROVIDER:
+        return "%s %s" % (LABEL_PROVIDER, _money(value, False))
+    if basis == SPEND_MEASURED:
+        return "%s %s" % (LABEL_MEASURED, _money(value, False))
+    return "%s %s" % (LABEL_ESTIMATED, _money(value, True))
+
+
+def format_forecast_label(amount: Optional[float]) -> str:
+    if amount is None:
+        return LABEL_UNAVAILABLE
+    try:
+        value = float(amount)
+    except (TypeError, ValueError):
+        return LABEL_UNAVAILABLE
+    if value <= 0:
+        return LABEL_UNAVAILABLE
+    return "%s %s" % (LABEL_FORECAST, _money(value, True))
+
+
+def format_savings_label(amount: Optional[float]) -> str:
+    if amount is None:
+        return LABEL_UNAVAILABLE
+    try:
+        value = float(amount)
+    except (TypeError, ValueError):
+        return LABEL_UNAVAILABLE
+    if value <= 0:
+        return LABEL_UNAVAILABLE
+    return "%s %s" % (LABEL_SAVINGS, _money(value, True))
+
+
+def spend_basis_from_provenance(
+    *,
+    estimated: bool,
+    cost_provenance: str,
+    has_amount: bool,
+) -> str:
+    if not has_amount:
+        return SPEND_UNAVAILABLE
+    provenance = str(cost_provenance or "").strip().lower()
+    if provenance == "provider" and not estimated:
+        return SPEND_PROVIDER
+    if provenance in ("live", "static") or (
+        provenance == "provider" and estimated
+    ):
+        return SPEND_MEASURED if provenance == "live" and not estimated else (
+            SPEND_MEASURED if provenance in ("live", "static") and not estimated
+            else SPEND_ESTIMATED
+        )
+    if estimated:
+        return SPEND_ESTIMATED
+    if provenance == "unknown":
+        return SPEND_UNAVAILABLE
+    return SPEND_ESTIMATED
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _route_forecast_from_artifacts(artifacts: Any) -> Optional[float]:
+    if not isinstance(artifacts, list):
+        return None
+    total = 0.0
+    found = False
+    for art in artifacts:
+        if not isinstance(art, dict):
+            continue
+        if str(art.get("type") or "").strip().upper() != "ROUTING":
+            continue
+        amount = _as_float(art.get("est_cost_usd") or art.get("estimated_cost_usd"))
+        if amount is None:
+            continue
+        total += amount
+        found = True
+    if not found:
+        return None
+    return round(total, 6)
+
+
+def build_local_financial_receipt(
+    job_id: str,
+    *,
+    spend_usd: float = 0.0,
+    estimated: bool = True,
+    cost_provenance: str = "default",
+    tokens: int = 0,
+    artifacts: Optional[list] = None,
+    routing_saved_usd: float = 0.0,
+    routing_savings_basis: str = "estimated",
+    provider_cost_usd: Optional[float] = None,
+) -> dict:
+    """One terminal receipt for a Marionette-owned local job."""
+    has_provider = provider_cost_usd is not None and float(provider_cost_usd or 0.0) > 0
+    amount = float(spend_usd or 0.0)
+    if has_provider:
+        amount = float(provider_cost_usd or 0.0)
+        basis = SPEND_PROVIDER
+        estimated = False
+        cost_provenance = "provider"
+    else:
+        basis = spend_basis_from_provenance(
+            estimated=estimated,
+            cost_provenance=cost_provenance,
+            has_amount=amount > 0 or (int(tokens or 0) > 0 and amount == 0 and cost_provenance == "provider" and not estimated),
+        )
+        if amount <= 0 and int(tokens or 0) <= 0:
+            basis = SPEND_UNAVAILABLE
+        elif amount <= 0 and estimated:
+            basis = SPEND_UNAVAILABLE
+    forecast = _route_forecast_from_artifacts(artifacts)
+    savings = _as_float(routing_saved_usd) or 0.0
+    receipt = {
+        "job_id": str(job_id or "").strip(),
+        "owner": "local",
+        "spend_usd": round(amount, 6) if basis != SPEND_UNAVAILABLE else None,
+        "spend_basis": basis,
+        "estimated": bool(estimated) if basis != SPEND_PROVIDER else False,
+        "cost_provenance": (
+            "provider" if basis == SPEND_PROVIDER
+            else ("unknown" if basis == SPEND_UNAVAILABLE else str(cost_provenance or "default"))
+        ),
+        "tokens": int(tokens or 0),
+        "route_forecast_usd": forecast,
+        "estimated_savings_usd": round(savings, 6) if savings > 0 else None,
+        "estimated_savings_basis": (
+            str(routing_savings_basis or "estimated") if savings > 0 else None
+        ),
+        "label": format_spend_label(
+            amount if basis != SPEND_UNAVAILABLE else None,
+            basis,
+        ),
+        "forecast_label": format_forecast_label(forecast),
+        "savings_label": format_savings_label(savings if savings > 0 else None),
+        "identifier": format_job_identifier(job_id),
+    }
+    return receipt
+
+
+def apply_local_receipt(job: dict, receipt: dict) -> dict:
+    """Persist the receipt and project the same spend onto workers.
+
+    One worker: job cost equals worker cost.
+    Multiple workers without per-task receipts: keep the job figure only.
+    """
+    if not isinstance(job, dict) or not isinstance(receipt, dict):
+        return job
+    job["financial_receipt"] = receipt
+    spend = receipt.get("spend_usd")
+    basis = str(receipt.get("spend_basis") or SPEND_UNAVAILABLE)
+    if spend is not None:
+        job["est_cost_usd"] = round(float(spend), 6)
+    elif basis == SPEND_UNAVAILABLE:
+        # Do not keep a leftover routing forecast as spend.
+        if float(job.get("est_cost_usd") or 0.0) > 0 and _route_forecast_from_artifacts(
+            job.get("artifacts")
+        ) == float(job.get("est_cost_usd") or 0.0):
+            job["est_cost_usd"] = 0.0
+    job["estimated"] = bool(receipt.get("estimated"))
+    job["cost_provenance"] = str(receipt.get("cost_provenance") or job.get("cost_provenance") or "default")
+    if receipt.get("route_forecast_usd") is not None:
+        job["route_forecast_usd"] = receipt.get("route_forecast_usd")
+    if receipt.get("estimated_savings_usd") is not None:
+        job["routing_saved_usd"] = receipt.get("estimated_savings_usd")
+        job["routing_savings_basis"] = receipt.get("estimated_savings_basis") or "estimated"
+    tasks = job.get("tasks")
+    if not isinstance(tasks, list) or not tasks:
+        return job
+    concrete = [
+        t for t in tasks
+        if isinstance(t, dict) and t.get("est_cost_usd") is not None
+    ]
+    if len(tasks) == 1 and isinstance(tasks[0], dict):
+        _copy_spend_onto_task(tasks[0], job, receipt)
+    elif len(tasks) > 1 and not concrete:
+        # Do not invent a split. Job estimate stays on the job only.
+        pass
+    return job
+
+
+def _copy_spend_onto_task(task: dict, job: dict, receipt: dict) -> None:
+    spend = receipt.get("spend_usd")
+    if spend is not None:
+        task["est_cost_usd"] = round(float(spend), 6)
+    elif job.get("est_cost_usd") is not None:
+        task["est_cost_usd"] = round(float(job.get("est_cost_usd") or 0.0), 6)
+    task["estimated"] = bool(receipt.get("estimated", job.get("estimated", True)))
+    task["cost_provenance"] = str(
+        receipt.get("cost_provenance") or job.get("cost_provenance") or "default"
+    )
+    if not task.get("tokens") and job.get("tokens"):
+        task["tokens"] = int(job.get("tokens") or 0)
+
+
+def project_historical_one_worker_spend(job: dict) -> dict:
+    """Historical one-worker jobs reuse the sound job estimate as Estimated cost.
+
+    Never copies a ROUTING forecast onto the worker as spend.
+    """
+    if not isinstance(job, dict):
+        return job
+    tasks = job.get("tasks")
+    if not isinstance(tasks, list) or len(tasks) != 1 or not isinstance(tasks[0], dict):
+        return job
+    task = tasks[0]
+    if task.get("est_cost_usd") is not None:
+        return job
+    job_spend = _as_float(job.get("est_cost_usd"))
+    forecast = _route_forecast_from_artifacts(job.get("artifacts"))
+    receipt = job.get("financial_receipt")
+    if isinstance(receipt, dict) and receipt.get("spend_usd") is not None:
+        _copy_spend_onto_task(task, job, receipt)
+        return job
+    if job_spend is None:
+        return job
+    # A lone job figure that is only the routing forecast is not spend.
+    if forecast is not None and abs(job_spend - forecast) < 1e-9 and job.get("estimated") is not False:
+        if not job.get("tokens"):
+            return job
+    if job_spend > 0 or job.get("tokens"):
+        task["est_cost_usd"] = round(job_spend, 6)
+        task["estimated"] = bool(job.get("estimated", True))
+        task["cost_provenance"] = str(job.get("cost_provenance") or "default")
+        if not task.get("tokens") and job.get("tokens"):
+            task["tokens"] = int(job.get("tokens") or 0)
+    return job
+
+
+def consume_pm_cost_report(report: dict) -> dict:
+    """Normalize PM ``cost --json`` output. Does not recalculate prices."""
+    if not isinstance(report, dict):
+        return {}
+    actual = report.get("actual_cost") if isinstance(report.get("actual_cost"), dict) else {}
+    counterfactual = report.get("counterfactual")
+    if counterfactual is not None and not isinstance(counterfactual, dict):
+        counterfactual = None
+    spend_usd, basis, estimated, provenance = _spend_from_actual(actual)
+    forecast = _as_float(report.get("total_estimated_cost_usd"))
+    savings = None
+    if isinstance(counterfactual, dict):
+        savings = _as_float(counterfactual.get("avoided_usd"))
+    job_id = str(report.get("job_id") or "").strip()
+    return {
+        "job_id": job_id,
+        "owner": "pm",
+        "source": "puppetmaster_cost_json",
+        "pm_report": report,
+        "spend_usd": spend_usd,
+        "spend_basis": basis,
+        "estimated": estimated,
+        "cost_provenance": provenance,
+        "route_forecast_usd": forecast,
+        "estimated_savings_usd": savings,
+        "estimated_savings_basis": "estimated" if savings else None,
+        "counterfactual": counterfactual,
+        "label": format_spend_label(spend_usd, basis),
+        "forecast_label": format_forecast_label(forecast),
+        "savings_label": format_savings_label(savings),
+        "identifier": format_job_identifier(job_id),
+    }
+
+
+def _spend_from_actual(actual: dict) -> tuple:
+    if not actual:
+        return None, SPEND_UNAVAILABLE, True, "unknown"
+    measured = _as_float(actual.get("measured_cost_usd"))
+    estimated_cost = _as_float(actual.get("estimated_cost_usd"))
+    total = _as_float(actual.get("total_marginal_cost_usd"))
+    measured_runs = int(actual.get("measured_runs") or 0)
+    estimated_runs = int(actual.get("estimated_runs") or 0)
+    priced = int(actual.get("priced_tasks") or 0)
+    plan = False
+    by_model = actual.get("by_model") or {}
+    if isinstance(by_model, dict) and by_model:
+        billings = [
+            str((bucket or {}).get("billing") or "").strip().lower()
+            for bucket in by_model.values()
+            if isinstance(bucket, dict)
+        ]
+        plan = bool(billings) and all(b == "plan" for b in billings)
+    if not priced and total is None:
+        return None, SPEND_UNAVAILABLE, True, "unknown"
+    if plan:
+        return 0.0, SPEND_PROVIDER, False, "plan"
+    if measured_runs and not estimated_runs and measured is not None:
+        return measured, SPEND_MEASURED, False, "provider"
+    if estimated_runs and not measured_runs and estimated_cost is not None:
+        return estimated_cost, SPEND_ESTIMATED, True, "static"
+    if total is not None:
+        mixed = bool(estimated_runs and measured_runs)
+        return total, (SPEND_ESTIMATED if mixed or estimated_runs else SPEND_MEASURED), mixed or bool(estimated_runs), (
+            "mixed" if mixed else "static"
+        )
+    return None, SPEND_UNAVAILABLE, True, "unknown"
+
+
+def try_pm_build_cost_report():
+    """Reusable PM function if the leftover extract has landed; else None."""
+    try:
+        from puppetmaster.cost import build_cost_report  # type: ignore
+    except Exception:
+        return None
+    if callable(build_cost_report):
+        return build_cost_report
+    return None
+
+
+def assemble_pm_cost_report(store: Any, job_id: str, registry: Optional[list] = None) -> dict:
+    """Consume PM primitives into the CLI ``cost --json`` shape.
+
+    Leftover: Puppetmaster should expose this as one reusable function shared
+    by CLI, MCP, and Mari. This assembler mirrors ``_run_cost_command`` and
+    does not invent pricing.
+    """
+    import dataclasses
+
+    from puppetmaster.cost import job_counterfactual, price_job
+    from puppetmaster.usage import aggregate_token_usage
+
+    artifacts = store.list_artifacts(job_id) if store is not None else []
+    if registry is None:
+        try:
+            from puppetmaster.model_registry import default_registry_path, load_registry
+
+            registry = load_registry(default_registry_path()) or []
+        except Exception:
+            registry = []
+    routing_rows, routing_by_model, routing_total = _routing_estimate_rows(artifacts)
+    job_cost = price_job(artifacts, registry)
+    counterfactual = job_counterfactual(job_cost, registry)
+    actual_by_model = {
+        mid: {
+            "calls": v["calls"],
+            "tokens_in": v["tokens_in"],
+            "tokens_out": v["tokens_out"],
+            "marginal_cost_usd": v["marginal_cost_usd"],
+            "billing": v["billing"],
+        }
+        for mid, v in (getattr(job_cost, "by_model", None) or {}).items()
+    }
+    return {
+        "job_id": job_id,
+        "cost_basis": "preflight_routing_estimate",
+        "total_estimated_cost_usd": routing_total,
+        "by_model": {
+            mid: {"calls": v["calls"], "estimated_cost_usd": round(v["cost"], 6)}
+            for mid, v in routing_by_model.items()
+        },
+        "token_usage": aggregate_token_usage(artifacts),
+        "actual_cost": {
+            "cost_basis": "measured_usage_x_registry_price",
+            "total_marginal_cost_usd": job_cost.total_marginal_cost_usd,
+            "measured_cost_usd": job_cost.measured_cost_usd,
+            "estimated_cost_usd": job_cost.estimated_cost_usd,
+            "measured_runs": job_cost.measured_runs,
+            "estimated_runs": job_cost.estimated_runs,
+            "priced_tasks": job_cost.priced_tasks,
+            "unpriced_tasks": job_cost.unpriced_tasks,
+            "by_model": actual_by_model,
+            "tasks": [dataclasses.asdict(t) for t in job_cost.tasks],
+        },
+        "counterfactual": (
+            dataclasses.asdict(counterfactual) if counterfactual is not None else None
+        ),
+        "tasks": routing_rows if routing_rows else [dataclasses.asdict(t) for t in job_cost.tasks],
+    }
+
+
+def _routing_estimate_rows(artifacts) -> tuple:
+    try:
+        from puppetmaster.cli.commands_gate import _routing_estimate_rows as pm_rows
+
+        return pm_rows(artifacts)
+    except Exception:
+        pass
+    try:
+        from puppetmaster.models import ArtifactType
+    except Exception:
+        return [], {}, 0.0
+    rows: list = []
+    by_model: dict = {}
+    total = 0.0
+    seen: set = set()
+    for artifact in artifacts or []:
+        if getattr(artifact, "type", None) != ArtifactType.ROUTING:
+            continue
+        if getattr(artifact, "created_by", None) != "router":
+            continue
+        task_id = getattr(artifact, "task_id", None)
+        if task_id:
+            if task_id in seen:
+                continue
+            seen.add(task_id)
+        payload = getattr(artifact, "payload", None) or {}
+        model_id = payload.get("model_id", "<unknown>")
+        cost = float(payload.get("estimated_cost_usd") or 0.0)
+        total += cost
+        rows.append({
+            "task_id": task_id,
+            "role": payload.get("role"),
+            "model_id": model_id,
+            "adapter": payload.get("adapter"),
+            "policy": payload.get("policy"),
+            "capability_needed": payload.get("capability_needed"),
+            "estimated_cost_usd": cost,
+        })
+        bucket = by_model.setdefault(model_id, {"calls": 0, "cost": 0.0})
+        bucket["calls"] += 1
+        bucket["cost"] += cost
+    return rows, by_model, round(total, 6)
+
+
+def load_pm_cost_report(store: Any, job_id: str, registry: Optional[list] = None) -> dict:
+    """Return the canonical PM cost report, preferring a reusable PM function."""
+    builder = try_pm_build_cost_report()
+    if builder is not None:
+        try:
+            return builder(store, job_id, registry=registry)  # type: ignore[misc]
+        except TypeError:
+            try:
+                return builder(store, job_id)
+            except Exception:
+                pass
+        except Exception:
+            pass
+    return assemble_pm_cost_report(store, job_id, registry=registry)
+
+
+def persistable_pm_receipt(report: dict) -> dict:
+    """Thin carry-through object stored on terminal result / live row / Economics."""
+    return consume_pm_cost_report(report)

--- a/harness/local_job_swarm_view.py
+++ b/harness/local_job_swarm_view.py
@@ -172,6 +172,10 @@ def project_local_job_for_swarm_live(job: dict) -> dict:
         "source": str(job.get("source") or "harness"),
         "actions": _normalize_actions(job.get("actions")),
     }
+    if isinstance(job.get("financial_receipt"), dict):
+        row["financial_receipt"] = dict(job["financial_receipt"])
+    if job.get("route_forecast_usd") is not None:
+        row["route_forecast_usd"] = job.get("route_forecast_usd")
 
     # Preserve pre-merge accounting from annotate_job_accounting; stamp harness
     # locals when absent so /api/swarm/live session savings count them once.
@@ -229,7 +233,8 @@ def project_local_job_for_swarm_live(job: dict) -> dict:
             if job.get(key) not in (None, "", [], {}):
                 row[key] = job.get(key)
 
-    return row
+    from harness.financial_receipt import project_historical_one_worker_spend
+    return project_historical_one_worker_spend(row)
 
 
 def merge_local_jobs_into_swarm_live(

--- a/harness/local_jobs.py
+++ b/harness/local_jobs.py
@@ -886,6 +886,28 @@ class LocalJobsMixin:
                 job["cost_provenance"] = "provider"
             if job.get("tasks"):
                 job["tasks"][0]["status"] = terminal
+            try:
+                from harness.financial_receipt import (
+                    apply_local_receipt,
+                    build_local_financial_receipt,
+                )
+                provider_cost = float(est_cost_usd or 0.0) if (
+                    real_cost and est_cost_usd and not cost_unsplit
+                ) else None
+                receipt = build_local_financial_receipt(
+                    job_id,
+                    spend_usd=float(job.get("est_cost_usd") or real_cost or 0.0),
+                    estimated=bool(job.get("estimated", True)),
+                    cost_provenance=str(job.get("cost_provenance") or "default"),
+                    tokens=int(job.get("tokens") or tokens or 0),
+                    artifacts=job.get("artifacts"),
+                    routing_saved_usd=float(job.get("routing_saved_usd") or 0.0),
+                    routing_savings_basis=str(job.get("routing_savings_basis") or "estimated"),
+                    provider_cost_usd=provider_cost,
+                )
+                apply_local_receipt(job, receipt)
+            except Exception:
+                pass
             if isinstance(worker_provenance, dict):
                 job["worker_provenance"] = copy.deepcopy(worker_provenance)
             summary_text = summary or ""
@@ -1174,7 +1196,27 @@ class LocalJobsMixin:
                 job["tokens"] = measured_tokens
             if measured_cost > 0:
                 job["est_cost_usd"] = round(measured_cost, 6)
+                job["estimated"] = False
+                job["cost_provenance"] = "provider"
             job["updated_at"] = time.time()
+            try:
+                from harness.financial_receipt import (
+                    apply_local_receipt,
+                    build_local_financial_receipt,
+                )
+                apply_local_receipt(job, build_local_financial_receipt(
+                    job_id,
+                    spend_usd=float(job.get("est_cost_usd") or 0.0),
+                    estimated=bool(job.get("estimated", measured_cost <= 0)),
+                    cost_provenance=str(job.get("cost_provenance") or "default"),
+                    tokens=int(job.get("tokens") or 0),
+                    artifacts=job.get("artifacts"),
+                    routing_saved_usd=float(job.get("routing_saved_usd") or 0.0),
+                    routing_savings_basis=str(job.get("routing_savings_basis") or "estimated"),
+                    provider_cost_usd=measured_cost if measured_cost > 0 else None,
+                ))
+            except Exception:
+                pass
             for artifact in job.get("artifacts") or []:
                 if not isinstance(artifact, dict):
                     continue

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -795,7 +795,23 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         delivered_arts, artifact_delivery = _swarm_artifact_delivery(
             session, _job_id_text, ordered,
         )
-    yield ConvEvent('action_result', {
+    _pm_receipt = None
+    _store_jid_early = str(getattr(result, "job_id", "") or "").strip()
+    if _store_jid_early.startswith("job_") and not _demo_refused:
+        try:
+            from harness.financial_receipt import (
+                load_pm_cost_report,
+                persistable_pm_receipt,
+            )
+            durable = session.state()
+            store = getattr(durable, "store", None)
+            if store is not None:
+                _pm_receipt = persistable_pm_receipt(
+                    load_pm_cost_report(store, _store_jid_early)
+                )
+        except Exception:
+            _pm_receipt = None
+    _action_result = {
         'id': aid,
         'job_id': result.job_id,
         'num': _ui_num,
@@ -805,7 +821,10 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         'mode': result.mode,
         'auth_failure': auth_failure,
         'error': ('demo substrate -- not real codebase analysis' if _demo_refused else None),
-    })
+    }
+    if _pm_receipt:
+        _action_result['financial_receipt'] = _pm_receipt
+    yield ConvEvent('action_result', _action_result)
     _has_signal = bool(_signal)
     # Quality gate: a "finding" with no substance (a one-liner with no file
     # reference) must not turn the badge green -- a swarm whose workers choked
@@ -845,6 +864,8 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         'artifacts': delivered_arts,
         'artifact_delivery': artifact_delivery,
     }
+    if _pm_receipt:
+        _badge['financial_receipt'] = _pm_receipt
     _job_engine = _ui_adapter if _demo_refused else (result.adapter or 'agentic')
     # Best-effort routed model so finish cannot clobber a preview ROUTING stamp
     # with bare agentic/native.

--- a/tests/test_financial_receipt.py
+++ b/tests/test_financial_receipt.py
@@ -1,0 +1,154 @@
+"""Receipt-first spend for local jobs and consumed PM cost reports (#102)."""
+from __future__ import annotations
+
+from harness.financial_receipt import (
+    LABEL_ESTIMATED,
+    LABEL_FORECAST,
+    LABEL_SAVINGS,
+    LABEL_UNAVAILABLE,
+    apply_local_receipt,
+    build_local_financial_receipt,
+    consume_pm_cost_report,
+    format_job_identifier,
+    format_savings_label,
+    format_spend_label,
+    project_historical_one_worker_spend,
+)
+from harness.local_job_swarm_view import project_local_job_for_swarm_live
+
+
+def test_job_identifier_is_copyable_and_neutral():
+    assert format_job_identifier("local-e0d790a9") == "Job local-e0d790a9"
+    assert format_job_identifier("job_41123fa7ff1b") == "Job job_41123fa7ff1b"
+
+
+def test_labels_name_their_basis():
+    assert format_spend_label(0.1095, "estimated").startswith(LABEL_ESTIMATED)
+    assert "~$" in format_spend_label(0.1095, "estimated")
+    assert format_spend_label(0.02, "provider").startswith("Provider-reported")
+    assert "~" not in format_spend_label(0.02, "provider")
+    assert format_spend_label(None, "unavailable") == LABEL_UNAVAILABLE
+    assert format_savings_label(0.0278).startswith(LABEL_SAVINGS)
+
+
+def test_local_one_worker_receipt_equals_job_and_worker():
+    job = {
+        "id": "local-abc",
+        "est_cost_usd": 0.0185,
+        "artifacts": [{
+            "type": "ROUTING",
+            "est_cost_usd": 0.0185,
+        }],
+        "routing_saved_usd": 0.0278,
+        "tasks": [{"id": "local-abc-w0", "status": "completed"}],
+    }
+    receipt = build_local_financial_receipt(
+        "local-abc",
+        spend_usd=0.1095,
+        estimated=True,
+        cost_provenance="static",
+        tokens=10948,
+        artifacts=job["artifacts"],
+        routing_saved_usd=0.0278,
+    )
+    apply_local_receipt(job, receipt)
+    assert job["est_cost_usd"] == job["tasks"][0]["est_cost_usd"] == 0.1095
+    assert job["financial_receipt"]["route_forecast_usd"] == 0.0185
+    assert job["financial_receipt"]["spend_usd"] == 0.1095
+    assert job["financial_receipt"]["spend_usd"] != job["financial_receipt"]["route_forecast_usd"]
+    assert job["financial_receipt"]["savings_label"].startswith(LABEL_SAVINGS)
+    assert job["financial_receipt"]["forecast_label"].startswith(LABEL_FORECAST)
+
+
+def test_historical_one_worker_reuses_job_estimate_not_forecast():
+    row = project_local_job_for_swarm_live({
+        "id": "local-e0d790a9",
+        "goal": "edit",
+        "status": "completed",
+        "est_cost_usd": 0.1095,
+        "estimated": True,
+        "tokens": 10948,
+        "artifacts": [{"type": "ROUTING", "est_cost_usd": 0.0185}],
+        "tasks": [{"id": "local-e0d790a9-w0", "status": "completed", "role": "implement"}],
+    })
+    assert row["tasks"][0]["est_cost_usd"] == 0.1095
+    assert row["tasks"][0]["est_cost_usd"] != 0.0185
+    assert row["est_cost_usd"] == row["tasks"][0]["est_cost_usd"]
+
+
+def test_multi_worker_without_task_receipts_does_not_invent_split():
+    job = {
+        "id": "local-multi",
+        "est_cost_usd": 0.40,
+        "estimated": True,
+        "tokens": 20000,
+        "tasks": [
+            {"id": "w0", "status": "completed"},
+            {"id": "w1", "status": "completed"},
+        ],
+    }
+    receipt = build_local_financial_receipt(
+        "local-multi",
+        spend_usd=0.40,
+        estimated=True,
+        tokens=20000,
+    )
+    apply_local_receipt(job, receipt)
+    assert job["est_cost_usd"] == 0.40
+    assert "est_cost_usd" not in job["tasks"][0]
+    assert "est_cost_usd" not in job["tasks"][1]
+    projected = project_historical_one_worker_spend(job)
+    assert "est_cost_usd" not in projected["tasks"][0]
+
+
+def test_consume_pm_report_does_not_use_preflight_as_spend():
+    report = {
+        "job_id": "job_41123fa7ff1b",
+        "cost_basis": "preflight_routing_estimate",
+        "total_estimated_cost_usd": 0.0185,
+        "actual_cost": {
+            "cost_basis": "measured_usage_x_registry_price",
+            "total_marginal_cost_usd": 0.1095,
+            "measured_cost_usd": 0.1095,
+            "estimated_cost_usd": 0.0,
+            "measured_runs": 1,
+            "estimated_runs": 0,
+            "priced_tasks": 1,
+            "unpriced_tasks": 0,
+            "by_model": {"m": {"billing": "metered", "calls": 1, "tokens_in": 1, "tokens_out": 1, "marginal_cost_usd": 0.1095}},
+            "tasks": [],
+        },
+        "counterfactual": {"avoided_usd": 0.0278, "reference_model_id": "flagship"},
+    }
+    receipt = consume_pm_cost_report(report)
+    assert receipt["identifier"] == "Job job_41123fa7ff1b"
+    assert receipt["spend_usd"] == 0.1095
+    assert receipt["route_forecast_usd"] == 0.0185
+    assert receipt["spend_usd"] != receipt["route_forecast_usd"]
+    assert receipt["estimated_savings_usd"] == 0.0278
+    assert receipt["savings_label"].startswith(LABEL_SAVINGS)
+    assert receipt["pm_report"] is report
+
+
+def test_finish_local_job_stamps_matching_job_and_worker_receipt(tmp_path):
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+
+    sess = ConversationalSession(HarnessConfig(state_dir=str(tmp_path)))
+    sess._register_local_job("local-fin", "do work", role="implement")
+    sess._finish_local_job(
+        "local-fin",
+        ok=True,
+        summary="done",
+        tokens=10948,
+        est_cost_usd=0.1095,
+        engine="agentic",
+        model="cheap-model",
+    )
+    job = sess._local_jobs["local-fin"]
+    receipt = job["financial_receipt"]
+    assert receipt["identifier"] == "Job local-fin"
+    assert receipt["spend_usd"] == job["est_cost_usd"] == job["tasks"][0]["est_cost_usd"]
+    assert receipt["spend_usd"] == 0.1095
+    assert receipt["spend_basis"] == "provider"
+    assert job["tasks"][0]["cost_provenance"] == "provider"

--- a/tests/test_job_swarm_accounting.py
+++ b/tests/test_job_swarm_accounting.py
@@ -172,11 +172,7 @@ def test_job_swarm_accounting_uses_actual_usage_not_routing_estimate():
 
 
 def test_job_swarm_accounting_keeps_estimate_when_usage_unpriceable():
-    """Usage from a model the registry cannot price must not zero the cost.
-
-    Regression: a finished job showed the routing estimate while running, then
-    snapped to $0 on completion because price_job returned 0 for its unpriced
-    usage records and that 0 was treated as authoritative."""
+    """Unpriceable usage is Cost unavailable — never a routing forecast."""
     arts = [
         _artifact(
             task_id="t1",
@@ -195,7 +191,10 @@ def test_job_swarm_accounting_keeps_estimate_when_usage_unpriceable():
     ]
     tokens, cost = _job_swarm_accounting(arts, registry=[])
     assert tokens == 360_000
-    assert abs(cost - 0.0067) < 1e-9
+    assert cost == 0.0
+    detail = _job_swarm_accounting_detail(arts, registry=[])
+    assert abs(detail.get("route_forecast_usd") - 0.0067) < 1e-9
+    assert detail.get("spend_is_forecast") is False
 
 
 def test_job_swarm_accounting_prices_unknown_models_from_live_map(monkeypatch):
@@ -231,6 +230,7 @@ def test_job_swarm_accounting_prices_unknown_models_from_live_map(monkeypatch):
 
 
 def test_job_swarm_accounting_falls_back_to_routing_before_usage():
+    """Before usage lands, spend is unavailable; forecast stays separate."""
     registry = [_registry_spec("worker-model")]
     arts = [
         _artifact(
@@ -242,7 +242,9 @@ def test_job_swarm_accounting_falls_back_to_routing_before_usage():
     ]
     tokens, cost = _job_swarm_accounting(arts, registry)
     assert tokens == 0
-    assert abs(cost - 0.062) < 1e-6
+    assert cost == 0.0
+    detail = _job_swarm_accounting_detail(arts, registry)
+    assert abs(detail.get("route_forecast_usd") - 0.062) < 1e-6
 
 
 def test_job_swarm_accounting_prices_verification_without_routing():
@@ -324,9 +326,10 @@ def test_task_swarm_accounting_falls_back_to_routing_estimate():
     ]
     by_task = _task_swarm_accounting(arts, registry)
     assert by_task["t1"]["tokens"] == 0
-    assert abs(by_task["t1"]["est_cost_usd"] - 0.062) < 1e-9
+    assert "est_cost_usd" not in by_task["t1"]
+    assert abs(by_task["t1"]["route_forecast_usd"] - 0.062) < 1e-9
     assert by_task["t2"]["tokens"] == 0
-    assert abs(by_task["t2"]["est_cost_usd"] - 0.0048) < 1e-9
+    assert abs(by_task["t2"]["route_forecast_usd"] - 0.0048) < 1e-9
 
 
 def test_task_swarm_accounting_keeps_estimate_when_usage_unpriceable():
@@ -348,7 +351,8 @@ def test_task_swarm_accounting_keeps_estimate_when_usage_unpriceable():
     ]
     by_task = _task_swarm_accounting(arts, registry=[])
     assert by_task["t1"]["tokens"] == 360_000
-    assert abs(by_task["t1"]["est_cost_usd"] - 0.0067) < 1e-9
+    assert "est_cost_usd" not in by_task["t1"]
+    assert abs(by_task["t1"]["route_forecast_usd"] - 0.0067) < 1e-9
 
 
 def test_zero_work_job_does_not_inherit_routing_estimate():

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -125,7 +125,7 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("vis-1")).toBeInTheDocument();
+    expect(await screen.findByText("Job vis-1")).toBeInTheDocument();
     expect(screen.getByText(/visible only/)).toBeInTheDocument();
     expect(screen.queryByText("$9.99")).not.toBeInTheDocument();
     expect(screen.queryByText("~$9.99")).not.toBeInTheDocument();

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import SwarmPane, { jobSavings, workerOutcome } from "../components/SwarmPane";
+import SwarmPane, { jobIdentifier, jobSavings, namedSavings, workerSpend, workerOutcome } from "../components/SwarmPane";
 import { api, type Job, type SwarmLive } from "../lib/api";
 import { dispatchProjectSelected } from "../lib/panelTransition";
 import { clearSWRCache, writeSWRCache } from "../lib/useStaleWhileRevalidate";
@@ -836,8 +836,8 @@ describe("SwarmPane mid-run job-row meters", () => {
     await waitFor(() => {
       expect(screen.getAllByText("12,000t").length).toBeGreaterThan(0);
       expect(screen.getByText("1,500 compact")).toBeInTheDocument();
-      expect(screen.getAllByText("~$0.0500").length).toBeGreaterThan(0);
-      expect(screen.getByText("~$0.0553 saved")).toBeInTheDocument();
+      expect(screen.getAllByText("Estimated cost ~$0.0500").length).toBeGreaterThan(0);
+      expect(screen.getByText("Estimated savings ~$0.0553")).toBeInTheDocument();
     });
     expect(screen.queryByText("8,000 cached")).not.toBeInTheDocument();
     expect(screen.getByTitle(/model selection value vs frontier-equivalent list price/)).toBeInTheDocument();
@@ -871,13 +871,13 @@ describe("SwarmPane mid-run job-row meters", () => {
       render(<SwarmPane />);
 
       await waitFor(() => {
-        expect(screen.getByText("$0.0200 saved")).toBeInTheDocument();
+        expect(screen.getByText("Estimated savings ~$0.0200")).toBeInTheDocument();
       });
 
       await vi.advanceTimersByTimeAsync(6000);
 
       await waitFor(() => {
-        expect(screen.getByText("$0.1100 saved")).toBeInTheDocument();
+        expect(screen.getByText("Estimated savings ~$0.1100")).toBeInTheDocument();
       });
     } finally {
       vi.useRealTimers();
@@ -1732,9 +1732,9 @@ describe("SwarmPane worker tokens and cost", () => {
       expect(screen.getByText("Workers (2)")).toBeInTheDocument();
     });
     expect(screen.getByText("120,000t")).toBeInTheDocument();
-    expect(screen.getByText("~$0.1400")).toBeInTheDocument();
+    expect(screen.getByText("Estimated cost ~$0.1400")).toBeInTheDocument();
     expect(screen.getByText("60,000t")).toBeInTheDocument();
-    expect(screen.getByText("~$0.0700")).toBeInTheDocument();
+    expect(screen.getByText("Estimated cost ~$0.0700")).toBeInTheDocument();
     expect(screen.queryByText("build it")).not.toBeInTheDocument();
     expect(screen.queryByText("check it")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /implement/ }));
@@ -2802,5 +2802,43 @@ describe("SwarmPane job-card expansion persistence", () => {
     render(<SwarmPane />);
     const job = await screen.findByRole("button", { name: /Running swarm/ });
     expect(job).toHaveAttribute("aria-expanded", "true");
+  });
+});
+
+
+describe("receipt-first spend (#102)", () => {
+  it("names job identifiers and never uses routing forecast as worker spend", () => {
+    expect(jobIdentifier("local-e0d790a9")).toBe("Job local-e0d790a9");
+    expect(jobIdentifier("job_41123fa7ff1b")).toBe("Job job_41123fa7ff1b");
+    expect(namedSavings(0.0278)).toBe("Estimated savings ~$0.0278");
+
+    const job = {
+      id: "local-e0d790a9",
+      goal: "x",
+      status: "complete",
+      est_cost_usd: 0.1095,
+      estimated: true,
+      tokens: 10948,
+      tasks: [{ id: "local-e0d790a9-w0", role: "implement", instruction: "", status: "done", adapter: "agentic" }],
+    } as Job;
+    const spend = workerSpend(job.tasks![0], job);
+    expect(spend?.cost).toBeCloseTo(0.1095, 6);
+    expect(spend?.basis).toBe("estimated");
+  });
+
+  it("does not invent a split for multi-worker jobs without task receipts", () => {
+    const job = {
+      id: "local-multi",
+      goal: "x",
+      status: "complete",
+      est_cost_usd: 0.40,
+      estimated: true,
+      tasks: [
+        { id: "w0", role: "a", instruction: "", status: "done", adapter: "agentic" },
+        { id: "w1", role: "b", instruction: "", status: "done", adapter: "agentic" },
+      ],
+    } as Job;
+    expect(workerSpend(job.tasks![0], job)).toBeNull();
+    expect(workerSpend(job.tasks![1], job)).toBeNull();
   });
 });

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -141,8 +141,8 @@ export default function EconomicsDurable({
         <div className="flex items-center justify-between mb-1 text-faint">
           <span>
             {referenceId
-              ? `list-price vs ${referenceId}, not a refund`
-              : "list-price vs reference, not a refund"}
+              ? `Estimated savings vs ${referenceId}`
+              : "Estimated savings"}
           </span>
           <span className="tabular-nums">{fmtUnknownMoney(avoided)}</span>
         </div>
@@ -167,7 +167,7 @@ export default function EconomicsDurable({
             return (
               <div key={job.job_id || `${job.source}-${job.status}`} className="mb-2">
                 <div className="flex items-center justify-between text-faint">
-                  <span className="truncate pr-2">{job.job_id || "job"}</span>
+                  <span className="truncate pr-2">{job.job_id ? `Job ${job.job_id}` : "Job"}</span>
                   <span className="tabular-nums shrink-0">
                     {owned
                       ? `${fmtUnknownMoney(actual)} vs ${fmtUnknownMoney(jobAvoided)}${costBasisLabel(job.cost_basis)}`

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -655,6 +655,65 @@ function formatWorkerCost(
   return formatKnownCost(cost, estimated);
 }
 
+export type SpendBasis = "provider" | "measured" | "estimated" | "unavailable";
+
+export function namedSpend(cost: unknown, basis: SpendBasis): string {
+  if (basis === "unavailable" || typeof cost !== "number" || !isFinite(cost)) {
+    return "Cost unavailable";
+  }
+  if (basis === "provider") return `Provider-reported cost ${formatCost(cost, false)}`;
+  if (basis === "measured") return `Measured usage cost ${formatCost(cost, false)}`;
+  return `Estimated cost ${formatCost(cost, true)}`;
+}
+
+export function namedForecast(cost: unknown): string {
+  if (typeof cost !== "number" || !isFinite(cost) || !(cost > 0)) return "Cost unavailable";
+  return `Route forecast ${formatCost(cost, true)}`;
+}
+
+export function namedSavings(cost: unknown): string {
+  if (typeof cost !== "number" || !isFinite(cost) || !(cost > 0)) return "Cost unavailable";
+  return `Estimated savings ${formatCost(cost, true)}`;
+}
+
+export function jobIdentifier(id: string): string {
+  const jid = (id || "").trim();
+  return jid ? `Job ${jid}` : "Job";
+}
+
+export function spendBasisFor(jobOrTask: {
+  estimated?: boolean;
+  cost_provenance?: string;
+  est_cost_usd?: number;
+}): SpendBasis {
+  const estimated = jobOrTask.estimated !== false && jobOrTask.cost_provenance !== "provider";
+  const cost = jobOrTask.est_cost_usd;
+  if (typeof cost !== "number" || !isFinite(cost)) return "unavailable";
+  if (jobOrTask.cost_provenance === "unknown") return "unavailable";
+  if (jobOrTask.cost_provenance === "provider" && estimated === false) return "provider";
+  if (jobOrTask.cost_provenance === "live" && estimated === false) return "measured";
+  if (!(cost > 0) && estimated) return "unavailable";
+  if (estimated) return "estimated";
+  return "measured";
+}
+
+/** Worker spend never falls back to a ROUTING forecast. */
+export function workerSpend(
+  task: Task,
+  job: Job,
+): { cost: number | undefined; estimated: boolean; basis: SpendBasis } | null {
+  if (task.est_cost_usd != null) {
+    const estimated = task.estimated !== false && task.cost_provenance !== "provider";
+    return { cost: task.est_cost_usd, estimated, basis: spendBasisFor(task) };
+  }
+  const tasks = job.tasks || [];
+  if (tasks.length === 1 && hasMeaningfulJobCost(job)) {
+    const estimated = job.estimated !== false && job.cost_provenance !== "provider";
+    return { cost: job.est_cost_usd, estimated, basis: spendBasisFor(job) };
+  }
+  return null;
+}
+
 function positiveUsd(n?: number): number {
   return typeof n === "number" && isFinite(n) && n > 0 ? n : 0;
 }
@@ -800,7 +859,7 @@ export function SavingsChip({ parts, className }: { parts: SavingsParts; classNa
       title={`List-price value from model selection, prompt-cache, and compaction (additive, not billed): ${savingsDetail(parts)}`}
     >
       <span className="text-good/45" aria-hidden="true">{"\u2193"}</span>
-      {formatCost(parts.total, parts.modelSelectionEstimated || parts.cachePartial)} saved
+      {namedSavings(parts.total)}
     </span>
   );
 }
@@ -1490,6 +1549,18 @@ export default function SwarmPane() {
               <Tooltip label={j.goal} className="font-semibold text-[11px] text-txt truncate">
                 {j.goal}
               </Tooltip>
+              <button
+                type="button"
+                className="shrink-0 font-mono text-[9px] text-faint hover:text-muted"
+                title="Copy job identifier"
+                aria-label={jobIdentifier(j.id)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void navigator.clipboard?.writeText(jobIdentifier(j.id));
+                }}
+              >
+                {jobIdentifier(j.id)}
+              </button>
             </div>
             <div className="flex items-center gap-2 shrink-0 text-[10px]">
               {/* Kill: running jobs only. Best-effort cooperative cancel on the
@@ -1540,11 +1611,11 @@ export default function SwarmPane() {
                     <span className="text-accent/80">{jobCompactTokens(j).toLocaleString()} compact</span>
                   )}
                   {showJobCost && (
-                    <span className="text-good/85">
-                      {formatKnownCost(
-                        j.est_cost_usd,
-                        j.estimated !== false && j.cost_provenance !== "provider",
-                      )}
+                    <span
+                      className="text-good/85"
+                      title={namedSpend(j.est_cost_usd, spendBasisFor(j))}
+                    >
+                      {namedSpend(j.est_cost_usd, spendBasisFor(j))}
                     </span>
                   )}
                   {showJobSavings && <SavingsChip parts={savings} className="font-sans" />}
@@ -1691,13 +1762,14 @@ export default function SwarmPane() {
                     const hasRejected = !!(routing?.rejected && routing.rejected.length > 0);
                     const altKey = `${j.id}:${task.id}`;
                     const altsExpanded = !!expandedAlts[altKey];
-                    const costValue = task.est_cost_usd ?? routing?.est_cost_usd;
-                    const costEstimated = task.est_cost_usd != null
-                      ? task.estimated !== false && task.cost_provenance !== "provider"
-                      : true;
+                    const spend = workerSpend(task, j);
+                    const costValue = spend?.cost;
+                    const costEstimated = spend?.estimated ?? true;
                     const showTokens = (task.tokens ?? 0) > 0;
-                    const showCost = isKnownPositiveCost(costValue)
-                      || isProviderAttestedExactZero(costValue, costEstimated);
+                    const showCost = spend != null && (
+                      isKnownPositiveCost(costValue)
+                      || isProviderAttestedExactZero(costValue, costEstimated)
+                    );
                     const showSpend = showTokens || showCost;
                     const roleLabel = task.role || "Worker";
                     const detailsId = `swarm-worker-${task.id}`;
@@ -1753,11 +1825,13 @@ export default function SwarmPane() {
                                   )}
                                   {showCost && (
                                     <span className="text-good/85">
-                                      {formatWorkerCost(
-                                        costValue,
-                                        costEstimated,
-                                        isPlanBilledRouting(routing),
-                                      )}
+                                      {spend
+                                        ? namedSpend(costValue, spend.basis)
+                                        : formatWorkerCost(
+                                            costValue,
+                                            costEstimated,
+                                            isPlanBilledRouting(routing),
+                                          )}
                                     </span>
                                   )}
                                 </span>

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -194,6 +194,8 @@ export type Task = {
   cost_provenance?: "provider" | "live" | "static" | "default";
   /** True when the dollar figure is not a full provider receipt. */
   estimated?: boolean;
+  /** Pre-run routing forecast — never spend. */
+  route_forecast_usd?: number;
 };
 export type Job = {
   id: string;
@@ -215,6 +217,9 @@ export type Job = {
   cost_provenance?: "provider" | "live" | "static" | "default";
   /** True when the dollar figure is not a full provider receipt. */
   estimated?: boolean;
+  /** Pre-run routing forecast — never spend. */
+  route_forecast_usd?: number;
+  financial_receipt?: Record<string, unknown>;
   model?: string;
   /** Prompt-cache hits on this job's usage-bearing artifacts. */
   tokens_cached?: number;


### PR DESCRIPTION
## Summary
- Local jobs mint one terminal financial receipt on worker finish and project the same spend onto that worker (job cost == worker cost). Historical one-worker rows reuse the sound job estimate; multi-worker jobs without task receipts keep the job figure and do not invent a split.
- Routing forecasts stay on a separate `route_forecast_usd` field. Tracker/Economics never paint a pre-run forecast as spend. Counterfactuals are labeled **Estimated savings**.
- PM `job_*` rows consume the structured `puppetmaster cost --json` report and carry it through the terminal action result, Swarm Tracker, and Economics so those surfaces show the same persisted numbers.

Closes #102

## Test plan
- [x] `pytest -q tests/test_financial_receipt.py tests/test_job_swarm_accounting.py tests/test_local_job_swarm_view.py tests/test_api_economics_peel.py tests/test_local_job_persistence.py`
- [x] Additional local-job / cost suite (125 passed)
- [x] `vitest run src/__tests__/SwarmPane.test.tsx src/__tests__/EconomicsPane.test.tsx` (96 passed)
- [ ] Confirm a finished one-worker `local-*` job shows the same labeled spend on header and worker, with routing as **Route forecast** only
- [ ] Confirm a `job_*` Tracker/Economics row matches `puppetmaster cost <id> --json`

## Leftover PM-repo cut
Puppetmaster still builds `cost --json` only inside `puppetmaster.cli.commands_gate._run_cost_command`. Mari consumes that JSON shape (and the same `price_job` / `job_counterfactual` primitives) via `harness.financial_receipt.assemble_pm_cost_report`, preferring `puppetmaster.cost.build_cost_report` if it lands later.

Extract `_run_cost_command`'s JSON payload into one reusable PM function shared by CLI, MCP (`puppetmaster_job_cost`), and Mari. Do not invent a second economics database.