### PR TITLE
v0.9.292: drop competing swarm findings counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.26` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.290, deliberately pre-1.0. Rides puppetmaster-ai==1.22.26. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.292, deliberately pre-1.0. Rides puppetmaster-ai==1.22.26. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.290"
+__version__ = "0.9.292"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.290"
+version = "0.9.292"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.290"
+version = "0.9.292"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.290",
+  "version": "0.9.292",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.290",
+      "version": "0.9.292",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.290",
+  "version": "0.9.292",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -836,6 +836,29 @@ describe("SwarmPane routing dedupe", () => {
     fireEvent.click(screen.getByRole("button", { name: /Worker/ }));
     expect(screen.getByText("escalation")).toBeInTheDocument();
   });
+
+  it("shows only the grouped Findings row count", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job-findings-count", "Grouped findings", {
+        artifacts_complete: true,
+        artifacts: [
+          { id: "finding-1", type: "finding", headline: "One real finding" },
+          ...Array.from({ length: 4 }, (_, i) => ({
+            id: `verification-${i}`,
+            type: "verification",
+            headline: "Repeated verification",
+          })),
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    fireEvent.click(await screen.findByText("Finished"));
+    fireEvent.click(await screen.findByText("Grouped findings"));
+
+    expect(screen.getByText("Findings (2)")).toBeInTheDocument();
+    expect(screen.queryByText(/Findings \(2 of 5\)/)).toBeNull();
+  });
 });
 
 describe("SwarmPane mid-run job-row meters", () => {

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -521,6 +521,27 @@ describe("transcript presentation contract", () => {
     expect(screen.getByTestId("pending-review-receipt")).toHaveTextContent(/review ready/i);
   });
 
+  it("does not repeat findings and artifact counts in the chat result body", () => {
+    const summary = "8 findings via agentic (18 artifacts)";
+    render(
+      <TranscriptList
+        {...listProps([{
+          kind: "swarm_result",
+          job_id: "job_countcopy01",
+          applied: true,
+          files: [],
+          summary,
+          error: null,
+          objective: "review count semantics",
+        }])}
+      />,
+    );
+
+    const card = screen.getByTestId("swarm-result-card");
+    fireEvent.click(within(card).getByRole("button", { name: /swarm done/i }));
+    expect(screen.queryByText(summary)).toBeNull();
+  });
+
   it("pending_review receipt click focuses Review tab and refreshes", () => {
     const focusSpy = vi.fn();
     const refreshSpy = vi.fn();

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -1945,7 +1945,7 @@ export default function SwarmPane() {
             {streamArts.length > 0 && (() => {
               const findingRows = dedupeFindings(streamArts);
               const sectionOpen = findingsOpen[j.id] !== false;
-              const countLabel = `${findingRows.length}${findingRows.length !== streamArts.length ? ` of ${streamArts.length}` : ""}`;
+              const countLabel = `${findingRows.length}`;
               return (
               <div className="border-t border-edge/20 pt-1.5 flex flex-col">
                 <button

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -3558,6 +3558,13 @@ function visibleReuseReason(reason?: string): string {
   return value === "first_pass" || value === "no_reusable_candidate" ? "" : value;
 }
 
+function visibleSwarmSummary(summary: string): string {
+  const value = (summary || "").trim();
+  return /^\d+\s+findings\s+via\s+.+\(\d+\s+artifacts?\)$/i.test(value)
+    ? ""
+    : value;
+}
+
 /** Bounded relative-path summary for partial reuse honesty (no secrets). */
 function formatInvalidatedPaths(paths?: string[], limit = 6): string {
   const clean = (paths || [])
@@ -3623,6 +3630,7 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, cwd
   const reuseReasonLabel = visibleReuseReason(reuseReason);
   const pathSummary = formatInvalidatedPaths(invalidatedPaths);
   const primaryJobId = (jobId || "").trim();
+  const displaySummary = visibleSwarmSummary(summary);
   // Operator honesty: held_for_review / analysis_ok are successful non-applies —
   // never paint them as "swarm done" (applied) or "swarm failed".
   const tone: "applied" | "held" | "analysis" | "failed" = applied
@@ -3661,7 +3669,7 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, cwd
   // Full-swarm rejection reasons (e.g. environment_changed) must surface even
   // when the status is merely "fresh" — never drop the gate reason in the UI.
   const hasBody = !!(
-    summary
+    displaySummary
     || (tone === "failed" && error)
     || (applied && files.length > 0)
     || tone === "held"
@@ -3715,11 +3723,13 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, cwd
         {tone === "applied"
           ? (files.length > 0
             ? <span className="text-faint shrink-0 tabular-nums">{files.length} file{files.length === 1 ? "" : "s"}</span>
-            : <span className="text-faint shrink-0 truncate max-w-[45%]">{summary}</span>)
+            : displaySummary
+              ? <span className="text-faint shrink-0 truncate max-w-[45%]">{displaySummary}</span>
+              : null)
           : tone === "held"
             ? <span className="text-accent/70 shrink-0 truncate max-w-[45%]">awaiting review</span>
             : tone === "analysis"
-              ? <span className="text-faint shrink-0 truncate max-w-[45%]">{summary || "findings"}</span>
+              ? <span className="text-faint shrink-0 truncate max-w-[45%]">{displaySummary || "findings"}</span>
               : <span className="text-risk/70 shrink-0 truncate max-w-[45%]">{error || "error"}</span>}
         {hasBody && (open
           ? <ChevronDown size={12} className="text-faint shrink-0" />
@@ -3864,8 +3874,8 @@ function SwarmResultCard({ jobId, applied, files, summary, error, objective, cwd
           {!applied && error && (
             <div className="text-[10px] text-risk/90 font-mono whitespace-pre-wrap leading-relaxed break-words">{error}</div>
           )}
-          {summary && (
-            <div className="text-[10.5px] text-muted whitespace-pre-wrap leading-relaxed break-words">{summary}</div>
+          {displaySummary && (
+            <div className="text-[10.5px] text-muted whitespace-pre-wrap leading-relaxed break-words">{displaySummary}</div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Absorb [PR #132](https://github.com/professorpalmer/marionette/pull/132): drop `X findings via Y (Z artifacts)` from chat cards; Tracker shows `Findings (A)` only.
- No new API. Pin unchanged (291 is the pin-only cut).

Closes #132.

## Test plan
- [ ] `vitest` SwarmPane + transcriptPresentation counts
- [ ] CI green