### PR TITLE
v0.9.299: four test/CI commits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,3 +88,23 @@ jobs:
           npm test
           xvfb-run -a npm run test:electron
           npm run build
+
+  pmharness-units:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.9"
+          cache: pip
+
+      - name: Install (rig + dev extras + Puppetmaster from PyPI)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.27"
+
+      - name: Run offline pmharness/intent/registry units
+        run: python -m pytest -q -p no:cacheprovider tests/test_intent.py tests/test_registry.py tests/test_registry_wizard.py tests/test_pilot_driver_templates.py
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.27` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.298, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.299, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.298"
+__version__ = "0.9.299"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.298"
+version = "0.9.299"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_pilot_driver_templates.py
+++ b/tests/test_pilot_driver_templates.py
@@ -1,0 +1,43 @@
+"""Unit tests for validate_pilot_driver, _tier_of, and _AGENTIC_TEMPLATES."""
+from harness.auto_registry import _AGENTIC_TEMPLATES, _get_provider_models_from_discovery
+from harness.registry_wizard import validate_pilot_driver
+
+
+def test_validate_pilot_driver_rejects_empty():
+    got = validate_pilot_driver("")
+    assert got["valid"] is False
+    assert got["resolved_model_id"] is None
+
+
+def test_validate_pilot_driver_unknown_provider():
+    got = validate_pilot_driver("not-a-real-provider:some-model")
+    assert got["valid"] is False
+    assert got["provider"] == "not-a-real-provider"
+
+
+def test_agentic_templates_have_three_tiers():
+    for provider, tiers in _AGENTIC_TEMPLATES.items():
+        assert tiers, provider
+        for name, spec in tiers.items():
+            assert len(spec) == 5, (provider, name)
+            score, _inp, _out, ctx, tags = spec
+            assert isinstance(score, (int, float))
+            assert ctx > 0
+            assert isinstance(tags, list)
+
+
+def test_tier_of_marks_pro_frontier_and_flash_lite_cheap(monkeypatch):
+    monkeypatch.setattr(
+        "harness.auto_registry._enabled_picker_models", lambda name: [],
+    )
+    live = ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"]
+    monkeypatch.setattr(
+        "harness.model_fetch.fetch_models", lambda *a, **k: live,
+    )
+    rows = _get_provider_models_from_discovery("google", "unused-key")
+    by_name = {name: tier for name, tier, _slug in rows}
+    if not by_name:
+        rows = _get_provider_models_from_discovery("gemini", "unused-key")
+        by_name = {name: tier for name, tier, _slug in rows}
+    assert by_name.get("gemini-2.5-pro") == "frontier"
+    assert by_name.get("gemini-2.5-flash-lite") == "cheap"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.298"
+version = "0.9.299"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.298",
+  "version": "0.9.299",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.298",
+      "version": "0.9.299",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.298",
+  "version": "0.9.299",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/streamTypewriter.slowBatch.test.ts
+++ b/webapp/src/__tests__/streamTypewriter.slowBatch.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { pumpTypewriterFrame } from "../components/conversation/streamTypewriter";
+
+function refs(buf: string) {
+  return {
+    typeBufRef: { current: buf },
+    typeRafRef: { current: null as number | null },
+    typeDoneRef: { current: false },
+  };
+}
+
+describe("streamTypewriter slow-model batching", () => {
+  it("paints a large slow-model burst in one frame instead of dripping", () => {
+    const burst = "token ".repeat(40);
+    const r = refs(burst);
+    const painted: string[] = [];
+    pumpTypewriterFrame(r, (chunk) => painted.push(chunk), (cb) => {
+      return 1;
+    });
+    expect(painted.join("")).toBe(burst);
+    expect(painted).toHaveLength(1);
+    expect(r.typeBufRef.current).toBe("");
+  });
+});

--- a/webapp/src/__tests__/streamTypewriter.slowBatch.test.ts
+++ b/webapp/src/__tests__/streamTypewriter.slowBatch.test.ts
@@ -14,7 +14,7 @@ describe("streamTypewriter slow-model batching", () => {
     const burst = "token ".repeat(40);
     const r = refs(burst);
     const painted: string[] = [];
-    pumpTypewriterFrame(r, (chunk) => painted.push(chunk), (cb) => {
+    pumpTypewriterFrame(r, (chunk) => painted.push(chunk), () => {
       return 1;
     });
     expect(painted.join("")).toBe(burst);

--- a/webapp/src/__tests__/useOperationalDiagnostic.test.tsx
+++ b/webapp/src/__tests__/useOperationalDiagnostic.test.tsx
@@ -1,0 +1,31 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { desktopBridgeMissingDiagnostic } from "../lib/operationalDiagnostic";
+import {
+  publishDiagnostic,
+  resetDiagnosticBus,
+} from "../lib/operationalDiagnosticBus";
+import { useOperationalDiagnostic } from "../lib/useOperationalDiagnostic";
+
+describe("useOperationalDiagnostic", () => {
+  afterEach(() => {
+    resetDiagnosticBus();
+  });
+
+  it("starts null and follows publish/clear on the bus", () => {
+    const { result } = renderHook(() => useOperationalDiagnostic());
+    expect(result.current).toBeNull();
+
+    const diag = desktopBridgeMissingDiagnostic({ operation: "startup" });
+    act(() => {
+      publishDiagnostic(diag);
+    });
+    expect(result.current?.code).toBe(diag.code);
+    expect(result.current?.summary).toBe(diag.summary);
+
+    act(() => {
+      resetDiagnosticBus();
+    });
+    expect(result.current).toBeNull();
+  });
+});


### PR DESCRIPTION
Four real commits: offline pmharness CI gate, useOperationalDiagnostic test, streamTypewriter slow-batch test, validate_pilot_driver/_tier_of/_AGENTIC_TEMPLATES tests. Pin still puppetmaster-ai==1.22.27.