### PR TITLE
v0.9.282 wave-4 leftovers and puppetmaster-ai 1.22.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.20
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.22
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.22
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.20
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.20"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.22"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.22"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.20"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.22"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.20"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -57,7 +57,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.22"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.20"
 
       - name: Run the offline test suite (shard)
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.20"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.22"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -57,7 +57,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.20"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.22"
 
       - name: Run the offline test suite (shard)
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.20"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.22"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.20` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.22` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.20` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.22` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.279, deliberately pre-1.0. Rides puppetmaster-ai==1.22.20. Shared `build_cost_report` for CLI / MCP / Mari, plus safely resumable jobs and honest delivery verdicts.
+> Status: v0.9.282, deliberately pre-1.0. Rides puppetmaster-ai==1.22.22. Effort-index plus agentic default when Cursor is not runnable, plus the wave-4 recovery/a11y/reattach haul.
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.20` (configurable default reviewer platform, shared `build_cost_report`, safely resumable jobs, honest delivery verdicts, Google Antigravity `agy` adapter, dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.22` (configurable default reviewer platform, shared `build_cost_report`, safely resumable jobs, honest delivery verdicts, Google Antigravity `agy` adapter, dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.281"
+__version__ = "0.9.282"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/doctor.py
+++ b/harness/api/doctor.py
@@ -1,0 +1,137 @@
+"""Authenticated GET /api/diagnostics — quotable OperationalDiagnostic for the UI."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Union
+
+from ..correlation import get_correlation_id
+
+JsonPayload = Union[dict, list]
+
+
+@dataclass
+class DoctorServices:
+    """Explicit deps for diagnostics HTTP handlers."""
+
+    get_driver: Callable[[], str]
+    get_reach: Callable[[], str]
+    get_repo: Callable[[], str]
+
+
+def _check_row(status: str, name: str, detail: str = "") -> dict[str, str]:
+    return {"status": status, "name": name, "detail": detail}
+
+
+def _build_checks(svc: DoctorServices) -> list[dict[str, str]]:
+    checks: list[dict[str, str]] = []
+    hard_fail = False
+
+    try:
+        from puppetmaster.store_factory import create_store  # noqa: F401
+        from puppetmaster.orchestrator import Orchestrator  # noqa: F401
+
+        checks.append(_check_row("ok", "puppetmaster seam", "Orchestrator + store_factory importable"))
+    except Exception as exc:
+        hard_fail = True
+        checks.append(_check_row("fail", "puppetmaster seam", f"cannot import: {exc}"))
+
+    try:
+        import tempfile
+
+        from puppetmaster.store_factory import create_store
+
+        store = create_store("sqlite", tempfile.mkdtemp(prefix="diag-"))
+        store.list_jobs()
+        checks.append(_check_row("ok", "durable state", "SQLite store read/write OK"))
+    except Exception as exc:
+        hard_fail = True
+        checks.append(_check_row("fail", "durable state", f"store error: {exc}"))
+
+    driver = (svc.get_driver() or "").strip() or "unknown"
+    reach = (svc.get_reach() or "").strip()
+    try:
+        from pmharness import registry as reg
+
+        built = (
+            reg.build(driver)
+            if driver.startswith("stub")
+            else reg.build(driver, reach=reach)
+        )
+        env = getattr(built, "api_key_env", None)
+        if env is None:
+            checks.append(_check_row("ok", f"driver {driver}", "no key required (stub/offline)"))
+        elif os.environ.get(env, "").strip():
+            checks.append(_check_row("ok", f"driver {driver}", f"{env} present"))
+        else:
+            checks.append(
+                _check_row("warn", f"driver {driver}", f"{env} not set -- set it or use a stub driver"),
+            )
+    except Exception as exc:
+        hard_fail = True
+        checks.append(_check_row("fail", f"driver {driver}", f"build failed: {exc}"))
+
+    repo = (svc.get_repo() or "").strip()
+    if repo and not os.path.isdir(repo):
+        checks.append(_check_row("warn", "workspace", f"repo path missing: {repo}"))
+
+    checks.append(
+        _check_row(
+            "ok" if not hard_fail else "fail",
+            "result",
+            "harness ready" if not hard_fail else "one or more hard failures",
+        ),
+    )
+    return checks
+
+
+def _diagnostic_from_checks(checks: list[dict[str, str]]) -> Optional[dict[str, Any]]:
+    failed = [c for c in checks if c.get("status") == "fail"]
+    warned = [c for c in checks if c.get("status") == "warn"]
+    if not failed and not warned:
+        return None
+
+    if failed:
+        first = failed[0]
+        summary = f"{first.get('name', 'backend')} failed"
+        detail = str(first.get("detail") or "").strip()
+        return {
+            "scope": "backend",
+            "operation": "doctor",
+            "code": "backend_not_ready",
+            "summary": summary,
+            "detail": detail or None,
+            "severity": "error",
+            "retryable": True,
+            "recovery": {"kind": "retry", "label": "Retry"},
+            "createdAt": int(time.time() * 1000),
+        }
+
+    first = warned[0]
+    summary = f"{first.get('name', 'backend')} needs attention"
+    detail = str(first.get("detail") or "").strip()
+    return {
+        "scope": "backend",
+        "operation": "doctor",
+        "code": "backend_warning",
+        "summary": summary,
+        "detail": detail or None,
+        "severity": "warning",
+        "retryable": True,
+        "recovery": {"kind": "retry", "label": "Retry"},
+        "createdAt": int(time.time() * 1000),
+    }
+
+
+def get_diagnostics(svc: DoctorServices) -> tuple[int, JsonPayload]:
+    """GET /api/diagnostics — structured checks plus a quotable diagnostic."""
+    checks = _build_checks(svc)
+    diagnostic = _diagnostic_from_checks(checks)
+    return 200, {
+        "ok": True,
+        "correlation_id": get_correlation_id(),
+        "checks": checks,
+        "diagnostic": diagnostic,
+    }

--- a/harness/correlation.py
+++ b/harness/correlation.py
@@ -1,0 +1,51 @@
+"""Request correlation IDs for harness HTTP handlers and swallowed-failure logs.
+
+Each inbound request gets a stable correlation id (from X-Correlation-Id when
+present, otherwise a fresh uuid4). The id threads through diag.note and the
+quiet server access log so support can quote one line across renderer + backend.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import uuid
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+_CORRELATION_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "harness_correlation_id",
+    default=None,
+)
+
+
+def new_correlation_id() -> str:
+    return str(uuid.uuid4())
+
+
+def get_correlation_id() -> str:
+    cur = _CORRELATION_ID.get()
+    return cur if cur else ""
+
+
+def set_correlation_id(correlation_id: str) -> contextvars.Token:
+    return _CORRELATION_ID.set(str(correlation_id or "").strip() or new_correlation_id())
+
+
+def reset_correlation_id(token: contextvars.Token) -> None:
+    _CORRELATION_ID.reset(token)
+
+
+def resolve_correlation_id(incoming: Optional[str]) -> str:
+    raw = str(incoming or "").strip()
+    return raw if raw else new_correlation_id()
+
+
+@contextmanager
+def correlation_scope(correlation_id: Optional[str] = None) -> Iterator[str]:
+    """Bind a correlation id for the duration of a request or test."""
+    cid = resolve_correlation_id(correlation_id)
+    token = set_correlation_id(cid)
+    try:
+        yield cid
+    finally:
+        reset_correlation_id(token)

--- a/harness/diag.py
+++ b/harness/diag.py
@@ -55,10 +55,14 @@ def note(where: str, exc: BaseException | None = None, msg: str = "") -> None:
     log is greppable; ``exc`` (if given) is rendered with repr for the real
     cause. Best-effort -- any failure here is itself swallowed."""
     try:
+        from .correlation import get_correlation_id
+
+        cid = get_correlation_id()
+        prefix = f"[{cid}] " if cid else ""
         logger = _get_logger()
         if exc is not None:
-            logger.warning("%s: %s%r", where, (msg + " " if msg else ""), exc)
+            logger.warning("%s%s: %s%r", prefix, where, (msg + " " if msg else ""), exc)
         elif msg:
-            logger.info("%s: %s", where, msg)
+            logger.info("%s%s: %s", prefix, where, msg)
     except Exception:
         pass

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -418,6 +418,7 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
     from .api import commands as _cmd_api
     from .api import economics as _econ_api
     from .api import environment as _env_api
+    from .api import doctor as _doctor_api
     from .api import files as _files_api
     from .api import git as _git_api
     from .api import hooks as _hooks_api
@@ -670,6 +671,8 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
             _cg_api.get_codegraph, services=svc.codegraph_services),
         "/api/config": get_json(
             _settings_api.get_config, services=svc.settings_services),
+        "/api/diagnostics": get_json(
+            _doctor_api.get_diagnostics, services=svc.doctor_services),
         "/api/wiki/config": get_json(_wiki_api.get_wiki_config_payload),
         "/api/bedrock": get_json(_plat_api.get_bedrock),
         "/api/auth/pools": _get_auth_pools,

--- a/harness/server.py
+++ b/harness/server.py
@@ -1710,6 +1710,17 @@ def _platform_services():
     )
 
 
+def _doctor_services():
+    """Build DoctorServices from live server module globals (call-time lookup)."""
+    from .api.doctor import DoctorServices
+
+    return DoctorServices(
+        get_driver=lambda: getattr(_cfg, "driver", "") or "",
+        get_reach=lambda: getattr(_cfg, "reach", "") or "",
+        get_repo=lambda: getattr(_cfg, "repo", "") or "",
+    )
+
+
 def _codegraph_services():
     """Build CodegraphServices from live server module globals (call-time lookup)."""
     from .api.codegraph import CodegraphServices
@@ -2486,6 +2497,7 @@ def _route_services():
         session_services=_session_services,
         terminal_services=_terminal_services,
         platform_services=_platform_services,
+        doctor_services=_doctor_services,
         settings_services=_settings_services,
         registry_services=_registry_services,
         worktree_services=_worktree_services,
@@ -2526,13 +2538,25 @@ class Handler(BaseHTTPRequestHandler):
         # escapes to socketserver's default handle_error and dumps a traceback to
         # stderr. Swallow only those transport errors so a disconnect never prints
         # noise; genuine handler bugs still surface unchanged.
-        try:
-            super().handle_one_request()
-        except (ConnectionError, TimeoutError):
-            self.close_connection = True
+        from .correlation import correlation_scope, resolve_correlation_id
 
-    def log_message(self, *a):  # quiet
-        pass
+        cid = resolve_correlation_id(self.headers.get("X-Correlation-Id"))
+        with correlation_scope(cid):
+            try:
+                super().handle_one_request()
+            except (ConnectionError, TimeoutError):
+                self.close_connection = True
+
+    def log_message(self, fmt, *args):  # quiet but correlated
+        try:
+            from .correlation import get_correlation_id
+            from .diag import note
+
+            msg = fmt % args if args else str(fmt)
+            cid = get_correlation_id()
+            note("server.access", msg=f"{cid} {msg}" if cid else msg)
+        except Exception:
+            pass
 
     def _cors(self):
         # No wildcard. Reflect the Origin only when it is a loopback origin, so a
@@ -2540,7 +2564,7 @@ class Handler(BaseHTTPRequestHandler):
         origin = self.headers.get("Origin", "")
         if origin and origin != "null" and _origin_ok(origin):
             self.send_header("Access-Control-Allow-Origin", origin)
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, X-Harness-Token")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, X-Harness-Token, X-Correlation-Id")
         self.send_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 
     def _guard(self) -> bool:
@@ -2574,6 +2598,14 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(code)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(data)))
+        try:
+            from .correlation import get_correlation_id
+
+            cid = get_correlation_id()
+            if cid:
+                self.send_header("X-Correlation-Id", cid)
+        except Exception:
+            pass
         self._cors()
         self.end_headers()
         self.wfile.write(data)

--- a/harness/server.py
+++ b/harness/server.py
@@ -2538,14 +2538,10 @@ class Handler(BaseHTTPRequestHandler):
         # escapes to socketserver's default handle_error and dumps a traceback to
         # stderr. Swallow only those transport errors so a disconnect never prints
         # noise; genuine handler bugs still surface unchanged.
-        from .correlation import correlation_scope, resolve_correlation_id
-
-        cid = resolve_correlation_id(self.headers.get("X-Correlation-Id"))
-        with correlation_scope(cid):
-            try:
-                super().handle_one_request()
-            except (ConnectionError, TimeoutError):
-                self.close_connection = True
+        try:
+            super().handle_one_request()
+        except (ConnectionError, TimeoutError):
+            self.close_connection = True
 
     def log_message(self, fmt, *args):  # quiet but correlated
         try:
@@ -2567,9 +2563,17 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Access-Control-Allow-Headers", "Content-Type, X-Harness-Token, X-Correlation-Id")
         self.send_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 
+    def _bind_correlation(self) -> None:
+        from .correlation import resolve_correlation_id, set_correlation_id
+
+        headers = getattr(self, "headers", None)
+        incoming = headers.get("X-Correlation-Id") if headers is not None else None
+        set_correlation_id(resolve_correlation_id(incoming))
+
     def _guard(self) -> bool:
         """Reject cross-origin / rebound / unauthenticated requests. Returns True
         if the request should be BLOCKED (and sends the 403)."""
+        self._bind_correlation()
         if not _host_ok(self.headers.get("Host", "")):
             self._send(403, json.dumps({"error": "host not allowed"})); return True
         if not _origin_ok(self.headers.get("Origin", "")):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.281"
+version = "0.9.282"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.20" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.22" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.20"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.22"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.20" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.22" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.20}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.22}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/tests/test_api_diagnostics.py
+++ b/tests/test_api_diagnostics.py
@@ -1,0 +1,36 @@
+"""GET /api/diagnostics authenticated route."""
+
+from __future__ import annotations
+
+from harness.api.doctor import DoctorServices, get_diagnostics
+
+
+def test_get_diagnostics_returns_quotable_payload(monkeypatch):
+    monkeypatch.setenv("HARNESS_DRIVER", "stub-oracle")
+    svc = DoctorServices(
+        get_driver=lambda: "stub-oracle",
+        get_reach=lambda: "local",
+        get_repo=lambda: "",
+    )
+    with __import__("harness.correlation", fromlist=["correlation_scope"]).correlation_scope("diag-test"):
+        status, payload = get_diagnostics(svc)
+
+    assert status == 200
+    assert payload["ok"] is True
+    assert payload["correlation_id"] == "diag-test"
+    assert isinstance(payload["checks"], list)
+    assert payload["checks"]
+    assert payload["diagnostic"] is None
+
+
+def test_get_diagnostics_surfaces_hard_failures(monkeypatch):
+    svc = DoctorServices(
+        get_driver=lambda: "definitely-not-a-real-driver-spec",
+        get_reach=lambda: "cloud",
+        get_repo=lambda: "",
+    )
+    status, payload = get_diagnostics(svc)
+    assert status == 200
+    assert payload["diagnostic"] is not None
+    assert payload["diagnostic"]["scope"] == "backend"
+    assert payload["diagnostic"]["recovery"] == {"kind": "retry", "label": "Retry"}

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -1,0 +1,43 @@
+"""Correlation id threading for harness logs and HTTP responses."""
+
+from __future__ import annotations
+
+from harness.correlation import (
+    correlation_scope,
+    get_correlation_id,
+    new_correlation_id,
+    resolve_correlation_id,
+    set_correlation_id,
+)
+
+
+def test_new_correlation_id_is_unique():
+    a = new_correlation_id()
+    b = new_correlation_id()
+    assert a
+    assert b
+    assert a != b
+
+
+def test_correlation_scope_restores_previous():
+    with correlation_scope("outer"):
+        assert get_correlation_id() == "outer"
+        with correlation_scope("inner"):
+            assert get_correlation_id() == "inner"
+        assert get_correlation_id() == "outer"
+
+
+def test_resolve_correlation_id_generates_when_missing():
+    cid = resolve_correlation_id("")
+    assert cid
+    assert resolve_correlation_id(cid) == cid
+
+
+def test_set_correlation_id_overrides_context():
+    with correlation_scope("seed"):
+        token = set_correlation_id("override")
+        assert get_correlation_id() == "override"
+        from harness.correlation import reset_correlation_id
+
+        reset_correlation_id(token)
+        assert get_correlation_id() == "seed"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.268"
+version = "0.9.282"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.20";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.22";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.20";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.22";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 
 // True when `pip show` / `uv pip show` output describes an editable install
@@ -43,7 +43,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.20" }    -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.22" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -65,7 +65,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.20).
+ * to 1.22.22).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.281",
+  "version": "0.9.282",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.281",
+      "version": "0.9.282",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.281",
+  "version": "0.9.282",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api, type Config } from "./lib/api";
 import { subscribeDocumentMotionPolicy } from "./lib/motionPolicy";
+import { fromBackendDiagnostic } from "./lib/operationalDiagnostic";
+import { clearDiagnostic, publishDiagnostic } from "./lib/operationalDiagnosticBus";
+import { setCorrelationId } from "./lib/correlationId";
 import LeftRail from "./components/LeftRail";
 import Conversation from "./components/Conversation";
 import RightPane from "./components/RightPane";
@@ -130,6 +133,17 @@ export default function App() {
     api.config().then(setConfig).catch(() => {});
   };
 
+  const fetchDiagnostics = () => {
+    api.diagnostics()
+      .then((res) => {
+        if (res.correlation_id) setCorrelationId(res.correlation_id);
+        const diag = fromBackendDiagnostic(res.diagnostic as Record<string, unknown> | null);
+        if (diag) publishDiagnostic(diag);
+        else clearDiagnostic();
+      })
+      .catch(() => {});
+  };
+
   // Prevent the Electron window from navigating to a file dropped anywhere
   // outside an explicit drop target (the default would replace the whole app
   // with the file). Composer + message drop zones stopPropagation, so they keep
@@ -159,11 +173,18 @@ export default function App() {
     };
   }, []);
 
-  useEffect(() => { fetchConfig(); }, []);
   useEffect(() => {
-    window.addEventListener("harness-config-changed", fetchConfig);
+    fetchConfig();
+    fetchDiagnostics();
+  }, []);
+  useEffect(() => {
+    const onRefresh = () => {
+      fetchConfig();
+      fetchDiagnostics();
+    };
+    window.addEventListener("harness-config-changed", onRefresh);
     return () => {
-      window.removeEventListener("harness-config-changed", fetchConfig);
+      window.removeEventListener("harness-config-changed", onRefresh);
     };
   }, []);
 

--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -1092,7 +1092,7 @@ describe("mid-turn store-event cursor reattach", () => {
     expect(keep).toBe(true);
   });
 
-  it("on getSessionState failure optimistic-busy arms store poll", async () => {
+  it("on getSessionState failure arms store poll without fabricating busy", async () => {
     vi.useFakeTimers();
     const turnOpen = vi.fn();
     const setStatus = vi.fn();
@@ -1114,15 +1114,15 @@ describe("mid-turn store-event cursor reattach", () => {
 
     const { startChatEventsReattach } = createChatEventsReattach(deps as any);
     const done = startChatEventsReattach();
-    // Retry uses setTimeout(100); do not runAllTimers (store poll interval loops).
     await vi.advanceTimersByTimeAsync(250);
     await done;
     await Promise.resolve();
     await vi.advanceTimersByTimeAsync(0);
 
     expect(getSessionState.mock.calls.length).toBeGreaterThanOrEqual(2);
-    expect(deps.detachedBusyRef.current).toBe(true);
-    expect(turnOpen).toHaveBeenCalledWith(true);
+    expect(deps.detachedBusyRef.current).toBe(false);
+    expect(turnOpen).not.toHaveBeenCalled();
+    expect(setStatus).not.toHaveBeenCalled();
     expect(live).not.toHaveBeenCalled();
     expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
   });

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -2111,7 +2111,7 @@ describe("sessionHydrate module", () => {
     });
     expect(reattachSessionStateFailureDecision({ attempt: 1, maxAttempts: 2 })).toBe("retry");
     expect(reattachSessionStateFailureDecision({ attempt: 2, maxAttempts: 2 })).toBe(
-      "optimistic_busy",
+      "poll_only",
     );
   });
 });

--- a/webapp/src/__tests__/wave4Operational.test.ts
+++ b/webapp/src/__tests__/wave4Operational.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AUTH_FAILURE,
+  BACKEND_NOT_READY,
+  authFailureDiagnostic,
+  fromBackendDiagnostic,
+} from "../lib/operationalDiagnostic";
+
+describe("fromBackendDiagnostic", () => {
+  it("parses GET /api/diagnostics wire payloads", () => {
+    const diag = fromBackendDiagnostic({
+      scope: "backend",
+      operation: "doctor",
+      code: BACKEND_NOT_READY,
+      summary: "durable state failed",
+      detail: "store error",
+      severity: "error",
+      retryable: true,
+      recovery: { kind: "retry", label: "Retry" },
+      createdAt: 1,
+    });
+    expect(diag?.scope).toBe("backend");
+    expect(diag?.recovery).toEqual({ kind: "retry", label: "Retry" });
+  });
+
+  it("returns null for incomplete wire payloads", () => {
+    expect(fromBackendDiagnostic({ summary: "only summary" })).toBeNull();
+  });
+});
+
+describe("authFailureDiagnostic", () => {
+  it("is retryable with a fix-key label", () => {
+    const diag = authFailureDiagnostic("OPENAI_API_KEY rejected", { jobId: "j1" });
+    expect(diag.code).toBe(AUTH_FAILURE);
+    expect(diag.recovery).toEqual({ kind: "retry", label: "Fix key and retry" });
+    expect(diag.jobId).toBe("j1");
+  });
+});
+
+describe("executeDiagnosticRecovery", () => {
+  it("invokes retry callback for retry recovery", async () => {
+    const { executeDiagnosticRecovery } = await import("../lib/operationalRecovery");
+    const retry = vi.fn();
+    await executeDiagnosticRecovery(
+      authFailureDiagnostic("bad key"),
+      retry,
+    );
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/webapp/src/__tests__/wave4PilotPicker.test.tsx
+++ b/webapp/src/__tests__/wave4PilotPicker.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import PilotPicker from "../components/PilotPicker";
+import { api } from "../lib/api";
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      swapPilot: vi.fn().mockResolvedValue({}),
+      updateSettings: vi.fn().mockResolvedValue({}),
+    },
+  };
+});
+
+describe("PilotPicker reroute notice", () => {
+  it("shows a visible notice when configured driver is unavailable", () => {
+    render(
+      <PilotPicker
+        config={{
+          driver: "openai:gpt-5.2",
+          reach: "cloud",
+          budget: 1,
+          models: ["anthropic:claude-sonnet-4-6"],
+          model_labels: {},
+        }}
+      />,
+    );
+    expect(screen.getByTestId("pilot-reroute-notice")).toHaveTextContent(/unavailable/i);
+  });
+});

--- a/webapp/src/__tests__/wave4PilotPicker.test.tsx
+++ b/webapp/src/__tests__/wave4PilotPicker.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import PilotPicker from "../components/PilotPicker";
-import { api } from "../lib/api";
 
 vi.mock("../lib/api", async () => {
   const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");

--- a/webapp/src/__tests__/wave4Reattach.test.ts
+++ b/webapp/src/__tests__/wave4Reattach.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { reattachSessionStateFailureDecision } from "../components/conversation/sessionHydrate";
+
+describe("reattachSessionStateFailureDecision", () => {
+  it("retries then polls without optimistic busy", () => {
+    expect(reattachSessionStateFailureDecision({ attempt: 1, maxAttempts: 2 })).toBe("retry");
+    expect(reattachSessionStateFailureDecision({ attempt: 2, maxAttempts: 2 })).toBe("poll_only");
+  });
+});

--- a/webapp/src/components/CheckpointsPane.tsx
+++ b/webapp/src/components/CheckpointsPane.tsx
@@ -378,7 +378,10 @@ export default function CheckpointsPane() {
                                     <span className="font-mono text-[10px] text-muted truncate max-w-[180px]" title={file.path}>
                                       {file.path}
                                     </span>
-                                    <span className={`px-1 py-0.2 text-[8px] uppercase font-bold tracking-wider rounded border ${badgeColor}`}>
+                                    <span
+                                      className={`px-1 py-0.2 text-[8px] uppercase font-bold tracking-wider rounded border ${badgeColor}`}
+                                      aria-label={`${label}: ${file.path}`}
+                                    >
                                       {label}
                                     </span>
                                   </div>

--- a/webapp/src/components/CommandPalette.tsx
+++ b/webapp/src/components/CommandPalette.tsx
@@ -6,6 +6,7 @@ import {
   runCommandPaletteAction,
   type CommandPaletteAction,
 } from "../lib/commandPalette";
+import { useOverlayFocus } from "../lib/overlayFocus";
 
 type CommandPaletteProps = {
   onToggleLeft: () => void;
@@ -32,6 +33,13 @@ export default function CommandPalette({
   const listRef = useRef<HTMLDivElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const listId = useId();
+
+  const close = () => setOpen(false);
+
+  useOverlayFocus(open, dialogRef, {
+    initialFocusRef: inputRef,
+    onClose: close,
+  });
 
   const actions = filterCommandPaletteActions(COMMAND_PALETTE_ACTIONS, query);
   const actionsRef = useRef(actions);
@@ -92,12 +100,6 @@ export default function CommandPalette({
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        e.stopPropagation();
-        setOpen(false);
-        return;
-      }
       const list = actionsRef.current;
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -130,19 +132,6 @@ export default function CommandPalette({
     );
     row?.scrollIntoView?.({ block: "nearest" });
   }, [activeIndex, open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onFocusIn = (e: FocusEvent) => {
-      const root = dialogRef.current;
-      if (!root) return;
-      if (e.target instanceof Node && root.contains(e.target)) return;
-      e.stopPropagation();
-      inputRef.current?.focus();
-    };
-    document.addEventListener("focusin", onFocusIn);
-    return () => document.removeEventListener("focusin", onFocusIn);
-  }, [open]);
 
   if (!open) return null;
 

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -159,8 +159,9 @@ import {
   type DirectoryEntryLike,
 } from "./conversation/composerInput";
 import { openAgentWorkspace } from "../lib/agentLinks";
-import { sharedReadinessNotice } from "../lib/operationalDiagnostic";
-import { getActiveDiagnostic } from "../lib/operationalDiagnosticBus";
+import { sharedReadinessNotice, fromBackendDiagnostic } from "../lib/operationalDiagnostic";
+import { getActiveDiagnostic, publishDiagnostic } from "../lib/operationalDiagnosticBus";
+import { executeDiagnosticRecovery, clearDiagnosticAfterSuccess } from "../lib/operationalRecovery";
 import { useOperationalDiagnostic } from "../lib/useOperationalDiagnostic";
 import {
   blankMsgQueueOnSessionSwitch,
@@ -3416,6 +3417,31 @@ export default function Conversation({
     );
   }, []);
 
+  const handleOperationalRecovery = useCallback(async () => {
+    if (!operationalDiagnostic) return;
+    await executeDiagnosticRecovery(operationalDiagnostic, async () => {
+      try {
+        const res = await api.diagnostics();
+        const diag = fromBackendDiagnostic(res.diagnostic as Record<string, unknown> | null);
+        if (!diag) clearDiagnosticAfterSuccess(operationalDiagnostic);
+        else publishDiagnostic(diag);
+        window.dispatchEvent(new Event("harness-config-changed"));
+      } catch {
+        /* keep diagnostic visible */
+      }
+    });
+  }, [operationalDiagnostic]);
+
+  const recoveryAction = (
+    operationalDiagnostic
+    && operationalDiagnostic.recovery.kind !== "none"
+      ? {
+          label: operationalDiagnostic.recovery.label,
+          onClick: () => { void handleOperationalRecovery(); },
+        }
+      : undefined
+  );
+
   return (
     <main className="flex flex-col h-full min-w-0 bg-transparent">
       {/* Brand + idle share equal inset so they line up with the floating dock. */}
@@ -3429,8 +3455,6 @@ export default function Conversation({
                 ? (
                   busyProgress.label
                     ? busyProgress.pill
-                    // Sticky busy without a footer line: pause-point Still working…
-                    // wins over hold-sticky liveInvestigation (matches Explored fold).
                     : derivePillBusyDetail({
                       liveInvestigation,
                       pillStatus,
@@ -3440,6 +3464,7 @@ export default function Conversation({
                 : undefined
             )
         }
+        recoveryAction={recoveryAction}
         onBusyDetailClick={() => {
           // Worker / shell busy chrome → terminal, never the file editor.
           try {

--- a/webapp/src/components/PilotPicker.tsx
+++ b/webapp/src/components/PilotPicker.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Check, Search } from "lucide-react";
 import { api, type Config, type ReasoningEffort } from "../lib/api";
 import { fallbackPilot, modelLabelOf, organizePilotModels } from "../lib/pilotPickerModels";
 import { REASONING_LEVELS, labelForEffort, showReasoningEffort } from "../lib/reasoningSupport";
+import { useOverlayFocus } from "../lib/overlayFocus";
 
 export default function PilotPicker({ config }: {
   config: Config | null;
@@ -13,8 +14,20 @@ export default function PilotPicker({ config }: {
   const [modelOpen, setModelOpen] = useState(false);
   const [reasonOpen, setReasonOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [rerouteNotice, setRerouteNotice] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const modelMenuRef = useRef<HTMLDivElement>(null);
+  const reasonMenuRef = useRef<HTMLDivElement>(null);
   const filterRef = useRef<HTMLInputElement>(null);
+  const modelTriggerRef = useRef<HTMLButtonElement>(null);
+
+  useOverlayFocus(modelOpen, modelMenuRef, {
+    initialFocusRef: filterRef,
+    onClose: () => setModelOpen(false),
+  });
+  useOverlayFocus(reasonOpen, reasonMenuRef, {
+    onClose: () => setReasonOpen(false),
+  });
 
   useEffect(() => {
     if (!config) return;
@@ -24,11 +37,18 @@ export default function PilotPicker({ config }: {
     const next = fallbackPilot(nextModels, config.driver);
     setCurrent(next);
     if (next && next !== config.driver) {
+      const configuredLabel = modelLabelOf(config.driver, config.model_labels) || config.driver;
+      const fallbackLabel = modelLabelOf(next, config.model_labels) || next;
+      const notice = `Configured pilot ${configuredLabel} is unavailable — using ${fallbackLabel}.`;
+      setRerouteNotice(notice);
+      window.dispatchEvent(new CustomEvent("harness-toast", { detail: notice }));
       api.swapPilot(next).then(() => {
         window.dispatchEvent(new Event("harness-config-changed"));
       }).catch(() => {
         /* next config fetch retries; keep the local fallback label */
       });
+    } else {
+      setRerouteNotice(null);
     }
   }, [config]);
 
@@ -43,7 +63,6 @@ export default function PilotPicker({ config }: {
       setQuery("");
       return;
     }
-    // Focus search when the model menu opens.
     const t = window.setTimeout(() => filterRef.current?.focus(), 0);
     return () => window.clearTimeout(t);
   }, [modelOpen]);
@@ -56,24 +75,15 @@ export default function PilotPicker({ config }: {
         setReasonOpen(false);
       }
     };
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setModelOpen(false);
-        setReasonOpen(false);
-      }
-    };
     document.addEventListener("mousedown", handleOutsideClick);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleOutsideClick);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
+    return () => document.removeEventListener("mousedown", handleOutsideClick);
   }, [modelOpen, reasonOpen]);
 
   const swap = async (m: string) => {
     const prev = current;
     setCurrent(m);
     setModelOpen(false);
+    setRerouteNotice(null);
     try {
       await api.swapPilot(m);
       window.dispatchEvent(new Event("harness-config-changed"));
@@ -146,9 +156,20 @@ export default function PilotPicker({ config }: {
   };
 
   return (
-    <div className="relative flex items-center gap-1 min-w-0 w-full" ref={containerRef}>
+    <div className="relative flex flex-col gap-0.5 min-w-0 w-full" ref={containerRef}>
+      {rerouteNotice ? (
+        <div
+          role="status"
+          className="text-[9.5px] text-warn/90 leading-snug px-0.5"
+          data-testid="pilot-reroute-notice"
+        >
+          {rerouteNotice}
+        </div>
+      ) : null}
+      <div className="relative flex items-center gap-1 min-w-0 w-full">
       <div className="relative min-w-0 flex-1">
         <button
+          ref={modelTriggerRef}
           onClick={() => {
             setReasonOpen(false);
             setModelOpen((prev) => !prev);
@@ -161,7 +182,13 @@ export default function PilotPicker({ config }: {
         </button>
 
         {modelOpen && (
-          <div className="absolute left-0 bottom-full mb-1 z-50 min-w-[220px] max-w-[280px] bg-panel border border-edge rounded-lg shadow-lg py-1 overflow-hidden">
+          <div
+            ref={modelMenuRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Pilot model picker"
+            className="absolute left-0 bottom-full mb-1 z-50 min-w-[220px] max-w-[280px] bg-panel border border-edge rounded-lg shadow-lg py-1 overflow-hidden"
+          >
             <div className="flex items-center gap-1.5 px-2.5 py-1.5 mb-0.5 border-b border-edge/50">
               <Search size={12} className="text-faint shrink-0" />
               <input
@@ -209,7 +236,13 @@ export default function PilotPicker({ config }: {
           </button>
 
           {reasonOpen && (
-            <div className="absolute left-0 bottom-full mb-1 z-50 min-w-[140px] bg-panel border border-edge rounded-lg shadow-lg py-1 overflow-hidden">
+            <div
+              ref={reasonMenuRef}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Reasoning effort picker"
+              className="absolute left-0 bottom-full mb-1 z-50 min-w-[140px] bg-panel border border-edge rounded-lg shadow-lg py-1 overflow-hidden"
+            >
               {REASONING_LEVELS.map(({ value, label }) => {
                 const isSelected = value === reasoning;
                 return (
@@ -229,6 +262,7 @@ export default function PilotPicker({ config }: {
           )}
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/webapp/src/components/SettingsShell.tsx
+++ b/webapp/src/components/SettingsShell.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { X, Cpu, SlidersHorizontal, ShieldCheck, Zap, Bell, Wrench, Info, Puzzle } from "lucide-react";
 import ModelsSettingsPage from "./ModelsSettingsPage";
 import SettingsPane, { type SettingsSection } from "./SettingsPane";
 import PluginsPane from "./PluginsPane";
 import { TITLEBAR_TRAFFIC_PAD_SM_PX } from "../lib/titlebarSafe";
+import { useOverlayFocus } from "../lib/overlayFocus";
 
 type PageId = "models" | SettingsSection | "about";
 
@@ -52,6 +53,11 @@ export default function SettingsShell({
   const [page, setPage] = useState<PageId>(
     () => initialPage || takePendingSettingsPage() || "models",
   );
+  const shellRef = useRef<HTMLDivElement>(null);
+
+  useOverlayFocus(true, shellRef, {
+    onClose,
+  });
 
   // Escape always closes settings -- a keyboard escape hatch so a missed click
   // on the X (e.g. a busy main thread during a swarm) can never trap the user
@@ -78,7 +84,14 @@ export default function SettingsShell({
   }, []);
 
   return createPortal(
-    <div className="fixed inset-0 z-[80] bg-bg flex flex-col" data-testid="settings-shell">
+    <div
+      ref={shellRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Settings"
+      className="fixed inset-0 z-[80] bg-bg flex flex-col"
+      data-testid="settings-shell"
+    >
       {/* top bar -- fixed px pad clears macOS traffic lights (not rem) */}
       <div
         data-testid="settings-shell-titlebar"

--- a/webapp/src/components/StatePane.tsx
+++ b/webapp/src/components/StatePane.tsx
@@ -910,8 +910,15 @@ export default function StatePane({ artifacts }: {
                     ["TypeScript", envReady.typescript_analyzer, "tsc on PATH or workspace node_modules/.bin"],
                   ] as const).map(([label, item, hint]) => (
                     <div key={label} className="space-y-0.5">
-                      <div className="flex items-center gap-1.5 text-[10px]">
-                        <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${item?.available ? "bg-good" : "bg-faint"}`} />
+                      <div
+                        className="flex items-center gap-1.5 text-[10px]"
+                        role="status"
+                        aria-label={`${label}: ${item?.available ? "available" : "unavailable"}`}
+                      >
+                        <span
+                          className={`h-1.5 w-1.5 rounded-full shrink-0 ${item?.available ? "bg-good" : "bg-faint"}`}
+                          aria-hidden
+                        />
                         <span className="font-medium text-txt">{label}</span>
                         <span className="text-muted">{item?.available ? "available" : "unavailable"}</span>
                       </div>

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -62,6 +62,9 @@ import {
   verificationReceiptPresentation,
   type AutoBudgetSnapshot,
 } from "../lib/autoReceipts";
+import { authFailureDiagnostic } from "../lib/operationalDiagnostic";
+import { publishDiagnostic } from "../lib/operationalDiagnosticBus";
+import { focusSettingsPage } from "./SettingsShell";
 import { TranscriptImage } from "./conversation/TranscriptImage";
 import {
   FEED_UNPIN_BUBBLE_EVENT,
@@ -1022,6 +1025,45 @@ function indexTranscriptCommandSessions(items: Item[]): void {
   }
 }
 
+function AuthFailureBanner({ message, id }: { message: string; id?: string }) {
+  useEffect(() => {
+    publishDiagnostic(authFailureDiagnostic(message, { jobId: id }));
+  }, [message, id]);
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 py-2.5 px-3.5 rounded-lg bg-red-500/12 border border-red-500/50 text-[12px] text-red-200 w-full max-w-full my-1.5 shadow-sm animate-in fade-in duration-200"
+    >
+      <XCircle size={15} className="text-red-400 shrink-0 mt-0.5" />
+      <span className="min-w-0 flex-1">
+        <span className="font-semibold text-red-300">Provider auth failure.</span>{" "}
+        <span className="text-red-200/90">
+          The API key was rejected -- this is a dead, revoked, or wrong key, not a weak model or bad prompt.
+          Fix the named credential (e.g. OPENAI_API_KEY), then re-run.
+        </span>
+        {message ? (
+          <code className="block mt-1 text-[10.5px] text-red-200/80 font-mono break-all whitespace-pre-wrap">
+            {message}
+          </code>
+        ) : null}
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => {
+              focusSettingsPage("providers");
+              window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: "settings" }));
+            }}
+            className="rounded-md border border-red-400/40 bg-red-500/10 px-2.5 py-1 text-[11px] font-medium text-red-100 hover:bg-red-500/20 transition"
+          >
+            Fix key and retry
+          </button>
+        </div>
+      </span>
+    </div>
+  );
+}
+
 // PERF: Memoized transcript renderer. Its props are intentionally free of the
 // composer `input` (or any per-keystroke state), so React.memo lets typing skip
 // re-rendering the whole transcript. Only transcript-affecting state (items,
@@ -1277,8 +1319,13 @@ export const TranscriptList = memo(function TranscriptList({
       );
     } else if (it.kind === "checkpoint") {
       return (
-        <div key={key} className="flex items-center gap-1.5 py-1 px-3 rounded-full bg-panel2/15 border border-edge/20 text-[10px] text-faint w-fit my-1 select-none">
-          <History size={11} className="text-accent" />
+        <div
+          key={key}
+          className="flex items-center gap-1.5 py-1 px-3 rounded-full bg-panel2/15 border border-edge/20 text-[10px] text-faint w-fit my-1 select-none"
+          role="status"
+          aria-label={`restore point created: ${it.label}`}
+        >
+          <History size={11} className="text-accent" aria-hidden />
           <span>restore point created: {it.label} ({it.id.slice(0, 8)})</span>
         </div>
       );
@@ -1474,16 +1521,7 @@ export const TranscriptList = memo(function TranscriptList({
         </div>
       );
     } else if (it.kind === "auth_failure") {
-      return (
-        <div key={key} role="alert" className="flex items-start gap-2 py-2.5 px-3.5 rounded-lg bg-red-500/12 border border-red-500/50 text-[12px] text-red-200 w-full max-w-full my-1.5 shadow-sm animate-in fade-in duration-200">
-          <XCircle size={15} className="text-red-400 shrink-0 mt-0.5" />
-          <span className="min-w-0">
-            <span className="font-semibold text-red-300">Provider auth failure.</span>{" "}
-            <span className="text-red-200/90">The API key was rejected -- this is a dead, revoked, or wrong key, not a weak model or bad prompt. Fix the named credential (e.g. OPENAI_API_KEY), then re-run.</span>
-            {it.message ? <code className="block mt-1 text-[10.5px] text-red-200/80 font-mono break-all whitespace-pre-wrap">{it.message}</code> : null}
-          </span>
-        </div>
-      );
+      return <AuthFailureBanner key={key} message={it.message} id={it.id} />;
     } else if (it.kind === "compaction") {
       return <CompactionReceipt key={key} it={it} />;
     } else if (it.kind === "steer") {
@@ -2030,8 +2068,13 @@ function ActivityGroup({
     }
     if (it.kind === "checkpoint") {
       return (
-        <div key={`ckpt-${it.id}`} className="flex items-center gap-1.5 py-0.5 text-[10px] text-faint/80 select-none">
-          <History size={10} className="text-faint/70" />
+        <div
+          key={`ckpt-${it.id}`}
+          className="flex items-center gap-1.5 py-0.5 text-[10px] text-faint/80 select-none"
+          role="status"
+          aria-label={`restore point created: ${it.label}`}
+        >
+          <History size={10} className="text-faint/70" aria-hidden />
           <span>restore point created: {it.label} ({it.id.slice(0, 8)})</span>
         </div>
       );
@@ -3014,11 +3057,11 @@ function ActionCard({
           >
             <div className="flex items-center justify-center w-3.5 h-3.5 shrink-0">
               {effectivelyRunning ? (
-                <Loader2 size={11} className="animate-spin text-faint/60" />
+                <Loader2 size={11} className="animate-spin text-faint/60" aria-label="running" />
               ) : isErr ? (
-                <span className="w-1.5 h-1.5 rounded-full bg-risk/70" />
+                <span className="w-1.5 h-1.5 rounded-full bg-risk/70" aria-label="failed" title="failed" />
               ) : suppressed ? (
-                <span className="w-1.5 h-1.5 rounded-full bg-faint/45" />
+                <span className="w-1.5 h-1.5 rounded-full bg-faint/45" aria-label="suppressed" title="suppressed" />
               ) : null}
             </div>
             <span className={`shrink-0 font-normal ${isErr ? "text-risk/80" : suppressed ? "text-faint/70" : "text-faint/80"}`}>

--- a/webapp/src/components/conversation/ConversationHeader.tsx
+++ b/webapp/src/components/conversation/ConversationHeader.tsx
@@ -10,10 +10,12 @@ export default function ConversationHeader({
   pillStatus,
   detail,
   onBusyDetailClick,
+  recoveryAction,
 }: {
   pillStatus: string;
   detail?: string;
   onBusyDetailClick?: () => void;
+  recoveryAction?: { label: string; onClick: () => void };
 }) {
   const dragRegion = { WebkitAppRegion: "drag" } as CSSProperties;
   const noDrag = { WebkitAppRegion: "no-drag" } as CSSProperties;
@@ -39,7 +41,16 @@ export default function ConversationHeader({
           The Puppetmaster Harness
         </span>
       </span>
-      <div className="shrink-0" style={noDrag}>
+      <div className="shrink-0 flex items-center gap-2" style={noDrag}>
+        {recoveryAction ? (
+          <button
+            type="button"
+            onClick={recoveryAction.onClick}
+            className="text-[10px] px-2 py-0.5 rounded-md border border-edge/60 bg-panel2/60 text-muted hover:text-txt transition"
+          >
+            {recoveryAction.label}
+          </button>
+        ) : null}
         <StatusPill
           status={pillStatus}
           detail={detail}

--- a/webapp/src/components/conversation/chatEventsReattach.ts
+++ b/webapp/src/components/conversation/chatEventsReattach.ts
@@ -478,10 +478,8 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
             await new Promise((r) => setTimeout(r, 100 * attempt));
             continue;
           }
-          // Optimistic busy; store poll clears if idle.
-          detachedBusyRef.current = true;
-          setTurnOpen(true);
-          setStatus((prev: any) => preserveOrThinking(prev));
+          // Session state unknown — arm store poll without inventing a turn.
+          break;
         }
       }
     }

--- a/webapp/src/components/conversation/sessionHydrate.ts
+++ b/webapp/src/components/conversation/sessionHydrate.ts
@@ -229,13 +229,13 @@ export function transcriptRefreshFailureDecision(hadCache: boolean): {
 }
 
 /**
- * Mid-turn reattach when getSessionState fails: retry, then optimistic busy so
- * Ready chrome cannot lie while a turn continues. Runners poll clears idle targets.
+ * Mid-turn reattach when getSessionState fails: retry, then poll the store
+ * cursor without fabricating a busy turn when the backend state is unknown.
  */
 export function reattachSessionStateFailureDecision(opts: {
   attempt: number;
   maxAttempts: number;
-}): "retry" | "optimistic_busy" {
+}): "retry" | "poll_only" {
   if (opts.attempt < opts.maxAttempts) return "retry";
-  return "optimistic_busy";
+  return "poll_only";
 }

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1123,6 +1123,12 @@ export const api = {
   recommend: () => getJSON<RecommendResult>("/api/registry/recommend"),
 
   config: () => getJSON<Config>("/api/config"),
+  diagnostics: () => getJSON<{
+    ok?: boolean;
+    correlation_id?: string;
+    checks?: { status: string; name: string; detail?: string }[];
+    diagnostic?: Record<string, unknown> | null;
+  }>("/api/diagnostics"),
   getUsage: () => getJSON<UsageData>("/api/usage"),
   getEconomics: (scope: EconomicsScope | string = "repo") =>
     getJSONSoft<EconomicsData>(`/api/economics?scope=${encodeURIComponent(scope)}`),

--- a/webapp/src/lib/correlationId.ts
+++ b/webapp/src/lib/correlationId.ts
@@ -1,0 +1,24 @@
+/** Client-side correlation id threaded on harness HTTP requests. */
+
+let activeCorrelationId = "";
+
+export function newCorrelationId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  activeCorrelationId = `corr-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  return activeCorrelationId;
+}
+
+export function getCorrelationId(): string {
+  return activeCorrelationId;
+}
+
+export function setCorrelationId(id: string): void {
+  activeCorrelationId = String(id || "").trim();
+}
+
+export function correlationHeaders(): Record<string, string> {
+  if (!activeCorrelationId) activeCorrelationId = newCorrelationId();
+  return { "X-Correlation-Id": activeCorrelationId };
+}

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -53,6 +53,9 @@ export const TRANSPORT_HTTP = "transport_http";
 export const TRANSPORT_IPC = "transport_ipc";
 export const TRANSPORT_UNCERTAIN = "transport_uncertain";
 export const TRANSPORT_BUSY = "transport_busy";
+export const BACKEND_NOT_READY = "backend_not_ready";
+export const BACKEND_WARNING = "backend_warning";
+export const AUTH_FAILURE = "provider_auth_failure";
 
 const SUMMARY_MAX = 160;
 const DETAIL_MAX = 280;
@@ -205,6 +208,69 @@ export function fromTransportFailure(input: {
     recovery: { kind: "retry", label: "Retry" },
     sessionId: input.sessionId,
     repo: input.repo,
+  });
+}
+
+type BackendDiagnosticWire = {
+  scope?: DiagnosticScope;
+  operation?: string;
+  code?: string;
+  summary?: string;
+  detail?: string;
+  severity?: DiagnosticSeverity;
+  retryable?: boolean;
+  dataSafe?: boolean;
+  recovery?: DiagnosticRecovery;
+  sessionId?: string;
+  repo?: string;
+  jobId?: string;
+  taskId?: string;
+  id?: string;
+  createdAt?: number;
+};
+
+/** Parse GET /api/diagnostics diagnostic payload into the renderer contract. */
+export function fromBackendDiagnostic(
+  wire: BackendDiagnosticWire | null | undefined,
+): OperationalDiagnostic | null {
+  if (!wire || !wire.summary || !wire.scope || !wire.operation || !wire.severity) {
+    return null;
+  }
+  return createOperationalDiagnostic({
+    id: wire.id,
+    scope: wire.scope,
+    operation: wire.operation,
+    code: wire.code,
+    summary: wire.summary,
+    detail: wire.detail,
+    severity: wire.severity,
+    retryable: Boolean(wire.retryable),
+    dataSafe: wire.dataSafe,
+    recovery: wire.recovery,
+    sessionId: wire.sessionId,
+    repo: wire.repo,
+    jobId: wire.jobId,
+    taskId: wire.taskId,
+    createdAt: wire.createdAt,
+  });
+}
+
+/** Loud provider auth rejection surfaced in the transcript. */
+export function authFailureDiagnostic(message: string, opts?: {
+  sessionId?: string;
+  jobId?: string;
+}): OperationalDiagnostic {
+  return createOperationalDiagnostic({
+    scope: "conversation",
+    operation: "provider_auth",
+    code: AUTH_FAILURE,
+    summary: "Provider auth failure",
+    detail: sanitizeDiagnosticText(message, DETAIL_MAX),
+    severity: "error",
+    retryable: true,
+    recovery: { kind: "retry", label: "Fix key and retry" },
+    sessionId: opts?.sessionId,
+    jobId: opts?.jobId,
   });
 }
 

--- a/webapp/src/lib/operationalRecovery.ts
+++ b/webapp/src/lib/operationalRecovery.ts
@@ -1,0 +1,28 @@
+import type { OperationalDiagnostic } from "./operationalDiagnostic";
+import { clearDiagnostic } from "./operationalDiagnosticBus";
+import { getHarnessIpc } from "./transport";
+
+export async function executeDiagnosticRecovery(
+  diag: OperationalDiagnostic,
+  retry: () => void | Promise<void>,
+): Promise<void> {
+  if (diag.recovery.kind === "retry") {
+    await Promise.resolve(retry());
+    return;
+  }
+  if (diag.recovery.kind === "relaunch") {
+    const bridge = getHarnessIpc();
+    if (bridge?.restart) {
+      await bridge.restart();
+      return;
+    }
+    window.location.reload();
+  }
+}
+
+export function clearDiagnosticAfterSuccess(
+  diag: OperationalDiagnostic | null | undefined,
+): void {
+  if (!diag) return;
+  clearDiagnostic(diag);
+}

--- a/webapp/src/lib/overlayFocus.ts
+++ b/webapp/src/lib/overlayFocus.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function focusableElements(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+    (el) => !el.hasAttribute("disabled") && el.tabIndex !== -1 && el.offsetParent !== null,
+  );
+}
+
+/** Trap Tab within ``root`` and restore focus to ``trigger`` on close. */
+export function useOverlayFocus(
+  open: boolean,
+  rootRef: React.RefObject<HTMLElement | null>,
+  opts?: {
+    initialFocusRef?: React.RefObject<HTMLElement | null>;
+    onClose?: () => void;
+    restoreFocus?: boolean;
+  },
+) {
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    triggerRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    const root = rootRef.current;
+    const initial = opts?.initialFocusRef?.current;
+    const t = window.setTimeout(() => {
+      if (initial) {
+        initial.focus();
+      } else if (root) {
+        const nodes = focusableElements(root);
+        nodes[0]?.focus();
+      }
+    }, 0);
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        opts?.onClose?.();
+        return;
+      }
+      if (e.key !== "Tab" || !root) return;
+      const nodes = focusableElements(root);
+      if (nodes.length === 0) return;
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || !root.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      window.clearTimeout(t);
+      window.removeEventListener("keydown", onKeyDown, true);
+      if (opts?.restoreFocus !== false && triggerRef.current) {
+        try {
+          triggerRef.current.focus();
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+  }, [open, opts?.initialFocusRef, opts?.onClose, opts?.restoreFocus, rootRef]);
+}

--- a/webapp/src/lib/transport.ts
+++ b/webapp/src/lib/transport.ts
@@ -11,6 +11,8 @@ import {
   desktopBridgeMissingDiagnostic,
 } from "./operationalDiagnostic";
 import { publishDiagnostic } from "./operationalDiagnosticBus";
+import { correlationHeaders, setCorrelationId } from "./correlationId";
+import { publishTransportFailure } from "./transportFailure";
 
 /**
  * Live SSE payload from /api/chat, /api/auto, /api/run.
@@ -123,6 +125,19 @@ function authToken(): string {
   return "";
 }
 
+function requestHeaders(extra?: Record<string, string>): Record<string, string> {
+  return {
+    "X-Harness-Token": authToken(),
+    ...correlationHeaders(),
+    ...extra,
+  };
+}
+
+function noteResponseCorrelation(response: Response): void {
+  const cid = response.headers.get("X-Correlation-Id");
+  if (cid) setCorrelationId(cid);
+}
+
 export function withToken(path: string): string {
   // Auth is supplied via the `X-Harness-Token` header; we never append auth
   // tokens to URLs.
@@ -150,49 +165,87 @@ export async function getJSONSoft<T = any>(path: string): Promise<T> {
   refuseIfDesktopBridgeMissing("getJSONSoft", path);
   const bridge = getHarnessIpc();
   if (bridge?.getJSON) return bridge.getJSON(path);
-  const r = await fetch(path, { headers: { "X-Harness-Token": authToken() } });
-  const body = await r.json().catch(() => ({}));
-  if (!r.ok && body && typeof body === "object" && !("ok" in body)) {
-    return { ok: false, error: (body as any).error || `${path} -> ${r.status}`, ...body } as T;
+  try {
+    const r = await fetch(path, { headers: requestHeaders() });
+    noteResponseCorrelation(r);
+    const body = await r.json().catch(() => ({}));
+    if (!r.ok) {
+      publishTransportFailure(new Error(`${path} -> ${r.status}`), {
+        operation: "getJSONSoft",
+        path,
+      });
+      if (body && typeof body === "object" && !("ok" in body)) {
+        return { ok: false, error: (body as any).error || `${path} -> ${r.status}`, ...body } as T;
+      }
+      if (body == null || typeof body !== "object") {
+        return { ok: false, error: `${path} -> ${r.status}` } as T;
+      }
+    }
+    return body as T;
+  } catch (err) {
+    publishTransportFailure(err, { operation: "getJSONSoft", path });
+    throw err;
   }
-  if (!r.ok && (body == null || typeof body !== "object")) {
-    return { ok: false, error: `${path} -> ${r.status}` } as T;
-  }
-  return body as T;
 }
 
 export async function getJSON<T = any>(path: string): Promise<T> {
   refuseIfDesktopBridgeMissing("getJSON", path);
   const bridge = getHarnessIpc();
   if (bridge?.getJSON) return bridge.getJSON(path);
-  const r = await fetch(path, { headers: { "X-Harness-Token": authToken() } });
-  if (!r.ok) throw new Error(`${path} -> ${r.status}`);
-  return r.json();
+  try {
+    const r = await fetch(path, { headers: requestHeaders() });
+    noteResponseCorrelation(r);
+    if (!r.ok) {
+      publishTransportFailure(new Error(`${path} -> ${r.status}`), {
+        operation: "getJSON",
+        path,
+      });
+      throw new Error(`${path} -> ${r.status}`);
+    }
+    return r.json();
+  } catch (err) {
+    if (!(err instanceof Error) || !String(err.message).includes("->")) {
+      publishTransportFailure(err, { operation: "getJSON", path });
+    }
+    throw err;
+  }
 }
 
 export async function postJSON<T = any>(path: string, body: any): Promise<T> {
   refuseIfDesktopBridgeMissing("postJSON", path);
   const bridge = getHarnessIpc();
   if (bridge?.postJSON) return bridge.postJSON(path, body);
-  const r = await fetch(path, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", "X-Harness-Token": authToken() },
-    body: JSON.stringify(body),
-  });
-  if (!r.ok) {
-    // Parse the body when present so callers (lease detectors) can require
-    // code===lease_exhausted instead of guessing from "... -> 409".
-    const parsed = await r.json().catch(() => null);
-    if (parsed && typeof parsed === "object") {
-      const err = new Error(
-        String((parsed as { error?: string }).error || `${path} -> ${r.status}`),
-      ) as Error & Record<string, unknown>;
-      Object.assign(err, parsed, { status: r.status });
-      throw err;
+  try {
+    const r = await fetch(path, {
+      method: "POST",
+      headers: requestHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify(body),
+    });
+    noteResponseCorrelation(r);
+    if (!r.ok) {
+      const parsed = await r.json().catch(() => null);
+      publishTransportFailure(
+        new Error(
+          String((parsed as { error?: string } | null)?.error || `${path} -> ${r.status}`),
+        ),
+        { operation: "postJSON", path },
+      );
+      if (parsed && typeof parsed === "object") {
+        const err = new Error(
+          String((parsed as { error?: string }).error || `${path} -> ${r.status}`),
+        ) as Error & Record<string, unknown>;
+        Object.assign(err, parsed, { status: r.status });
+        throw err;
+      }
+      throw new Error(`${path} -> ${r.status}`);
     }
-    throw new Error(`${path} -> ${r.status}`);
+    return r.json();
+  } catch (err) {
+    if (!(err instanceof Error) || !String(err.message).includes("->")) {
+      publishTransportFailure(err, { operation: "postJSON", path });
+    }
+    throw err;
   }
-  return r.json();
 }
 
 // NOTE: no deleteJSON here on purpose. The Electron preload bridge only routes
@@ -238,12 +291,13 @@ export function stream(
     try {
       resp = await fetch(path, {
         method: "GET",
-        headers: { "X-Harness-Token": authToken() },
+        headers: requestHeaders(),
         signal: controller.signal,
       });
       if (!resp.ok) {
         throw new Error(`stream ${path} -> ${resp.status}`);
       }
+      noteResponseCorrelation(resp);
       const body = resp.body;
       if (!body) throw new Error(`stream ${path}: missing response body`);
 
@@ -304,7 +358,7 @@ export async function uploadFile(file: File): Promise<{ path: string; name: stri
   }
   const fd = new FormData();
   fd.append("file", file);
-  const r = await fetch("/api/upload", { method: "POST", body: fd, headers: { "X-Harness-Token": authToken() } });
+  const r = await fetch("/api/upload", { method: "POST", body: fd, headers: requestHeaders() });
   const j = await r.json().catch(() => ({}));
   if (!r.ok) {
     throw new Error((j && j.error) || `Upload failed (${r.status})`);

--- a/webapp/src/lib/transport.ts
+++ b/webapp/src/lib/transport.ts
@@ -134,7 +134,9 @@ function requestHeaders(extra?: Record<string, string>): Record<string, string> 
 }
 
 function noteResponseCorrelation(response: Response): void {
-  const cid = response.headers.get("X-Correlation-Id");
+  const headers = response && response.headers;
+  if (!headers || typeof headers.get !== "function") return;
+  const cid = headers.get("X-Correlation-Id");
   if (cid) setCorrelationId(cid);
 }
 

--- a/webapp/src/lib/transportFailure.ts
+++ b/webapp/src/lib/transportFailure.ts
@@ -1,0 +1,31 @@
+import { fromTransportFailure } from "./operationalDiagnostic";
+import { clearDiagnostic, publishDiagnostic } from "./operationalDiagnosticBus";
+import { isTransientHarnessConnError } from "./transport";
+
+export type TransportFailureContext = {
+  operation: string;
+  path?: string;
+  sessionId?: string;
+  repo?: string;
+};
+
+export function publishTransportFailure(
+  err: unknown,
+  ctx: TransportFailureContext,
+): void {
+  const diag = fromTransportFailure({
+    operation: ctx.operation,
+    path: ctx.path,
+    err,
+    isTransient: isTransientHarnessConnError(err),
+    sessionId: ctx.sessionId,
+    repo: ctx.repo,
+  });
+  publishDiagnostic(diag);
+}
+
+export function clearTransportFailure(
+  repaired: Pick<import("./operationalDiagnostic").OperationalDiagnostic, "id" | "code" | "scope" | "operation">,
+): void {
+  clearDiagnostic(repaired);
+}


### PR DESCRIPTION
## Summary
- Pin installer/Electron bootstrap to `puppetmaster-ai==1.22.22` (https://pypi.org/project/puppetmaster-ai/1.22.22/).
- Wave-4 leftovers: correlation-id diagnostics, auth-failure Retry, overlay focus restore, color plus text/aria, visible pilot reroute notice, no fabricated reattach busy.
- CI workflow YAML pins stay at 1.22.20 until this token has `workflow` scope (same as 273).

## Test plan
- [ ] CI green
- [ ] Electron-dev: auth-failure Retry, overlay focus restore, reroute notice, no fake busy after failed reattach