### PR TITLE
v0.9.301: plugin integrity and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.300, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.301, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.300"
+__version__ = "0.9.301"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/agent_plugins.py
+++ b/harness/agent_plugins.py
@@ -7,6 +7,7 @@ No remote schema fetch and no Python import from packages.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -28,7 +29,9 @@ _PLUGIN_FIELDS = {
     "license",
     "keywords",
     "extensions",
+    "permissions",
 }
+_PLUGIN_PERMISSIONS = frozenset({"network", "filesystem"})
 _AUTHOR_FIELDS = {"name", "email", "url"}
 _STDIO_FIELDS = {"type", "command", "args", "env", "cwd"}
 _REMOTE_FIELDS = {"type", "url", "headers"}
@@ -60,6 +63,9 @@ class AgentPluginSkill:
     frontmatter: Mapping[str, Any]
 
 
+STAMP_FILENAME = ".integrity.json"
+
+
 @dataclass(frozen=True)
 class AgentPluginPackage:
     name: str
@@ -70,7 +76,49 @@ class AgentPluginPackage:
     manifest: Mapping[str, Any]
     skills: Tuple[AgentPluginSkill, ...]
     mcp_servers: Mapping[str, Dict[str, Any]]
+    permissions: Tuple[str, ...]
+    content_sha256: str
     diagnostics: Tuple[AgentPluginDiagnostic, ...]
+
+
+def compute_plugin_content_sha256(plugin_root: Path) -> str:
+    """Canonical sha256 over regular files under the installed package root.
+
+    Skips the integrity stamp file itself and any path under ``.git``.
+    Volatile per-install data under ``plugin_data_root`` is outside the package
+    tree and is intentionally excluded.
+    """
+    root = Path(plugin_root).resolve(strict=False)
+    if not root.is_dir():
+        raise AgentPluginError("plugin root must be a directory")
+    hasher = hashlib.sha256()
+    try:
+        paths = sorted(
+            (
+                path
+                for path in root.rglob("*")
+                if path.is_file() and not path.is_symlink()
+            ),
+            key=lambda path: path.relative_to(root).as_posix(),
+        )
+    except OSError as exc:
+        raise AgentPluginError(f"cannot hash plugin contents: {exc}") from exc
+    for path in paths:
+        rel = path.relative_to(root).as_posix()
+        parts = rel.split("/")
+        if STAMP_FILENAME in parts or ".git" in parts:
+            continue
+        hasher.update(rel.encode("utf-8"))
+        hasher.update(b"\0")
+        try:
+            hasher.update(path.read_bytes())
+        except OSError as exc:
+            raise AgentPluginError(f"cannot hash plugin file {rel}: {exc}") from exc
+        hasher.update(b"\0")
+    return hasher.hexdigest()
+
+
+compute_package_sha256 = compute_plugin_content_sha256
 
 
 def _inside(path: Path, root: Path) -> bool:
@@ -249,6 +297,20 @@ def _validate_manifest(root: Path) -> Tuple[dict, List[AgentPluginDiagnostic]]:
                 "plugin.json author may contain only string name, email, and url fields"
             )
 
+    if "permissions" in manifest:
+        permissions = manifest["permissions"]
+        if not isinstance(permissions, list) or any(
+            not isinstance(value, str) for value in permissions
+        ):
+            raise AgentPluginError("plugin.json permissions must be an array of strings")
+        unknown = [value for value in permissions if value not in _PLUGIN_PERMISSIONS]
+        if unknown:
+            raise AgentPluginError(
+                "plugin.json permissions may only include network and filesystem"
+            )
+        if len(set(permissions)) != len(permissions):
+            raise AgentPluginError("plugin.json permissions must not contain duplicates")
+
     if "extensions" in manifest:
         extensions = manifest["extensions"]
         if not isinstance(extensions, dict):
@@ -279,6 +341,13 @@ def _validate_manifest(root: Path) -> Tuple[dict, List[AgentPluginDiagnostic]]:
                         )
 
     return manifest, diagnostics
+
+
+def _manifest_permissions(manifest: Mapping[str, Any]) -> Tuple[str, ...]:
+    raw = manifest.get("permissions")
+    if not isinstance(raw, list):
+        return ()
+    return tuple(value for value in raw if isinstance(value, str))
 
 
 def _valid_skill_frontmatter(
@@ -610,6 +679,8 @@ def load_agent_plugin(plugin_root: Path, data_root: Path) -> AgentPluginPackage:
         manifest=dict(manifest),
         skills=skills,
         mcp_servers=mcp_servers,
+        permissions=_manifest_permissions(manifest),
+        content_sha256=compute_plugin_content_sha256(root),
         diagnostics=tuple(diagnostics),
     )
 

--- a/harness/plugin_registry.py
+++ b/harness/plugin_registry.py
@@ -18,9 +18,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from .agent_plugins import (
+    STAMP_FILENAME,
     AgentPluginDiagnostic,
     AgentPluginError,
     AgentPluginPackage,
+    compute_package_sha256,
     load_agent_plugin,
     read_agent_plugin_manifest,
 )
@@ -34,6 +36,44 @@ _lock = threading.RLock()
 
 def _pmharness_root() -> Path:
     return Path(os.path.expanduser("~/.pmharness"))
+
+
+def integrity_stamp_path(plugin_root: Path) -> Path:
+    return Path(plugin_root) / STAMP_FILENAME
+
+
+def write_integrity_stamp(plugin_root: Path) -> str:
+    digest = compute_package_sha256(plugin_root)
+    payload = {"sha256": digest}
+    path = integrity_stamp_path(plugin_root)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    restrict_to_owner(str(path))
+    return digest
+
+
+def read_integrity_stamp(plugin_root: Path) -> Optional[str]:
+    path = integrity_stamp_path(plugin_root)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    value = data.get("sha256")
+    return value if isinstance(value, str) and value else None
+
+
+def verify_integrity_stamp(plugin_root: Path) -> str:
+    """Return current digest. Raise if stamp missing or mismatched."""
+    current = compute_package_sha256(plugin_root)
+    stamped = read_integrity_stamp(plugin_root)
+    if stamped is None:
+        raise AgentPluginError("plugin integrity stamp is missing")
+    if stamped != current:
+        raise AgentPluginError("plugin integrity stamp mismatch")
+    return current
 
 
 def plugins_dir() -> Path:
@@ -147,6 +187,10 @@ class PluginRecord:
     namespace: str
     skill_count: int = 0
     mcp_count: int = 0
+    permissions: List[str] = field(default_factory=list)
+    content_sha256: str = ""
+    sha256: str = ""
+    stamp_ok: bool = False
     diagnostics: List[Dict[str, str]] = field(default_factory=list)
     error: str = ""
 
@@ -155,6 +199,39 @@ def _diag_dicts(
     diagnostics: Tuple[AgentPluginDiagnostic, ...]
 ) -> List[Dict[str, str]]:
     return [{"scope": d.scope, "message": d.message} for d in diagnostics]
+
+
+def _record_from_package(
+    plugin_id: str,
+    package: AgentPluginPackage,
+    *,
+    enabled: bool,
+    extra_diagnostics: Tuple[AgentPluginDiagnostic, ...] = (),
+    error: str = "",
+    digest: str = "",
+    stamp_ok: bool = False,
+) -> PluginRecord:
+    namespace = portable_skill_namespace(plugin_id)
+    diagnostics = list(_diag_dicts(package.diagnostics))
+    diagnostics.extend(_diag_dicts(extra_diagnostics))
+    sha256 = digest or package.content_sha256
+    return PluginRecord(
+        id=plugin_id,
+        name=package.name,
+        version=package.version,
+        description=package.description,
+        path=str(package.root),
+        enabled=enabled,
+        namespace=namespace,
+        skill_count=len(package.skills),
+        mcp_count=len(package.mcp_servers),
+        permissions=list(package.permissions),
+        content_sha256=sha256,
+        sha256=sha256,
+        stamp_ok=stamp_ok,
+        diagnostics=diagnostics,
+        error=error,
+    )
 
 
 def discover_plugins() -> List[PluginRecord]:
@@ -180,23 +257,37 @@ def discover_plugins() -> List[PluginRecord]:
         namespace = portable_skill_namespace(plugin_id)
         try:
             package = load_agent_plugin(child, plugin_data_root() / namespace)
+            stamp_error = ""
+            stamp_ok = False
+            digest = package.content_sha256
+            try:
+                digest = verify_integrity_stamp(package.root)
+                stamp_ok = True
+            except AgentPluginError as stamp_exc:
+                stamp_error = str(stamp_exc)
+                _diag("agent_plugins.stamp", msg=f"{plugin_id}: {stamp_exc}")
+            extra: Tuple[AgentPluginDiagnostic, ...] = ()
+            if stamp_error:
+                extra = (AgentPluginDiagnostic("integrity", stamp_error),)
             records.append(
-                PluginRecord(
-                    id=plugin_id,
-                    name=package.name,
-                    version=package.version,
-                    description=package.description,
-                    path=str(package.root),
+                _record_from_package(
+                    plugin_id,
+                    package,
                     enabled=plugin_id in enabled,
-                    namespace=namespace,
-                    skill_count=len(package.skills),
-                    mcp_count=len(package.mcp_servers),
-                    diagnostics=_diag_dicts(package.diagnostics),
+                    extra_diagnostics=extra,
+                    error=stamp_error,
+                    digest=digest,
+                    stamp_ok=stamp_ok,
                 )
             )
         except AgentPluginError as exc:
             try:
                 manifest, diagnostics = read_agent_plugin_manifest(child)
+                perms = [
+                    value
+                    for value in (manifest.get("permissions") or [])
+                    if isinstance(value, str)
+                ]
                 records.append(
                     PluginRecord(
                         id=plugin_id,
@@ -206,6 +297,7 @@ def discover_plugins() -> List[PluginRecord]:
                         path=str(child.resolve(strict=False)),
                         enabled=plugin_id in enabled,
                         namespace=namespace,
+                        permissions=perms,
                         diagnostics=_diag_dicts(diagnostics),
                         error=str(exc),
                     )
@@ -262,22 +354,15 @@ def install_from_path(source: str) -> PluginRecord:
             shutil.copytree(str(src), str(dest), symlinks=False)
         except OSError as exc:
             raise AgentPluginError(f"failed to install plugin: {exc}") from exc
+        digest = write_integrity_stamp(dest)
         # Ensure default-disabled: remove from enabled if somehow present.
         enabled = [x for x in _read_enabled() if x != install_id]
         _write_enabled(enabled)
     namespace = portable_skill_namespace(install_id)
     loaded = load_agent_plugin(dest, plugin_data_root() / namespace)
-    return PluginRecord(
-        id=install_id,
-        name=loaded.name,
-        version=loaded.version,
-        description=loaded.description,
-        path=str(loaded.root),
-        enabled=False,
-        namespace=namespace,
-        skill_count=len(loaded.skills),
-        mcp_count=len(loaded.mcp_servers),
-        diagnostics=_diag_dicts(loaded.diagnostics),
+    digest = verify_integrity_stamp(dest)
+    return _record_from_package(
+        install_id, loaded, enabled=False, digest=digest, stamp_ok=True
     )
 
 
@@ -291,22 +376,14 @@ def enable_plugin(plugin_id: str) -> PluginRecord:
         raise AgentPluginError(f"plugin not found: {plugin_id}")
     namespace = portable_skill_namespace(plugin_id)
     package = load_agent_plugin(path, plugin_data_root() / namespace)
+    digest = verify_integrity_stamp(path)
     with _lock:
         enabled = _read_enabled()
         if plugin_id not in enabled:
             enabled.append(plugin_id)
             _write_enabled(enabled)
-    return PluginRecord(
-        id=plugin_id,
-        name=package.name,
-        version=package.version,
-        description=package.description,
-        path=str(package.root),
-        enabled=True,
-        namespace=namespace,
-        skill_count=len(package.skills),
-        mcp_count=len(package.mcp_servers),
-        diagnostics=_diag_dicts(package.diagnostics),
+    return _record_from_package(
+        plugin_id, package, enabled=True, digest=digest, stamp_ok=True
     )
 
 
@@ -328,18 +405,20 @@ def disable_plugin(plugin_id: str) -> PluginRecord:
         enabled = [x for x in _read_enabled() if x != plugin_id]
         _write_enabled(enabled)
     if package is not None:
-        return PluginRecord(
-            id=plugin_id,
-            name=package.name,
-            version=package.version,
-            description=package.description,
-            path=str(package.root),
+        digest = read_integrity_stamp(path) or package.content_sha256
+        stamp_ok = False
+        try:
+            digest = verify_integrity_stamp(path)
+            stamp_ok = True
+        except AgentPluginError:
+            pass
+        return _record_from_package(
+            plugin_id,
+            package,
             enabled=False,
-            namespace=namespace,
-            skill_count=len(package.skills),
-            mcp_count=len(package.mcp_servers),
-            diagnostics=_diag_dicts(package.diagnostics),
             error=record_error,
+            digest=digest,
+            stamp_ok=stamp_ok,
         )
     return PluginRecord(
         id=plugin_id,
@@ -364,6 +443,7 @@ def _load_enabled_packages() -> List[Tuple[str, str, AgentPluginPackage]]:
         namespace = portable_skill_namespace(plugin_id)
         try:
             package = load_agent_plugin(path, plugin_data_root() / namespace)
+            verify_integrity_stamp(path)
         except Exception as exc:
             _diag("agent_plugins.load_enabled", msg=f"{plugin_id}: {exc}")
             continue
@@ -425,6 +505,7 @@ def namespaced_mcp_ids_for_plugin(plugin_id: str) -> List[str]:
         return []
     namespace = portable_skill_namespace(plugin_id)
     try:
+        verify_integrity_stamp(path)
         package = load_agent_plugin(path, plugin_data_root() / namespace)
     except Exception:
         return []
@@ -442,6 +523,10 @@ def plugin_record_to_dict(record: PluginRecord) -> Dict[str, Any]:
         "namespace": record.namespace,
         "skill_count": record.skill_count,
         "mcp_count": record.mcp_count,
+        "permissions": list(record.permissions),
+        "content_sha256": record.content_sha256,
+        "sha256": record.sha256,
+        "stamp_ok": record.stamp_ok,
         "diagnostics": list(record.diagnostics),
         "error": record.error,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.300"
+version = "0.9.301"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -11,15 +11,18 @@ from harness.agent_plugins import (
     MCP_SCHEMA_V1,
     PLUGIN_SCHEMA_V1,
     AgentPluginError,
+    compute_plugin_content_sha256,
     load_agent_plugin,
 )
 from harness.mcp_manager import McpManager
 from harness.plugin_registry import (
     disable_plugin,
+    discover_plugins,
     enable_plugin,
     install_from_path,
     list_enabled_mcp_servers,
     list_enabled_plugin_skills,
+    plugin_record_to_dict,
     portable_skill_namespace,
 )
 
@@ -270,3 +273,72 @@ def test_extensions_marionette_capabilities_survives_load(tmp_path: Path) -> Non
     marionette = package.manifest["extensions"]["marionette"]
     assert marionette["capabilities"] == ["adaptive-depth"]
     assert marionette["task_types"] == ["micro", "standard"]
+
+
+def test_manifest_permissions_surface_on_package(tmp_path: Path) -> None:
+    root = _valid_package(tmp_path / "plugin")
+    _write_json(
+        root / "plugin.json",
+        _manifest(permissions=["network", "filesystem"]),
+    )
+    package = load_agent_plugin(root, tmp_path / "data")
+    assert package.permissions == ("network", "filesystem")
+
+
+@pytest.mark.parametrize(
+    "permissions",
+    [
+        ["sudo"],
+        ["network", "sudo"],
+        ["network", "network"],
+    ],
+)
+def test_rejects_invalid_permissions(tmp_path: Path, permissions: list[str]) -> None:
+    root = _valid_package(tmp_path / "plugin")
+    _write_json(root / "plugin.json", _manifest(permissions=permissions))
+    with pytest.raises(AgentPluginError, match="permissions"):
+        load_agent_plugin(root, tmp_path / "data")
+
+
+def test_install_writes_content_stamp_and_enable_loads(
+    plugins_home: Path, tmp_path: Path
+) -> None:
+    source = _valid_package(tmp_path / "src-plugin")
+    record = install_from_path(str(source))
+    assert record.content_sha256
+    assert record.content_sha256 == compute_plugin_content_sha256(Path(record.path))
+
+    payload = plugin_record_to_dict(record)
+    assert payload["content_sha256"] == record.content_sha256
+    assert payload["permissions"] == []
+
+    enabled = enable_plugin(record.id)
+    assert enabled.enabled is True
+    assert list_enabled_plugin_skills()
+
+
+def test_stamp_mismatch_rejects_enable_and_warns_on_discover(
+    plugins_home: Path, tmp_path: Path
+) -> None:
+    source = _valid_package(tmp_path / "src-plugin")
+    record = install_from_path(str(source))
+    plugin_root = Path(record.path)
+    (plugin_root / "skills" / "summarize" / "SKILL.md").write_text(
+        (plugin_root / "skills" / "summarize" / "SKILL.md").read_text(encoding="utf-8")
+        + "\n# tampered\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AgentPluginError, match="integrity"):
+        enable_plugin(record.id)
+
+    assert list_enabled_plugin_skills() == []
+
+    discovered = discover_plugins()
+    assert len(discovered) == 1
+    row = discovered[0]
+    assert any(d["scope"] == "integrity" for d in row.diagnostics)
+    assert "integrity" in row.error or any(
+        "integrity" in d["message"] for d in row.diagnostics
+    )
+

--- a/tests/test_plugin_integrity.py
+++ b/tests/test_plugin_integrity.py
@@ -1,0 +1,66 @@
+"""Agent plugin integrity stamp + permission list (hermetic)."""
+
+from __future__ import annotations
+
+pytest_plugins = ["tests.test_agent_plugins"]
+
+import json
+from pathlib import Path
+
+import pytest
+
+from harness.agent_plugins import AgentPluginError, PLUGIN_SCHEMA_V1, load_agent_plugin
+from harness.plugin_registry import (
+    enable_plugin,
+    install_from_path,
+    verify_integrity_stamp,
+)
+from tests.test_agent_plugins import _valid_package, _write_json
+
+
+def test_stamp_match_install_and_enable(plugins_home: Path, tmp_path: Path) -> None:
+    source = _valid_package(tmp_path / "src")
+    record = install_from_path(str(source))
+    assert record.stamp_ok is True
+    assert record.sha256
+    assert record.permissions == []
+    enabled = enable_plugin(record.id)
+    assert enabled.enabled is True
+    assert enabled.stamp_ok is True
+
+
+def test_stamp_mismatch_rejects_enable(plugins_home: Path, tmp_path: Path) -> None:
+    source = _valid_package(tmp_path / "src")
+    record = install_from_path(str(source))
+    installed = Path(record.path)
+    (installed / "plugin.json").write_text(
+        (installed / "plugin.json").read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(AgentPluginError, match="mismatch"):
+        enable_plugin(record.id)
+    with pytest.raises(AgentPluginError, match="mismatch"):
+        verify_integrity_stamp(installed)
+
+
+def test_manifest_permissions_surface(tmp_path: Path) -> None:
+    root = _valid_package(tmp_path / "plugin")
+    manifest = json.loads((root / "plugin.json").read_text(encoding="utf-8"))
+    manifest["permissions"] = ["network", "filesystem"]
+    _write_json(root / "plugin.json", manifest)
+    package = load_agent_plugin(root, tmp_path / "data")
+    assert package.permissions == ("network", "filesystem")
+
+
+def test_rejects_unknown_permission(tmp_path: Path) -> None:
+    root = _valid_package(tmp_path / "plugin")
+    _write_json(
+        root / "plugin.json",
+        {
+            "$schema": PLUGIN_SCHEMA_V1,
+            "name": "portable.test",
+            "permissions": ["marketplace"],
+        },
+    )
+    with pytest.raises(AgentPluginError, match="permissions"):
+        load_agent_plugin(root, tmp_path / "data")

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.300"
+version = "0.9.301"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.300",
+  "version": "0.9.301",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.300",
+      "version": "0.9.301",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.300",
+  "version": "0.9.301",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Stamp + permissions on the existing plugin_registry / AgentPluginPackage path.

- In-package `.integrity.json` (`{ "sha256": "<hex>" }`) written by `install_from_path`.
- Canonical sha256 over regular files; skips the stamp file and `.git`.
- `enable_plugin` rejects missing or mismatched stamps.
- `discover_plugins` surfaces integrity diagnostics without crashing; `_load_enabled_packages` skips failed/tampered enabled plugins.
- Manifest `permissions` may only include `network` and `filesystem` (deduped); unknown is fatal.

Pin remains `puppetmaster-ai==1.22.28`. No marketplace. No AGNT. No signing CA.