### PR TITLE
Release v0.9.274

### DIFF
--- a/docs/CHAT_QUALITY_DIAGNOSIS.md
+++ b/docs/CHAT_QUALITY_DIAGNOSIS.md
@@ -1,0 +1,50 @@
+# Chat-quality diagnosis (Ox Alpha / Muse Spark 1.2 inconsistency)
+
+Diagnostic pass, read-only, over the model-routing + provider + pilot-loop layer.
+Reference transcript to reproduce: `fe7ecaf24bbd`.
+
+Run by a concurrent two-role Puppetmaster swarm (codex / gpt-5.4-mini), 2026-08-23.
+Verdict: **inconsistency is harness/backend-caused, not model-caused.** The
+evidence points upstream to model routing and prompt construction; the SSE
+streaming layer preserves order and cursor semantics and is NOT the primary bug.
+
+## Top root causes (ranked by expected impact on chat-surface quality)
+
+### 1. Bare-model pilot resolution can silently reroute the same visible spec
+`harness/model_visibility.py` + `harness/auto_registry.py` + `harness/providers.py`
+resolve a bare model string to a concrete backend by key availability and
+provider order. If discovery is transiently stale or a key is missing, the *same*
+model string can land on a different provider (or fall back to OpenRouter) across
+sessions. Ox Alpha / Muse Spark lose capability metadata or hit the wrong endpoint.
+Mitigation: treat `~/.puppetmaster/models.json` and the auto-registry as advisory
+unless discovery is stable; validate that the selected provider actually serves the
+claimed model id + capabilities before promoting it into the pilot registry.
+
+### 2. OpenCode Go mutates the outbound request shape per model family
+`harness/opencode_go.py` + `harness/opencode_common.py`. Namespace stripping,
+protocol selection, `max_tokens` clamping, temperature overrides, and
+reasoning-body injection vary by model family. This is a harness-side source of
+model-dependent quality shifts *before* the request reaches the vendor — so the
+same model can behave differently depending on which branch of the adapter runs.
+
+### 3. The turn loop rebuilds the system prompt per iteration
+`harness/conversation.py` / `harness/pilot.py`. The system prompt is rebuilt on
+every non-append-only step, dynamic context blocks are appended, then the base
+prompt is restored after dispatch. That defeats prefix stability and adds
+prompt-cache churn / turn-to-turn jitter even when the user asks the same thing.
+Hermes treats prompt-cache stability as sacred; this is the same failure mode.
+
+### 4. (Adjacent) OpenCode Zen routes "Ox Alpha Free" through the wrong API mode
+`harness/opencode_zen.py` — the free variant can be sent in a degraded request
+mode, which lowers output quality independent of the model itself.
+
+## Not the bug
+- SSE / stream replay: preserves event order + cursor semantics; marked misses
+  as `cursor_gap` / `generation_mismatch` rather than silently replaying a hole.
+- Mid-turn reattach: on a gap it hydrates from the durable transcript sidecar.
+
+## Transcript location
+Session transcripts are JSON sidecars at `<state_dir>/transcripts/<sid>.json`,
+where `<state_dir>` is the server's session-state base (`_cfg.state_dir`, or the
+process temp dir when unset). For `fe7ecaf24bbd`:
+`<state_dir>/transcripts/fe7ecaf24bbd.json`.

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.273"
+__version__ = "0.9.274"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -2405,6 +2405,14 @@ class ConversationalSession(
             return message
 
     def _ensure_frozen_system_prompt(self, base_sys: str) -> str:
+        """Byte-stable system prompt for the life of the conversation.
+
+        The immutable base (identity + MCP catalog) is composed ONCE and then
+        reused verbatim every step and every turn; history[0] is re-synced to
+        it so no path (send's finally, compaction, resume) can swap in a
+        different prefix mid-conversation. Turn-varying context rides in the
+        user trailer / appended messages, never by mutating the base.
+        """
         if self._frozen_system_prompt is not None:
             # Re-sync history after send()'s finally may have briefly restored
             # the pre-freeze base between turns.

--- a/harness/opencode_common.py
+++ b/harness/opencode_common.py
@@ -142,10 +142,16 @@ def build_opencode_driver(
     api_key_env: str,
     max_tokens: int,
     base_url: str,
-    temperature: float = 0.0,
+    temperature: Optional[float] = None,
     extra_body: Optional[dict] = None,
 ):
-    """Driver for one OpenCode model after the profile has chosen *api_mode*."""
+    """Driver for one OpenCode model after the profile has chosen *api_mode*.
+
+    ``temperature`` and ``extra_body`` are OPT-IN: only a model that genuinely
+    requires them on this relay gets them stamped into the driver. A profile
+    that omits them ships the user-selected defaults untouched, so the outbound
+    request shape does not silently vary as a side effect of family dispatch.
+    """
     bare = normalize_model_id(model)
     if api_mode == ANTHROPIC_MESSAGES:
         from pmharness.drivers.anthropic import AnthropicDriver
@@ -164,10 +170,13 @@ def build_opencode_driver(
         )
     from pmharness.drivers.openai_compat import OpenAICompatDriver
 
-    return OpenAICompatDriver(
-        name=spec, model=bare, base_url=base_url,
-        api_key_env=api_key_env, max_tokens=max_tokens,
-        temperature=temperature,
-        extra_body=extra_body or None,
-        extra_headers={"User-Agent": USER_AGENT},
-    )
+    driver_kwargs = {
+        "name": spec, "model": bare, "base_url": base_url,
+        "api_key_env": api_key_env, "max_tokens": max_tokens,
+        "extra_headers": {"User-Agent": USER_AGENT},
+    }
+    if temperature is not None:
+        driver_kwargs["temperature"] = temperature
+    if extra_body:
+        driver_kwargs["extra_body"] = extra_body
+    return OpenAICompatDriver(**driver_kwargs)

--- a/harness/opencode_go.py
+++ b/harness/opencode_go.py
@@ -120,16 +120,19 @@ def max_tokens_for_model(model: Optional[str], requested: Optional[int]) -> int:
     return min(int(requested), cap)
 
 
-def temperature_for_model(model: Optional[str], requested: float = 0.0) -> float:
-    """Temperature accepted by the Go relay for *model*.
+def temperature_for_model(model: Optional[str], requested: float = 0.0):
+    """Temperature override the Go relay requires for *model*, else None.
 
     Kimi's Go endpoints currently accept only ``1``; sending Marionette's
-    normal deterministic ``0`` is rejected as ``invalid temperature``.
+    normal deterministic ``0`` is rejected as ``invalid temperature``. Every
+    other family ships the caller's requested value untouched -- returning
+    None means "no override", so the request shape does not vary as a side
+    effect of family dispatch.
     """
     bare = normalize_model_id(model).lower()
     if bare.startswith("kimi-"):
         return 1.0
-    return float(requested)
+    return None
 
 
 def _is_glm_5_3(bare: str) -> bool:
@@ -172,15 +175,24 @@ def reasoning_body_extras(model: Optional[str], effort: Optional[str] = None) ->
       :func:`max_tokens_for_model`.
 
     An unrecognized model returns ``{}`` so the relay default stands.
+
+    The default effort (``low``, from :mod:`harness.reasoning_effort`) is NOT
+    injected as a side effect of family dispatch: a user who never touched
+    the reasoning setting gets the relay's own default request shape. Only
+    GLM-5.3 keeps an explicit ``low`` mapping, because omitting ``thinking``
+    fails that request outright.
     """
     from .reasoning_effort import current_reasoning_effort, normalize_reasoning_effort
 
     bare = normalize_model_id(model).lower()
     if not bare:
         return {}
+    requested_explicit = effort is not None
     level = normalize_reasoning_effort(
-        effort if effort is not None else current_reasoning_effort()
+        effort if requested_explicit else current_reasoning_effort()
     )
+    if not requested_explicit and level == "low" and not _is_glm_5_3(bare):
+        return {}
 
     if _is_glm_5_3(bare):
         if level in ("none", "low"):

--- a/harness/opencode_zen.py
+++ b/harness/opencode_zen.py
@@ -65,26 +65,47 @@ DISPLAY_NAMES = {
 MODELS_DEV_PROVIDER = "opencode"
 
 # Current Zen endpoint table (https://opencode.ai/docs/zen/). Conservative
-# default is chat/completions for unknown ids (including Ox Alpha).
+# default is chat/completions for unknown ids. The free variants are
+# chat-completions ONLY: the relay serves them on /chat/completions, and the
+# Responses dialect silently degrades their output (Ox Alpha Free /
+# muse-spark-*-free). Free ids win over the paid-family prefix table.
 _ANTHROPIC_MESSAGES_PREFIXES = ("claude-", "qwen")
 _OPENAI_RESPONSES_PREFIXES = ("gpt-", "grok-", "muse-spark-")
+_CHAT_COMPLETIONS_SUFFIXES = ("-free",)
+
+
+def is_free_variant(model: Optional[str]) -> bool:
+    """True for a Zen free-tier variant id (``...-free``, ``x-preview-f-free``)."""
+    bare = normalize_model_id(model).lower()
+    if not bare:
+        return False
+    return bare.endswith(_CHAT_COMPLETIONS_SUFFIXES) or bare in {
+        "x-preview-f-free", "big-pickle",
+    }
+
+
+def api_mode_for_model(model: Optional[str]) -> str:
+    """Which wire protocol the Zen endpoint table assigns to *model*.
+
+    Free variants are hard-routed to Chat Completions regardless of any paid
+    family prefix they share, so the free tier can never be dispatched through
+    the degraded Responses mode.
+    """
+    bare = normalize_model_id(model).lower()
+    if not bare:
+        return CHAT_COMPLETIONS
+    if bare.startswith(_ANTHROPIC_MESSAGES_PREFIXES) and not is_free_variant(bare):
+        return ANTHROPIC_MESSAGES
+    if is_free_variant(bare):
+        return CHAT_COMPLETIONS
+    if bare.startswith(_OPENAI_RESPONSES_PREFIXES):
+        return OPENAI_RESPONSES
+    return CHAT_COMPLETIONS
 
 
 def driver_base_url(base_url: Optional[str] = None) -> str:
     """The ``/v1`` root every Marionette driver expects for Zen."""
     return _shared_driver_base_url(base_url, default=BASE_URL)
-
-
-def api_mode_for_model(model: Optional[str]) -> str:
-    """Which wire protocol the Zen endpoint table assigns to *model*."""
-    bare = normalize_model_id(model).lower()
-    if not bare:
-        return CHAT_COMPLETIONS
-    if bare.startswith(_ANTHROPIC_MESSAGES_PREFIXES):
-        return ANTHROPIC_MESSAGES
-    if bare.startswith(_OPENAI_RESPONSES_PREFIXES):
-        return OPENAI_RESPONSES
-    return CHAT_COMPLETIONS
 
 
 def display_name_for(model: Optional[str], metadata: Optional[dict] = None) -> str:

--- a/harness/providers.py
+++ b/harness/providers.py
@@ -438,6 +438,27 @@ def _finalize_driver(driver):
     return maybe_wrap_cassette(driver)
 
 
+def resolve_bare_model(model: str) -> tuple:
+    """Deterministic provider for a BARE model id (no 'provider:' prefix).
+
+    Resolution is CANONICAL, not key-order-dependent: the first candidate in
+    PROVIDERS declaration order that serves the model wins, with one stable
+    preference (openai-codex over openai for a shared id). Transient key
+    presence never reroutes an id to a different backend across sessions --
+    when the canonical provider is not currently keyed we FAIL LOUDLY with the
+    provider to enable instead of silently falling back (e.g. to OpenRouter).
+    Returns (provider, model) and raises ProviderError when nothing serves it.
+    """
+    candidates = [p for p in PROVIDERS if model in p.pilot_models]
+    if not candidates:
+        return (None, model)
+    for preferred in ("openai-codex",):
+        for p in candidates:
+            if p.name == preferred:
+                return (p, model)
+    return (candidates[0], model)
+
+
 def build_pilot(spec: str, *, max_tokens: int | None = None):
     """Build a thin driver for a pilot spec.
 
@@ -484,19 +505,20 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
         pname, model = spec.split(":", 1)
         provider = get_provider(pname)
     if provider is None:
-        # Resolve a bare model name to a provider that lists it. Prefer
-        # openai-codex over openai when both advertise the same id so a
-        # ChatGPT plan OAuth burn isn't shadowed by OPENAI_API_KEY.
-        candidates = [p for p in available_providers() if model in p.pilot_models]
-        for preferred in ("openai-codex",):
-            for p in candidates:
-                if p.name == preferred:
-                    provider = p
-                    break
-            if provider is not None:
-                break
-        if provider is None and candidates:
-            provider = candidates[0]
+        # Resolve a bare model name against the CANONICAL provider table (see
+        # resolve_bare_model): stable winner independent of which keys happen
+        # to be present, so the same spec never silently lands on a different
+        # backend (or an OpenRouter fallback) between sessions.
+        canonical, model = resolve_bare_model(model)
+        if canonical is not None:
+            if not canonical.available:
+                raise ProviderError(
+                    f"pilot {spec!r} resolves to {canonical.display_name} "
+                    f"(canonical provider for model {model!r}), but no key is "
+                    f"configured. Set: {' or '.join(canonical.env_vars)}. "
+                    "Marionette does not silently reroute an explicit selection."
+                )
+            provider = canonical
     if provider is None:
         # last resort: OpenRouter (one key, whole field) if present.
         # Translate a catalog short-name (e.g. "qwen3-coder-30b") to its real

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.273"
+version = "0.9.274"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_opencode_go.py
+++ b/tests/test_opencode_go.py
@@ -142,7 +142,10 @@ def test_mimo_pro_output_ceiling_is_clamped_to_what_xiaomi_serves():
 def test_kimi_models_use_the_temperature_the_go_relay_accepts():
     assert go.temperature_for_model("kimi-k3") == 1.0
     assert go.temperature_for_model("opencode-go/kimi-k2.7-code") == 1.0
-    assert go.temperature_for_model("deepseek-v4-flash") == 0.0
+    # Non-Kimi families get NO override: the caller's temperature ships
+    # untouched instead of being silently rewritten to a family default.
+    assert go.temperature_for_model("deepseek-v4-flash") is None
+    assert go.temperature_for_model("glm-5.3") is None
 
 
 @pytest.mark.parametrize("effort,expected", [

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -236,3 +236,37 @@ def test_build_pilot_selects_bedrock_driver(monkeypatch):
     d = prov.build_pilot(f"bedrock:{model}")
     assert isinstance(d, BedrockDriver)
     assert d.model == model
+
+
+def test_resolve_bare_model_is_canonical_not_key_dependent():
+    """The canonical winner for a bare id is stable regardless of keys."""
+    p, model = prov.resolve_bare_model("gpt-5.5")
+    assert p.name == "openai-codex" and model == "gpt-5.5"
+    p2, _ = prov.resolve_bare_model("glm-5.3")
+    assert p2.name == "zai"
+    p3, _ = prov.resolve_bare_model("claude-opus-4-8")
+    assert p3.name == "anthropic"
+
+
+def test_build_pilot_bare_model_fails_loudly_when_canonical_unkeyed(monkeypatch):
+    """A bare spec whose canonical provider has no key must raise, not
+    silently reroute to whichever keyed provider (e.g. OpenRouter) is up."""
+    from harness import credential_pool as cp
+
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-xxx")
+    cp.clear_pools_for_tests()
+    try:
+        with pytest.raises(prov.ProviderError) as exc:
+            prov.build_pilot("glm-5.2")
+        assert "zai" in str(exc.value).lower() or "GLM" in str(exc.value)
+    finally:
+        cp.clear_pools_for_tests()
+
+
+def test_build_pilot_bare_model_uses_canonical_provider_when_keyed(monkeypatch):
+    """With the canonical key present, the bare spec lands on that vendor."""
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("GLM_API_KEY", "glm-test")
+    driver = prov.build_pilot("glm-5.2")
+    assert driver.base_url.startswith("https://api.z.ai")

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.273",
+  "version": "0.9.274",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.273",
+      "version": "0.9.274",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.273",
+  "version": "0.9.274",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/agentCommandIndex.test.ts
+++ b/webapp/src/__tests__/agentCommandIndex.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import {
   getAgentCommandIndexVersion,
+  listAgentCommandSessions,
   lookupAgentCommandSession,
   lookupAgentCommandSessionById,
   normalizeCommandKey,
@@ -18,12 +19,23 @@ describe("agentCommandIndex", () => {
   });
 
   it("looks up the latest session for a command", () => {
-    registerAgentCommandSession({ id: "old", command: "git pull", output: "a" });
-    registerAgentCommandSession({ id: "live", command: "$ git pull", output: "b" });
+    registerAgentCommandSession({ id: "old", command: "git pull", output: "a", state: "done" });
+    registerAgentCommandSession({ id: "live", command: "$ git pull", output: "b", state: "running" });
     const found = lookupAgentCommandSession("git pull");
     expect(found?.id).toBe("live");
     expect(found?.output).toBe("b");
+    expect(found?.state).toBe("running");
     expect(lookupAgentCommandSessionById("old")?.command).toBe("git pull");
+  });
+
+  it("keeps the latest terminal state and lists sessions newest-first", () => {
+    registerAgentCommandSession({ id: "card-1", command: "pytest -q", state: "running" });
+    registerAgentCommandSession({ id: "card-2", command: "npm test", state: "failed" });
+    registerAgentCommandSession({ id: "card-1", command: "pytest -q", output: "ok\n", state: "done" });
+    const sessions = listAgentCommandSessions();
+    expect(sessions.map((s) => s.id)).toEqual(["card-1", "card-2"]);
+    expect(lookupAgentCommandSessionById("card-1")?.state).toBe("done");
+    expect(lookupAgentCommandSessionById("card-2")?.state).toBe("failed");
   });
 
   it("does not bump version on streaming output for the same id", () => {

--- a/webapp/src/__tests__/composerStatusStack.test.ts
+++ b/webapp/src/__tests__/composerStatusStack.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildComposerStatusStackRows } from "../components/conversation/composerStatusStackData";
+
+describe("composerStatusStack", () => {
+  it("filters to owned jobs and hides stale terminal rows", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [
+        {
+          id: "job_abc123def456",
+          goal: "Audit composer stack",
+          source: "harness",
+          status: "running",
+          updated_at: now - 1000,
+        } as any,
+        {
+          id: "job_zzz999yyy888",
+          goal: "CLI noise",
+          source: "cli",
+          status: "running",
+          updated_at: now - 1000,
+        } as any,
+        {
+          id: "job_failed000001",
+          goal: "Old failed job",
+          source: "harness",
+          status: "failed",
+          updated_at: now - 13_000,
+        } as any,
+      ],
+      commandSessions: [
+        {
+          id: "cmd-1",
+          command: "pytest -q",
+          output: "running...",
+          state: "running",
+          updatedAt: now - 500,
+        },
+        {
+          id: "cmd-2",
+          command: "npm test",
+          output: "done",
+          state: "done",
+          updatedAt: now - 5_000,
+        },
+        {
+          id: "cmd-3",
+          command: "pnpm lint",
+          output: "failed",
+          state: "failed",
+          updatedAt: now - 13_000,
+        },
+      ],
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["job_abc123def456", "cmd-1"]);
+    expect(rows[0]).toMatchObject({
+      kind: "swarm",
+      state: "running",
+      label: "Audit composer stack",
+    });
+    expect(rows[1]).toMatchObject({
+      kind: "terminal",
+      state: "running",
+      label: "pytest -q",
+    });
+  });
+});

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
-import { api, type Config } from "../lib/api";
+import { api, type Config, type Job } from "../lib/api";
 import { usePolling } from "../lib/usePolling";
 import FileEditorPane from "./FileEditorPane";
 import {
@@ -539,6 +539,7 @@ export default function Conversation({
   useEffect(() => { pendingJobIdsRef.current = pendingJobIds; }, [pendingJobIds]);
   const processedSwarmJobIdsRef = useRef<string[]>([]);
   const [backendPendingSwarms, setBackendPendingSwarms] = useState(false);
+  const [swarmLiveJobs, setSwarmLiveJobs] = useState<Job[]>([]);
 
   // Hold investigation / Still working… after switch/hydrate while background
   // jobs fly, even if status briefly flaps idle before awaiting_swarm paints.
@@ -1495,6 +1496,7 @@ export default function Conversation({
     setPendingJobIds([]);
     processedSwarmJobIdsRef.current = [];
     setBackendPendingSwarms(false);
+    setSwarmLiveJobs([]);
     if (activeSessionId) {
       // Peek first for pending_swarms / latch visibility. Consume only once we
       // commit to scheduling resume so a mid-flight switch cannot steal it.
@@ -2302,6 +2304,7 @@ export default function Conversation({
               return null;
             }
             const jobs = Array.isArray(live?.jobs) ? live.jobs : [];
+            setSwarmLiveJobs(jobs);
             const hasActions = jobs.some(
               (j) => Array.isArray(j.actions) && j.actions.length > 0,
             );
@@ -3389,6 +3392,7 @@ export default function Conversation({
         dragIndex={dragIndex}
         dragOverIndex={dragOverIndex}
         queueItems={queueItems}
+        swarmLiveJobs={swarmLiveJobs}
         queueLoadError={queueLoadError}
         queueDragIndex={queueDragIndex}
         queueDragOverIndex={queueDragOverIndex}
@@ -3499,4 +3503,3 @@ export default function Conversation({
     </main>
   );
 }
-

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -2143,28 +2143,32 @@ export default function SwarmPane() {
                 stays a short list. Non-destructive: "Clear" only hides. */}
             {finished.length > 0 && (
               <div className="shrink-0 flex flex-col gap-2">
-                <div className="flex items-center justify-between px-1 pt-0.5">
+                <div className="swarm-finished-head flex items-center justify-between px-1 pt-0.5">
                   <button
                     onClick={() => setFinishedOpen((o) => !o)}
-                    className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-faint font-semibold hover:text-muted focus:outline-none"
+                    className="flex items-center gap-1 min-w-0 text-[10px] uppercase tracking-wider text-faint font-semibold hover:text-muted focus:outline-none"
                   >
                     {finishedOpen ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
-                    Finished
-                    <span className="text-faint/60 normal-case tracking-normal">({finished.length})</span>
-                    {failedCount > 0 && (
-                      <span className="text-risk/70 normal-case tracking-normal">{"\u00b7"} {failedCount} failed</span>
-                    )}
-                    {warningCount > 0 && (
-                      <span className="text-warn/80 normal-case tracking-normal">{"\u00b7"} {warningCount} untrustworthy</span>
-                    )}
-                    {cancelledCount > 0 && (
-                      <span className="text-muted normal-case tracking-normal">{"\u00b7"} {cancelledCount} cancelled</span>
-                    )}
+                    <span className="whitespace-nowrap">
+                      Finished{" "}
+                      <span className="text-faint/60 normal-case tracking-normal">({finished.length})</span>
+                    </span>
+                    <span className="swarm-finished-chips flex flex-wrap items-center min-w-0">
+                      {failedCount > 0 && (
+                        <span className="swarm-chip swarm-chip-failed whitespace-nowrap text-risk/70 normal-case tracking-normal">{"\u00b7"} {failedCount} failed</span>
+                      )}
+                      {warningCount > 0 && (
+                        <span className="swarm-chip swarm-chip-warn whitespace-nowrap text-warn/80 normal-case tracking-normal">{"\u00b7"} {warningCount} untrustworthy</span>
+                      )}
+                      {cancelledCount > 0 && (
+                        <span className="swarm-chip swarm-chip-cancel whitespace-nowrap text-muted normal-case tracking-normal">{"\u00b7"} {cancelledCount} cancelled</span>
+                      )}
+                    </span>
                   </button>
                   <button
                     onClick={clearFinished}
                     title="Hide all finished runs from the tracker (stays in Puppetmaster history)"
-                    className="text-[9px] text-faint/70 hover:text-risk uppercase tracking-wider focus:outline-none"
+                    className="shrink-0 whitespace-nowrap text-[9px] text-faint/70 hover:text-risk uppercase tracking-wider focus:outline-none"
                   >
                     Clear
                   </button>

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -975,10 +975,29 @@ function indexCardCommandSession(card: Card): void {
   const { linkKind, value } = classifyActionGoal(card.kind || "", rawGoal);
   const id = String(card.id || card.result?.job_id || "").trim();
   if (linkKind !== "command" || !id || !value) return;
+  const rawStatus = String(card.result?.status || "").trim().toLowerCase();
+  const exitCode =
+    typeof card.result?.exit_code === "number"
+      ? card.result.exit_code
+      : typeof card.result?.exit_code === "string" && /^-?\d+$/.test(card.result.exit_code.trim())
+        ? Number(card.result.exit_code.trim())
+        : null;
+  const state =
+    rawStatus.includes("fail")
+    || rawStatus.includes("error")
+    || rawStatus.includes("cancel")
+    || rawStatus.includes("timeout")
+    || rawStatus.includes("truncat")
+    || (exitCode != null && exitCode !== 0)
+      ? "failed"
+      : card.running || rawStatus.includes("run") || rawStatus.includes("pend")
+        ? "running"
+        : "done";
   registerAgentCommandSession({
     id,
     command: value,
     output: String(card.result?.output || ""),
+    state,
   });
 }
 

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -25,9 +25,10 @@ import {
   Brain,
   RefreshCw,
 } from "lucide-react";
-import { api, type Config, type ContextUsageResponse } from "../../lib/api";
+import { api, type Config, type ContextUsageResponse, type Job } from "../../lib/api";
 import PilotPicker from "../PilotPicker";
 import WorkspaceChip from "./WorkspaceChip";
+import ComposerStatusStack from "./ComposerStatusStack";
 import { formatMentionListingCapMessage, type MentionListingCap } from "./slashCommands";
 import { filterSlashCommands } from "./composerInput";
 import {
@@ -66,6 +67,7 @@ export default function ComposerDock({
   dragIndex,
   dragOverIndex,
   queueItems,
+  swarmLiveJobs = [],
   queueLoadError,
   queueDragIndex,
   queueDragOverIndex,
@@ -156,6 +158,7 @@ export default function ComposerDock({
   dragIndex: number | null;
   dragOverIndex: number | null;
   queueItems: ServerQueueItem[];
+  swarmLiveJobs?: Job[];
   queueLoadError?: string | null;
   queueDragIndex: number | null;
   queueDragOverIndex: number | null;
@@ -478,6 +481,7 @@ export default function ComposerDock({
             })}
           </div>
         )}
+        <ComposerStatusStack swarmJobs={swarmLiveJobs} />
         {/* Server-side PROMPT QUEUE, stacked ABOVE the composer (Cursor-style)
             so the "runs next" items are always visible right over the input.
             These prompts are drained by the backend one full turn at a time. */}

--- a/webapp/src/components/conversation/ComposerStatusStack.tsx
+++ b/webapp/src/components/conversation/ComposerStatusStack.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { ChevronRight, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { openAgentCommand, openAgentSwarmJob } from "../../lib/agentLinks";
+import {
+  getAgentCommandIndexVersion,
+  listAgentCommandSessions,
+  subscribeAgentCommandIndex,
+} from "../../lib/agentCommandIndex";
+import { buildComposerStatusStackRows, type ComposerStatusStackRow } from "./composerStatusStackData";
+import type { Job } from "../../lib/api";
+
+function statusIcon(row: ComposerStatusStackRow) {
+  if (row.state === "running") {
+    return <Loader2 className="size-3.5 animate-spin text-muted-foreground/80" aria-hidden />;
+  }
+  if (row.state === "failed") {
+    return <XCircle className="size-3.5 text-rose-500/85" aria-hidden />;
+  }
+  return <CheckCircle2 className="size-3.5 text-emerald-500/85" aria-hidden />;
+}
+
+function rowKindLabel(kind: ComposerStatusStackRow["kind"]): string {
+  return kind === "swarm" ? "PM" : "TERMINAL";
+}
+
+function rowActionLabel(row: ComposerStatusStackRow): string {
+  if (row.kind === "swarm") return "Open swarm";
+  return "Open terminal";
+}
+
+function groupLabel(kind: ComposerStatusStackRow["kind"]): string {
+  return kind === "swarm" ? "Puppetmaster" : "Terminal";
+}
+
+export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly Job[] }) {
+  const [nowTick, setNowTick] = useState(() => Date.now());
+  const commandIndexVersion = useSyncExternalStore(
+    subscribeAgentCommandIndex,
+    getAgentCommandIndexVersion,
+    getAgentCommandIndexVersion,
+  );
+  const commandSessions = useMemo(
+    () => listAgentCommandSessions(),
+    [commandIndexVersion],
+  );
+  const rows = useMemo(
+    () => buildComposerStatusStackRows({ swarmJobs, commandSessions, nowMs: nowTick }),
+    [commandSessions, nowTick, swarmJobs],
+  );
+  const hasTerminalRows = rows.some((row) => row.state !== "running");
+
+  useEffect(() => {
+    if (!rows.length || !hasTerminalRows) return;
+    const timer = window.setInterval(() => setNowTick(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [hasTerminalRows, rows.length]);
+
+  const grouped = useMemo(() => {
+    const out: Array<{ kind: ComposerStatusStackRow["kind"]; rows: ComposerStatusStackRow[] }> = [];
+    for (const row of rows) {
+      const bucket = out[out.length - 1];
+      if (bucket && bucket.kind === row.kind) {
+        bucket.rows.push(row);
+      } else {
+        out.push({ kind: row.kind, rows: [row] });
+      }
+    }
+    return out;
+  }, [rows]);
+
+  if (grouped.length === 0) return null;
+
+  return (
+    <div
+      className="mx-2 mb-2 overflow-hidden rounded-2xl border border-edge/80 bg-panel2/80 shadow-lg shadow-black/15"
+      data-slot="composer-status-stack"
+    >
+      <div className="divide-y divide-edge/60">
+        {grouped.map((group) => (
+          <div key={group.kind} className="px-2.5 py-2">
+            <div className="mb-1 flex items-center justify-between px-0.5">
+              <span className="text-[9px] font-semibold uppercase tracking-[0.22em] text-muted-foreground/70">
+                {groupLabel(group.kind)}
+              </span>
+              <span className="text-[9px] font-mono text-muted-foreground/60">
+                {group.rows.length}
+              </span>
+            </div>
+            <div className="space-y-1">
+              {group.rows.map((row) => {
+                const onClick = () => {
+                  if (row.kind === "swarm") {
+                    openAgentSwarmJob(row.id);
+                    return;
+                  }
+                  openAgentCommand(row.command || row.label, {
+                    id: row.id,
+                    output: row.output || "",
+                  });
+                };
+
+                return (
+                  <button
+                    key={`${row.kind}:${row.id}`}
+                    type="button"
+                    onClick={onClick}
+                    title={row.title}
+                    className="flex w-full items-center gap-2 rounded-xl border border-edge/60 bg-panel/70 px-2.5 py-1.5 text-left text-[11px] leading-4 text-txt/90 transition hover:border-edge2 hover:bg-panel2/80 focus-visible:border-accent/60 focus-visible:outline-none"
+                  >
+                    <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-edge/60 bg-panel text-[8px] font-semibold tracking-[0.18em] text-muted-foreground/70">
+                      {rowKindLabel(row.kind)}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate">{row.label}</span>
+                    <span className="flex shrink-0 items-center gap-1 text-[9px] uppercase tracking-[0.18em] text-muted-foreground/70">
+                      {statusIcon(row)}
+                      <span>{rowActionLabel(row)}</span>
+                    </span>
+                    <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/50" aria-hidden />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/conversation/composerStatusStackData.ts
+++ b/webapp/src/components/conversation/composerStatusStackData.ts
@@ -1,0 +1,144 @@
+import type { Job } from "../../lib/api";
+import type { AgentCommandSession } from "../../lib/agentCommandIndex";
+
+export type ComposerStatusStackKind = "swarm" | "terminal";
+export type ComposerStatusStackState = "running" | "done" | "failed";
+
+export type ComposerStatusStackRow = {
+  id: string;
+  kind: ComposerStatusStackKind;
+  label: string;
+  state: ComposerStatusStackState;
+  updatedAt: number;
+  title: string;
+  command?: string;
+  output?: string;
+};
+
+export type ComposerStatusStackSource = {
+  commandSessions: readonly AgentCommandSession[];
+  nowMs?: number;
+  swarmJobs: readonly Job[];
+};
+
+const SWARM_SUCCESS_LINGER_MS = 4_000;
+const SWARM_FAILURE_LINGER_MS = 12_000;
+const COMMAND_SUCCESS_LINGER_MS = 4_000;
+const COMMAND_FAILURE_LINGER_MS = 12_000;
+
+function timestampMs(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 1e12 ? value : value * 1000;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+function normalizeState(status: unknown): ComposerStatusStackState {
+  const s = String(status || "").trim().toLowerCase();
+  if (
+    s.includes("fail")
+    || s.includes("error")
+    || s.includes("stall")
+    || s.includes("dead")
+    || s.includes("interrupt")
+    || s.includes("cancel")
+    || /time(?:d)?[-_ ]?out/.test(s)
+  ) {
+    return "failed";
+  }
+  if (
+    s.includes("run")
+    || s.includes("progress")
+    || s.includes("active")
+    || s.includes("pend")
+    || s.includes("queue")
+  ) {
+    return "running";
+  }
+  if (s.includes("complete") || s.includes("done") || s.includes("success") || s === "ok" || s.includes("finish")) {
+    return "done";
+  }
+  return "running";
+}
+
+function jobAccountingOwned(job: Job): boolean {
+  if (job.accounting_owned === true) return true;
+  if (job.accounting_owned === false) return false;
+  return (job.source || "harness").toLowerCase() !== "cli";
+}
+
+function jobUpdatedAt(job: Job): number | null {
+  return timestampMs(job.updated_at ?? job.created_at ?? null);
+}
+
+function visibleSwarmJob(job: Job, nowMs: number): ComposerStatusStackRow | null {
+  if (!jobAccountingOwned(job)) return null;
+  const state = normalizeState(job.status);
+  const updatedAt = jobUpdatedAt(job);
+  if (state !== "running" && updatedAt == null) return null;
+  if (state === "done" && updatedAt != null && nowMs - updatedAt > SWARM_SUCCESS_LINGER_MS) return null;
+  if (state === "failed" && updatedAt != null && nowMs - updatedAt > SWARM_FAILURE_LINGER_MS) return null;
+  const id = String(job.id || "").trim();
+  if (!id) return null;
+  const label = String(job.goal || job.role || job.id || "").trim() || id;
+  return {
+    id,
+    kind: "swarm",
+    label,
+    state,
+    updatedAt: updatedAt ?? nowMs,
+    title: label,
+  };
+}
+
+function visibleCommandSession(
+  session: AgentCommandSession,
+  nowMs: number,
+): ComposerStatusStackRow | null {
+  const id = String(session.id || "").trim();
+  const command = String(session.command || "").trim();
+  if (!id || !command) return null;
+  const state = session.state || "running";
+  if (state === "done" && nowMs - session.updatedAt > COMMAND_SUCCESS_LINGER_MS) return null;
+  if (state === "failed" && nowMs - session.updatedAt > COMMAND_FAILURE_LINGER_MS) return null;
+  return {
+    id,
+    kind: "terminal",
+    label: command,
+    state,
+    updatedAt: session.updatedAt,
+    title: command,
+    command,
+    output: session.output,
+  };
+}
+
+export function buildComposerStatusStackRows(
+  source: ComposerStatusStackSource,
+): ComposerStatusStackRow[] {
+  const nowMs = source.nowMs ?? Date.now();
+  const rows: ComposerStatusStackRow[] = [];
+
+  for (const job of source.swarmJobs) {
+    const row = visibleSwarmJob(job, nowMs);
+    if (row) rows.push(row);
+  }
+
+  for (const session of source.commandSessions) {
+    const row = visibleCommandSession(session, nowMs);
+    if (row) rows.push(row);
+  }
+
+  return rows.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === "swarm" ? -1 : 1;
+    if (a.state !== b.state) {
+      const order: Record<ComposerStatusStackState, number> = { running: 0, failed: 1, done: 2 };
+      return order[a.state] - order[b.state];
+    }
+    return b.updatedAt - a.updatedAt;
+  });
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -439,6 +439,26 @@ body.is-row-resizing iframe {
   color: var(--text, #e4e7eb);
 }
 
+/* Swarm tracker "Finished" accordion header: keep the metric chips on ONE line
+   at any sidebar width. Each chip is an atomic whitespace-nowrap unit, so a
+   chip can never split mid-token ("39" / "failed" on separate rows) -- the
+   ragged double-row from before. When the pane narrows, container queries drop
+   the least-important chips (cancelled, then untrustworthy) so the row stays a
+   single clean line instead of wrapping. Risk (failed) always remains. */
+.swarm-finished-head {
+  container-type: inline-size;
+  min-width: 0;
+}
+.swarm-finished-chips {
+  gap: 0.375rem;
+}
+@container (max-width: 340px) {
+  .swarm-chip-cancel { display: none; }
+}
+@container (max-width: 250px) {
+  .swarm-chip-warn { display: none; }
+}
+
 .right-pane-badge {
   display: inline-flex;
   align-items: center;

--- a/webapp/src/lib/agentCommandIndex.ts
+++ b/webapp/src/lib/agentCommandIndex.ts
@@ -9,6 +9,7 @@ export type AgentCommandSession = {
   id: string;
   command: string;
   output: string;
+  state: "running" | "done" | "failed";
   updatedAt: number;
 };
 
@@ -52,23 +53,38 @@ export function registerAgentCommandSession(input: {
   id: string;
   command: string;
   output?: string;
+  state?: AgentCommandSession["state"];
 }): AgentCommandSession | null {
   const id = String(input.id || "").trim();
   const command = normalizeCommandKey(input.command);
   if (!id || !command || command.length > 500) return null;
   const output = String(input.output || "");
+  const state = input.state;
   const existing = byId.get(id);
   const now = Date.now();
   if (existing && existing.command === command) {
+    const prevState = existing.state;
     existing.output = output;
     existing.updatedAt = now;
+    if (state) existing.state = state;
+    if (state && state !== prevState) {
+      emit(true);
+      rememberCommandId(command, id);
+      return existing;
+    }
     rememberCommandId(command, id);
     return existing;
   }
   if (existing && existing.command !== command) {
     forgetCommandId(existing.command, id);
   }
-  const session: AgentCommandSession = { id, command, output, updatedAt: now };
+  const session: AgentCommandSession = {
+    id,
+    command,
+    output,
+    state: state || "running",
+    updatedAt: now,
+  };
   byId.set(id, session);
   rememberCommandId(command, id);
   emit(true);
@@ -98,6 +114,10 @@ export function subscribeAgentCommandIndex(onStoreChange: () => void): () => voi
 
 export function getAgentCommandIndexVersion(): number {
   return version;
+}
+
+export function listAgentCommandSessions(): AgentCommandSession[] {
+  return [...byId.values()].sort((a, b) => b.updatedAt - a.updatedAt);
 }
 
 /** Test helper: wipe the index between cases. */


### PR DESCRIPTION
## Summary
- Stop Finished metric chips from double-rowing on a narrow Swarm Tracker sidebar (`01f20f26`).
- Hermes-style composer status stack: PM jobs open Swarm Tracker, terminal jobs open the live terminal (`b867c1e5`).
- Chat-quality root causes: canonical bare-model resolve (fail loud instead of silent OpenRouter fallback for catalogued ids), OpenCode Go request-shape opt-in, Zen `*-free` forced to Chat Completions, frozen system-prompt documented (`0be6b64c`).
- Version bump to v0.9.274. Puppetmaster pin stays `1.22.18`.

## Test plan
- [x] Local pytest previously green on these changes (`4976 passed, 76 skipped`)
- [x] `tests/test_version_consistency.py` green after the bump
- [ ] CI `tests` matrix green
- [ ] Tag `v0.9.274` after merge when the tree matches