### PR TITLE
release: v0.9.278 stream reliability

### DIFF
--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.277"
+__version__ = "0.9.278"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/sse.py
+++ b/harness/api/sse.py
@@ -16,6 +16,7 @@ import threading
 import time
 from collections import deque
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, Callable, Deque, Dict, Optional, Tuple, TypedDict, Union
 
 from harness.diag import note as _diag_note
@@ -522,6 +523,32 @@ def sse_pump(
                 ring.append("done", {})
             except Exception as exc:
                 _diag_note("sse_pump.ring_append_done", exc)
+    except Exception as exc:
+        # Headers already sent. A generator crash must still yield a terminal
+        # SSE the UI trusts (kind=error). Socket close is not a turn result.
+        _diag_note("sse_pump.gen", exc)
+        err_data = {
+            "error": str(exc) or type(exc).__name__,
+            "terminal_cause": "transport_error",
+        }
+        if ring is not None:
+            try:
+                ring.append("error", err_data)
+            except Exception as ring_exc:
+                _diag_note("sse_pump.ring_append_error", ring_exc)
+        if not detached:
+            err_ev = SimpleNamespace(kind="error", turn=0, data=err_data)
+            try:
+                sse_write(wfile, frame_for_event(err_ev))
+            except Exception as write_exc:
+                _diag_note("sse_pump.error_frame", write_exc)
+            if write_done:
+                sse_write(wfile, b"data: {\"kind\": \"done\"}\n\n")
+        if write_done and ring is not None:
+            try:
+                ring.append("done", {})
+            except Exception as ring_exc:
+                _diag_note("sse_pump.ring_append_done", ring_exc)
     finally:
         if ring is not None:
             ring.pinned = False

--- a/harness/api/streams.py
+++ b/harness/api/streams.py
@@ -14,6 +14,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
+from harness.diag import note as _diag_note
+
 from .sse import StreamEventDict, _sse_ring_begin, sse_pump, sse_write
 
 # Event kinds that mean a tool result / action completion has just been appended
@@ -21,7 +23,17 @@ from .sse import StreamEventDict, _sse_ring_begin, sse_pump, sse_write
 # crash right after an action never loses that appended chunk of the transcript.
 # Wave 4: action_result also covers background command pending receipts (job_id)
 # so launch identity survives a crash before the child process settles.
-CHECKPOINT_KINDS = frozenset({"action_result", "swarm_result"})
+CHECKPOINT_KINDS = frozenset({
+    "action_result",
+    "swarm_result",
+    # Terminal kinds: a crash in the 2s throttle window must not lose the
+    # final assistant text / error / interrupt receipt.
+    "assistant_done",
+    "error",
+    "interrupted",
+    "auto_halt",
+    "final",
+})
 
 
 def should_force_transcript_checkpoint(ev: Any) -> bool:
@@ -631,8 +643,8 @@ def stream_chat(
             _maybe_checkpoint(ev)
             try:
                 ring.append(ev.kind, ev.data or {}, getattr(ev, "turn", None))
-            except Exception:
-                pass
+            except Exception as exc:
+                _diag_note("stream_chat.ring_append", exc)
             if detached:
                 continue
             if not sse_write(handler.wfile, _encode_chat_sse_frame(ev)):
@@ -641,7 +653,7 @@ def stream_chat(
             sse_write(handler.wfile, b"data: {\"kind\": \"done\"}\n\n")
         try:
             ring.append("done", {})
-        except Exception:
-            pass
+        except Exception as exc:
+            _diag_note("stream_chat.ring_append_done", exc)
     finally:
         svc.finalize_turn(ctx)

--- a/harness/schedule_store.py
+++ b/harness/schedule_store.py
@@ -153,7 +153,9 @@ def default_db_path() -> Path:
     return new_default
 
 
-# Backward-compatible name; computed at call time via default_db_path().
+# Legacy import-time home path only. Production and tests must call
+# default_db_path() (HARNESS_STATE_DIR / pytest-temp / migrate). Do not open
+# this constant as the live DB — it ignores env and pytest isolation.
 DEFAULT_DB_PATH = Path(os.path.expanduser("~/.pmharness/state/schedules.sqlite"))
 
 # remove() outcomes (truthy when the schedule was found).

--- a/harness/scheduler.py
+++ b/harness/scheduler.py
@@ -682,8 +682,11 @@ class SchedulerDaemon:
         if sid:
             try:
                 self.store.request_cancel(sid)
-            except Exception:
-                pass
+            except Exception as exc:
+                print(
+                    f"scheduler stop: cancel {sid} failed: "
+                    f"{type(exc).__name__}: {exc}"
+                )
 
     def tick(self, now: Optional[datetime] = None) -> List[dict]:
         return run_due(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.277"
+version = "0.9.278"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_command_job_reattach.py
+++ b/tests/test_command_job_reattach.py
@@ -287,6 +287,10 @@ def test_should_force_transcript_checkpoint_for_command_jobs():
     assert should_force_transcript_checkpoint(start) is True
     delta = SimpleNamespace(kind="message_delta", data={"text": "hi"})
     assert should_force_transcript_checkpoint(delta) is False
+    for kind in ("assistant_done", "error", "interrupted", "auto_halt", "final"):
+        assert should_force_transcript_checkpoint(
+            SimpleNamespace(kind=kind, data={})
+        ) is True
 
 
 def test_live_recoverable_running_before_restart(session):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -384,6 +384,20 @@ def test_daemon_stop_cancels_and_interruptible_wait(tmp_path):
     assert time.time() - started < 2.0
 
 
+def test_daemon_stop_logs_cancel_failure(tmp_path, capsys):
+    class _BoomStore:
+        def request_cancel(self, schedule_id):
+            raise RuntimeError("cancel-unavailable")
+
+    daemon = SchedulerDaemon(_BoomStore())
+    daemon._active["schedule_id"] = "sched-boom"
+    daemon.stop()
+    assert daemon._stop is True
+    out = capsys.readouterr().out
+    assert "sched-boom" in out
+    assert "cancel-unavailable" in out
+
+
 def test_keyboard_interrupt_leaves_recoverable_state(tmp_path):
     store = _store(tmp_path)
     s = _add_due(store, tmp_path, "crash")

--- a/tests/test_sse_pump_terminal.py
+++ b/tests/test_sse_pump_terminal.py
@@ -1,0 +1,91 @@
+"""sse_pump must emit a terminal error frame when the turn generator raises."""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from harness.api.sse import SseEventRing, sse_pump, _sse_ring_clear_for_tests
+
+
+class _Wfile:
+    def __init__(self):
+        self.chunks = []
+
+    def write(self, payload):
+        self.chunks.append(payload)
+
+    def flush(self):
+        pass
+
+    def kinds(self):
+        out = []
+        for raw in self.chunks:
+            line = raw.decode()
+            if not line.startswith("data: "):
+                continue
+            payload = json.loads(line[6:].strip())
+            out.append(payload.get("kind"))
+        return out
+
+    def last_error(self):
+        for raw in reversed(self.chunks):
+            line = raw.decode()
+            if not line.startswith("data: "):
+                continue
+            payload = json.loads(line[6:].strip())
+            if payload.get("kind") == "error":
+                return payload
+        return None
+
+
+def _frame(ev):
+    frame = {"kind": ev.kind, "data": getattr(ev, "data", {}) or {}}
+    if getattr(ev, "turn", None) is not None:
+        frame["turn"] = ev.turn
+    return ("data: %s\n\n" % json.dumps(frame)).encode()
+
+
+def _boom_gen():
+    yield SimpleNamespace(kind="message_delta", data={"text": "partial"}, turn=0)
+    raise RuntimeError("mid-turn boom")
+
+
+def test_sse_pump_emits_error_and_done_when_generator_raises():
+    _sse_ring_clear_for_tests()
+    ring = SseEventRing("sess-boom", generation=1, cap=32, ttl=60.0)
+    wfile = _Wfile()
+    detached = sse_pump(wfile, _boom_gen(), _frame, ring=ring)
+    assert detached is False
+    assert wfile.kinds() == ["message_delta", "error", "done"]
+    err = wfile.last_error()
+    assert err["data"]["error"] == "mid-turn boom"
+    assert err["data"]["terminal_cause"] == "transport_error"
+    kinds = [e["kind"] for e in ring.since(0)["events"]]
+    assert kinds == ["message_delta", "error", "done"]
+    assert ring.since(0)["events"][1]["cursor"] == 2
+
+
+def test_sse_pump_write_done_false_still_emits_error_not_done():
+    """stream_chat owns framing done; pump still must emit error."""
+    _sse_ring_clear_for_tests()
+    ring = SseEventRing("sess-chat", generation=1, cap=32, ttl=60.0)
+    wfile = _Wfile()
+    sse_pump(wfile, _boom_gen(), _frame, write_done=False, ring=ring)
+    assert wfile.kinds() == ["message_delta", "error"]
+    kinds = [e["kind"] for e in ring.since(0)["events"]]
+    assert kinds == ["message_delta", "error"]
+    assert "done" not in kinds
+
+
+def test_sse_pump_clean_path_unchanged():
+    _sse_ring_clear_for_tests()
+    ring = SseEventRing("sess-ok", generation=1, cap=32, ttl=60.0)
+    wfile = _Wfile()
+
+    def _ok():
+        yield SimpleNamespace(kind="assistant_done", data={"turns": 1}, turn=0)
+
+    detached = sse_pump(wfile, _ok(), _frame, ring=ring)
+    assert detached is False
+    assert wfile.kinds() == ["assistant_done", "done"]
+    assert [e["kind"] for e in ring.since(0)["events"]] == ["assistant_done", "done"]

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.277",
+  "version": "0.9.278",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.277",
+      "version": "0.9.278",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.277",
+  "version": "0.9.278",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/turnTerminal.wave3.test.ts
+++ b/webapp/src/__tests__/turnTerminal.wave3.test.ts
@@ -479,6 +479,22 @@ describe("Wave 3 last-mile: one terminal explanation", () => {
     expect(chips[0]?.text).not.toMatch(/connection lost|closed before/i);
     expect(state.settle?.cause).toBe("length");
   });
+
+  it("error then framing done keeps the error settle (done is not success)", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({ kind: "message_delta", data: { text: "partial" } });
+    apply({
+      kind: "error",
+      data: { error: "mid-turn boom", terminal_cause: "transport_error" },
+    });
+    expect(state.status).toBe("error");
+    expect(state.turnSettledRef.current).toBe(true);
+    apply({ kind: "done" });
+    expect(state.status).toBe("error");
+    expect(state.settle?.lifecycle).toBe("error");
+    const chips = state.items.filter((it) => it.kind === "turn_terminal");
+    expect(chips).toHaveLength(1);
+  });
 });
 
 describe("Wave 3 last-mile: session switch isolates recovery", () => {


### PR DESCRIPTION
## Summary
- Validate the DeepSeek wave-2 reliability audit against live `origin/main` (v0.9.277 / `19e3c764`). Most cited line numbers and symbols had already drifted or never existed.
- Real: `sse_pump` now emits a terminal `kind=error` SSE (+ ring frame) when the turn generator raises, instead of dropping the socket. `stream_chat` ring append failures log via diag. Force transcript checkpoint on `assistant_done` / `error` / `interrupted` / `auto_halt` / `final`. Scheduler daemon `stop()` logs cancel failure instead of `except: pass`. Honest comment on `DEFAULT_DB_PATH` (import-time home path, not the resolver).
- Overstated / skipped: content-keyed assistant dedupe (`dedupeAssistantFinalContent`, `_record_assistant_final`, 0.25s chunk drop), uuid4 replay `event_id` (ring already uses stable cursors), WAL swallow / `_locked` double-apply, `settleFn` global / `flushInterruptDiscardEvents`, `StopRequested` double-send, fan-out of every bare `except`.

## Test plan
- [x] `pytest tests/test_sse_pump_terminal.py tests/test_command_job_reattach.py::test_should_force_transcript_checkpoint_for_command_jobs tests/test_scheduler.py::test_daemon_stop_logs_cancel_failure tests/test_sse_ring_buffer.py tests/test_sse_detach.py`
- [x] `vitest run src/__tests__/turnTerminal.wave3.test.ts`
- [x] `tsc -b` in webapp
- [ ] CI `tests` matrix green before merge/tag