### PR TITLE
Release v0.9.276

### DIFF
--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.275"
+__version__ = "0.9.276"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/swarm_cost.py
+++ b/harness/api/swarm_cost.py
@@ -10,6 +10,50 @@ from __future__ import annotations
 from .cost_accounting import CACHE_READ_MULTIPLIER
 from .cost import _diag, _server_attr
 
+def _by_model_rows_from_job_cost(job_cost) -> dict:
+    """Normalize JobCost.by_model plus live-priced unpriced tasks."""
+    rows: dict = {}
+    by_model = getattr(job_cost, "by_model", None) or {}
+    for mid, bucket in by_model.items():
+        info = bucket if isinstance(bucket, dict) else {}
+        try:
+            cost = float(info.get("marginal_cost_usd") or info.get("cost") or 0.0)
+        except (TypeError, ValueError):
+            cost = 0.0
+        try:
+            tokens_in = int(info.get("tokens_in") or 0)
+            tokens_out = int(info.get("tokens_out") or 0)
+            calls = int(info.get("calls") or 0)
+        except (TypeError, ValueError):
+            tokens_in, tokens_out, calls = 0, 0, 0
+        key = str(mid or "unknown")
+        rows[key] = {
+            "est_cost_usd": round(cost, 6),
+            "tokens_used": tokens_in + tokens_out,
+            "tokens_in": tokens_in,
+            "tokens_out": tokens_out,
+            "calls": calls,
+        }
+    for task in getattr(job_cost, "tasks", None) or []:
+        extra = _live_price_task(task)
+        if extra <= 0:
+            continue
+        key = str(getattr(task, "model_id", None) or "unknown")
+        row = rows.setdefault(
+            key,
+            {"est_cost_usd": 0.0, "tokens_used": 0, "tokens_in": 0, "tokens_out": 0, "calls": 0},
+        )
+        tin = int(getattr(task, "tokens_in", 0) or 0)
+        tout = int(getattr(task, "tokens_out", 0) or 0)
+        row["est_cost_usd"] = round(float(row["est_cost_usd"]) + extra, 6)
+        row["tokens_in"] += tin
+        row["tokens_out"] += tout
+        row["tokens_used"] += tin + tout
+        row["calls"] += 1
+    return rows
+
+
+
 def _swarm_registry() -> list:
     """Load the model registry for per-job actual-cost pricing. Best-effort."""
     try:
@@ -163,19 +207,23 @@ def _job_swarm_accounting_detail(raw_arts, registry: list) -> dict:
                 "est_cost_usd": 0.0,
                 "cost_provenance": "provider",
                 "estimated": False,
+                "by_model": {},
             }
         return {
             "tokens": 0,
             "est_cost_usd": round(real_total, 6),
             "cost_provenance": "provider",
             "estimated": False,
+            "by_model": {},
         }
 
     est_cost_usd = 0.0
     provenance = "default"
     estimated = True
+    by_model = {}
     try:
         job_cost = price_job(arts_for_usage, registry)
+        by_model = _by_model_rows_from_job_cost(job_cost)
         registry_cost = float(getattr(job_cost, "total_marginal_cost_usd", 0.0) or 0.0)
         live_topup = float(_live_price_unpriced_tasks(job_cost) or 0.0)
         usage_cost = registry_cost + live_topup
@@ -230,6 +278,16 @@ def _job_swarm_accounting_detail(raw_arts, registry: list) -> dict:
         forecast = float(_routing_estimate_cost(raw_arts) or 0.0)
     except Exception:
         forecast = 0.0
+    if not by_model and float(est_cost_usd or 0.0) > 0:
+        by_model = {
+            "unknown": {
+                "est_cost_usd": round(float(est_cost_usd or 0.0), 6),
+                "tokens_used": int(tokens or 0),
+                "tokens_in": 0,
+                "tokens_out": 0,
+                "calls": 1,
+            }
+        }
     return {
         "tokens": tokens,
         "est_cost_usd": round(float(est_cost_usd or 0.0), 6),
@@ -237,6 +295,7 @@ def _job_swarm_accounting_detail(raw_arts, registry: list) -> dict:
         "estimated": bool(estimated),
         "route_forecast_usd": round(forecast, 6),
         "spend_is_forecast": False,
+        "by_model": by_model,
     }
 
 

--- a/harness/api/usage.py
+++ b/harness/api/usage.py
@@ -44,6 +44,37 @@ class UsageServices:
 JsonPayload = Union[dict, list]
 
 
+
+def _merge_swarm_by_model(acc: dict, by_model) -> None:
+    if not isinstance(by_model, dict):
+        return
+    for mid, bucket in by_model.items():
+        info = bucket if isinstance(bucket, dict) else {}
+        key = str(mid or "unknown")
+        row = acc.setdefault(
+            key,
+            {"model": key, "est_cost_usd": 0.0, "tokens_used": 0, "calls": 0},
+        )
+        try:
+            row["est_cost_usd"] = round(float(row["est_cost_usd"]) + float(info.get("est_cost_usd") or 0.0), 6)
+        except (TypeError, ValueError):
+            pass
+        try:
+            row["tokens_used"] += int(info.get("tokens_used") or 0)
+            row["calls"] += int(info.get("calls") or 0)
+        except (TypeError, ValueError):
+            pass
+
+
+def _usage_swarm_by_model_payload(acc: dict) -> list:
+    rows = [
+        r for r in acc.values()
+        if float(r.get("est_cost_usd") or 0.0) > 0 or int(r.get("tokens_used") or 0) > 0
+    ]
+    rows.sort(key=lambda r: (-float(r["est_cost_usd"]), str(r["model"])))
+    return rows
+
+
 def _usage_pilot_by_model() -> list:
     """Best-effort per-model rows; never fail the usage pill."""
     try:
@@ -121,6 +152,7 @@ def get_usage(repo_override: str, svc: UsageServices) -> tuple[int, JsonPayload]
     # worker dollars stay at each worker's own model rate.
     est_session_cost = svc.boot_session_cost(price_in, price_out)
     jobs_list = []
+    swarm_by_model_acc: dict = {}
     session_total = None
     routing_saved_usd = 0.0
     delegation_saved_usd = 0.0
@@ -248,6 +280,7 @@ def get_usage(repo_override: str, svc: UsageServices) -> tuple[int, JsonPayload]
                 tokens, est_cost_usd = svc.job_swarm_accounting(raw_arts, registry)
                 provenance = "default"
                 job_estimated = True
+                detail = {}
                 try:
                     from .cost import _server_attr
                     from .swarm_cost import _job_swarm_accounting_detail
@@ -258,16 +291,19 @@ def get_usage(repo_override: str, svc: UsageServices) -> tuple[int, JsonPayload]
                     detail = detail_fn(raw_arts, registry)
                     # Only trust provenance when it agrees with the spend helper
                     # (detects monkeypatched stubs that return fixed dollars).
-                    if (
+                    detail_trusted = (
                         int(detail.get("tokens") or 0) == int(tokens or 0)
                         and abs(
                             float(detail.get("est_cost_usd") or 0.0)
                             - float(est_cost_usd or 0.0)
                         )
                         < 1e-9
-                    ):
+                    )
+                    if detail_trusted:
                         provenance = detail.get("cost_provenance") or "default"
                         job_estimated = bool(detail.get("estimated", True))
+                    else:
+                        detail = {}
                 except Exception:
                     pass
                 try:
@@ -288,6 +324,24 @@ def get_usage(repo_override: str, svc: UsageServices) -> tuple[int, JsonPayload]
                     "estimated": bool(job_estimated),
                     **svc.job_savings_fields(jid),
                 })
+                detail_models = {}
+                try:
+                    detail_models = detail.get("by_model") or {}
+                except Exception:
+                    detail_models = {}
+                if detail_models:
+                    _merge_swarm_by_model(swarm_by_model_acc, detail_models)
+                elif float(est_cost_usd or 0.0) > 0:
+                    _merge_swarm_by_model(
+                        swarm_by_model_acc,
+                        {
+                            "unknown": {
+                                "est_cost_usd": float(est_cost_usd or 0.0),
+                                "tokens_used": int(tokens or 0),
+                                "calls": 1,
+                            }
+                        },
+                    )
             except Exception as e:
                 svc.diag("server.usage_job_cost", e, msg=f"job={jid}")
         session_total = svc.active_session_total(session_jids, _job_arts, registry)
@@ -452,6 +506,8 @@ def get_usage(repo_override: str, svc: UsageServices) -> tuple[int, JsonPayload]
             # Locked cumulative spend per pilot that actually ran. Picker
             # swaps must not reprice these rows at the newly selected model.
             "pilot_by_model": _usage_pilot_by_model(),
+            "swarm_by_model": _usage_swarm_by_model_payload(swarm_by_model_acc),
+            "swarm_cost_usd": round(swarm_cost, 6),
             # Routing + delegation + swarm-cache savings over the boot-repo
             # epoch job set (additive to the pilot cache/compaction figures).
             "routing_saved_usd": round(routing_saved_usd, 6),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.275"
+version = "0.9.276"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_usage_peel.py
+++ b/tests/test_api_usage_peel.py
@@ -94,5 +94,6 @@ def test_get_usage_builds_session_pill(monkeypatch):
     assert payload["session"]["price_in"] == 1.0
     assert payload["session"]["tokens_used"] == 100
     assert isinstance(payload["session"].get("pilot_by_model"), list)
+    assert isinstance(payload["session"].get("swarm_by_model"), list)
     assert "jobs" in payload
     assert store  # cached

--- a/tests/test_job_swarm_accounting.py
+++ b/tests/test_job_swarm_accounting.py
@@ -425,3 +425,23 @@ def test_task_zero_work_does_not_keep_routing_estimate():
     assert by_task["t1"]["tokens"] == 0
     assert by_task["t1"]["est_cost_usd"] == 0.0
     assert by_task["t1"]["estimated"] is False
+
+
+def test_by_model_rows_from_job_cost_uses_marginal_usd():
+    from harness.api.swarm_cost import _by_model_rows_from_job_cost
+
+    job_cost = SimpleNamespace(
+        by_model={
+            "z-ai/glm-5.3": {
+                "calls": 30,
+                "tokens_in": 297924,
+                "tokens_out": 5570,
+                "marginal_cost_usd": 0.15814,
+            }
+        },
+        tasks=[],
+    )
+    rows = _by_model_rows_from_job_cost(job_cost)
+    assert rows["z-ai/glm-5.3"]["est_cost_usd"] == 0.15814
+    assert rows["z-ai/glm-5.3"]["calls"] == 30
+    assert rows["z-ai/glm-5.3"]["tokens_used"] == 297924 + 5570

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.275",
+  "version": "0.9.276",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.275",
+      "version": "0.9.276",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.275",
+  "version": "0.9.276",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CostBreakdown.test.tsx
+++ b/webapp/src/__tests__/CostBreakdown.test.tsx
@@ -101,6 +101,30 @@ describe("CostBreakdown", () => {
     expect(screen.getByText("~$0.52")).toBeInTheDocument();
   });
 
+  it("lists swarm models next to the locked pilot and separates list-price value", () => {
+    render(
+      <CostBreakdown
+        data={{
+          ...baseData,
+          est_cost_usd: 0.16,
+          cost_source: "mixed",
+          estimated: true,
+          pilot_by_model: [
+            { model: "openrouter:deepseek/deepseek-v4-flash-vision-exp", est_cost_usd: 0.01 },
+          ],
+          swarm_by_model: [
+            { model: "openrouter:z-ai/glm-5.3", est_cost_usd: 0.15, calls: 30 },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText("Spend (mixed)")).toBeInTheDocument();
+    expect(screen.getByText("deepseek-v4-flash-vision-exp")).toBeInTheDocument();
+    expect(screen.getByText("glm-5.3")).toBeInTheDocument();
+    expect(screen.getByText("swarm")).toBeInTheDocument();
+    expect(screen.getByText(/Not an OpenRouter invoice/i)).toBeInTheDocument();
+  });
+
   it("renders the session cost fields it is given", () => {
     render(<CostBreakdown data={baseData} />);
 
@@ -419,7 +443,7 @@ describe("CostBreakdown", () => {
     // 0.02 pilot gross + 0.05 swarm = ~$0.07
     expect(within(cacheRow!).getByText("~$0.07")).toBeInTheDocument();
     expect(screen.getByText("Tokens from cache")).toBeInTheDocument();
-    expect(screen.getByText(/model selection value vs frontier-equivalent list price/)).toBeInTheDocument();
+    expect(screen.getByText(/Not an OpenRouter invoice/i)).toBeInTheDocument();
   });
 
   it("omits zero or absent savings rows", () => {
@@ -441,7 +465,7 @@ describe("CostBreakdown", () => {
     expect(screen.queryByText("Swarm cache saved")).not.toBeInTheDocument();
     expect(screen.queryByText("Compact tool outputs saved")).not.toBeInTheDocument();
     expect(
-      screen.getByText(/Each task step is routed to the cheapest capable model/),
+      screen.getByText(/Cash is this app run/i),
     ).toBeInTheDocument();
   });
 

--- a/webapp/src/__tests__/composerTasks.test.ts
+++ b/webapp/src/__tests__/composerTasks.test.ts
@@ -42,4 +42,20 @@ describe("buildComposerTasks + progress", () => {
     expect(taskProgress(tasks)).toEqual({ done: 2, total: 5 });
     expect(tasks[2].state).toBe("in_progress");
   });
+
+  it("collapses a multi-line worker prompt onto one line", () => {
+    const tasks = buildComposerTasks(job("j", "running", "sess-1", [
+      {
+        id: "1",
+        role: "reviewer",
+        instruction: "Audit the Marionette harness\n\nPython backend under harness/.\nReact UI under webapp/src/.",
+        status: "running",
+        adapter: "x",
+      },
+    ]));
+    expect(tasks[0].content).toBe(
+      "reviewer · Audit the Marionette harness Python backend under harness/. React UI under webapp/src/.",
+    );
+    expect(tasks[0].content.includes("\n")).toBe(false);
+  });
 });

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -799,7 +799,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       {/* (b) List-price value -- not cash, not a refund. */}
       {(promptCacheSaved > 0 || modelSelectionSaved > 0 || showRoutingDecision || compactSavings > 0 || valueTotal > 0) ? (
       <div className="mt-2 pt-2 border-t border-edge/50">
-      <div className="text-[10px] uppercase tracking-wide text-faint mb-1">List-price value</div>
+      <div className="text-[10px] uppercase tracking-wide text-faint mb-1">Not billed</div>
       <p className="text-[10px] text-muted mb-1.5 leading-snug">
         Counterfactual vs catalog/frontier rates. Not an OpenRouter invoice and not a refund of the spend above.
       </p>

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -89,6 +89,13 @@ export type CostBreakdownData = {
     tokens_out?: number;
     tokens_cached?: number;
   }>;
+  swarm_by_model?: Array<{
+    model: string;
+    est_cost_usd: number;
+    tokens_used?: number;
+    calls?: number;
+  }>;
+  swarm_cost_usd?: number;
 };
 
 /** Map GET /api/usage session meters into the Economics panel body. */
@@ -150,6 +157,8 @@ export function usageToCostBreakdownData(
     price_in: session.price_in,
     price_out: session.price_out,
     pilot_by_model: session.pilot_by_model,
+    swarm_by_model: session.swarm_by_model,
+    swarm_cost_usd: session.swarm_cost_usd,
   };
 }
 
@@ -739,7 +748,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
         Process spend since launch. Resets on full quit — not Swarm pane repo-session spend, not conversation lifetime.
       </p>
 
-      {/* (a) App-run spend. Provider-billed when OpenRouter (etc.) returned usage.cost. */}
+      {/* (a) Cash this run. Provider-billed when OpenRouter returned usage.cost. */}
       {est > 0 ? (
         <div className="flex items-center justify-between mb-1">
           <span className="text-muted">{spendLabel}</span>
@@ -752,11 +761,14 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
             .filter((row) => typeof row?.est_cost_usd === "number" && isFinite(row.est_cost_usd) && row.est_cost_usd > 0)
             .map((row) => (
               <div
-                key={row.model}
+                key={`pilot:${row.model}`}
                 className="flex items-center justify-between mb-1 pl-2 text-faint"
-                title={`Locked to ${row.model} — swapping the pilot does not reprice this row.`}
+                title={`Pilot ${row.model} — swapping the picker does not reprice this row.`}
               >
-                <span className="truncate pr-2">{shortPilotModel(row.model)}</span>
+                <span className="min-w-0 truncate pr-2">
+                  <span className="mr-1.5 text-[9px] uppercase tracking-wide text-faint/80">pilot</span>
+                  {shortPilotModel(row.model)}
+                </span>
                 <span className="tabular-nums shrink-0">
                   {spendPrefix}{fmtCost(row.est_cost_usd)}
                 </span>
@@ -764,7 +776,33 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
             ))
         : null}
 
-      {/* (b) Prompt-cache value -- uncapped pilot gross + swarm store. */}
+      {Array.isArray(data.swarm_by_model)
+        ? data.swarm_by_model
+            .filter((row) => typeof row?.est_cost_usd === "number" && isFinite(row.est_cost_usd) && row.est_cost_usd > 0)
+            .map((row) => (
+              <div
+                key={`swarm:${row.model}`}
+                className="flex items-center justify-between mb-1 pl-2 text-faint"
+                title={`Swarm ${row.model}${row.calls ? ` · ${row.calls} task${row.calls === 1 ? "" : "s"}` : ""}`}
+              >
+                <span className="min-w-0 truncate pr-2">
+                  <span className="mr-1.5 text-[9px] uppercase tracking-wide text-faint/80">swarm</span>
+                  {shortPilotModel(row.model)}
+                </span>
+                <span className="tabular-nums shrink-0">
+                  {spendPrefix}{fmtCost(row.est_cost_usd)}
+                </span>
+              </div>
+            ))
+        : null}
+
+      {/* (b) List-price value -- not cash, not a refund. */}
+      {(promptCacheSaved > 0 || modelSelectionSaved > 0 || showRoutingDecision || compactSavings > 0 || valueTotal > 0) ? (
+      <div className="mt-2 pt-2 border-t border-edge/50">
+      <div className="text-[10px] uppercase tracking-wide text-faint mb-1">List-price value</div>
+      <p className="text-[10px] text-muted mb-1.5 leading-snug">
+        Counterfactual vs catalog/frontier rates. Not an OpenRouter invoice and not a refund of the spend above.
+      </p>
       {promptCacheSaved > 0 ? (
         <div
           className="flex items-center justify-between mb-1"
@@ -811,6 +849,27 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
         </div>
       ) : null}
 
+      {compactSavings > 0 ? (
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-muted">Compact tool outputs saved</span>
+          <span className="text-accent font-medium tabular-nums">~{fmtCost(compactSavings)}</span>
+        </div>
+      ) : null}
+
+      {valueTotal > 0 || valueBasis === "unknown" ? (
+        <div
+          className="mt-1.5 pt-1.5 border-t border-edge/50 flex items-center justify-between font-medium"
+          title="Prompt-cache value + model-selection value + compact-output value. Additive list-price value, not a cash refund or billed-spend subtraction. Label follows the weakest included evidence basis."
+        >
+          <span className="text-txt">{valueHeading}</span>
+          <span className="text-good tabular-nums">
+            {valueTotal > 0 ? `~${fmtCost(valueTotal)}` : (valueBasis === "unknown" ? "unknown basis" : "—")}
+          </span>
+        </div>
+      ) : null}
+      </div>
+      ) : null}
+
       {routingUnknown && typeof data.routing_saved_usd === "number" && data.routing_saved_usd > 0 ? (
         <div
           className="flex items-center justify-between mb-1 text-faint"
@@ -836,25 +895,6 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
             {pilotCached > 0 && swarmCached > 0
               ? ` (pilot ${fmtTokens(pilotCached)} · swarm ${fmtTokens(swarmCached)})`
               : ""}
-          </span>
-        </div>
-      ) : null}
-
-      {compactSavings > 0 ? (
-        <div className="flex items-center justify-between mb-1">
-          <span className="text-muted">Compact tool outputs saved</span>
-          <span className="text-accent font-medium tabular-nums">~{fmtCost(compactSavings)}</span>
-        </div>
-      ) : null}
-
-      {valueTotal > 0 || valueBasis === "unknown" ? (
-        <div
-          className="mt-1.5 pt-1.5 border-t border-edge/50 flex items-center justify-between font-medium"
-          title="Prompt-cache value + model-selection value + compact-output value. Additive list-price value, not a cash refund or billed-spend subtraction. Label follows the weakest included evidence basis."
-        >
-          <span className="text-txt">{valueHeading}</span>
-          <span className="text-good tabular-nums">
-            {valueTotal > 0 ? `~${fmtCost(valueTotal)}` : (valueBasis === "unknown" ? "unknown basis" : "—")}
           </span>
         </div>
       ) : null}
@@ -981,37 +1021,10 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       {/* (c) Additive value framing — routing list-price + cache + compact
           are separate mechanisms (not overlapping cash refunds). */}
       <div className="mt-2 pt-2 border-t border-edge/60 text-[10px] leading-snug text-muted/90">
-        {promptCacheSaved > 0 || compactSavings > 0 || modelSelectionSaved > 0 ? (
-          <span>
-            Routed per-step to the cheapest capable model
-            {modelSelectionSaved > 0 ? (
-              <>
-                , with{" "}
-                <span className="text-accent">~{fmtCost(modelSelectionSaved)}</span> model
-                selection value vs frontier-equivalent list price
-                {routingEstimated && delegationSaved <= 0 ? " (estimate)" : ""}
-              </>
-            ) : null}
-            {promptCacheSaved > 0 ? (
-              <>
-                , plus <span className="text-accent">~{fmtCost(promptCacheSaved)}</span>{" "}
-                prompt-cache value
-              </>
-            ) : null}
-            {compactSavings > 0 ? (
-              <>
-                , and <span className="text-accent">~{fmtCost(compactSavings)}</span>{" "}
-                avoided by compact tool outputs
-              </>
-            ) : null}
-            .
-          </span>
-        ) : (
-          <span>
-            Each task step is routed to the cheapest capable model instead of a
-            single frontier-equivalent list-price baseline.
-          </span>
-        )}
+        <span>
+          Cash is this app run. List-price value is what those same tokens would
+          have cost on a frontier-equivalent catalog rate, not money back.
+        </span>
       </div>
     </div>
   );

--- a/webapp/src/components/conversation/ComposerStatusStack.tsx
+++ b/webapp/src/components/conversation/ComposerStatusStack.tsx
@@ -11,12 +11,12 @@ import type { Job } from "../../lib/api";
 
 function statusIcon(row: ComposerStatusStackRow) {
   if (row.state === "running") {
-    return <Loader2 className="size-3.5 animate-spin text-muted-foreground/80" aria-hidden />;
+    return <Loader2 className="size-3 animate-spin text-muted-foreground/80" aria-hidden />;
   }
   if (row.state === "failed") {
-    return <XCircle className="size-3.5 text-rose-500/85" aria-hidden />;
+    return <XCircle className="size-3 text-rose-500/85" aria-hidden />;
   }
-  return <CheckCircle2 className="size-3.5 text-emerald-500/85" aria-hidden />;
+  return <CheckCircle2 className="size-3 text-emerald-500/85" aria-hidden />;
 }
 
 function rowKindLabel(kind: ComposerStatusStackRow["kind"]): string {
@@ -72,21 +72,21 @@ export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly
 
   return (
     <div
-      className="mx-2 mb-2 overflow-hidden rounded-2xl border border-edge/80 bg-panel2/80 shadow-lg shadow-black/15"
+      className="mx-2 mb-1 overflow-hidden rounded-lg border border-edge/70 bg-panel2/70"
       data-slot="composer-status-stack"
     >
-      <div className="divide-y divide-edge/60">
+      <div className="divide-y divide-edge/50">
         {grouped.map((group) => (
-          <div key={group.kind} className="px-2.5 py-2">
-            <div className="mb-1 flex items-center justify-between px-0.5">
-              <span className="text-[9px] font-semibold uppercase tracking-[0.22em] text-muted-foreground/70">
+          <div key={group.kind} className="px-2 py-1">
+            <div className="mb-0.5 flex items-center justify-between">
+              <span className="text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/65">
                 {groupLabel(group.kind)}
               </span>
-              <span className="text-[9px] font-mono text-muted-foreground/60">
+              <span className="text-[9px] font-mono text-muted-foreground/55">
                 {group.rows.length}
               </span>
             </div>
-            <div className="space-y-1">
+            <div className="space-y-0.5">
               {group.rows.map((row) => {
                 const onClick = () => {
                   if (row.kind === "swarm") {
@@ -105,17 +105,17 @@ export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly
                     type="button"
                     onClick={onClick}
                     title={row.title}
-                    className="flex w-full items-center gap-2 rounded-xl border border-edge/60 bg-panel/70 px-2.5 py-1.5 text-left text-[11px] leading-4 text-txt/90 transition hover:border-edge2 hover:bg-panel2/80 focus-visible:border-accent/60 focus-visible:outline-none"
+                    className="flex w-full items-center gap-1.5 rounded-md border border-edge/50 bg-panel/60 px-1.5 py-1 text-left text-[11px] leading-4 text-txt/85 transition hover:border-edge2 hover:bg-panel2/70 focus-visible:border-accent/60 focus-visible:outline-none"
                   >
-                    <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-edge/60 bg-panel text-[8px] font-semibold tracking-[0.18em] text-muted-foreground/70">
+                    <span className="flex size-4 shrink-0 items-center justify-center rounded-full border border-edge/50 bg-panel text-[7px] font-semibold tracking-[0.12em] text-muted-foreground/70">
                       {rowKindLabel(row.kind)}
                     </span>
                     <span className="min-w-0 flex-1 truncate">{row.label}</span>
-                    <span className="flex shrink-0 items-center gap-1 text-[9px] uppercase tracking-[0.18em] text-muted-foreground/70">
+                    <span className="flex shrink-0 items-center gap-1 text-[9px] uppercase tracking-[0.12em] text-muted-foreground/65">
                       {statusIcon(row)}
                       <span>{rowActionLabel(row)}</span>
                     </span>
-                    <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/50" aria-hidden />
+                    <ChevronRight className="size-3 shrink-0 text-muted-foreground/45" aria-hidden />
                   </button>
                 );
               })}

--- a/webapp/src/components/conversation/ComposerTasksPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTasksPanel.tsx
@@ -4,10 +4,10 @@ import type { Job } from "../../lib/api";
 import { buildComposerTasks, pickTaskSourceJob, taskProgress, type ComposerTask } from "../../lib/composerTasks";
 
 function TaskIcon({ state }: { state: ComposerTask["state"] }) {
-  if (state === "completed") return <CheckCircle2 size={13} className="shrink-0 text-good" />;
-  if (state === "failed") return <XCircle size={13} className="shrink-0 text-risk" />;
-  if (state === "in_progress") return <Loader2 size={13} className="shrink-0 animate-spin text-accent" />;
-  return <Circle size={13} className="shrink-0 text-faint" />;
+  if (state === "completed") return <CheckCircle2 size={12} className="shrink-0 text-good" />;
+  if (state === "failed") return <XCircle size={12} className="shrink-0 text-risk" />;
+  if (state === "in_progress") return <Loader2 size={12} className="shrink-0 animate-spin text-accent" />;
+  return <Circle size={12} className="shrink-0 text-faint" />;
 }
 
 export default function ComposerTasksPanel({
@@ -18,31 +18,43 @@ export default function ComposerTasksPanel({
   sessionId: string;
 }) {
   const [open, setOpen] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const job = pickTaskSourceJob(jobs, sessionId);
   const tasks = buildComposerTasks(job);
   const { done, total } = taskProgress(tasks);
   if (!total) return null;
 
   return (
-    <div className="mx-2 mb-2 overflow-hidden rounded-2xl border border-edge/80 bg-panel2/80 shadow-lg shadow-black/15">
+    <div className="mx-2 mb-1 overflow-hidden rounded-lg border border-edge/70 bg-panel2/70">
       <button
         type="button"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-txt/90 hover:bg-panel/40"
+        className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[11px] leading-4 text-txt/85 hover:bg-panel/35"
       >
-        {open ? <ChevronDown size={13} className="text-faint" /> : <ChevronRight size={13} className="text-faint" />}
-        <ListChecks size={13} className="text-faint" />
+        {open ? <ChevronDown size={11} className="text-faint" /> : <ChevronRight size={11} className="text-faint" />}
+        <ListChecks size={11} className="text-faint" />
         <span className="font-medium">Tasks {done}/{total}</span>
       </button>
       {open && (
-        <div className="border-t border-edge/60 px-2.5 py-1.5 space-y-1">
-          {tasks.map((task) => (
-            <div key={task.id} className="flex items-start gap-2 py-0.5 text-[12px] leading-4">
-              <TaskIcon state={task.state} />
-              <span className={task.state === "pending" ? "text-faint" : "text-txt/90"}>{task.content}</span>
-            </div>
-          ))}
+        <div className="border-t border-edge/50 px-2 py-1 space-y-0.5">
+          {tasks.map((task) => {
+            const expanded = expandedId === task.id;
+            return (
+              <button
+                key={task.id}
+                type="button"
+                title={task.content}
+                onClick={() => setExpandedId((id) => (id === task.id ? null : task.id))}
+                className="flex w-full items-start gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[11px] leading-4 hover:bg-panel/30"
+              >
+                <TaskIcon state={task.state} />
+                <span className={`${task.state === "pending" ? "text-faint" : "text-txt/85"} ${expanded ? "whitespace-pre-wrap break-words" : "min-w-0 truncate"}`}>
+                  {task.content}
+                </span>
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -695,6 +695,14 @@ export type UsageData = {
       tokens_out?: number;
       tokens_cached?: number;
     }>;
+    /** App-run swarm jobs, priced from store usage (not the locked pilot). */
+    swarm_by_model?: Array<{
+      model: string;
+      est_cost_usd: number;
+      tokens_used?: number;
+      calls?: number;
+    }>;
+    swarm_cost_usd?: number;
     tokens_cached?: number;
     /** Pilot prompt-input tokens (exclusive of worker-folded split). */
     pilot_input_tokens?: number;

--- a/webapp/src/lib/composerTasks.ts
+++ b/webapp/src/lib/composerTasks.ts
@@ -35,10 +35,19 @@ export function pickTaskSourceJob(jobs: readonly Job[], activeSessionId: string)
   })[0];
 }
 
+function oneLineLabel(task: Task): string {
+  const role = String(task.role || "").replace(/\s+/g, " ").trim();
+  const instruction = String(task.instruction || "").replace(/\s+/g, " ").trim();
+  if (role && instruction && !instruction.toLowerCase().startsWith(role.toLowerCase())) {
+    return `${role} · ${instruction}`;
+  }
+  return instruction || role || String(task.id || "Task");
+}
+
 export function buildComposerTasks(job: Job | null): ComposerTask[] {
   return (job?.tasks || []).map((task: Task, i) => ({
     id: String(task.id || `${job?.id || "job"}-${i}`),
-    content: String(task.instruction || task.role || task.id || "Task").trim(),
+    content: oneLineLabel(task),
     state: taskState(task.status),
   }));
 }


### PR DESCRIPTION
## Summary
- Compact composer Tasks N/M (one-line prompts, click for full text)
- Slimmer Puppetmaster / Open swarm status stack
- Spend bar: pilot + swarm model cash, list-price value called out as not an invoice

## Test plan
- [ ] Open a live swarm session and confirm Tasks header is small
- [ ] Expand Tasks: rows are one line; click a row to see the rest
- [ ] Economics: mixed spend lists pilot and swarm models
- [ ] List-price value section says it is not billed