### PR TITLE
release: v0.9.281 remaining stream lurch

### DIFF
--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.280"
+__version__ = "0.9.281"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.280"
+version = "0.9.281"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.280",
+  "version": "0.9.281",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.280",
+      "version": "0.9.281",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.280",
+  "version": "0.9.281",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/feedScroll.test.ts
+++ b/webapp/src/__tests__/feedScroll.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  FEED_GESTURE_IDLE_MS,
   FEED_REPIN_THRESHOLD_PX,
   chooseFeedFollowFlush,
   feedBottomClearancePx,
@@ -9,6 +10,7 @@ import {
   scrollTopAfterFeedHeightChange,
   settleFrameResult,
   shouldCancelFeedResizeFollowForManualScrollAway,
+  shouldDeferFollowDuringUserGesture,
   shouldShowJumpToBottom,
   shouldUnpinOnTouchMove,
   shouldUnpinOnWheel,
@@ -92,7 +94,7 @@ describe("scrollTopAfterFeedHeightChange", () => {
     const newHeight = 2200;
     const distanceFromBottom = newHeight - oldMax - client;
     expect(distanceFromBottom).toBeGreaterThan(FEED_REPIN_THRESHOLD_PX);
-    // Geometry-based reclassification would drop pin before follow runs.
+    // Growth must keep pin so ResizeObserver follow can advance to the new max.
     expect(
       nextFeedPinState({
         wasPinned: true,
@@ -104,7 +106,7 @@ describe("scrollTopAfterFeedHeightChange", () => {
         settling: false,
         repinPx: FEED_REPIN_THRESHOLD_PX,
       }),
-    ).toEqual({ pinned: false, releasedByGesture: false });
+    ).toEqual({ pinned: true, releasedByGesture: false });
     expect(
       scrollTopAfterFeedHeightChange({
         scrollHeight: newHeight,
@@ -464,5 +466,185 @@ describe("feedBottomClearancePx", () => {
     expect(feedBottomClearancePx(0)).toBe(96);
     expect(feedBottomClearancePx(12)).toBe(72);
     expect(feedBottomClearancePx(800)).toBe(480);
+  });
+});
+
+describe("feedScroll user-gesture deferral", () => {
+  const height = 2000;
+  const client = 400;
+  const max = height - client;
+
+  it("defers follow while a user gesture is active", () => {
+    expect(shouldDeferFollowDuringUserGesture(true)).toBe(true);
+    expect(shouldDeferFollowDuringUserGesture(false)).toBe(false);
+    expect(FEED_GESTURE_IDLE_MS).toBe(150);
+  });
+
+  it("does not re-pin into the 28px band while the user gesture is still active", () => {
+    const lightUpTop = height - client - 40;
+    expect(
+      nextFeedPinState({
+        wasPinned: false,
+        releasedByGesture: true,
+        scrollHeight: height,
+        scrollTop: height - client - 10,
+        clientHeight: client,
+        prevScrollTop: lightUpTop,
+        settling: false,
+        repinPx: FEED_REPIN_THRESHOLD_PX,
+        userGestureActive: true,
+      }),
+    ).toEqual({ pinned: false, releasedByGesture: true });
+    expect(
+      scrollTopAfterFeedHeightChange({
+        scrollHeight: height + 80,
+        scrollTop: height - client - 10,
+        clientHeight: client,
+        pinned: false,
+        settling: false,
+        releasedByGesture: true,
+        userGestureActive: true,
+      }),
+    ).toBeNull();
+    expect(
+      feedResizeScrollFollowDecision({
+        scrollHeight: height + 80,
+        scrollTop: height - client - 10,
+        clientHeight: client,
+        offsetHeight: client,
+        snapshotPinned: false,
+        snapshotSettling: false,
+        snapshotScrollTop: height - client - 10,
+        snapshotScrollHeight: height,
+        releasedByGesture: true,
+        userGestureActive: true,
+      }),
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("does not steal scrollTop mid-flick above the tail", () => {
+    expect(
+      scrollTopAfterFeedHeightChange({
+        scrollHeight: 2400,
+        scrollTop: 800,
+        clientHeight: client,
+        pinned: false,
+        settling: false,
+        releasedByGesture: true,
+        userGestureActive: true,
+      }),
+    ).toBeNull();
+    expect(
+      feedResizeScrollFollowDecision({
+        scrollHeight: 2400,
+        scrollTop: 800,
+        clientHeight: client,
+        offsetHeight: client,
+        snapshotPinned: true,
+        snapshotSettling: false,
+        snapshotScrollTop: max,
+        snapshotScrollHeight: height,
+        releasedByGesture: true,
+        userGestureActive: true,
+      }),
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("re-pins after gesture idle when near the tight bottom band", () => {
+    const lightUpTop = height - client - 40;
+    expect(
+      nextFeedPinState({
+        wasPinned: false,
+        releasedByGesture: true,
+        scrollHeight: height,
+        scrollTop: height - client - 10,
+        clientHeight: client,
+        prevScrollTop: lightUpTop,
+        settling: false,
+        repinPx: FEED_REPIN_THRESHOLD_PX,
+        userGestureActive: false,
+      }),
+    ).toEqual({ pinned: true, releasedByGesture: false });
+    expect(
+      scrollTopAfterFeedHeightChange({
+        scrollHeight: height,
+        scrollTop: height - client - 10,
+        clientHeight: client,
+        pinned: true,
+        settling: false,
+        releasedByGesture: false,
+        userGestureActive: false,
+      }),
+    ).toBe(max);
+  });
+
+  it("keeps pin when growth leaves the old max outside the re-pin band", () => {
+    const oldMax = 1600 - client;
+    const newHeight = 2200;
+    expect(newHeight - oldMax - client).toBeGreaterThan(FEED_REPIN_THRESHOLD_PX);
+    expect(
+      nextFeedPinState({
+        wasPinned: true,
+        releasedByGesture: false,
+        scrollHeight: newHeight,
+        scrollTop: oldMax,
+        clientHeight: client,
+        prevScrollTop: oldMax,
+        settling: false,
+        userGestureActive: false,
+      }),
+    ).toEqual({ pinned: true, releasedByGesture: false });
+  });
+
+  it("follows to the new max after arriving at the tail plus immediate growth", () => {
+    const arrived = nextFeedPinState({
+      wasPinned: false,
+      releasedByGesture: true,
+      scrollHeight: height,
+      scrollTop: max,
+      clientHeight: client,
+      prevScrollTop: max - 20,
+      settling: false,
+      userGestureActive: true,
+    });
+    expect(arrived).toEqual({ pinned: true, releasedByGesture: false });
+    const newHeight = height + 120;
+    expect(
+      nextFeedPinState({
+        wasPinned: arrived.pinned,
+        releasedByGesture: arrived.releasedByGesture,
+        scrollHeight: newHeight,
+        scrollTop: max,
+        clientHeight: client,
+        prevScrollTop: max,
+        settling: false,
+        userGestureActive: true,
+      }),
+    ).toEqual({ pinned: true, releasedByGesture: false });
+    expect(
+      scrollTopAfterFeedHeightChange({
+        scrollHeight: newHeight,
+        scrollTop: max,
+        clientHeight: client,
+        pinned: true,
+        settling: false,
+        releasedByGesture: false,
+        userGestureActive: true,
+      }),
+    ).toBe(newHeight - client);
+    expect(
+      feedResizeScrollFollowDecision({
+        scrollHeight: newHeight,
+        scrollTop: max,
+        clientHeight: client,
+        offsetHeight: client,
+        snapshotPinned: true,
+        snapshotSettling: false,
+        snapshotScrollTop: max,
+        snapshotScrollHeight: height,
+        releasedByGesture: false,
+        userGestureActive: true,
+      }),
+    ).toEqual({ kind: "follow", scrollTop: newHeight - client });
   });
 });

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -99,6 +99,7 @@ import {
 import { runCommandPaletteAction } from "../lib/commandPalette";
 import { focusSettingsPage } from "./SettingsShell";
 import {
+  FEED_GESTURE_IDLE_MS,
   FEED_REPIN_THRESHOLD_PX,
   chooseFeedFollowFlush,
   feedResizeScrollFollowDecision,
@@ -1088,6 +1089,9 @@ export default function Conversation({
   // scrolls back toward the true bottom — do not re-pin from the soft
   // "near bottom" band (that fight feels like scroll stutter while streaming).
   const scrollReleasedByGestureRef = useRef(false);
+  const userScrollGestureRef = useRef(false);
+  const programmaticScrollRef = useRef(false);
+  const gestureIdleTimerRef = useRef<number | null>(null);
   const prevFeedScrollTopRef = useRef<number | null>(null);
   // Hermes session-switch settle: while true, height-driven follow keeps
   // scrolling to bottom until height stabilizes (or wall-clock timeout).
@@ -1108,12 +1112,50 @@ export default function Conversation({
     scrollReleasedByGestureRef.current = false;
     setShowJumpToBottom(false);
     const scrollToEnd = scrollFeedToEndRef.current;
-    if (scrollToEnd) scrollToEnd();
-    else if (feedRef.current) feedRef.current.scrollTop = feedRef.current.scrollHeight;
+    if (scrollToEnd) {
+      programmaticScrollRef.current = true;
+      scrollToEnd();
+    } else if (feedRef.current) {
+      programmaticScrollRef.current = true;
+      feedRef.current.scrollTop = feedRef.current.scrollHeight;
+    }
   };
   useEffect(() => {
     const el = feedRef.current;
     if (!el) return;
+    const clearGestureIdleTimer = () => {
+      if (gestureIdleTimerRef.current != null) {
+        window.clearTimeout(gestureIdleTimerRef.current);
+        gestureIdleTimerRef.current = null;
+      }
+    };
+    const snapToBottomIfNear = () => {
+      const node = feedRef.current;
+      if (!node) return;
+      const distance = node.scrollHeight - node.scrollTop - node.clientHeight;
+      if (distance >= FEED_REPIN_THRESHOLD_PX) return;
+      scrollReleasedByGestureRef.current = false;
+      pinnedToBottomRef.current = true;
+      const maxScrollTop = Math.max(0, node.scrollHeight - node.clientHeight);
+      if (Math.abs(node.scrollTop - maxScrollTop) >= 0.5) {
+        programmaticScrollRef.current = true;
+        node.scrollTop = maxScrollTop;
+      }
+      prevFeedScrollTopRef.current = node.scrollTop;
+      publishJumpVisibilityRef.current();
+    };
+    const endUserScrollGesture = () => {
+      userScrollGestureRef.current = false;
+      snapToBottomIfNear();
+    };
+    const markUserScrollGesture = () => {
+      userScrollGestureRef.current = true;
+      clearGestureIdleTimer();
+      gestureIdleTimerRef.current = window.setTimeout(() => {
+        gestureIdleTimerRef.current = null;
+        endUserScrollGesture();
+      }, FEED_GESTURE_IDLE_MS);
+    };
     const applyPinState = () => {
       const next = nextFeedPinState({
         wasPinned: pinnedToBottomRef.current,
@@ -1124,6 +1166,7 @@ export default function Conversation({
         prevScrollTop: prevFeedScrollTopRef.current,
         settling: scrollSettlingRef.current,
         repinPx: FEED_REPIN_THRESHOLD_PX,
+        userGestureActive: userScrollGestureRef.current,
       });
       pinnedToBottomRef.current = next.pinned;
       scrollReleasedByGestureRef.current = next.releasedByGesture;
@@ -1131,12 +1174,21 @@ export default function Conversation({
       publishJumpVisibilityRef.current();
     };
     const onScroll = () => {
+      if (programmaticScrollRef.current) {
+        programmaticScrollRef.current = false;
+        applyPinState();
+        return;
+      }
+      markUserScrollGesture();
       applyPinState();
     };
     // Fast-path unpin on upward wheel/touch before the next thinking token
     // re-runs stick-to-bottom -- otherwise long reasoning streams keep yanking
     // the feed back to the end and the user cannot scroll the Thought block.
     const onWheel = (e: WheelEvent) => {
+      if (e.deltaY !== 0) {
+        markUserScrollGesture();
+      }
       if (shouldUnpinOnWheel(e.deltaY, scrollSettlingRef.current)) {
         scrollSettlingRef.current = false;
         scrollReleasedByGestureRef.current = true;
@@ -1155,6 +1207,7 @@ export default function Conversation({
       touchY = e.touches[0]?.clientY ?? null;
     };
     const onTouchMove = (e: TouchEvent) => {
+      markUserScrollGesture();
       const y = e.touches[0]?.clientY;
       if (shouldUnpinOnTouchMove(touchY, y ?? null, scrollSettlingRef.current)) {
         scrollSettlingRef.current = false;
@@ -1164,6 +1217,9 @@ export default function Conversation({
       }
       touchY = y ?? touchY;
     };
+    const onTouchEnd = () => {
+      markUserScrollGesture();
+    };
     el.addEventListener("scroll", onScroll, { passive: true });
     // Capture phase: nested ThinkingBlock stops wheel bubble while scrolling
     // inside its pane — unpin must run first or stream tokens re-yank the feed.
@@ -1171,12 +1227,17 @@ export default function Conversation({
     el.addEventListener(FEED_UNPIN_BUBBLE_EVENT, onNestedFeedUnpin);
     el.addEventListener("touchstart", onTouchStart, { passive: true });
     el.addEventListener("touchmove", onTouchMove, { passive: true });
+    el.addEventListener("touchend", onTouchEnd, { passive: true });
+    el.addEventListener("touchcancel", onTouchEnd, { passive: true });
     return () => {
+      clearGestureIdleTimer();
       el.removeEventListener("scroll", onScroll);
       el.removeEventListener("wheel", onWheel, feedWheelUnpinListenerOptions().capture);
       el.removeEventListener(FEED_UNPIN_BUBBLE_EVENT, onNestedFeedUnpin);
       el.removeEventListener("touchstart", onTouchStart);
       el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("touchend", onTouchEnd);
+      el.removeEventListener("touchcancel", onTouchEnd);
     };
   }, []);
   const applyFeedResizeFollow = (
@@ -1194,9 +1255,11 @@ export default function Conversation({
       snapshotScrollTop: snapshot.scrollTop,
       snapshotScrollHeight: snapshot.scrollHeight,
       releasedByGesture: scrollReleasedByGestureRef.current,
+      userGestureActive: userScrollGestureRef.current,
     });
     if (result.kind === "noop") return;
     if (result.kind === "follow") {
+      programmaticScrollRef.current = true;
       el.scrollTop = result.scrollTop;
     }
     pinnedToBottomRef.current = true;
@@ -1256,8 +1319,13 @@ export default function Conversation({
     scrollSettlingRef.current = true;
     setShowJumpToBottom(false);
     const scrollToEnd = scrollFeedToEndRef.current;
-    if (scrollToEnd) scrollToEnd();
-    else el.scrollTop = el.scrollHeight;
+    if (scrollToEnd) {
+      programmaticScrollRef.current = true;
+      scrollToEnd();
+    } else {
+      programmaticScrollRef.current = true;
+      el.scrollTop = el.scrollHeight;
+    }
     let frame = 0;
     let stableFrames = 0;
     let lastHeight = el.scrollHeight;
@@ -1285,8 +1353,13 @@ export default function Conversation({
       frame = step.frame;
       lastHeight = height;
       const scrollToEnd = scrollFeedToEndRef.current;
-      if (scrollToEnd) scrollToEnd();
-      else node.scrollTop = height;
+      if (scrollToEnd) {
+        programmaticScrollRef.current = true;
+        scrollToEnd();
+      } else {
+        programmaticScrollRef.current = true;
+        node.scrollTop = height;
+      }
       pinnedToBottomRef.current = true;
       if (step.done) {
         scrollSettlingRef.current = false;
@@ -1319,6 +1392,7 @@ export default function Conversation({
         raf2 = window.requestAnimationFrame(() => {
           const node = feedRef.current;
           if (!node) return;
+          programmaticScrollRef.current = true;
           node.scrollTop = restoreFeedScrollAfterFocus({
             savedScrollTop: saved,
             pinned: pinnedToBottomRef.current,
@@ -1359,6 +1433,7 @@ export default function Conversation({
       return;
     }
     if (!isChatColumnActive(prev) && isChatColumnActive(activeTab)) {
+      programmaticScrollRef.current = true;
       node.scrollTop = restoreFeedScrollAfterFocus({
         savedScrollTop: fileTabScrollTopRef.current,
         pinned: pinnedToBottomRef.current,

--- a/webapp/src/components/conversation/feedScroll.ts
+++ b/webapp/src/components/conversation/feedScroll.ts
@@ -11,6 +11,10 @@ export const FEED_PIN_THRESHOLD_PX = 120;
  * and fight streaming growth.
  */
 export const FEED_REPIN_THRESHOLD_PX = 28;
+/** After the last wheel/touch/user-scroll event, wait this long before re-pin. */
+export const FEED_GESTURE_IDLE_MS = 150;
+/** Treat the viewport as at the true tail (not merely the 28px re-pin band). */
+export const FEED_TAIL_EPSILON_PX = 0.5;
 /** Inner live-reasoning pane re-pin threshold (smaller than outer feed). */
 export const THINKING_INNER_PIN_THRESHOLD_PX = 48;
 export const FEED_SETTLE_STABLE_FRAMES = 5;
@@ -76,8 +80,28 @@ export function pinStateFromScrollGeometry(
  * Rules:
  * - Upward wheel/touch sets ``releasedByGesture``; stay unpinned until the user
  *   scrolls toward the bottom AND lands within ``repinPx`` of the end.
+ * - A still-active user gesture does not re-pin merely by entering the 28px
+ *   band (mid-flick). Hitting the true tail (distance ~ 0) latches pin.
+ * - ``wasPinned && !releasedByGesture`` survives content growth that pushes
+ *   distance past the re-pin band — follow still owns the new max.
  * - Without a gesture release, pin follows the tight re-pin threshold only.
  */
+export function shouldDeferFollowDuringUserGesture(
+  userGestureActive: boolean,
+): boolean {
+  return userGestureActive;
+}
+
+export function isAtFeedTail(
+  scrollHeight: number,
+  scrollTop: number,
+  clientHeight: number,
+  epsilonPx: number = FEED_TAIL_EPSILON_PX,
+): boolean {
+  const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
+  return Math.abs(scrollTop - maxScrollTop) < epsilonPx;
+}
+
 export function nextFeedPinState(opts: {
   wasPinned: boolean;
   releasedByGesture: boolean;
@@ -88,26 +112,52 @@ export function nextFeedPinState(opts: {
   prevScrollTop: number | null;
   settling: boolean;
   repinPx?: number;
+  /** Wheel/touch/scrollbar/keyboard gesture still in flight. */
+  userGestureActive?: boolean;
 }): { pinned: boolean; releasedByGesture: boolean } {
   const repinPx = opts.repinPx ?? FEED_REPIN_THRESHOLD_PX;
+  const userGestureActive = opts.userGestureActive ?? false;
   const distance =
     opts.scrollHeight - opts.scrollTop - opts.clientHeight;
   const nearBottom = distance < repinPx;
+  const atTail = isAtFeedTail(
+    opts.scrollHeight,
+    opts.scrollTop,
+    opts.clientHeight,
+  );
   const scrolledTowardBottom =
     opts.prevScrollTop != null && opts.scrollTop > opts.prevScrollTop + 0.5;
+  const scrolledAway =
+    opts.prevScrollTop != null && opts.scrollTop < opts.prevScrollTop - 0.5;
 
   if (opts.settling) {
     return { pinned: true, releasedByGesture: false };
   }
 
   if (opts.releasedByGesture) {
-    if (scrolledTowardBottom && nearBottom) {
+    // Mid-flick above the tail: do not latch just because we entered 28px.
+    if (userGestureActive && !atTail) {
+      return { pinned: false, releasedByGesture: true };
+    }
+    if (atTail || (scrolledTowardBottom && nearBottom)) {
       return { pinned: true, releasedByGesture: false };
     }
     return { pinned: false, releasedByGesture: true };
   }
 
-  if (nearBottom) {
+  // Keep stick-to-bottom across token growth. Height can jump so the old
+  // max sits well outside the 28px band before follow writes the new max.
+  if (opts.wasPinned) {
+    if (scrolledAway && !nearBottom) {
+      return { pinned: false, releasedByGesture: false };
+    }
+    return { pinned: true, releasedByGesture: false };
+  }
+
+  if (nearBottom && !userGestureActive) {
+    return { pinned: true, releasedByGesture: false };
+  }
+  if (atTail) {
     return { pinned: true, releasedByGesture: false };
   }
   return { pinned: false, releasedByGesture: false };
@@ -175,8 +225,19 @@ export function scrollTopAfterFeedHeightChange(opts: {
   pinned: boolean;
   settling: boolean;
   releasedByGesture: boolean;
+  userGestureActive?: boolean;
 }): number | null {
   if (opts.releasedByGesture) {
+    return null;
+  }
+  // Mid-flick above the tail: do not steal scrollTop. Once pinned (they
+  // latched the end), keep following growth even if the downward gesture
+  // has not idled yet — otherwise new tokens walk out from under them.
+  if (
+    shouldDeferFollowDuringUserGesture(opts.userGestureActive ?? false) &&
+    !opts.pinned &&
+    !opts.settling
+  ) {
     return null;
   }
   if (!opts.pinned && !opts.settling) {
@@ -256,11 +317,19 @@ export function feedResizeScrollFollowDecision(opts: {
   snapshotScrollTop: number;
   snapshotScrollHeight: number;
   releasedByGesture: boolean;
+  userGestureActive?: boolean;
 }): FeedResizeFollowResult {
   if (isOccludedScrollParentSize(opts.clientHeight, opts.offsetHeight)) {
     return { kind: "noop" };
   }
   if (opts.releasedByGesture) {
+    return { kind: "noop" };
+  }
+  if (
+    shouldDeferFollowDuringUserGesture(opts.userGestureActive ?? false) &&
+    !opts.snapshotPinned &&
+    !opts.snapshotSettling
+  ) {
     return { kind: "noop" };
   }
   if (


### PR DESCRIPTION
## Summary
- Remaining lurch was mid-gesture re-pin while catching the tail, plus lost pin on token growth: `nextFeedPinState` unpinned when `scrollHeight` grew past the 28px band before follow wrote the new max, so new tokens were left below the viewport.
- Follow no longer writes `scrollTop` while a wheel/touch/scrollbar gesture is in flight above the tail. After ~150ms idle, if the viewport is in the tight bottom band, re-pin and snap once.
- Once the user actually latches the end (`wasPinned` or distance ~ 0), pin survives growth and follow stays on the tail.

## Test plan
- [x] vitest `src/__tests__/feedScroll.test.ts` (34)
- [x] `tsc -b`
- [ ] CI `tests` matrix green on this dest tree