### PR TITLE
Release v0.9.275

### DIFF
--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.274"
+__version__ = "0.9.275"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/model_visibility.py
+++ b/harness/model_visibility.py
@@ -341,6 +341,35 @@ def catalog(available_only: bool = True, *, force: bool = False) -> list:
     return out
 
 
+def compute_reasoning_support(specs: Optional[list] = None) -> dict:
+    """Per-spec ``supports_reasoning_effort`` map for the frontend picker.
+
+    Returns ``{"provider:model": true|false, ...}`` for all specs in *specs*
+    (or ``enabled_pilots()``).  Uses
+    :func:`harness.provider_capabilities.model_supports_reasoning_effort` so
+    the backend's existing per-adapter logic is the single source of truth.
+    """
+    visible: list[str] = []
+    seen: set[str] = set()
+    source = specs if specs is not None else enabled_pilots()
+    for spec in source or []:
+        text = str(spec or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            visible.append(text)
+    if not visible:
+        return {}
+    from .provider_capabilities import model_supports_reasoning_effort
+
+    out: dict[str, bool] = {}
+    for spec in visible:
+        parts = spec.split(":", 1)
+        provider_name = parts[0] if len(parts) > 1 else ""
+        model_id = parts[1] if len(parts) > 1 else parts[0]
+        out[spec] = model_supports_reasoning_effort(provider_name, model_id)
+    return out
+
+
 def picker_model_labels(specs: Optional[list] = None, *, force: bool = False) -> dict:
     """Friendly names for visible picker specs, keyed by ``provider:model``.
 

--- a/harness/provider_capabilities.py
+++ b/harness/provider_capabilities.py
@@ -96,3 +96,61 @@ def cursor_platform_workers_ready(env: Optional[Any] = None) -> bool:
         return bool(str(mapping.get("CURSOR_API_KEY") or "").strip())
     except Exception:
         return False
+
+
+def model_supports_reasoning_effort(provider_name: str, model_id: str) -> bool:
+    """Return True when the given *provider_name*:*model_id* pair supports a
+    reasoning-effort knob over the wire.
+
+    Uses the existing per-adapter logic so no new model-family knowledge is
+    duplicated:
+
+    * ``openai-codex`` / ``codex-plan`` / ``chatgpt-codex`` — always True
+      (Codex Responses ``reasoning_effort``).
+    * ``anthropic`` / ``bedrock`` — delegates to
+      :func:`harness.reasoning_effort.model_supports_anthropic_thinking`.
+    * ``opencode-go`` — delegates to
+      :func:`harness.opencode_go.reasoning_body_extras`; True when the
+      function returns a non-empty dict (meaning it has a dialect for this
+      model).
+    * ``opencode-zen`` — always True (relay passes ``reasoning_effort``
+      through; backend degrades gracefully on unknown models).
+    * ``openrouter`` — always True (same relay-semantics reasoning).
+    * Everything else — defaults to True so the user-visible knob never
+      disappears (``None`` or unrecognized providers are treated
+      permissively).
+    """
+    from . import providers as prov
+    from .reasoning_effort import model_supports_anthropic_thinking
+
+    name = (provider_name or "").strip().lower()
+    mid = (model_id or "").strip().lower()
+
+    # Resolve aliases to canonical provider name.
+    p = prov.get_provider(name)
+    if p is not None:
+        name = p.name
+
+    # -- Codex family always supports reasoning_effort --
+    if name in ("openai-codex",):
+        return True
+
+    # -- Anthropic / Bedrock Claude (opus / sonnet, not haiku) --
+    if name in ("anthropic", "bedrock"):
+        return model_supports_anthropic_thinking(mid)
+
+    # -- OpenCode Go: ask the per-family adapter --
+    if name == "opencode-go":
+        try:
+            from .opencode_go import reasoning_body_extras
+            extras = reasoning_body_extras(mid, effort="high")
+            return bool(extras)
+        except Exception:
+            return True  # permissive fallback
+
+    # -- OpenCode Zen / OpenRouter: relay passes reasoning_effort through --
+    if name in ("opencode-zen", "openrouter"):
+        return True
+
+    # -- Default: show the knob --
+    return True

--- a/harness/reasoning_effort.py
+++ b/harness/reasoning_effort.py
@@ -36,6 +36,7 @@ _ALIASES = {
     "extra high": "xhigh",
     "extrahigh": "xhigh",
     "x-high": "xhigh",
+    "ultra": "xhigh",
 }
 
 

--- a/harness/server.py
+++ b/harness/server.py
@@ -2944,10 +2944,12 @@ def _get_settings_dict():
     preflight_ok = (_session.preflight() is None)
     models = _available_pilots()
     try:
-        from .model_visibility import picker_model_labels
+        from .model_visibility import picker_model_labels, compute_reasoning_support
         model_labels = picker_model_labels(models, force=False)
+        reasoning_support = compute_reasoning_support(models)
     except Exception:
         model_labels = {}
+        reasoning_support = {}
     return {
         "driver": _cfg.driver,
         "reach": reach,
@@ -2970,6 +2972,7 @@ def _get_settings_dict():
             os.environ.get("HARNESS_WORKER_TOKEN_BUDGET", "").strip() or "250000"
         ),
         "reasoning_effort": current_reasoning_effort(),
+        "reasoning_support": reasoning_support,
         "compactionResidual": _settings_compaction_residual(),
         "state_dir": _session.state_dir,
         "repo": _cfg.repo,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.274"
+version = "0.9.275"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -77,3 +77,76 @@ def test_product_worker_adapter_prefers_keyed_agentic(monkeypatch):
     from harness.swarm_worker_route import resolve_product_worker_adapter
 
     assert resolve_product_worker_adapter() == "agentic"
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-effort support per model spec
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_support_codex_always():
+    from harness.provider_capabilities import model_supports_reasoning_effort
+
+    # canonical name
+    assert model_supports_reasoning_effort("openai-codex", "gpt-5.6-luna") is True
+    assert model_supports_reasoning_effort("openai-codex", "gpt-5.6-sol") is True
+    # aliases
+    assert model_supports_reasoning_effort("codex-plan", "gpt-5.6-luna") is True
+    assert model_supports_reasoning_effort("chatgpt-codex", "gpt-5.6-sol") is True
+
+
+def test_reasoning_support_anthropic_uses_model_check():
+    from harness.provider_capabilities import model_supports_reasoning_effort
+
+    # opus → True
+    assert model_supports_reasoning_effort("anthropic", "claude-opus-4-8") is True
+    # sonnet → True
+    assert model_supports_reasoning_effort("anthropic", "claude-sonnet-4-5") is True
+    # Bedrock sonnet → True
+    assert model_supports_reasoning_effort("bedrock", "us.anthropic.claude-sonnet-4-20250514-v1:0") is True
+    # haiku → False
+    assert model_supports_reasoning_effort("anthropic", "claude-haiku-4-5") is False
+    # non-claude → False
+    assert model_supports_reasoning_effort("anthropic", "gpt-5.6-luna") is False
+
+
+def test_reasoning_support_opencode_go_known_families():
+    from harness.provider_capabilities import model_supports_reasoning_effort
+
+    # GLM-5.3 has a dialect
+    assert model_supports_reasoning_effort("opencode-go", "glm-5.3") is True
+    # GLM-5.2 has a dialect
+    assert model_supports_reasoning_effort("opencode-go", "glm-5.2") is True
+    # Kimi K2 has a dialect
+    assert model_supports_reasoning_effort("opencode-go", "kimi-k2.7-code") is True
+    # DeepSeek-thinking has a dialect
+    assert model_supports_reasoning_effort("opencode-go", "deepseek-v4-flash") is True
+    # Unrecognised → False (reasoning_body_extras returns {})
+    assert model_supports_reasoning_effort("opencode-go", "mimo-v2.5") is False
+    assert model_supports_reasoning_effort("opencode-go", "grok-4.5") is False
+
+    # alias resolution for "opencode_go"
+    assert model_supports_reasoning_effort("opencode_go", "glm-5.3") is True
+
+
+def test_reasoning_support_opencode_zen_and_openrouter():
+    from harness.provider_capabilities import model_supports_reasoning_effort
+
+    # Always True: relay passes reasoning_effort through
+    assert model_supports_reasoning_effort("opencode-zen", "deepseek-v4-flash-free") is True
+    assert model_supports_reasoning_effort("opencode-zen", "mimo-v2.5-free") is True
+    assert model_supports_reasoning_effort("openrouter", "anthropic/claude-sonnet-4") is True
+    assert model_supports_reasoning_effort("openrouter", "openai/gpt-5.6-luna") is True
+
+    # alias resolution
+    assert model_supports_reasoning_effort("opencode_zen", "deepseek-v4-flash-free") is True
+
+
+def test_reasoning_support_unknown_provider_default_true():
+    """Where genuinely unknowable, the user wants the knob to appear."""
+    from harness.provider_capabilities import model_supports_reasoning_effort
+
+    assert model_supports_reasoning_effort("cursor-cli", "gpt-5.6-luna") is True
+    assert model_supports_reasoning_effort("nous", "model-x") is True
+    assert model_supports_reasoning_effort("", "") is True
+    assert model_supports_reasoning_effort("gemini", "gemini-2.5-pro") is True

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -22,6 +22,8 @@ from harness.reasoning_effort import (
     ("Medium", "medium"),
     ("EXTRA HIGH", "xhigh"),
     ("extra_high", "xhigh"),
+    ("ultra", "xhigh"),
+    ("ULtra", "xhigh"),
     ("none", "none"),
     ("off", "none"),
     ("", DEFAULT_CODEX_REASONING_EFFORT),

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.274",
+  "version": "0.9.275",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.274",
+      "version": "0.9.275",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.274",
+  "version": "0.9.275",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -52,6 +52,25 @@ function expectBefore(first: HTMLElement, second: HTMLElement) {
   expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 }
 
+async function expandJob(name: string | RegExp) {
+  const job = await screen.findByRole("button", { name });
+  if (job.getAttribute("aria-expanded") === "false") {
+    fireEvent.click(job);
+  }
+  return job;
+}
+
+async function expandVisibleJobs() {
+  await waitFor(() => {
+    expect(screen.queryByText("Loading swarm jobs...")).not.toBeInTheDocument();
+  });
+  for (const btn of screen.getAllByRole("button")) {
+    if (btn.getAttribute("aria-expanded") === "false" && (btn.getAttribute("aria-label") || "").trim()) {
+      fireEvent.click(btn);
+    }
+  }
+}
+
 describe("SwarmPane sort and filter controls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -210,6 +229,7 @@ describe("SwarmPane model badge", () => {
     );
 
     const { container } = render(<SwarmPane />);
+    await expandVisibleJobs();
     const worker = await screen.findByRole("button", { name: /Worker/ });
     const job = screen.getByRole("button", { name: /Audit auth flow/ });
     const aggregate = screen.getByText("1 running");
@@ -253,6 +273,7 @@ describe("SwarmPane model badge", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     const worker = await screen.findByRole("button", { name: /Worker/ });
     expect(worker).toHaveTextContent("openrouter");
@@ -282,6 +303,7 @@ describe("SwarmPane model badge", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     const worker = await screen.findByRole("button", { name: /implement \(agentic\)/ });
     expect(worker).toHaveTextContent("routing…");
@@ -305,6 +327,7 @@ describe("SwarmPane model badge", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     await waitFor(() => {
       expect(screen.getByLabelText("Model: model-a")).toBeInTheDocument();
@@ -333,6 +356,7 @@ describe("SwarmPane model badge", () => {
       });
 
       render(<SwarmPane />);
+    await expandVisibleJobs();
       await waitFor(() => expect(screen.getByText("routing…")).toBeInTheDocument());
       expect(screen.queryByLabelText("Model: routed-model")).not.toBeInTheDocument();
       await vi.advanceTimersByTimeAsync(6000);
@@ -380,6 +404,7 @@ describe("SwarmPane model badge", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     const queued = await screen.findByRole("button", { name: /queued-worker/ });
     const pending = screen.getByRole("button", { name: /pending-worker/ });
@@ -532,7 +557,7 @@ describe("SwarmPane worker details", () => {
 
     render(<SwarmPane />);
     mockSwarmCancel.mockResolvedValue({ ok: true, job_id: "job-keys" });
-    const job = await screen.findByRole("button", { name: /Keyboard disclosure/ });
+    const job = await expandJob(/Keyboard disclosure/);
     expect(job).toHaveAttribute("aria-expanded", "true");
     expect(job.className).toMatch(/focus-visible:outline/);
     expect(job.getAttribute("aria-label") || "").toMatch(/Keyboard disclosure/);
@@ -605,6 +630,7 @@ describe("SwarmPane pin attribution", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     const worker = await screen.findByRole("button", { name: /Worker/ });
     expect(worker).toHaveTextContent("agentic/meta/muse-spark-1.1");
@@ -652,6 +678,7 @@ describe("SwarmPane pin attribution", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     const worker = await screen.findByRole("button", { name: /Worker/ });
     expect(worker).not.toHaveTextContent("—");
@@ -686,6 +713,7 @@ describe("SwarmPane pin attribution", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     const worker = await screen.findByRole("button", { name: /Worker/ });
     fireEvent.click(worker);
@@ -769,6 +797,7 @@ describe("SwarmPane routing dedupe", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     await waitFor(() => {
       expect(screen.getByLabelText("Model: final-model-0")).toBeInTheDocument();
@@ -797,6 +826,7 @@ describe("SwarmPane routing dedupe", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     await waitFor(() => {
       expect(screen.getByLabelText("Model: escalated-model")).toBeInTheDocument();
@@ -1063,6 +1093,7 @@ describe("SwarmPane mid-run job-row meters", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
     const worker = await screen.findByRole("button", { name: /implement \(agentic\)/ });
     expect(worker).toHaveTextContent("cheap-model");
     expect(screen.queryByText("initial-cheap")).not.toBeInTheDocument();
@@ -1472,6 +1503,7 @@ describe("SwarmPane worker-owned routing surface", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     const worker = await screen.findByRole("button", { name: /test-coverage-reviewer/ });
     expect(worker).toHaveTextContent("test-coverage-reviewer");
@@ -1516,6 +1548,7 @@ describe("SwarmPane worker-owned routing surface", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     await waitFor(() => {
       expect(screen.getByText("Workers (1)")).toBeInTheDocument();
@@ -1582,6 +1615,7 @@ describe("SwarmPane worker-owned routing surface", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
     const worker = await screen.findByRole("button", { name: /Worker/ });
     expect(screen.queryByText("2 alternatives")).not.toBeInTheDocument();
     fireEvent.click(worker);
@@ -1617,6 +1651,7 @@ describe("SwarmPane worker-owned routing surface", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
     const worker = await screen.findByRole("button", { name: /Worker/ });
     expect(worker).not.toHaveTextContent("—");
     expect(screen.queryByText("$0")).not.toBeInTheDocument();
@@ -1655,6 +1690,7 @@ describe("SwarmPane worker-owned routing surface", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
     const worker = await screen.findByRole("button", { name: /Worker/ });
     expect(worker).toHaveTextContent("$0");
     expect(worker).not.toHaveTextContent("—");
@@ -1681,6 +1717,7 @@ describe("SwarmPane worker-owned routing surface", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
     const worker = await screen.findByRole("button", { name: /Worker/ });
     expect(worker).toHaveTextContent("$0");
   });
@@ -1727,6 +1764,7 @@ describe("SwarmPane worker tokens and cost", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     // Running jobs auto-expand; do not click the goal (that collapses the card).
     await waitFor(() => {
@@ -1767,6 +1805,7 @@ describe("SwarmPane worker progress", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     await waitFor(() => {
       expect(screen.getByText("Workers (3)")).toBeInTheDocument();
@@ -1892,6 +1931,7 @@ describe("SwarmPane worker outcome hierarchy", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
     await waitFor(() => {
       expect(screen.getByText("2/3 · 1 failed")).toBeInTheDocument();
     });
@@ -1913,6 +1953,7 @@ describe("SwarmPane worker outcome hierarchy", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
     const progress = await screen.findByLabelText(/1 of 3 workers finished, 0 failed, 0 degraded/);
     expect(screen.getByText("Workers (3)")).toBeInTheDocument();
     expect(progress).toHaveTextContent("1/3");
@@ -2457,6 +2498,7 @@ describe("SwarmPane final-review blockers", () => {
     );
 
     render(<SwarmPane />);
+    await expandVisibleJobs();
 
     const worker = await screen.findByRole("button", { name: /Worker/ });
     expect(worker).toHaveTextContent("final-routed-model");
@@ -2522,6 +2564,7 @@ describe("SwarmPane final-review blockers", () => {
       });
 
       render(<SwarmPane />);
+    await expandVisibleJobs();
       await waitFor(() => expect(screen.getByText("routing…")).toBeInTheDocument());
 
       await vi.advanceTimersByTimeAsync(6000);
@@ -2564,6 +2607,7 @@ describe("SwarmPane final-review blockers", () => {
       });
 
       render(<SwarmPane />);
+    await expandVisibleJobs();
       const worker = await screen.findByRole("button", { name: /^worker, failed/i });
       fireEvent.click(worker);
       expect(screen.getByText("codex_turn_failed")).toBeInTheDocument();
@@ -2655,6 +2699,7 @@ describe("SwarmPane final-review blockers", () => {
     );
 
     renderInCompactRail(320);
+    await expandVisibleJobs();
 
     const worker = await screen.findByRole("button", { name: /test-coverage-reviewer/ });
     expect(worker).toHaveTextContent("test-coverage-reviewer");
@@ -2696,6 +2741,7 @@ describe("SwarmPane final-review blockers", () => {
     );
 
     const container = renderInCompactRail(220);
+    await expandVisibleJobs();
 
     const worker = await screen.findByRole("button", { name: /test-coverage-reviewer/ });
     expect(worker).toHaveTextContent("test-coverage-reviewer");
@@ -2729,8 +2775,10 @@ describe("SwarmPane job-card expansion persistence", () => {
 
     const { unmount } = render(<SwarmPane />);
     const job = await screen.findByRole("button", { name: /Running swarm/ });
-    expect(job).toHaveAttribute("aria-expanded", "true");
+    expect(job).toHaveAttribute("aria-expanded", "false");
 
+    fireEvent.click(job);
+    expect(job).toHaveAttribute("aria-expanded", "true");
     fireEvent.click(job);
     expect(job).toHaveAttribute("aria-expanded", "false");
 
@@ -2780,6 +2828,9 @@ describe("SwarmPane job-card expansion persistence", () => {
 
     render(<SwarmPane />);
     const jobA = await screen.findByRole("button", { name: /Repo A running/ });
+    expect(jobA).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(jobA);
+    expect(jobA).toHaveAttribute("aria-expanded", "true");
     fireEvent.click(jobA);
     expect(jobA).toHaveAttribute("aria-expanded", "false");
 
@@ -2787,7 +2838,7 @@ describe("SwarmPane job-card expansion persistence", () => {
     clearSWRCache();
 
     const jobB = await screen.findByRole("button", { name: /Repo B running/ });
-    expect(jobB).toHaveAttribute("aria-expanded", "true");
+    expect(jobB).toHaveAttribute("aria-expanded", "false");
 
     const stored = JSON.parse(localStorage.getItem("swarm.expanded.v1") || "{}");
     expect(stored[REPO_A]?.["shared-job"]).toBe(false);
@@ -2802,7 +2853,7 @@ describe("SwarmPane job-card expansion persistence", () => {
 
     render(<SwarmPane />);
     const job = await screen.findByRole("button", { name: /Running swarm/ });
-    expect(job).toHaveAttribute("aria-expanded", "true");
+    expect(job).toHaveAttribute("aria-expanded", "false");
   });
 });
 

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       swarmLive: vi.fn(),
       swarmCancel: vi.fn(),
       artifacts: vi.fn(),
+      sessions: vi.fn().mockResolvedValue([]),
     },
   };
 });

--- a/webapp/src/__tests__/composerTasks.test.ts
+++ b/webapp/src/__tests__/composerTasks.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildComposerTasks, pickTaskSourceJob, taskProgress, taskState } from "../lib/composerTasks";
+import type { Job } from "../lib/api";
+
+const job = (id: string, status: string, session_id: string, tasks: Job["tasks"]): Job => ({
+  id,
+  goal: id,
+  status,
+  session_id,
+  tasks,
+});
+
+describe("taskState", () => {
+  it("maps worker statuses", () => {
+    expect(taskState("complete")).toBe("completed");
+    expect(taskState("running")).toBe("in_progress");
+    expect(taskState("pending")).toBe("pending");
+    expect(taskState("failed")).toBe("failed");
+  });
+});
+
+describe("pickTaskSourceJob", () => {
+  it("prefers the active session running job", () => {
+    const picked = pickTaskSourceJob([
+      job("old", "complete", "sess-1", [{ id: "t0", role: "review", instruction: "old", status: "complete", adapter: "x" }]),
+      job("live", "running", "sess-1", [{ id: "t1", role: "impl", instruction: "Implement one-time reheat", status: "running", adapter: "x" }]),
+      job("other", "running", "sess-2", [{ id: "t2", role: "impl", instruction: "other", status: "running", adapter: "x" }]),
+    ], "sess-1");
+    expect(picked?.id).toBe("live");
+  });
+});
+
+describe("buildComposerTasks + progress", () => {
+  it("builds a Tasks N/M list", () => {
+    const tasks = buildComposerTasks(job("j", "running", "sess-1", [
+      { id: "1", role: "r", instruction: "Reproduce lifecycle", status: "complete", adapter: "x" },
+      { id: "2", role: "r", instruction: "Add failing test", status: "complete", adapter: "x" },
+      { id: "3", role: "r", instruction: "Implement reheat", status: "running", adapter: "x" },
+      { id: "4", role: "r", instruction: "Run frontend tests", status: "pending", adapter: "x" },
+      { id: "5", role: "r", instruction: "Commit and push", status: "pending", adapter: "x" },
+    ]));
+    expect(taskProgress(tasks)).toEqual({ done: 2, total: 5 });
+    expect(tasks[2].state).toBe("in_progress");
+  });
+});

--- a/webapp/src/__tests__/jobScope.test.ts
+++ b/webapp/src/__tests__/jobScope.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { filterJobsByScope, jobInActiveSession } from "../lib/jobScope";
+
+const jobs = [
+  { id: "a", session_id: "sess-1" },
+  { id: "b", session_id: "sess-2" },
+  { id: "c" },
+];
+
+describe("jobInActiveSession", () => {
+  it("requires both ids", () => {
+    expect(jobInActiveSession({ session_id: "sess-1" }, "")).toBe(false);
+    expect(jobInActiveSession({}, "sess-1")).toBe(false);
+    expect(jobInActiveSession({ session_id: "sess-1" }, "sess-1")).toBe(true);
+  });
+});
+
+describe("filterJobsByScope", () => {
+  it("session keeps only the active chat", () => {
+    expect(filterJobsByScope(jobs, "session", "sess-1").map((j) => j.id)).toEqual(["a"]);
+  });
+
+  it("repo keeps the full already-visible list", () => {
+    expect(filterJobsByScope(jobs, "repo", "sess-1").map((j) => j.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("session without an active id keeps the list", () => {
+    expect(filterJobsByScope(jobs, "session", "").map((j) => j.id)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/webapp/src/__tests__/reasoningSupport.test.ts
+++ b/webapp/src/__tests__/reasoningSupport.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  REASONING_LEVELS,
+  labelForEffort,
+  showReasoningEffort,
+} from "../lib/reasoningSupport";
+
+describe("labelForEffort", () => {
+  it("labels xhigh as Ultra", () => {
+    expect(labelForEffort("xhigh")).toBe("Ultra");
+    expect(REASONING_LEVELS.some((l) => l.value === "xhigh" && l.label === "Ultra")).toBe(true);
+  });
+});
+
+describe("showReasoningEffort", () => {
+  it("fails open when the map is missing or empty", () => {
+    expect(showReasoningEffort(undefined, "openrouter:stealth/ox-alpha")).toBe(true);
+    expect(showReasoningEffort(null, "anthropic:claude-haiku-4-5")).toBe(true);
+    expect(showReasoningEffort({}, "openai-codex:gpt-5.6-luna")).toBe(true);
+  });
+
+  it("honors an explicit false and does not fail open on a missing key", () => {
+    const support = {
+      "openai-codex:gpt-5.6-luna": true,
+      "anthropic:claude-haiku-4-5": false,
+      "opencode-go:ox-alpha-free": false,
+      "openrouter:stealth/ox-alpha": true,
+    };
+    expect(showReasoningEffort(support, "openai-codex:gpt-5.6-luna")).toBe(true);
+    expect(showReasoningEffort(support, "anthropic:claude-haiku-4-5")).toBe(false);
+    expect(showReasoningEffort(support, "opencode-go:ox-alpha-free")).toBe(false);
+    expect(showReasoningEffort(support, "openrouter:stealth/ox-alpha")).toBe(true);
+    expect(showReasoningEffort(support, "opencode-go:muse-spark-1.2-contributor")).toBe(false);
+  });
+});

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -3393,6 +3393,7 @@ export default function Conversation({
         dragOverIndex={dragOverIndex}
         queueItems={queueItems}
         swarmLiveJobs={swarmLiveJobs}
+        sessionId={activeSessionId || cachedSessionIdRef.current || ""}
         queueLoadError={queueLoadError}
         queueDragIndex={queueDragIndex}
         queueDragOverIndex={queueDragOverIndex}

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -104,6 +104,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     () => localStorage.getItem(SESSION_JOBS_COLLAPSED_KEY) === "1",
   );
   const [hiddenJobIds, setHiddenJobIds] = useState<Set<string>>(loadHiddenSessionJobs);
+  const [jobScope, setJobScope] = useState<JobScope>(() => loadJobScope());
   const [confirmClearJobs, setConfirmClearJobs] = useState(false);
   const [showAllJobs, setShowAllJobs] = useState(false);
   const [expandedJobs, setExpandedJobs] = useState<Record<string, boolean>>({});
@@ -1153,7 +1154,8 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     });
   };
 
-  const sortedJobs = jobs.slice().reverse();
+  const activeSessionId = sessions.find((session) => session.active)?.id || "";
+  const sortedJobs = filterJobsByScope(jobs.slice().reverse(), jobScope, activeSessionId);
   const visibleJobs = sortedJobs.filter(
     (j) => !hiddenJobIds.has(j.id) || !isTerminalJob(j),
   );
@@ -1853,7 +1855,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
             className="h-6 flex items-center gap-1 min-w-0 text-[11px] uppercase tracking-wider text-muted font-semibold hover:text-txt focus:outline-none"
           >
             {sessionJobsCollapsed ? <ChevronRight size={11} className="shrink-0" /> : <ChevronDown size={11} className="shrink-0" />}
-            <span className="truncate">Session Jobs</span>
+            <span className="truncate">Jobs</span>
             {jobsValidating && !sessionJobsCollapsed && (
               <Loader2 size={10} className="animate-spin text-muted shrink-0" />
             )}
@@ -1861,6 +1863,22 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
               <span className="text-faint/70 normal-case tracking-normal shrink-0">({visibleJobs.length})</span>
             )}
           </button>
+          {!sessionJobsCollapsed && (
+            <div className="flex h-5 overflow-hidden rounded border border-edge/70 shrink-0">
+              {(["session", "repo"] as const).map((scope) => (
+                <button
+                  key={scope}
+                  type="button"
+                  aria-pressed={jobScope === scope}
+                  aria-label={scope === "session" ? "This session" : "This repo, ever"}
+                  onClick={(e) => { e.stopPropagation(); setJobScope(scope); saveJobScope(scope); }}
+                  className={`px-1.5 text-[9px] uppercase tracking-wider ${jobScope === scope ? "bg-accent/15 text-txt" : "text-muted hover:text-txt"}`}
+                >
+                  {scope === "session" ? "Session" : "Repo"}
+                </button>
+              ))}
+            </div>
+          )}
           {!sessionJobsCollapsed && terminalVisibleJobs.length > 0 && (
             confirmClearJobs ? (
               <div className="flex items-center gap-2 text-[10px] shrink-0">
@@ -1899,7 +1917,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                   </div>
                 ) : (
                 <Empty>
-                  {hiddenJobCount > 0 ? "All session jobs cleared" : "No jobs yet"}
+                  {hiddenJobCount > 0 ? "All jobs in this view cleared" : "No jobs in this view"}
                 </Empty>
                 )}
                 {hiddenJobCount > 0 && (

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -17,6 +17,7 @@ import {
 import { writeTranscriptCache } from "./Conversation";
 import { sharedReadinessNotice } from "../lib/operationalDiagnostic";
 import { useOperationalDiagnostic } from "../lib/useOperationalDiagnostic";
+import { filterJobsByScope, loadJobScope, saveJobScope, type JobScope } from "../lib/jobScope";
 
 export {
   SESSION_LEASE_EXHAUSTED_MESSAGE,

--- a/webapp/src/components/PilotPicker.tsx
+++ b/webapp/src/components/PilotPicker.tsx
@@ -12,20 +12,6 @@ const REASONING_LEVELS: { value: ReasoningEffort; label: string }[] = [
   { value: "max", label: "Max" },
 ];
 
-const CODEX_REACHES = new Set(["openai-codex", "codex-plan", "chatgpt-codex"]);
-
-/** Effort picker: Codex always; Anthropic/Bedrock Claude opus|sonnet only. */
-function supportsReasoningEffort(driver: string): boolean {
-  const reach = (driver.split(":")[0] || "").toLowerCase();
-  const model = (driver.split(":")[1] || "").toLowerCase();
-  if (CODEX_REACHES.has(reach)) return true;
-  if (reach === "anthropic" || reach === "bedrock") {
-    if (model.includes("haiku")) return false;
-    return model.includes("opus") || model.includes("sonnet");
-  }
-  return false;
-}
-
 function labelForEffort(value: ReasoningEffort): string {
   return REASONING_LEVELS.find((l) => l.value === value)?.label || "Low";
 }
@@ -151,7 +137,7 @@ export default function PilotPicker({ config }: {
   if (!config) return null;
 
   const currentLabel = labelOf(current);
-  const showReasoning = supportsReasoningEffort(current);
+  const showReasoning = config?.reasoning_support?.[current] ?? true;
   const hasRows = !!organized.current || organized.groups.some((g) => g.items.length > 0);
 
   const renderRow = (m: string) => {

--- a/webapp/src/components/PilotPicker.tsx
+++ b/webapp/src/components/PilotPicker.tsx
@@ -2,19 +2,7 @@ import { useEffect, useMemo, useState, useRef } from "react";
 import { ChevronDown, Check, Search } from "lucide-react";
 import { api, type Config, type ReasoningEffort } from "../lib/api";
 import { fallbackPilot, modelLabelOf, organizePilotModels } from "../lib/pilotPickerModels";
-
-const REASONING_LEVELS: { value: ReasoningEffort; label: string }[] = [
-  { value: "none", label: "None" },
-  { value: "low", label: "Low" },
-  { value: "medium", label: "Medium" },
-  { value: "high", label: "High" },
-  { value: "xhigh", label: "Extra High" },
-  { value: "max", label: "Max" },
-];
-
-function labelForEffort(value: ReasoningEffort): string {
-  return REASONING_LEVELS.find((l) => l.value === value)?.label || "Low";
-}
+import { REASONING_LEVELS, labelForEffort, showReasoningEffort } from "../lib/reasoningSupport";
 
 export default function PilotPicker({ config }: {
   config: Config | null;
@@ -137,7 +125,7 @@ export default function PilotPicker({ config }: {
   if (!config) return null;
 
   const currentLabel = labelOf(current);
-  const showReasoning = config?.reasoning_support?.[current] ?? true;
+  const showReasoning = showReasoningEffort(config?.reasoning_support, current);
   const hasRows = !!organized.current || organized.groups.some((g) => g.items.length > 0);
 
   const renderRow = (m: string) => {

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -217,8 +217,8 @@ function saveDismissed(repo: string | undefined, ids: Set<string>): void {
 }
 
 // Outer job-card expand/collapse is view state, scoped per repo like dismiss.
-// Explicit true/false overrides the in_progress default on remount; missing keys
-// keep active jobs open and terminal jobs closed. Soft-capped per repo.
+// Missing keys stay closed (live and terminal). Explicit true/false is remembered
+// across remount. Soft-capped per repo.
 const EXPAND_KEY = "swarm.expanded.v1";
 const EXPAND_CAP = DISMISS_CAP;
 
@@ -1463,7 +1463,7 @@ export default function SwarmPane() {
     const st = jobStatus(j);
     const outcomeWarning = st === "completed" && j.outcome?.trustworthy === false;
     const manualExpanded = expandedJobs[j.id];
-    const isExpanded = manualExpanded !== undefined ? manualExpanded : (st === "in_progress");
+    const isExpanded = manualExpanded === true;
     const phase = jobPhase(j);
 
     const artifacts = jobArtifactList(j);

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -10,6 +10,7 @@ import {
   peekPendingSwarmOpenJob,
 } from "../lib/pendingSwarmOpenJob";
 import { useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
+import { filterJobsByScope, loadJobScope, saveJobScope, type JobScope } from "../lib/jobScope";
 
 // A clean, self-contained hover tooltip. The native `title=` tooltip renders as a
 // large unstyled OS box that covers the tracker and never wraps sensibly; this
@@ -1069,6 +1070,8 @@ export default function SwarmPane() {
   const [finishedOpen, setFinishedOpen] = useState(false);
   const [jobFilter, setJobFilter] = useState<JobFilter>("all");
   const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
+  const [jobScope, setJobScope] = useState<JobScope>(() => loadJobScope());
+  const [activeSessionId, setActiveSessionId] = useState("");
   // Job ids we have asked the backend to cancel. Held in local view state so the
   // row can show a subtle 'cancelling...' affordance immediately, before the next
   // poll reflects the terminal 'cancelled' status from /api/swarm/live.
@@ -1078,6 +1081,22 @@ export default function SwarmPane() {
   // Bumped every second so relative "last activity" times re-render while a job
   // runs, making a live worker visibly move rather than freeze between polls.
   const [nowTick, setNowTick] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!scopedRepo) {
+      setActiveSessionId("");
+      return;
+    }
+    let cancelled = false;
+    api.sessions(scopedRepo).then((rows) => {
+      if (cancelled) return;
+      const active = (rows || []).find((s) => s.active);
+      setActiveSessionId(active?.id || "");
+    }).catch(() => {
+      if (!cancelled) setActiveSessionId("");
+    });
+    return () => { cancelled = true; };
+  }, [scopedRepo]);
 
   const toggleTask = (id: string) => setExpandedTasks((p) => ({ ...p, [id]: !p[id] }));
   const toggleFinding = (id: string) => setExpandedFindings((p) => ({ ...p, [id]: !p[id] }));
@@ -1363,7 +1382,7 @@ export default function SwarmPane() {
     };
   }, [scopedRepo, applyLive]);
 
-  const allJobs = data?.jobs || [];
+  const allJobs = filterJobsByScope(data?.jobs || [], jobScope, activeSessionId);
   // Clear/dismiss is archive chrome for finished runs only. Live (and pending)
   // jobs must stay visible even if their id was previously dismissed — otherwise
   // a CLI-started swarm looks "gone" while workers are still running, and pilots
@@ -2092,6 +2111,20 @@ export default function SwarmPane() {
           <option value="newest">Newest first</option>
           <option value="oldest">Oldest first</option>
         </select>
+        <div className="col-span-2 flex h-6 overflow-hidden rounded border border-edge">
+          {(["session", "repo"] as const).map((scope) => (
+            <button
+              key={scope}
+              type="button"
+              aria-pressed={jobScope === scope}
+              aria-label={scope === "session" ? "This session" : "This repo, ever"}
+              onClick={() => { setJobScope(scope); saveJobScope(scope); }}
+              className={`flex-1 text-[10px] ${jobScope === scope ? "bg-accent/15 text-txt" : "bg-panel2/40 text-muted hover:text-txt"}`}
+            >
+              {scope === "session" ? "This session" : "This repo"}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Scrollable Jobs list. min-h-0 is load-bearing: without it a flex-1 item

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -29,6 +29,7 @@ import { api, type Config, type ContextUsageResponse, type Job } from "../../lib
 import PilotPicker from "../PilotPicker";
 import WorkspaceChip from "./WorkspaceChip";
 import ComposerStatusStack from "./ComposerStatusStack";
+import ComposerTasksPanel from "./ComposerTasksPanel";
 import { formatMentionListingCapMessage, type MentionListingCap } from "./slashCommands";
 import { filterSlashCommands } from "./composerInput";
 import {
@@ -68,6 +69,7 @@ export default function ComposerDock({
   dragOverIndex,
   queueItems,
   swarmLiveJobs = [],
+  sessionId = "",
   queueLoadError,
   queueDragIndex,
   queueDragOverIndex,
@@ -159,6 +161,7 @@ export default function ComposerDock({
   dragOverIndex: number | null;
   queueItems: ServerQueueItem[];
   swarmLiveJobs?: Job[];
+  sessionId?: string;
   queueLoadError?: string | null;
   queueDragIndex: number | null;
   queueDragOverIndex: number | null;
@@ -481,6 +484,7 @@ export default function ComposerDock({
             })}
           </div>
         )}
+        <ComposerTasksPanel jobs={swarmLiveJobs} sessionId={sessionId} />
         <ComposerStatusStack swarmJobs={swarmLiveJobs} />
         {/* Server-side PROMPT QUEUE, stacked ABOVE the composer (Cursor-style)
             so the "runs next" items are always visible right over the input.

--- a/webapp/src/components/conversation/ComposerTasksPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTasksPanel.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { CheckCircle2, ChevronDown, ChevronRight, Circle, Loader2, ListChecks, XCircle } from "lucide-react";
+import type { Job } from "../../lib/api";
+import { buildComposerTasks, pickTaskSourceJob, taskProgress, type ComposerTask } from "../../lib/composerTasks";
+
+function TaskIcon({ state }: { state: ComposerTask["state"] }) {
+  if (state === "completed") return <CheckCircle2 size={13} className="shrink-0 text-good" />;
+  if (state === "failed") return <XCircle size={13} className="shrink-0 text-risk" />;
+  if (state === "in_progress") return <Loader2 size={13} className="shrink-0 animate-spin text-accent" />;
+  return <Circle size={13} className="shrink-0 text-faint" />;
+}
+
+export default function ComposerTasksPanel({
+  jobs,
+  sessionId,
+}: {
+  jobs: readonly Job[];
+  sessionId: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const job = pickTaskSourceJob(jobs, sessionId);
+  const tasks = buildComposerTasks(job);
+  const { done, total } = taskProgress(tasks);
+  if (!total) return null;
+
+  return (
+    <div className="mx-2 mb-2 overflow-hidden rounded-2xl border border-edge/80 bg-panel2/80 shadow-lg shadow-black/15">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-txt/90 hover:bg-panel/40"
+      >
+        {open ? <ChevronDown size={13} className="text-faint" /> : <ChevronRight size={13} className="text-faint" />}
+        <ListChecks size={13} className="text-faint" />
+        <span className="font-medium">Tasks {done}/{total}</span>
+      </button>
+      {open && (
+        <div className="border-t border-edge/60 px-2.5 py-1.5 space-y-1">
+          {tasks.map((task) => (
+            <div key={task.id} className="flex items-start gap-2 py-0.5 text-[12px] leading-4">
+              <TaskIcon state={task.state} />
+              <span className={task.state === "pending" ? "text-faint" : "text-txt/90"}>{task.content}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -203,6 +203,8 @@ export type Job = {
   id: string;
   goal: string;
   status: string;
+  /** Harness chat that dispatched this job, when stamped. */
+  session_id?: string;
   role?: string;
   adapter?: string;
   /** "harness" (Marionette-dispatched) or "cli" (Cursor MCP / terminal PM). */

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -47,6 +47,8 @@ export type Config = {
   /** Any keyed harness provider, including Pilot-only cursor-cli. */
   pilot_ready?: boolean;
   reasoning_effort?: ReasoningEffort;
+  /** Per-model-spec reasoning-effort support map (keyed by "provider:model"). */
+  reasoning_support?: Record<string, boolean>;
 };
 export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max";
 export type Settings = {

--- a/webapp/src/lib/composerTasks.ts
+++ b/webapp/src/lib/composerTasks.ts
@@ -1,0 +1,51 @@
+import type { Job, Task } from "./api";
+import { jobInActiveSession } from "./jobScope";
+
+export type ComposerTaskState = "pending" | "in_progress" | "completed" | "failed";
+
+export type ComposerTask = {
+  id: string;
+  content: string;
+  state: ComposerTaskState;
+};
+
+export function taskState(status: unknown): ComposerTaskState {
+  const s = String(status || "").trim().toLowerCase();
+  if (s.includes("fail") || s.includes("error") || s.includes("dead")) return "failed";
+  if (s.includes("complete") || s.includes("done") || s === "ok" || s.includes("success")) return "completed";
+  if (s.includes("run") || s.includes("progress") || s.includes("active")) return "in_progress";
+  return "pending";
+}
+
+function jobRank(job: Job): number {
+  const st = taskState(job.status);
+  if (st === "in_progress") return 0;
+  if (st === "failed") return 1;
+  if (st === "completed") return 2;
+  return 3;
+}
+
+export function pickTaskSourceJob(jobs: readonly Job[], activeSessionId: string): Job | null {
+  const scoped = jobs.filter((job) => jobInActiveSession(job, activeSessionId) && (job.tasks || []).length);
+  if (!scoped.length) return null;
+  return [...scoped].sort((a, b) => {
+    const rank = jobRank(a) - jobRank(b);
+    if (rank !== 0) return rank;
+    return String(b.updated_at || b.created_at || "").localeCompare(String(a.updated_at || a.created_at || ""));
+  })[0];
+}
+
+export function buildComposerTasks(job: Job | null): ComposerTask[] {
+  return (job?.tasks || []).map((task: Task, i) => ({
+    id: String(task.id || `${job?.id || "job"}-${i}`),
+    content: String(task.instruction || task.role || task.id || "Task").trim(),
+    state: taskState(task.status),
+  }));
+}
+
+export function taskProgress(tasks: readonly ComposerTask[]): { done: number; total: number } {
+  return {
+    done: tasks.filter((t) => t.state === "completed").length,
+    total: tasks.length,
+  };
+}

--- a/webapp/src/lib/jobScope.ts
+++ b/webapp/src/lib/jobScope.ts
@@ -1,0 +1,46 @@
+/** Session vs repo-ever views over already-visible jobs. */
+
+export type JobScope = "session" | "repo";
+
+export type ScopedJob = {
+  session_id?: string | null;
+};
+
+export function jobSessionId(job: ScopedJob): string {
+  return String(job.session_id || "").trim();
+}
+
+export function jobInActiveSession(job: ScopedJob, activeSessionId: string): boolean {
+  const sid = jobSessionId(job);
+  const active = (activeSessionId || "").trim();
+  return Boolean(sid && active && sid === active);
+}
+
+export function filterJobsByScope<T extends ScopedJob>(
+  jobs: readonly T[],
+  scope: JobScope,
+  activeSessionId: string,
+): T[] {
+  if (scope !== "session") return [...jobs];
+  // No active chat yet: keep the repo list rather than going blank.
+  if (!(activeSessionId || "").trim()) return [...jobs];
+  return jobs.filter((job) => jobInActiveSession(job, activeSessionId));
+}
+
+export const JOB_SCOPE_KEY = "marionette.jobScope.v1";
+
+export function loadJobScope(): JobScope {
+  try {
+    return localStorage.getItem(JOB_SCOPE_KEY) === "repo" ? "repo" : "session";
+  } catch {
+    return "session";
+  }
+}
+
+export function saveJobScope(scope: JobScope): void {
+  try {
+    localStorage.setItem(JOB_SCOPE_KEY, scope);
+  } catch {
+    /* ignore */
+  }
+}

--- a/webapp/src/lib/reasoningSupport.ts
+++ b/webapp/src/lib/reasoningSupport.ts
@@ -1,0 +1,39 @@
+/** Reasoning-effort picker visibility and labels. */
+
+export type ReasoningEffortLevel = {
+  value: "none" | "low" | "medium" | "high" | "xhigh" | "max";
+  label: string;
+};
+
+/** Canonical ladder. Ultra is the label for wire value xhigh. */
+export const REASONING_LEVELS: ReasoningEffortLevel[] = [
+  { value: "none", label: "None" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "Ultra" },
+  { value: "max", label: "Max" },
+];
+
+export function labelForEffort(value: string): string {
+  return REASONING_LEVELS.find((l) => l.value === value)?.label || "Low";
+}
+
+/**
+ * Show the effort knob when:
+ * - the backend has not shipped a map yet (old payload / empty) -- fail open
+ * - the map has an explicit true for this spec
+ *
+ * A present map with a missing or false key hides the knob. That stops a
+ * catalogued false (haiku, Go with no dialect) from being overridden by
+ * `?? true` after a spec-key miss.
+ */
+export function showReasoningEffort(
+  support: Record<string, boolean> | null | undefined,
+  spec: string,
+): boolean {
+  if (support == null) return true;
+  const keys = Object.keys(support);
+  if (keys.length === 0) return true;
+  return support[spec] === true;
+}


### PR DESCRIPTION
## Summary
- Show the reasoning-effort picker from the backend support map (c2c2bc45).
- Label xhigh as Ultra. If the map is present, missing/false keys hide the knob instead of `?? true`.
- Version bump to v0.9.275. Puppetmaster pin stays 1.22.18.

## Test plan
- [x] vitest reasoningSupport + pilotPickerModels (19)
- [x] tsc clean
- [x] pytest version + provider_capabilities + reasoning_effort (41)
- [ ] CI tests matrix green
- [ ] Tag v0.9.275 after merge