### PR TITLE
Simplify swarm result counts

### DIFF
--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -836,6 +836,29 @@ describe("SwarmPane routing dedupe", () => {
     fireEvent.click(screen.getByRole("button", { name: /Worker/ }));
     expect(screen.getByText("escalation")).toBeInTheDocument();
   });
+
+  it("shows only the grouped Findings row count", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job-findings-count", "Grouped findings", {
+        artifacts_complete: true,
+        artifacts: [
+          { id: "finding-1", type: "finding", headline: "One real finding" },
+          ...Array.from({ length: 4 }, (_, i) => ({
+            id: `verification-${i}`,
+            type: "verification",
+            headline: "Repeated verification",
+          })),
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    fireEvent.click(await screen.findByText("Finished"));
+    fireEvent.click(await screen.findByText("Grouped findings"));
+
+    expect(screen.getByText("Findings (2)")).toBeInTheDocument();
+    expect(screen.queryByText(/Findings \(2 of 5\)/)).toBeNull();
+  });
 });
 
 describe("SwarmPane mid-run job-row meters", () => {

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -521,6 +521,27 @@ describe("transcript presentation contract", () => {
     expect(screen.getByTestId("pending-review-receipt")).toHaveTextContent(/review ready/i);
   });
 
+  it("does not repeat findings and artifact counts in the chat result body", () => {
+    const summary = "8 findings via agentic (18 artifacts)";
+    render(
+      <TranscriptList
+        {...listProps([{
+          kind: "swarm_result",
+          job_id: "job_countcopy01",
+          applied: true,
+          files: [],
+          summary,
+          error: null,
+          objective: "review count semantics",
+        }])}
+      />,
+    );
+
+    const card = screen.getByTestId("swarm-result-card");
+    fireEvent.click(within(card).getByRole("button", { name: /swarm done/i }));
+    expect(screen.queryByText(summary)).toBeNull();
+  });
+
   it("pending_review receipt click focuses Review tab and refreshes", () => {
     const focusSpy = vi.fn();
     const refreshSpy = vi.fn();

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -1945,7 +1945,7 @@ export default function SwarmPane() {
             {streamArts.length > 0 && (() => {
               const findingRows = dedupeFindings(streamArts);
               const sectionOpen = findingsOpen[j.id] !== false;
-              const countLabel = `${findingRows.length}${findingRows.length !== streamArts.length ? ` of ${streamArts.length}` : ""}`;
+              const countLabel = `${findingRows.length}`;
               return (
               <div className="border-t border-edge/20 pt-1.5 flex flex-col">
                 <button

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -3558,6 +3558,13 @@ function visibleReuseReason(reason?: string): string {
   return value === "first_pass" || value === "no_reusable_candidate" ? "" : value;
 }
 
+function visibleSwarmSummary(summary: string): string {
+  const value = (summary || "").trim();
+  return /^\d+\s+findings\s+via\s+.+\(\d+\s+artifacts?\)$/i.test(value)
+    ? ""
+    : value;
+}
+
 /** Bounded relative-path summary for partial reuse honesty (no secrets). */
 function formatInvalidatedPaths(paths?: string[], limit = 6): string {
   const clean = (paths || [])
@@ -3623,6 +3630,7 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, cwd
   const reuseReasonLabel = visibleReuseReason(reuseReason);
   const pathSummary = formatInvalidatedPaths(invalidatedPaths);
   const primaryJobId = (jobId || "").trim();
+  const displaySummary = visibleSwarmSummary(summary);
   // Operator honesty: held_for_review / analysis_ok are successful non-applies —
   // never paint them as "swarm done" (applied) or "swarm failed".
   const tone: "applied" | "held" | "analysis" | "failed" = applied
@@ -3661,7 +3669,7 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, cwd
   // Full-swarm rejection reasons (e.g. environment_changed) must surface even
   // when the status is merely "fresh" — never drop the gate reason in the UI.
   const hasBody = !!(
-    summary
+    displaySummary
     || (tone === "failed" && error)
     || (applied && files.length > 0)
     || tone === "held"
@@ -3715,11 +3723,13 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, cwd
         {tone === "applied"
           ? (files.length > 0
             ? <span className="text-faint shrink-0 tabular-nums">{files.length} file{files.length === 1 ? "" : "s"}</span>
-            : <span className="text-faint shrink-0 truncate max-w-[45%]">{summary}</span>)
+            : displaySummary
+              ? <span className="text-faint shrink-0 truncate max-w-[45%]">{displaySummary}</span>
+              : null)
           : tone === "held"
             ? <span className="text-accent/70 shrink-0 truncate max-w-[45%]">awaiting review</span>
             : tone === "analysis"
-              ? <span className="text-faint shrink-0 truncate max-w-[45%]">{summary || "findings"}</span>
+              ? <span className="text-faint shrink-0 truncate max-w-[45%]">{displaySummary || "findings"}</span>
               : <span className="text-risk/70 shrink-0 truncate max-w-[45%]">{error || "error"}</span>}
         {hasBody && (open
           ? <ChevronDown size={12} className="text-faint shrink-0" />
@@ -3864,8 +3874,8 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, cwd
           {!applied && error && (
             <div className="text-[10px] text-risk/90 font-mono whitespace-pre-wrap leading-relaxed break-words">{error}</div>
           )}
-          {summary && (
-            <div className="text-[10.5px] text-muted whitespace-pre-wrap leading-relaxed break-words">{summary}</div>
+          {displaySummary && (
+            <div className="text-[10.5px] text-muted whitespace-pre-wrap leading-relaxed break-words">{displaySummary}</div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Problem

Swarm results described the same run with competing counts:
<img width="506" height="277" alt="Screenshot 2026-08-23 at 4 42 33 PM" src="https://github.com/user-attachments/assets/60f0dd4e-2844-41ff-9118-71fc05ab8956" />
<img width="280" height="23" alt="Screenshot 2026-08-23 at 4 42 39 PM" src="https://github.com/user-attachments/assets/60a0e23a-4d39-404f-ba81-69d073c9147f" />


The numbers came from different filters and grouping rules. They were technically explainable but not useful to the user.

## Fix

- Remove the redundant `X findings via Y (Z artifacts)` sentence from chat result cards.
- Show only the grouped row count in Tracker: `Findings (A)`.
- Keep duplicate `xN` badges and the canonical artifact receipt unchanged.

No new terminology, state, API fields, or backend behavior.

<img width="499" height="254" alt="Screenshot 2026-08-23 at 4 58 29 PM" src="https://github.com/user-attachments/assets/defd7253-8bf8-4431-8217-f04a0d1fa770" />
<img width="132" height="32" alt="Screenshot 2026-08-23 at 4 58 35 PM" src="https://github.com/user-attachments/assets/c9ebe342-c58f-4c5e-bed1-a3a753839a80" />


## Proof

- `vitest run src/__tests__/transcriptPresentation.test.tsx src/__tests__/SwarmPane.test.tsx` — 121 passed
- Frontend production build passed
