### PR TITLE
Complete single-job terminal evidence delivery

### DIFF
--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -3567,7 +3567,9 @@ class ConversationalSession(
         finally:
             # Free the objective claimed at run_implement dispatch (external path).
             self._release_objective(objective)
-            # Cleanup state_dir if present
+            # Ephemeral PM child state. The queued result already carries the
+            # complete artifact snapshot from _await_and_apply_job, so late
+            # drain / reload can reconcile without this directory.
             if state_dir:
                 import shutil
                 shutil.rmtree(state_dir, ignore_errors=True)

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -470,21 +470,31 @@ class ConversationJobsMixin:
         summary = "\n".join(summary_parts) if summary_parts else "Successfully completed implement task"
 
         ar_list = []
-        for a in artifacts[:8]:
+        for a in artifacts:
             if not isinstance(a, dict):
                 continue
             t = a.get("type", "finding")
             headline = ""
+            payload = a.get("payload") or {}
+            if not isinstance(payload, dict):
+                payload = {}
             if t == "patch":
-                files = (a.get("payload") or {}).get("files") or []
+                files = payload.get("files") or []
                 headline = f"Patch: modified {', '.join(files)}" if files else "Patch generated"
             elif t == "finding":
-                claim = (a.get("payload") or {}).get("claim") or ""
-                rep = (a.get("payload") or {}).get("report") or ""
+                claim = payload.get("claim") or ""
+                rep = payload.get("report") or ""
                 headline = claim or rep[:80] or "Finding"
             else:
                 headline = f"{t.capitalize()} artifact"
-            ar_list.append({"type": t, "headline": headline})
+            row = {"type": t, "headline": headline}
+            for key in ("id", "task_id", "sha256"):
+                val = a.get(key)
+                if val in (None, ""):
+                    val = payload.get(key)
+                if val not in (None, ""):
+                    row[key] = val
+            ar_list.append(row)
 
         # 5. Apply patch
         # CORRECTNESS (comment these in code): Guard the git apply operation with self._apply_lock
@@ -1417,24 +1427,35 @@ class ConversationJobsMixin:
                         display_error = res_job.get("error") or err_bit or None
                     else:
                         err_bit = ""
-                        # Model-visible history is handle-first (job_id + headlines
-                        # + artifact://). Full summary stays on display/UI.
-                        try:
-                            from harness.worker_handles import format_handle_first_result
-                            arts = _background_artifacts(res_job, stamped)
-                            handle = format_handle_first_result(job_id, arts)
-                            msg_content = (
-                                f"[swarm result for: {objective}]\n{handle}"
-                            )
-                        except Exception:
-                            msg_content = f"[swarm result for: {objective}] {summary}"
+                        msg_content = f"[swarm result for: {objective}]"
                         if applied and applied_files:
                             msg_content += f"; applied {len(applied_files)} files"
                         elif held_for_review:
-                            msg_content += f"; held for review"
+                            msg_content += "; held for review"
                         elif res_job.get("has_patch_art") and not applied:
                             msg_content += f"; patch failed to apply: {res_job.get('apply_msg')}"
                         display_error = res_job.get("error") or None
+
+                    try:
+                        from harness.send_loop_dispatch import (
+                            _render_swarm_delivery_manifest,
+                            _swarm_artifact_delivery,
+                        )
+                        snapshot = list(_background_artifacts(res_job, stamped))
+                        delivered, delivery = _swarm_artifact_delivery(
+                            self, job_id, snapshot, require_store=False,
+                        )
+                        if isinstance(res_job, dict):
+                            res_job["artifacts"] = delivered
+                            res_job["artifact_delivery"] = delivery
+                        manifest = _render_swarm_delivery_manifest(
+                            job_id, delivered, delivery,
+                        )
+                        if manifest:
+                            msg_content = f"{msg_content}\n{manifest}"
+                    except Exception:
+                        delivered = []
+                        delivery = None
 
                     boundary = _background_evidence_boundary(
                         self, job_id, res_job, stamped,
@@ -1460,6 +1481,9 @@ class ConversationJobsMixin:
                         "held_for_review": bool(held_for_review),
                         "analysis_ok": bool(analysis_ok),
                     }
+                    if delivery is not None:
+                        display_result["artifacts"] = delivered
+                        display_result["artifact_delivery"] = delivery
                     worker_provenance = res_job.get("worker_provenance") or {}
                     if worker_provenance:
                         display_result["worker_provenance"] = worker_provenance

--- a/harness/local_job_artifacts.py
+++ b/harness/local_job_artifacts.py
@@ -37,8 +37,6 @@ TERMINAL_EXECUTION_ARTIFACT_TYPES = frozenset({
     ANALYSIS_ARTIFACT_TYPE, PATCH_ARTIFACT_TYPE, ERROR_ARTIFACT_TYPE,
 })
 
-_MAX_FINDING_ARTIFACTS = 20
-
 
 def is_bookkeeping_artifact(artifact: Any) -> bool:
     """True for a ROUTING / placeholder / error / bookkeeping row."""
@@ -144,8 +142,9 @@ def normalize_finding_artifacts(
 ) -> List[Dict[str, Any]]:
     """Carry a worker's real structured findings onto the sidecar row.
 
-    Bounded and id-stamped so ``artifact://<job>/<id>`` stays resolvable, and
+    Id-stamped so ``artifact://<job>/<id>`` stays resolvable, and
     filtered to substantive rows so plumbing cannot inflate the count.
+    Every substantive finding is kept — first-N is not the accounting set.
 
     Finding / risk / decision rows receive an ``execution_ref`` pointing at the
     parent job (and terminal artifact) so readers can join spend/model without
@@ -176,8 +175,6 @@ def normalize_finding_artifacts(
             for key in _SPEND_FIELDS:
                 row.pop(key, None)
         out.append(row)
-        if len(out) >= _MAX_FINDING_ARTIFACTS:
-            break
     return out
 
 

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -110,8 +110,19 @@ def _session_durable(session):
     raise AttributeError("session has no durable artifact store")
 
 
-def _swarm_artifact_delivery(session, job_id: str, result_rows: list[dict]) -> tuple[list[dict], dict]:
-    """Reconcile the PM store with the result projection; never model-pull evidence."""
+def _swarm_artifact_delivery(
+    session,
+    job_id: str,
+    result_rows: list[dict],
+    *,
+    require_store: bool = True,
+) -> tuple[list[dict], dict]:
+    """Reconcile the PM store with the result projection; never model-pull evidence.
+
+    ``require_store=True`` (synchronous PM swarm): a missing ledger is incomplete.
+    ``require_store=False`` (background / local / snapshot): a durable result
+    snapshot is the accounting authority after ephemeral PM state is gone.
+    """
 
     expected_refs = [_artifact_ref(row) for row in result_rows]
     canonical_rows: list[dict] = []
@@ -156,15 +167,16 @@ def _swarm_artifact_delivery(session, job_id: str, result_rows: list[dict]) -> t
             ordered.append(row)
     ordered.extend(anonymous_rows)
 
-    if not store_ok:
+    if not store_ok and require_store:
         missing.insert(0, {"id": "pm-store", "task_id": "unavailable"})
     pm_artifacts = len(expected_refs)
     artifact_missing = [row for row in missing if row.get("id") != "pm-store"]
     available = max(0, pm_artifacts - len(artifact_missing))
+    store_complete = store_ok if require_store else True
     return ordered, {
         "pm_artifacts": pm_artifacts,
         "available_to_inspect": available,
-        "complete": store_ok and not artifact_missing,
+        "complete": store_complete and not artifact_missing,
         "missing": missing,
     }
 
@@ -489,8 +501,15 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                         'type': a.get('type') or 'finding',
                         'headline': a.get('headline') or a.get('uri') or '',
                         'id': a.get('id'),
+                        'task_id': a.get('task_id'),
+                        'sha256': a.get('sha256'),
                     }
-                    for a in (_reuse_decision.compact_artifacts or [])
+                    for a in (
+                        (getattr(_reuse_decision, 'candidate', None) or {}).get('artifacts')
+                        if isinstance(getattr(_reuse_decision, 'candidate', None), dict)
+                        else None
+                    ) or (_reuse_decision.compact_artifacts or [])
+                    if isinstance(a, dict)
                 ],
                 reuse_status='reused',
                 source_job_id=_reuse_decision.source_job_id,
@@ -524,6 +543,24 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                 act, aid, f'(swarm {aid} failed: {err})', is_native,
             )
             return None
+        try:
+            from harness.local_job_artifacts import is_bookkeeping_artifact
+            _cand = getattr(_reuse_decision, 'candidate', None)
+            _source_job = _cand if isinstance(_cand, dict) else {}
+            _source_rows = [
+                a for a in (_source_job.get('artifacts') or [])
+                if isinstance(a, dict) and not is_bookkeeping_artifact(a)
+            ]
+        except Exception:
+            _source_rows = []
+        if not _source_rows:
+            _source_rows = list(_reuse_decision.compact_artifacts or [])
+        _delivered_reuse, _delivery_reuse = _swarm_artifact_delivery(
+            session,
+            _reuse_decision.source_job_id or _sync_local_id,
+            _source_rows,
+            require_store=False,
+        )
         _badge = {
             'job_id': _sync_local_id,
             'applied': True,
@@ -532,6 +569,8 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             'error': None,
             'objective': act.goal,
             'adapter': 'reuse',
+            'artifacts': _delivered_reuse,
+            'artifact_delivery': _delivery_reuse,
             **_prov,
         }
         yield ConvEvent('action_result', {

--- a/tests/test_terminal_evidence_pr1.py
+++ b/tests/test_terminal_evidence_pr1.py
@@ -1,0 +1,262 @@
+"""PR 1: complete terminal evidence for every single job.
+
+Public-boundary RED: exact (job_id, task_id, artifact_id, sha256, type) sets
+must agree across the job snapshot, the durable receipt, and the pilot
+synthesis manifest. First-N / handle-first projections are not authority.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from unittest.mock import patch
+
+from harness.config import HarnessConfig
+from harness.conversation import ConversationalSession
+from harness.local_job_artifacts import normalize_finding_artifacts
+
+
+def _identity(job_id, row):
+    return (
+        str(job_id),
+        str(row.get("task_id") or ""),
+        str(row.get("id") or ""),
+        str(row.get("sha256") or ""),
+        str(row.get("type") or ""),
+    )
+
+
+def _session(tmp_path):
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
+    cfg.repo = str(tmp_path)
+    return ConversationalSession(cfg)
+
+
+def _canonical_rows(job_id, n=17):
+    return [
+        {
+            "type": "finding",
+            "id": f"{job_id}-finding-{i}",
+            "task_id": f"task-{i % 5}",
+            "sha256": f"sha-{i}",
+            "headline": f"Finding {i} in harness/foo.py:{i}",
+        }
+        for i in range(n)
+    ]
+
+
+def test_background_drain_receipt_matches_canonical_identity_set(tmp_path):
+    job_id = "job_pr1_bg"
+    rows = _canonical_rows(job_id)
+    expected = {_identity(job_id, r) for r in rows}
+    session = _session(tmp_path)
+    session._local_jobs[job_id] = {
+        "id": job_id,
+        "cwd": str(tmp_path),
+        "artifacts": rows,
+    }
+    session._swarm_results.put({
+        "job_id": job_id,
+        "objective": "audit the router",
+        "result": {
+            "applied": True,
+            "files": [],
+            "summary": "FULL SUMMARY " + ("word " * 400),
+            "analysis_ok": True,
+            "artifacts": rows,
+        },
+    })
+
+    events = list(session.drain_swarm_results())
+    swarm = next(e.data["result"] for e in events if e.kind == "swarm_result")
+    receipt = {_identity(job_id, r) for r in swarm["artifacts"]}
+    assert receipt == expected
+    assert swarm["artifact_delivery"]["pm_artifacts"] == 17
+    assert swarm["artifact_delivery"]["available_to_inspect"] == 17
+    assert swarm["artifact_delivery"]["complete"] is True
+    assert swarm["artifact_delivery"]["missing"] == []
+
+    display = next(d for d in session._display_transcript if d.get("job_id") == job_id)
+    assert {_identity(job_id, r) for r in display["artifacts"]} == expected
+    assert display["artifact_delivery"] == swarm["artifact_delivery"]
+
+    hist = next(
+        m["content"] for m in session._history
+        if m.get("role") == "assistant" and job_id in (m.get("content") or "")
+    )
+    assert "PM SWARM ARTIFACT MANIFEST:" in hist
+    assert "Available to inspect: 17/17" in hist
+    assert "peek_artifact" not in hist
+    assert "FETCH full bodies" not in hist
+    assert "FULL SUMMARY" not in hist
+    for i in range(17):
+        assert f"{job_id}-finding-{i}" in hist
+        assert f"sha-{i}" in hist
+
+
+def test_failed_and_held_jobs_still_carry_complete_receipt(tmp_path):
+    session = _session(tmp_path)
+    failed_id = "job_pr1_fail"
+    held_id = "job_pr1_held"
+    fail_rows = _canonical_rows(failed_id, n=3)
+    held_rows = _canonical_rows(held_id, n=4)
+    session._swarm_results.put({
+        "job_id": failed_id,
+        "objective": "failed implement",
+        "result": {
+            "applied": False,
+            "files": [],
+            "summary": "worker died",
+            "error": "provider timeout",
+            "degraded": True,
+            "artifacts": fail_rows,
+        },
+    })
+    session._swarm_results.put({
+        "job_id": held_id,
+        "objective": "held implement",
+        "result": {
+            "applied": False,
+            "files": [],
+            "summary": "held",
+            "held_for_review": True,
+            "artifacts": held_rows,
+        },
+    })
+
+    events = list(session.drain_swarm_results())
+    results = {
+        e.data["job_id"]: e.data["result"]
+        for e in events if e.kind == "swarm_result"
+    }
+    assert {_identity(failed_id, r) for r in results[failed_id]["artifacts"]} == {
+        _identity(failed_id, r) for r in fail_rows
+    }
+    assert results[failed_id]["artifact_delivery"]["complete"] is True
+    assert {_identity(held_id, r) for r in results[held_id]["artifacts"]} == {
+        _identity(held_id, r) for r in held_rows
+    }
+    assert results[held_id]["artifact_delivery"]["complete"] is True
+
+
+def test_partial_delivery_names_missing_evidence(tmp_path):
+    job_id = "job_pr1_partial"
+    rows = _canonical_rows(job_id, n=5)
+    expected_plus_missing = rows + [{
+        "type": "finding",
+        "id": f"{job_id}-finding-missing",
+        "task_id": "task-x",
+        "sha256": "sha-missing",
+        "headline": "ghost",
+    }]
+    session = _session(tmp_path)
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    ledger = SimpleNamespace(
+        store=SimpleNamespace(
+            list_artifacts=lambda _jid: [
+                SimpleNamespace(
+                    id=r["id"], task_id=r["task_id"], sha256=r["sha256"], type=r["type"],
+                )
+                for r in expected_plus_missing
+            ]
+        ),
+        format_artifacts=lambda _raw: rows,
+    )
+    with patch("harness.send_loop_dispatch._session_durable", return_value=ledger):
+        session._swarm_results.put({
+            "job_id": job_id,
+            "objective": "partial",
+            "result": {
+                "applied": True,
+                "files": [],
+                "summary": "partial",
+                "analysis_ok": True,
+                "artifacts": rows,
+            },
+        })
+        events = list(session.drain_swarm_results())
+    swarm = next(e.data["result"] for e in events if e.kind == "swarm_result")
+    assert swarm["artifact_delivery"]["complete"] is False
+    assert swarm["artifact_delivery"]["missing"] == [
+        {"id": f"{job_id}-finding-missing", "task_id": "task-x"},
+    ]
+    hist = next(
+        m["content"] for m in session._history
+        if m.get("role") == "assistant" and job_id in (m.get("content") or "")
+    )
+    assert "Synthesis continued with incomplete PM evidence" in hist
+    assert f"missing {job_id}-finding-missing task=task-x" in hist
+
+
+def test_await_and_apply_ar_list_is_unbounded(tmp_path):
+    import subprocess
+
+    session = _session(tmp_path)
+    artifacts = [
+        {
+            "id": f"art-{i}",
+            "task_id": f"task-{i}",
+            "sha256": f"sha-{i}",
+            "type": "finding",
+            "payload": {"claim": f"claim {i}", "report": f"report {i}"},
+        }
+        for i in range(12)
+    ]
+    original_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and any(arg == "await" for arg in cmd):
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+        if isinstance(cmd, list) and any(arg == "artifacts" for arg in cmd):
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps(artifacts), stderr="",
+            )
+        return original_run(cmd, *args, **kwargs)
+
+    with patch("subprocess.run", side_effect=mock_run):
+        res = session._await_and_apply_job("job_pr1_pm")
+
+    assert len(res["ar_list"]) == 12
+    assert len(res["artifacts"]) == 12
+    got = {_identity("job_pr1_pm", r) for r in res["ar_list"]}
+    expected = {
+        ("job_pr1_pm", f"task-{i}", f"art-{i}", f"sha-{i}", "finding")
+        for i in range(12)
+    }
+    assert got == expected
+
+
+def test_finding_normalization_keeps_every_substantive_row():
+    findings = [
+        {"type": "finding", "headline": f"Finding {i} in harness/foo.py:{i}"}
+        for i in range(25)
+    ]
+    out = normalize_finding_artifacts("job_pr1_find", findings)
+    assert len(out) == 25
+    assert [row["id"] for row in out] == [
+        f"job_pr1_find-finding-{i}" for i in range(25)
+    ]
+
+
+def test_ephemeral_state_cleanup_does_not_drop_snapshot_refs(tmp_path):
+    """Single-job snapshot survives after the PM state_dir is removed."""
+    job_id = "job_pr1_snap"
+    rows = _canonical_rows(job_id, n=9)
+    session = _session(tmp_path)
+    session._swarm_results.put({
+        "job_id": job_id,
+        "objective": "late drain",
+        "result": {
+            "applied": True,
+            "files": ["a.py"],
+            "summary": "ok",
+            "artifacts": rows,
+        },
+    })
+    events = list(session.drain_swarm_results())
+    swarm = next(e.data["result"] for e in events if e.kind == "swarm_result")
+    assert {_identity(job_id, r) for r in swarm["artifacts"]} == {
+        _identity(job_id, r) for r in rows
+    }
+    assert swarm["artifact_delivery"]["complete"] is True

--- a/tests/test_worker_handles.py
+++ b/tests/test_worker_handles.py
@@ -266,7 +266,7 @@ def test_session_durable_ignores_ui_status_string():
     assert _session_durable(session) is ledger
 
 
-def test_drain_swarm_results_history_is_handle_first(monkeypatch, tmp_path):
+def test_drain_swarm_results_history_is_complete_delivery(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "harness.conversation.RuleStore",
         lambda *a, **k: __import__("harness.rule_store", fromlist=["RuleStore"]).RuleStore(
@@ -306,11 +306,14 @@ def test_drain_swarm_results_history_is_handle_first(monkeypatch, tmp_path):
         if m.get("role") == "assistant" and "swarm result for" in (m.get("content") or "")
     ]
     assert hist
-    assert "job_id=job_drain_hf" in hist[0]
+    assert "PM SWARM ARTIFACT MANIFEST:" in hist[0]
+    assert "job_drain_hf-finding-0" in hist[0]
+    assert "artifact://job_drain_hf/job_drain_hf-finding-0" in hist[0]
     assert "Drain headline one" in hist[0]
-    assert "artifact://" in hist[0]
+    assert "peek_artifact" not in hist[0]
     assert fat_summary not in hist[0]
-    # UI/display still gets the full summary for cards.
     display = [d for d in session._display_transcript if d.get("type") == "swarm_result"]
     assert display
     assert display[0].get("summary") == fat_summary
+    assert display[0]["artifact_delivery"]["complete"] is True
+    assert [row["id"] for row in display[0]["artifacts"]] == ["job_drain_hf-finding-0"]


### PR DESCRIPTION
## Summary
- Implements issue #101 PR 1 only: every single-job terminal path now treats the exact `(job_id, task_id, artifact_id, sha256, type)` set as the accounting authority, not first-N / handle-first previews.
- Background drain, external PM implement `ar_list`, local finding normalization, and reused single-job receipts persist the same compact `artifact_delivery` receipt already used by synchronous `run_swarm` (`SwarmResultCard`). Completeness stays independent of applied / held / failed / degraded.
- Single-job snapshots are taken before ephemeral PM `state_dir` cleanup so late drain and reload still reconcile. Raw bodies stay out of pilot context.

## Test plan
- [x] `pytest tests/test_terminal_evidence_pr1.py tests/test_worker_handles.py tests/test_conversation_jobs_mixin.py tests/test_swarm_background_evidence_boundary.py tests/test_validation_reuse.py tests/test_send_loop_dispatch.py tests/test_local_job_provenance.py tests/test_post_swarm_synthesis.py tests/test_swarm_run_facts.py tests/test_swarm_surfaced_honesty.py tests/test_local_jobs_mixin.py tests/test_transcript_cards.py` (274 passed)
- [x] `git diff --check`

Closes none. Implements the first cut of #101. PR 2 (parallel child composition) and PR 3 (reuse rewrite / retire handle-first formatter) remain.