### PR TITLE
v0.9.295: close scheduler store on daemon stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.27` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.294, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.295, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.294"
+__version__ = "0.9.295"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/scheduler.py
+++ b/harness/scheduler.py
@@ -687,6 +687,12 @@ class SchedulerDaemon:
                     f"scheduler stop: cancel {sid} failed: "
                     f"{type(exc).__name__}: {exc}"
                 )
+        closer = getattr(self.store, "close", None)
+        if callable(closer):
+            try:
+                closer()
+            except Exception:
+                pass
 
     def tick(self, now: Optional[datetime] = None) -> List[dict]:
         return run_due(
@@ -720,5 +726,6 @@ class SchedulerDaemon:
                     print(f"tick error (continuing): {type(exc).__name__}: {exc}")
                 self._interruptible_wait(tick_seconds)
         except KeyboardInterrupt:
-            self.stop()
             print("scheduler daemon stopped")
+        finally:
+            self.stop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.294"
+version = "0.9.295"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -378,10 +378,23 @@ def test_daemon_stop_cancels_and_interruptible_wait(tmp_path):
     daemon._active["schedule_id"] = s.id
     started = time.time()
     # stop() should request cancel; interruptible wait should return quickly.
+    cancels = []
+    real_cancel = store.request_cancel
+    store.request_cancel = lambda sid: cancels.append(sid) or real_cancel(sid)
     daemon.stop()
-    assert store.cancel_requested(s.id)
+    assert cancels == [s.id]
     daemon._interruptible_wait(30)
     assert time.time() - started < 2.0
+
+
+def test_daemon_stop_closes_store(tmp_path):
+    store = _store(tmp_path)
+    closed = []
+    real_close = store.close
+    store.close = lambda: closed.append(True) or real_close()
+    daemon = SchedulerDaemon(store)
+    daemon.stop()
+    assert closed == [True]
 
 
 def test_daemon_stop_logs_cancel_failure(tmp_path, capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.294"
+version = "0.9.295"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.294",
+  "version": "0.9.295",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.294",
+      "version": "0.9.295",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.294",
+  "version": "0.9.295",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- \`SchedulerDaemon.stop()\` / \`serve()\` call \`store.close()\` on shutdown.
- Test: \`stop()\` closes the store.
- Pin still \`puppetmaster-ai==1.22.27\`.

## Test plan
- [ ] \`pytest tests/test_scheduler.py::test_daemon_stop_closes_store\`
- [ ] CI green