### PR TITLE
Fix diagnostics to check the live pilot provider

### DIFF
--- a/harness/api/doctor.py
+++ b/harness/api/doctor.py
@@ -17,8 +17,8 @@ class DoctorServices:
     """Explicit deps for diagnostics HTTP handlers."""
 
     get_driver: Callable[[], str]
-    get_reach: Callable[[], str]
     get_repo: Callable[[], str]
+    build_driver: Callable[[str], Any]
 
 
 def _check_row(status: str, name: str, detail: str = "") -> dict[str, str]:
@@ -51,15 +51,8 @@ def _build_checks(svc: DoctorServices) -> list[dict[str, str]]:
         checks.append(_check_row("fail", "durable state", f"store error: {exc}"))
 
     driver = (svc.get_driver() or "").strip() or "unknown"
-    reach = (svc.get_reach() or "").strip()
     try:
-        from pmharness import registry as reg
-
-        built = (
-            reg.build(driver)
-            if driver.startswith("stub")
-            else reg.build(driver, reach=reach)
-        )
+        built = svc.build_driver(driver)
         env = getattr(built, "api_key_env", None)
         if env is None:
             checks.append(_check_row("ok", f"driver {driver}", "no key required (stub/offline)"))

--- a/harness/server.py
+++ b/harness/server.py
@@ -1714,10 +1714,19 @@ def _doctor_services():
     """Build DoctorServices from live server module globals (call-time lookup)."""
     from .api.doctor import DoctorServices
 
+    def _build_driver(spec: str):
+        if spec.startswith("stub"):
+            from pmharness.registry import build
+
+            return build(spec)
+        from .providers import build_pilot
+
+        return build_pilot(spec)
+
     return DoctorServices(
         get_driver=lambda: getattr(_cfg, "driver", "") or "",
-        get_reach=lambda: getattr(_cfg, "reach", "") or "",
         get_repo=lambda: getattr(_cfg, "repo", "") or "",
+        build_driver=_build_driver,
     )
 
 

--- a/tests/test_api_diagnostics.py
+++ b/tests/test_api_diagnostics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from harness.api.doctor import DoctorServices, get_diagnostics
 
 
@@ -9,8 +11,8 @@ def test_get_diagnostics_returns_quotable_payload(monkeypatch):
     monkeypatch.setenv("HARNESS_DRIVER", "stub-oracle")
     svc = DoctorServices(
         get_driver=lambda: "stub-oracle",
-        get_reach=lambda: "local",
         get_repo=lambda: "",
+        build_driver=lambda _spec: SimpleNamespace(api_key_env=None),
     )
     with __import__("harness.correlation", fromlist=["correlation_scope"]).correlation_scope("diag-test"):
         status, payload = get_diagnostics(svc)
@@ -26,8 +28,8 @@ def test_get_diagnostics_returns_quotable_payload(monkeypatch):
 def test_get_diagnostics_surfaces_hard_failures(monkeypatch):
     svc = DoctorServices(
         get_driver=lambda: "definitely-not-a-real-driver-spec",
-        get_reach=lambda: "cloud",
         get_repo=lambda: "",
+        build_driver=lambda spec: (_ for _ in ()).throw(KeyError(spec)),
     )
     with __import__("harness.correlation", fromlist=["correlation_scope"]).correlation_scope("diag-fail"):
         status, payload = get_diagnostics(svc)
@@ -36,3 +38,30 @@ def test_get_diagnostics_surfaces_hard_failures(monkeypatch):
     assert payload["diagnostic"]["scope"] == "backend"
     assert payload["diagnostic"]["recovery"] == {"kind": "retry", "label": "Retry"}
     assert payload["diagnostic"]["correlation_id"] == "diag-fail"
+
+
+def test_diagnostics_uses_live_pilot_builder_for_arbitrary_model(monkeypatch):
+    calls = []
+    spec = "future-provider:future-model-x"
+
+    def build_driver(requested):
+        calls.append(requested)
+        return SimpleNamespace(api_key_env=None)
+
+    monkeypatch.setattr(
+        "pmharness.registry.build",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("research registry must not validate the live pilot")
+        ),
+    )
+    svc = DoctorServices(
+        get_driver=lambda: spec,
+        get_repo=lambda: "",
+        build_driver=build_driver,
+    )
+
+    status, payload = get_diagnostics(svc)
+
+    assert status == 200
+    assert payload["diagnostic"] is None
+    assert calls == [spec]


### PR DESCRIPTION
## Problem

Marionette could successfully answer with the configured pilot while its readiness check said that same model was unknown.

The check was looking in the research model catalog instead of asking the live pilot provider that actually built the conversation model.

## Fix

- Validate normal pilots through the live provider path.
- Keep stub/offline drivers on the existing research path.
- Test the ownership boundary with an arbitrary future model name, so the test cannot become stale when today’s models change.

Closes #129

## Proof

- `pytest -q tests/test_api_diagnostics.py tests/test_providers.py tests/test_api_settings_peel.py` — 36 passed
- `vitest run src/__tests__/composerWaitHint.test.ts src/__tests__/operationalDiagnostic.test.ts` — 30 passed against v0.9.287
- Frontend production build passed
- Mounted `/api/diagnostics` reports the working Luna pilot ready and returns no diagnostic
