### PR TITLE
v0.9.294: honest live session measured vs estimated

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.27` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.293, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.294, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.293"
+__version__ = "0.9.294"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/jobs.py
+++ b/harness/api/jobs.py
@@ -672,13 +672,20 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
     swarm_input = 0
     job_tokens_sum = 0
     store_job_cost = 0.0
+    store_job_measured = 0.0
+    store_job_estimated = 0.0
     try:
         for j in res_jobs:
             if not j.get("accounting_owned"):
                 continue
             is_local = str(j.get("id") or "").startswith("local-")
             if not is_local:
-                store_job_cost += float(j.get("est_cost_usd") or 0.0)
+                _job_cost = float(j.get("est_cost_usd") or 0.0)
+                store_job_cost += _job_cost
+                if j.get("estimated") is False:
+                    store_job_measured += _job_cost
+                else:
+                    store_job_estimated += _job_cost
                 job_tokens_sum += int(j.get("tokens") or 0)
             # Savings meters: every visible row counts once (store + local).
             # merge_local_jobs_into_swarm_live already dedupes store ids.
@@ -864,10 +871,19 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
         _live_estimated = _spend_is_estimated(_live_cost_source, price_source)
     except Exception:
         _live_estimated = _live_cost_source != "provider"
+    session_measured = float(store_job_measured)
+    session_estimated = float(store_job_estimated)
+    pilot_portion = max(0.0, float(est_session_cost) - float(store_job_cost))
+    if _live_estimated:
+        session_estimated += pilot_portion
+    else:
+        session_measured += pilot_portion
     return 200, {
         "session": {
             "tokens_used": tokens_used,
             "est_cost_usd": round(est_session_cost, 6),
+            "measured_cost_usd": round(session_measured, 6),
+            "estimated_cost_usd": round(session_estimated, 6),
             "cost_source": _live_cost_source,
             "price_source": price_source,
             "estimated": bool(_live_estimated),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.293"
+version = "0.9.294"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_swarm_live.py
+++ b/tests/test_swarm_live.py
@@ -174,9 +174,13 @@ def test_session_total_includes_swarm_store_job_cost(monkeypatch):
             live = json.loads(
                 _get(port, "/api/swarm/live", headers=headers).read().decode()
             )
-            # Live is receipt-first. It does not add /api/usage boot carry
-            # (see _boot_usage_reset_for_tests). The store-job receipt is 0.37.
-            assert abs(live["session"]["est_cost_usd"] - 0.37) < 1e-6
+            # Live headline may include leftover estimated pilot; receipt is measured.
+            live_sess = live["session"]
+            assert abs(float(live_sess.get("measured_cost_usd") or 0.0) - 0.37) < 1e-6
+            headline = float(live_sess.get("est_cost_usd") or 0.0)
+            measured = float(live_sess.get("measured_cost_usd") or 0.0)
+            estimated = float(live_sess.get("estimated_cost_usd") or 0.0)
+            assert abs(headline - (measured + estimated)) < 1e-6
         finally:
             httpd.shutdown()
     finally:

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.293"
+version = "0.9.294"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.293",
+  "version": "0.9.294",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.293",
+      "version": "0.9.294",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.293",
+  "version": "0.9.294",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Live session now emits \`measured_cost_usd\` / \`estimated_cost_usd\`. Headline \`est_cost_usd\` is their sum (no double-count).
- Fixes \`test_session_total_includes_swarm_store_job_cost\`: receipt 0.37 is measured; leftover estimated pilot may sit in the headline.

Keeps #131. Pin still \`puppetmaster-ai==1.22.27\`.

## Test plan
- [ ] pytest tests/test_swarm_live.py::test_session_total_includes_swarm_store_job_cost
- [ ] CI green on main so release tests-already-green recovers