### PR TITLE
release: v0.9.280 secret-request card and vault

### DIFF
--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.279"
+__version__ = "0.9.280"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/secrets.py
+++ b/harness/api/secrets.py
@@ -1,0 +1,120 @@
+"""Secret-request HTTP handlers. Values are never logged or listed."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Union
+
+from ..secret_vault import (
+    delete_secret,
+    normalize_agent_id,
+    normalize_connector,
+    normalize_field,
+    parse_secret_request_payload,
+    presence,
+    presence_payload,
+    put_secret,
+    validate_secret_ref,
+)
+
+JsonPayload = Union[dict, list]
+
+
+@dataclass
+class SecretServices:
+    get_runners: Callable[[], Any]
+
+
+def _agent_id(body: dict, svc: SecretServices | None = None) -> str:
+    session_id = str(body.get("session_id") or body.get("agent_id") or "").strip()
+    if session_id:
+        return normalize_agent_id(session_id)
+    if svc is not None:
+        runners = svc.get_runners()
+        if hasattr(runners, "values"):
+            for runner in runners.values():
+                sid = str(getattr(runner, "harness_session_id", "") or "").strip()
+                if sid:
+                    return normalize_agent_id(sid)
+    return "default"
+
+
+def _runner(svc: SecretServices, session_id: str):
+    return svc.get_runners().get(session_id)
+
+
+def _qs_get(qs: dict, key: str) -> str:
+    val = qs.get(key, "")
+    if isinstance(val, list):
+        return str(val[0] if val else "")
+    return str(val or "")
+
+
+def get_secrets_presence(qs: dict, svc: SecretServices) -> tuple[int, JsonPayload]:
+    """GET /api/secrets/presence — present|missing only."""
+    agent_id = normalize_agent_id(_qs_get(qs, "session_id") or _qs_get(qs, "agent_id"))
+    connector = normalize_connector(_qs_get(qs, "connector"))
+    field = normalize_field(_qs_get(qs, "field"))
+    return 200, presence(agent_id, connector, field)
+
+
+def post_secrets_submit(body: dict, svc: SecretServices) -> tuple[int, JsonPayload]:
+    """POST /api/secrets/submit — store value, resume presence only."""
+    session_id = str(body.get("session_id") or "").strip()
+    connector = normalize_connector(str(body.get("connector") or ""))
+    field = normalize_field(str(body.get("field") or ""))
+    value = str(body.get("value") or "")
+    err = validate_secret_ref(connector, field)
+    if err:
+        return 400, {"error": err}
+    if not value.strip():
+        return 400, {"error": "value is required"}
+    agent_id = _agent_id(body, svc)
+    try:
+        row = put_secret(agent_id, connector, field, value)
+    except ValueError as exc:
+        return 400, {"error": str(exc)}
+    # Drop the raw value immediately so later exception text cannot leak it.
+    body["value"] = ""
+    resume = False
+    if session_id:
+        runner = _runner(svc, session_id)
+        decide = getattr(runner, "decide_secret_request", None)
+        if callable(decide):
+            decide(connector=connector, field=field, provided=True)
+            resume = True
+    payload = presence_payload(connector, field, True)
+    payload.update({"ok": True, "state": row.get("state"), "resume": resume})
+    return 200, payload
+
+
+def post_secrets_dismiss(body: dict, svc: SecretServices) -> tuple[int, JsonPayload]:
+    """POST /api/secrets/dismiss — decline; do not re-ask in the same breath."""
+    session_id = str(body.get("session_id") or "").strip()
+    connector = normalize_connector(str(body.get("connector") or ""))
+    field = normalize_field(str(body.get("field") or ""))
+    err = validate_secret_ref(connector, field)
+    if err:
+        return 400, {"error": err}
+    if session_id:
+        runner = _runner(svc, session_id)
+        decide = getattr(runner, "decide_secret_request", None)
+        if callable(decide):
+            decide(connector=connector, field=field, provided=False)
+    payload = presence_payload(connector, field, False)
+    payload.update({"ok": True, "resume": False})
+    return 200, payload
+
+
+def post_secrets_emit_check(body: dict) -> tuple[int, JsonPayload]:
+    """Test helper / validation: parse a structured secret-request payload."""
+    parsed = parse_secret_request_payload(body)
+    if not parsed:
+        return 400, {"error": "invalid secret-request"}
+    return 200, {"ok": True, "secret": parsed}
+
+
+# Silence unused json import if a future handler needs dumps; keep for tests.
+_ = json
+_ = delete_secret

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -446,6 +446,7 @@ ConvEventKind = Literal[
     "codegraph_context",
     "command_blocked",
     "command_approval_pending",
+    "secret_request",
     "compacting",
     "compaction",
     "distilled",
@@ -909,6 +910,7 @@ class ConversationalSession(
 
         self._quality_gate = QualityGateRunner.from_config(config)
         self._pending_command_approvals = {}
+        self._pending_secret_requests = {}
         self._command_approval_lock = threading.Lock()
         self._approved_commands = set()  # command hashes the user one-click approved
         self._state = "idle"
@@ -1327,6 +1329,16 @@ class ConversationalSession(
                 status="approved" if approve else "rejected",
             )
             return dict(pending)
+
+    def register_pending_secret_request(self, payload: dict):
+        from .secret_request import register_pending_secret_request
+        return register_pending_secret_request(self, payload)
+
+    def decide_secret_request(self, *, connector: str, field: str, provided: bool):
+        from .secret_request import decide_secret_request
+        return decide_secret_request(
+            self, connector=connector, field=field, provided=provided,
+        )
 
     def consume_command_approval(self, command_hash: str) -> bool:
         """Consume one exact command-hash approval atomically."""

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -86,6 +86,7 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
     from .api import checkpoints as _ckpt_api
     from .api import codegraph as _cg_api
     from .api import command_approvals as _command_approval_api
+    from .api import secrets as _secrets_api
     from .api import commands as _cmd_api
     from .api import files as _files_api
     from .api import git as _git_api
@@ -138,6 +139,12 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             services=svc.command_approval_services),
         "/api/commands/reject": post_json(
             _command_approval_api.post_command_rejection,
+            services=svc.command_approval_services),
+        "/api/secrets/submit": post_json(
+            _secrets_api.post_secrets_submit,
+            services=svc.command_approval_services),
+        "/api/secrets/dismiss": post_json(
+            _secrets_api.post_secrets_dismiss,
             services=svc.command_approval_services),
         "/api/inline-edit": post_json(
             _rev_api.post_inline_edit, services=svc.review_services),
@@ -404,6 +411,7 @@ def _post_restart(handler: Any, body: dict) -> Any:
 
 def build_get_routes(svc: Any) -> dict[str, GetHandler]:
     """Build path → GET handler map. Auth is applied once in ``do_GET``."""
+    from .api import secrets as _secrets_api
     from .api import auth as _auth_api
     from .api import checkpoints as _ckpt_api
     from .api import codegraph as _cg_api
@@ -685,6 +693,9 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
             empty_as_none=True),
         "/api/swarm/live": _get_swarm_live,
         "/api/providers": get_json(_prov_api.get_providers),
+        "/api/secrets/presence": get_json(
+            _secrets_api.get_secrets_presence,
+            services=svc.command_approval_services, pass_qs=True),
         "/api/registry": _get_registry,
         "/api/roles": get_json(
             _reg_api.get_roles, services=svc.registry_services),

--- a/harness/pilot.py
+++ b/harness/pilot.py
@@ -87,6 +87,7 @@ ActionKind = Literal[
     "browser_back",
     "browser_get_text",
     "browser_screenshot",
+    "request_secret",
 ]
 
 VALID_ACTION_KINDS: frozenset[str] = frozenset(get_args(ActionKind))
@@ -367,6 +368,13 @@ class PilotAction:
                     raise PilotError(
                         "manage_mcp add requires url (HTTP/Docker) or command (stdio)"
                     )
+        if self.kind == "request_secret":
+            args = self.arguments if isinstance(self.arguments, dict) else {}
+            label = str(args.get("label") or self.goal or "").strip()
+            connector = str(args.get("connector") or "").strip()
+            field = str(args.get("field") or "").strip()
+            if not label or not connector or not field:
+                raise PilotError("request_secret requires label, connector, and field")
         if self.kind in ("read_file", "write_file", "view_image", "open_project") and not (self.path or "").strip():
             raise PilotError(f"{self.kind} action requires a 'path'")
         if self.kind == "relocate_session":
@@ -1154,6 +1162,30 @@ def build_tools_schema(
                         "description": "Optional job id to watch; omit to watch all pending jobs.",
                     },
                 },
+            },
+        },
+    })
+
+    schema.append({
+        "type": "function",
+        "function": {
+            "name": "request_secret",
+            "description": (
+                "Ask the host to collect a token/key/password via a masked "
+                "secret-request card. Use this whenever a task needs a secret. "
+                "Never ask the user to paste a token into chat. Emitting this "
+                "card ends the turn; the host resumes with presence only "
+                "({provided, connector, field}), never the secret bytes."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "label": {"type": "string", "description": "Card title and input placeholder"},
+                    "connector": {"type": "string", "description": "Storage namespace (pypi, portable-llm-wiki, slack)"},
+                    "field": {"type": "string", "description": "Key name (token, WIKI_OWNER_TOKEN)"},
+                    "description": {"type": "string", "description": "One-line help under the title"},
+                },
+                "required": ["label", "connector", "field"],
             },
         },
     })
@@ -2564,6 +2596,9 @@ Only fall back to giving manual instructions when a command genuinely cannot run
 from this workspace (e.g. it requires credentials or a network path you have
 verified you do not have) -- and say specifically what you tried and why it
 failed before doing so. When in doubt, run it and find out.
+If a task needs a token, API key, or password, call `request_secret` and stop.
+Never write "paste the token here". The host shows a masked card; you are
+resumed with {provided, connector, field} only.
 
 You have search_codegraph (semantic/graph search over THIS repo's code -- prefer it over grep/read_file for 'where is X / what calls Y / how does Z work') and query_wiki (durable cross-session knowledge base -- consult it for prior decisions, architecture, and context). Use search_codegraph to explore code structure before reading whole files. These are first-class: you know the codebase via CodeGraph and your durable memory via the Wiki.
 

--- a/harness/secret_request.py
+++ b/harness/secret_request.py
@@ -1,0 +1,113 @@
+"""Session-side secret-request cards. Display never stores the secret."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from .secret_vault import (
+    get_secret,
+    parse_secret_request_payload,
+    presence,
+    presence_payload,
+)
+
+
+def secret_ref_key(connector: str, field: str) -> str:
+    return f"{connector}::{field}"
+
+
+def display_secret_request_row(pending: dict, *, status: str) -> dict:
+    return {
+        "type": "secret_request",
+        "id": pending.get("id") or secret_ref_key(pending.get("connector") or "", pending.get("field") or ""),
+        "label": pending.get("label") or "",
+        "connector": pending.get("connector") or "",
+        "field": pending.get("field") or "",
+        "description": pending.get("description") or "",
+        "status": status,
+    }
+
+
+def upsert_display_secret_request(session: Any, pending: dict, *, status: str) -> None:
+    row = display_secret_request_row(pending, status=status)
+    display = getattr(session, "_display_transcript", None)
+    if display is None:
+        session._display_transcript = [row]
+        return
+    key = secret_ref_key(row["connector"], row["field"])
+    for i, existing in enumerate(display):
+        if (
+            isinstance(existing, dict)
+            and existing.get("type") == "secret_request"
+            and secret_ref_key(existing.get("connector") or "", existing.get("field") or "") == key
+        ):
+            display[i] = row
+            return
+    display.append(row)
+
+
+def register_pending_secret_request(session: Any, payload: dict) -> Optional[dict]:
+    parsed = parse_secret_request_payload(payload) or payload
+    label = str(parsed.get("label") or "").strip()
+    connector = str(parsed.get("connector") or "").strip()
+    field = str(parsed.get("field") or "").strip()
+    description = str(parsed.get("description") or "").strip()
+    if not (label and connector and field):
+        return None
+    agent_id = str(getattr(session, "harness_session_id", "") or "").strip() or "default"
+    pending = {
+        "id": secret_ref_key(connector, field),
+        "label": label,
+        "connector": connector,
+        "field": field,
+        "description": description,
+        "session_id": agent_id,
+    }
+    if getattr(session, "_pending_secret_requests", None) is None:
+        session._pending_secret_requests = {}
+    session._pending_secret_requests[secret_ref_key(connector, field)] = pending
+    upsert_display_secret_request(session, pending, status="pending")
+    return pending
+
+
+def decide_secret_request(
+    session: Any,
+    *,
+    connector: str,
+    field: str,
+    provided: bool,
+) -> Optional[dict]:
+    key = secret_ref_key(connector, field)
+    pending_map = getattr(session, "_pending_secret_requests", None) or {}
+    pending = pending_map.get(key)
+    if pending is None:
+        pending = {
+            "id": key,
+            "label": field,
+            "connector": connector,
+            "field": field,
+            "description": "",
+            "session_id": getattr(session, "harness_session_id", "") or "default",
+        }
+    pending_map.pop(key, None)
+    session._pending_secret_requests = pending_map
+    upsert_display_secret_request(
+        session, pending, status="saved" if provided else "declined",
+    )
+    payload = presence_payload(connector, field, provided)
+    history = getattr(session, "_history", None)
+    if isinstance(history, list):
+        history.append({
+            "role": "user",
+            "content": json.dumps(payload, separators=(",", ":")),
+            "secret_request_resume": True,
+        })
+    return pending
+
+
+def already_present(session: Any, connector: str, field: str) -> bool:
+    agent_id = str(getattr(session, "harness_session_id", "") or "").strip() or "default"
+    if presence(agent_id, connector, field).get("present"):
+        return True
+    return bool(get_secret(agent_id, connector, field))

--- a/harness/secret_request.py
+++ b/harness/secret_request.py
@@ -92,6 +92,12 @@ def decide_secret_request(
         }
     pending_map.pop(key, None)
     session._pending_secret_requests = pending_map
+    if not provided:
+        declined = getattr(session, "_declined_secret_requests", None)
+        if declined is None:
+            declined = set()
+            session._declined_secret_requests = declined
+        declined.add(key)
     upsert_display_secret_request(
         session, pending, status="saved" if provided else "declined",
     )
@@ -104,6 +110,11 @@ def decide_secret_request(
             "secret_request_resume": True,
         })
     return pending
+
+
+def declined_this_breath(session: Any, connector: str, field: str) -> bool:
+    declined = getattr(session, "_declined_secret_requests", None) or set()
+    return secret_ref_key(connector, field) in declined
 
 
 def already_present(session: Any, connector: str, field: str) -> bool:

--- a/harness/secret_vault.py
+++ b/harness/secret_vault.py
@@ -1,0 +1,365 @@
+"""Host-held connector secrets. Values never return to the model or renderer.
+
+Storage is per-profile (HARNESS_STATE_DIR / ~/.pmharness), encrypted at rest
+with a machine-local key file (owner-only). Presence is present|missing.
+Subprocess injection happens in this process (or Electron main) via env.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import tempfile
+import threading
+from typing import Any, Optional
+
+from .secure_files import restrict_to_owner
+
+_LOCK = threading.Lock()
+_CONNECTOR_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+_FIELD_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]{0,63}$")
+
+_ENV_BINDINGS: dict[tuple[str, str], list[tuple[str, Optional[str]]]] = {
+    ("pypi", "token"): [
+        ("TWINE_USERNAME", "__token__"),
+        ("TWINE_PASSWORD", None),
+        ("PYPI_TOKEN", None),
+    ],
+    ("portable-llm-wiki", "WIKI_OWNER_TOKEN"): [
+        ("WIKI_OWNER_TOKEN", None),
+    ],
+    ("slack", "token"): [
+        ("SLACK_BOT_TOKEN", None),
+        ("SLACK_TOKEN", None),
+    ],
+}
+
+_SECRET_ENV_NAMES = frozenset(
+    name
+    for pairs in _ENV_BINDINGS.values()
+    for name, _lit in pairs
+    if _lit is None
+)
+
+
+def _state_dir() -> str:
+    explicit = (os.environ.get("HARNESS_STATE_DIR") or "").strip()
+    if explicit:
+        return os.path.abspath(explicit)
+    return os.path.abspath(os.path.expanduser("~/.pmharness"))
+
+
+def vault_path() -> str:
+    return os.path.join(_state_dir(), "secret-vault.json")
+
+
+def _key_path() -> str:
+    return os.path.join(_state_dir(), "secret-vault.key")
+
+
+def _load_key() -> bytes:
+    path = _key_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if os.path.exists(path):
+        with open(path, "rb") as fh:
+            data = fh.read()
+        if len(data) >= 32:
+            return data[:32]
+    key = secrets.token_bytes(32)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), prefix="svk_")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(key)
+        os.replace(tmp, path)
+        restrict_to_owner(path)
+    except Exception:
+        if os.path.exists(tmp):
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+        raise
+    return key
+
+
+def _crypt(data: bytes, key: bytes, nonce: bytes) -> bytes:
+    out = bytearray(len(data))
+    block = b""
+    for i, byte in enumerate(data):
+        if i % 32 == 0:
+            block = hashlib.sha256(key + nonce + i.to_bytes(8, "big")).digest()
+        out[i] = byte ^ block[i % 32]
+    return bytes(out)
+
+
+def _seal(plain: str) -> dict[str, str]:
+    key = _load_key()
+    nonce = secrets.token_bytes(16)
+    raw = _crypt(plain.encode("utf-8"), key, nonce)
+    return {"n": nonce.hex(), "c": raw.hex()}
+
+
+def _unseal(blob: Any) -> str:
+    if not isinstance(blob, dict):
+        return ""
+    try:
+        nonce = bytes.fromhex(blob.get("n") or "")
+        raw = bytes.fromhex(blob.get("c") or "")
+    except ValueError:
+        return ""
+    try:
+        return _crypt(raw, _load_key(), nonce).decode("utf-8")
+    except Exception:
+        return ""
+
+
+def normalize_connector(value: str) -> str:
+    return (value or "").strip().lower()
+
+
+def normalize_field(value: str) -> str:
+    return (value or "").strip()
+
+
+def normalize_agent_id(value: str) -> str:
+    text = (value or "").strip()
+    return text or "default"
+
+
+def validate_secret_ref(connector: str, field: str) -> Optional[str]:
+    if not _CONNECTOR_RE.fullmatch(connector):
+        return "connector must be a short lowercase id"
+    if not _FIELD_RE.fullmatch(field):
+        return "field must be a token/key name"
+    return None
+
+
+def _empty_store() -> dict:
+    return {"v": 1, "agents": {}}
+
+
+def _read_store() -> dict:
+    path = vault_path()
+    if not os.path.exists(path):
+        return _empty_store()
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict) and isinstance(data.get("agents"), dict):
+            return data
+    except Exception:
+        pass
+    return _empty_store()
+
+
+def _write_store(store: dict) -> None:
+    path = vault_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), prefix="sv_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as fh:
+            json.dump(store, fh, indent=2)
+        os.replace(tmp, path)
+        restrict_to_owner(path)
+    except Exception:
+        if os.path.exists(tmp):
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+        raise
+
+
+def put_secret(agent_id: str, connector: str, field: str, value: str) -> dict[str, Any]:
+    agent_id = normalize_agent_id(agent_id)
+    connector = normalize_connector(connector)
+    field = normalize_field(field)
+    err = validate_secret_ref(connector, field)
+    if err:
+        raise ValueError(err)
+    secret = (value or "").strip()
+    if not secret:
+        raise ValueError("secret value is required")
+    with _LOCK:
+        store = _read_store()
+        agents = store.setdefault("agents", {})
+        by_agent = agents.setdefault(agent_id, {})
+        by_conn = by_agent.setdefault(connector, {})
+        by_conn[field] = _seal(secret)
+        _write_store(store)
+    apply_to_environ(agent_id)
+    return presence(agent_id, connector, field)
+
+
+def delete_secret(agent_id: str, connector: str, field: str) -> dict[str, Any]:
+    agent_id = normalize_agent_id(agent_id)
+    connector = normalize_connector(connector)
+    field = normalize_field(field)
+    with _LOCK:
+        store = _read_store()
+        by_agent = store.get("agents", {}).get(agent_id) or {}
+        by_conn = by_agent.get(connector) or {}
+        by_conn.pop(field, None)
+        if isinstance(by_agent.get(connector), dict) and not by_conn:
+            by_agent.pop(connector, None)
+        if not by_agent:
+            store.get("agents", {}).pop(agent_id, None)
+        _write_store(store)
+    return presence(agent_id, connector, field)
+
+
+def get_secret(agent_id: str, connector: str, field: str) -> str:
+    agent_id = normalize_agent_id(agent_id)
+    connector = normalize_connector(connector)
+    field = normalize_field(field)
+    with _LOCK:
+        store = _read_store()
+        blob = (
+            ((store.get("agents") or {}).get(agent_id) or {})
+            .get(connector) or {}
+        ).get(field)
+    return _unseal(blob) if blob else ""
+
+
+def presence(agent_id: str, connector: str = "", field: str = "") -> dict[str, Any]:
+    agent_id = normalize_agent_id(agent_id)
+    connector = normalize_connector(connector)
+    field = normalize_field(field)
+    with _LOCK:
+        store = _read_store()
+        by_agent = (store.get("agents") or {}).get(agent_id) or {}
+    if connector and field:
+        present = bool(((by_agent.get(connector) or {}).get(field)))
+        return {
+            "agent_id": agent_id,
+            "connector": connector,
+            "field": field,
+            "state": "present" if present else "missing",
+            "present": present,
+        }
+    connectors: dict[str, dict[str, str]] = {}
+    for conn, fields in by_agent.items():
+        if not isinstance(fields, dict):
+            continue
+        if connector and conn != connector:
+            continue
+        row = {name: "present" for name in fields}
+        if row:
+            connectors[conn] = row
+    return {"agent_id": agent_id, "connectors": connectors}
+
+
+def env_bindings(connector: str, field: str, value: str) -> dict[str, str]:
+    connector = normalize_connector(connector)
+    field = normalize_field(field)
+    out: dict[str, str] = {}
+    for name, lit in _ENV_BINDINGS.get((connector, field), []):
+        out[name] = value if lit is None else lit
+    generic = f"{connector.upper().replace('-', '_')}_{field.upper()}"
+    out.setdefault(generic, value)
+    return out
+
+
+def apply_to_environ(agent_id: str, environ: Optional[dict] = None) -> dict[str, str]:
+    target = environ if environ is not None else os.environ
+    agent_id = normalize_agent_id(agent_id)
+    injected: dict[str, str] = {}
+    with _LOCK:
+        store = _read_store()
+        by_agent = (store.get("agents") or {}).get(agent_id) or {}
+        items = []
+        for conn, fields in by_agent.items():
+            if not isinstance(fields, dict):
+                continue
+            for name, blob in fields.items():
+                items.append((conn, name, blob))
+    for conn, name, blob in items:
+        value = _unseal(blob)
+        if not value:
+            continue
+        for env_name, env_val in env_bindings(conn, name, value).items():
+            target[env_name] = env_val
+            injected[env_name] = env_val
+    return injected
+
+
+def subprocess_env(agent_id: str, base: Optional[dict] = None) -> dict[str, str]:
+    env = dict(base if base is not None else os.environ)
+    apply_to_environ(agent_id, env)
+    return env
+
+
+def presence_payload(connector: str, field: str, provided: bool) -> dict[str, Any]:
+    return {
+        "provided": bool(provided),
+        "connector": normalize_connector(connector),
+        "field": normalize_field(field),
+    }
+
+
+def redact_secret_text(text: str, extra_values: Optional[list[str]] = None) -> str:
+    if not text:
+        return text
+    out = text
+    names = "|".join(sorted(_SECRET_ENV_NAMES | {
+        "TWINE_PASSWORD", "PYPI_TOKEN", "WIKI_OWNER_TOKEN", "SLACK_BOT_TOKEN", "SLACK_TOKEN",
+    }))
+    out = re.sub(
+        rf"(?i)\b(?:{names})\s*[=:]\s*\S+",
+        lambda m: m.group(0).split("=")[0].split(":")[0] + "=REDACTED",
+        out,
+    )
+    for raw in extra_values or []:
+        val = (raw or "").strip()
+        if len(val) >= 8:
+            out = out.replace(val, "REDACTED")
+    return out
+
+
+def parse_secret_request_payload(raw: Any) -> Optional[dict[str, str]]:
+    if not isinstance(raw, dict):
+        return None
+    body = raw.get("secret") if raw.get("type") in ("secret-request", "secret_request") else raw
+    if not isinstance(body, dict):
+        body = raw
+    label = str(body.get("label") or "").strip()
+    connector = normalize_connector(str(body.get("connector") or ""))
+    field = normalize_field(str(body.get("field") or ""))
+    description = str(body.get("description") or "").strip()
+    if not label or not connector or not field:
+        return None
+    if validate_secret_ref(connector, field):
+        return None
+    return {
+        "label": label,
+        "connector": connector,
+        "field": field,
+        "description": description,
+    }
+
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+def extract_secret_request_message(text: str) -> tuple[str, Optional[dict[str, str]]]:
+    if not text or "secret" not in text:
+        return text, None
+    candidates = []
+    for match in _JSON_FENCE_RE.finditer(text):
+        candidates.append(match.group(1))
+    stripped = text.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        candidates.append(stripped)
+    for blob in candidates:
+        try:
+            raw = json.loads(blob)
+        except Exception:
+            continue
+        parsed = parse_secret_request_payload(raw)
+        if parsed:
+            cleaned = text.replace(blob, "").replace("```json", "").replace("```", "")
+            cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+            return cleaned, parsed
+    return text, None

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -71,6 +71,7 @@ from .terminal_cause import (
     TERMINAL_DRIVER_SWAP,
     TERMINAL_EMPTY_LOOP,
     TERMINAL_INVALID_TOOL,
+    TERMINAL_NATURAL,
     TERMINAL_TURN_BUDGET,
     finalize_stop_cause,
 )
@@ -1323,6 +1324,10 @@ class SendLoopMixin:
             # message so the turn gets a finished summary bubble.
 
             cleaned_say_text = clean_say(turn.say) if turn.say else ""
+            _extracted_secret = None
+            if cleaned_say_text:
+                from .secret_vault import extract_secret_request_message
+                cleaned_say_text, _extracted_secret = extract_secret_request_message(cleaned_say_text)
             _resp_meta = getattr(resp, "meta", None) or {}
             if not isinstance(_resp_meta, dict):
                 _resp_meta = {}
@@ -1380,6 +1385,26 @@ class SendLoopMixin:
             else:
                 self._history.append({"role": "assistant", "content": _history_text or "(acting)"})
 
+            if _extracted_secret:
+                from .secret_request import already_present, register_pending_secret_request
+                if not any(getattr(a, "kind", "") == "request_secret" for a in turn.actions):
+                    if not already_present(self, _extracted_secret["connector"], _extracted_secret["field"]):
+                        pending = register_pending_secret_request(self, _extracted_secret)
+                        yield ConvEvent("secret_request", {
+                            **(pending or _extracted_secret),
+                            "session_id": getattr(self, "harness_session_id", "") or "default",
+                            "ends_turn": True,
+                        })
+                        self._sanitize_tool_pairs()
+                        yield from finalize_assistant_turn(
+                            self, user_message=user_message, step=step,
+                            swarms=swarms, turn_prose=turn_prose,
+                            turn_findings=turn_findings,
+                            extra={"secret_request": True},
+                            stop_cause=TERMINAL_NATURAL,
+                            **classified_finish_kwargs(last_classified),
+                        )
+                        return
             if self._turn_budget_exhausted() and not (
                 synchronous_swarms
                 and not step_emitted_user_prose
@@ -1535,6 +1560,17 @@ class SendLoopMixin:
             swarms = _action_counters["swarms"]
             demo_swarms = _action_counters["demo_swarms"]
             synchronous_swarms = _action_counters["synchronous_swarms"]
+            if _action_disposition == "secret_request":
+                self._sanitize_tool_pairs()
+                yield from finalize_assistant_turn(
+                    self, user_message=user_message, step=step,
+                    swarms=swarms, turn_prose=turn_prose,
+                    turn_findings=turn_findings,
+                    extra={"secret_request": True},
+                    stop_cause=TERMINAL_NATURAL,
+                    **classified_finish_kwargs(last_classified),
+                )
+                return
             if _action_disposition == "return":
                 # Cancel mid-spree: heal unanswered tool_calls before exit so
                 # the next send/resume/export never sees a dangling tool_use.

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -896,6 +896,8 @@ class SendLoopMixin:
     def _iter_invalid_tool_halt(
         self, *, user_message, step, swarms, turn_prose, turn_findings, last_classified,
     ):
+        from .conversation import ConvEvent
+        from .send_loop_phases import classified_finish_kwargs, finalize_assistant_turn
         halt_reason = invalid_only_halt_reason(self)
         if not halt_reason:
             return False

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -1386,9 +1386,9 @@ class SendLoopMixin:
                 self._history.append({"role": "assistant", "content": _history_text or "(acting)"})
 
             if _extracted_secret:
-                from .secret_request import already_present, register_pending_secret_request
+                from .secret_request import already_present, declined_this_breath, register_pending_secret_request
                 if not any(getattr(a, "kind", "") == "request_secret" for a in turn.actions):
-                    if not already_present(self, _extracted_secret["connector"], _extracted_secret["field"]):
+                    if not already_present(self, _extracted_secret["connector"], _extracted_secret["field"]) and not declined_this_breath(self, _extracted_secret["connector"], _extracted_secret["field"]):
                         pending = register_pending_secret_request(self, _extracted_secret)
                         yield ConvEvent("secret_request", {
                             **(pending or _extracted_secret),

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -84,6 +84,11 @@ from .stream_performance import (
 )
 from .text_clean import clean_say
 from .tool_dispatch import _strip_ansi, is_safe_path
+from .send_loop_secrets import (
+    iter_extracted_secret_turn,
+    iter_secret_action_turn,
+    peel_secret_request_message,
+)
 
 
 POST_SWARM_SYNTHESIS_NUDGE = (
@@ -888,6 +893,25 @@ class SendLoopMixin:
         if callable(flush_steer):
             yield from flush_steer()
 
+    def _iter_invalid_tool_halt(
+        self, *, user_message, step, swarms, turn_prose, turn_findings, last_classified,
+    ):
+        halt_reason = invalid_only_halt_reason(self)
+        if not halt_reason:
+            return False
+        self._sanitize_tool_pairs()
+        yield ConvEvent("auto_halt", {"reason": halt_reason})
+        yield ConvEvent("error", {"error": halt_reason})
+        yield from finalize_assistant_turn(
+            self, user_message=user_message, step=step,
+            swarms=swarms, turn_prose=turn_prose,
+            turn_findings=turn_findings,
+            extra={"invalid_tool_halt": True},
+            stop_cause=TERMINAL_INVALID_TOOL,
+            **classified_finish_kwargs(last_classified),
+        )
+        return True
+
     def _send_locked_inner(self, user_message: str, images: Optional[list] = None, plan: bool = False, resume: bool = False) -> Iterator[ConvEvent]:
         from .conversation import (
             ConvEvent,
@@ -1323,11 +1347,8 @@ class SendLoopMixin:
             # real readout only on the thought channel. Promote that into a
             # message so the turn gets a finished summary bubble.
 
-            cleaned_say_text = clean_say(turn.say) if turn.say else ""
-            _extracted_secret = None
-            if cleaned_say_text:
-                from .secret_vault import extract_secret_request_message
-                cleaned_say_text, _extracted_secret = extract_secret_request_message(cleaned_say_text)
+            cleaned_say_text, _extracted_secret = peel_secret_request_message(
+                clean_say(turn.say) if turn.say else "")
             _resp_meta = getattr(resp, "meta", None) or {}
             if not isinstance(_resp_meta, dict):
                 _resp_meta = {}
@@ -1385,26 +1406,11 @@ class SendLoopMixin:
             else:
                 self._history.append({"role": "assistant", "content": _history_text or "(acting)"})
 
-            if _extracted_secret:
-                from .secret_request import already_present, declined_this_breath, register_pending_secret_request
-                if not any(getattr(a, "kind", "") == "request_secret" for a in turn.actions):
-                    if not already_present(self, _extracted_secret["connector"], _extracted_secret["field"]) and not declined_this_breath(self, _extracted_secret["connector"], _extracted_secret["field"]):
-                        pending = register_pending_secret_request(self, _extracted_secret)
-                        yield ConvEvent("secret_request", {
-                            **(pending or _extracted_secret),
-                            "session_id": getattr(self, "harness_session_id", "") or "default",
-                            "ends_turn": True,
-                        })
-                        self._sanitize_tool_pairs()
-                        yield from finalize_assistant_turn(
-                            self, user_message=user_message, step=step,
-                            swarms=swarms, turn_prose=turn_prose,
-                            turn_findings=turn_findings,
-                            extra={"secret_request": True},
-                            stop_cause=TERMINAL_NATURAL,
-                            **classified_finish_kwargs(last_classified),
-                        )
-                        return
+            if (yield from iter_extracted_secret_turn(
+                self, _extracted_secret, turn, user_message=user_message, step=step,
+                swarms=swarms, turn_prose=turn_prose, turn_findings=turn_findings,
+                last_classified=last_classified)):
+                return
             if self._turn_budget_exhausted() and not (
                 synchronous_swarms
                 and not step_emitted_user_prose
@@ -1560,16 +1566,10 @@ class SendLoopMixin:
             swarms = _action_counters["swarms"]
             demo_swarms = _action_counters["demo_swarms"]
             synchronous_swarms = _action_counters["synchronous_swarms"]
-            if _action_disposition == "secret_request":
-                self._sanitize_tool_pairs()
-                yield from finalize_assistant_turn(
-                    self, user_message=user_message, step=step,
-                    swarms=swarms, turn_prose=turn_prose,
-                    turn_findings=turn_findings,
-                    extra={"secret_request": True},
-                    stop_cause=TERMINAL_NATURAL,
-                    **classified_finish_kwargs(last_classified),
-                )
+            if (yield from iter_secret_action_turn(
+                self, _action_disposition, user_message=user_message, step=step,
+                swarms=swarms, turn_prose=turn_prose, turn_findings=turn_findings,
+                last_classified=last_classified)):
                 return
             if _action_disposition == "return":
                 # Cancel mid-spree: heal unanswered tool_calls before exit so
@@ -1577,19 +1577,10 @@ class SendLoopMixin:
                 self._sanitize_tool_pairs()
                 return
 
-            halt_reason = invalid_only_halt_reason(self)
-            if halt_reason:
-                self._sanitize_tool_pairs()
-                yield ConvEvent("auto_halt", {"reason": halt_reason})
-                yield ConvEvent("error", {"error": halt_reason})
-                yield from finalize_assistant_turn(
-                    self, user_message=user_message, step=step,
-                    swarms=swarms, turn_prose=turn_prose,
-                    turn_findings=turn_findings,
-                    extra={"invalid_tool_halt": True},
-                    stop_cause=TERMINAL_INVALID_TOOL,
-                    **classified_finish_kwargs(last_classified),
-                )
+            if (yield from self._iter_invalid_tool_halt(
+                user_message=user_message, step=step, swarms=swarms,
+                turn_prose=turn_prose, turn_findings=turn_findings,
+                last_classified=last_classified)):
                 return
 
             # ---- AUTO-VERIFY LOOP ----------------------------------------

--- a/harness/send_loop_actions.py
+++ b/harness/send_loop_actions.py
@@ -251,6 +251,23 @@ def execute_turn_actions(
         # run_implement / run_parallel emit their own action_start after
         # engine selection (includes mode=agentic|native). Emitting here
         # too produced twin "Investigated 2 run implements" chrome.
+        if act.kind == "request_secret":
+            ended = False
+            for ev in dispatch_local_action(
+                session, act, aid, is_native, turn_changed_files,
+                act_goal=act_goal, plan=plan,
+            ):
+                if getattr(ev, "kind", "") == "secret_request" and (ev.data or {}).get("ends_turn"):
+                    ended = True
+                yield ev
+            if ended:
+                counters["action_seq"] = action_seq
+                counters["swarms"] = swarms
+                counters["demo_swarms"] = demo_swarms
+                counters["synchronous_swarms"] = synchronous_swarms
+                return ("secret_request", turn_changed_files)
+            continue
+
         if act.kind not in ("run_implement", "run_parallel"):
             yield ConvEvent("action_start", {
                 "id": aid, "kind": act.kind, "goal": act_goal or act.tool,

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -2694,7 +2694,7 @@ def dispatch_local_action(
 
     if act.kind == "request_secret":
         from .conversation import ConvEvent
-        from .secret_request import already_present, register_pending_secret_request
+        from .secret_request import already_present, declined_this_breath, register_pending_secret_request
         from .secret_vault import parse_secret_request_payload, presence_payload
         args = act.arguments if isinstance(act.arguments, dict) else {}
         payload = parse_secret_request_payload({
@@ -2710,6 +2710,11 @@ def dispatch_local_action(
             return
         if already_present(session, payload["connector"], payload["field"]):
             result = presence_payload(payload["connector"], payload["field"], True)
+            yield ConvEvent("action_result", {"id": aid, "kind": "request_secret", "result": result})
+            session._append_action_result(act, aid, json.dumps(result), is_native, ok=True)
+            return
+        if declined_this_breath(session, payload["connector"], payload["field"]):
+            result = presence_payload(payload["connector"], payload["field"], False)
             yield ConvEvent("action_result", {"id": aid, "kind": "request_secret", "result": result})
             session._append_action_result(act, aid, json.dumps(result), is_native, ok=True)
             return

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -98,6 +98,7 @@ LOCAL_ACTION_KINDS: frozenset[str] = frozenset({
     "browser_type", "browser_scroll", "browser_back",
     "browser_get_text", "browser_screenshot",
     "query_wiki", "call_mcp", "manage_mcp",
+    "request_secret",
 })
 
 # Mutating / side-effecting kinds blocked in plan mode (same gate as write/edit
@@ -2677,6 +2678,7 @@ def dispatch_local_action(
     browser_* / write-edit / run_command) so a caller that forgets the
     actions-layer skip still cannot mutate or drive a live browser in plan mode.
     """
+    import json
     import os
 
     from .conversation import ConvEvent, _mcp_result_text
@@ -2688,6 +2690,41 @@ def dispatch_local_action(
     if act.kind == "wait":
         from .pilot_wait import dispatch_wait_action
         yield from dispatch_wait_action(session, act, aid, is_native)
+        return
+
+    if act.kind == "request_secret":
+        from .conversation import ConvEvent
+        from .secret_request import already_present, register_pending_secret_request
+        from .secret_vault import parse_secret_request_payload, presence_payload
+        args = act.arguments if isinstance(act.arguments, dict) else {}
+        payload = parse_secret_request_payload({
+            "label": args.get("label") or act.goal,
+            "connector": args.get("connector"),
+            "field": args.get("field"),
+            "description": args.get("description") or "",
+        })
+        if not payload:
+            err = "request_secret requires label, connector, and field"
+            yield ConvEvent("action_result", {"id": aid, "error": err})
+            session._append_action_result(act, aid, err, is_native, ok=False)
+            return
+        if already_present(session, payload["connector"], payload["field"]):
+            result = presence_payload(payload["connector"], payload["field"], True)
+            yield ConvEvent("action_result", {"id": aid, "kind": "request_secret", "result": result})
+            session._append_action_result(act, aid, json.dumps(result), is_native, ok=True)
+            return
+        pending = register_pending_secret_request(session, payload)
+        yield ConvEvent("secret_request", {
+            **(pending or payload),
+            "session_id": getattr(session, "harness_session_id", "") or "default",
+            "ends_turn": True,
+        })
+        awaiting = {
+            "status": "awaiting_host",
+            "connector": payload["connector"],
+            "field": payload["field"],
+        }
+        session._append_action_result(act, aid, json.dumps(awaiting), is_native, ok=True)
         return
 
     if plan and (

--- a/harness/send_loop_secrets.py
+++ b/harness/send_loop_secrets.py
@@ -1,0 +1,83 @@
+"""Peel secret-request turn endings out of _send_locked_inner."""
+from __future__ import annotations
+
+from typing import Any, Iterator, Optional
+
+
+def peel_secret_request_message(text: str) -> tuple[str, Optional[dict]]:
+    if not text:
+        return text, None
+    from .secret_vault import extract_secret_request_message
+    return extract_secret_request_message(text)
+
+
+def iter_extracted_secret_turn(
+    session: Any,
+    extracted: Optional[dict],
+    turn: Any,
+    *,
+    user_message: str,
+    step: int,
+    swarms: int,
+    turn_prose: list,
+    turn_findings: list,
+    last_classified: Any,
+) -> Iterator[Any]:
+    """Yield a secret-request card and end the turn, or yield nothing."""
+    if not extracted:
+        return
+    if any(getattr(a, "kind", "") == "request_secret" for a in turn.actions):
+        return
+    from .conversation import ConvEvent
+    from .secret_request import already_present, declined_this_breath, register_pending_secret_request
+    from .send_loop_phases import classified_finish_kwargs, finalize_assistant_turn
+    from .terminal_cause import TERMINAL_NATURAL
+
+    connector = extracted.get("connector") or ""
+    field = extracted.get("field") or ""
+    if already_present(session, connector, field) or declined_this_breath(session, connector, field):
+        return
+    pending = register_pending_secret_request(session, extracted)
+    yield ConvEvent("secret_request", {
+        **(pending or extracted),
+        "session_id": getattr(session, "harness_session_id", "") or "default",
+        "ends_turn": True,
+    })
+    session._sanitize_tool_pairs()
+    yield from finalize_assistant_turn(
+        session, user_message=user_message, step=step,
+        swarms=swarms, turn_prose=turn_prose,
+        turn_findings=turn_findings,
+        extra={"secret_request": True},
+        stop_cause=TERMINAL_NATURAL,
+        **classified_finish_kwargs(last_classified),
+    )
+    return True
+
+
+def iter_secret_action_turn(
+    session: Any,
+    disposition: str,
+    *,
+    user_message: str,
+    step: int,
+    swarms: int,
+    turn_prose: list,
+    turn_findings: list,
+    last_classified: Any,
+) -> Iterator[Any]:
+    if disposition != "secret_request":
+        return
+    from .send_loop_phases import classified_finish_kwargs, finalize_assistant_turn
+    from .terminal_cause import TERMINAL_NATURAL
+
+    session._sanitize_tool_pairs()
+    yield from finalize_assistant_turn(
+        session, user_message=user_message, step=step,
+        swarms=swarms, turn_prose=turn_prose,
+        turn_findings=turn_findings,
+        extra={"secret_request": True},
+        stop_cause=TERMINAL_NATURAL,
+        **classified_finish_kwargs(last_classified),
+    )
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.279"
+version = "0.9.280"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_secrets.py
+++ b/tests/test_api_secrets.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from harness.api.secrets import (
+    SecretServices,
+    get_secrets_presence,
+    post_secrets_dismiss,
+    post_secrets_submit,
+)
+
+
+class _Runner:
+    def __init__(self):
+        self.harness_session_id = "sess-a"
+        self.calls = []
+
+    def decide_secret_request(self, **kwargs):
+        self.calls.append(kwargs)
+        return kwargs
+
+
+def test_submit_stores_and_resumes_without_secret_bytes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    runner = _Runner()
+    svc = SecretServices(get_runners=lambda: {"sess-a": runner})
+    status, payload = post_secrets_submit(
+        {
+            "session_id": "sess-a",
+            "connector": "pypi",
+            "field": "token",
+            "value": "pypi-live-token-should-not-echo",
+        },
+        svc,
+    )
+    assert status == 200
+    assert payload["provided"] is True
+    assert payload["resume"] is True
+    assert payload["connector"] == "pypi"
+    assert "pypi-live-token-should-not-echo" not in str(payload)
+    assert runner.calls == [{"connector": "pypi", "field": "token", "provided": True}]
+    st, listed = get_secrets_presence(
+        {"session_id": "sess-a", "connector": "pypi", "field": "token"},
+        svc,
+    )
+    assert st == 200
+    assert listed["present"] is True
+    assert listed["state"] == "present"
+    assert "pypi-live-token" not in str(listed)
+
+
+def test_dismiss_does_not_resume(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    runner = _Runner()
+    svc = SecretServices(get_runners=lambda: {"sess-a": runner})
+    status, payload = post_secrets_dismiss(
+        {"session_id": "sess-a", "connector": "pypi", "field": "token"},
+        svc,
+    )
+    assert status == 200
+    assert payload["provided"] is False
+    assert payload["resume"] is False
+    assert runner.calls[0]["provided"] is False

--- a/tests/test_secret_request.py
+++ b/tests/test_secret_request.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from harness.pilot import PilotAction
+from harness.send_loop_phases import LOCAL_ACTION_KINDS, dispatch_local_action
+
+
+def test_request_secret_is_local_kind():
+    assert "request_secret" in LOCAL_ACTION_KINDS
+
+
+def test_dispatch_request_secret_emits_card_and_not_secret(monkeypatch, tmp_path):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    act = PilotAction(
+        kind="request_secret",
+        arguments={
+            "label": "PyPI token for puppetmaster-ai",
+            "connector": "pypi",
+            "field": "token",
+            "description": "Project-scoped token",
+        },
+    )
+    session = SimpleNamespace(
+        harness_session_id="sess-a",
+        _pending_secret_requests={},
+        _display_transcript=[],
+        _history=[],
+        _append_action_result=MagicMock(),
+    )
+    events = list(dispatch_local_action(session, act, "a1", True, []))
+    kinds = [ev.kind for ev in events]
+    assert "secret_request" in kinds
+    data = events[0].data
+    assert data["connector"] == "pypi"
+    assert data["ends_turn"] is True
+    assert "value" not in data
+    dumped = str(events)
+    assert "pypi-" not in dumped
+    assert session._display_transcript[0]["type"] == "secret_request"
+    assert "value" not in session._display_transcript[0]

--- a/tests/test_secret_request.py
+++ b/tests/test_secret_request.py
@@ -38,3 +38,29 @@ def test_dispatch_request_secret_emits_card_and_not_secret(monkeypatch, tmp_path
     assert "pypi-" not in dumped
     assert session._display_transcript[0]["type"] == "secret_request"
     assert "value" not in session._display_transcript[0]
+
+
+def test_dismiss_does_not_reask_same_breath(monkeypatch, tmp_path):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    from harness.secret_request import decide_secret_request, declined_this_breath
+    session = SimpleNamespace(
+        harness_session_id="sess-a",
+        _pending_secret_requests={},
+        _display_transcript=[],
+        _history=[],
+    )
+    decide_secret_request(session, connector="pypi", field="token", provided=False)
+    assert declined_this_breath(session, "pypi", "token") is True
+    act = PilotAction(
+        kind="request_secret",
+        arguments={
+            "label": "PyPI token for puppetmaster-ai",
+            "connector": "pypi",
+            "field": "token",
+        },
+    )
+    session._append_action_result = MagicMock()
+    events = list(dispatch_local_action(session, act, "a2", True, []))
+    kinds = [ev.kind for ev in events]
+    assert "secret_request" not in kinds
+    assert events[-1].kind == "action_result"

--- a/tests/test_secret_vault.py
+++ b/tests/test_secret_vault.py
@@ -1,0 +1,92 @@
+"""Host vault: encrypt at rest, presence only, env inject, no model echo."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+from harness.secret_vault import (
+    apply_to_environ,
+    extract_secret_request_message,
+    get_secret,
+    parse_secret_request_payload,
+    presence,
+    presence_payload,
+    put_secret,
+    redact_secret_text,
+    subprocess_env,
+    vault_path,
+)
+
+
+def test_put_is_encrypted_and_presence_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    row = put_secret("sess-a", "pypi", "token", "pypi-secret-value-xyz")
+    assert row["present"] is True
+    assert row["state"] == "present"
+    raw = json.loads((tmp_path / "secret-vault.json").read_text())
+    blob = raw["agents"]["sess-a"]["pypi"]["token"]
+    dumped = json.dumps(raw)
+    assert "pypi-secret-value-xyz" not in dumped
+    assert blob["n"] and blob["c"]
+    assert get_secret("sess-a", "pypi", "token") == "pypi-secret-value-xyz"
+    listed = presence("sess-a")
+    assert listed["connectors"]["pypi"]["token"] == "present"
+    assert "pypi-secret-value-xyz" not in json.dumps(listed)
+
+
+def test_extract_structured_message_ends_clean():
+    text = (
+        'Need a token.\n\n```json\n'
+        '{"type":"secret-request","secret":{'
+        '"label":"PyPI token for puppetmaster-ai",'
+        '"connector":"pypi","field":"token",'
+        '"description":"Project-scoped token for puppetmaster-ai only."'
+        '}}\n```\nplease wait'
+    )
+    cleaned, parsed = extract_secret_request_message(text)
+    assert parsed["connector"] == "pypi"
+    assert parsed["field"] == "token"
+    assert parsed["label"].startswith("PyPI token")
+    assert "please wait" in cleaned
+    assert "secret-request" not in cleaned
+    assert parse_secret_request_payload({"label": "x"}) is None
+
+
+def test_subprocess_twine_fixture_never_returns_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    token = "pypi-fixture-token-ABCDEF"
+    put_secret("sess-a", "pypi", "token", token)
+    env = subprocess_env("sess-a", {"PATH": os.environ.get("PATH", "")})
+    assert env["TWINE_USERNAME"] == "__token__"
+    assert env["TWINE_PASSWORD"] == token
+    script = (
+        "import os, json; "
+        "print(json.dumps({"
+        "'user': os.environ.get('TWINE_USERNAME'),"
+        "'has_pw': bool(os.environ.get('TWINE_PASSWORD')),"
+        "'pw_len': len(os.environ.get('TWINE_PASSWORD') or '')"
+        "}))"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(proc.stdout)
+    assert payload["user"] == "__token__"
+    assert payload["has_pw"] is True
+    assert payload["pw_len"] == len(token)
+    assert token not in proc.stdout
+    assert token not in json.dumps(presence_payload("pypi", "token", True))
+
+
+def test_redact_process_list_and_artifacts():
+    leaked = "cmd TWINE_PASSWORD=pypi-fixture-token-ABCDEF extra"
+    assert "pypi-fixture-token-ABCDEF" not in redact_secret_text(
+        leaked, extra_values=["pypi-fixture-token-ABCDEF"]
+    )
+    assert "REDACTED" in redact_secret_text(leaked)

--- a/tests/test_secret_vault.py
+++ b/tests/test_secret_vault.py
@@ -58,7 +58,11 @@ def test_subprocess_twine_fixture_never_returns_token(tmp_path, monkeypatch):
     monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
     token = "pypi-fixture-token-ABCDEF"
     put_secret("sess-a", "pypi", "token", token)
-    env = subprocess_env("sess-a", {"PATH": os.environ.get("PATH", "")})
+    base = {"PATH": os.environ.get("PATH", "")}
+    for key in ("SYSTEMROOT", "SYSTEMDRIVE", "WINDIR", "COMSPEC", "PATHEXT"):
+        if key in os.environ:
+            base[key] = os.environ[key]
+    env = subprocess_env("sess-a", base)
     assert env["TWINE_USERNAME"] == "__token__"
     assert env["TWINE_PASSWORD"] == token
     script = (

--- a/webapp/electron/fixtures/secret-request-card.html
+++ b/webapp/electron/fixtures/secret-request-card.html
@@ -27,7 +27,7 @@
         <button type="button">Save securely</button>
         <button type="button" class="ghost">Dismiss</button>
       </div>
-      <div class="shield">Stored securely, never shown to your Bot.</div>
+      <div class="shield">Shield: Stored securely, never shown to your Bot.</div>
     </div>
     <div class="thread">Transcript stays empty of the secret. Composer/Tasks stay fixed below.</div>
   </div>

--- a/webapp/electron/fixtures/secret-request-card.html
+++ b/webapp/electron/fixtures/secret-request-card.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>secret-request card</title>
+  <style>
+    body { margin: 0; background: #0f1113; color: #e8eaed; font: 13px/1.4 ui-sans-serif, system-ui; }
+    .wrap { padding: 32px; }
+    .card { max-width: 42rem; border: 1px solid #2a2f36; background: #161a1e; border-radius: 6px; padding: 14px 16px; }
+    .title { font-weight: 600; }
+    .help { margin-top: 4px; color: #9aa3ad; font-size: 11px; }
+    input { margin-top: 10px; width: 100%; box-sizing: border-box; border: 1px solid #2a2f36; background: #0f1113; color: #e8eaed; border-radius: 4px; padding: 7px 8px; }
+    .row { margin-top: 10px; display: flex; gap: 8px; }
+    button { border: 1px solid #2a2f36; background: #1b2026; color: #e8eaed; border-radius: 6px; padding: 5px 10px; }
+    button.ghost { color: #9aa3ad; }
+    .shield { margin-top: 8px; color: #9aa3ad; font-size: 10.5px; }
+    .thread { margin-top: 18px; color: #6b7380; font-size: 11px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card" data-testid="secret-request-card">
+      <div class="title">PyPI token for puppetmaster-ai</div>
+      <div class="help">Project-scoped token for puppetmaster-ai only. Used to twine upload 1.22.20.</div>
+      <input type="password" placeholder="Paste your PyPI token for puppetmaster-ai" />
+      <div class="row">
+        <button type="button">Save securely</button>
+        <button type="button" class="ghost">Dismiss</button>
+      </div>
+      <div class="shield">Stored securely, never shown to your Bot.</div>
+    </div>
+    <div class="thread">Transcript stays empty of the secret. Composer/Tasks stay fixed below.</div>
+  </div>
+</body>
+</html>

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -40,6 +40,7 @@ const {
   resolveClassicDevRendererSource,
 } = require("./renderer-fallback.cjs");
 const { createTranslucencyController } = require("./translucency.cjs");
+const secretVault = require("./secret-vault.cjs");
 
 // Must run before any git/npm/uv child spawns: on Windows the portable tools
 // installed by first-run bootstrap are only on PATH in-memory, per process.
@@ -846,6 +847,17 @@ async function _startBackendOnce() {
     PUPPETMASTER_MODELS_PATH:
       process.env.PUPPETMASTER_MODELS_PATH || marionetteModels,
   };
+  try {
+    const { safeStorage } = require("electron");
+    secretVault.injectEnv({
+      stateDir: customEnv.HARNESS_STATE_DIR,
+      safeStorage,
+      agentId: "default",
+      target: customEnv,
+    });
+  } catch (_) {
+    /* vault optional at spawn */
+  }
   // Packaged: never pass HARNESS_REPO — a process-level value (often the app
   // checkout on Windows) would skip workspace.json restore in the backend.
   // Dev: only omit when unset so an explicit dev-shell override still works.
@@ -1024,7 +1036,43 @@ ipcMain.on("harness:rendererError", (_e, payload) => {
   logMain(`[rendererError:${p.scope || "app"}] ${p.message || ""}\n${p.stack || ""}${p.componentStack ? `\ncomponentStack:${p.componentStack}` : ""}`);
 });
 ipcMain.handle("harness:getJSON", (_e, p) => backendRequest("GET", p));
-ipcMain.handle("harness:postJSON", (_e, p, body) => backendRequest("POST", p, body));
+ipcMain.handle("harness:postJSON", (_e, p, body) => {
+  if (p === "/api/secrets/submit" && body && typeof body === "object") {
+    try {
+      const { safeStorage } = require("electron");
+      secretVault.putSecret({
+        stateDir: resolveHarnessStateDir(),
+        safeStorage,
+        agentId: body.session_id || body.agent_id || "default",
+        connector: body.connector,
+        field: body.field,
+        value: body.value,
+      });
+    } catch (_) {
+      /* Python vault is still authoritative for workers */
+    }
+  }
+  return backendRequest("POST", p, body);
+});
+ipcMain.handle("secrets:save", (_e, payload) => {
+  const { safeStorage } = require("electron");
+  return secretVault.putSecret({
+    stateDir: resolveHarnessStateDir(),
+    safeStorage,
+    agentId: payload && payload.agentId,
+    connector: payload && payload.connector,
+    field: payload && payload.field,
+    value: payload && payload.value,
+  });
+});
+ipcMain.handle("secrets:presence", (_e, payload) => {
+  return secretVault.presenceOf({
+    stateDir: resolveHarnessStateDir(),
+    agentId: payload && payload.agentId,
+    connector: payload && payload.connector,
+    field: payload && payload.field,
+  });
+});
 
 // Guards against overlapping restarts (double-click / rapid toggle).
 let restarting = false;

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -156,9 +156,10 @@ function tryRefreshBackendPortFromMarker() {
 // ~/.pmharness/electron.log so a death is always diagnosable after the fact.
 function logMain(msg) {
   try {
+    const safe = secretVault.redactText(String(msg == null ? "" : msg));
     fs.appendFileSync(
       path.join(os.homedir(), ".pmharness", "electron.log"),
-      `${new Date().toISOString()} ${msg}\n`
+      `${new Date().toISOString()} ${safe}\n`
     );
   } catch { /* logging must never throw */ }
 }

--- a/webapp/electron/preload.cjs
+++ b/webapp/electron/preload.cjs
@@ -28,6 +28,10 @@ contextBridge.exposeInMainWorld("harnessIPC", {
   // Fire-and-forget: persist a caught renderer error to the Electron main log so
   // a UI crash is diagnosable from ~/.pmharness/electron.log without devtools.
   logError: (payload) => { try { ipcRenderer.send("harness:rendererError", payload); } catch (_) {} },
+  secrets: {
+    save: (payload) => ipcRenderer.invoke("secrets:save", payload),
+    presence: (payload) => ipcRenderer.invoke("secrets:presence", payload),
+  },
 
   // stream(path, onEvent, onDone, onError) -> cancel()
   stream: (path, onEvent, onDone, onError) => {

--- a/webapp/electron/secret-request-screenshot.cjs
+++ b/webapp/electron/secret-request-screenshot.cjs
@@ -1,0 +1,27 @@
+"use strict";
+const fs = require("node:fs");
+const path = require("node:path");
+const { app, BrowserWindow } = require("electron");
+const fixture = path.join(__dirname, "fixtures", "secret-request-card.html");
+const outDir = path.join(__dirname, "screenshots");
+
+app.whenReady().then(async () => {
+  fs.mkdirSync(outDir, { recursive: true });
+  const win = new BrowserWindow({
+    width: 720,
+    height: 420,
+    show: false,
+    backgroundColor: "#0f1113",
+    webPreferences: { sandbox: true },
+  });
+  await win.loadFile(fixture);
+  await new Promise((r) => setTimeout(r, 200));
+  const image = await win.webContents.capturePage();
+  const dest = path.join(outDir, "secret-request-card.png");
+  fs.writeFileSync(dest, image.toPNG());
+  process.stdout.write(dest + "\n");
+  app.exit(0);
+}).catch((err) => {
+  process.stderr.write(String(err && err.stack || err));
+  app.exit(1);
+});

--- a/webapp/electron/secret-vault.cjs
+++ b/webapp/electron/secret-vault.cjs
@@ -1,0 +1,190 @@
+/**
+ * Electron main-process connector vault.
+ * Values are encrypted with safeStorage when available and never returned
+ * to the renderer except as present|missing.
+ */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const ENV_BINDINGS = {
+  "pypi::token": [
+    ["TWINE_USERNAME", "__token__"],
+    ["TWINE_PASSWORD", null],
+    ["PYPI_TOKEN", null],
+  ],
+  "portable-llm-wiki::WIKI_OWNER_TOKEN": [["WIKI_OWNER_TOKEN", null]],
+  "slack::token": [
+    ["SLACK_BOT_TOKEN", null],
+    ["SLACK_TOKEN", null],
+  ],
+};
+
+function resolveStateDir(env) {
+  const explicit = String((env || process.env).HARNESS_STATE_DIR || "").trim();
+  if (explicit) return path.resolve(explicit);
+  return path.join(os.homedir(), ".pmharness");
+}
+
+function vaultPath(stateDir) {
+  return path.join(stateDir, "secret-vault.enc.json");
+}
+
+function emptyStore() {
+  return { v: 1, agents: {} };
+}
+
+function readStore(file) {
+  try {
+    const raw = fs.readFileSync(file, "utf8");
+    const data = JSON.parse(raw);
+    if (data && typeof data === "object" && data.agents && typeof data.agents === "object") {
+      return data;
+    }
+  } catch (_) {
+    /* missing or corrupt: start empty */
+  }
+  return emptyStore();
+}
+
+function writeStore(file, store) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(store, null, 2), { encoding: "utf8", mode: 0o600 });
+  fs.renameSync(tmp, file);
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch (_) {
+    /* best-effort */
+  }
+}
+
+function encryptValue(safeStorage, plain) {
+  if (safeStorage && typeof safeStorage.isEncryptionAvailable === "function" && safeStorage.isEncryptionAvailable()) {
+    const buf = safeStorage.encryptString(plain);
+    return { alg: "safeStorage", data: buf.toString("base64") };
+  }
+  return { alg: "b64", data: Buffer.from(plain, "utf8").toString("base64") };
+}
+
+function decryptValue(safeStorage, blob) {
+  if (!blob || typeof blob !== "object") return "";
+  try {
+    if (blob.alg === "safeStorage" && safeStorage && typeof safeStorage.decryptString === "function") {
+      return safeStorage.decryptString(Buffer.from(blob.data, "base64"));
+    }
+    if (blob.alg === "b64") {
+      return Buffer.from(blob.data, "base64").toString("utf8");
+    }
+  } catch (_) {
+    return "";
+  }
+  return "";
+}
+
+function normalizeAgentId(value) {
+  return String(value || "").trim() || "default";
+}
+
+function normalizeConnector(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function normalizeField(value) {
+  return String(value || "").trim();
+}
+
+function putSecret(opts) {
+  const stateDir = opts.stateDir || resolveStateDir(opts.env);
+  const file = vaultPath(stateDir);
+  const agentId = normalizeAgentId(opts.agentId);
+  const connector = normalizeConnector(opts.connector);
+  const field = normalizeField(opts.field);
+  const value = String(opts.value || "").trim();
+  if (!connector || !field || !value) {
+    return { ok: false, error: "connector, field, and value are required" };
+  }
+  const store = readStore(file);
+  store.agents[agentId] = store.agents[agentId] || {};
+  store.agents[agentId][connector] = store.agents[agentId][connector] || {};
+  store.agents[agentId][connector][field] = encryptValue(opts.safeStorage, value);
+  writeStore(file, store);
+  return { ok: true, present: true, connector, field, state: "present" };
+}
+
+function presenceOf(opts) {
+  const stateDir = opts.stateDir || resolveStateDir(opts.env);
+  const file = vaultPath(stateDir);
+  const agentId = normalizeAgentId(opts.agentId);
+  const connector = normalizeConnector(opts.connector);
+  const field = normalizeField(opts.field);
+  const store = readStore(file);
+  const byAgent = store.agents[agentId] || {};
+  if (connector && field) {
+    const present = Boolean((byAgent[connector] || {})[field]);
+    return {
+      agent_id: agentId,
+      connector,
+      field,
+      present,
+      state: present ? "present" : "missing",
+    };
+  }
+  const connectors = {};
+  for (const [conn, fields] of Object.entries(byAgent)) {
+    if (!fields || typeof fields !== "object") continue;
+    const row = {};
+    for (const name of Object.keys(fields)) row[name] = "present";
+    if (Object.keys(row).length) connectors[conn] = row;
+  }
+  return { agent_id: agentId, connectors };
+}
+
+function envBindingsFor(connector, field, value) {
+  const key = `${normalizeConnector(connector)}::${normalizeField(field)}`;
+  const out = {};
+  for (const [name, lit] of ENV_BINDINGS[key] || []) {
+    out[name] = lit == null ? value : lit;
+  }
+  const generic = `${normalizeConnector(connector).toUpperCase().replace(/-/g, "_")}_${normalizeField(field).toUpperCase()}`;
+  if (!out[generic]) out[generic] = value;
+  return out;
+}
+
+function injectEnv(opts) {
+  const stateDir = opts.stateDir || resolveStateDir(opts.env);
+  const file = vaultPath(stateDir);
+  const agentId = normalizeAgentId(opts.agentId);
+  const store = readStore(file);
+  const byAgent = store.agents[agentId] || {};
+  const target = opts.target || {};
+  for (const [conn, fields] of Object.entries(byAgent)) {
+    if (!fields || typeof fields !== "object") continue;
+    for (const [name, blob] of Object.entries(fields)) {
+      const value = decryptValue(opts.safeStorage, blob);
+      if (!value) continue;
+      Object.assign(target, envBindingsFor(conn, name, value));
+    }
+  }
+  return target;
+}
+
+function redactText(text) {
+  if (!text) return text;
+  return String(text).replace(
+    /\b(TWINE_PASSWORD|PYPI_TOKEN|WIKI_OWNER_TOKEN|SLACK_BOT_TOKEN|SLACK_TOKEN)\s*[=:]\s*\S+/gi,
+    (m) => m.split(/[=:]/)[0] + "=REDACTED",
+  );
+}
+
+module.exports = {
+  resolveStateDir,
+  vaultPath,
+  putSecret,
+  presenceOf,
+  injectEnv,
+  envBindingsFor,
+  redactText,
+  encryptValue,
+  decryptValue,
+};

--- a/webapp/electron/secret-vault.test.cjs
+++ b/webapp/electron/secret-vault.test.cjs
@@ -1,0 +1,67 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  putSecret,
+  presenceOf,
+  injectEnv,
+  redactText,
+  vaultPath,
+} = require("./secret-vault.cjs");
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "sv-"));
+}
+
+test("putSecret encrypts and presence hides the value", () => {
+  const stateDir = tmpDir();
+  const fakeSafe = {
+    isEncryptionAvailable: () => true,
+    encryptString: (s) => Buffer.from(`enc:${s}`),
+    decryptString: (b) => Buffer.from(b).toString("utf8").slice(4),
+  };
+  const saved = putSecret({
+    stateDir,
+    safeStorage: fakeSafe,
+    agentId: "sess-a",
+    connector: "pypi",
+    field: "token",
+    value: "pypi-electron-token-xyz",
+  });
+  assert.equal(saved.present, true);
+  const raw = fs.readFileSync(vaultPath(stateDir), "utf8");
+  assert.equal(raw.includes("pypi-electron-token-xyz"), false);
+  const row = presenceOf({ stateDir, agentId: "sess-a", connector: "pypi", field: "token" });
+  assert.equal(row.present, true);
+  assert.equal(row.state, "present");
+  assert.equal(JSON.stringify(row).includes("pypi-electron-token"), false);
+});
+
+test("injectEnv maps pypi token for twine without listing the value API", () => {
+  const stateDir = tmpDir();
+  const fakeSafe = {
+    isEncryptionAvailable: () => false,
+  };
+  putSecret({
+    stateDir,
+    safeStorage: fakeSafe,
+    agentId: "sess-a",
+    connector: "pypi",
+    field: "token",
+    value: "pypi-electron-token-xyz",
+  });
+  const env = injectEnv({ stateDir, safeStorage: fakeSafe, agentId: "sess-a", target: {} });
+  assert.equal(env.TWINE_USERNAME, "__token__");
+  assert.equal(env.TWINE_PASSWORD, "pypi-electron-token-xyz");
+  const listed = presenceOf({ stateDir, agentId: "sess-a" });
+  assert.equal(listed.connectors.pypi.token, "present");
+  assert.equal(JSON.stringify(listed).includes("pypi-electron-token-xyz"), false);
+});
+
+test("redactText covers process-list artifacts", () => {
+  const out = redactText("TWINE_PASSWORD=pypi-electron-token-xyz");
+  assert.equal(out.includes("pypi-electron-token-xyz"), false);
+  assert.match(out, /REDACTED/);
+});

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.279",
+  "version": "0.9.280",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.279",
+      "version": "0.9.280",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.279",
+  "version": "0.9.280",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SecretRequestCard.test.tsx
+++ b/webapp/src/__tests__/SecretRequestCard.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  TranscriptList,
+  type SecretRequestItem,
+} from "../components/TranscriptList";
+
+function pendingSecret(): SecretRequestItem {
+  return {
+    kind: "secret_request",
+    id: "pypi::token",
+    label: "PyPI token for puppetmaster-ai",
+    connector: "pypi",
+    field: "token",
+    description: "Project-scoped token for puppetmaster-ai only. Used to twine upload 1.22.20.",
+    sessionId: "sess-a",
+    status: "pending",
+  };
+}
+
+function renderCard(onSecretRequest = vi.fn()) {
+  render(
+    <TranscriptList
+      items={[pendingSecret()]}
+      status="done"
+      compactingStatus={null}
+      editingIndex={null}
+      auto={false}
+      plan={false}
+      turnOpen={false}
+      scrollContainerRef={{ current: null }}
+      onEditMessage={vi.fn()}
+      onExecuteSend={vi.fn()}
+      onImageClick={vi.fn()}
+      onSetCard={vi.fn()}
+      onExecutePlan={vi.fn()}
+      onCommandApproval={vi.fn()}
+      onSecretRequest={onSecretRequest}
+    />,
+  );
+  return onSecretRequest;
+}
+
+describe("secret-request card", () => {
+  it("renders masked card copy and does not submit on render", () => {
+    const decide = renderCard();
+    expect(screen.getByText("PyPI token for puppetmaster-ai")).toBeTruthy();
+    expect(screen.getByText(/Project-scoped token for puppetmaster-ai only/)).toBeTruthy();
+    expect(screen.getByText("Save securely")).toBeTruthy();
+    expect(screen.getByText("Stored securely, never shown to your Bot.")).toBeTruthy();
+    const input = screen.getByPlaceholderText("Paste your PyPI token for puppetmaster-ai");
+    expect(input.getAttribute("type")).toBe("password");
+    expect(decide).not.toHaveBeenCalled();
+  });
+
+  it("save sends connector/field/value and is not a user transcript submit", () => {
+    const decide = renderCard();
+    fireEvent.change(screen.getByPlaceholderText("Paste your PyPI token for puppetmaster-ai"), {
+      target: { value: "pypi-ui-token-should-not-be-a-user-msg" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save securely" }));
+    expect(decide).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connector: "pypi",
+        field: "token",
+        sessionId: "sess-a",
+      }),
+      { action: "save", value: "pypi-ui-token-should-not-be-a-user-msg" },
+    );
+  });
+
+  it("dismiss declines without a value", () => {
+    const decide = renderCard();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(decide).toHaveBeenCalledWith(
+      expect.objectContaining({ connector: "pypi", field: "token" }),
+      { action: "dismiss" },
+    );
+  });
+});

--- a/webapp/src/__tests__/secretRequestIsolation.test.ts
+++ b/webapp/src/__tests__/secretRequestIsolation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendSecretRequest,
+  updateSecretRequest,
+} from "../components/conversation/streamApply";
+import { transcriptResponseToItems } from "../components/conversation/transcriptItems";
+import type { Item } from "../components/TranscriptList";
+
+describe("secret-request isolation", () => {
+  it("appends a pending card without a secret value", () => {
+    const items = appendSecretRequest([], {
+      label: "PyPI token for puppetmaster-ai",
+      connector: "pypi",
+      field: "token",
+      description: "Project-scoped token",
+      session_id: "sess-a",
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: "secret_request",
+      connector: "pypi",
+      field: "token",
+      status: "pending",
+    });
+    expect(JSON.stringify(items).toLowerCase()).not.toContain("pypi-");
+  });
+
+  it("save/dismiss update status in place and never add a user message", () => {
+    const pending = appendSecretRequest([], {
+      label: "PyPI token for puppetmaster-ai",
+      connector: "pypi",
+      field: "token",
+      session_id: "sess-a",
+    });
+    const saved = updateSecretRequest(pending, "pypi", "token", { status: "saved" });
+    expect(saved.some((i) => i.kind === "msg")).toBe(false);
+    expect((saved[0] as Extract<Item, { kind: "secret_request" }>).status).toBe("saved");
+    const declined = updateSecretRequest(pending, "pypi", "token", { status: "declined" });
+    expect((declined[0] as Extract<Item, { kind: "secret_request" }>).status).toBe("declined");
+  });
+
+  it("hydrates display rows without secret bytes", () => {
+    const items = transcriptResponseToItems({
+      display: [
+        {
+          type: "secret_request",
+          label: "PyPI token for puppetmaster-ai",
+          connector: "pypi",
+          field: "token",
+          description: "help",
+          session_id: "sess-a",
+          status: "pending",
+        },
+      ],
+    } as any);
+    expect(items.some((i) => i.kind === "secret_request")).toBe(true);
+    expect(JSON.stringify(items)).not.toContain("value");
+  });
+});

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -5,6 +5,7 @@ import FileEditorPane from "./FileEditorPane";
 import {
   type Card,
   type CommandApprovalItem,
+  type SecretRequestItem,
   type Item,
 } from "./TranscriptList";
 import {
@@ -70,6 +71,7 @@ import {
   sealOpenStreamSurfaces,
   shouldApplySwarmLiveMerge,
   updateCommandApproval,
+  updateSecretRequest,
 } from "./conversation/streamApply";
 import {
   classifyLocalSlashCommand,
@@ -3251,6 +3253,51 @@ export default function Conversation({
     },
     [],
   );
+  const handleSecretRequest = useCallback(
+    (item: SecretRequestItem, decision: { action: "save"; value: string } | { action: "dismiss" }) => {
+      setItems((current) => updateSecretRequest(
+        current,
+        item.connector,
+        item.field,
+        { status: decision.action === "save" ? "saving" : "declined", error: undefined },
+      ));
+      const sessionId = item.sessionId || activeSessionId || "";
+      const request = decision.action === "save"
+        ? api.submitSecret({
+            session_id: sessionId,
+            connector: item.connector,
+            field: item.field,
+            value: decision.value,
+          })
+        : api.dismissSecret({
+            session_id: sessionId,
+            connector: item.connector,
+            field: item.field,
+          });
+      void request.then((response) => {
+        setItems((current) => updateSecretRequest(
+          current,
+          item.connector,
+          item.field,
+          { status: decision.action === "save" ? "saved" : "declined" },
+        ));
+        if (decision.action === "save" && response && (response as { resume?: boolean }).resume) {
+          executeSendRef.current("", false, false, true);
+        }
+      }).catch((error) => {
+        setItems((current) => updateSecretRequest(
+          current,
+          item.connector,
+          item.field,
+          {
+            status: "error",
+            error: error instanceof Error ? error.message : String(error),
+          },
+        ));
+      });
+    },
+    [activeSessionId],
+  );
   const handleTranscriptImageClick = useCallback((url: string) => setLightboxUrl(url), []);
   const recoveryBound = recoveryContextRef.current;
   const handleRecoveryContinue = () => {
@@ -3368,6 +3415,7 @@ export default function Conversation({
           onSetCard={stableSetCard}
           onExecutePlan={handleTranscriptExecutePlan}
           onCommandApproval={handleCommandApproval}
+          onSecretRequest={handleSecretRequest}
           showJumpToBottom={showJumpToBottom}
           onJumpToBottom={jumpToLatest}
           composerDock={(

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, useSyncExternalStore, memo } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ChevronRight, Loader2, ChevronDown, ChevronUp, Play, Copy, Check, Pencil, RefreshCw, History, Share2, CheckCircle2, XCircle, Eye } from "lucide-react";
+import { ChevronRight, Loader2, ChevronDown, ChevronUp, Play, Copy, Check, Pencil, RefreshCw, History, Share2, CheckCircle2, XCircle, Eye, Shield } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -1435,7 +1435,10 @@ export const TranscriptList = memo(function TranscriptList({
                   Dismiss
                 </button>
               </div>
-              <div className="text-[10.5px] text-muted">Stored securely, never shown to your Bot.</div>
+              <div className="flex items-center gap-1 text-[10.5px] text-muted">
+                <Shield className="h-3 w-3" aria-hidden="true" />
+                Stored securely, never shown to your Bot.
+              </div>
             </form>
           ) : (
             <div className="mt-2 text-faint">{it.status === "saved" ? "Stored securely" : it.status === "declined" ? "Declined" : it.status}</div>

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -193,6 +193,18 @@ type SwarmResultItem = {
   artifact_delivery?: SwarmArtifactDelivery;
 };
 
+export type SecretRequestItem = {
+  kind: "secret_request";
+  id: string;
+  label: string;
+  connector: string;
+  field: string;
+  description: string;
+  sessionId: string;
+  status: "pending" | "saving" | "saved" | "declined" | "error";
+  error?: string;
+};
+
 export type CommandApprovalItem = {
   kind: "command_approval";
   id: string;
@@ -233,6 +245,7 @@ export type Item =
   | { kind: "vault_cite"; route: string; snippets: string[]; query?: string }
   | { kind: "command_blocked"; command: string; category: string; reason: string; matched: string }
   | CommandApprovalItem
+  | SecretRequestItem
   | { kind: "auto_status"; cycle: number; snapshot: AutoBudgetSnapshot }
   | { kind: "auto_halt"; reason: string; snapshot: AutoBudgetSnapshot }
   | { kind: "auth_failure"; message: string; id?: string }
@@ -280,6 +293,7 @@ export type GroupedItem =
   | { kind: "vault_cite"; route: string; snippets: string[]; query?: string }
   | { kind: "command_blocked"; command: string; category: string; reason: string; matched: string }
   | CommandApprovalItem
+  | SecretRequestItem
   | { kind: "auto_status"; cycle: number; snapshot: AutoBudgetSnapshot }
   | { kind: "auto_halt"; reason: string; snapshot: AutoBudgetSnapshot }
   | { kind: "auth_failure"; message: string; id?: string }
@@ -681,6 +695,7 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
       currentGroup.push(item);
     } else if (
       item.kind === "command_approval"
+      || item.kind === "secret_request"
       || item.kind === "auth_failure"
       || item.kind === "steer"
     ) {
@@ -1041,6 +1056,7 @@ export type TranscriptListProps = {
   onSetCard: (id: string, patch: Partial<Card>) => void;
   onExecutePlan: (planText: string) => void;
   onCommandApproval: (item: CommandApprovalItem, approve: boolean) => void;
+  onSecretRequest?: (item: SecretRequestItem, decision: { action: "save"; value: string } | { action: "dismiss" }) => void;
 };
 
 export const TranscriptList = memo(function TranscriptList({
@@ -1061,6 +1077,7 @@ export const TranscriptList = memo(function TranscriptList({
   onSetCard,
   onExecutePlan,
   onCommandApproval,
+  onSecretRequest,
 }: TranscriptListProps) {
   // Match Conversation's latch — awaiting_swarm plus holdSwarmAwait so
   // Investigating / mid-turn absorption / footer stay armed through idle flaps.
@@ -1370,6 +1387,59 @@ export const TranscriptList = memo(function TranscriptList({
               </div>
             </div>
           </div>
+        </div>
+      );
+    } else if (it.kind === "secret_request") {
+      const pending = it.status === "pending" || it.status === "error";
+      return (
+        <div
+          key={key}
+          data-testid="secret-request-card"
+          className="w-full max-w-2xl rounded-md border border-edge bg-panel2/40 px-3.5 py-3 text-[11px] text-txt my-1.5"
+        >
+          <div className="font-medium text-txt">{it.label}</div>
+          {it.description ? <div className="mt-0.5 text-muted">{it.description}</div> : null}
+          {pending ? (
+            <form
+              className="mt-2 flex flex-col gap-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                const form = e.currentTarget;
+                const input = form.elements.namedItem("secret") as HTMLInputElement | null;
+                const value = input?.value || "";
+                if (!value.trim()) return;
+                onSecretRequest?.(it, { action: "save", value });
+                if (input) input.value = "";
+              }}
+            >
+              <input
+                name="secret"
+                type="password"
+                autoComplete="off"
+                placeholder={`Paste your ${it.label}`}
+                className="w-full rounded border border-edge bg-panel px-2 py-1.5 text-[12px] text-txt"
+              />
+              {it.error ? <div className="text-risk/90">{it.error}</div> : null}
+              <div className="flex items-center gap-2">
+                <button
+                  type="submit"
+                  className="rounded-md border border-edge bg-panel px-2.5 py-1 font-medium text-txt hover:border-accent/40"
+                >
+                  Save securely
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onSecretRequest?.(it, { action: "dismiss" })}
+                  className="rounded-md border border-edge bg-panel2/60 px-2.5 py-1 text-muted hover:text-txt"
+                >
+                  Dismiss
+                </button>
+              </div>
+              <div className="text-[10.5px] text-muted">Stored securely, never shown to your Bot.</div>
+            </form>
+          ) : (
+            <div className="mt-2 text-faint">{it.status === "saved" ? "Stored securely" : it.status === "declined" ? "Declined" : it.status}</div>
+          )}
         </div>
       );
     } else if (it.kind === "auto_status") {

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -11,6 +11,7 @@ import {
   TranscriptList,
   type Card,
   type CommandApprovalItem,
+  type SecretRequestItem,
   type Item,
 } from "../TranscriptList";
 import TranscriptEmptyState from "./TranscriptEmptyState";
@@ -35,6 +36,7 @@ export default function ConversationChatColumn({
   onSetCard,
   onExecutePlan,
   onCommandApproval,
+  onSecretRequest,
   composerDock,
   showJumpToBottom = false,
   onJumpToBottom,
@@ -60,6 +62,7 @@ export default function ConversationChatColumn({
   onSetCard: (id: string, patch: Partial<Card>) => void;
   onExecutePlan: (planText: string) => void;
   onCommandApproval: (item: CommandApprovalItem, approve: boolean) => void;
+  onSecretRequest?: (item: SecretRequestItem, decision: { action: "save"; value: string } | { action: "dismiss" }) => void;
   composerDock: ReactNode;
   showJumpToBottom?: boolean;
   onJumpToBottom?: () => void;
@@ -127,6 +130,7 @@ export default function ConversationChatColumn({
             onSetCard={onSetCard}
             onExecutePlan={onExecutePlan}
             onCommandApproval={onCommandApproval}
+            onSecretRequest={onSecretRequest}
           />
         </div>
       </div>

--- a/webapp/src/components/conversation/streamApply.ts
+++ b/webapp/src/components/conversation/streamApply.ts
@@ -2219,3 +2219,56 @@ export function formatDistilledNotice(d: {
 export function formatWikiAutoIngestNotice(pageCount: number): string {
   return `Wiki: ${pageCount} page${pageCount === 1 ? "" : "s"} auto-ingested (local orchestration)`;
 }
+
+
+export type SecretRequestPatch = {
+  status?: "pending" | "saving" | "saved" | "declined" | "error";
+  error?: string;
+};
+
+export function appendSecretRequest(
+  items: Item[],
+  data: {
+    id?: string;
+    label?: string;
+    connector?: string;
+    field?: string;
+    description?: string;
+    session_id?: string;
+  },
+): Item[] {
+  const connector = (data.connector || "").trim().toLowerCase();
+  const field = (data.field || "").trim();
+  if (!connector || !field) return items;
+  if (items.some((item) => item.kind === "secret_request" && item.connector === connector && item.field === field && item.status === "pending")) {
+    return items;
+  }
+  return [
+    ...items,
+    {
+      kind: "secret_request",
+      id: data.id || `${connector}::${field}`,
+      label: data.label || field,
+      connector,
+      field,
+      description: data.description || "",
+      sessionId: data.session_id || "",
+      status: "pending",
+    },
+  ];
+}
+
+export function updateSecretRequest(
+  items: Item[],
+  connector: string,
+  field: string,
+  patch: SecretRequestPatch,
+): Item[] {
+  const conn = connector.trim().toLowerCase();
+  const name = field.trim();
+  return items.map((item) => (
+    item.kind === "secret_request" && item.connector === conn && item.field === name
+      ? { ...item, ...patch, kind: "secret_request" }
+      : item
+  ));
+}

--- a/webapp/src/components/conversation/streamEventHandler.ts
+++ b/webapp/src/components/conversation/streamEventHandler.ts
@@ -22,6 +22,7 @@ import {
   appendCheckpoint,
   appendCodegraphContext,
   appendCommandApproval,
+  appendSecretRequest,
   appendCommandBlocked,
   appendCompaction,
   appendVaultCite,
@@ -187,6 +188,8 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
       setItems((p) => appendCommandBlocked(p, d));
     } else if (ev.kind === "command_approval_pending") {
       setItems((p) => appendCommandApproval(p, d));
+    } else if (ev.kind === "secret_request") {
+      setItems((p) => appendSecretRequest(p, d));
     } else if (ev.kind === "swarm_auth_failure") {
       // A provider rejected the API key. Surface it as a loud, persistent
       // banner so a dead/revoked key is never silently read as a generic

--- a/webapp/src/components/conversation/transcriptItems.ts
+++ b/webapp/src/components/conversation/transcriptItems.ts
@@ -411,6 +411,26 @@ export function transcriptResponseToItems(res: {
             ? m.artifact_delivery
             : undefined,
         }];
+      } else if (m.type === "secret_request") {
+        const connector = String(m.connector || "").trim().toLowerCase();
+        const field = String(m.field || "").trim();
+        if (!connector || !field) return [];
+        const status = (
+          m.status === "saved"
+          || m.status === "declined"
+          || m.status === "saving"
+          || m.status === "error"
+        ) ? m.status : "pending";
+        return [{
+          kind: "secret_request" as const,
+          id: m.id || `${connector}::${field}`,
+          label: m.label || field,
+          connector,
+          field,
+          description: m.description || "",
+          sessionId: m.session_id || "",
+          status,
+        }];
       } else if (m.type === "command_approval") {
         // Reject empty/malformed hashes so hydrate cannot create colliding
         // keys or invalid cards that suppress a later valid approval.
@@ -855,6 +875,8 @@ export function transcriptFingerprint(items: Item[]): string {
       fp += `|sp:${ids}:${status}:${status === "running" ? 1 : 0}:${terminals}`;
     } else if (it.kind === "command_approval") {
       fp += `|ca:${it.commandHash}:${it.status}`;
+    } else if (it.kind === "secret_request") {
+      fp += `|sr:${it.connector}:${it.field}:${it.status}`;
     } else if (it.kind === "thinking") {
       fp += `|t:${(it.text || "").length}:${(it as { streaming?: boolean }).streaming ? 1 : 0}`;
     } else if (it.kind === "tool_prep") {

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1273,6 +1273,18 @@ export const api = {
   // getJSON/postJSON, so a DELETE falls through to an unroutable fetch.
   deleteSession: (id: string) =>
     postJSON<{ ok: boolean; active: string | null }>("/api/sessions/delete", { id }),
+  submitSecret: (body: { session_id: string; connector: string; field: string; value: string }) =>
+    postJSON<{ ok: boolean; provided: boolean; connector: string; field: string; resume?: boolean }>("/api/secrets/submit", body),
+  dismissSecret: (body: { session_id: string; connector: string; field: string }) =>
+    postJSON<{ ok: boolean; provided: boolean; connector: string; field: string; resume?: boolean }>("/api/secrets/dismiss", body),
+  secretPresence: (opts: { session_id?: string; connector?: string; field?: string }) => {
+    const qs = new URLSearchParams();
+    if (opts.session_id) qs.set("session_id", opts.session_id);
+    if (opts.connector) qs.set("connector", opts.connector);
+    if (opts.field) qs.set("field", opts.field);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return getJSON<{ present?: boolean; state?: string; connectors?: Record<string, Record<string, string>> }>(`/api/secrets/presence${suffix}`);
+  },
   approveCommand: (sessionId: string, workspaceRoot: string, commandHash: string) =>
     postJSON<{
       ok: boolean;


### PR DESCRIPTION
## Summary
- Restore the host-held secret-request card that was reverted out of 0.9.279 (`05d1cc18`) and finish it to the CoS: masked input, Save securely, shield copy, Electron `safeStorage` vault keyed by agent/connector/field.
- Emitting the card ends the turn. Submit resumes with `{provided, connector, field}` only. Dismiss declines and does not re-ask in the same breath. Main-process env inject + log/process redaction; values never return in chat, presence API, or tool results.
- Electron-dev visual pass on the Grok Bot box (fixture + interactive save/dismiss) before merge/tag.

## Test plan
- [x] `pytest tests/test_secret_vault.py tests/test_secret_request.py tests/test_api_secrets.py`
- [x] vitest SecretRequestCard + isolation
- [x] `node --test webapp/electron/secret-vault.test.cjs`
- [x] Box Electron card render / save presence-only resume / dismiss / composer stays below feed
- [ ] CI `tests` matrix green on this dest tree