### PR TITLE
v0.9.302: classify_command on pending approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.301, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.302, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.301"
+__version__ = "0.9.302"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/command_approvals.py
+++ b/harness/api/command_approvals.py
@@ -18,12 +18,10 @@ JsonPayload = Union[dict, list]
 _SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
 
 
-def _decide(
+def _resolve_runner(
     body: dict,
     svc: CommandApprovalServices,
-    *,
-    approve: bool,
-) -> tuple[int, JsonPayload]:
+) -> tuple[int, JsonPayload] | tuple[None, Any]:
     session_id = str(body.get("session_id") or "").strip()
     workspace_root = str(body.get("workspace_root") or "").strip()
     command_hash = str(body.get("command_hash") or "").strip().lower()
@@ -39,6 +37,20 @@ def _decide(
         return 404, {"error": "session runner not found"}
     if getattr(runner, "harness_session_id", "") != session_id:
         return 409, {"error": "session runner scope mismatch"}
+    return None, (runner, session_id, workspace_root, command_hash)
+
+
+def _decide(
+    body: dict,
+    svc: CommandApprovalServices,
+    *,
+    approve: bool,
+) -> tuple[int, JsonPayload]:
+    resolved = _resolve_runner(body, svc)
+    if resolved[0] is not None:
+        return resolved  # type: ignore[return-value]
+    runner, session_id, workspace_root, command_hash = resolved[1]
+
     decide = getattr(runner, "decide_command_approval", None)
     if decide is None:
         return 409, {"error": "session runner cannot accept command approvals"}
@@ -79,3 +91,44 @@ def post_command_rejection(
 ) -> tuple[int, JsonPayload]:
     """POST /api/commands/reject."""
     return _decide(body, svc, approve=False)
+
+
+def post_command_approval_amendment(
+    body: dict, svc: CommandApprovalServices
+) -> tuple[int, JsonPayload]:
+    """POST /api/commands/approve-amendment.
+
+    Consumes the original pending hash and registers a one-shot approval for
+    ``sha256(suggested_amendment)``. Returns the amendment as ``retry_command``
+    plus the new ``command_hash``.
+    """
+    resolved = _resolve_runner(body, svc)
+    if resolved[0] is not None:
+        return resolved  # type: ignore[return-value]
+    runner, session_id, workspace_root, command_hash = resolved[1]
+
+    decide = getattr(runner, "decide_command_approval_amendment", None)
+    if decide is None:
+        return 409, {"error": "session runner cannot accept command amendments"}
+
+    try:
+        pending = decide(
+            command_hash=command_hash,
+            workspace_root=workspace_root,
+        )
+    except PermissionError as exc:
+        return 403, {"error": str(exc)}
+    except ValueError as exc:
+        return 400, {"error": str(exc)}
+    if pending is None:
+        return 404, {"error": "pending command approval not found"}
+
+    return 200, {
+        "ok": True,
+        "decision": "approved_amendment",
+        "session_id": session_id,
+        "workspace_root": pending["workspace_root"],
+        "command_hash": pending["command_hash"],
+        "original_command_hash": pending.get("original_command_hash") or command_hash,
+        "retry_command": pending["command"],
+    }

--- a/harness/command_policy.py
+++ b/harness/command_policy.py
@@ -407,6 +407,32 @@ def classify_command(command: str) -> CommandVerdict:
     return CommandVerdict(False, "", "", "")
 
 
+# Known rewrites only — not a general sanitizer. First rewrite: bare force-push
+# (`--force` / `-f`, but not `--force-with-lease`) → `--force-with-lease`.
+_FORCE_PUSH_LONG = re.compile(r"--force(?!-with-lease)\b", re.IGNORECASE)
+_FORCE_PUSH_SHORT = re.compile(r"(?<![\w-])-f(?![\w-])")
+_GIT_PUSH = re.compile(r"\bgit\s+push\b", re.IGNORECASE)
+
+
+def suggested_amendment(command: str) -> str | None:
+    """Return a safer rewrite for known patterns, else ``None``.
+
+    Only encodes curated substitutions (today: force-push → force-with-lease).
+    Does not invent a general command sanitizer.
+    """
+    cmd = command or ""
+    if not _GIT_PUSH.search(cmd):
+        return None
+    # Already the safe variant — never rewrite --force-with-lease.
+    if _FORCE_PUSH_LONG.search(cmd) is None and _FORCE_PUSH_SHORT.search(cmd) is None:
+        return None
+    amended = _FORCE_PUSH_LONG.sub("--force-with-lease", cmd)
+    amended = _FORCE_PUSH_SHORT.sub("--force-with-lease", amended)
+    if amended == cmd:
+        return None
+    return amended
+
+
 def run_cancellable(
     command: str,
     *,

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -1170,7 +1170,7 @@ class ConversationalSession(
         status: str,
     ) -> dict:
         """Serialize a durable display-transcript command-approval card."""
-        return {
+        row = {
             "type": "command_approval",
             "id": pending.get("action_id") or pending.get("command_hash") or "",
             "command": pending.get("command") or "",
@@ -1182,6 +1182,10 @@ class ConversationalSession(
             "matched": pending.get("matched") or "",
             "status": status,
         }
+        amendment = pending.get("suggested_amendment") or ""
+        if amendment:
+            row["suggested_amendment"] = amendment
+        return row
 
     def _pending_command_approval_from_display_row(self, row: Any) -> Optional[dict]:
         """Validate a durable pending approval card for decision-state restore.
@@ -1219,7 +1223,7 @@ class ConversationalSession(
         row_key = self._approval_workspace_key(workspace_root)
         if not canonical or not row_key or row_key != canonical:
             return None
-        return {
+        pending = {
             "session_id": session_id,
             "workspace_root": os.path.realpath(self.config.repo or ""),
             "command": command,
@@ -1229,6 +1233,15 @@ class ConversationalSession(
             "reason": str(row.get("reason") or ""),
             "matched": str(row.get("matched") or ""),
         }
+        amendment = row.get("suggested_amendment")
+        if isinstance(amendment, str) and amendment.strip():
+            pending["suggested_amendment"] = amendment
+        elif not pending.get("suggested_amendment"):
+            from .command_policy import suggested_amendment as _suggested_amendment
+            rewritten = _suggested_amendment(command)
+            if rewritten:
+                pending["suggested_amendment"] = rewritten
+        return pending
 
     def _restore_pending_command_approvals_from_display(self) -> None:
         """Rebuild in-memory pending decisions from durable display cards.
@@ -1277,6 +1290,7 @@ class ConversationalSession(
         category: str = "",
         reason: str = "",
         matched: str = "",
+        suggested_amendment: str = "",
     ) -> dict:
         """Retain one blocked full-auto command for an operator decision.
 
@@ -1284,6 +1298,12 @@ class ConversationalSession(
         transcript so ring-miss / cursor-gap hydrate can restore the card
         without depending on retained SSE frames.
         """
+        from .command_policy import suggested_amendment as _suggested_amendment
+
+        amendment = (suggested_amendment or "").strip()
+        if not amendment:
+            rewritten = _suggested_amendment(command)
+            amendment = rewritten or ""
         pending = {
             "session_id": self.harness_session_id,
             "workspace_root": os.path.realpath(self.config.repo or ""),
@@ -1294,6 +1314,8 @@ class ConversationalSession(
             "reason": reason or "",
             "matched": matched or "",
         }
+        if amendment:
+            pending["suggested_amendment"] = amendment
         with self._command_approval_lock_guard():
             self._pending_command_approvals[command_hash] = pending
             self._upsert_display_command_approval(pending, status="pending")
@@ -1329,6 +1351,52 @@ class ConversationalSession(
                 status="approved" if approve else "rejected",
             )
             return dict(pending)
+
+    def decide_command_approval_amendment(
+        self,
+        *,
+        command_hash: str,
+        workspace_root: str,
+    ) -> Optional[dict]:
+        """Approve the suggested amendment instead of the original command.
+
+        Consumes the original pending hash, registers a one-shot approval for
+        ``sha256(amendment)``, and returns a payload whose ``command`` /
+        ``command_hash`` refer to the amendment (for retry).
+        """
+        from .command_policy import suggested_amendment as _suggested_amendment
+
+        requested_workspace = self._approval_workspace_key(workspace_root)
+        with self._command_approval_lock_guard():
+            pending = self._pending_command_approvals.get(command_hash)
+            if pending is None:
+                return None
+            pending_workspace = self._approval_workspace_key(
+                pending.get("workspace_root") or ""
+            )
+            if not requested_workspace or requested_workspace != pending_workspace:
+                raise PermissionError("command approval workspace does not match")
+            if pending.get("session_id") != self.harness_session_id:
+                raise PermissionError("command approval session does not match")
+            amendment = str(pending.get("suggested_amendment") or "").strip()
+            if not amendment:
+                amendment = (_suggested_amendment(pending.get("command") or "") or "").strip()
+            if not amendment:
+                raise ValueError("pending command has no suggested amendment")
+            amendment_hash = hashlib.sha256(amendment.encode("utf-8")).hexdigest()
+            self._pending_command_approvals.pop(command_hash, None)
+            self._approved_commands.discard(command_hash)
+            self._approved_commands.add(amendment_hash)
+            self._upsert_display_command_approval(
+                pending,
+                status="approved",
+            )
+            result = dict(pending)
+            result["command"] = amendment
+            result["command_hash"] = amendment_hash
+            result["original_command_hash"] = command_hash
+            result["suggested_amendment"] = amendment
+            return result
 
     def register_pending_secret_request(self, payload: dict):
         from .secret_request import register_pending_secret_request

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -140,6 +140,9 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
         "/api/commands/reject": post_json(
             _command_approval_api.post_command_rejection,
             services=svc.command_approval_services),
+        "/api/commands/approve-amendment": post_json(
+            _command_approval_api.post_command_approval_amendment,
+            services=svc.command_approval_services),
         "/api/secrets/submit": post_json(
             _secrets_api.post_secrets_submit,
             services=svc.command_approval_services),

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -3222,6 +3222,11 @@ def dispatch_local_action(
                     "category": pending.get("category") or block.get("category"),
                     "reason": pending.get("reason") or block.get("reason"),
                     "matched": pending.get("matched") or block.get("matched"),
+                    **(
+                        {"suggested_amendment": pending["suggested_amendment"]}
+                        if pending.get("suggested_amendment")
+                        else {}
+                    ),
                 })
                 # Pair action_start so turn-end settle cannot invent opaque
                 # "missing action_result" while the approval card is open.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.301"
+version = "0.9.302"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_command_approvals.py
+++ b/tests/test_api_command_approvals.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from harness.api.command_approvals import (
     CommandApprovalServices,
     post_command_approval,
+    post_command_approval_amendment,
     post_command_rejection,
 )
 from harness.config import HarnessConfig
@@ -218,3 +219,102 @@ def test_api_approve_after_export_load_history_roundtrip(tmp_path):
     assert wrong[0] == 403
     assert command_hash in restored2._pending_command_approvals
     assert os.path.realpath(str(tmp_path / "other")) != pending["workspace_root"]
+
+
+def test_approve_amendment_uses_new_hash(tmp_path):
+    """Approve-amendment registers sha256(amendment); original approve path unchanged."""
+    cfg = HarnessConfig(repo=str(tmp_path), state_dir=str(tmp_path / "st"))
+    session = ConversationalSession(cfg)
+    session.harness_session_id = "session-a"
+    command = "git push --force origin main"
+    command_hash = hashlib.sha256(command.encode()).hexdigest()
+    amendment = "git push --force-with-lease origin main"
+    amendment_hash = hashlib.sha256(amendment.encode()).hexdigest()
+    pending = session.register_pending_command_approval(
+        command=command,
+        command_hash=command_hash,
+        action_id="call-amend",
+        category="force-push",
+        reason="history-rewriting git push",
+        matched="git push --force",
+    )
+    assert pending.get("suggested_amendment") == amendment
+    services = _services({"session-a": session})
+
+    status, payload = post_command_approval_amendment(
+        {
+            "session_id": "session-a",
+            "workspace_root": pending["workspace_root"],
+            "command_hash": command_hash,
+        },
+        services,
+    )
+    assert status == 200
+    assert payload["decision"] == "approved_amendment"
+    assert payload["retry_command"] == amendment
+    assert payload["command_hash"] == amendment_hash
+    assert payload["original_command_hash"] == command_hash
+    assert command_hash not in session._pending_command_approvals
+    assert amendment_hash in session._approved_commands
+    assert command_hash not in session._approved_commands
+
+
+def test_original_approve_path_unchanged_for_force_push(tmp_path):
+    """Approving the original command still approves the original hash."""
+    cfg = HarnessConfig(repo=str(tmp_path), state_dir=str(tmp_path / "st"))
+    session = ConversationalSession(cfg)
+    session.harness_session_id = "session-a"
+    command = "git push -f"
+    command_hash = hashlib.sha256(command.encode()).hexdigest()
+    pending = session.register_pending_command_approval(
+        command=command,
+        command_hash=command_hash,
+        action_id="call-orig",
+        category="force-push",
+        reason="history-rewriting git push",
+        matched="git push -f",
+    )
+    assert pending.get("suggested_amendment") == "git push --force-with-lease"
+    services = _services({"session-a": session})
+
+    status, payload = post_command_approval(
+        {
+            "session_id": "session-a",
+            "workspace_root": pending["workspace_root"],
+            "command_hash": command_hash,
+        },
+        services,
+    )
+    assert status == 200
+    assert payload["decision"] == "approved"
+    assert payload["retry_command"] == command
+    assert payload["command_hash"] == command_hash
+    assert command_hash in session._approved_commands
+
+
+def test_approve_amendment_rejects_when_no_suggestion(tmp_path):
+    cfg = HarnessConfig(repo=str(tmp_path), state_dir=str(tmp_path / "st"))
+    session = ConversationalSession(cfg)
+    session.harness_session_id = "session-a"
+    command = "ssh prod reboot"
+    command_hash = hashlib.sha256(command.encode()).hexdigest()
+    pending = session.register_pending_command_approval(
+        command=command,
+        command_hash=command_hash,
+        action_id="call-no-amend",
+        category="remote-shell",
+        reason="ssh",
+        matched="ssh",
+    )
+    assert not pending.get("suggested_amendment")
+    status, payload = post_command_approval_amendment(
+        {
+            "session_id": "session-a",
+            "workspace_root": pending["workspace_root"],
+            "command_hash": command_hash,
+        },
+        _services({"session-a": session}),
+    )
+    assert status == 400
+    assert "amendment" in payload["error"].lower()
+    assert command_hash in session._pending_command_approvals

--- a/tests/test_command_policy.py
+++ b/tests/test_command_policy.py
@@ -155,3 +155,33 @@ def test_verdict_shape():
     assert v.danger and v.category and v.reason and v.matched
     safe = classify_command("ls")
     assert not safe.danger and safe.category == "" and safe.matched == ""
+
+
+# ---- suggested_amendment: known rewrites only ---------------------------------
+
+from harness.command_policy import suggested_amendment
+
+
+@pytest.mark.parametrize("cmd,want", [
+    ("git push --force origin main", "git push --force-with-lease origin main"),
+    ("git push -f", "git push --force-with-lease"),
+    ("git push -f origin HEAD:main", "git push --force-with-lease origin HEAD:main"),
+    ("GIT push --Force origin main", "GIT push --force-with-lease origin main"),
+])
+def test_force_push_suggests_force_with_lease(cmd, want):
+    assert suggested_amendment(cmd) == want
+
+
+def test_force_with_lease_has_no_amendment():
+    assert suggested_amendment("git push --force-with-lease origin main") is None
+
+
+@pytest.mark.parametrize("cmd", [
+    "git push origin main",
+    "rm -rf /",
+    "ssh prod reboot",
+    "ls -la",
+    "",
+])
+def test_unknown_commands_have_no_amendment(cmd):
+    assert suggested_amendment(cmd) is None

--- a/tests/test_http_routes_table.py
+++ b/tests/test_http_routes_table.py
@@ -45,6 +45,7 @@ _SAMPLE_GUARDED_POST = (
     "/api/file/write",
     "/api/commands/approve",
     "/api/commands/reject",
+    "/api/commands/approve-amendment",
     "/api/restart",
     "/api/session/interrupt",
     "/api/session/compact",

--- a/tests/test_json_body_limit.py
+++ b/tests/test_json_body_limit.py
@@ -25,6 +25,7 @@ _POST_ROUTES_SAMPLE = (
     "/api/mcp/refresh",
     "/api/commands/approve",
     "/api/commands/reject",
+    "/api/commands/approve-amendment",
 )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.301"
+version = "0.9.302"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.301",
+  "version": "0.9.302",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.301",
+      "version": "0.9.302",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.301",
+  "version": "0.9.302",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CommandApprovalCard.test.tsx
+++ b/webapp/src/__tests__/CommandApprovalCard.test.tsx
@@ -6,7 +6,7 @@ import {
 } from "../components/TranscriptList";
 
 
-function pendingApproval(): CommandApprovalItem {
+function pendingApproval(overrides: Partial<CommandApprovalItem> = {}): CommandApprovalItem {
   return {
     kind: "command_approval",
     id: "call-1",
@@ -18,13 +18,17 @@ function pendingApproval(): CommandApprovalItem {
     reason: "remote command execution",
     matched: "ssh",
     status: "pending",
+    ...overrides,
   };
 }
 
-function renderApproval(onCommandApproval = vi.fn()) {
+function renderApproval(
+  item: CommandApprovalItem = pendingApproval(),
+  onCommandApproval = vi.fn(),
+) {
   render(
     <TranscriptList
-      items={[pendingApproval()]}
+      items={[item]}
       status="done"
       compactingStatus={null}
       editingIndex={null}
@@ -51,6 +55,8 @@ describe("full-auto command approval card", () => {
     expect(screen.getByText("Command needs approval")).toBeTruthy();
     expect(screen.getByText(/Full-auto did not run this command/i)).toBeTruthy();
     expect(screen.getByText("ssh prod reboot")).toBeTruthy();
+    expect(screen.getByText(/category: remote-shell/i)).toBeTruthy();
+    expect(screen.getByText(/matched: ssh/i)).toBeTruthy();
     expect(decide).not.toHaveBeenCalled();
   });
 
@@ -75,5 +81,30 @@ describe("full-auto command approval card", () => {
     fireEvent.click(screen.getByRole("button", { name: "Reject" }));
 
     expect(decide).toHaveBeenCalledWith(expect.any(Object), false);
+  });
+
+  it("shows a third button when a suggested amendment is present", () => {
+    const decide = renderApproval(pendingApproval({
+      command: "git push --force origin main",
+      category: "force-push",
+      reason: "history-rewriting git push",
+      matched: "git push --force",
+      suggestedAmendment: "git push --force-with-lease origin main",
+    }));
+
+    expect(screen.getByText(/Suggested safer rewrite/i)).toBeTruthy();
+    expect(screen.getByText("git push --force-with-lease origin main")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Approve suggested amendment" }));
+    expect(decide).toHaveBeenCalledWith(
+      expect.objectContaining({
+        suggestedAmendment: "git push --force-with-lease origin main",
+      }),
+      "amendment",
+    );
+  });
+
+  it("hides the amendment button when no rewrite exists", () => {
+    renderApproval();
+    expect(screen.queryByRole("button", { name: "Approve suggested amendment" })).toBeNull();
   });
 });

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -3315,15 +3315,20 @@ export default function Conversation({
     []
   );
   const handleCommandApproval = useCallback(
-    (item: CommandApprovalItem, approve: boolean) => {
+    (item: CommandApprovalItem, decision: boolean | "amendment") => {
+      const approveOriginal = decision === true;
+      const approveAmendment = decision === "amendment";
+      const approve = approveOriginal || approveAmendment;
       setItems((current) => updateCommandApproval(
         current,
         item.commandHash,
         { status: "approving", error: undefined },
       ));
-      const request = approve
-        ? api.approveCommand(item.sessionId, item.workspaceRoot, item.commandHash)
-        : api.rejectCommand(item.sessionId, item.workspaceRoot, item.commandHash);
+      const request = approveAmendment
+        ? api.approveCommandAmendment(item.sessionId, item.workspaceRoot, item.commandHash)
+        : approveOriginal
+          ? api.approveCommand(item.sessionId, item.workspaceRoot, item.commandHash)
+          : api.rejectCommand(item.sessionId, item.workspaceRoot, item.commandHash);
       void request.then((response) => {
         setItems((current) => updateCommandApproval(
           current,

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -223,6 +223,7 @@ export type CommandApprovalItem = {
   category: string;
   reason: string;
   matched: string;
+  suggestedAmendment?: string;
   status: "pending" | "approving" | "approved" | "rejected" | "error";
   error?: string;
 };
@@ -1128,7 +1129,7 @@ export type TranscriptListProps = {
   onImageClick: (url: string) => void;
   onSetCard: (id: string, patch: Partial<Card>) => void;
   onExecutePlan: (planText: string) => void;
-  onCommandApproval: (item: CommandApprovalItem, approve: boolean) => void;
+  onCommandApproval: (item: CommandApprovalItem, decision: boolean | "amendment") => void;
   onSecretRequest?: (item: SecretRequestItem, decision: { action: "save"; value: string } | { action: "dismiss" }) => void;
   /** Relaunch the failed turn after provider auth recovery (Settings still opens). */
   onAuthFailureRetry?: () => void;
@@ -1419,6 +1420,7 @@ export const TranscriptList = memo(function TranscriptList({
     } else if (it.kind === "command_approval") {
       const decisionPending = it.status === "pending" || it.status === "error";
       const statusCopy = commandApprovalStatusCopy(it.status);
+      const amendment = (it.suggestedAmendment || "").trim();
       return (
         <div
           key={key}
@@ -1433,6 +1435,13 @@ export const TranscriptList = memo(function TranscriptList({
                 Full-auto did not run this command.{" "}
                 {it.reason || it.category || "Safety policy requires an explicit decision."}
               </div>
+              {(it.category || it.matched) ? (
+                <div className="mt-1 text-[10px] text-faint font-mono">
+                  {it.category ? <span>category: {it.category}</span> : null}
+                  {it.category && it.matched ? <span> · </span> : null}
+                  {it.matched ? <span>matched: {it.matched}</span> : null}
+                </div>
+              ) : null}
               <button
                 type="button"
                 onClick={(e) => {
@@ -1445,8 +1454,14 @@ export const TranscriptList = memo(function TranscriptList({
               >
                 {it.command}
               </button>
+              {amendment ? (
+                <div className="mt-1.5 text-[10px] text-muted">
+                  Suggested safer rewrite:{" "}
+                  <span className="font-mono text-accent/85">{amendment}</span>
+                </div>
+              ) : null}
               {it.error ? <div className="mt-1.5 text-risk/90">{it.error}</div> : null}
-              <div className="mt-2 flex items-center gap-2">
+              <div className="mt-2 flex flex-wrap items-center gap-2">
                 {decisionPending ? (
                   <>
                     <button
@@ -1456,6 +1471,15 @@ export const TranscriptList = memo(function TranscriptList({
                     >
                       Approve once and retry
                     </button>
+                    {amendment ? (
+                      <button
+                        type="button"
+                        onClick={() => onCommandApproval(it, "amendment")}
+                        className="rounded-md border border-edge bg-panel px-2.5 py-1 font-medium text-txt hover:border-accent/40"
+                      >
+                        Approve suggested amendment
+                      </button>
+                    ) : null}
                     <button
                       type="button"
                       onClick={() => onCommandApproval(it, false)}

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -62,7 +62,7 @@ export default function ConversationChatColumn({
   onImageClick: (url: string) => void;
   onSetCard: (id: string, patch: Partial<Card>) => void;
   onExecutePlan: (planText: string) => void;
-  onCommandApproval: (item: CommandApprovalItem, approve: boolean) => void;
+  onCommandApproval: (item: CommandApprovalItem, decision: boolean | "amendment") => void;
   onSecretRequest?: (item: SecretRequestItem, decision: { action: "save"; value: string } | { action: "dismiss" }) => void;
   onAuthFailureRetry?: () => void;
   composerDock: ReactNode;

--- a/webapp/src/components/conversation/streamApply.ts
+++ b/webapp/src/components/conversation/streamApply.ts
@@ -900,6 +900,7 @@ export function appendCommandApproval(
     category?: string;
     reason?: string;
     matched?: string;
+    suggested_amendment?: string;
   },
 ): Item[] {
   // Reject empty/malformed hashes so they cannot occupy the empty-string
@@ -913,6 +914,7 @@ export function appendCommandApproval(
   )) {
     return items;
   }
+  const suggestedAmendment = (data.suggested_amendment || "").trim();
   return [
     ...items,
     {
@@ -925,6 +927,7 @@ export function appendCommandApproval(
       category: data.category || "",
       reason: data.reason || "",
       matched: data.matched || "",
+      ...(suggestedAmendment ? { suggestedAmendment } : {}),
       status: "pending",
     },
   ];

--- a/webapp/src/components/conversation/transcriptItems.ts
+++ b/webapp/src/components/conversation/transcriptItems.ts
@@ -454,6 +454,9 @@ export function transcriptResponseToItems(res: {
           category: m.category || "",
           reason: m.reason || "",
           matched: m.matched || "",
+          ...(typeof m.suggested_amendment === "string" && m.suggested_amendment.trim()
+            ? { suggestedAmendment: m.suggested_amendment.trim() }
+            : {}),
           status,
           ...(typeof m.error === "string" && m.error ? { error: m.error } : {}),
         }];

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1308,6 +1308,20 @@ export const api = {
       workspace_root: workspaceRoot,
       command_hash: commandHash,
     }),
+  approveCommandAmendment: (sessionId: string, workspaceRoot: string, commandHash: string) =>
+    postJSON<{
+      ok: boolean;
+      decision: "approved_amendment";
+      session_id: string;
+      workspace_root: string;
+      command_hash: string;
+      original_command_hash: string;
+      retry_command: string;
+    }>("/api/commands/approve-amendment", {
+      session_id: sessionId,
+      workspace_root: workspaceRoot,
+      command_hash: commandHash,
+    }),
   rejectCommand: (sessionId: string, workspaceRoot: string, commandHash: string) =>
     postJSON<{ ok: boolean; decision: "rejected"; command_hash: string }>(
       "/api/commands/reject",


### PR DESCRIPTION
## Summary
- Surface `classify_command` verdict (`category` / `reason` / `matched`) on pending full-auto command approvals.
- Known rewrite only: `git push --force` / `-f` → `--force-with-lease` as `suggested_amendment`.
- Third action: `POST /api/commands/approve-amendment` approves the amendment (new hash). Original approve/reject unchanged.
- Pin still `puppetmaster-ai==1.22.28`. No Guardian / hooks / execpolicy / Otel.

## Test plan
- [x] `suggested_amendment` hermetic cases in `tests/test_command_policy.py`
- [x] approve-amendment API + CommandApprovalCard tests
- [ ] CI green