### PR TITLE
v0.9.297: sanitize full text, one relocate path, more secret shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.27` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.296, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.297, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.296"
+__version__ = "0.9.297"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -226,7 +226,6 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
         "/api/sessions/create": post_json(
             _sessions_api.post_sessions_create, services=svc.session_services),
         "/api/sessions/relocate": _post_session_relocate,
-        "/api/sessions/move": _post_session_relocate,
         "/api/sessions/switch": post_json(
             _sessions_api.post_sessions_switch, services=svc.session_services),
         "/api/sessions/delete": post_json(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.296"
+version = "0.9.297"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_handler_dispatch.py
+++ b/tests/test_handler_dispatch.py
@@ -60,7 +60,8 @@ def test_route_tables_cover_known_paths():
     post = srv._post_json_routes()
     get = srv._get_routes()
     assert "/api/settings" in post
-    assert "/api/sessions/relocate" in post and "/api/sessions/move" in post
+    assert "/api/sessions/relocate" in post
+    assert "/api/sessions/move" not in post
     assert "/api/memory" in get
     assert "/api/wiki/connect" not in get  # pre-auth special case in do_GET
     assert len(post) >= 90

--- a/tests/test_http_routes_table.py
+++ b/tests/test_http_routes_table.py
@@ -39,7 +39,6 @@ _SAMPLE_GUARDED_GET = (
 _SAMPLE_GUARDED_POST = (
     "/api/settings",
     "/api/sessions/relocate",
-    "/api/sessions/move",
     "/api/sessions/create",
     "/api/platform",
     "/api/auth/pools",
@@ -103,3 +102,10 @@ def test_preauth_wiki_connect_not_in_get_table():
 def test_guarded_api_sample_not_in_public_allowlist():
     """No public GET allowlist remains on Handler."""
     assert not getattr(srv.Handler, "_PUBLIC_GET_PATHS", None)
+
+
+def test_sessions_relocate_is_the_only_mutating_relocate_path():
+    """POST table has relocate; move is not a live mutating alias."""
+    post, _ = _fresh_route_tables()
+    assert "/api/sessions/relocate" in post
+    assert "/api/sessions/move" not in post

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.296"
+version = "0.9.297"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.296",
+  "version": "0.9.297",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.296",
+      "version": "0.9.297",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.296",
+  "version": "0.9.297",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/operationalDiagnostic.test.ts
+++ b/webapp/src/__tests__/operationalDiagnostic.test.ts
@@ -49,9 +49,32 @@ describe("sanitizeDiagnosticText", () => {
     expect(sanitizeDiagnosticText("Authorization: Bearer sk-abc123456789")).not.toMatch(/sk-abc/);
   });
 
-  it("keeps a single line and bounds length", () => {
-    expect(sanitizeDiagnosticText("first\nsecond stack")).toBe("first");
+  it("keeps a multi-line auth error inside the budget", () => {
+    const out = sanitizeDiagnosticText("Error:\nanthropic.AuthenticationError: invalid x-api-key");
+    expect(out).toContain("anthropic.AuthenticationError");
+    expect(out.length).toBeLessThanOrEqual(160);
+  });
+
+  it("bounds length", () => {
     expect(sanitizeDiagnosticText("x".repeat(200)).length).toBeLessThanOrEqual(160);
+  });
+
+  it("redacts AIza, GitHub token, and JWT shapes", () => {
+    const google = "AIzaSyD-abcdefghijklmnopqrstuvwxyz012345";
+    const ghp = "ghp_" + "A".repeat(36);
+    const pat = "github_pat_" + "B".repeat(36);
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjw46_OwfmRMV94B7vjYTbxqgVwOKCsAXEzXkOfBk";
+    expect(sanitizeDiagnosticText(`key ${google}`)).toContain("[redacted]");
+    expect(sanitizeDiagnosticText(`key ${google}`)).not.toContain(google);
+    expect(sanitizeDiagnosticText(`key ${google}`)).not.toMatch(/AIza/);
+    expect(sanitizeDiagnosticText(`tok ${ghp}`)).toContain("[redacted]");
+    expect(sanitizeDiagnosticText(`tok ${ghp}`)).not.toContain(ghp);
+    expect(sanitizeDiagnosticText(`tok ${pat}`)).toContain("[redacted]");
+    expect(sanitizeDiagnosticText(`tok ${pat}`)).not.toContain(pat);
+    expect(sanitizeDiagnosticText(`jwt ${jwt}`)).toContain("[redacted]");
+    expect(sanitizeDiagnosticText(`jwt ${jwt}`)).not.toContain(jwt);
+    expect(sanitizeDiagnosticText(`jwt ${jwt}`)).not.toMatch(/eyJ/);
   });
 });
 
@@ -254,7 +277,8 @@ describe("createOperationalDiagnostic", () => {
       retryable: true,
     });
     expect(diag.summary).not.toMatch(/sk-abcd/);
-    expect(diag.detail).toBe("line1");
+    expect(diag.detail).toContain("line1");
+    expect(diag.detail).not.toContain("supersecret");
     expect(diag.recovery).toEqual({ kind: "none" });
   });
 

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -66,7 +66,7 @@ const SUMMARY_MAX = 160;
 const DETAIL_MAX = 280;
 
 const SECRET_LIKE =
-  /(?:bearer\s+[a-z0-9._\-+=\/]+|sk-[a-z0-9]{8,}|api[_-]?key\s*[:=]\s*\S+|x-harness-token\s*[:=]\s*\S+|authorization\s*[:=]\s*\S+)/gi;
+  /(?:bearer\s+[a-z0-9._\-+=\/]+|sk-[a-z0-9]{8,}|api[_-]?key\s*[:=]\s*\S+|x-harness-token\s*[:=]\s*\S+|authorization\s*[:=]\s*\S+|AIza[0-9A-Za-z_\-]{10,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)/gi;
 
 let nextId = 0;
 
@@ -96,8 +96,7 @@ export function isOperationalDiagnostic(value: unknown): value is OperationalDia
 }
 
 export function sanitizeDiagnosticText(text: string, max = SUMMARY_MAX): string {
-  const cut = String(text || "").replace(/\r/g, "").split("\n")[0] || "";
-  const redacted = cut.replace(SECRET_LIKE, "[redacted]").replace(SECRET_LIKE, "[redacted]");
+  const redacted = String(text || "").replace(/\r/g, "").replace(SECRET_LIKE, "[redacted]");
   if (redacted.length <= max) return redacted;
   return redacted.slice(0, Math.max(0, max - 1)).trimEnd() + "…";
 }


### PR DESCRIPTION
sanitizeDiagnosticText redacts full text then truncates. SECRET_LIKE adds AIza/ghp_/github_pat_/JWT. One relocate path; /move removed. Pin still puppetmaster-ai==1.22.27.