### PR TITLE
v0.9.293: swarm job total is measured plus estimated

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.26` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.290, deliberately pre-1.0. Rides puppetmaster-ai==1.22.26. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.293, deliberately pre-1.0. Rides puppetmaster-ai==1.22.26. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.290"
+__version__ = "0.9.293"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.290"
+version = "0.9.293"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.290"
+version = "0.9.293"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.290",
+  "version": "0.9.293",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.290",
+      "version": "0.9.293",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.290",
+  "version": "0.9.293",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import EconomicsPane from "../components/EconomicsPane";
 import { api } from "../lib/api";
@@ -131,11 +131,13 @@ describe("EconomicsPane", () => {
     expect(screen.queryByText("$9.99")).not.toBeInTheDocument();
     expect(screen.queryByText("~$9.99")).not.toBeInTheDocument();
     expect(screen.getByText("$1.25 vs $2.00 · measured")).toBeInTheDocument();
-    expect(screen.getByText("Measured")).toBeInTheDocument();
-    expect(screen.getByText("Estimated")).toBeInTheDocument();
-    const measuredLines = screen.getAllByText("$1.25");
-    expect(measuredLines.length).toBeGreaterThanOrEqual(2);
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+    const ownedRow = screen.getByText("Job owned-1").closest(".mb-2");
+    expect(ownedRow).toBeTruthy();
+    const ownedScope = within(ownedRow as HTMLElement);
+    expect(ownedScope.getByText("Measured")).toBeInTheDocument();
+    expect(ownedScope.getByText("Estimated")).toBeInTheDocument();
+    expect(ownedScope.getAllByText("$1.25").length).toBeGreaterThanOrEqual(1);
+    expect(ownedScope.getAllByText("—").length).toBeGreaterThanOrEqual(1);
   });
 
   it("shows headline sum and measured/estimated lines for mixed job cost", async () => {
@@ -186,7 +188,9 @@ describe("EconomicsPane", () => {
     render(<EconomicsPane />);
 
     expect(await screen.findByText("$2.00 vs — · measured")).toBeInTheDocument();
-    expect(screen.getAllByText("$2.00").length).toBeGreaterThanOrEqual(2);
+    const row = within(screen.getByText("Job meas-1").closest(".mb-2") as HTMLElement);
+    expect(row.getByText("Measured").parentElement).toHaveTextContent("Measured$2.00");
+    expect(row.getByText("Estimated").parentElement).toHaveTextContent("Estimated—");
     expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
   });
 
@@ -210,7 +214,9 @@ describe("EconomicsPane", () => {
     render(<EconomicsPane />);
 
     expect(await screen.findByText("$0.75 vs — · estimated")).toBeInTheDocument();
-    expect(screen.getAllByText("$0.75").length).toBeGreaterThanOrEqual(2);
+    const row = within(screen.getByText("Job est-1").closest(".mb-2") as HTMLElement);
+    expect(row.getByText("Measured").parentElement).toHaveTextContent("Measured—");
+    expect(row.getByText("Estimated").parentElement).toHaveTextContent("Estimated$0.75");
     expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
   });
 

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -107,6 +107,7 @@ describe("EconomicsPane", () => {
           tokens_per_typed_artifact: 400,
           degraded_rate: 0,
           actual_marginal_usd: 1.25,
+          measured_cost_usd: 1.25,
           cost_basis: "measured_usage_x_registry_price",
           counterfactual: { avoided_usd: 2.0 },
         },
@@ -130,6 +131,109 @@ describe("EconomicsPane", () => {
     expect(screen.queryByText("$9.99")).not.toBeInTheDocument();
     expect(screen.queryByText("~$9.99")).not.toBeInTheDocument();
     expect(screen.getByText("$1.25 vs $2.00 · measured")).toBeInTheDocument();
+    expect(screen.getByText("Measured")).toBeInTheDocument();
+    expect(screen.getByText("Estimated")).toBeInTheDocument();
+    const measuredLines = screen.getAllByText("$1.25");
+    expect(measuredLines.length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows headline sum and measured/estimated lines for mixed job cost", async () => {
+    mockGetUsage.mockResolvedValue({ session: usageSession, jobs: [] });
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      recent_jobs: [
+        {
+          job_id: "mixed-1",
+          accounting_owned: true,
+          models: [{ model_id: "composer-2" }],
+          tokens: 1200,
+          measured_cost_usd: 1.25,
+          estimated_cost_usd: 0.25,
+          actual_marginal_usd: 1.25,
+          cost_basis: "mixed",
+          counterfactual: { avoided_usd: 3.0 },
+        },
+      ],
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("$1.50 vs $3.00 · mixed basis")).toBeInTheDocument();
+    expect(screen.getByText("Measured")).toBeInTheDocument();
+    expect(screen.getByText("Estimated")).toBeInTheDocument();
+    expect(screen.getAllByText("$1.25").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("$0.25")).toBeInTheDocument();
+  });
+
+  it("shows measured-only headline without faking a zero estimated line", async () => {
+    mockGetUsage.mockResolvedValue({ session: usageSession, jobs: [] });
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      recent_jobs: [
+        {
+          job_id: "meas-1",
+          accounting_owned: true,
+          models: [{ model_id: "composer-2" }],
+          tokens: 800,
+          measured_cost_usd: 2.0,
+          actual_marginal_usd: 2.0,
+          cost_basis: "measured_usage_x_registry_price",
+        },
+      ],
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("$2.00 vs — · measured")).toBeInTheDocument();
+    expect(screen.getAllByText("$2.00").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
+  });
+
+  it("shows estimated-only headline without faking a zero measured line", async () => {
+    mockGetUsage.mockResolvedValue({ session: usageSession, jobs: [] });
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      recent_jobs: [
+        {
+          job_id: "est-1",
+          accounting_owned: true,
+          models: [{ model_id: "composer-2" }],
+          tokens: 500,
+          estimated_cost_usd: 0.75,
+          actual_marginal_usd: null,
+          cost_basis: "estimated",
+        },
+      ],
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("$0.75 vs — · estimated")).toBeInTheDocument();
+    expect(screen.getAllByText("$0.75").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
+  });
+
+  it("falls back to actual_marginal_usd for headline when split fields are missing", async () => {
+    mockGetUsage.mockResolvedValue({ session: usageSession, jobs: [] });
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      recent_jobs: [
+        {
+          job_id: "legacy-1",
+          accounting_owned: true,
+          models: [{ model_id: "composer-2" }],
+          tokens: 600,
+          actual_marginal_usd: 1.1,
+          cost_basis: "measured",
+        },
+      ],
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("$1.10 vs — · measured")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
   });
 
   it("clears durable state when getEconomics returns a soft 400", async () => {

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -54,6 +54,18 @@ function costBasisLabel(basis: string | null | undefined): string {
   return "";
 }
 
+/** Headline total: measured + estimated when either is known; else legacy actual_marginal. */
+export function jobHeadlineTotal(job: Pick<EconomicsJobRow, "measured_cost_usd" | "estimated_cost_usd" | "actual_marginal_usd">): number | null {
+  const measured = job.measured_cost_usd;
+  const estimated = job.estimated_cost_usd;
+  const hasMeasured = isFiniteNumber(measured);
+  const hasEstimated = isFiniteNumber(estimated);
+  if (hasMeasured || hasEstimated) {
+    return (hasMeasured ? measured : 0) + (hasEstimated ? estimated : 0);
+  }
+  return isFiniteNumber(job.actual_marginal_usd) ? job.actual_marginal_usd : null;
+}
+
 export default function EconomicsDurable({
   data,
   scope,
@@ -162,7 +174,7 @@ export default function EconomicsDurable({
           <div className="text-[10px] uppercase tracking-wide text-faint mb-2">Recent jobs</div>
           {jobs.map((job) => {
             const owned = Boolean(job.accounting_owned);
-            const actual = owned ? job.actual_marginal_usd : null;
+            const headlineTotal = owned ? jobHeadlineTotal(job) : null;
             const jobAvoided = owned ? job.counterfactual?.avoided_usd : null;
             return (
               <div key={job.job_id || `${job.source}-${job.status}`} className="mb-2">
@@ -170,10 +182,22 @@ export default function EconomicsDurable({
                   <span className="truncate pr-2">{job.job_id ? `Job ${job.job_id}` : "Job"}</span>
                   <span className="tabular-nums shrink-0">
                     {owned
-                      ? `${fmtUnknownMoney(actual)} vs ${fmtUnknownMoney(jobAvoided)}${costBasisLabel(job.cost_basis)}`
+                      ? `${fmtUnknownMoney(headlineTotal)} vs ${fmtUnknownMoney(jobAvoided)}${costBasisLabel(job.cost_basis)}`
                       : "—"}
                   </span>
                 </div>
+                {owned ? (
+                  <>
+                    <div className="flex items-center justify-between text-faint pl-2">
+                      <span>Measured</span>
+                      <span className="tabular-nums shrink-0">{fmtUnknownMoney(job.measured_cost_usd)}</span>
+                    </div>
+                    <div className="flex items-center justify-between text-faint pl-2">
+                      <span>Estimated</span>
+                      <span className="tabular-nums shrink-0">{fmtUnknownMoney(job.estimated_cost_usd)}</span>
+                    </div>
+                  </>
+                ) : null}
                 <div className="flex items-center justify-between text-faint">
                   <span className="truncate pr-2">
                     {jobModel(job)}


### PR DESCRIPTION
## Summary
- Headline swarm/job total is measured + estimated (existing fields, no new cost math).
- Two labeled lines: Measured / Estimated. Missing stays em-dash, never a fake $0.
- Legacy jobs without split fields still fall back to `actual_marginal_usd` for the headline.

Closes #131.

## Test plan
- [ ] EconomicsPane mixed / measured-only / estimated-only / legacy cases
- [ ] CI green