### PR TITLE
v0.9.300: swarm tracker usage pills

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.27
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.28
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.27"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.28"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.27"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.28"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -57,7 +57,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.27"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.28"
 
       - name: Run the offline test suite (shard)
         env:
@@ -103,7 +103,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.27"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.28"
 
       - name: Run offline pmharness/intent/registry units
         run: python -m pytest -q -p no:cacheprovider tests/test_intent.py tests/test_registry.py tests/test_registry_wizard.py tests/test_pilot_driver_templates.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.27"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.28"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.27` (CI,
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.28` (CI,
    desktop bootstrap, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.27` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.299, deliberately pre-1.0. Rides puppetmaster-ai==1.22.27. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.300, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.27` (configurable default reviewer platform, shared `build_cost_report`, safely resumable jobs, honest delivery verdicts, Google Antigravity `agy` adapter, dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.28` (configurable default reviewer platform, shared `build_cost_report`, safely resumable jobs, honest delivery verdicts, Google Antigravity `agy` adapter, dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |
 | **Honest token economics** | Prompt caching across Anthropic/OpenAI/Gemini with a stable + moving cache breakpoint, cost billed at the real cache-read discount, and the context meter driven by the driver's actual token usage -- so cost and context reflect reality and the status bar shows the dollars caching saved you. Savings-gated tool-output offload, absolute-token compaction advice, and optional per-turn output budgets (`+Nk` / `+Nk!`) cut waste without hiding results. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.299"
+__version__ = "0.9.300"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.299"
+version = "0.9.300"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.27" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.28" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.27"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.28"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.27" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.28" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.27}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.28}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.299"
+version = "0.9.300"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.27";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.28";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.27";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.28";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 const HARNESS_DIST_NAME = "pm-harness";
 
@@ -95,7 +95,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.27" }    -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.28" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -117,7 +117,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.27).
+ * to 1.22.28).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.299",
+  "version": "0.9.300",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.299",
+      "version": "0.9.300",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.299",
+  "version": "0.9.300",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -2957,4 +2957,49 @@ describe("swarm tracker usage pills (0.9.300)", () => {
     expect(screen.getByText("Estimated")).toBeInTheDocument();
     expect(screen.getByText("$0.25")).toBeInTheDocument();
   });
+
+  it("keeps worker usage collapsed until the usage pill is clicked", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        goal: "Worker usage pill",
+        tasks: [
+          {
+            id: "t-usage",
+            role: "implement",
+            instruction: "hidden until row expand",
+            status: "completed",
+            adapter: "agentic",
+            tokens: 42_000,
+            est_cost_usd: 0.14,
+          },
+        ],
+      }),
+    );
+    render(<SwarmPane />);
+    await expandVisibleJobs();
+    expect(screen.queryByText("42,000t")).not.toBeInTheDocument();
+    expect(screen.queryByText("Estimated cost ~$0.1400")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Show tokens and cost" }));
+    expect(screen.getByText("42,000t")).toBeInTheDocument();
+    expect(screen.getByText("Estimated cost ~$0.1400")).toBeInTheDocument();
+  });
+
+  it("still shows grouped Findings count unchanged", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job-findings-pills", "Grouped findings pill chrome", {
+        artifacts_complete: true,
+        artifacts: [
+          { type: "finding", headline: "one" },
+          { type: "finding", headline: "two" },
+          { type: "finding", headline: "one" },
+        ],
+      }),
+    );
+    render(<SwarmPane />);
+    fireEvent.click(await screen.findByText("Finished"));
+    fireEvent.click(await screen.findByText("Grouped findings pill chrome"));
+    expect(screen.getByText("Findings (2)")).toBeInTheDocument();
+    expect(screen.queryByText(/Findings \(2 of/)).toBeNull();
+  });
 });

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -465,7 +465,7 @@ describe("SwarmPane worker details", () => {
     fireEvent.click(screen.getByText("Finished"));
     fireEvent.click(await screen.findByText("Inspect completed worker"));
 
-    const worker = screen.getByText("completed-worker").closest('[role="button"]');
+    const worker = screen.getAllByText("completed-worker")[0].closest('[role="button"]');
     expect(worker).not.toBeNull();
     expect(worker).toHaveAttribute("aria-expanded", "false");
     fireEvent.click(worker!);
@@ -889,10 +889,12 @@ describe("SwarmPane mid-run job-row meters", () => {
 
     await waitFor(() => {
       expect(screen.getAllByText("12,000t").length).toBeGreaterThan(0);
-      expect(screen.getByText("1,500 compact")).toBeInTheDocument();
-      expect(screen.getAllByText("Estimated cost ~$0.0500").length).toBeGreaterThan(0);
+      expect(screen.getByText(/1,500 compact/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Job cost/ })).toHaveTextContent("$0.05");
       expect(screen.getByText("Estimated savings ~$0.0553")).toBeInTheDocument();
     });
+    fireEvent.click(screen.getByRole("button", { name: /Job cost/ }));
+    expect(screen.getByText("Estimated")).toBeInTheDocument();
     expect(screen.queryByText("8,000 cached")).not.toBeInTheDocument();
     expect(screen.getByTitle(/model selection value vs frontier-equivalent list price/)).toBeInTheDocument();
     expect(screen.getByTitle(/prompt-cache value/)).toBeInTheDocument();
@@ -1536,7 +1538,7 @@ describe("SwarmPane worker-owned routing surface", () => {
     expect(modelSlot.className).toMatch(/truncate/);
     expect(modelSlot.className).toMatch(/min-w-0/);
     expect(modelSlot).not.toHaveAttribute("title");
-    expect(screen.queryByText("running")).not.toBeInTheDocument();
+    expect(screen.getByText("running")).toBeInTheDocument();
     expect(worker).not.toHaveTextContent("—");
     expect(screen.queryByText("review every uncovered branch in the swarm tracker")).not.toBeInTheDocument();
     expect(screen.queryByText("Routing")).not.toBeInTheDocument();
@@ -1714,6 +1716,7 @@ describe("SwarmPane worker-owned routing surface", () => {
 
     render(<SwarmPane />);
     await expandVisibleJobs();
+    fireEvent.click(screen.getByRole("button", { name: "Show tokens and cost" }));
     const worker = await screen.findByRole("button", { name: /Worker/ });
     expect(worker).toHaveTextContent("$0");
     expect(worker).not.toHaveTextContent("—");
@@ -1741,6 +1744,7 @@ describe("SwarmPane worker-owned routing surface", () => {
 
     render(<SwarmPane />);
     await expandVisibleJobs();
+    fireEvent.click(screen.getByRole("button", { name: "Show tokens and cost" }));
     const worker = await screen.findByRole("button", { name: /Worker/ });
     expect(worker).toHaveTextContent("$0");
   });
@@ -1793,8 +1797,12 @@ describe("SwarmPane worker tokens and cost", () => {
     await waitFor(() => {
       expect(screen.getByText("Workers (2)")).toBeInTheDocument();
     });
+    expect(screen.queryByText("120,000t")).not.toBeInTheDocument();
+    expect(screen.queryByText("Estimated cost ~$0.1400")).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Show tokens and cost" })[0]);
     expect(screen.getByText("120,000t")).toBeInTheDocument();
     expect(screen.getByText("Estimated cost ~$0.1400")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Show tokens and cost" })[1]);
     expect(screen.getByText("60,000t")).toBeInTheDocument();
     expect(screen.getByText("Estimated cost ~$0.0700")).toBeInTheDocument();
     expect(screen.queryByText("build it")).not.toBeInTheDocument();
@@ -1935,7 +1943,7 @@ describe("SwarmPane worker outcome hierarchy", () => {
     fireEvent.click(await screen.findByText("Fully successful terminal"));
 
     expect(screen.getByText("Workers (3)")).toBeInTheDocument();
-    expect(screen.queryByText("3/3")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Workers")).toHaveTextContent("3/3");
     expect(screen.getByLabelText(/3 of 3 workers finished, 0 failed, 0 degraded/)).toBeInTheDocument();
   });
 
@@ -2017,7 +2025,7 @@ describe("SwarmPane worker outcome hierarchy", () => {
     expect(workerA).not.toHaveTextContent("degraded");
     expect(workerB).not.toHaveTextContent("degraded");
     expect(screen.queryByText(/degraded/)).not.toBeInTheDocument();
-    expect(screen.queryByText("2/2")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Workers")).toHaveTextContent("2/2");
   });
 
   it("does not paint workers failed or degraded from job-level degraded without task-scoped artifact", async () => {
@@ -2915,5 +2923,38 @@ describe("receipt-first spend (#102)", () => {
     } as Job;
     expect(workerSpend(job.tasks![0], job)).toBeNull();
     expect(workerSpend(job.tasks![1], job)).toBeNull();
+  });
+});
+
+
+describe("swarm tracker usage pills (0.9.300)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    clearSWRCache();
+    mockArtifacts.mockResolvedValue([]);
+  });
+
+  it("keeps header cost collapsed until click expands Measured / Estimated", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        status: "running",
+        tokens: 12_000,
+        est_cost_usd: 1.5,
+        measured_cost_usd: 1.25,
+        estimated_cost_usd: 0.25,
+      }),
+    );
+    render(<SwarmPane />);
+    const cost = await screen.findByRole("button", { name: /Job cost/ });
+    expect(cost).toHaveTextContent("$1.50");
+    expect(screen.queryByText("Measured")).not.toBeInTheDocument();
+    expect(screen.queryByText("Estimated")).not.toBeInTheDocument();
+    fireEvent.click(cost);
+    expect(screen.getByText("Measured")).toBeInTheDocument();
+    expect(screen.getByText("$1.25")).toBeInTheDocument();
+    expect(screen.getByText("Estimated")).toBeInTheDocument();
+    expect(screen.getByText("$0.25")).toBeInTheDocument();
   });
 });

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -11,6 +11,7 @@ import {
 } from "../lib/pendingSwarmOpenJob";
 import { useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
 import { filterJobsByScope, loadJobScope, saveJobScope, type JobScope } from "../lib/jobScope";
+import { jobHeadlineTotal } from "./EconomicsDurable";
 
 // A clean, self-contained hover tooltip. The native `title=` tooltip renders as a
 // large unstyled OS box that covers the tracker and never wraps sensibly; this
@@ -568,6 +569,29 @@ function workerModelView(task: Task, routing?: Artifact): WorkerModelView {
 const DISCLOSURE_FOCUS =
   "focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-accent";
 
+/** Composer-family meter pills — same chip language as dock / Tasks trackers. */
+const SWARM_METER_PILL =
+  "composer-family inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-panel2/80 border border-edge/80 text-[9px] shrink-0";
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/** Unknown stays em-dash — never a measured $0. */
+function fmtMeterMoney(value: number | null | undefined): string {
+  if (!isFiniteNumber(value)) return "—";
+  if (value < 0.001 && value !== 0) return `$${value.toFixed(4)}`;
+  if (value < 0.01 && value !== 0) return `$${value.toFixed(3)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+function terminalWorkerCount(tasks: Task[]): number {
+  return tasks.filter((t) => {
+    const s = taskState(t);
+    return s === "done" || s === "fail";
+  }).length;
+}
+
 /** Merge a fresh /swarm/live poll into cached state without wiping expanded full artifacts. */
 function mergeSwarmLive(prev: SwarmLive | null | undefined, next: SwarmLive): SwarmLive {
   if (!prev?.jobs?.length) return next;
@@ -713,6 +737,74 @@ export function workerSpend(
     return { cost: job.est_cost_usd, estimated, basis: spendBasisFor(job) };
   }
   return null;
+}
+
+type JobSpendSplit = {
+  headline: number | null;
+  measured: number | null | undefined;
+  estimated: number | null | undefined;
+  showMeasured: boolean;
+  showEstimated: boolean;
+};
+
+/** Map swarm job spend onto Economics headline/split rules. */
+function jobSpendSplit(j: Job): JobSpendSplit {
+  const hasMeasuredField = isFiniteNumber(j.measured_cost_usd);
+  const hasEstimatedField = isFiniteNumber(j.estimated_cost_usd);
+  if (hasMeasuredField || hasEstimatedField) {
+    const headline = jobHeadlineTotal({
+      measured_cost_usd: j.measured_cost_usd,
+      estimated_cost_usd: j.estimated_cost_usd,
+      actual_marginal_usd: j.est_cost_usd,
+    });
+    return {
+      headline,
+      measured: hasMeasuredField ? j.measured_cost_usd : null,
+      estimated: hasEstimatedField ? j.estimated_cost_usd : null,
+      showMeasured: hasMeasuredField,
+      showEstimated: hasEstimatedField,
+    };
+  }
+  if (!hasMeaningfulJobCost(j)) {
+    return {
+      headline: null,
+      measured: null,
+      estimated: null,
+      showMeasured: false,
+      showEstimated: false,
+    };
+  }
+  const headline = jobHeadlineTotal({
+    measured_cost_usd: undefined,
+    estimated_cost_usd: undefined,
+    actual_marginal_usd: j.est_cost_usd,
+  });
+  const basis = spendBasisFor(j);
+  if (basis === "measured" || basis === "provider") {
+    return {
+      headline,
+      measured: j.est_cost_usd,
+      estimated: null,
+      showMeasured: true,
+      showEstimated: false,
+    };
+  }
+  if (basis === "estimated") {
+    return {
+      headline,
+      measured: null,
+      estimated: j.est_cost_usd,
+      showMeasured: false,
+      showEstimated: true,
+    };
+  }
+  return {
+    headline,
+    measured: null,
+    estimated: null,
+    showMeasured: false,
+    showEstimated: false,
+  };
 }
 
 function positiveUsd(n?: number): number {
@@ -1058,6 +1150,9 @@ export default function SwarmPane() {
   const projectSwitching = useProjectSwitching();
   const [expandedAlts, setExpandedAlts] = useState<Record<string, boolean>>({});
   const [expandedTasks, setExpandedTasks] = useState<Record<string, boolean>>({});
+  const [expandedJobCost, setExpandedJobCost] = useState<Record<string, boolean>>({});
+  const [expandedJobSavings, setExpandedJobSavings] = useState<Record<string, boolean>>({});
+  const [expandedWorkerUsage, setExpandedWorkerUsage] = useState<Record<string, boolean>>({});
   const [expandedFindings, setExpandedFindings] = useState<Record<string, boolean>>({});
   // Findings section open/closed per job. Default open (missing key); user toggle sticks.
   const [findingsOpen, setFindingsOpen] = useState<Record<string, boolean>>({});
@@ -1497,9 +1592,13 @@ export default function SwarmPane() {
     const savings = jobSavings(j);
     const showJobTokens = jobTokens(j) > 0;
     const showJobCompactTokens = jobCompactTokens(j) > 0;
-    const showJobCost = hasMeaningfulJobCost(j);
+    const spendSplit = jobSpendSplit(j);
+    const showJobCost = hasMeaningfulJobCost(j) || spendSplit.headline != null;
     const showJobSavings = savings.total > 0;
     const hasHeaderMeters = showJobTokens || showJobCompactTokens || showJobCost || showJobSavings;
+    const costExpanded = !!expandedJobCost[j.id];
+    const savingsExpanded = !!expandedJobSavings[j.id];
+    const finishedWorkers = terminalWorkerCount(tasks);
 
     const toggle = () => {
       const next = !isExpanded;
@@ -1618,29 +1717,93 @@ export default function SwarmPane() {
             </div>
           </div>
 
-          {/* One quiet receipt line: spend first, then execution identity.
-              Rare provenance remains textual so the header never becomes a
-              dashboard of pills. */}
+          {/* Usage meters: one row of stacking pills; identity/provenance stays textual. */}
           {(hasHeaderMeters || headerModel || showJobRoutingPlaceholder || workerCount > 0 || adapter || j.source === "cli" || (workerCount === 0 && attestedPolicy === "explicit_pin")) && (
             <div className="flex items-center gap-x-2 gap-y-1 pl-6 pr-1 mt-1.5 flex-wrap text-[9px]">
               {hasHeaderMeters && (
-                <span className="inline-flex items-center gap-1.5 min-w-0 flex-wrap font-mono text-muted tabular-nums">
-                  {showJobTokens && <span>{jobTokens(j).toLocaleString()}t</span>}
-                  {showJobCompactTokens && (
-                    <span className="text-accent/80">{jobCompactTokens(j).toLocaleString()} compact</span>
-                  )}
-                  {showJobCost && (
+                <div className="inline-flex items-center gap-1 min-w-0 flex-wrap">
+                  {(showJobTokens || showJobCompactTokens) && (
                     <span
-                      className="text-good/85"
-                      title={namedSpend(j.est_cost_usd, spendBasisFor(j))}
+                      className={`${SWARM_METER_PILL} font-mono text-muted tabular-nums`}
+                      title="Token usage"
                     >
-                      {namedSpend(j.est_cost_usd, spendBasisFor(j))}
+                      {showJobTokens && <span>{jobTokens(j).toLocaleString()}t</span>}
+                      {showJobCompactTokens && (
+                        <span className={showJobTokens ? "text-accent/80" : "text-muted"}>
+                          {showJobTokens ? " · " : ""}
+                          {jobCompactTokens(j).toLocaleString()} compact
+                        </span>
+                      )}
                     </span>
                   )}
-                  {showJobSavings && <SavingsChip parts={savings} className="font-sans" />}
+                  {showJobCost && spendSplit.headline != null && (
+                    <div className="inline-flex flex-col gap-0.5 min-w-0">
+                      <button
+                        type="button"
+                        aria-expanded={costExpanded}
+                        aria-label={`Job cost ${fmtMeterMoney(spendSplit.headline)}`}
+                        title={namedSpend(j.est_cost_usd, spendBasisFor(j))}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setExpandedJobCost((prev) => ({ ...prev, [j.id]: !costExpanded }));
+                        }}
+                        onKeyDown={(e) => e.stopPropagation()}
+                        className={`${SWARM_METER_PILL} font-mono text-good/85 tabular-nums hover:border-good/30 transition-colors ${DISCLOSURE_FOCUS}`}
+                      >
+                        {fmtMeterMoney(spendSplit.headline)}
+                        {costExpanded ? <ChevronDown size={8} className="shrink-0" /> : <ChevronRight size={8} className="shrink-0" />}
+                      </button>
+                      {costExpanded && (
+                        <div className="flex flex-col gap-px text-[8.5px] text-muted font-mono tabular-nums pl-1">
+                          <span>
+                            Measured{" "}
+                            <span className="text-txt/80">{fmtMeterMoney(spendSplit.measured)}</span>
+                          </span>
+                          <span>
+                            Estimated{" "}
+                            <span className="text-txt/80">{fmtMeterMoney(spendSplit.estimated)}</span>
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                  {showJobSavings && (
+                    <div className="inline-flex flex-col gap-0.5 min-w-0">
+                      <button
+                        type="button"
+                        aria-expanded={savingsExpanded}
+                        aria-label={namedSavings(savings.total)}
+                        title={savingsDetail(savings)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setExpandedJobSavings((prev) => ({ ...prev, [j.id]: !savingsExpanded }));
+                        }}
+                        onKeyDown={(e) => e.stopPropagation()}
+                        className={`${SWARM_METER_PILL} font-sans text-good/85 tabular-nums hover:border-good/30 transition-colors ${DISCLOSURE_FOCUS}`}
+                      >
+                        <span className="text-good/45" aria-hidden="true">{"\u2193"}</span>
+                        {namedSavings(savings.total)}
+                        {savingsExpanded ? <ChevronDown size={8} className="shrink-0" /> : <ChevronRight size={8} className="shrink-0" />}
+                      </button>
+                      {savingsExpanded && (
+                        <p className="text-[8.5px] text-good/75 leading-snug pl-1 max-w-xs">
+                          {savingsDetail(savings)}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+              {workerCount > 0 && (
+                <span
+                  className={`${SWARM_METER_PILL} text-muted tabular-nums`}
+                  aria-label="Workers"
+                  title={`${finishedWorkers} of ${workerCount} workers terminal`}
+                >
+                  {finishedWorkers}/{workerCount}
                 </span>
               )}
-              {hasHeaderMeters && (headerModel || showJobRoutingPlaceholder || workerCount > 0 || adapter) && (
+              {hasHeaderMeters && (headerModel || showJobRoutingPlaceholder || adapter) && (
                 <span className="h-2.5 w-px bg-edge/70" aria-hidden="true" />
               )}
               {headerModel ? (
@@ -1662,11 +1825,6 @@ export default function SwarmPane() {
                   title="explicit_pin · not auto-routed"
                 >
                   pin
-                </span>
-              )}
-              {workerCount > 0 && (
-                <span className="text-muted tabular-nums">
-                  {workerCount} worker{workerCount > 1 ? "s" : ""}
                 </span>
               )}
               {adapter && adapter.toLowerCase() !== displayModel.toLowerCase() && (
@@ -1835,26 +1993,67 @@ export default function SwarmPane() {
                                   : <ChevronRight size={9} />}
                               </span>
                             </div>
-                            <div className="mt-0.5 flex items-center gap-x-2 gap-y-0.5 min-w-0 flex-wrap">
-                              <WorkerModelSlot view={view} />
-                              {showSpend && (
-                                <span className="text-muted font-mono text-[8.5px] flex items-center gap-1 tabular-nums">
-                                  {showTokens && (
-                                    <span>{Number(task.tokens).toLocaleString()}t</span>
-                                  )}
-                                  {showCost && (
-                                    <span className="text-good/85">
-                                      {spend
-                                        ? namedSpend(costValue, spend.basis)
-                                        : formatWorkerCost(
-                                            costValue,
-                                            costEstimated,
-                                            isPlanBilledRouting(routing),
-                                          )}
-                                    </span>
-                                  )}
+                            <div className="mt-0.5 flex items-center gap-1 min-w-0 flex-wrap">
+                              <span className={`${SWARM_METER_PILL} font-semibold text-txt truncate max-w-[9rem]`}>
+                                {roleLabel}
+                              </span>
+                              {(rawStatus || outcome !== "ok") && (
+                                <span
+                                  className={`${SWARM_METER_PILL} ${
+                                    outcome === "failed"
+                                      ? "text-risk/90"
+                                      : outcome === "degraded"
+                                      ? "text-warn/90"
+                                      : "text-muted"
+                                  }`}
+                                >
+                                  {outcome !== "ok" ? outcome : rawStatus}
                                 </span>
                               )}
+                              {view.slot && (
+                                <span className={`${SWARM_METER_PILL} min-w-0 max-w-full`}>
+                                  <WorkerModelSlot view={view} />
+                                </span>
+                              )}
+                              {showSpend && (() => {
+                                const usageOpen = !!expandedWorkerUsage[task.id];
+                                return (
+                                  <div className="inline-flex flex-col gap-0.5 min-w-0">
+                                    <button
+                                      type="button"
+                                      aria-expanded={usageOpen}
+                                      aria-label="Show tokens and cost"
+                                      className={`${SWARM_METER_PILL} ${DISCLOSURE_FOCUS} font-mono text-muted tabular-nums hover:border-edge transition-colors`}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        setExpandedWorkerUsage((prev) => ({ ...prev, [task.id]: !usageOpen }));
+                                      }}
+                                      onKeyDown={(e) => e.stopPropagation()}
+                                    >
+                                      Usage
+                                      {usageOpen ? <ChevronDown size={8} className="shrink-0" /> : <ChevronRight size={8} className="shrink-0" />}
+                                    </button>
+                                    {usageOpen && (
+                                      <span className="text-muted font-mono text-[8.5px] flex items-center gap-1 tabular-nums pl-1">
+                                        {showTokens && (
+                                          <span>{Number(task.tokens).toLocaleString()}t</span>
+                                        )}
+                                        {showCost && (
+                                          <span className="text-good/85">
+                                            {spend
+                                              ? namedSpend(costValue, spend.basis)
+                                              : formatWorkerCost(
+                                                  costValue,
+                                                  costEstimated,
+                                                  isPlanBilledRouting(routing),
+                                                )}
+                                          </span>
+                                        )}
+                                      </span>
+                                    )}
+                                  </div>
+                                );
+                              })()}
                             </div>
                           </div>
                         </div>

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -219,6 +219,10 @@ export type Job = {
   updated_at?: number | string | null;
   tokens?: number;
   est_cost_usd?: number;
+  /** Measured provider/live spend when split from estimated (financial receipt). */
+  measured_cost_usd?: number | null;
+  /** Estimated/unpriced spend when split from measured (financial receipt). */
+  estimated_cost_usd?: number | null;
   /** provider | live | static | default — how this job's dollars were derived. */
   cost_provenance?: "provider" | "live" | "static" | "default";
   /** True when the dollar figure is not a full provider receipt. */


### PR DESCRIPTION
## Summary
- Tracker header is one row of composer-family pills: tokens, cost, savings, workers N/M.
- Cost pill shows the 293 headline total (measured+estimated). Click expands Measured / Estimated. No new math.
- Worker rows keep role/status/model as pills. Per-worker tokens/$ hide behind a usage pill (collapsed by default).
- Findings (N) unchanged. Pin `puppetmaster-ai==1.22.28`.

## Test plan
- [ ] Header cost starts collapsed; click shows Measured / Estimated
- [ ] Worker usage starts collapsed; click shows tokens and cost
- [ ] Findings (N) still groups as 292