### PR TITLE
Pin CI workflows to puppetmaster-ai==1.22.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.17
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.18
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.17"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.18"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.17"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.18"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -57,7 +57,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.17"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.18"
 
       - name: Run the offline test suite (shard)
         env:


### PR DESCRIPTION
## Summary
- Pin `.github/workflows/tests.yml`, `tests-full.yml`, and `release.yml` to `puppetmaster-ai==1.22.18` so they match `DEFAULT_PUPPETMASTER_SPEC`.
- Unreds `frontend-build` (`operational Puppetmaster pins match DEFAULT_PUPPETMASTER_SPEC`). No Marionette version bump.

## Test plan
- [x] YAML pins are 1.22.18 only (no leftover 1.22.17)
- [ ] `tests` on the dest PR / merged tip is green (especially frontend-build)