### PR TITLE
Merge CI pin 1.22.18 to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.17
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.18
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.17"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.18"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.17"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.18"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -57,7 +57,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.17"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.18"
 
       - name: Run the offline test suite (shard)
         env:


### PR DESCRIPTION
## Summary
- Fast-forward / merge `dev` onto `main` so workflow pins (`puppetmaster-ai==1.22.18`) match `DEFAULT_PUPPETMASTER_SPEC`.
- No version bump.

## Test plan
- [ ] `tests` on main is green after equate