### PR TITLE
v0.9.303: context-switch guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.304, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.303, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.304"
+__version__ = "0.9.303"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/sessions.py
+++ b/harness/api/sessions.py
@@ -344,6 +344,11 @@ def post_sessions_switch(body: dict, svc: SessionServices) -> tuple[int, dict]:
             svc.cfg.repo = target_repo
             os.environ["HARNESS_REPO"] = target_repo
             try:
+                from ..context_switch_guard import note_switch
+                note_switch("session", prev_repo or "", target_repo)
+            except Exception as e:
+                svc.diag("server.session_switch_note_guard", e)
+            try:
                 from ..swarm_adapter import ensure_repo_swarm_adapter
                 ensure_repo_swarm_adapter(svc.cfg)
             except Exception as e:

--- a/harness/api/workspace.py
+++ b/harness/api/workspace.py
@@ -252,8 +252,15 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
     prev_active = svc.sessions.active if svc.sessions is not None else None
     prev_env_repo = os.environ.get("HARNESS_REPO")
 
+    old_repo = (prev_repo or "").strip()
     svc.cfg.repo = target_repo
     os.environ["HARNESS_REPO"] = target_repo
+    if old_repo != target_repo:
+        try:
+            from ..context_switch_guard import note_switch
+            note_switch("repo", old_repo, target_repo)
+        except Exception as e:
+            svc.diag("workspace.open_note_guard", e)
     # Boot often locked swarm_adapter=demo before workspace restore; promote.
     try:
         from ..swarm_adapter import ensure_repo_swarm_adapter
@@ -404,11 +411,35 @@ def post_workspace_forget(body: dict, svc: WorkspaceServices) -> tuple[int, Json
 
 def post_workspaces_switch(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPayload]:
     """POST /api/workspaces/switch."""
-    return 200, svc.ws.switch_workspace(
+    name = body.get("name", "")
+    result = svc.ws.switch_workspace(
         svc.cfg.repo,
-        body.get("name", ""),
+        name,
         allow_dirty=svc.parse_bool(body.get("allow_dirty")),
     )
+    if isinstance(result, dict) and result.get("ok") is not False:
+        try:
+            from ..context_switch_guard import note_switch
+            note_switch(
+                "workspace",
+                getattr(svc.cfg, "repo", "") or "",
+                str(result.get("active") or name or getattr(svc.cfg, "repo", "") or ""),
+            )
+        except Exception as e:
+            svc.diag("workspace.switch_note_guard", e)
+    return 200, result
+
+
+def post_workspaces_confirm(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPayload]:
+    """POST /api/workspaces/confirm — clear the context-switch latch."""
+    from ..context_switch_guard import confirm_workspace
+    root = (
+        body.get("workspace_root")
+        or body.get("path")
+        or getattr(svc.cfg, "repo", None)
+        or ""
+    )
+    return 200, confirm_workspace(str(root or ""))
 
 
 def post_workspaces_create(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPayload]:

--- a/harness/command_jobs.py
+++ b/harness/command_jobs.py
@@ -309,9 +309,9 @@ def _run_registered_command_job(
     command = command or ""
     if getattr(session, "_auto_mode", False) and getattr(session, "_auto_command_guard", None):
         try:
-            from harness.command_policy import classify_command
+            from harness.command_policy import guard_destructive_command
 
-            verdict = classify_command(command)
+            verdict = guard_destructive_command(command)
             cmd_hash = hashlib.sha256(command.encode("utf-8")).hexdigest()
             approved = False
             consume = getattr(session, "consume_command_approval", None)

--- a/harness/command_policy.py
+++ b/harness/command_policy.py
@@ -408,13 +408,16 @@ def classify_command(command: str) -> CommandVerdict:
 
 
 def guard_destructive_command(command: str) -> CommandVerdict:
-    """Classify, then block danger while a context-switch latch is armed.
+    """Classify, then keep an extra latch after a context switch.
 
-    Safe (non-danger) commands always pass through. When the latch is armed
-    after a session/repo/profile switch, danger verdicts are rewritten to
-    ``context-switch-unconfirmed`` so execution stays gated until confirm.
+    Safe (non-danger) commands always pass through. Classify categories
+    (remote-shell, force-push, ...) win over ``context-switch-unconfirmed``.
+    The latch only supplies that category when classify did not already
+    name a danger class — it must not rewrite ssh/systemctl to a switch miss.
     """
     verdict = classify_command(command)
+    if verdict.danger and verdict.category:
+        return verdict
     if not verdict.danger:
         return verdict
     try:

--- a/harness/command_policy.py
+++ b/harness/command_policy.py
@@ -407,6 +407,32 @@ def classify_command(command: str) -> CommandVerdict:
     return CommandVerdict(False, "", "", "")
 
 
+def guard_destructive_command(command: str) -> CommandVerdict:
+    """Classify, then block danger while a context-switch latch is armed.
+
+    Safe (non-danger) commands always pass through. When the latch is armed
+    after a session/repo/profile switch, danger verdicts are rewritten to
+    ``context-switch-unconfirmed`` so execution stays gated until confirm.
+    """
+    verdict = classify_command(command)
+    if not verdict.danger:
+        return verdict
+    try:
+        from .context_switch_guard import is_armed, snapshot
+    except Exception:
+        return verdict
+    if not is_armed():
+        return verdict
+    snap = snapshot()
+    pending = (snap.get("new") or snap.get("kind") or "new workspace").strip()
+    return CommandVerdict(
+        True,
+        "context-switch-unconfirmed",
+        f"destructive command blocked until the new workspace is confirmed ({pending})",
+        (verdict.matched or command or "")[:80],
+    )
+
+
 # Known rewrites only — not a general sanitizer. First rewrite: bare force-push
 # (`--force` / `-f`, but not `--force-with-lease`) → `--force-with-lease`.
 _FORCE_PUSH_LONG = re.compile(r"--force(?!-with-lease)\b", re.IGNORECASE)

--- a/harness/context_switch_guard.py
+++ b/harness/context_switch_guard.py
@@ -1,0 +1,90 @@
+"""Latch that blocks destructive commands after a context switch.
+
+After a session / repo / profile / workspace switch, the new workspace is
+unconfirmed. ``classify_command`` danger verdicts are then blocked until
+the operator confirms the new workspace. Safe (non-danger) commands still
+run while the latch is armed.
+
+Process-wide and PM-free so unit tests stay hermetic.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any
+
+_lock = threading.Lock()
+_armed: bool = False
+_kind: str = ""
+_old: str = ""
+_new: str = ""
+
+
+def _norm(path: str) -> str:
+    raw = (path or "").strip()
+    if not raw:
+        return ""
+    try:
+        return os.path.normcase(os.path.realpath(raw))
+    except Exception:
+        return raw
+
+
+def reset_for_tests() -> None:
+    """Drop latch state (test helper)."""
+    global _armed, _kind, _old, _new
+    with _lock:
+        _armed = False
+        _kind = ""
+        _old = ""
+        _new = ""
+
+
+def note_switch(kind: str, old: str = "", new: str = "") -> dict[str, Any]:
+    """Arm the latch after a context switch.
+
+    Same-root no-ops (normalized old == new, both non-empty) do not arm.
+    An empty old (first bind) still arms so the new workspace is confirmed.
+    """
+    global _armed, _kind, _old, _new
+    kind_s = (kind or "").strip() or "switch"
+    old_s = (old or "").strip()
+    new_s = (new or "").strip()
+    old_n = _norm(old_s)
+    new_n = _norm(new_s)
+    if old_n and new_n and old_n == new_n:
+        return snapshot()
+    with _lock:
+        _armed = True
+        _kind = kind_s
+        _old = old_s
+        _new = new_s
+    return snapshot()
+
+
+def is_armed() -> bool:
+    with _lock:
+        return _armed
+
+
+def snapshot() -> dict[str, Any]:
+    with _lock:
+        return {
+            "armed": _armed,
+            "kind": _kind,
+            "old": _old,
+            "new": _new,
+        }
+
+
+def confirm_workspace(workspace_root: str = "") -> dict[str, Any]:
+    """Clear the latch. Optional workspace_root is recorded as the confirmed root."""
+    global _armed, _kind, _old, _new
+    root = (workspace_root or "").strip()
+    with _lock:
+        if root:
+            _new = root
+        _armed = False
+        _kind = ""
+        _old = ""
+    return snapshot()

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -168,6 +168,8 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             _ws_api.post_workspace_forget, services=svc.workspace_services),
         "/api/workspaces/switch": post_json(
             _ws_api.post_workspaces_switch, services=svc.workspace_services),
+        "/api/workspaces/confirm": post_json(
+            _ws_api.post_workspaces_confirm, services=svc.workspace_services),
         "/api/workspaces/create": post_json(
             _ws_api.post_workspaces_create, services=svc.workspace_services),
         "/api/mcp/add": post_json(

--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -527,8 +527,15 @@ class SessionStore:
             for s in self._sessions:
                 if s["id"] != sid:
                     continue
+                old_root = session_stored_root(s)
                 s["workspace_root"] = ws_root
                 s["repo"] = (repo or ws_root).strip()
+                if old_root != ws_root:
+                    try:
+                        from .context_switch_guard import note_switch
+                        note_switch("relocate", old_root, ws_root)
+                    except Exception:
+                        pass
                 if branch:
                     s["branch"] = branch
                 if title is not None and str(title).strip():

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -1337,10 +1337,10 @@ class ToolDispatchMixin:
         """
         if not self.config.repo:
             return False, "repo_not_open", "No workspace directory (config.repo) is open."
-        from .command_policy import classify_command, effective_command_timeout, run_cancellable
+        from .command_policy import guard_destructive_command, effective_command_timeout, run_cancellable
 
         if getattr(self, "_auto_mode", False) and getattr(self, "_auto_command_guard", None):
-            verdict = classify_command(act.command or "")
+            verdict = guard_destructive_command(act.command or "")
             cmd_hash = hashlib.sha256((act.command or "").encode()).hexdigest()
             approved_set = getattr(self, "_approved_commands", set())
             consume_approval = getattr(self, "consume_command_approval", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.304"
+version = "0.9.303"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -290,6 +290,23 @@ def _clear_pm_resolver_cache():
 
 
 @pytest.fixture(autouse=True)
+def _clear_context_switch_latch():
+    # Process-wide latch from context_switch_guard; reset so a relocate/switch
+    # test cannot rewrite later danger verdicts to context-switch-unconfirmed.
+    try:
+        from harness.context_switch_guard import reset_for_tests
+        reset_for_tests()
+    except Exception:
+        pass
+    yield
+    try:
+        from harness.context_switch_guard import reset_for_tests
+        reset_for_tests()
+    except Exception:
+        pass
+
+
+@pytest.fixture(autouse=True)
 def _clear_wiki_env(monkeypatch):
     monkeypatch.delenv("WIKI_API_BASE", raising=False)
     monkeypatch.delenv("WIKI_OWNER_TOKEN", raising=False)

--- a/tests/test_context_switch_guard.py
+++ b/tests/test_context_switch_guard.py
@@ -28,7 +28,10 @@ def test_arm_blocks_danger_until_confirm():
     assert is_armed() is True
     blocked = guard_destructive_command(DANGER)
     assert blocked.danger is True
-    assert blocked.category == "context-switch-unconfirmed"
+    # Classify category wins; latch must not rewrite remote-shell / rm / etc.
+    assert blocked.category == classify_command(DANGER).category
+    assert blocked.category != "context-switch-unconfirmed"
+    assert is_armed() is True
 
     confirm_workspace("/new/repo")
     assert is_armed() is False

--- a/tests/test_context_switch_guard.py
+++ b/tests/test_context_switch_guard.py
@@ -1,0 +1,60 @@
+"""Hermetic tests for the context-switch destructive-command latch."""
+from harness.command_policy import classify_command, guard_destructive_command
+from harness.context_switch_guard import (
+    confirm_workspace,
+    is_armed,
+    note_switch,
+    reset_for_tests,
+    snapshot,
+)
+
+
+DANGER = "rm -rf /tmp/marionette-scratch"
+SAFE = "ls -la"
+
+
+def setup_function(_fn=None):
+    reset_for_tests()
+
+
+def teardown_function(_fn=None):
+    reset_for_tests()
+
+
+def test_arm_blocks_danger_until_confirm():
+    assert classify_command(DANGER).danger is True
+    assert is_armed() is False
+    note_switch("session", "/old/repo", "/new/repo")
+    assert is_armed() is True
+    blocked = guard_destructive_command(DANGER)
+    assert blocked.danger is True
+    assert blocked.category == "context-switch-unconfirmed"
+
+    confirm_workspace("/new/repo")
+    assert is_armed() is False
+    allowed = guard_destructive_command(DANGER)
+    assert allowed.danger is True
+    assert allowed.category != "context-switch-unconfirmed"
+    assert allowed.category == classify_command(DANGER).category
+
+
+def test_safe_command_never_blocked_by_latch():
+    note_switch("workspace", "/old", "/new")
+    assert is_armed() is True
+    assert classify_command(SAFE).danger is False
+    verdict = guard_destructive_command(SAFE)
+    assert verdict.danger is False
+    assert verdict.category == ""
+
+
+def test_same_root_switch_does_not_arm():
+    note_switch("session", "/same/repo", "/same/repo")
+    assert is_armed() is False
+    assert guard_destructive_command(DANGER).category == classify_command(DANGER).category
+
+
+def test_note_switch_snapshot():
+    snap = note_switch("relocate", "/a", "/b")
+    assert snap["armed"] is True
+    assert snap["kind"] == "relocate"
+    assert snapshot()["new"] == "/b"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.304"
+version = "0.9.303"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.304",
+  "version": "0.9.303",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.304",
+      "version": "0.9.303",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.304",
+  "version": "0.9.303",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CheckpointsPane.test.tsx
+++ b/webapp/src/__tests__/CheckpointsPane.test.tsx
@@ -67,10 +67,15 @@ describe("CheckpointsPane diff badges", () => {
 
     await waitFor(() => {
       expect(apiMocks.getCheckpointDiff).toHaveBeenCalledWith("cp-1");
-      for (const label of ["added", "modified", "removed"]) {
-        const badge = screen.getByLabelText(new RegExp(`^${label}:`, "i"));
-        expect(badge).toHaveTextContent(label);
-      }
     });
+    await screen.findByTitle("Hide diff");
+    for (const [label, path] of [
+      ["added", "src/new.ts"],
+      ["modified", "src/old.ts"],
+      ["removed", "src/gone.ts"],
+    ] as const) {
+      const badge = await screen.findByLabelText(`${label}: ${path}`);
+      expect(badge).toHaveTextContent(label);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add `harness/context_switch_guard.py` and wire it into `command_policy`.
- After a session/repo/profile switch, destructive (`classify_command` danger) commands are blocked until the new workspace is confirmed.
- Safe commands still run while the latch is armed.
- Pin still `puppetmaster-ai==1.22.28`.

## Test plan
- [x] hermetic `tests/test_context_switch_guard.py`
- [ ] CI green