### PR TITLE
Compose parallel waves from independent child receipts

### DIFF
--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -1448,6 +1448,15 @@ class ConversationJobsMixin:
                         if isinstance(res_job, dict):
                             res_job["artifacts"] = delivered
                             res_job["artifact_delivery"] = delivery
+                        try:
+                            with self._local_jobs_lock:
+                                local = (getattr(self, "_local_jobs", {}) or {}).get(job_id)
+                                if isinstance(local, dict):
+                                    local["artifact_delivery"] = delivery
+                                    if delivered and not local.get("artifacts"):
+                                        local["artifacts"] = list(delivered)
+                        except Exception:
+                            pass
                         manifest = _render_swarm_delivery_manifest(
                             job_id, delivered, delivery,
                         )
@@ -1522,6 +1531,11 @@ class ConversationJobsMixin:
                             if isinstance(res_job, dict) and res_job.get(_rk) in (None, "", [], {}):
                                 res_job[_rk] = value
                     self._display_transcript.append(display_result)
+                    if delivery is not None:
+                        try:
+                            self._note_parallel_child_receipt(job_id)
+                        except Exception:
+                            pass
                     # Nested actions are progressive via /api/swarm/live; mirror
                     # onto display cards only here under _busy for reload durability.
                     try:

--- a/harness/local_jobs.py
+++ b/harness/local_jobs.py
@@ -393,6 +393,240 @@ class LocalJobsMixin:
                 }]
             self._persist_local_jobs_locked()
 
+    def _register_parallel_wave(
+        self,
+        wave_id: str,
+        *,
+        child_job_ids: list,
+        objective: str = "",
+        action_id: str = "",
+    ) -> dict:
+        """Persist parent membership for a run_parallel wave.
+
+        The parent owns accepted-child membership and aggregate lifecycle
+        only. Each child keeps its own outcome, artifacts, and PR 1 delivery
+        receipt. No parent artifact aggregate is recorded.
+        """
+        import time
+        from harness.job_scoping import ACCOUNTING_SCOPE_MARIONETTE, job_label_for_session
+
+        ids = [str(x) for x in (child_job_ids or []) if str(x)]
+        now = time.time()
+        session_id = self.harness_session_id or ""
+        with self._local_jobs_lock:
+            existing = self._local_jobs.get(wave_id)
+            if isinstance(existing, dict) and existing.get("job_kind") == "parallel_wave":
+                existing["child_job_ids"] = ids
+                existing["child_count"] = len(ids)
+                existing["goal"] = objective or existing.get("goal") or ""
+                if action_id:
+                    existing["action_id"] = str(action_id)
+                existing["updated_at"] = now
+                for cid in ids:
+                    child = self._local_jobs.get(cid)
+                    if isinstance(child, dict):
+                        child["parent_wave_id"] = wave_id
+                self._sync_parallel_wave_locked(existing)
+                self._upsert_display_parallel_wave_locked(existing)
+                self._persist_local_jobs_locked()
+                return copy.deepcopy(existing)
+            row = {
+                "id": wave_id,
+                "goal": objective or f"Parallel wave ({len(ids)} jobs)",
+                "status": "running",
+                "role": "parallel_wave",
+                "adapter": "parallel_wave",
+                "model": "",
+                "job_kind": "parallel_wave",
+                "session_id": session_id,
+                "action_id": str(action_id or ""),
+                "cwd": self.config.repo or "",
+                "label": job_label_for_session(session_id),
+                "created_at": now,
+                "started_at": now,
+                "updated_at": now,
+                "task_count": len(ids),
+                "tokens": 0,
+                "est_cost_usd": 0.0,
+                "artifacts": [],
+                "tasks": [{
+                    "id": f"{wave_id}-w0",
+                    "role": "parallel_wave",
+                    "instruction": objective or f"Parallel wave ({len(ids)} jobs)",
+                    "status": "running",
+                    "adapter": "parallel_wave",
+                }],
+                "actions": [],
+                "source": "harness",
+                "accounting_owned": True,
+                "accounting_scope": ACCOUNTING_SCOPE_MARIONETTE,
+                "terminal_receipt": None,
+                "child_job_ids": ids,
+                "terminal_job_ids": [],
+                "child_count": len(ids),
+                "mixed_terminal": False,
+            }
+            self._local_jobs[wave_id] = row
+            for cid in ids:
+                child = self._local_jobs.get(cid)
+                if isinstance(child, dict):
+                    child["parent_wave_id"] = wave_id
+            self._upsert_display_parallel_wave_locked(row)
+            self._persist_local_jobs_locked()
+            return copy.deepcopy(row)
+
+    def _parallel_wave_id_for_child(self, child_id: str) -> str:
+        cid = str(child_id or "").strip()
+        if not cid:
+            return ""
+        with self._local_jobs_lock:
+            child = self._local_jobs.get(cid) or {}
+            wid = str(child.get("parent_wave_id") or "").strip()
+            if wid:
+                return wid
+            for job in self._local_jobs.values():
+                if not isinstance(job, dict):
+                    continue
+                if job.get("job_kind") != "parallel_wave":
+                    continue
+                if cid in [str(x) for x in (job.get("child_job_ids") or [])]:
+                    return str(job.get("id") or "")
+        return ""
+
+    def _note_parallel_child_receipt(self, child_id: str) -> None:
+        """Record that an accepted child produced a durable receipt."""
+        wave_id = self._parallel_wave_id_for_child(child_id)
+        if not wave_id:
+            return
+        cid = str(child_id or "").strip()
+        with self._local_jobs_lock:
+            parent = self._local_jobs.get(wave_id)
+            if not isinstance(parent, dict) or parent.get("job_kind") != "parallel_wave":
+                return
+            terminals = [str(x) for x in (parent.get("terminal_job_ids") or []) if str(x)]
+            if cid and cid not in terminals:
+                terminals.append(cid)
+            parent["terminal_job_ids"] = terminals
+            self._sync_parallel_wave_locked(parent)
+            self._upsert_display_parallel_wave_locked(parent)
+            self._persist_local_jobs_locked()
+
+    def _sync_parallel_wave_from_children(self, wave_id: str) -> None:
+        wid = str(wave_id or "").strip()
+        if not wid:
+            return
+        with self._local_jobs_lock:
+            parent = self._local_jobs.get(wid)
+            if not isinstance(parent, dict) or parent.get("job_kind") != "parallel_wave":
+                return
+            self._sync_parallel_wave_locked(parent)
+            self._upsert_display_parallel_wave_locked(parent)
+            self._persist_local_jobs_locked()
+
+    def _sync_parallel_wave_locked(self, parent: dict) -> None:
+        """Refresh aggregate lifecycle from accepted children. No artifact merge."""
+        import time
+
+        child_ids = [str(x) for x in (parent.get("child_job_ids") or []) if str(x)]
+        terminals = [str(x) for x in (parent.get("terminal_job_ids") or []) if str(x)]
+        statuses: list[str] = []
+        for cid in child_ids:
+            child = self._local_jobs.get(cid) or {}
+            st = str(child.get("status") or "")
+            if st in _TERMINAL_LOCAL_JOB_STATUSES and cid not in terminals:
+                terminals.append(cid)
+            if child.get("artifact_delivery") is not None and cid not in terminals:
+                terminals.append(cid)
+            if cid in terminals:
+                if st in _TERMINAL_LOCAL_JOB_STATUSES:
+                    statuses.append(st)
+                elif child.get("error") or (
+                    isinstance(child.get("artifact_delivery"), dict)
+                    and child.get("status") == "failed"
+                ):
+                    statuses.append("failed")
+                else:
+                    # Drain-stamped receipt without a local terminal status:
+                    # treat as completed unless the child row already failed.
+                    statuses.append("completed")
+            else:
+                statuses.append(st or "running")
+        parent["terminal_job_ids"] = terminals
+        parent["updated_at"] = time.time()
+        parent["child_count"] = len(child_ids)
+        parent["task_count"] = len(child_ids)
+        # Parent never owns child evidence.
+        parent["artifacts"] = []
+
+        all_settled = bool(child_ids) and all(cid in terminals for cid in child_ids)
+        if not all_settled:
+            parent["status"] = "running"
+            parent["terminal_receipt"] = None
+            parent["mixed_terminal"] = False
+            if parent.get("tasks"):
+                try:
+                    parent["tasks"][0]["status"] = "running"
+                except Exception:
+                    pass
+            return
+
+        mixed = len(set(statuses)) > 1
+        if any(s in ("failed", "timeout", "truncated") for s in statuses):
+            aggregate = "failed"
+        elif any(s == "cancelled" for s in statuses):
+            aggregate = "cancelled"
+        else:
+            aggregate = "completed"
+        parent["status"] = aggregate
+        parent["mixed_terminal"] = mixed
+        if parent.get("tasks"):
+            try:
+                parent["tasks"][0]["status"] = aggregate
+            except Exception:
+                pass
+        counts: dict[str, int] = {}
+        for s in statuses:
+            counts[s] = counts.get(s, 0) + 1
+        parent["terminal_receipt"] = {
+            "status": aggregate,
+            "summary": (
+                "wave " + aggregate + ": "
+                + ", ".join(f"{n} {name}" for name, n in sorted(counts.items()))
+            ),
+            "finished_at": parent["updated_at"],
+            "child_statuses": dict(counts),
+            "mixed_terminal": mixed,
+            "child_job_ids": list(child_ids),
+            "terminal_job_ids": list(terminals),
+        }
+
+    def _upsert_display_parallel_wave_locked(self, parent: dict) -> None:
+        display = getattr(self, "_display_transcript", None)
+        if not isinstance(display, list):
+            return
+        child_ids = [str(x) for x in (parent.get("child_job_ids") or []) if str(x)]
+        terminals = [str(x) for x in (parent.get("terminal_job_ids") or []) if str(x)]
+        wave_id = str(parent.get("id") or "")
+        settled = bool(child_ids) and all(cid in terminals for cid in child_ids)
+        row = {
+            "type": "swarm_pending",
+            "wave_id": wave_id,
+            "job_ids": list(child_ids),
+            "objective": str(parent.get("goal") or ""),
+            "terminal_job_ids": list(terminals),
+            "status": "done" if settled else "running",
+        }
+        for i, existing in enumerate(display):
+            if not isinstance(existing, dict) or existing.get("type") != "swarm_pending":
+                continue
+            same_wave = wave_id and existing.get("wave_id") == wave_id
+            same_members = set(str(x) for x in (existing.get("job_ids") or [])) == set(child_ids)
+            if same_wave or same_members:
+                existing.update(row)
+                display[i] = existing
+                return
+        display.append(row)
+
     def _checkpoint_command_job_launch(self, job_id: str) -> bool:
         """Persist a launch checkpoint *before* the child process can start.
 
@@ -1102,6 +1336,10 @@ class LocalJobsMixin:
             export_local_job_terminal(**export_job)
         except Exception:
             pass
+        try:
+            self._note_parallel_child_receipt(job_id)
+        except Exception:
+            pass
 
     def _fail_or_drop_local_job(self, job_id: str, summary: str = "") -> None:
         """Best-effort settle a registered job after finish failure.
@@ -1258,6 +1496,11 @@ class LocalJobsMixin:
                     job.get("job_kind") == "run_command_batch"
                     or job.get("role") == "command_batch"
                 )
+                is_parallel_wave = job.get("job_kind") == "parallel_wave"
+                if is_parallel_wave:
+                    # Parent has no private execution; children own interrupt.
+                    self._local_jobs[jid] = job
+                    continue
                 # Durable terminal receipt is authoritative — never reopen.
                 prior_receipt = job.get("terminal_receipt")
                 receipt_status = (
@@ -1346,6 +1589,10 @@ class LocalJobsMixin:
                     reason="interrupted by restart",
                 )
                 self._local_jobs[jid] = job
+            for job in list(self._local_jobs.values()):
+                if isinstance(job, dict) and job.get("job_kind") == "parallel_wave":
+                    self._sync_parallel_wave_locked(job)
+                    self._upsert_display_parallel_wave_locked(job)
             # Rewrite so the healed statuses are the new on-disk baseline.
             self._persist_local_jobs_locked()
 

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -89,6 +89,45 @@ def _artifact_ref(row: Any) -> dict[str, str]:
     }
 
 
+def _artifact_job_id(row: Any) -> str:
+    # Top-level job_id is store ownership. execution_ref is provenance of a
+    # surfaced row and must not hide foreign-attributed evidence on this job.
+    if isinstance(row, dict):
+        return str(row.get("job_id") or "").strip()
+    return str(getattr(row, "job_id", "") or "").strip()
+
+
+def _rows_for_job(rows, job_id: str) -> list:
+    """Drop rows that claim a different job — identical artifact ids may collide."""
+    current = str(job_id or "").strip()
+    out = []
+    for row in rows or []:
+        claimed = _artifact_job_id(row)
+        if claimed and current and claimed != current:
+            continue
+        out.append(row)
+    return out
+
+
+def _bind_parallel_wave(session, aid, job_ids, objective: str) -> None:
+    """Record accepted-child membership on the existing local-job owner."""
+    register = getattr(session, "_register_parallel_wave", None)
+    if not callable(register):
+        return
+    ids = [str(x) for x in (job_ids or []) if str(x)]
+    if not ids:
+        return
+    try:
+        register(
+            f"local-wave-{aid}",
+            child_job_ids=ids,
+            objective=objective,
+            action_id=str(aid or ""),
+        )
+    except Exception:
+        pass
+
+
 def _session_durable(session):
     """Resolve the DurableState-like ledger used for PM artifact listing.
 
@@ -124,23 +163,26 @@ def _swarm_artifact_delivery(
     snapshot is the accounting authority after ephemeral PM state is gone.
     """
 
-    expected_refs = [_artifact_ref(row) for row in result_rows]
+    scoped_result = _rows_for_job(result_rows, job_id)
+    expected_refs = [_artifact_ref(row) for row in scoped_result]
     canonical_rows: list[dict] = []
     store_ok = False
     try:
         durable = _session_durable(session)
-        raw_rows = list(durable.store.list_artifacts(job_id))
+        raw_rows = _rows_for_job(list(durable.store.list_artifacts(job_id)), job_id)
         store_ok = True
         if raw_rows:
             expected_refs = [_artifact_ref(row) for row in raw_rows]
-            canonical_rows = list(durable.format_artifacts(raw_rows))
+            canonical_rows = _rows_for_job(
+                list(durable.format_artifacts(raw_rows)), job_id,
+            )
     except Exception:
         canonical_rows = []
         store_ok = False
 
     by_id: dict[str, dict] = {}
     anonymous_rows: list[dict] = []
-    for row in [*result_rows, *canonical_rows]:
+    for row in [*scoped_result, *canonical_rows]:
         artifact_id = str(row.get("id") or "").strip()
         if not artifact_id:
             if row not in anonymous_rows:
@@ -1558,6 +1600,10 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                 if sub_aid not in emitted_results:
                     yield _result({'id': sub_aid, 'error': 'No jobs successfully dispatched'})
             if job_ids_collected:
+                _bind_parallel_wave(
+                    session, aid, job_ids_collected,
+                    f"Parallel wave of goals: {', '.join(goals)}",
+                )
                 yield ConvEvent('swarm_pending', {'job_ids': job_ids_collected, 'objective': f"Parallel wave of goals: {', '.join(goals)}"})
                 yield _result({'id': aid, 'job_id': ','.join(job_ids_collected), 'status': 'pending', 'message': f"Dispatched parallel background swarm jobs: {', '.join(job_ids_collected)}"})
                 session._append_action_result(act, aid, f"(run_parallel dispatched {len(job_ids_collected)} jobs in background: {', '.join(job_ids_collected)})", is_native)
@@ -1999,6 +2045,10 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                 yield ConvEvent('action_result', {'id': aid, 'status': 'skipped', 'message': skip_msg})
                 session._append_action_result(act, aid, f'(run_parallel {aid} skipped -- all {len(goals)} objectives already in flight)', is_native)
                 return None
+            _bind_parallel_wave(
+                session, aid, job_ids_collected,
+                f"Parallel wave of goals: {', '.join(goals)}",
+            )
             yield ConvEvent('swarm_pending', {'job_ids': job_ids_collected, 'objective': f"Parallel wave of goals: {', '.join(goals)}"})
             for _reuse_ev in buffered_reuse_events:
                 yield _reuse_ev

--- a/tests/test_terminal_evidence_pr2.py
+++ b/tests/test_terminal_evidence_pr2.py
@@ -1,0 +1,217 @@
+"""PR 2: compose parallel waves from independent child receipts.
+
+Public-boundary RED: each accepted child owns its exact
+(job_id, task_id, artifact_id, sha256, type) receipt. The parent owns
+membership and aggregate lifecycle only — never a merged artifact set.
+"""
+from __future__ import annotations
+
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from harness.config import HarnessConfig
+from harness.conversation import ConversationalSession
+
+
+def _identity(job_id, row):
+    return (
+        str(job_id),
+        str(row.get("task_id") or ""),
+        str(row.get("id") or ""),
+        str(row.get("sha256") or ""),
+        str(row.get("type") or ""),
+    )
+
+
+def _session(tmp_path):
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
+    cfg.repo = str(tmp_path)
+    return ConversationalSession(cfg)
+
+
+def _child_rows(job_id, *, sha_prefix, n=4, artifact_id="shared-finding"):
+    """Identical artifact ids across jobs; identity is namespaced by job_id."""
+    return [
+        {
+            "type": "finding",
+            "id": artifact_id if n == 1 else f"{artifact_id}-{i}",
+            "task_id": f"task-{i}",
+            "sha256": f"{sha_prefix}-{i}",
+            "headline": f"{job_id} finding {i}",
+            "job_id": job_id,
+        }
+        for i in range(n)
+    ]
+
+
+def _enqueue(session, job_id, rows, *, applied=True, error=None, degraded=False):
+    session._local_jobs.setdefault(job_id, {"id": job_id, "artifacts": rows})
+    session._local_jobs[job_id]["artifacts"] = rows
+    session._swarm_results.put({
+        "job_id": job_id,
+        "objective": f"goal for {job_id}",
+        "result": {
+            "applied": applied,
+            "files": [],
+            "summary": f"summary {job_id}",
+            "error": error,
+            "degraded": degraded,
+            "analysis_ok": bool(applied) and not error,
+            "artifacts": rows,
+        },
+    })
+
+
+def _results_by_job(events):
+    return {
+        e.data["job_id"]: e.data["result"]
+        for e in events if e.kind == "swarm_result"
+    }
+
+
+def test_parallel_children_keep_exact_independent_receipts(tmp_path):
+    session = _session(tmp_path)
+    ok_id = "job_pr2_ok"
+    bad_id = "job_pr2_fail"
+    ok_rows = _child_rows(ok_id, sha_prefix="sha-ok", n=5)
+    bad_rows = _child_rows(bad_id, sha_prefix="sha-bad", n=5)
+    # Same artifact ids, different job ids — must not leak.
+    assert [r["id"] for r in ok_rows] == [r["id"] for r in bad_rows]
+
+    wave = session._register_parallel_wave(
+        "local-wave-pr2",
+        child_job_ids=[ok_id, bad_id],
+        objective="Parallel wave of goals: ok, fail",
+        action_id="a-pr2",
+    )
+    assert wave["child_job_ids"] == [ok_id, bad_id]
+    assert wave["status"] == "running"
+    assert wave.get("terminal_receipt") is None
+    assert list(wave.get("artifacts") or []) == []
+
+    _enqueue(session, ok_id, ok_rows)
+    first = _results_by_job(list(session.drain_swarm_results()))
+    assert set(first) == {ok_id}
+    assert {_identity(ok_id, r) for r in first[ok_id]["artifacts"]} == {
+        _identity(ok_id, r) for r in ok_rows
+    }
+    assert first[ok_id]["artifact_delivery"]["complete"] is True
+    assert first[ok_id]["artifact_delivery"]["pm_artifacts"] == 5
+
+    parent = session._local_jobs["local-wave-pr2"]
+    assert parent["status"] == "running"
+    assert parent.get("terminal_receipt") is None
+    assert ok_id in parent["terminal_job_ids"]
+    assert bad_id not in parent["terminal_job_ids"]
+    assert list(parent.get("artifacts") or []) == []
+
+    pending = next(
+        row for row in session.export_display_transcript()
+        if row.get("type") == "swarm_pending"
+    )
+    assert set(pending["job_ids"]) == {ok_id, bad_id}
+    assert set(pending["terminal_job_ids"]) == {ok_id}
+    assert pending.get("status") != "done"
+
+    # Reload membership without losing the open parent or the settled child.
+    payload = session.export_transcript_data()
+    reloaded = _session(tmp_path)
+    reloaded._local_jobs = {
+        jid: dict(row) for jid, row in session._local_jobs.items()
+    }
+    reloaded.load_history(payload)
+    parent = reloaded._local_jobs["local-wave-pr2"]
+    assert parent["status"] == "running"
+    assert set(parent["child_job_ids"]) == {ok_id, bad_id}
+    display_ok = next(
+        row for row in reloaded._display_transcript
+        if row.get("type") == "swarm_result" and row.get("job_id") == ok_id
+    )
+    assert {_identity(ok_id, r) for r in display_ok["artifacts"]} == {
+        _identity(ok_id, r) for r in ok_rows
+    }
+
+    _enqueue(reloaded, bad_id, bad_rows, applied=False, error="worker died", degraded=True)
+    second = _results_by_job(list(reloaded.drain_swarm_results()))
+    assert set(second) == {bad_id}
+    assert {_identity(bad_id, r) for r in second[bad_id]["artifacts"]} == {
+        _identity(bad_id, r) for r in bad_rows
+    }
+    assert second[bad_id]["artifact_delivery"]["complete"] is True
+    # Failed sibling kept its own truth; success receipt is untouched.
+    display_ok = next(
+        row for row in reloaded._display_transcript
+        if row.get("type") == "swarm_result" and row.get("job_id") == ok_id
+    )
+    assert {_identity(ok_id, r) for r in display_ok["artifacts"]} == {
+        _identity(ok_id, r) for r in ok_rows
+    }
+    assert "sha-bad" not in {r.get("sha256") for r in display_ok["artifacts"]}
+
+    parent = reloaded._local_jobs["local-wave-pr2"]
+    assert set(parent["terminal_job_ids"]) == {ok_id, bad_id}
+    assert parent["status"] in {"failed", "completed"}
+    receipt = parent["terminal_receipt"]
+    assert receipt is not None
+    assert set(receipt["child_job_ids"]) == {ok_id, bad_id}
+    assert "artifacts" not in receipt
+    assert list(parent.get("artifacts") or []) == []
+
+    pending = next(
+        row for row in reloaded.export_display_transcript()
+        if row.get("type") == "swarm_pending"
+    )
+    assert set(pending["terminal_job_ids"]) == {ok_id, bad_id}
+    assert pending.get("status") == "done"
+
+
+def test_identical_artifact_ids_do_not_leak_through_shared_store(tmp_path):
+    session = _session(tmp_path)
+    a_id = "job_pr2_a"
+    b_id = "job_pr2_b"
+    # One artifact id, two jobs, two hashes.
+    a_rows = _child_rows(a_id, sha_prefix="sha-a", n=1, artifact_id="shared-id")
+    b_rows = _child_rows(b_id, sha_prefix="sha-b", n=1, artifact_id="shared-id")
+    session._register_parallel_wave(
+        "local-wave-leak",
+        child_job_ids=[a_id, b_id],
+        objective="leak probe",
+        action_id="a-leak",
+    )
+
+    mixed = [
+        SimpleNamespace(
+            id=r["id"], task_id=r["task_id"], sha256=r["sha256"],
+            type=r["type"], job_id=r["job_id"],
+        )
+        for r in a_rows + b_rows
+    ]
+    ledger = SimpleNamespace(
+        store=SimpleNamespace(list_artifacts=lambda _jid: mixed),
+        format_artifacts=lambda raw: [
+            {
+                "id": getattr(x, "id", ""),
+                "task_id": getattr(x, "task_id", ""),
+                "sha256": getattr(x, "sha256", ""),
+                "type": getattr(x, "type", ""),
+                "job_id": getattr(x, "job_id", ""),
+            }
+            for x in raw
+        ],
+    )
+    with patch("harness.send_loop_dispatch._session_durable", return_value=ledger):
+        _enqueue(session, a_id, a_rows)
+        _enqueue(session, b_id, b_rows)
+        results = _results_by_job(list(session.drain_swarm_results()))
+
+    assert {_identity(a_id, r) for r in results[a_id]["artifacts"]} == {
+        _identity(a_id, r) for r in a_rows
+    }
+    assert {_identity(b_id, r) for r in results[b_id]["artifacts"]} == {
+        _identity(b_id, r) for r in b_rows
+    }
+    assert results[a_id]["artifact_delivery"]["pm_artifacts"] == 1
+    assert results[b_id]["artifact_delivery"]["pm_artifacts"] == 1
+    assert [r.get("sha256") for r in results[a_id]["artifacts"]] == ["sha-a-0"]
+    assert [r.get("sha256") for r in results[b_id]["artifacts"]] == ["sha-b-0"]


### PR DESCRIPTION
## Summary
- Implements issue #101 PR 2 only: each accepted parallel child owns its outcome, artifacts, and unchanged PR 1 `artifact_delivery` receipt. The parent wave owns membership (`child_job_ids`) and aggregate lifecycle, and settles only after every accepted child has a receipt.
- Exact `(job_id, task_id, artifact_id, sha256, type)` identity is preserved per child, including identical artifact IDs under different job IDs (no cross-job leakage through a shared store). Staggered drain + reload keeps independent success/failed sibling truth. No parent artifact aggregate.

## Test plan
- [x] `uv run pytest -q tests/test_terminal_evidence_pr2.py tests/test_terminal_evidence_pr1.py tests/test_run_parallel_provider.py tests/test_conversation_jobs_mixin.py tests/test_swarm_background_evidence_boundary.py tests/test_local_jobs_mixin.py tests/test_command_batches.py tests/test_worker_handles.py tests/test_send_loop_dispatch.py tests/test_validation_reuse.py tests/test_local_job_provenance.py tests/test_post_swarm_synthesis.py tests/test_swarm_run_facts.py tests/test_swarm_surfaced_honesty.py tests/test_transcript_cards.py` (280 passed)
- [x] `git diff --check`

Closes none. Stacks on #104 (PR 1). Implements the second cut of #101. PR 3 (reuse rewrite / retire handle-first formatter) remains.