### PR TITLE
v0.9.296: flush dirty session stores on SIGINT/SIGTERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.27` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.295, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.296, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.295"
+__version__ = "0.9.296"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -16,6 +16,7 @@ import atexit
 import json
 import os
 import re
+import signal
 import tempfile
 import threading
 import time
@@ -81,14 +82,42 @@ _preview_cache: dict[tuple[str, int], tuple[float, str]] = {}
 # Live stores flushed on process exit (weak so tests do not pin instances).
 _live_session_stores: weakref.WeakSet = weakref.WeakSet()
 _atexit_flush_registered = False
+_signal_flush_registered = False
+# Prior handlers restored after flush so SIGINT/SIGTERM still terminate.
+_prior_signal_handlers: dict[int, Any] = {}
+
+
+def _session_store_signal_handler(signum: int, frame: Any) -> None:
+    """Flush dirty SessionStores, then continue default / prior termination."""
+    try:
+        _flush_all_session_stores()
+    except Exception:
+        pass
+    previous = _prior_signal_handlers.get(signum, signal.SIG_DFL)
+    if previous is signal.SIG_IGN:
+        return
+    if callable(previous):
+        previous(signum, frame)
+        return
+    # Default disposition: do not swallow — exit so atexit still runs when possible.
+    raise SystemExit(128 + int(signum))
 
 
 def _register_session_store(store: "SessionStore") -> None:
-    global _atexit_flush_registered
+    global _atexit_flush_registered, _signal_flush_registered
     _live_session_stores.add(store)
     if not _atexit_flush_registered:
         atexit.register(_flush_all_session_stores)
         _atexit_flush_registered = True
+    if not _signal_flush_registered:
+        _signal_flush_registered = True
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                _prior_signal_handlers[sig] = signal.getsignal(sig)
+                signal.signal(sig, _session_store_signal_handler)
+            except ValueError:
+                # Not on the main thread (e.g. some test runners) — atexit still covers exit.
+                pass
 
 
 def _flush_all_session_stores() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.295"
+version = "0.9.296"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_session_store_debounce.py
+++ b/tests/test_session_store_debounce.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import signal
 import time
 from unittest import mock
 
@@ -90,6 +91,40 @@ def test_flush_writes_pending_dirty_state(tmp_path, monkeypatch):
         assert wrapped.call_count == 1
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["sessions"][0]["title"] == "Pending"
+
+
+def test_dirty_store_flushes_on_signal_shutdown_path(tmp_path):
+    """SIGINT/SIGTERM handler path must persist dirty stores (not atexit-only).
+
+    Under pytest ``_save`` flushes immediately, so mark ``_dirty`` directly
+    instead of relying on debounce.
+    """
+    path = tmp_path / "harness_sessions.json"
+    store = SessionStore(str(path))
+    store.create(title="BeforeSignal", repo=str(tmp_path / "repo"))
+    with store._lock:
+        store._sessions[0]["title"] = "AfterSignal"
+        store._dirty = True
+
+    continued = {"n": 0}
+
+    def _continue(signum, frame):
+        continued["n"] += 1
+
+    prior = sessions._prior_signal_handlers.get(signal.SIGTERM)
+    sessions._prior_signal_handlers[signal.SIGTERM] = _continue
+    try:
+        sessions._session_store_signal_handler(signal.SIGTERM, None)
+    finally:
+        if prior is None:
+            sessions._prior_signal_handlers.pop(signal.SIGTERM, None)
+        else:
+            sessions._prior_signal_handlers[signal.SIGTERM] = prior
+
+    assert continued["n"] == 1
+    assert store._dirty is False
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["sessions"][0]["title"] == "AfterSignal"
 
 
 def test_list_snapshots_metadata_under_lock_before_preview_io(tmp_path, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.295"
+version = "0.9.296"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.295",
+  "version": "0.9.296",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.295",
+      "version": "0.9.296",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.295",
+  "version": "0.9.296",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- \`SessionStore\` dirty flush on SIGINT/SIGTERM (then continue default termination).
- Atomic temp+\`os.replace\` unchanged. atexit path kept.
- Test: dirty store flushes on the signal/shutdown handler path.
- Pin still \`puppetmaster-ai==1.22.27\`.

## Test plan
- [ ] \`pytest tests/test_session_store_debounce.py\`
- [ ] CI green