### PR TITLE
v0.9.298: release daemon claim on stop; drop MCP error bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.27` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.297, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.298, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.297"
+__version__ = "0.9.298"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/mcp_http_client.py
+++ b/harness/mcp_http_client.py
@@ -289,7 +289,11 @@ class HttpMcpClient:
         except urllib.error.HTTPError as e:
             # Application HTTP errors (4xx/5xx) do not clear liveness; the
             # server answered. Redirect/SSRF blocks also arrive as HTTPError.
-            raise McpError(f"MCP server '{self.name}' HTTP {e.code}: {e.read()[:200].decode(errors='replace')}")
+            try:
+                e.read()
+            except Exception:
+                pass
+            raise McpError(f"MCP server '{self.name}' HTTP {e.code}")
         except urllib.error.URLError as e:
             # Transport failure → not alive (do not keep sticky init).
             self._initialized = False
@@ -312,7 +316,7 @@ class HttpMcpClient:
         try:
             return json.loads(raw)
         except json.JSONDecodeError:
-            raise McpError(f"MCP server '{self.name}': non-JSON response: {raw[:200]}")
+            raise McpError(f"MCP server '{self.name}': non-JSON response")
 
     def _notify(self, method: str, params: dict) -> None:
         self._post({"jsonrpc": "2.0", "method": method, "params": params}, self.timeout)

--- a/harness/schedule_store.py
+++ b/harness/schedule_store.py
@@ -826,6 +826,41 @@ class ScheduleStore:
                     pass
                 raise
 
+    def release_claim(self, schedule_id: str, run_id=None) -> bool:
+        """Clear this schedule live claim so another daemon can take over.
+
+        If run_id is set, only the matching claim_run_id is released.
+        """
+        with self._lock:
+            if run_id:
+                cur = self._conn.execute(
+                    """
+                    UPDATE schedules SET
+                        claim_owner = '',
+                        claim_at = 0,
+                        claim_lease_until = 0,
+                        claim_fire_at = 0,
+                        claim_run_id = ''
+                    WHERE id = ? AND claim_run_id = ? AND claim_owner != ''
+                    """,
+                    (schedule_id, run_id),
+                )
+            else:
+                cur = self._conn.execute(
+                    """
+                    UPDATE schedules SET
+                        claim_owner = '',
+                        claim_at = 0,
+                        claim_lease_until = 0,
+                        claim_fire_at = 0,
+                        claim_run_id = ''
+                    WHERE id = ? AND claim_owner != ''
+                    """,
+                    (schedule_id,),
+                )
+            self._conn.commit()
+            return cur.rowcount > 0
+
     def request_cancel(self, schedule_id: str) -> bool:
         """Ask an active claim to cancel cooperatively."""
         with self._lock:

--- a/harness/scheduler.py
+++ b/harness/scheduler.py
@@ -687,6 +687,17 @@ class SchedulerDaemon:
                     f"scheduler stop: cancel {sid} failed: "
                     f"{type(exc).__name__}: {exc}"
                 )
+            releaser = getattr(self.store, "release_claim", None)
+            if callable(releaser):
+                try:
+                    releaser(sid, run_id=self._active.get("run_id") or None)
+                except TypeError:
+                    try:
+                        releaser(sid)
+                    except Exception:
+                        pass
+                except Exception:
+                    pass
         closer = getattr(self.store, "close", None)
         if callable(closer):
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.297"
+version = "0.9.298"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_mcp_http_error_body.py
+++ b/tests/test_mcp_http_error_body.py
@@ -1,0 +1,78 @@
+"""MCP HTTP errors keep status/code and drop raw response bodies."""
+from __future__ import annotations
+
+import http.server
+import threading
+
+import pytest
+
+from harness.mcp_client import McpError
+from harness.mcp_http_client import HttpMcpClient
+
+
+class _SecretHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, format, *args):  # noqa: A003
+        return
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        body = b"sk-abc123456789 leaked ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        self.send_response(403)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class _NonJsonHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, format, *args):  # noqa: A003
+        return
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        body = b"not-json sk-abc123456789"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _serve(handler):
+    server = http.server.HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def test_http_error_keeps_status_and_drops_secret_body(monkeypatch):
+    monkeypatch.setenv("HARNESS_ALLOW_PRIVATE_URLS", "1")
+    server = _serve(_SecretHandler)
+    try:
+        client = HttpMcpClient("sec", f"http://127.0.0.1:{server.server_address[1]}/rpc")
+        with pytest.raises(McpError) as exc:
+            client._post({"jsonrpc": "2.0", "id": 1, "method": "ping"}, timeout=5.0)
+        msg = str(exc.value)
+        assert "HTTP 403" in msg
+        assert "sk-abc" not in msg
+        assert "ghp_" not in msg
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_non_json_response_does_not_echo_body(monkeypatch):
+    monkeypatch.setenv("HARNESS_ALLOW_PRIVATE_URLS", "1")
+    server = _serve(_NonJsonHandler)
+    try:
+        client = HttpMcpClient("nj", f"http://127.0.0.1:{server.server_address[1]}/rpc")
+        with pytest.raises(McpError) as exc:
+            client._post({"jsonrpc": "2.0", "id": 1, "method": "ping"}, timeout=5.0)
+        msg = str(exc.value)
+        assert "non-JSON" in msg
+        assert "sk-abc" not in msg
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -809,3 +809,17 @@ def test_complete_claim_false_on_refusal_returns_superseded(tmp_path):
     assert run["status"] == "superseded"
     assert run["halt_reason"] == "ownership_lost"
     assert notifier.calls == []
+
+
+def test_daemon_stop_releases_live_claim(tmp_path):
+    store = _store(tmp_path)
+    s = _add_due(store, tmp_path, "release-claim")
+    store.try_claim(s.id, fire_at=1.0, owner="daemon-active", lease_seconds=600)
+    assert store.get(s.id).claim_owner
+    daemon = SchedulerDaemon(store)
+    daemon._active["schedule_id"] = s.id
+    daemon.stop()
+    got = ScheduleStore(str(tmp_path / "s.sqlite")).get(s.id)
+    assert not got.claim_owner
+    assert not got.claim_run_id
+    assert (got.claim_lease_until or 0) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.297"
+version = "0.9.298"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.297",
+  "version": "0.9.298",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.297",
+      "version": "0.9.298",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.297",
+  "version": "0.9.298",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
stop() releases this daemon claim (owner/lease/run_id). MCP HTTP errors keep status/code and drop raw bodies. Pin still puppetmaster-ai==1.22.27.