### PR TITLE
v0.9.285 Trace persist + SSE write timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.23` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.284, deliberately pre-1.0. Rides puppetmaster-ai==1.22.23. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.285, deliberately pre-1.0. Rides puppetmaster-ai==1.22.23. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.284"
+__version__ = "0.9.285"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/doctor.py
+++ b/harness/api/doctor.py
@@ -107,6 +107,7 @@ def _diagnostic_from_checks(checks: list[dict[str, str]]) -> Optional[dict[str, 
             "retryable": True,
             "recovery": {"kind": "retry", "label": "Retry"},
             "createdAt": int(time.time() * 1000),
+            "correlation_id": get_correlation_id(),
         }
 
     first = warned[0]
@@ -122,6 +123,7 @@ def _diagnostic_from_checks(checks: list[dict[str, str]]) -> Optional[dict[str, 
         "retryable": True,
         "recovery": {"kind": "retry", "label": "Retry"},
         "createdAt": int(time.time() * 1000),
+        "correlation_id": get_correlation_id(),
     }
 
 

--- a/harness/api/sse.py
+++ b/harness/api/sse.py
@@ -12,6 +12,7 @@ and keeps thin ``Handler`` wrappers so tests keep binding
 from __future__ import annotations
 
 import json
+import socket
 import threading
 import time
 from collections import deque
@@ -48,6 +49,8 @@ _SSE_RING_MAX_SESSIONS = 32
 # Soft cap prefers unpinned rings; hard cap force-evicts oldest (even pinned)
 # so a stuck-pin storm cannot grow the map without bound.
 _SSE_RING_HARD_MAX_SESSIONS = 64
+# Slow-client guard: a blocked write+flush must not stall the pump thread.
+_SSE_WRITE_TIMEOUT_S = 30.0
 
 
 # 3.9-safe optional fields via TypedDict inheritance (NotRequired is 3.11+;
@@ -453,7 +456,54 @@ def stream_chat_events(
         time.sleep(_CHAT_EVENTS_WATCH_POLL_S)
 
 
-def sse_write(wfile: Any, payload: bytes) -> bool:
+def _wfile_socket(wfile: Any) -> Any:
+    """Best-effort socket behind an HTTP wfile/buffer."""
+    sock = getattr(wfile, "socket", None)
+    if sock is not None:
+        return sock
+    raw = getattr(wfile, "raw", None)
+    if raw is not None:
+        return getattr(raw, "_sock", None) or getattr(raw, "socket", None)
+    return getattr(wfile, "_sock", None)
+
+
+def _write_flush_with_deadline(wfile: Any, payload: bytes, timeout_s: float) -> None:
+    """Write one SSE frame; raise TimeoutError when the client stops reading."""
+    sock = _wfile_socket(wfile)
+    if sock is not None and hasattr(sock, "settimeout"):
+        prev = sock.gettimeout()
+        try:
+            sock.settimeout(timeout_s)
+            wfile.write(payload)
+            wfile.flush()
+        finally:
+            try:
+                sock.settimeout(prev)
+            except OSError:
+                pass
+        return
+
+    exc_holder: list[BaseException] = []
+    done = threading.Event()
+
+    def _do_write() -> None:
+        try:
+            wfile.write(payload)
+            wfile.flush()
+        except BaseException as exc:
+            exc_holder.append(exc)
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=_do_write, daemon=True)
+    thread.start()
+    if not done.wait(timeout_s):
+        raise TimeoutError("sse write timed out")
+    if exc_holder:
+        raise exc_holder[0]
+
+
+def sse_write(wfile: Any, payload: bytes, *, timeout_s: Optional[float] = None) -> bool:
     """Write one SSE frame. Returns False if the client has detached.
 
     View detach (EventSource close / navigate away) must NOT cancel the
@@ -462,10 +512,13 @@ def sse_write(wfile: Any, payload: bytes) -> bool:
     generator's own finally.
     """
     try:
-        wfile.write(payload)
-        wfile.flush()
+        _write_flush_with_deadline(
+            wfile,
+            payload,
+            _SSE_WRITE_TIMEOUT_S if timeout_s is None else timeout_s,
+        )
         return True
-    except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+    except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, TimeoutError, socket.timeout):
         # ConnectionAbortedError is the common Windows EventSource/nav-close
         # path; it is not a subclass of BrokenPipe/Reset. Treat it as detach
         # so the pump can keep draining instead of gen.close()-aborting mid-yield.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.284"
+version = "0.9.285"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_diagnostics.py
+++ b/tests/test_api_diagnostics.py
@@ -29,8 +29,10 @@ def test_get_diagnostics_surfaces_hard_failures(monkeypatch):
         get_reach=lambda: "cloud",
         get_repo=lambda: "",
     )
-    status, payload = get_diagnostics(svc)
+    with __import__("harness.correlation", fromlist=["correlation_scope"]).correlation_scope("diag-fail"):
+        status, payload = get_diagnostics(svc)
     assert status == 200
     assert payload["diagnostic"] is not None
     assert payload["diagnostic"]["scope"] == "backend"
     assert payload["diagnostic"]["recovery"] == {"kind": "retry", "label": "Retry"}
+    assert payload["diagnostic"]["correlation_id"] == "diag-fail"

--- a/tests/test_sse_write_timeout.py
+++ b/tests/test_sse_write_timeout.py
@@ -1,0 +1,56 @@
+"""SSE write timeout must detach slow clients without stalling the pump."""
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+
+from harness.api.sse import SseEventRing, _sse_ring_clear_for_tests, sse_pump, sse_write
+
+
+class _BlockingWfile:
+    """Blocks on write after the first successful frame."""
+
+    def __init__(self) -> None:
+        self.writes = 0
+
+    def write(self, _payload: bytes) -> None:
+        self.writes += 1
+        if self.writes > 1:
+            time.sleep(5.0)
+
+    def flush(self) -> None:
+        if self.writes > 1:
+            time.sleep(5.0)
+
+
+def test_sse_write_returns_false_when_write_blocks_past_deadline(monkeypatch):
+    monkeypatch.setattr("harness.api.sse._SSE_WRITE_TIMEOUT_S", 0.05)
+    wfile = _BlockingWfile()
+    assert sse_write(wfile, b"data: first\n\n") is True
+    assert sse_write(wfile, b"data: second\n\n") is False
+
+
+def test_sse_pump_continues_and_ring_appends_after_slow_client_detach(monkeypatch):
+    monkeypatch.setattr("harness.api.sse._SSE_WRITE_TIMEOUT_S", 0.05)
+    _sse_ring_clear_for_tests()
+    ring = SseEventRing("sess-slow", generation=1, cap=32, ttl=60.0)
+    wfile = _BlockingWfile()
+
+    events = [
+        SimpleNamespace(kind="token", data={"t": "a"}, turn=1),
+        SimpleNamespace(kind="token", data={"t": "b"}, turn=1),
+        SimpleNamespace(kind="assistant_done", data={}, turn=1),
+    ]
+
+    detached = sse_pump(
+        wfile,
+        iter(events),
+        lambda ev: ("data: %s\n\n" % json.dumps({"kind": ev.kind})).encode(),
+        ring=ring,
+    )
+    assert detached is True
+    kinds = [e["kind"] for e in ring.since(0)["events"]]
+    assert kinds.count("token") == 2
+    assert "assistant_done" in kinds
+    assert "done" in kinds

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.284"
+version = "0.9.285"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.284",
+  "version": "0.9.285",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.284",
+      "version": "0.9.285",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.284",
+  "version": "0.9.285",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/correlationTrace.test.tsx
+++ b/webapp/src/__tests__/correlationTrace.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ConversationHeader from "../components/conversation/ConversationHeader";
+import { TranscriptList, type Item } from "../components/TranscriptList";
+import { setCorrelationId } from "../lib/correlationId";
+
+function listProps(items: Item[]) {
+  return {
+    items,
+    status: "done" as const,
+    compactingStatus: null as string | null,
+    editingIndex: null as number | null,
+    auto: false,
+    plan: false,
+    turnOpen: false,
+    scrollContainerRef: { current: null },
+    onEditMessage: vi.fn(),
+    onExecuteSend: vi.fn(),
+    onImageClick: vi.fn(),
+    onSetCard: vi.fn(),
+    onExecutePlan: vi.fn(),
+    onCommandApproval: vi.fn(),
+  };
+}
+
+describe("correlation trace chrome", () => {
+  it("ConversationHeader shows a copyable trace when the error pill has a correlation id", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    render(
+      <ConversationHeader
+        pillStatus="error"
+        detail="Request failed"
+        correlationId="trace-header-1"
+      />,
+    );
+
+    const trace = screen.getByTestId("trace-copy");
+    expect(trace).toHaveTextContent("Trace: trace-header-1");
+    fireEvent.click(trace);
+    expect(writeText).toHaveBeenCalledWith("trace-header-1");
+  });
+
+  it("ConversationHeader hides trace when idle or missing correlation id", () => {
+    const { rerender } = render(
+      <ConversationHeader pillStatus="error" detail="Request failed" />,
+    );
+    expect(screen.queryByTestId("trace-copy")).toBeNull();
+
+    rerender(
+      <ConversationHeader
+        pillStatus="idle"
+        correlationId="trace-header-1"
+      />,
+    );
+    expect(screen.queryByTestId("trace-copy")).toBeNull();
+  });
+
+  it("AuthFailureBanner shows a copyable trace from the client correlation id", () => {
+    setCorrelationId("trace-auth-99");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    render(
+      <TranscriptList
+        {...listProps([
+          {
+            kind: "auth_failure",
+            message: "OPENAI_API_KEY rejected",
+            id: "auth-1",
+          },
+        ])}
+      />,
+    );
+
+    const trace = screen.getByTestId("trace-copy");
+    expect(trace).toHaveTextContent("Trace: trace-auth-99");
+    fireEvent.click(trace);
+    expect(writeText).toHaveBeenCalledWith("trace-auth-99");
+    setCorrelationId("");
+  });
+});

--- a/webapp/src/__tests__/operationalDiagnostic.test.ts
+++ b/webapp/src/__tests__/operationalDiagnostic.test.ts
@@ -238,4 +238,19 @@ describe("createOperationalDiagnostic", () => {
     expect(diag.detail).toBe("line1");
     expect(diag.recovery).toEqual({ kind: "none" });
   });
+
+  it("inherits the active client correlation id when none is supplied", async () => {
+    const { getCorrelationId, setCorrelationId } = await import("../lib/correlationId");
+    setCorrelationId("client-corr-abc");
+    const diag = createOperationalDiagnostic({
+      scope: "conversation",
+      operation: "send",
+      summary: "Turn failed",
+      severity: "error",
+      retryable: true,
+    });
+    expect(diag.correlationId).toBe("client-corr-abc");
+    expect(getCorrelationId()).toBe("client-corr-abc");
+    setCorrelationId("");
+  });
 });

--- a/webapp/src/__tests__/wave4Operational.test.ts
+++ b/webapp/src/__tests__/wave4Operational.test.ts
@@ -19,9 +19,11 @@ describe("fromBackendDiagnostic", () => {
       retryable: true,
       recovery: { kind: "retry", label: "Retry" },
       createdAt: 1,
+      correlation_id: "diag-wire-1",
     });
     expect(diag?.scope).toBe("backend");
     expect(diag?.recovery).toEqual({ kind: "retry", label: "Retry" });
+    expect(diag?.correlationId).toBe("diag-wire-1");
   });
 
   it("returns null for incomplete wire payloads", () => {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -3474,6 +3474,11 @@ export default function Conversation({
       {/* Brand + idle share equal inset so they line up with the floating dock. */}
       <ConversationHeader
         pillStatus={pillStatus}
+        correlationId={
+          pillStatus === "error" && operationalDiagnostic?.correlationId
+            ? operationalDiagnostic.correlationId
+            : undefined
+        }
         detail={
           pillStatus === "error" && operationalDiagnostic
             ? operationalDiagnostic.summary

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, useSyncExternalStore, memo } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, useSyncExternalStore, useMemo, memo } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronRight, Loader2, ChevronDown, ChevronUp, Play, Copy, Check, Pencil, RefreshCw, History, Share2, CheckCircle2, XCircle, Eye, Shield } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -63,8 +63,10 @@ import {
   type AutoBudgetSnapshot,
 } from "../lib/autoReceipts";
 import { authFailureDiagnostic } from "../lib/operationalDiagnostic";
+import { getCorrelationId } from "../lib/correlationId";
 import { publishDiagnostic } from "../lib/operationalDiagnosticBus";
 import { executeDiagnosticRecovery } from "../lib/operationalRecovery";
+import TraceCopy from "./conversation/TraceCopy";
 import { focusSettingsPage } from "./SettingsShell";
 import { TranscriptImage } from "./conversation/TranscriptImage";
 import {
@@ -1037,16 +1039,22 @@ function AuthFailureBanner({
   id?: string;
   onRetry?: () => void;
 }) {
+  const diagnostic = useMemo(
+    () => authFailureDiagnostic(message, { jobId: id }),
+    [message, id],
+  );
+  const correlationId = diagnostic.correlationId || getCorrelationId();
+
   useEffect(() => {
-    publishDiagnostic(authFailureDiagnostic(message, { jobId: id }));
-  }, [message, id]);
+    publishDiagnostic(diagnostic);
+  }, [diagnostic]);
 
   const handleRetry = () => {
     focusSettingsPage("providers");
     window.dispatchEvent(new CustomEvent("harness-focus-tab", { detail: "settings" }));
     if (!onRetry) return;
     void executeDiagnosticRecovery(
-      authFailureDiagnostic(message, { jobId: id }),
+      diagnostic,
       onRetry,
     );
   };
@@ -1067,6 +1075,11 @@ function AuthFailureBanner({
           <code className="block mt-1 text-[10.5px] text-red-200/80 font-mono break-all whitespace-pre-wrap">
             {message}
           </code>
+        ) : null}
+        {correlationId ? (
+          <div className="mt-1.5">
+            <TraceCopy correlationId={correlationId} />
+          </div>
         ) : null}
         <div className="mt-2">
           <button

--- a/webapp/src/components/conversation/ConversationHeader.tsx
+++ b/webapp/src/components/conversation/ConversationHeader.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import StatusPill from "./StatusPill";
+import TraceCopy from "./TraceCopy";
 import {
   TITLEBAR_CHROME_PAD_X_PX,
   TITLEBAR_TRAFFIC_PAD_PX,
@@ -9,11 +10,13 @@ import {
 export default function ConversationHeader({
   pillStatus,
   detail,
+  correlationId,
   onBusyDetailClick,
   recoveryAction,
 }: {
   pillStatus: string;
   detail?: string;
+  correlationId?: string;
   onBusyDetailClick?: () => void;
   recoveryAction?: { label: string; onClick: () => void };
 }) {
@@ -50,6 +53,9 @@ export default function ConversationHeader({
           >
             {recoveryAction.label}
           </button>
+        ) : null}
+        {pillStatus === "error" && correlationId ? (
+          <TraceCopy correlationId={correlationId} />
         ) : null}
         <StatusPill
           status={pillStatus}

--- a/webapp/src/components/conversation/TraceCopy.tsx
+++ b/webapp/src/components/conversation/TraceCopy.tsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { Check } from "lucide-react";
+
+/** Copyable request correlation id for failed-turn support. */
+export default function TraceCopy({ correlationId }: { correlationId: string }) {
+  const [copied, setCopied] = useState(false);
+  const id = String(correlationId || "").trim();
+  if (!id) return null;
+
+  const handleCopy = () => {
+    void navigator.clipboard?.writeText(id).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      data-testid="trace-copy"
+      className="text-[10px] font-mono text-faint/90 hover:text-muted truncate max-w-[28ch] flex items-center gap-1"
+      title="Copy trace id for support"
+    >
+      <span className="truncate">Trace: {id}</span>
+      {copied ? <Check size={11} className="text-good shrink-0" /> : null}
+    </button>
+  );
+}

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -7,6 +7,8 @@
  * failure — not a second durable store, not form validation, not a PM taxonomy.
  */
 
+import { getCorrelationId } from "./correlationId";
+
 export type DiagnosticScope =
   | "desktop_bridge"
   | "transport"
@@ -45,6 +47,8 @@ export type OperationalDiagnostic = {
   repo?: string;
   jobId?: string;
   taskId?: string;
+  /** Request correlation id for support / log cross-reference. */
+  correlationId?: string;
   createdAt: number;
 };
 
@@ -128,6 +132,7 @@ export function createOperationalDiagnostic(
   },
 ): OperationalDiagnostic {
   const recovery = input.recovery || { kind: "none" };
+  const correlationId = input.correlationId ?? (getCorrelationId() || undefined);
   return {
     ...input,
     id: input.id || newDiagnosticId(),
@@ -135,6 +140,7 @@ export function createOperationalDiagnostic(
     summary: sanitizeDiagnosticText(input.summary, SUMMARY_MAX),
     detail: input.detail ? sanitizeDiagnosticText(input.detail, DETAIL_MAX) : undefined,
     recovery,
+    correlationId,
   };
 }
 
@@ -227,6 +233,7 @@ type BackendDiagnosticWire = {
   taskId?: string;
   id?: string;
   createdAt?: number;
+  correlation_id?: string;
 };
 
 /** Parse GET /api/diagnostics diagnostic payload into the renderer contract. */
@@ -252,6 +259,7 @@ export function fromBackendDiagnostic(
     jobId: wire.jobId,
     taskId: wire.taskId,
     createdAt: wire.createdAt,
+    correlationId: wire.correlation_id,
   });
 }
 


### PR DESCRIPTION
## Summary
- Persist `correlationId` / `correlation_id` on the diagnostic record (request-scoped cid already existed).
- Copyable `Trace: <id>` on the error header and AuthFailureBanner.
- `sse_write` now has a write timeout; timeout detaches like BrokenPipe and does not cancel the turn.
- Pin stays `puppetmaster-ai==1.22.23`. No Pi worker. No doctor UI / scheduler / invented recovery.

## Test plan
- [ ] CI green
- [ ] Failed turn shows copyable Trace
- [ ] Hung SSE client detaches without killing the turn