### PR TITLE
v0.9.287: sidecar driver miss is not a failed turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.24` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.286, deliberately pre-1.0. Rides puppetmaster-ai==1.22.24. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.287, deliberately pre-1.0. Rides puppetmaster-ai==1.22.24. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.286"
+__version__ = "0.9.287"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.286"
+version = "0.9.287"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.286"
+version = "0.9.287"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.286",
+  "version": "0.9.287",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.286",
+      "version": "0.9.287",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.286",
+  "version": "0.9.287",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/composerWaitHint.test.ts
+++ b/webapp/src/__tests__/composerWaitHint.test.ts
@@ -4,6 +4,8 @@ import {
   waitHintForBusyProgress,
 } from "../lib/composerWaitHint";
 import { deriveBusyProgress } from "../lib/turnProgress";
+import { getActiveDiagnostic, publishDiagnostic, resetDiagnosticBus } from "../lib/operationalDiagnosticBus";
+import { createOperationalDiagnostic } from "../lib/operationalDiagnostic";
 
 type StreamStatus = "error" | "idle" | "done" | "thinking" | "awaiting_swarm" | "executing" | "streaming";
 import { createApplyStreamEvent } from "../components/conversation/streamEventHandler";
@@ -135,5 +137,34 @@ describe("createApplyStreamEvent provider failure wait hints", () => {
     apply({ kind: "error", data: { error: "provider rejected" } });
     expect(state.waitHint).toBe(failureNotice);
     expect(state.status).toBe("error");
+  });
+});
+
+describe("recovered vision sidecar driver miss is not a failed turn", () => {
+  const sidecar = "driver openrouter:deepseek/deepseek-v4-flash-vision-exp failed";
+
+  it("does not latch wait-hint or Error/Trace after a successful turn", () => {
+    resetDiagnosticBus();
+    publishDiagnostic(createOperationalDiagnostic({
+      scope: "conversation",
+      operation: "send",
+      code: "sidecar_noise",
+      summary: sidecar,
+      severity: "error",
+      retryable: true,
+      recovery: { kind: "retry", label: "Retry" },
+    }));
+    const { state, apply } = makeWaitHintApplyDeps();
+    apply({ kind: "notice", data: { kind: "wait", message: sidecar } });
+    apply({ kind: "message_delta", data: { text: "The turn worked.", stream_id: "a1", channel: "answer" } });
+    expect(state.waitHint).toBeNull();
+    apply({ kind: "notice", data: { kind: "wait", message: sidecar } });
+    expect(state.waitHint).toBeNull();
+    apply({ kind: "error", data: { error: sidecar } });
+    expect(state.status).not.toBe("error");
+    apply({ kind: "assistant_done", data: { stop_cause: "natural" } });
+    expect(state.waitHint).toBeNull();
+    expect(state.status).toBe("done");
+    expect(getActiveDiagnostic()).toBeNull();
   });
 });

--- a/webapp/src/__tests__/composerWaitHint.test.ts
+++ b/webapp/src/__tests__/composerWaitHint.test.ts
@@ -1,16 +1,19 @@
 import {
   formatDriverFailureWaitHint,
   isProviderFailureWaitHint,
+  noticeShouldLatchWaitHint,
   waitHintForBusyProgress,
 } from "../lib/composerWaitHint";
 import { deriveBusyProgress } from "../lib/turnProgress";
-import { getActiveDiagnostic, publishDiagnostic, resetDiagnosticBus } from "../lib/operationalDiagnosticBus";
-import { createOperationalDiagnostic } from "../lib/operationalDiagnostic";
-
-type StreamStatus = "error" | "idle" | "done" | "thinking" | "awaiting_swarm" | "executing" | "streaming";
+import { CONVERSATION_TURN_FAILURE } from "../lib/operationalDiagnostic";
+import { getActiveDiagnostic, resetDiagnosticBus } from "../lib/operationalDiagnosticBus";
+import { syncConversationTurnFailureDiagnostic } from "../lib/operationalRecovery";
+import { setCorrelationId } from "../lib/correlationId";
 import { createApplyStreamEvent } from "../components/conversation/streamEventHandler";
 import type { Item } from "../components/TranscriptList";
 import { describe, expect, it } from "vitest";
+
+type StreamStatus = "error" | "idle" | "done" | "thinking" | "awaiting_swarm" | "executing" | "streaming";
 
 describe("composerWaitHint", () => {
   it("recognizes driver failure notices", () => {
@@ -31,6 +34,14 @@ describe("composerWaitHint", () => {
     expect(
       waitHintForBusyProgress(hint, { hasSignal: true, turnFailed: true }),
     ).toBe(hint);
+  });
+
+  it("does not latch provider failure notices after live progress", () => {
+    const sidecar = "driver openrouter:deepseek/deepseek-v4-flash-vision-exp failed";
+    expect(noticeShouldLatchWaitHint(sidecar, { hasLiveProgress: false, turnSettled: false })).toBe(true);
+    expect(noticeShouldLatchWaitHint(sidecar, { hasLiveProgress: true, turnSettled: false })).toBe(false);
+    expect(noticeShouldLatchWaitHint(sidecar, { hasLiveProgress: false, turnSettled: true })).toBe(false);
+    expect(noticeShouldLatchWaitHint("Provider still working", { hasLiveProgress: true, turnSettled: false })).toBe(true);
   });
 });
 
@@ -71,16 +82,24 @@ function makeWaitHintApplyDeps() {
     typeBufRef: { current: "" },
     waitHint: null as string | null,
     status: "thinking" as StreamStatus,
+    turnSettled: false,
   };
   state.itemsRef.current = state.items;
   const pendingJobIdsRef = { current: [] as string[] };
+  const turnSettledRef = { current: false };
   const setItems = (updater: Item[] | ((prev: Item[]) => Item[])) => {
     const next = typeof updater === "function" ? updater(state.items) : updater;
     state.items = next;
     state.itemsRef.current = next;
   };
+  const recordTurnSettle = (settle: Parameters<typeof syncConversationTurnFailureDiagnostic>[0]) => {
+    state.turnSettled = true;
+    turnSettledRef.current = true;
+    syncConversationTurnFailureDiagnostic(settle);
+  };
   return {
     state,
+    turnSettledRef,
     apply: createApplyStreamEvent({
       setCompactingStatus: () => {},
       setItems,
@@ -99,7 +118,7 @@ function makeWaitHintApplyDeps() {
       setSafeTimeout: () => {},
       itemsRef: state.itemsRef,
       planTurnRef: { current: false },
-      turnSettledRef: { current: false },
+      turnSettledRef,
       resumeQueuedRef: { current: false },
       typeBufRef: state.typeBufRef,
       flushTypewriter: () => {},
@@ -111,6 +130,7 @@ function makeWaitHintApplyDeps() {
       handleSwarmResult: () => {},
       refreshQueue: () => {},
       fetchContextUsage: () => {},
+      recordTurnSettle,
     }),
   };
 }
@@ -145,26 +165,53 @@ describe("recovered vision sidecar driver miss is not a failed turn", () => {
 
   it("does not latch wait-hint or Error/Trace after a successful turn", () => {
     resetDiagnosticBus();
-    publishDiagnostic(createOperationalDiagnostic({
-      scope: "conversation",
-      operation: "send",
-      code: "sidecar_noise",
-      summary: sidecar,
-      severity: "error",
-      retryable: true,
-      recovery: { kind: "retry", label: "Retry" },
-    }));
+    setCorrelationId("trace-sidecar-ok");
     const { state, apply } = makeWaitHintApplyDeps();
     apply({ kind: "notice", data: { kind: "wait", message: sidecar } });
+    expect(state.waitHint).toBe(sidecar);
     apply({ kind: "message_delta", data: { text: "The turn worked.", stream_id: "a1", channel: "answer" } });
     expect(state.waitHint).toBeNull();
     apply({ kind: "notice", data: { kind: "wait", message: sidecar } });
     expect(state.waitHint).toBeNull();
-    apply({ kind: "error", data: { error: sidecar } });
-    expect(state.status).not.toBe("error");
     apply({ kind: "assistant_done", data: { stop_cause: "natural" } });
     expect(state.waitHint).toBeNull();
     expect(state.status).toBe("done");
     expect(getActiveDiagnostic()).toBeNull();
+    const busy = deriveBusyProgress(state.items, state.status, null, {
+      modelLabel: "openrouter:deepseek/deepseek-v4-flash-vision-exp",
+      waitHint: state.waitHint,
+    });
+    expect(busy.label).not.toMatch(/failed/i);
+    setCorrelationId("");
+  });
+
+  it("does not publish Trace/Retry when the sidecar arrives as error then the turn succeeds", () => {
+    resetDiagnosticBus();
+    setCorrelationId("trace-sidecar-error-kind");
+    const { state, apply } = makeWaitHintApplyDeps();
+    apply({ kind: "error", data: { error: sidecar } });
+    expect(state.status).not.toBe("error");
+    expect(getActiveDiagnostic()).toBeNull();
+    apply({ kind: "message_delta", data: { text: "The turn worked.", stream_id: "a1", channel: "answer" } });
+    apply({ kind: "assistant_done", data: { stop_cause: "natural" } });
+    expect(state.waitHint).toBeNull();
+    expect(state.status).toBe("done");
+    expect(getActiveDiagnostic()).toBeNull();
+    setCorrelationId("");
+  });
+
+  it("still shows Trace+Retry on a genuinely failed turn", () => {
+    resetDiagnosticBus();
+    setCorrelationId("trace-turn-fail");
+    const { state, apply } = makeWaitHintApplyDeps();
+    apply({ kind: "notice", data: { kind: "wait", message: sidecar } });
+    apply({ kind: "error", data: { error: "all routes exhausted" } });
+    expect(state.waitHint).toBe(sidecar);
+    expect(state.status).toBe("error");
+    const diag = getActiveDiagnostic();
+    expect(diag?.code).toBe(CONVERSATION_TURN_FAILURE);
+    expect(diag?.recovery).toEqual({ kind: "retry", label: "Retry" });
+    expect(diag?.correlationId).toBe("trace-turn-fail");
+    setCorrelationId("");
   });
 });

--- a/webapp/src/__tests__/operationalDiagnostic.test.ts
+++ b/webapp/src/__tests__/operationalDiagnostic.test.ts
@@ -3,14 +3,17 @@ import {
   DESKTOP_BRIDGE_MISSING,
   TRANSPORT_HTTP,
   TRANSPORT_UNCERTAIN,
+  CONVERSATION_TURN_FAILURE,
   belongsToActiveScope,
   classifyFailure,
   conversationLifecycleAfterFailure,
+  conversationTurnFailureDiagnostic,
   createOperationalDiagnostic,
   desktopBridgeMissing,
   desktopBridgeMissingDiagnostic,
   desktopShellExpected,
   fromTransportFailure,
+  isConversationTurnFailureDiagnostic,
   isOperationalDiagnostic,
   isUncertainTransport,
   nextDiagnostic,
@@ -221,6 +224,22 @@ describe("diagnostic bus", () => {
     publishDiagnostic(flap);
     expect(getActiveDiagnostic()?.code).toBe(DESKTOP_BRIDGE_MISSING);
     resetDiagnosticBus();
+  });
+});
+
+describe("conversationTurnFailureDiagnostic", () => {
+  it("is retryable conversation scope with Trace correlation", async () => {
+    const { setCorrelationId } = await import("../lib/correlationId");
+    setCorrelationId("trace-turn-1");
+    const diag = conversationTurnFailureDiagnostic("[error] provider rejected");
+    expect(diag.code).toBe(CONVERSATION_TURN_FAILURE);
+    expect(diag.scope).toBe("conversation");
+    expect(diag.operation).toBe("turn");
+    expect(diag.summary).toBe("provider rejected");
+    expect(diag.recovery).toEqual({ kind: "retry", label: "Retry" });
+    expect(diag.correlationId).toBe("trace-turn-1");
+    expect(isConversationTurnFailureDiagnostic(diag)).toBe(true);
+    setCorrelationId("");
   });
 });
 

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -164,7 +164,11 @@ import {
 import { openAgentWorkspace } from "../lib/agentLinks";
 import { AUTH_FAILURE, sharedReadinessNotice, fromBackendDiagnostic } from "../lib/operationalDiagnostic";
 import { getActiveDiagnostic, publishDiagnostic } from "../lib/operationalDiagnosticBus";
-import { executeDiagnosticRecovery, clearDiagnosticAfterSuccess } from "../lib/operationalRecovery";
+import {
+  executeDiagnosticRecovery,
+  clearDiagnosticAfterSuccess,
+  syncConversationTurnFailureDiagnostic,
+} from "../lib/operationalRecovery";
 import { useOperationalDiagnostic } from "../lib/useOperationalDiagnostic";
 import {
   blankMsgQueueOnSessionSwitch,
@@ -2581,6 +2585,10 @@ export default function Conversation({
     lastSettleRef.current = settle;
     setTurnLifecycle(settle.lifecycle);
     setTerminalCause(settle.cause === "natural" ? null : settle.cause);
+    syncConversationTurnFailureDiagnostic(
+      settle,
+      cachedSessionIdRef.current || activeSessionId || undefined,
+    );
     recoveryDispatchingRef.current = false;
     if (recoveryControlsAvailable(settle.lifecycle)) {
       const sessionId = cachedSessionIdRef.current || activeSessionId || "";

--- a/webapp/src/components/conversation/streamEventHandler.ts
+++ b/webapp/src/components/conversation/streamEventHandler.ts
@@ -59,9 +59,10 @@ import {
 import {
   clearProviderFailureWaitHint,
   isProviderFailureWaitHint,
+  noticeShouldLatchWaitHint,
 } from "../../lib/composerWaitHint";
+import { turnHasLiveInvestigation, turnHasLiveProgressSignal } from "../../lib/turnProgress";
 import { clearDiagnostic } from "../../lib/operationalDiagnosticBus";
-import { turnHasLiveInvestigation } from "../../lib/turnProgress";
 import { notifyWorkspaceMutated } from "../../lib/workspaceMutationEvents";
 import { shouldRefreshBusyChrome } from "./streamTerminal";
 import { waitHintForAssistantDone } from "./swarmPoll";
@@ -175,7 +176,6 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
         setWaitHint((prev) => (isProviderFailureWaitHint(prev) ? prev : null));
       } else {
         setWaitHint(null);
-        // A recovered sidecar miss must not leave Error/Trace/Retry up.
         clearDiagnostic();
       }
     }
@@ -283,16 +283,17 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
       // permanent "Waiting on provider" footer.
       if (!refreshBusyChrome()) return;
       const hint = truncateWaitHint(d.message || "");
-      if (!hint) return;
-      // Vision/sidecar driver misses are not a failed turn. Do not latch (or
-      // re-latch after tokens) a `driver … failed` wait-hint once the turn
-      // already has an answer or has settled.
-      if (isProviderFailureWaitHint(hint)) {
-        const recovered =
-          turnSettledRef.current
-          || Boolean(typeBufRef.current)
-          || hasPartialAssistantAnswer(itemsRef.current);
-        if (recovered) return;
+      if (
+        !hint
+        || !noticeShouldLatchWaitHint(hint, {
+          hasLiveProgress:
+            Boolean(typeBufRef.current)
+            || hasPartialAssistantAnswer(itemsRef.current)
+            || turnHasLiveProgressSignal(itemsRef.current),
+          turnSettled: turnSettledRef.current,
+        })
+      ) {
+        return;
       }
       setWaitHint(hint);
     } else if (ev.kind === "thinking") {

--- a/webapp/src/components/conversation/streamEventHandler.ts
+++ b/webapp/src/components/conversation/streamEventHandler.ts
@@ -60,6 +60,7 @@ import {
   clearProviderFailureWaitHint,
   isProviderFailureWaitHint,
 } from "../../lib/composerWaitHint";
+import { clearDiagnostic } from "../../lib/operationalDiagnosticBus";
 import { turnHasLiveInvestigation } from "../../lib/turnProgress";
 import { notifyWorkspaceMutated } from "../../lib/workspaceMutationEvents";
 import { shouldRefreshBusyChrome } from "./streamTerminal";
@@ -174,6 +175,8 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
         setWaitHint((prev) => (isProviderFailureWaitHint(prev) ? prev : null));
       } else {
         setWaitHint(null);
+        // A recovered sidecar miss must not leave Error/Trace/Retry up.
+        clearDiagnostic();
       }
     }
     recordTurnSettle?.(settle);
@@ -280,7 +283,18 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
       // permanent "Waiting on provider" footer.
       if (!refreshBusyChrome()) return;
       const hint = truncateWaitHint(d.message || "");
-      if (hint) setWaitHint(hint);
+      if (!hint) return;
+      // Vision/sidecar driver misses are not a failed turn. Do not latch (or
+      // re-latch after tokens) a `driver … failed` wait-hint once the turn
+      // already has an answer or has settled.
+      if (isProviderFailureWaitHint(hint)) {
+        const recovered =
+          turnSettledRef.current
+          || Boolean(typeBufRef.current)
+          || hasPartialAssistantAnswer(itemsRef.current);
+        if (recovered) return;
+      }
+      setWaitHint(hint);
     } else if (ev.kind === "thinking") {
       // Live reasoning deltas (delta:true) paint mid-turn so GLM/OR token
       // climbs are visible. Full post-answer reasoning dumps (no delta) stay
@@ -653,6 +667,17 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
       // optimistic first-send rename missed or the server derived a different slug.
       window.dispatchEvent(new Event("harness-config-changed"));
     } else if (ev.kind === "error") {
+      const errText = String(d.error || d.message || "");
+      if (isProviderFailureWaitHint(errText)) {
+        const recovered =
+          turnSettledRef.current
+          || Boolean(typeBufRef.current)
+          || hasPartialAssistantAnswer(itemsRef.current);
+        if (recovered) {
+          clearWaitHintOnProgress();
+          return;
+        }
+      }
       const settle = settleFromStreamError(d.error, d.terminal_cause);
       paintTurnSettle(settle);
       setCompactingStatus(null);

--- a/webapp/src/components/conversation/streamEventHandler.ts
+++ b/webapp/src/components/conversation/streamEventHandler.ts
@@ -673,11 +673,23 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
         const recovered =
           turnSettledRef.current
           || Boolean(typeBufRef.current)
-          || hasPartialAssistantAnswer(itemsRef.current);
+          || hasPartialAssistantAnswer(itemsRef.current)
+          || turnHasLiveProgressSignal(itemsRef.current);
         if (recovered) {
           clearWaitHintOnProgress();
           return;
         }
+        const hint = truncateWaitHint(errText);
+        if (
+          hint
+          && noticeShouldLatchWaitHint(hint, {
+            hasLiveProgress: false,
+            turnSettled: turnSettledRef.current,
+          })
+        ) {
+          setWaitHint(hint);
+        }
+        return;
       }
       const settle = settleFromStreamError(d.error, d.terminal_cause);
       paintTurnSettle(settle);

--- a/webapp/src/lib/composerWaitHint.ts
+++ b/webapp/src/lib/composerWaitHint.ts
@@ -41,3 +41,20 @@ export function formatDriverFailureWaitHint(driver: string): string {
   const label = String(driver || "").trim() || "provider";
   return `driver ${label} failed`;
 }
+
+/**
+ * Whether a wait notice should latch composer/header wait chrome.
+ * Recovered driver-route failures after live progress must not re-open.
+ */
+export function noticeShouldLatchWaitHint(
+  message: string | null | undefined,
+  opts: { hasLiveProgress: boolean; turnSettled: boolean },
+): boolean {
+  const hint = String(message || "").trim();
+  if (!hint) return false;
+  if (isProviderFailureWaitHint(hint)) {
+    if (opts.turnSettled) return false;
+    if (opts.hasLiveProgress) return false;
+  }
+  return true;
+}

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -60,6 +60,7 @@ export const TRANSPORT_BUSY = "transport_busy";
 export const BACKEND_NOT_READY = "backend_not_ready";
 export const BACKEND_WARNING = "backend_warning";
 export const AUTH_FAILURE = "provider_auth_failure";
+export const CONVERSATION_TURN_FAILURE = "conversation_turn_failure";
 
 const SUMMARY_MAX = 160;
 const DETAIL_MAX = 280;
@@ -261,6 +262,39 @@ export function fromBackendDiagnostic(
     createdAt: wire.createdAt,
     correlationId: wire.correlation_id,
   });
+}
+
+/** Settled conversation turn failure — Trace + Retry in ConversationHeader. */
+export function conversationTurnFailureDiagnostic(
+  summary: string,
+  opts?: { sessionId?: string; detail?: string },
+): OperationalDiagnostic {
+  const text = sanitizeDiagnosticText(
+    String(summary || "").replace(/^\[(?:error|aborted)\]\s*/i, "").trim() || "Turn failed",
+    SUMMARY_MAX,
+  );
+  return createOperationalDiagnostic({
+    scope: "conversation",
+    operation: "turn",
+    code: CONVERSATION_TURN_FAILURE,
+    summary: text,
+    detail: opts?.detail,
+    severity: "error",
+    retryable: true,
+    recovery: { kind: "retry", label: "Retry" },
+    sessionId: opts?.sessionId,
+  });
+}
+
+export function isConversationTurnFailureDiagnostic(
+  diag: Pick<OperationalDiagnostic, "code" | "scope" | "operation"> | null | undefined,
+): boolean {
+  return Boolean(
+    diag
+    && diag.scope === "conversation"
+    && diag.operation === "turn"
+    && diag.code === CONVERSATION_TURN_FAILURE,
+  );
 }
 
 /** Loud provider auth rejection surfaced in the transcript. */

--- a/webapp/src/lib/operationalRecovery.ts
+++ b/webapp/src/lib/operationalRecovery.ts
@@ -1,6 +1,8 @@
+import { isProviderFailureWaitHint } from "./composerWaitHint";
 import {
   conversationTurnFailureDiagnostic,
   isConversationTurnFailureDiagnostic,
+  isUncertainTransport,
   type OperationalDiagnostic,
 } from "./operationalDiagnostic";
 import {
@@ -46,15 +48,27 @@ export function syncConversationTurnFailureDiagnostic(
   settle: TurnSettle,
   sessionId?: string,
 ): void {
-  if (settle.lifecycle === TURN_ERROR || settle.lifecycle === TURN_ABORTED) {
-    const summary = String(settle.explanation || "Turn failed").trim();
-    publishDiagnostic(conversationTurnFailureDiagnostic(summary, { sessionId }));
+  const explanation = String(settle.explanation || "").trim();
+  // Sidecar driver miss is a wait notice, not Trace/Retry.
+  if (isProviderFailureWaitHint(explanation)) {
     return;
   }
-  if (settle.lifecycle === TURN_SETTLED_COMPLETE) {
+  const failed =
+    settle.status === "error"
+    || settle.lifecycle === TURN_ERROR
+    || settle.lifecycle === TURN_ABORTED;
+  if (failed) {
+    publishDiagnostic(conversationTurnFailureDiagnostic(explanation || "Turn failed", { sessionId }));
+    return;
+  }
+  if (settle.lifecycle === TURN_SETTLED_COMPLETE || settle.status === "done") {
     const active = getActiveDiagnostic();
     if (isConversationTurnFailureDiagnostic(active)) {
       clearDiagnostic(active!);
+      return;
+    }
+    if (active && isUncertainTransport(active)) {
+      clearDiagnostic(active);
     }
   }
 }

--- a/webapp/src/lib/operationalRecovery.ts
+++ b/webapp/src/lib/operationalRecovery.ts
@@ -1,5 +1,19 @@
-import type { OperationalDiagnostic } from "./operationalDiagnostic";
-import { clearDiagnostic } from "./operationalDiagnosticBus";
+import {
+  conversationTurnFailureDiagnostic,
+  isConversationTurnFailureDiagnostic,
+  type OperationalDiagnostic,
+} from "./operationalDiagnostic";
+import {
+  clearDiagnostic,
+  getActiveDiagnostic,
+  publishDiagnostic,
+} from "./operationalDiagnosticBus";
+import {
+  TURN_ABORTED,
+  TURN_ERROR,
+  TURN_SETTLED_COMPLETE,
+  type TurnSettle,
+} from "./turnTerminal";
 import { getHarnessIpc } from "./transport";
 
 export async function executeDiagnosticRecovery(
@@ -25,4 +39,22 @@ export function clearDiagnosticAfterSuccess(
 ): void {
   if (!diag) return;
   clearDiagnostic(diag);
+}
+
+/** Publish or clear the settled turn-failure diagnostic — never from wait notices. */
+export function syncConversationTurnFailureDiagnostic(
+  settle: TurnSettle,
+  sessionId?: string,
+): void {
+  if (settle.lifecycle === TURN_ERROR || settle.lifecycle === TURN_ABORTED) {
+    const summary = String(settle.explanation || "Turn failed").trim();
+    publishDiagnostic(conversationTurnFailureDiagnostic(summary, { sessionId }));
+    return;
+  }
+  if (settle.lifecycle === TURN_SETTLED_COMPLETE) {
+    const active = getActiveDiagnostic();
+    if (isConversationTurnFailureDiagnostic(active)) {
+      clearDiagnostic(active!);
+    }
+  }
 }

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -497,6 +497,23 @@ function turnHasThinking(items: TurnItem[]): boolean {
   return false;
 }
 
+/** True once the turn shows reasoning, tools, or assistant text (not bare TTFT). */
+export function turnHasLiveProgressSignal(items: TurnItem[]): boolean {
+  let toolPrep = "";
+  for (const it of [...itemsInCurrentTurn(items)].reverse()) {
+    if (it.kind === "tool_prep") {
+      toolPrep = String((it as { name?: string }).name || "").trim();
+      break;
+    }
+  }
+  return (
+    cardsInTurn(items).length > 0
+    || Boolean(toolPrep)
+    || turnHasThinking(items)
+    || turnHasAssistantText(items)
+  );
+}
+
 /** True when the current turn already ran tools / tool_prep (agent loop). */
 export function turnHasInvestigationActivity(items: TurnItem[]): boolean {
   for (const it of itemsInCurrentTurn(items)) {


### PR DESCRIPTION
## Summary
- A recovered vision-sidecar notice (`driver openrouter:deepseek/deepseek-v4-flash-vision-exp failed`) is wait chrome, not a failed turn.
- After a successful turn, neither the composer wait-hint nor header Error/Trace/Retry remains.
- Real failed turns still publish `CONVERSATION_TURN_FAILURE` with Trace + Retry.
- Pin stays `puppetmaster-ai==1.22.24`. No cell UI. No startup-rebind work.

## Test plan
- [ ] `cd webapp && npx vitest run src/__tests__/composerWaitHint.test.ts src/__tests__/operationalDiagnostic.test.ts`
- [ ] Live: send a turn that emits the vision-sidecar notice then succeeds — wait-hint clears, no salmon Error/Trace/Retry
- [ ] Live: a genuinely failed turn still shows Trace + Retry