### PR TITLE
v0.9.284 live bugs: wait-hint, lurch, retry, editable rebind

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.23` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.283, deliberately pre-1.0. Rides puppetmaster-ai==1.22.23. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.284, deliberately pre-1.0. Rides puppetmaster-ai==1.22.23. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.283"
+__version__ = "0.9.284"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.283"
+version = "0.9.284"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.283"
+version = "0.9.284"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/electron/feed-lurch-vm.cjs
+++ b/webapp/electron/feed-lurch-vm.cjs
@@ -1,0 +1,43 @@
+"use strict";
+
+const path = require("node:path");
+const { app, BrowserWindow } = require("electron");
+
+const fixture = path.join(__dirname, "fixtures", "feed-lurch.html");
+
+app.whenReady().then(async () => {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 560,
+    show: false,
+    backgroundColor: "#111111",
+    webPreferences: { sandbox: true },
+  });
+  await win.loadFile(fixture);
+  await new Promise((r) => setTimeout(r, 150));
+  const pinned = await win.webContents.executeJavaScript("window.__pinToEnd()");
+  const frames = [];
+  for (let i = 0; i < 12; i++) {
+    const step = await win.webContents.executeJavaScript("window.__growTail(2)");
+    frames.push(step);
+    await win.webContents.executeJavaScript(
+      "new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))"
+    );
+  }
+  const lurches = frames.filter((f) => {
+    const jumped = Math.abs(f.after.scrollTop - (f.before.scrollTop + f.deltaHeight)) > 2;
+    const crossed = f.before.overflow <= 1 && f.after.overflow > 8 && f.after.distance > 2;
+    return jumped || crossed;
+  });
+  process.stdout.write(JSON.stringify({
+    ok: lurches.length === 0,
+    pinned,
+    frames: frames.length,
+    lurches: lurches.length,
+    last: frames[frames.length - 1],
+  }));
+  app.exit(lurches.length ? 2 : 0);
+}).catch((err) => {
+  process.stderr.write(String(err && err.stack || err));
+  app.exit(1);
+});

--- a/webapp/electron/feed-scroll.cjs
+++ b/webapp/electron/feed-scroll.cjs
@@ -1,0 +1,8 @@
+"use strict";
+
+/** Authoritative scrollTop for stick-to-bottom (shared with feedScroll.ts). */
+function scrollToFeedEnd(scrollHeight, clientHeight) {
+  return Math.max(0, scrollHeight - clientHeight);
+}
+
+module.exports = { scrollToFeedEnd };

--- a/webapp/electron/feed-scroll.test.cjs
+++ b/webapp/electron/feed-scroll.test.cjs
@@ -1,0 +1,23 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { scrollToFeedEnd } = require("./feed-scroll.cjs");
+
+/**
+ * Electron-side feed scroll contract (jsdom layout tests live in feedScroll.test.ts).
+ * Repro harness: pinned tail + growth should land at scrollHeight - clientHeight.
+ */
+test("scrollToEnd contract matches Marionette feedScroll helper", () => {
+  assert.equal(scrollToFeedEnd(2000, 400), 1600);
+  assert.equal(scrollToFeedEnd(350, 400), 0);
+});
+
+test("stream-to-fold live tail growth outside the virtual window still pins to the true end", () => {
+  const client = 400;
+  const virtualHeadHeight = 1600;
+  const initialTail = 80;
+  const pinnedTop = scrollToFeedEnd(virtualHeadHeight + initialTail, client);
+  const grownTail = 320;
+  const nextTop = scrollToFeedEnd(virtualHeadHeight + grownTail, client);
+  assert.equal(nextTop, pinnedTop + (grownTail - initialTail));
+});

--- a/webapp/electron/feed-scroll.test.cjs
+++ b/webapp/electron/feed-scroll.test.cjs
@@ -21,3 +21,39 @@ test("stream-to-fold live tail growth outside the virtual window still pins to t
   const nextTop = scrollToFeedEnd(virtualHeadHeight + grownTail, client);
   assert.equal(nextTop, pinnedTop + (grownTail - initialTail));
 });
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function electronBin() {
+  const resolved = require("electron");
+  if (typeof resolved === "string" && fs.existsSync(resolved)) return resolved;
+  return "electron";
+}
+
+test("Electron VM: stream-to-fold live tail does not lurch", () => {
+  const script = path.join(__dirname, "feed-lurch-vm.cjs");
+  const bin = electronBin();
+  const args = [
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    script,
+  ];
+  const result = spawnSync(bin, args, {
+    encoding: "utf8",
+    env: { ...process.env, ELECTRON_NO_ATTACH_CONSOLE: "1" },
+    timeout: 30000,
+  });
+  if (result.error || result.status !== 0) {
+    const detail = [result.error && result.error.message, result.stderr, result.stdout]
+      .filter(Boolean)
+      .join("\n");
+    assert.equal(result.status, 0, detail);
+  }
+  const payload = JSON.parse((result.stdout || "").trim().split("\n").pop());
+  assert.equal(payload.ok, true, JSON.stringify(payload));
+  assert.equal(payload.lurches, 0);
+});

--- a/webapp/electron/fixtures/feed-lurch.html
+++ b/webapp/electron/fixtures/feed-lurch.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<style>
+  html, body { margin: 0; height: 100%; background: #111; }
+  #feed {
+    height: 400px;
+    overflow-y: auto;
+    position: relative;
+    background: #1a1a1a;
+    color: #eee;
+    font: 14px/20px ui-sans-serif, system-ui, sans-serif;
+  }
+  #virtual-head { height: 1600px; }
+  #live-tail {
+    padding: 8px 12px;
+    white-space: pre-wrap;
+    min-height: 40px;
+  }
+  #clearance { height: 96px; }
+</style>
+</head>
+<body>
+  <div id="feed" data-testid="transcript-log">
+    <div id="virtual-head" data-testid="transcript-virtual-list"></div>
+    <div id="live-tail" data-testid="transcript-live-tail">line\n</div>
+    <div id="clearance" data-testid="feed-bottom-clearance"></div>
+  </div>
+  <script>
+    function scrollToFeedEnd(scrollHeight, clientHeight) {
+      return Math.max(0, scrollHeight - clientHeight);
+    }
+    const feed = document.getElementById("feed");
+    const tail = document.getElementById("live-tail");
+    function sample() {
+      const last = tail.getBoundingClientRect();
+      const box = feed.getBoundingClientRect();
+      const distance = feed.scrollHeight - feed.clientHeight - feed.scrollTop;
+      return {
+        scrollTop: feed.scrollTop,
+        scrollHeight: feed.scrollHeight,
+        clientHeight: feed.clientHeight,
+        lastBottom: last.bottom,
+        feedBottom: box.bottom,
+        overflow: last.bottom - box.bottom,
+        distance,
+      };
+    }
+    window.__pinToEnd = function () {
+      feed.scrollTop = scrollToFeedEnd(feed.scrollHeight, feed.clientHeight);
+      return sample();
+    };
+    window.__growTail = function (lines) {
+      const before = sample();
+      tail.textContent += (Array(lines).fill("token line of streaming text\n").join(""));
+      // Same-layout follow, matching Conversation before-paint RO follow.
+      feed.scrollTop = scrollToFeedEnd(feed.scrollHeight, feed.clientHeight);
+      const after = sample();
+      return { before, after, deltaHeight: after.scrollHeight - before.scrollHeight };
+    };
+    window.__sample = sample;
+  </script>
+</body>
+</html>

--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -20,12 +20,18 @@
 const { spawn, execFile } = require("node:child_process");
 const path = require("node:path");
 const os = require("node:os");
+const fs = require("node:fs");
 
-const { chooseFetchRemote } = require("./update-remote.cjs");
+const { chooseFetchRemote, canonicalGitHubRemote } = require("./update-remote.cjs");
 const { resolveBehindCount, shouldCountCommits } = require("./update-count.cjs");
 const { overallPercent } = require("./update-steps.cjs");
 const { runRebuildWithRetry } = require("./update-rebuild.cjs");
-const { resolveCheckoutPin: resolvePuppetmasterPin } = require("./update-pm.cjs");
+const {
+  resolveCheckoutPin: resolvePuppetmasterPin,
+  planStaleHarnessEditable,
+  parseEditableProjectLocation,
+  HARNESS_DIST_NAME,
+} = require("./update-pm.cjs");
 const { runtimeParityFields } = require("./puppetmaster-runtime.cjs");
 const marker = require("./update-marker.cjs");
 const {
@@ -277,6 +283,105 @@ async function inspectTree(repoRoot, branch) {
   const aheadRes = await gitCapture(repoRoot, ["rev-list", "--count", "FETCH_HEAD..HEAD"]);
   const ahead = aheadRes.ok ? (parseInt(aheadRes.out, 10) || 0) : 0;
   return { dirty, dirtyFiles, ahead };
+}
+
+// When the venv's editable pm-harness points at a different checkout than the
+// tree we just pulled, fast-forward that checkout (same remote, clean ff) or
+// rebind the venv to repoRoot so the backend cannot keep importing stale code.
+async function resolveStaleHarnessEditable({
+  repoRoot,
+  targetSha,
+  branch,
+  py,
+  hasUv,
+  childEnv,
+  progress,
+}) {
+  const harnessShow = hasUv
+    ? await execCapture("uv", ["pip", "show", "--python", py, HARNESS_DIST_NAME], { env: childEnv })
+    : await execCapture(py, ["-m", "pip", "show", HARNESS_DIST_NAME], { env: childEnv });
+
+  let repoRootRealpath;
+  try {
+    repoRootRealpath = fs.realpathSync(repoRoot);
+  } catch {
+    return { notice: null };
+  }
+
+  const editableLocation = parseEditableProjectLocation(harnessShow.out);
+  if (!editableLocation) return { notice: null };
+
+  let editableRealpath = editableLocation;
+  try {
+    editableRealpath = fs.realpathSync(editableLocation);
+  } catch {
+    // Missing editable tree — rebind the venv to repoRoot.
+  }
+
+  if (repoRootRealpath === editableRealpath) return { notice: null };
+
+  let sameRemote = false;
+  let editableCanFf = false;
+  const editGit = await gitCapture(editableLocation, ["rev-parse", "--git-dir"], 10000, childEnv);
+  if (editGit.ok) {
+    const repoOrigin = await gitCapture(repoRoot, ["config", "--get", "remote.origin.url"], 10000, childEnv);
+    await gitCapture(editableLocation, ["fetch", "--no-tags", "origin", branch], 45000, childEnv);
+    const editOrigin = await gitCapture(editableLocation, ["config", "--get", "remote.origin.url"], 10000, childEnv);
+    sameRemote = !!(
+      repoOrigin.ok &&
+      editOrigin.ok &&
+      canonicalGitHubRemote(repoOrigin.out) &&
+      canonicalGitHubRemote(repoOrigin.out) === canonicalGitHubRemote(editOrigin.out)
+    );
+    const { dirty, ahead } = await inspectTree(editableLocation, branch);
+    const ancestor = await gitCapture(
+      editableLocation,
+      ["merge-base", "--is-ancestor", "HEAD", targetSha],
+      10000,
+      childEnv
+    );
+    editableCanFf = ancestor.ok && ahead === 0 && !dirty;
+  }
+
+  const plan = planStaleHarnessEditable({
+    repoRootRealpath,
+    editableLocationRealpath: editableRealpath,
+    pipShowOutput: harnessShow.out,
+    sameRemote,
+    editableCanFf,
+  });
+  if (plan.skip) return { notice: null };
+
+  appendUpdateLog(
+    `[harness] stale editable at ${plan.editableLocation} (repo=${repoRootRealpath}); action=${plan.action}`
+  );
+  progress("deps", plan.notice, 0.15);
+
+  if (plan.action === "ff") {
+    const ff = await runStreamed(
+      "git",
+      ["-C", editableLocation, "merge", "--ff-only", targetSha],
+      { env: childEnv },
+      (l) => appendUpdateLog(`[harness] ${l}`)
+    );
+    if (ff.code === 0) {
+      appendUpdateLog(`[harness] fast-forwarded editable checkout to ${targetSha}`);
+      return { notice: plan.notice, action: "ff" };
+    }
+    appendUpdateLog(`[harness] fast-forward failed (${ff.tail || "unknown"}); rebinding venv`);
+  }
+
+  progress("deps", "Rebinding harness venv to updated checkout", 0.2);
+  const onRebindLine = (l) => { appendUpdateLog(`[harness] ${l}`); progress("deps", "Rebinding harness venv to updated checkout", 0.22); };
+  const rebind = hasUv
+    ? await runStreamed("uv", ["pip", "install", "--python", py, "-e", "."], { cwd: repoRoot, env: childEnv }, onRebindLine)
+    : await runStreamed(py, ["-m", "pip", "install", "-e", ".", "--quiet"], { cwd: repoRoot, env: childEnv }, onRebindLine);
+  if (rebind.code !== 0) {
+    appendUpdateLog(`[harness] venv rebind failed: ${rebind.tail || "unknown"}`);
+  } else {
+    appendUpdateLog(`[harness] venv rebound to ${repoRoot}`);
+  }
+  return { notice: plan.notice, action: "rebind" };
 }
 
 // Stream a child process, forwarding trimmed output lines to onLine, resolving
@@ -549,6 +654,20 @@ async function applyUpdate({ repoRoot, branch = DEFAULT_BRANCH, strategy = "ff",
     // venv. Detected once and reused for both the app and the Puppetmaster step.
     const hasUv = await detectUv(childEnv);
 
+    let harnessEditableNotice = null;
+    if (afterSha) {
+      const harnessResult = await resolveStaleHarnessEditable({
+        repoRoot,
+        targetSha: afterSha,
+        branch,
+        py,
+        hasUv,
+        childEnv,
+        progress,
+      });
+      harnessEditableNotice = harnessResult.notice || null;
+    }
+
     if (pyChanged) {
       progress("deps", "Updating Python dependencies", 0.3);
       const onDepLine = (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating Python dependencies", 0.4); };
@@ -627,7 +746,7 @@ async function applyUpdate({ repoRoot, branch = DEFAULT_BRANCH, strategy = "ff",
         : "Update ready -- relaunching",
       1
     );
-    return { ok: true, mainProcessChanged };
+    return { ok: true, mainProcessChanged, harnessEditableNotice };
   } catch (e) {
     return { ok: false, error: String(e && e.message ? e.message : e) };
   } finally {
@@ -922,4 +1041,5 @@ module.exports = {
   describeMainProcessUpdate,
   emptyApplyPlanResult,
   resolvePuppetmasterPin,
+  resolveStaleHarnessEditable,
 };

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -23,11 +23,63 @@ const path = require("node:path");
 
 const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.23";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
+const HARNESS_DIST_NAME = "pm-harness";
 
 // True when `pip show` / `uv pip show` output describes an editable install
 // (a dev checkout linked with `-e`), which we must not overwrite from PyPI.
 function isEditableInstall(pipShowOutput) {
   return /^Editable project location:\s*\S/m.test(String(pipShowOutput || ""));
+}
+
+// Path from `pip show` / `uv pip show` for an editable install (`-e` checkout).
+function parseEditableProjectLocation(pipShowOutput) {
+  const m = String(pipShowOutput || "").match(/^Editable project location:\s*(.+)$/m);
+  return m ? m[1].trim() : "";
+}
+
+function staleHarnessEditableNotice(editablePath) {
+  return (
+    `Harness was an editable install at ${editablePath}; brought it to the pulled tree ` +
+    "so the server cannot keep serving a stale checkout."
+  );
+}
+
+// Decide how to reconcile a venv whose editable pm-harness points at a different
+// checkout than the tree we just pulled. Returns { skip: true } when aligned or
+// not editable; otherwise { skip: false, action: "ff"|"rebind", notice, ... }.
+function planStaleHarnessEditable({
+  repoRootRealpath,
+  editableLocationRealpath,
+  pipShowOutput,
+  sameRemote,
+  editableCanFf,
+} = {}) {
+  const editableLocation = parseEditableProjectLocation(pipShowOutput);
+  if (!isEditableInstall(pipShowOutput) || !editableLocation) {
+    return { skip: true, reason: "not an editable harness install" };
+  }
+  const editPath = String(editableLocationRealpath || editableLocation);
+  const repoPath = String(repoRootRealpath || "");
+  if (repoPath && editPath && repoPath === editPath) {
+    return { skip: true, reason: "editable already aligned with repo root" };
+  }
+  const notice = staleHarnessEditableNotice(editableLocation);
+  if (sameRemote && editableCanFf) {
+    return {
+      skip: false,
+      action: "ff",
+      notice,
+      editableLocation,
+      editableLocationRealpath: editPath,
+    };
+  }
+  return {
+    skip: false,
+    action: "rebind",
+    notice,
+    editableLocation,
+    editableLocationRealpath: editPath,
+  };
 }
 
 function pinnedVersionFromSpec(spec) {
@@ -93,7 +145,11 @@ function resolveCheckoutPin(repoRoot) {
 module.exports = {
   DEFAULT_PUPPETMASTER_SPEC,
   PUPPETMASTER_DIST_NAME,
+  HARNESS_DIST_NAME,
   isEditableInstall,
+  parseEditableProjectLocation,
+  staleHarnessEditableNotice,
+  planStaleHarnessEditable,
   pinnedVersionFromSpec,
   installedPuppetmasterVersion,
   planPuppetmasterUpgrade,

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -160,6 +160,86 @@ test("isEditableInstall: matches only the editable marker line", () => {
   assert.equal(pm.isEditableInstall(""), false);
 });
 
+test("parseEditableProjectLocation: extracts the editable checkout path from pip show", () => {
+  const out = [
+    "Name: pm-harness",
+    "Version: 0.9.284",
+    "Editable project location: /Users/dev/Projects/marionette",
+    "Location: /Users/.marionette/marionette/.venv/lib/python3.11/site-packages",
+  ].join("\n");
+  assert.equal(pm.parseEditableProjectLocation(out), "/Users/dev/Projects/marionette");
+  assert.equal(pm.parseEditableProjectLocation("Name: pm-harness\nVersion: 0.9.284"), "");
+});
+
+test("planStaleHarnessEditable: aligned editable location is a no-op", () => {
+  const pip = "Name: pm-harness\nEditable project location: /app/marionette\n";
+  const plan = pm.planStaleHarnessEditable({
+    repoRootRealpath: "/app/marionette",
+    editableLocationRealpath: "/app/marionette",
+    pipShowOutput: pip,
+    sameRemote: true,
+    editableCanFf: true,
+  });
+  assert.equal(plan.skip, true);
+  assert.match(plan.reason, /aligned/);
+});
+
+test("planStaleHarnessEditable: mismatched path + clean same-remote plans fast-forward", () => {
+  const pip = "Name: pm-harness\nEditable project location: /Users/dev/Projects/marionette\n";
+  const plan = pm.planStaleHarnessEditable({
+    repoRootRealpath: "/Users/.marionette/marionette",
+    editableLocationRealpath: "/Users/dev/Projects/marionette",
+    pipShowOutput: pip,
+    sameRemote: true,
+    editableCanFf: true,
+  });
+  assert.equal(plan.skip, false);
+  assert.equal(plan.action, "ff");
+  assert.match(plan.notice, /Harness was an editable install at/);
+  assert.match(plan.notice, /stale checkout/);
+});
+
+test("planStaleHarnessEditable: dirty or diverged editable checkout plans rebind", () => {
+  const pip = "Name: pm-harness\nEditable project location: /Users/dev/Projects/marionette\n";
+  const dirty = pm.planStaleHarnessEditable({
+    repoRootRealpath: "/Users/.marionette/marionette",
+    editableLocationRealpath: "/Users/dev/Projects/marionette",
+    pipShowOutput: pip,
+    sameRemote: true,
+    editableCanFf: false,
+  });
+  assert.equal(dirty.skip, false);
+  assert.equal(dirty.action, "rebind");
+
+  const remote = pm.planStaleHarnessEditable({
+    repoRootRealpath: "/Users/.marionette/marionette",
+    editableLocationRealpath: "/Users/dev/fork/marionette",
+    pipShowOutput: "Name: pm-harness\nEditable project location: /Users/dev/fork/marionette\n",
+    sameRemote: false,
+    editableCanFf: true,
+  });
+  assert.equal(remote.action, "rebind");
+});
+
+test("planStaleHarnessEditable: after rebind alignment the plan is a no-op", () => {
+  const home = "/Users/.marionette/marionette";
+  const pip = `Name: pm-harness\nEditable project location: ${home}\n`;
+  const plan = pm.planStaleHarnessEditable({
+    repoRootRealpath: home,
+    editableLocationRealpath: home,
+    pipShowOutput: pip,
+    sameRemote: true,
+    editableCanFf: true,
+  });
+  assert.equal(plan.skip, true);
+});
+
+test("staleHarnessEditableNotice: names the old editable path", () => {
+  const notice = pm.staleHarnessEditableNotice("/Users/dev/Projects/marionette");
+  assert.match(notice, /\/Users\/dev\/Projects\/marionette/);
+  assert.match(notice, /cannot keep serving a stale checkout/);
+});
+
 test("buildUpdaterEnv: login-shell PATH is prepended so npm/uv resolve (fixes spawn ENOENT)", () => {
   // Join fixture PATHs with the platform delimiter -- hardcoded ":" would not
   // split on Windows and the assertions below would see one giant segment.

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.283",
+  "version": "0.9.284",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.283",
+      "version": "0.9.284",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.283",
+  "version": "0.9.284",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CheckpointsPane.test.tsx
+++ b/webapp/src/__tests__/CheckpointsPane.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import CheckpointsPane from "../components/CheckpointsPane";
+
+vi.mock("../lib/panelTransition", () => ({
+  lastSelectedProjectRoot: "/repo",
+}));
+
+vi.mock("../lib/useOperationalDiagnostic", () => ({
+  usePanelNotice: (value: string | null) => value,
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  getCheckpoints: vi.fn(),
+  getCheckpointDiff: vi.fn(),
+  getWorkspace: vi.fn(),
+  sessions: vi.fn(),
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getCheckpoints: apiMocks.getCheckpoints,
+      getCheckpointDiff: apiMocks.getCheckpointDiff,
+      getWorkspace: apiMocks.getWorkspace,
+      sessions: apiMocks.sessions,
+    },
+  };
+});
+
+describe("CheckpointsPane diff badges", () => {
+  beforeEach(() => {
+    apiMocks.getCheckpoints.mockReset();
+    apiMocks.getCheckpointDiff.mockReset();
+    apiMocks.getWorkspace.mockReset();
+    apiMocks.sessions.mockReset();
+    apiMocks.getWorkspace.mockResolvedValue({ repo: "/repo" });
+    apiMocks.sessions.mockResolvedValue([{ id: "s1", active: true }]);
+    apiMocks.getCheckpoints.mockResolvedValue([
+      {
+        id: "cp-1",
+        label: "before edits",
+        timestamp: 1,
+        files: [],
+      },
+    ]);
+    apiMocks.getCheckpointDiff.mockResolvedValue({
+      ok: true,
+      diff: "",
+      truncated: false,
+      files: [
+        { path: "src/new.ts", status: "added" },
+        { path: "src/old.ts", status: "modified" },
+        { path: "src/gone.ts", status: "removed" },
+      ],
+    });
+  });
+
+  it("renders added/modified/removed badges with visible text and aria labels", async () => {
+    render(<CheckpointsPane />);
+
+    const toggle = await screen.findByTitle("View diff");
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(apiMocks.getCheckpointDiff).toHaveBeenCalledWith("cp-1");
+    });
+
+    for (const label of ["added", "modified", "removed"]) {
+      const badge = screen.getByLabelText(new RegExp(`^${label}:`, "i"));
+      expect(badge).toHaveTextContent(label);
+    }
+  });
+});

--- a/webapp/src/__tests__/composerWaitHint.test.ts
+++ b/webapp/src/__tests__/composerWaitHint.test.ts
@@ -3,7 +3,9 @@ import {
   isProviderFailureWaitHint,
   waitHintForBusyProgress,
 } from "../lib/composerWaitHint";
-import { deriveBusyProgress, type BusyStatus } from "../lib/turnProgress";
+import { deriveBusyProgress } from "../lib/turnProgress";
+
+type StreamStatus = "error" | "idle" | "done" | "thinking" | "awaiting_swarm" | "executing" | "streaming";
 import { createApplyStreamEvent } from "../components/conversation/streamEventHandler";
 import type { Item } from "../components/TranscriptList";
 import { describe, expect, it } from "vitest";
@@ -66,7 +68,7 @@ function makeWaitHintApplyDeps() {
     itemsRef: { current: [] as Item[] },
     typeBufRef: { current: "" },
     waitHint: null as string | null,
-    status: "thinking" as BusyStatus,
+    status: "thinking" as StreamStatus,
   };
   state.itemsRef.current = state.items;
   const pendingJobIdsRef = { current: [] as string[] };

--- a/webapp/src/__tests__/composerWaitHint.test.ts
+++ b/webapp/src/__tests__/composerWaitHint.test.ts
@@ -3,7 +3,7 @@ import {
   isProviderFailureWaitHint,
   waitHintForBusyProgress,
 } from "../lib/composerWaitHint";
-import { deriveBusyProgress } from "../lib/turnProgress";
+import { deriveBusyProgress, type BusyStatus } from "../lib/turnProgress";
 import { createApplyStreamEvent } from "../components/conversation/streamEventHandler";
 import type { Item } from "../components/TranscriptList";
 import { describe, expect, it } from "vitest";
@@ -66,7 +66,7 @@ function makeWaitHintApplyDeps() {
     itemsRef: { current: [] as Item[] },
     typeBufRef: { current: "" },
     waitHint: null as string | null,
-    status: "thinking" as string,
+    status: "thinking" as BusyStatus,
   };
   state.itemsRef.current = state.items;
   const pendingJobIdsRef = { current: [] as string[] };

--- a/webapp/src/__tests__/composerWaitHint.test.ts
+++ b/webapp/src/__tests__/composerWaitHint.test.ts
@@ -1,0 +1,137 @@
+import {
+  formatDriverFailureWaitHint,
+  isProviderFailureWaitHint,
+  waitHintForBusyProgress,
+} from "../lib/composerWaitHint";
+import { deriveBusyProgress } from "../lib/turnProgress";
+import { createApplyStreamEvent } from "../components/conversation/streamEventHandler";
+import type { Item } from "../components/TranscriptList";
+import { describe, expect, it } from "vitest";
+
+describe("composerWaitHint", () => {
+  it("recognizes driver failure notices", () => {
+    const hint = formatDriverFailureWaitHint("openrouter:deepseek");
+    expect(hint).toBe("driver openrouter:deepseek failed");
+    expect(isProviderFailureWaitHint(hint)).toBe(true);
+    expect(isProviderFailureWaitHint("Still working…")).toBe(false);
+  });
+
+  it("suppresses stale failure chrome after the turn shows live progress", () => {
+    const hint = formatDriverFailureWaitHint("openrouter:deepseek");
+    expect(
+      waitHintForBusyProgress(hint, { hasSignal: true, turnFailed: false }),
+    ).toBeNull();
+    expect(
+      waitHintForBusyProgress(hint, { hasSignal: false, turnFailed: false }),
+    ).toBe(hint);
+    expect(
+      waitHintForBusyProgress(hint, { hasSignal: true, turnFailed: true }),
+    ).toBe(hint);
+  });
+});
+
+describe("deriveBusyProgress recover-after-fail", () => {
+  it("does not keep driver failure in the busy label after tokens arrive", () => {
+    const failureHint = formatDriverFailureWaitHint("openrouter:glm-5");
+    const waiting = deriveBusyProgress(
+      [
+        {
+          kind: "msg",
+          msg: { role: "assistant", text: "Recovered answer", streaming: true },
+        },
+      ],
+      "streaming",
+      null,
+      { modelLabel: "openrouter:glm-5", waitHint: failureHint },
+    );
+    expect(waiting.label).not.toMatch(/failed/i);
+    expect(waiting.pill).not.toMatch(/failed/i);
+  });
+
+  it("keeps driver failure in the busy label when the turn settles in error", () => {
+    const failureHint = formatDriverFailureWaitHint("openrouter:glm-5");
+    const errored = deriveBusyProgress(
+      [{ kind: "msg", msg: { role: "user", text: "go" } }],
+      "error",
+      null,
+      { modelLabel: "openrouter:glm-5", waitHint: failureHint },
+    );
+    expect(errored.label).toMatch(/failed/i);
+  });
+});
+
+function makeWaitHintApplyDeps() {
+  const state = {
+    items: [{ kind: "msg", msg: { role: "user", text: "go" } }] as Item[],
+    itemsRef: { current: [] as Item[] },
+    typeBufRef: { current: "" },
+    waitHint: null as string | null,
+    status: "thinking" as string,
+  };
+  state.itemsRef.current = state.items;
+  const pendingJobIdsRef = { current: [] as string[] };
+  const setItems = (updater: Item[] | ((prev: Item[]) => Item[])) => {
+    const next = typeof updater === "function" ? updater(state.items) : updater;
+    state.items = next;
+    state.itemsRef.current = next;
+  };
+  return {
+    state,
+    apply: createApplyStreamEvent({
+      setCompactingStatus: () => {},
+      setItems,
+      setDistillNotice: () => {},
+      setWikiPrepared: () => {},
+      setMemoryProposals: () => {},
+      setWaitHint: (value) => {
+        state.waitHint = typeof value === "function" ? value(state.waitHint) : value;
+      },
+      setStatus: (value) => {
+        state.status = typeof value === "function" ? value(state.status) : value;
+      },
+      setTurnOpen: () => {},
+      setPendingJobIds: () => {},
+      pendingJobIdsRef,
+      setSafeTimeout: () => {},
+      itemsRef: state.itemsRef,
+      planTurnRef: { current: false },
+      turnSettledRef: { current: false },
+      resumeQueuedRef: { current: false },
+      typeBufRef: state.typeBufRef,
+      flushTypewriter: () => {},
+      startTypewriter: () => {},
+      appendStreamingText: () => {},
+      setCard: () => {},
+      onArtifacts: () => {},
+      onJobChange: () => {},
+      handleSwarmResult: () => {},
+      refreshQueue: () => {},
+      fetchContextUsage: () => {},
+    }),
+  };
+}
+
+describe("createApplyStreamEvent provider failure wait hints", () => {
+  const failureNotice = formatDriverFailureWaitHint("openrouter:deepseek");
+
+  it("clears driver failure wait hints after message_delta recovery in the same turn", () => {
+    const { state, apply } = makeWaitHintApplyDeps();
+    apply({ kind: "notice", data: { kind: "wait", message: failureNotice } });
+    expect(state.waitHint).toBe(failureNotice);
+    apply({ kind: "message_delta", data: { text: "Recovered", stream_id: "a1", channel: "answer" } });
+    expect(state.waitHint).toBeNull();
+    const busy = deriveBusyProgress(state.items, "streaming", null, {
+      modelLabel: "openrouter:deepseek",
+      waitHint: state.waitHint,
+    });
+    expect(busy.label).not.toMatch(/failed/i);
+  });
+
+  it("keeps driver failure wait hints when the turn settles in error", () => {
+    const { state, apply } = makeWaitHintApplyDeps();
+    apply({ kind: "notice", data: { kind: "wait", message: failureNotice } });
+    apply({ kind: "error", data: { error: "provider rejected" } });
+    expect(state.waitHint).toBe(failureNotice);
+    expect(state.status).toBe("error");
+  });
+});

--- a/webapp/src/__tests__/feedScroll.test.ts
+++ b/webapp/src/__tests__/feedScroll.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
   FEED_GESTURE_IDLE_MS,
   FEED_REPIN_THRESHOLD_PX,
+  FEED_TAIL_EPSILON_PX,
   chooseFeedFollowFlush,
   feedBottomClearancePx,
   feedResizeScrollFollowDecision,
+  isAtFeedTail,
   mergeFeedResizeObservationSnapshots,
   nextFeedPinState,
   scrollTopAfterFeedHeightChange,
+  scrollToFeedEnd,
   settleFrameResult,
   shouldCancelFeedResizeFollowForManualScrollAway,
   shouldDeferFollowDuringUserGesture,
@@ -646,5 +649,120 @@ describe("feedScroll user-gesture deferral", () => {
         userGestureActive: true,
       }),
     ).toEqual({ kind: "follow", scrollTop: newHeight - client });
+  });
+});
+
+describe("feedScroll layout contracts", () => {
+  const client = 400;
+
+  it("scrollToEnd lands at scrollHeight - clientHeight", () => {
+    expect(scrollToFeedEnd(2000, client)).toBe(1600);
+    expect(scrollToFeedEnd(350, client)).toBe(0);
+  });
+
+  it("last-row growth while pinned at first overflow follows in one write", () => {
+    const startHeight = 500;
+    const pinnedTop = scrollToFeedEnd(startHeight, client);
+    const grown = startHeight + 120;
+    const nextTop = scrollTopAfterFeedHeightChange({
+      scrollHeight: grown,
+      scrollTop: pinnedTop,
+      clientHeight: client,
+      pinned: true,
+      settling: false,
+      releasedByGesture: false,
+    });
+    expect(nextTop).toBe(scrollToFeedEnd(grown, client));
+  });
+
+  it("last-row taller than viewport while pinned follows growth", () => {
+    const tall = 1200;
+    const top = scrollToFeedEnd(tall, client);
+    const taller = 1800;
+    expect(
+      scrollTopAfterFeedHeightChange({
+        scrollHeight: taller,
+        scrollTop: top,
+        clientHeight: client,
+        pinned: true,
+        settling: false,
+        releasedByGesture: false,
+      }),
+    ).toBe(scrollToFeedEnd(taller, client));
+  });
+
+  it("overscan estimate remount does not unpin when wasPinned and growth follows", () => {
+    const estimateHeight = 2000;
+    const measuredHeight = 2120;
+    const oldTop = scrollToFeedEnd(estimateHeight, client);
+    expect(
+      nextFeedPinState({
+        wasPinned: true,
+        releasedByGesture: false,
+        scrollHeight: measuredHeight,
+        scrollTop: oldTop,
+        clientHeight: client,
+        prevScrollTop: oldTop,
+        settling: false,
+      }).pinned,
+    ).toBe(true);
+  });
+
+  it("chrome shrink applies clearance in one scrollTop write", () => {
+    const height = 2000;
+    const oldClient = 400;
+    const newClient = 320;
+    const top = scrollToFeedEnd(height, oldClient);
+    expect(
+      scrollTopAfterFeedHeightChange({
+        scrollHeight: height,
+        scrollTop: top,
+        clientHeight: newClient,
+        pinned: true,
+        settling: false,
+        releasedByGesture: false,
+      }),
+    ).toBe(scrollToFeedEnd(height, newClient));
+  });
+
+  it("idle after flick that never hits epsilon-tail does not snap", () => {
+    const height = 2000;
+    const nearButNotTail = height - client - 20;
+    expect(isAtFeedTail(height, nearButNotTail, client, FEED_TAIL_EPSILON_PX)).toBe(false);
+    expect(
+      nextFeedPinState({
+        wasPinned: false,
+        releasedByGesture: true,
+        scrollHeight: height,
+        scrollTop: nearButNotTail,
+        clientHeight: client,
+        prevScrollTop: nearButNotTail,
+        settling: false,
+        userGestureActive: false,
+      }),
+    ).toEqual({ pinned: false, releasedByGesture: true });
+  });
+
+  it("DOM scroller grows last row in normal flow while pinned at tail", () => {
+    const scroller = document.createElement("div");
+    scroller.style.height = "400px";
+    scroller.style.overflow = "auto";
+    const inner = document.createElement("div");
+    inner.style.height = "500px";
+    scroller.append(inner);
+    document.body.append(scroller);
+    scroller.scrollTop = scrollToFeedEnd(scroller.scrollHeight, scroller.clientHeight);
+    inner.style.height = "620px";
+    const nextTop = scrollTopAfterFeedHeightChange({
+      scrollHeight: scroller.scrollHeight,
+      scrollTop: scroller.scrollTop,
+      clientHeight: scroller.clientHeight,
+      pinned: true,
+      settling: false,
+      releasedByGesture: false,
+    });
+    if (nextTop != null) scroller.scrollTop = nextTop;
+    expect(scroller.scrollTop).toBe(scrollToFeedEnd(scroller.scrollHeight, scroller.clientHeight));
+    scroller.remove();
   });
 });

--- a/webapp/src/__tests__/overlayFocus.test.tsx
+++ b/webapp/src/__tests__/overlayFocus.test.tsx
@@ -1,0 +1,76 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useRef } from "react";
+import { useOverlayFocus } from "../lib/overlayFocus";
+
+function OverlayTrapFixture({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const firstRef = useRef<HTMLButtonElement>(null);
+  useOverlayFocus(open, rootRef, {
+    initialFocusRef: firstRef,
+    onClose,
+    restoreFocus: true,
+  });
+  if (!open) return null;
+  return (
+    <div ref={rootRef} role="dialog" aria-label="trap">
+      <button ref={firstRef} type="button">
+        First
+      </button>
+      <button type="button">Second</button>
+    </div>
+  );
+}
+
+describe("useOverlayFocus", () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "offsetParent", {
+      configurable: true,
+      get() {
+        return this.parentElement;
+      },
+    });
+  });
+
+  it("wraps Tab at the ends and restores focus on Escape", async () => {
+    const onClose = vi.fn();
+    const trigger = document.createElement("button");
+    trigger.type = "button";
+    trigger.textContent = "Trigger";
+    document.body.append(trigger);
+    trigger.focus();
+
+    const { rerender } = render(<OverlayTrapFixture open onClose={onClose} />);
+
+    const first = screen.getByRole("button", { name: "First" });
+    const second = screen.getByRole("button", { name: "Second" });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(first);
+    });
+
+    second.focus();
+    expect(document.activeElement).toBe(second);
+
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(second);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender(<OverlayTrapFixture open={false} onClose={onClose} />);
+    });
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.remove();
+  });
+});

--- a/webapp/src/__tests__/thinkingStreamUx.test.ts
+++ b/webapp/src/__tests__/thinkingStreamUx.test.ts
@@ -1399,6 +1399,36 @@ describe("createApplyStreamEvent waitHint lifecycle", () => {
     expect(hintState.waitHint).toBe("Still working…");
     expect(hintState.status).toBe("awaiting_swarm");
   });
+
+  it("clears driver failure wait hints on reasoning progress", () => {
+    const { state, apply } = makeWaitHintDeps();
+    apply({
+      kind: "notice",
+      data: { kind: "wait", message: "driver openrouter:deepseek failed" },
+    });
+    apply({ kind: "thinking", data: { text: "Retry route", delta: true, stream_id: "r1" } });
+    expect(state.waitHint).toBeNull();
+  });
+
+  it("clears driver failure wait hints on assistant_done success", () => {
+    const { state, apply } = makeWaitHintDeps();
+    apply({
+      kind: "notice",
+      data: { kind: "wait", message: "driver openrouter:deepseek failed" },
+    });
+    apply({ kind: "assistant_done", data: { stop_cause: "natural" } });
+    expect(state.waitHint).toBeNull();
+  });
+
+  it("keeps driver failure wait hints when the turn settles in error", () => {
+    const { state, apply } = makeWaitHintDeps();
+    apply({
+      kind: "notice",
+      data: { kind: "wait", message: "driver openrouter:deepseek failed" },
+    });
+    apply({ kind: "error", data: { error: "all routes failed" } });
+    expect(state.waitHint).toBe("driver openrouter:deepseek failed");
+  });
 });
 
 describe("message_delta cover gate without eager setState updaters", () => {

--- a/webapp/src/__tests__/transcriptLiveTail.test.ts
+++ b/webapp/src/__tests__/transcriptLiveTail.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { GroupedItem } from "../components/TranscriptList";
+import { partitionTranscriptLiveTail } from "../components/conversation/transcriptLiveTail";
+
+describe("partitionTranscriptLiveTail", () => {
+  const streamingMsg: GroupedItem = {
+    kind: "msg",
+    msg: { role: "assistant", text: "live", streaming: true },
+  };
+  const sealedMsg: GroupedItem = {
+    kind: "msg",
+    msg: { role: "user", text: "hi" },
+  };
+
+  it("keeps streaming tail rows out of the virtual window while the loop is open", () => {
+    const grouped: GroupedItem[] = [sealedMsg, streamingMsg];
+    const part = partitionTranscriptLiveTail(grouped, {
+      lastLiveActivityIdx: -1,
+      agentLoopOpen: true,
+    });
+    expect(part.head).toEqual([sealedMsg]);
+    expect(part.tail).toEqual([streamingMsg]);
+    expect(part.tailStartIndex).toBe(1);
+  });
+
+  it("virtualizes the full list when the turn is closed", () => {
+    const grouped: GroupedItem[] = [sealedMsg, streamingMsg];
+    const part = partitionTranscriptLiveTail(grouped, {
+      lastLiveActivityIdx: -1,
+      agentLoopOpen: false,
+    });
+    expect(part.head).toEqual(grouped);
+    expect(part.tail).toEqual([]);
+  });
+});

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -666,8 +666,8 @@ describe("investigation UX residual debts (nested / fold prefs / workerStream)",
 
     render(<TranscriptList {...listProps(items)} />);
     fireEvent.click(screen.getByRole("button", { name: /Explored/i }));
-    expect(screen.getByLabelText("failed")).toBeTruthy();
-    expect(screen.getByText("failed", { selector: ".sr-only" })).toBeTruthy();
+    expect(screen.getAllByLabelText("failed").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("failed", { selector: ".sr-only" }).length).toBeGreaterThan(0);
   });
 
   it("clearActivityFoldPrefs drops sticky open state after a user toggle", () => {

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -638,6 +638,38 @@ describe("investigation UX residual debts (nested / fold prefs / workerStream)",
     expect(nested[1]).toHaveAttribute("data-action-id", "nested-edit-1");
   });
 
+  it("marks failed nested worker rows with visible failed chrome", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "implement the fix" } },
+      {
+        kind: "card",
+        card: {
+          id: "run-impl-fail",
+          goal: "ship nested tools",
+          cwd: null,
+          kind: "run_implement",
+          running: false,
+          open: false,
+          actions: [
+            {
+              action_id: "nested-fail-1",
+              kind: "read_file",
+              goal: "missing.ts",
+              status: "failed",
+            },
+          ],
+          result: { status: "error", error: "worker failed" },
+        },
+      },
+      { kind: "msg", msg: { role: "assistant", text: "Stopped." } },
+    ];
+
+    render(<TranscriptList {...listProps(items)} />);
+    fireEvent.click(screen.getByRole("button", { name: /Explored/i }));
+    expect(screen.getByLabelText("failed")).toBeTruthy();
+    expect(screen.getByText("failed", { selector: ".sr-only" })).toBeTruthy();
+  });
+
   it("clearActivityFoldPrefs drops sticky open state after a user toggle", () => {
     const card: Extract<Item, { kind: "card" }> = {
       kind: "card",

--- a/webapp/src/__tests__/wave4Operational.test.ts
+++ b/webapp/src/__tests__/wave4Operational.test.ts
@@ -5,6 +5,7 @@ import {
   authFailureDiagnostic,
   fromBackendDiagnostic,
 } from "../lib/operationalDiagnostic";
+import { executeDiagnosticRecovery } from "../lib/operationalRecovery";
 
 describe("fromBackendDiagnostic", () => {
   it("parses GET /api/diagnostics wire payloads", () => {
@@ -39,12 +40,20 @@ describe("authFailureDiagnostic", () => {
 
 describe("executeDiagnosticRecovery", () => {
   it("invokes retry callback for retry recovery", async () => {
-    const { executeDiagnosticRecovery } = await import("../lib/operationalRecovery");
     const retry = vi.fn();
     await executeDiagnosticRecovery(
       authFailureDiagnostic("bad key"),
       retry,
     );
     expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("auth failure retry relaunches the failed turn instead of only refreshing diagnostics", async () => {
+    const retry = vi.fn();
+    const diag = authFailureDiagnostic("OPENAI_API_KEY rejected");
+    expect(diag.recovery.kind).toBe("retry");
+    await executeDiagnosticRecovery(diag, retry);
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(diag.code).toBe(AUTH_FAILURE);
   });
 });

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -101,9 +101,12 @@ import { focusSettingsPage } from "./SettingsShell";
 import {
   FEED_GESTURE_IDLE_MS,
   FEED_REPIN_THRESHOLD_PX,
+  FEED_TAIL_EPSILON_PX,
   chooseFeedFollowFlush,
   feedResizeScrollFollowDecision,
+  isAtFeedTail,
   nextFeedPinState,
+  scrollToFeedEnd,
   settleFrameResult,
   shouldShowJumpToBottom,
   shouldUnpinOnTouchMove,
@@ -159,7 +162,7 @@ import {
   type DirectoryEntryLike,
 } from "./conversation/composerInput";
 import { openAgentWorkspace } from "../lib/agentLinks";
-import { sharedReadinessNotice, fromBackendDiagnostic } from "../lib/operationalDiagnostic";
+import { AUTH_FAILURE, sharedReadinessNotice, fromBackendDiagnostic } from "../lib/operationalDiagnostic";
 import { getActiveDiagnostic, publishDiagnostic } from "../lib/operationalDiagnosticBus";
 import { executeDiagnosticRecovery, clearDiagnosticAfterSuccess } from "../lib/operationalRecovery";
 import { useOperationalDiagnostic } from "../lib/useOperationalDiagnostic";
@@ -1118,7 +1121,8 @@ export default function Conversation({
       scrollToEnd();
     } else if (feedRef.current) {
       programmaticScrollRef.current = true;
-      feedRef.current.scrollTop = feedRef.current.scrollHeight;
+      const el = feedRef.current;
+      el.scrollTop = scrollToFeedEnd(el.scrollHeight, el.clientHeight);
     }
   };
   useEffect(() => {
@@ -1133,12 +1137,18 @@ export default function Conversation({
     const snapToBottomIfNear = () => {
       const node = feedRef.current;
       if (!node) return;
-      const distance = node.scrollHeight - node.scrollTop - node.clientHeight;
-      if (distance >= FEED_REPIN_THRESHOLD_PX) return;
+      if (!isAtFeedTail(
+        node.scrollHeight,
+        node.scrollTop,
+        node.clientHeight,
+        FEED_TAIL_EPSILON_PX,
+      )) {
+        return;
+      }
       scrollReleasedByGestureRef.current = false;
       pinnedToBottomRef.current = true;
-      const maxScrollTop = Math.max(0, node.scrollHeight - node.clientHeight);
-      if (Math.abs(node.scrollTop - maxScrollTop) >= 0.5) {
+      const maxScrollTop = scrollToFeedEnd(node.scrollHeight, node.clientHeight);
+      if (Math.abs(node.scrollTop - maxScrollTop) >= FEED_TAIL_EPSILON_PX) {
         programmaticScrollRef.current = true;
         node.scrollTop = maxScrollTop;
       }
@@ -1325,7 +1335,7 @@ export default function Conversation({
       scrollToEnd();
     } else {
       programmaticScrollRef.current = true;
-      el.scrollTop = el.scrollHeight;
+      el.scrollTop = scrollToFeedEnd(el.scrollHeight, el.clientHeight);
     }
     let frame = 0;
     let stableFrames = 0;
@@ -3420,6 +3430,16 @@ export default function Conversation({
   const handleOperationalRecovery = useCallback(async () => {
     if (!operationalDiagnostic) return;
     await executeDiagnosticRecovery(operationalDiagnostic, async () => {
+      if (operationalDiagnostic.code === AUTH_FAILURE) {
+        focusSettingsPage("providers");
+        window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: "settings" }));
+        const ask = latestUserAsk(itemsRef.current);
+        if (ask) {
+          recoveryDispatchingRef.current = true;
+          executeSendRef.current(ask, auto, plan);
+        }
+        return;
+      }
       try {
         const res = await api.diagnostics();
         const diag = fromBackendDiagnostic(res.diagnostic as Record<string, unknown> | null);
@@ -3430,7 +3450,14 @@ export default function Conversation({
         /* keep diagnostic visible */
       }
     });
-  }, [operationalDiagnostic]);
+  }, [operationalDiagnostic, auto, plan]);
+
+  const handleAuthFailureRetry = useCallback(() => {
+    const ask = latestUserAsk(itemsRef.current);
+    if (!ask) return;
+    recoveryDispatchingRef.current = true;
+    executeSendRef.current(ask, auto, plan);
+  }, [auto, plan]);
 
   const recoveryAction = (
     operationalDiagnostic
@@ -3516,6 +3543,7 @@ export default function Conversation({
           onExecutePlan={handleTranscriptExecutePlan}
           onCommandApproval={handleCommandApproval}
           onSecretRequest={handleSecretRequest}
+          onAuthFailureRetry={handleAuthFailureRetry}
           showJumpToBottom={showJumpToBottom}
           onJumpToBottom={jumpToLatest}
           composerDock={(

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -64,15 +64,18 @@ import {
 } from "../lib/autoReceipts";
 import { authFailureDiagnostic } from "../lib/operationalDiagnostic";
 import { publishDiagnostic } from "../lib/operationalDiagnosticBus";
+import { executeDiagnosticRecovery } from "../lib/operationalRecovery";
 import { focusSettingsPage } from "./SettingsShell";
 import { TranscriptImage } from "./conversation/TranscriptImage";
 import {
   FEED_UNPIN_BUBBLE_EVENT,
   nextFeedPinState,
+  scrollToFeedEnd,
   shouldStopNestedWheelBubble,
   shouldUnpinInnerOnWheel,
   THINKING_INNER_PIN_THRESHOLD_PX,
 } from "./conversation/feedScroll";
+import { partitionTranscriptLiveTail } from "./conversation/transcriptLiveTail";
 import {
   isOccludedScrollParentSize,
   shouldUseVirtualTranscriptWindow,
@@ -1025,10 +1028,28 @@ function indexTranscriptCommandSessions(items: Item[]): void {
   }
 }
 
-function AuthFailureBanner({ message, id }: { message: string; id?: string }) {
+function AuthFailureBanner({
+  message,
+  id,
+  onRetry,
+}: {
+  message: string;
+  id?: string;
+  onRetry?: () => void;
+}) {
   useEffect(() => {
     publishDiagnostic(authFailureDiagnostic(message, { jobId: id }));
   }, [message, id]);
+
+  const handleRetry = () => {
+    focusSettingsPage("providers");
+    window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: "settings" }));
+    if (!onRetry) return;
+    void executeDiagnosticRecovery(
+      authFailureDiagnostic(message, { jobId: id }),
+      onRetry,
+    );
+  };
 
   return (
     <div
@@ -1050,10 +1071,7 @@ function AuthFailureBanner({ message, id }: { message: string; id?: string }) {
         <div className="mt-2">
           <button
             type="button"
-            onClick={() => {
-              focusSettingsPage("providers");
-              window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: "settings" }));
-            }}
+            onClick={handleRetry}
             className="rounded-md border border-red-400/40 bg-red-500/10 px-2.5 py-1 text-[11px] font-medium text-red-100 hover:bg-red-500/20 transition"
           >
             Fix key and retry
@@ -1099,6 +1117,8 @@ export type TranscriptListProps = {
   onExecutePlan: (planText: string) => void;
   onCommandApproval: (item: CommandApprovalItem, approve: boolean) => void;
   onSecretRequest?: (item: SecretRequestItem, decision: { action: "save"; value: string } | { action: "dismiss" }) => void;
+  /** Relaunch the failed turn after provider auth recovery (Settings still opens). */
+  onAuthFailureRetry?: () => void;
 };
 
 export const TranscriptList = memo(function TranscriptList({
@@ -1120,6 +1140,7 @@ export const TranscriptList = memo(function TranscriptList({
   onExecutePlan,
   onCommandApproval,
   onSecretRequest,
+  onAuthFailureRetry,
 }: TranscriptListProps) {
   // Match Conversation's latch — awaiting_swarm plus holdSwarmAwait so
   // Investigating / mid-turn absorption / footer stay armed through idle flaps.
@@ -1141,6 +1162,12 @@ export const TranscriptList = memo(function TranscriptList({
 
   const intermediateItems = collectIntermediateAssistantItems(items, agentLoopOpen);
   const grouped = groupAgentActivity(items, intermediateItems);
+  const lastActivityGroupIdx = liveActivityGroupIndex(grouped);
+  const { head: virtualGrouped, tail: liveTailGrouped, tailStartIndex } =
+    partitionTranscriptLiveTail(grouped, {
+      lastLiveActivityIdx: lastActivityGroupIdx,
+      agentLoopOpen,
+    });
 
   // Virtualizer scroll parent is the feed column (composer is a sibling). The
   // list sits below empty-state / padding, so scrollMargin tracks that offset.
@@ -1185,12 +1212,12 @@ export const TranscriptList = memo(function TranscriptList({
   }, [scrollContainerRef, grouped.length, scrollEpoch]);
 
   const rowVirtualizer = useVirtualizer({
-    count: grouped.length,
+    count: virtualGrouped.length,
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: () => FEED_ROW_ESTIMATE_PX,
     overscan: FEED_VIRTUAL_OVERSCAN,
     scrollMargin,
-    getItemKey: (index) => stableItemKey(grouped[index]!, index),
+    getItemKey: (index) => stableItemKey(virtualGrouped[index]!, index),
     measureElement:
       typeof window !== "undefined" &&
       !/firefox/i.test(window.navigator.userAgent)
@@ -1198,13 +1225,10 @@ export const TranscriptList = memo(function TranscriptList({
         : undefined,
   });
   const scrollToEnd = useCallback(() => {
-    const last = grouped.length - 1;
-    if (last >= 0) {
-      rowVirtualizer.scrollToIndex(last, { align: "end" });
-    }
     const el = scrollContainerRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [grouped.length, rowVirtualizer, scrollContainerRef]);
+    if (!el) return;
+    el.scrollTop = scrollToFeedEnd(el.scrollHeight, el.clientHeight);
+  }, [scrollContainerRef, grouped.length, liveTailGrouped.length]);
   useLayoutEffect(() => {
     if (!scrollToEndRef) return;
     scrollToEndRef.current = scrollToEnd;
@@ -1245,7 +1269,6 @@ export const TranscriptList = memo(function TranscriptList({
   // Only the newest fold AFTER the latest user message may be live. Prior
   // turns stay sealed even while turnOpen/busy — otherwise a new prompt
   // reactivates the previous Investigating pill until turn-2 tools land.
-  const lastActivityGroupIdx = liveActivityGroupIndex(grouped);
 
   const renderGroupedItem = (i: number) => {
     const it = grouped[i];
@@ -1521,7 +1544,14 @@ export const TranscriptList = memo(function TranscriptList({
         </div>
       );
     } else if (it.kind === "auth_failure") {
-      return <AuthFailureBanner key={key} message={it.message} id={it.id} />;
+      return (
+        <AuthFailureBanner
+          key={key}
+          message={it.message}
+          id={it.id}
+          onRetry={onAuthFailureRetry}
+        />
+      );
     } else if (it.kind === "compaction") {
       return <CompactionReceipt key={key} it={it} />;
     } else if (it.kind === "steer") {
@@ -1682,6 +1712,14 @@ export const TranscriptList = memo(function TranscriptList({
       {grouped.map((_, i) => renderGroupedItem(i))}
     </div>
   );
+  const liveTailList = useVirtualWindow && liveTailGrouped.length > 0 ? (
+    <div
+      data-testid="transcript-live-tail"
+      className="flex flex-col gap-1 w-full"
+    >
+      {liveTailGrouped.map((_, i) => renderGroupedItem(tailStartIndex + i))}
+    </div>
+  ) : null;
 
   const busyProgress = deriveBusyProgress(items, status, busyElapsedMs);
   // Hide the under-fold line only while a card / prep / stream already
@@ -1707,6 +1745,7 @@ export const TranscriptList = memo(function TranscriptList({
       data-testid="transcript-log"
     >
       {list}
+      {liveTailList}
       {compactingStatus && (
         <div className="flex items-center gap-1.5 py-1 px-3 rounded-full bg-panel2/15 border border-edge/20 text-[11px] text-faint w-fit my-1 select-none animate-pulse">
           <Loader2 size={11} className="animate-spin text-accent" />
@@ -3146,7 +3185,9 @@ function ActionCard({
                   {action.status === "running" && effectivelyRunning ? (
                     <Loader2 size={10} className="animate-spin text-faint/60" />
                   ) : nestedErr ? (
-                    <span className="w-1 h-1 rounded-full bg-risk/70" />
+                    <span className="w-1 h-1 rounded-full bg-risk/70" aria-label="failed" title="failed">
+                      <span className="sr-only">failed</span>
+                    </span>
                   ) : null}
                 </div>
                 <span className={`shrink-0 ${nestedErr ? "text-risk/80" : "text-faint/75"}`}>

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -37,6 +37,7 @@ export default function ConversationChatColumn({
   onExecutePlan,
   onCommandApproval,
   onSecretRequest,
+  onAuthFailureRetry,
   composerDock,
   showJumpToBottom = false,
   onJumpToBottom,
@@ -63,6 +64,7 @@ export default function ConversationChatColumn({
   onExecutePlan: (planText: string) => void;
   onCommandApproval: (item: CommandApprovalItem, approve: boolean) => void;
   onSecretRequest?: (item: SecretRequestItem, decision: { action: "save"; value: string } | { action: "dismiss" }) => void;
+  onAuthFailureRetry?: () => void;
   composerDock: ReactNode;
   showJumpToBottom?: boolean;
   onJumpToBottom?: () => void;
@@ -131,6 +133,7 @@ export default function ConversationChatColumn({
             onExecutePlan={onExecutePlan}
             onCommandApproval={onCommandApproval}
             onSecretRequest={onSecretRequest}
+            onAuthFailureRetry={onAuthFailureRetry}
           />
         </div>
       </div>

--- a/webapp/src/components/conversation/feedScroll.ts
+++ b/webapp/src/components/conversation/feedScroll.ts
@@ -43,6 +43,13 @@ export function feedBottomClearancePx(chromeHeight: number): number {
   return Math.max(72, Math.min(Math.round(chromeHeight), 480));
 }
 
+import { scrollToFeedEnd as scrollToFeedEndImpl } from "../../../electron/feed-scroll.cjs";
+
+/** Authoritative scrollTop for stick-to-bottom (not scrollToIndex align:end). */
+export function scrollToFeedEnd(scrollHeight: number, clientHeight: number): number {
+  return scrollToFeedEndImpl(scrollHeight, clientHeight);
+}
+
 export function isPinnedToBottom(
   scrollHeight: number,
   scrollTop: number,

--- a/webapp/src/components/conversation/feedScroll.ts
+++ b/webapp/src/components/conversation/feedScroll.ts
@@ -43,11 +43,9 @@ export function feedBottomClearancePx(chromeHeight: number): number {
   return Math.max(72, Math.min(Math.round(chromeHeight), 480));
 }
 
-import { scrollToFeedEnd as scrollToFeedEndImpl } from "../../../electron/feed-scroll.cjs";
-
 /** Authoritative scrollTop for stick-to-bottom (not scrollToIndex align:end). */
 export function scrollToFeedEnd(scrollHeight: number, clientHeight: number): number {
-  return scrollToFeedEndImpl(scrollHeight, clientHeight);
+  return Math.max(0, scrollHeight - clientHeight);
 }
 
 export function isPinnedToBottom(

--- a/webapp/src/components/conversation/streamEventHandler.ts
+++ b/webapp/src/components/conversation/streamEventHandler.ts
@@ -56,6 +56,10 @@ import {
   finalizeOpenPilotBubble,
   sealedAssistantCoversDelta,
 } from "./streamBubbles";
+import {
+  clearProviderFailureWaitHint,
+  isProviderFailureWaitHint,
+} from "../../lib/composerWaitHint";
 import { turnHasLiveInvestigation } from "../../lib/turnProgress";
 import { notifyWorkspaceMutated } from "../../lib/workspaceMutationEvents";
 import { shouldRefreshBusyChrome } from "./streamTerminal";
@@ -147,7 +151,12 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
     recordTurnSettle,
   } = deps;
 
-  const clearWaitHintOnProgress = () => setWaitHint(null);
+  const clearWaitHintOnProgress = () =>
+    setWaitHint((prev) => {
+      if (!prev) return prev;
+      if (isProviderFailureWaitHint(prev)) return clearProviderFailureWaitHint(prev);
+      return null;
+    });
   const refreshBusyChrome = () =>
     shouldRefreshBusyChrome({
       turnSettled: turnSettledRef.current,
@@ -161,7 +170,11 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
       setWaitHint(awaitHint || "Still working…");
     } else {
       setStatus(settle.status);
-      setWaitHint(null);
+      if (settle.status === "error") {
+        setWaitHint((prev) => (isProviderFailureWaitHint(prev) ? prev : null));
+      } else {
+        setWaitHint(null);
+      }
     }
     recordTurnSettle?.(settle);
   };

--- a/webapp/src/components/conversation/transcriptLiveTail.ts
+++ b/webapp/src/components/conversation/transcriptLiveTail.ts
@@ -1,0 +1,56 @@
+import type { GroupedItem } from "../TranscriptList";
+
+function isLiveTailRow(
+  row: GroupedItem,
+  index: number,
+  lastLiveActivityIdx: number,
+): boolean {
+  if (row.kind === "msg" && row.msg.role === "assistant" && row.msg.streaming === true) {
+    return true;
+  }
+  if (row.kind === "thinking" && row.streaming === true) {
+    return true;
+  }
+  if (row.kind === "activity_group" && index === lastLiveActivityIdx) {
+    return true;
+  }
+  return false;
+}
+
+export type TranscriptLiveTailPartition = {
+  head: GroupedItem[];
+  tail: GroupedItem[];
+  /** Index in the full grouped array where tail begins (== head.length). */
+  tailStartIndex: number;
+};
+
+/**
+ * Keep streaming / live-investigation rows in normal document flow after the
+ * virtual window so token growth pushes footer clearance in the same layout pass.
+ */
+export function partitionTranscriptLiveTail(
+  grouped: GroupedItem[],
+  opts: { lastLiveActivityIdx: number; agentLoopOpen: boolean },
+): TranscriptLiveTailPartition {
+  if (!opts.agentLoopOpen || grouped.length === 0) {
+    return { head: grouped, tail: [], tailStartIndex: grouped.length };
+  }
+
+  let tailStart = grouped.length;
+  for (let i = grouped.length - 1; i >= 0; i -= 1) {
+    if (!isLiveTailRow(grouped[i], i, opts.lastLiveActivityIdx)) {
+      break;
+    }
+    tailStart = i;
+  }
+
+  if (tailStart >= grouped.length) {
+    return { head: grouped, tail: [], tailStartIndex: grouped.length };
+  }
+
+  return {
+    head: grouped.slice(0, tailStart),
+    tail: grouped.slice(tailStart),
+    tailStartIndex: tailStart,
+  };
+}

--- a/webapp/src/lib/composerWaitHint.ts
+++ b/webapp/src/lib/composerWaitHint.ts
@@ -1,0 +1,43 @@
+/**
+ * Composer wait-hint hygiene for Hermes/driver route retries.
+ *
+ * Drivers emit notices like ``driver openrouter:deepseek failed`` while the
+ * harness retries another route. Progress events must clear stale failure
+ * chrome so a recovered turn does not keep lying in the busy footer.
+ */
+
+const PROVIDER_FAILURE_HINT_RE = /^driver\s+.+\s+failed\b/i;
+
+/** True for driver-route failure notices painted as composer wait hints. */
+export function isProviderFailureWaitHint(hint: string | null | undefined): boolean {
+  const text = String(hint || "").trim();
+  if (!text) return false;
+  return PROVIDER_FAILURE_HINT_RE.test(text);
+}
+
+/** Drop stale provider failure hints; leave swarm await footnotes alone. */
+export function clearProviderFailureWaitHint(prev: string | null): string | null {
+  return isProviderFailureWaitHint(prev) ? null : prev;
+}
+
+/**
+ * Suppress a stale failure hint once the turn shows live progress again.
+ * Keep the failure visible when the turn actually ended in error.
+ */
+export function waitHintForBusyProgress(
+  hint: string | null | undefined,
+  opts: { hasSignal: boolean; turnFailed?: boolean },
+): string | null {
+  const text = String(hint || "").trim();
+  if (!text) return null;
+  if (isProviderFailureWaitHint(text) && opts.hasSignal && !opts.turnFailed) {
+    return null;
+  }
+  return text;
+}
+
+/** Format a driver failure notice for SSE wait chrome (harness + driver contract). */
+export function formatDriverFailureWaitHint(driver: string): string {
+  const label = String(driver || "").trim() || "provider";
+  return `driver ${label} failed`;
+}

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -635,6 +635,24 @@ export function deriveBusyProgress(
     };
   }
 
+  const hint = waitHintForBusyProgress(opts?.waitHint, {
+    hasSignal,
+    turnFailed: status === "error",
+  })?.trim() || "";
+
+  // Settled error still shows a leftover driver-failure hint. Recovered
+  // turns already cleared it in waitHintForBusyProgress.
+  if (status === "error" && hint) {
+    return {
+      phase: "error",
+      label: hint,
+      pill: hint,
+      step,
+      runningGoal,
+      runningKind,
+    };
+  }
+
   if (!busy) {
     return {
       phase,
@@ -648,10 +666,6 @@ export function deriveBusyProgress(
 
   // Background job pause: paint the await hint as the primary line (not
   // "Waiting on <pilot>" — the pilot turn already ended).
-  const hint = waitHintForBusyProgress(opts?.waitHint, {
-    hasSignal,
-    turnFailed: status === "error",
-  })?.trim() || "";
   if (awaitingSwarm) {
     const line = hint || "Still working…";
     const waiting = elapsed ? `${line} · ${elapsed}` : line;

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -6,6 +6,8 @@
  * activity fold already knows about -- pure, so vitest can pin the contract.
  */
 
+import { waitHintForBusyProgress } from "./composerWaitHint";
+
 export type BusyStatus = "idle" | "thinking" | "executing" | "done" | "error" | "streaming" | string;
 
 export type TurnCard = {
@@ -646,7 +648,10 @@ export function deriveBusyProgress(
 
   // Background job pause: paint the await hint as the primary line (not
   // "Waiting on <pilot>" — the pilot turn already ended).
-  const hint = (opts?.waitHint || "").trim();
+  const hint = waitHintForBusyProgress(opts?.waitHint, {
+    hasSignal,
+    turnFailed: status === "error",
+  })?.trim() || "";
   if (awaitingSwarm) {
     const line = hint || "Still working…";
     const waiting = elapsed ? `${line} · ${elapsed}` : line;


### PR DESCRIPTION
## Summary
- Clear `driver … failed` waitHint after later progress; keep it only if the turn settles error.
- In-flow live tail + feed follow so stream-at-fold does not lurch a frame late.
- auth_failure Retry relaunches the last user ask.
- overlayFocus Tab-cycle + restore test; nested failed-dot text/aria; CheckpointsPane badge test.
- After update, if `pip show` editable path != pulled tree, ff/rebind + notice.
- Pin stays `puppetmaster-ai==1.22.23`. No Pi worker.

## Test plan
- [ ] Unit/Electron helper tests in CI
- [ ] Real Electron VM: Autopilot stream until tail hits viewport bottom; no jump
- [ ] Recovered OpenRouter route does not leave `driver openrouter:… failed` in the composer line