### PR TITLE
v0.9.290: composer-family chrome for the three stacked bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.26` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.289, deliberately pre-1.0. Rides puppetmaster-ai==1.22.26. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.290, deliberately pre-1.0. Rides puppetmaster-ai==1.22.26. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.289"
+__version__ = "0.9.290"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.289"
+version = "0.9.290"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.289"
+version = "0.9.290"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.289",
+  "version": "0.9.290",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.289",
+      "version": "0.9.290",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.289",
+  "version": "0.9.290",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/composerFamilyChrome.test.tsx
+++ b/webapp/src/__tests__/composerFamilyChrome.test.tsx
@@ -1,0 +1,164 @@
+import { createRef } from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ComposerDock from "../components/conversation/ComposerDock";
+import ComposerStatusStack from "../components/conversation/ComposerStatusStack";
+import ComposerTasksPanel from "../components/conversation/ComposerTasksPanel";
+import { COMPOSER_FAMILY_CLASS } from "../components/conversation/composerFamily";
+import type { Job } from "../lib/api";
+
+vi.mock("../lib/api", () => ({
+  api: {},
+}));
+vi.mock("../components/PilotPicker", () => ({
+  default: () => <div data-testid="pilot-picker" />,
+}));
+vi.mock("../components/conversation/WorkspaceChip", () => ({
+  default: () => <div data-testid="workspace-chip" />,
+}));
+vi.mock("../lib/agentCommandIndex", () => ({
+  subscribeAgentCommandIndex: (cb: () => void) => {
+    void cb;
+    return () => {};
+  },
+  getAgentCommandIndexVersion: () => 1,
+  listAgentCommandSessions: () => [],
+}));
+
+const noop = () => {};
+
+function renderDock() {
+  return render(
+    <ComposerDock
+      config={null}
+      taRef={createRef<HTMLTextAreaElement>()}
+      input=""
+      auto={false}
+      plan={false}
+      composerBusy={false}
+      transcriptStale={false}
+      wikiPrepared={null}
+      memoryProposals={[]}
+      distillNotice={null}
+      msgQueue={[]}
+      dragIndex={null}
+      dragOverIndex={null}
+      queueItems={[]}
+      queueDragIndex={null}
+      queueDragOverIndex={null}
+      editingIndex={null}
+      canRevertEdit={false}
+      editNotice={null}
+      editBusy={false}
+      showContextPanel={false}
+      contextUsage={null}
+      mentionSearch={null}
+      filteredFiles={[]}
+      filteredFolders={[]}
+      symbolResults={[]}
+      mentionListingCap={null}
+      selectedFileIndex={0}
+      codegraphStatus={null}
+      slashSearch={null}
+      selectedSlashIndex={0}
+      allSlashCommands={[]}
+      attachedImages={[]}
+      isDragOver={false}
+      uploadError={null}
+      onSetWikiPrepared={noop}
+      onSetMemoryProposals={noop}
+      onSetDistillNotice={noop}
+      onSetMsgQueue={noop}
+      onSetInput={noop}
+      onSetAuto={noop}
+      onSetPlan={noop}
+      onSetCanRevertEdit={noop}
+      onSetEditNotice={noop}
+      onSetShowContextPanel={noop}
+      onSetSelectedFileIndex={noop}
+      onSetSelectedSlashIndex={noop}
+      onSetAttachedImages={noop}
+      onSetUploadError={noop}
+      onSetLightboxUrl={noop}
+      setSafeTimeout={noop}
+      fetchContextUsage={noop}
+      handleDragStart={noop}
+      handleDragOver={noop}
+      handleDragLeave={noop}
+      handleDrop={noop}
+      handleDragEnd={noop}
+      moveQueueItem={noop}
+      handleQueueClearAll={noop}
+      handleQueueDragStart={noop}
+      handleQueueDragOver={noop}
+      handleQueueDragLeave={noop}
+      handleQueueDrop={noop}
+      handleQueueDragEnd={noop}
+      handleQueueEdit={noop}
+      handleQueueRemove={noop}
+      handleComposerDragOver={noop}
+      handleComposerDragLeave={noop}
+      handleComposerDrop={noop}
+      handleRevertEdit={noop}
+      handleCancelEdit={noop}
+      handleInputChange={noop}
+      handleKeyDown={noop}
+      handlePaste={noop}
+      insertMention={noop}
+      insertFolder={noop}
+      insertSymbol={noop}
+      insertCodebase={noop}
+      showCodebaseMention={false}
+      insertSlashCommand={noop}
+      handleQueueAdd={noop}
+      stop={noop}
+      send={noop}
+    />,
+  );
+}
+
+const taskJob = {
+  id: "job_tasks",
+  goal: "Ship composer-family chrome",
+  status: "running",
+  session_id: "sess-1",
+  source: "harness",
+  tasks: [
+    { id: "t1", role: "impl", instruction: "Restyle trackers", status: "running", adapter: "x" },
+  ],
+} as Job;
+
+const swarmJob = {
+  id: "job_abc123def456",
+  goal: "Audit composer stack",
+  source: "harness",
+  status: "running",
+  updated_at: Date.now(),
+} as Job;
+
+describe("composer-family chrome", () => {
+  it("puts the same class family and tokens on dock, tasks, and PM tracker", () => {
+    const dock = renderDock();
+    const tasks = render(
+      <ComposerTasksPanel jobs={[taskJob]} sessionId="sess-1" />,
+    );
+    const stack = render(
+      <ComposerStatusStack swarmJobs={[swarmJob]} />,
+    );
+
+    const surfaces = [
+      dock.container.querySelector(".composer-dock"),
+      tasks.container.querySelector("[data-slot=composer-tasks-panel]"),
+      stack.container.querySelector("[data-slot=composer-status-stack]"),
+    ];
+
+    for (const el of surfaces) {
+      expect(el).toBeTruthy();
+      expect(el).toHaveClass(COMPOSER_FAMILY_CLASS);
+      expect(el).toHaveClass("bg-panel2/80");
+      expect(el).toHaveClass("rounded-2xl");
+      expect(el).toHaveClass("border-edge");
+      expect(el?.className).not.toMatch(/text-muted-foreground|rose-500|uppercase tracking-\[0\.16em\]/);
+    }
+  });
+});

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -569,7 +569,7 @@ export default function ComposerDock({
           onDragOver={handleComposerDragOver}
           onDragLeave={handleComposerDragLeave}
           onDrop={handleComposerDrop}
-          className={`composer-dock relative bg-panel2/80 border rounded-2xl focus-within:border-edge2 shadow-lg shadow-black/20 transition ${
+          className={`composer-dock composer-family relative bg-panel2/80 border rounded-2xl focus-within:border-edge2 shadow-lg shadow-black/20 transition ${
             isDragOver ? "border-accent ring-1 ring-accent" : "border-edge"
           }`}
         >

--- a/webapp/src/components/conversation/ComposerStatusStack.tsx
+++ b/webapp/src/components/conversation/ComposerStatusStack.tsx
@@ -7,20 +7,21 @@ import {
   subscribeAgentCommandIndex,
 } from "../../lib/agentCommandIndex";
 import { buildComposerStatusStackRows, type ComposerStatusStackRow } from "./composerStatusStackData";
+import { COMPOSER_FAMILY_LABEL, COMPOSER_FAMILY_SURFACE } from "./composerFamily";
 import type { Job } from "../../lib/api";
 
 function statusIcon(row: ComposerStatusStackRow) {
   if (row.state === "running") {
-    return <Loader2 className="size-3 animate-spin text-muted-foreground/80" aria-hidden />;
+    return <Loader2 size={11} className="animate-spin text-faint" aria-hidden />;
   }
   if (row.state === "failed") {
-    return <XCircle className="size-3 text-rose-500/85" aria-hidden />;
+    return <XCircle size={11} className="text-risk" aria-hidden />;
   }
-  return <CheckCircle2 className="size-3 text-emerald-500/85" aria-hidden />;
+  return <CheckCircle2 size={11} className="text-good" aria-hidden />;
 }
 
 function rowKindLabel(kind: ComposerStatusStackRow["kind"]): string {
-  return kind === "swarm" ? "PM" : "TERMINAL";
+  return kind === "swarm" ? "PM" : "Term";
 }
 
 function rowActionLabel(row: ComposerStatusStackRow): string {
@@ -72,17 +73,17 @@ export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly
 
   return (
     <div
-      className="mx-2 mb-1 overflow-hidden rounded-lg border border-edge/70 bg-panel2/70"
+      className={`mx-2 mb-1 overflow-hidden ${COMPOSER_FAMILY_SURFACE}`}
       data-slot="composer-status-stack"
     >
       <div className="divide-y divide-edge/50">
         {grouped.map((group) => (
           <div key={group.kind} className="px-2 py-1">
             <div className="mb-0.5 flex items-center justify-between">
-              <span className="text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/65">
+              <span className={`${COMPOSER_FAMILY_LABEL} font-medium`}>
                 {groupLabel(group.kind)}
               </span>
-              <span className="text-[9px] font-mono text-muted-foreground/55">
+              <span className="text-[10.5px] font-mono text-muted">
                 {group.rows.length}
               </span>
             </div>
@@ -105,17 +106,17 @@ export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly
                     type="button"
                     onClick={onClick}
                     title={row.title}
-                    className="flex w-full items-center gap-1.5 rounded-md border border-edge/50 bg-panel/60 px-1.5 py-1 text-left text-[11px] leading-4 text-txt/85 transition hover:border-edge2 hover:bg-panel2/70 focus-visible:border-accent/60 focus-visible:outline-none"
+                    className="flex w-full items-center gap-1.5 rounded-md border border-edge/50 bg-panel/60 px-1.5 py-1 text-left text-[10.5px] leading-4 text-txt transition hover:border-edge2 hover:bg-panel2/70 focus-visible:border-accent/60 focus-visible:outline-none"
                   >
-                    <span className="flex size-4 shrink-0 items-center justify-center rounded-full border border-edge/50 bg-panel text-[7px] font-semibold tracking-[0.12em] text-muted-foreground/70">
+                    <span className="flex h-[20px] shrink-0 items-center rounded-md border border-edge/30 bg-panel2/40 px-1 text-[10.5px] font-medium text-faint">
                       {rowKindLabel(row.kind)}
                     </span>
                     <span className="min-w-0 flex-1 truncate">{row.label}</span>
-                    <span className="flex shrink-0 items-center gap-1 text-[9px] uppercase tracking-[0.12em] text-muted-foreground/65">
+                    <span className="flex shrink-0 items-center gap-1 text-[10.5px] text-muted">
                       {statusIcon(row)}
                       <span>{rowActionLabel(row)}</span>
                     </span>
-                    <ChevronRight className="size-3 shrink-0 text-muted-foreground/45" aria-hidden />
+                    <ChevronRight size={11} className="shrink-0 text-faint" aria-hidden />
                   </button>
                 );
               })}

--- a/webapp/src/components/conversation/ComposerTasksPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTasksPanel.tsx
@@ -2,12 +2,13 @@ import { useState } from "react";
 import { CheckCircle2, ChevronDown, ChevronRight, Circle, Loader2, ListChecks, XCircle } from "lucide-react";
 import type { Job } from "../../lib/api";
 import { buildComposerTasks, pickTaskSourceJob, taskProgress, type ComposerTask } from "../../lib/composerTasks";
+import { COMPOSER_FAMILY_SURFACE } from "./composerFamily";
 
 function TaskIcon({ state }: { state: ComposerTask["state"] }) {
-  if (state === "completed") return <CheckCircle2 size={12} className="shrink-0 text-good" />;
-  if (state === "failed") return <XCircle size={12} className="shrink-0 text-risk" />;
-  if (state === "in_progress") return <Loader2 size={12} className="shrink-0 animate-spin text-accent" />;
-  return <Circle size={12} className="shrink-0 text-faint" />;
+  if (state === "completed") return <CheckCircle2 size={11} className="shrink-0 text-good" />;
+  if (state === "failed") return <XCircle size={11} className="shrink-0 text-risk" />;
+  if (state === "in_progress") return <Loader2 size={11} className="shrink-0 animate-spin text-accent" />;
+  return <Circle size={11} className="shrink-0 text-faint" />;
 }
 
 export default function ComposerTasksPanel({
@@ -25,12 +26,15 @@ export default function ComposerTasksPanel({
   if (!total) return null;
 
   return (
-    <div className="mx-2 mb-1 overflow-hidden rounded-lg border border-edge/70 bg-panel2/70">
+    <div
+      className={`mx-2 mb-1 overflow-hidden ${COMPOSER_FAMILY_SURFACE}`}
+      data-slot="composer-tasks-panel"
+    >
       <button
         type="button"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[11px] leading-4 text-txt/85 hover:bg-panel/35"
+        className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[10.5px] leading-4 text-txt hover:bg-panel/35"
       >
         {open ? <ChevronDown size={11} className="text-faint" /> : <ChevronRight size={11} className="text-faint" />}
         <ListChecks size={11} className="text-faint" />
@@ -46,10 +50,10 @@ export default function ComposerTasksPanel({
                 type="button"
                 title={task.content}
                 onClick={() => setExpandedId((id) => (id === task.id ? null : task.id))}
-                className="flex w-full items-start gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[11px] leading-4 hover:bg-panel/30"
+                className="flex w-full items-start gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[10.5px] leading-4 hover:bg-panel/30"
               >
                 <TaskIcon state={task.state} />
-                <span className={`${task.state === "pending" ? "text-faint" : "text-txt/85"} ${expanded ? "whitespace-pre-wrap break-words" : "min-w-0 truncate"}`}>
+                <span className={`${task.state === "pending" ? "text-faint" : "text-txt"} ${expanded ? "whitespace-pre-wrap break-words" : "min-w-0 truncate"}`}>
                   {task.content}
                 </span>
               </button>

--- a/webapp/src/components/conversation/composerFamily.ts
+++ b/webapp/src/components/conversation/composerFamily.ts
@@ -1,0 +1,9 @@
+/** Shared chrome tokens so the three stacked composer bars read as one family. */
+export const COMPOSER_FAMILY_CLASS = "composer-family";
+
+/** Surface tokens copied from the composer dock (source of truth). */
+export const COMPOSER_FAMILY_SURFACE =
+  "composer-family composer-family-surface bg-panel2/80 border border-edge rounded-2xl";
+
+export const COMPOSER_FAMILY_LABEL = "composer-family-label text-[10.5px] text-faint";
+export const COMPOSER_FAMILY_HAIRLINE = "composer-family-hairline border-edge/50";

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -172,6 +172,23 @@ body {
   min-width: 0;
 }
 
+.composer-family {
+  /* Marker + shared chrome language for dock + stacked trackers. */
+}
+
+.composer-family-surface {
+  background-color: color-mix(in srgb, var(--panel2, #16181b) 80%, transparent);
+  border-color: var(--edge, #2a2d31);
+}
+
+.composer-family-label {
+  color: var(--faint, #8b919a);
+}
+
+.composer-family-hairline {
+  border-color: color-mix(in srgb, var(--edge, #2a2d31) 50%, transparent);
+}
+
 .composer-toolbar {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
Chrome-only restyle so the three stacked composer pieces (Tasks tracker, PM job tracker, composer dock) read as one family.

### Before
- Tasks and PM trackers used shouty uppercase + huge letter-spacing (`uppercase tracking-[0.16em] text-[9px]`).
- Status stack used shadcn `text-muted-foreground`, `rose-500`, and `emerald-500` on a `rounded-lg` / `bg-panel2/70` surface.
- Mixed icon language (`size-3` + 7px pills) against the dock's lucide size 11 / `rounded-md` chips.

### After
- Shared `composer-family` class family (`composerFamily.ts` + index.css tokens).
- Trackers use the dock tokens: `bg-panel2/80`, `border-edge`, `rounded-2xl`, `text-txt` / `text-faint` / `text-muted` / `text-risk` / `text-good`.
- Group labels are title-case (`Puppetmaster`, `Terminal`). Same click targets and stacking; no layout rewrite, no new features, no whole-app theme.
- Pin stays `puppetmaster-ai==1.22.26`. Version 0.9.290.

## Test plan
- [ ] `cd webapp && npx vitest run src/__tests__/composerFamilyChrome.test.tsx` — dock, Tasks panel, and `[data-slot=composer-status-stack]` all have `composer-family` plus the shared surface tokens.
- [ ] Visual: the three stacked bars look like one chrome family (no shouty PM/TERMINAL tracking, no rose/emerald on the stack).
- [ ] Do not merge or tag unless CI is fully green.