### PR TITLE
v0.9.304: billing envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.302, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.304, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.302"
+__version__ = "0.9.304"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/usage.py
+++ b/harness/api/usage.py
@@ -44,6 +44,53 @@ class UsageServices:
 JsonPayload = Union[dict, list]
 
 
+def _usage_spent_usd(payload: dict) -> float:
+    """Reuse GET /api/usage session dollars — no second cost formula."""
+    session = payload.get("session") if isinstance(payload, dict) else None
+    if not isinstance(session, dict):
+        return 0.0
+    try:
+        return max(0.0, float(session.get("est_cost_usd") or 0.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def attach_billing_envelope(payload: dict) -> dict:
+    """Fold monthly envelope onto a usage payload (works with no runner)."""
+    from harness.billing_envelope import observe_spend
+
+    out = dict(payload) if isinstance(payload, dict) else {"session": {}, "jobs": []}
+    try:
+        out["envelope"] = observe_spend(_usage_spent_usd(out))
+    except Exception:
+        from harness.billing_envelope import snapshot, load_envelope
+
+        try:
+            out["envelope"] = snapshot(load_envelope())
+        except Exception:
+            out["envelope"] = {
+                "month_key": "",
+                "spent_usd": 0.0,
+                "cap": None,
+                "remaining": None,
+                "blocked": False,
+                "auto_reload": {"enabled": False, "amount": 0.0},
+                "last_reload": None,
+            }
+    return out
+
+
+def post_usage(body: dict) -> tuple[int, JsonPayload]:
+    """POST /api/usage — set monthly cap and optional auto-reload intent."""
+    from harness.billing_envelope import apply_settings
+
+    try:
+        env = apply_settings(body if isinstance(body, dict) else {})
+    except ValueError as exc:
+        return 400, {"error": str(exc)}
+    return 200, {"envelope": env}
+
+
 
 def _merge_swarm_by_model(acc: dict, by_model) -> None:
     if not isinstance(by_model, dict):
@@ -95,6 +142,18 @@ def get_context_usage(svc: UsageServices) -> tuple[int, JsonPayload]:
 
 
 def get_usage(repo_override: str, svc: UsageServices) -> tuple[int, JsonPayload]:
+    """GET /api/usage — process-lifetime StatusBar cost pill.
+
+    Must succeed with no live turn / no session runner: meters default to
+    zero and the billing envelope is still returned.
+    """
+    try:
+        return _get_usage_body(repo_override, svc)
+    except Exception:
+        return 200, attach_billing_envelope({"session": {}, "jobs": []})
+
+
+def _get_usage_body(repo_override: str, svc: UsageServices) -> tuple[int, JsonPayload]:
     """GET /api/usage — process-lifetime StatusBar cost pill."""
     # Resolve real per-Mtok pricing for the active driver via resolve_price
     # (historical seam: live → catalog → defaults). Surface price_source so
@@ -141,7 +200,7 @@ def get_usage(repo_override: str, svc: UsageServices) -> tuple[int, JsonPayload]
     )
     cached_usage = svc.usage_cache_get(usage_cache_key)
     if cached_usage is not None:
-        return 200, cached_usage
+        return 200, attach_billing_envelope(cached_usage)
     tokens_used = int(boot_meters.get("_tokens_used", 0) or 0)
     t_in = int(boot_meters.get("_tokens_in", 0) or 0)
     t_cached = int(boot_meters.get("_tokens_cached", 0) or 0)
@@ -536,4 +595,4 @@ def get_usage(repo_override: str, svc: UsageServices) -> tuple[int, JsonPayload]
         svc.usage_cache_put(usage_cache_key, response_data)
     except Exception:
         pass
-    return 200, response_data
+    return 200, attach_billing_envelope(response_data)

--- a/harness/billing_envelope.py
+++ b/harness/billing_envelope.py
@@ -1,0 +1,196 @@
+"""Monthly billing envelope: cap + optional auto-reload intent.
+
+Persists under HARNESS_STATE_DIR (or ~/.pmharness). Does not charge a card.
+Spend figures are whatever the caller already computed — no second cost math.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .secure_files import restrict_to_owner
+
+_FILENAME = "billing_envelope.json"
+_lock = threading.RLock()
+
+
+def _state_dir() -> Path:
+    explicit = (os.environ.get("HARNESS_STATE_DIR") or "").strip()
+    if explicit:
+        return Path(explicit)
+    return Path(os.path.expanduser("~/.pmharness"))
+
+
+def envelope_path() -> Path:
+    return _state_dir() / _FILENAME
+
+
+def month_key(now: Optional[datetime] = None) -> str:
+    stamp = now or datetime.now(timezone.utc)
+    return stamp.strftime("%Y-%m")
+
+
+def _empty(month: str) -> Dict[str, Any]:
+    return {
+        "month": month,
+        "spent_usd": 0.0,
+        "cap_usd": None,
+        "auto_reload": {"enabled": False, "amount_usd": 0.0},
+        "last_reload": None,
+    }
+
+
+def load_envelope() -> Dict[str, Any]:
+    path = envelope_path()
+    month = month_key()
+    if not path.is_file():
+        return _empty(month)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return _empty(month)
+    if not isinstance(data, dict):
+        return _empty(month)
+    stored_month = str(data.get("month") or "")
+    if stored_month != month:
+        data = _empty(month)
+    else:
+        try:
+            data["spent_usd"] = float(data.get("spent_usd") or 0.0)
+        except (TypeError, ValueError):
+            data["spent_usd"] = 0.0
+        cap = data.get("cap_usd")
+        if cap is not None:
+            try:
+                data["cap_usd"] = float(cap)
+            except (TypeError, ValueError):
+                data["cap_usd"] = None
+        reload_cfg = data.get("auto_reload")
+        if not isinstance(reload_cfg, dict):
+            data["auto_reload"] = {"enabled": False, "amount_usd": 0.0}
+        else:
+            try:
+                amount = float(reload_cfg.get("amount_usd") or 0.0)
+            except (TypeError, ValueError):
+                amount = 0.0
+            data["auto_reload"] = {
+                "enabled": bool(reload_cfg.get("enabled")),
+                "amount_usd": amount,
+            }
+    return data
+
+
+def save_envelope(data: Dict[str, Any]) -> Dict[str, Any]:
+    path = envelope_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = dict(data)
+    payload["month"] = str(payload.get("month") or month_key())
+    with _lock:
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        restrict_to_owner(str(path))
+    return payload
+
+
+def set_envelope(*, cap_usd: Any = None, auto_reload_enabled: Any = None, auto_reload_amount: Any = None) -> Dict[str, Any]:
+    with _lock:
+        data = load_envelope()
+        if cap_usd is not None:
+            if cap_usd == "" or cap_usd is False:
+                data["cap_usd"] = None
+            else:
+                data["cap_usd"] = float(cap_usd)
+        reload_cfg = dict(data.get("auto_reload") or {})
+        if auto_reload_enabled is not None:
+            reload_cfg["enabled"] = bool(auto_reload_enabled)
+        if auto_reload_amount is not None:
+            reload_cfg["amount_usd"] = float(auto_reload_amount)
+        data["auto_reload"] = {
+            "enabled": bool(reload_cfg.get("enabled")),
+            "amount_usd": float(reload_cfg.get("amount_usd") or 0.0),
+        }
+        if data["auto_reload"]["enabled"] and data["auto_reload"]["amount_usd"] > 0:
+            data["last_reload"] = {"intent": True, "amount_usd": data["auto_reload"]["amount_usd"]}
+        return save_envelope(data)
+
+
+def sync_spent(spent_usd: float) -> Dict[str, Any]:
+    """Record caller-computed spend for the current month. No new cost math."""
+    with _lock:
+        data = load_envelope()
+        try:
+            data["spent_usd"] = max(0.0, float(spent_usd))
+        except (TypeError, ValueError):
+            data["spent_usd"] = 0.0
+        return save_envelope(data)
+
+
+def envelope_public(data: Optional[Dict[str, Any]] = None, *, spent_usd: Optional[float] = None) -> Dict[str, Any]:
+    env = dict(data or load_envelope())
+    if spent_usd is not None:
+        try:
+            env["spent_usd"] = max(0.0, float(spent_usd))
+        except (TypeError, ValueError):
+            pass
+    cap = env.get("cap_usd")
+    spent = float(env.get("spent_usd") or 0.0)
+    remaining = None
+    blocked = False
+    if cap is not None:
+        remaining = round(float(cap) - spent, 6)
+        blocked = spent >= float(cap)
+    reload_cfg = env.get("auto_reload") if isinstance(env.get("auto_reload"), dict) else {}
+    return {
+        "month": env.get("month") or month_key(),
+        "spent_usd": round(spent, 6),
+        "cap_usd": None if cap is None else float(cap),
+        "remaining_usd": remaining,
+        "blocked": blocked,
+        "auto_reload": {
+            "enabled": bool(reload_cfg.get("enabled")),
+            "amount_usd": float(reload_cfg.get("amount_usd") or 0.0),
+        },
+        "last_reload": env.get("last_reload"),
+    }
+
+
+
+def snapshot(data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    public = envelope_public(data)
+    return {
+        "month_key": public["month"],
+        "spent_usd": public["spent_usd"],
+        "cap": public["cap_usd"],
+        "remaining": public["remaining_usd"],
+        "blocked": public["blocked"],
+        "auto_reload": {
+            "enabled": public["auto_reload"]["enabled"],
+            "amount": public["auto_reload"]["amount_usd"],
+        },
+        "last_reload": public["last_reload"],
+    }
+
+
+def observe_spend(spent_usd: float) -> Dict[str, Any]:
+    return snapshot(sync_spent(spent_usd))
+
+
+def apply_settings(body: Dict[str, Any]) -> Dict[str, Any]:
+    body = body or {}
+    cap = body.get("cap_usd", body.get("cap"))
+    enabled = body.get("auto_reload_enabled")
+    if enabled is None:
+        raw = body.get("auto_reload")
+        if isinstance(raw, dict):
+            enabled = raw.get("enabled")
+            if body.get("auto_reload_amount_usd") is None and body.get("amount_usd") is None:
+                body = dict(body)
+                body["auto_reload_amount_usd"] = raw.get("amount_usd", raw.get("amount"))
+        elif raw is not None:
+            enabled = raw
+    amount = body.get("auto_reload_amount_usd", body.get("amount_usd"))
+    env = set_envelope(cap_usd=cap, auto_reload_enabled=enabled, auto_reload_amount=amount)
+    return snapshot(env)

--- a/harness/billing_envelope.py
+++ b/harness/billing_envelope.py
@@ -31,7 +31,14 @@ def envelope_path() -> Path:
 
 def month_key(now: Optional[datetime] = None) -> str:
     stamp = now or datetime.now(timezone.utc)
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    else:
+        stamp = stamp.astimezone(timezone.utc)
     return stamp.strftime("%Y-%m")
+
+
+utc_month_key = month_key
 
 
 def _empty(month: str) -> Dict[str, Any]:
@@ -44,9 +51,9 @@ def _empty(month: str) -> Dict[str, Any]:
     }
 
 
-def load_envelope() -> Dict[str, Any]:
+def load_envelope(*, now: Optional[datetime] = None) -> Dict[str, Any]:
     path = envelope_path()
-    month = month_key()
+    month = month_key(now)
     if not path.is_file():
         return _empty(month)
     try:
@@ -57,7 +64,14 @@ def load_envelope() -> Dict[str, Any]:
         return _empty(month)
     stored_month = str(data.get("month") or "")
     if stored_month != month:
+        kept_cap = data.get("cap_usd")
+        kept_reload = data.get("auto_reload") if isinstance(data.get("auto_reload"), dict) else {}
         data = _empty(month)
+        data["cap_usd"] = kept_cap
+        data["auto_reload"] = {
+            "enabled": bool(kept_reload.get("enabled")),
+            "amount_usd": float(kept_reload.get("amount_usd") or 0.0),
+        }
     else:
         try:
             data["spent_usd"] = float(data.get("spent_usd") or 0.0)
@@ -84,20 +98,20 @@ def load_envelope() -> Dict[str, Any]:
     return data
 
 
-def save_envelope(data: Dict[str, Any]) -> Dict[str, Any]:
+def save_envelope(data: Dict[str, Any], *, now: Optional[datetime] = None) -> Dict[str, Any]:
     path = envelope_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = dict(data)
-    payload["month"] = str(payload.get("month") or month_key())
+    payload["month"] = str(payload.get("month") or month_key(now))
     with _lock:
         path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
         restrict_to_owner(str(path))
     return payload
 
 
-def set_envelope(*, cap_usd: Any = None, auto_reload_enabled: Any = None, auto_reload_amount: Any = None) -> Dict[str, Any]:
+def set_envelope(*, cap_usd: Any = None, auto_reload_enabled: Any = None, auto_reload_amount: Any = None, now: Optional[datetime] = None) -> Dict[str, Any]:
     with _lock:
-        data = load_envelope()
+        data = load_envelope(now=now)
         if cap_usd is not None:
             if cap_usd == "" or cap_usd is False:
                 data["cap_usd"] = None
@@ -112,20 +126,50 @@ def set_envelope(*, cap_usd: Any = None, auto_reload_enabled: Any = None, auto_r
             "enabled": bool(reload_cfg.get("enabled")),
             "amount_usd": float(reload_cfg.get("amount_usd") or 0.0),
         }
-        if data["auto_reload"]["enabled"] and data["auto_reload"]["amount_usd"] > 0:
-            data["last_reload"] = {"intent": True, "amount_usd": data["auto_reload"]["amount_usd"]}
-        return save_envelope(data)
+        cap = data.get("cap_usd")
+        spent = float(data.get("spent_usd") or 0.0)
+        if data["auto_reload"]["enabled"] and cap is not None and spent >= float(cap):
+            amount = float(data["auto_reload"]["amount_usd"] or 0.0)
+            stamp = now or datetime.now(timezone.utc)
+            if stamp.tzinfo is None:
+                stamp = stamp.replace(tzinfo=timezone.utc)
+            else:
+                stamp = stamp.astimezone(timezone.utc)
+            data["last_reload"] = {
+                "intent": True,
+                "charged": False,
+                "at": stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "amount": amount,
+                "amount_usd": amount,
+            }
+        return save_envelope(data, now=now)
 
 
-def sync_spent(spent_usd: float) -> Dict[str, Any]:
+def sync_spent(spent_usd: float, *, now: Optional[datetime] = None) -> Dict[str, Any]:
     """Record caller-computed spend for the current month. No new cost math."""
     with _lock:
-        data = load_envelope()
+        data = load_envelope(now=now)
         try:
-            data["spent_usd"] = max(0.0, float(spent_usd))
+            data["spent_usd"] = max(float(data.get("spent_usd") or 0.0), max(0.0, float(spent_usd)))
         except (TypeError, ValueError):
             data["spent_usd"] = 0.0
-        return save_envelope(data)
+        cap = data.get("cap_usd")
+        reload_cfg = data.get("auto_reload") or {}
+        if reload_cfg.get("enabled") and cap is not None and float(data.get("spent_usd") or 0.0) >= float(cap):
+            amount = float(reload_cfg.get("amount_usd") or 0.0)
+            stamp = now or datetime.now(timezone.utc)
+            if stamp.tzinfo is None:
+                stamp = stamp.replace(tzinfo=timezone.utc)
+            else:
+                stamp = stamp.astimezone(timezone.utc)
+            data["last_reload"] = {
+                "intent": True,
+                "charged": False,
+                "at": stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "amount": amount,
+                "amount_usd": amount,
+            }
+        return save_envelope(data, now=now)
 
 
 def envelope_public(data: Optional[Dict[str, Any]] = None, *, spent_usd: Optional[float] = None) -> Dict[str, Any]:
@@ -174,11 +218,11 @@ def snapshot(data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     }
 
 
-def observe_spend(spent_usd: float) -> Dict[str, Any]:
-    return snapshot(sync_spent(spent_usd))
+def observe_spend(spent_usd: float, *, now: Optional[datetime] = None) -> Dict[str, Any]:
+    return snapshot(sync_spent(spent_usd, now=now))
 
 
-def apply_settings(body: Dict[str, Any]) -> Dict[str, Any]:
+def apply_settings(body: Optional[Dict[str, Any]] = None, *, now: Optional[datetime] = None) -> Dict[str, Any]:
     body = body or {}
     cap = body.get("cap_usd", body.get("cap"))
     enabled = body.get("auto_reload_enabled")
@@ -192,5 +236,5 @@ def apply_settings(body: Dict[str, Any]) -> Dict[str, Any]:
         elif raw is not None:
             enabled = raw
     amount = body.get("auto_reload_amount_usd", body.get("amount_usd"))
-    env = set_envelope(cap_usd=cap, auto_reload_enabled=enabled, auto_reload_amount=amount)
+    env = set_envelope(cap_usd=cap, auto_reload_enabled=enabled, auto_reload_amount=amount, now=now)
     return snapshot(env)

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -105,6 +105,7 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
     from .api import settings as _settings_api
     from .api import skills as _skills_api
     from .api import terminals as _term_api
+    from .api import usage as _usage_api
     from .api import wiki as _wiki_api
     from .api import workspace as _ws_api
     from .api import worktrees as _wt_api
@@ -307,6 +308,7 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             _plat_api.post_platform, services=svc.platform_services),
         "/api/settings": post_json(
             _settings_api.post_settings, services=svc.settings_services),
+        "/api/usage": post_json(_usage_api.post_usage),
         "/api/providers/probe": post_json(_prov_api.post_providers_probe),
         "/api/providers/key": post_json(
             _prov_api.post_providers_key, services=svc.provider_services),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.302"
+version = "0.9.304"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_billing_envelope.py
+++ b/tests/test_billing_envelope.py
@@ -9,7 +9,7 @@ from harness.billing_envelope import (
     apply_settings,
     load_envelope,
     observe_spend,
-    utc_month_key,
+    month_key,
 )
 
 
@@ -62,7 +62,7 @@ def test_usage_without_runner_returns_envelope(tmp_path, monkeypatch):
     assert code == 200
     assert "session" in payload
     env = payload["envelope"]
-    assert env["month_key"] == utc_month_key()
+    assert env["month_key"] == month_key()
     assert env["month_key"] == datetime.now(timezone.utc).strftime("%Y-%m")
     assert env["spent_usd"] == 0.42
     assert env["cap"] is None
@@ -78,7 +78,7 @@ def test_usage_survives_missing_services(tmp_path, monkeypatch):
     svc.boot_usage_meters = lambda: (_ for _ in ()).throw(RuntimeError("no meters"))
     code, payload = get_usage("", svc)
     assert code == 200
-    assert payload["envelope"]["month_key"] == utc_month_key()
+    assert payload["envelope"]["month_key"] == month_key()
     assert payload["envelope"]["spent_usd"] == 0.0
 
 
@@ -137,11 +137,11 @@ def test_month_key_rolls_spent(tmp_path, monkeypatch):
     apply_settings({"cap": 20.0}, now=july)
     observe_spend(4.0, now=july)
     stored = load_envelope(now=july)
-    assert stored["month_key"] == "2026-07"
+    assert stored["month"] == "2026-07"
     assert stored["spent_usd"] == 4.0
 
     august = datetime(2026, 8, 1, 0, 1, tzinfo=timezone.utc)
     rolled = load_envelope(now=august)
-    assert rolled["month_key"] == "2026-08"
+    assert rolled["month"] == "2026-08"
     assert rolled["spent_usd"] == 0.0
-    assert rolled["cap"] == 20.0
+    assert rolled["cap_usd"] == 20.0

--- a/tests/test_billing_envelope.py
+++ b/tests/test_billing_envelope.py
@@ -1,0 +1,147 @@
+"""Hermetic monthly billing envelope + /api/usage without a runner."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from harness.api.usage import UsageServices, get_usage, post_usage
+from harness.billing_envelope import (
+    apply_settings,
+    load_envelope,
+    observe_spend,
+    utc_month_key,
+)
+
+
+def _svc(*, driver="m1", repo="", meters=None, cache=None, pilot=None):
+    meters = meters or {
+        "_tokens_used": 100,
+        "_tokens_cached": 10,
+        "_worker_tokens_in": 0,
+        "_worker_tokens_out": 0,
+        "_worker_cost_usd": 0.0,
+        "_provider_cost_usd": 0.0,
+    }
+    store = {} if cache is None else cache
+    return UsageServices(
+        cfg=SimpleNamespace(driver=driver, repo=repo),
+        boot_repos=lambda: set(),
+        boot_usage_meters=lambda: dict(meters),
+        usage_cache_get=lambda k: store.get(k),
+        usage_cache_put=lambda k, p: store.__setitem__(k, p),
+        boot_session_cost=lambda pin, pout: 0.42,
+        scoped_jobs_with_stores=lambda repo_root=None: ([], None, None),
+        job_in_cost_window=lambda created: True,
+        swarm_registry=lambda: [],
+        job_swarm_accounting=lambda arts, reg: (0, 0.0),
+        tokens_cached_swarm=lambda arts: 0,
+        job_savings_fields=lambda jid: {},
+        active_session_total=lambda ids, arts, reg: None,
+        sum_job_set_savings=lambda ids, arts, reg, **kw: (0.0, 0.0),
+        sum_job_set_savings_detail=lambda ids, arts, reg, **kw: {
+            "routing_saved_usd": 0.0,
+            "cache_saved_usd_swarm": 0.0,
+            "routing_savings_basis": "unknown",
+            "routing_tokens_compared": 0,
+        },
+        cache_savings=lambda cached, pin: 0.0,
+        cache_savings_gross=lambda cached, pin: 0.0,
+        boot_cost_source=lambda: "estimated",
+        tool_output_savings_fields=lambda pin, process_wide=False: {},
+        persist_boot_usage=lambda **kw: None,
+        retry_on_locked=lambda fn: fn(),
+        diag=lambda *a, **k: None,
+        get_pilot=lambda: (_ for _ in ()).throw(RuntimeError("no runner")),
+    ), store
+
+
+def test_usage_without_runner_returns_envelope(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    svc, _ = _svc()
+    code, payload = get_usage("", svc)
+    assert code == 200
+    assert "session" in payload
+    env = payload["envelope"]
+    assert env["month_key"] == utc_month_key()
+    assert env["month_key"] == datetime.now(timezone.utc).strftime("%Y-%m")
+    assert env["spent_usd"] == 0.42
+    assert env["cap"] is None
+    assert env["remaining"] is None
+    assert env["blocked"] is False
+    assert env["auto_reload"] == {"enabled": False, "amount": 0.0}
+    assert env["last_reload"] is None
+
+
+def test_usage_survives_missing_services(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    svc, _ = _svc()
+    svc.boot_usage_meters = lambda: (_ for _ in ()).throw(RuntimeError("no meters"))
+    code, payload = get_usage("", svc)
+    assert code == 200
+    assert payload["envelope"]["month_key"] == utc_month_key()
+    assert payload["envelope"]["spent_usd"] == 0.0
+
+
+def test_cap_blocks_when_spent_reaches_cap(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    status, body = post_usage({"cap": 0.10})
+    assert status == 200
+    assert body["envelope"]["cap"] == 0.10
+    assert body["envelope"]["blocked"] is False
+
+    env = observe_spend(0.10)
+    assert env["blocked"] is True
+    assert env["remaining"] == 0.0
+    assert env["spent_usd"] == 0.10
+
+    svc, _ = _svc()
+    code, payload = get_usage("", svc)
+    assert code == 200
+    assert payload["envelope"]["blocked"] is True
+    assert payload["envelope"]["spent_usd"] >= 0.10
+
+
+def test_auto_reload_persists_intent_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    status, body = post_usage({
+        "cap": 1.0,
+        "auto_reload": {"enabled": True, "amount": 5.0},
+    })
+    assert status == 200
+    auto = body["envelope"]["auto_reload"]
+    assert auto["enabled"] is True
+    assert auto["amount"] == 5.0
+    assert body["envelope"]["last_reload"] is None
+
+    env = apply_settings({})  # reload from disk
+    assert env["auto_reload"]["enabled"] is True
+    assert env["auto_reload"]["amount"] == 5.0
+
+    blocked = observe_spend(1.5)
+    assert blocked["blocked"] is True
+    last = blocked["last_reload"]
+    assert last is not None
+    assert last["amount"] == 5.0
+    assert last["charged"] is False
+    assert last["at"]
+    # Cap is unchanged — no card charge / no reload of funds.
+    assert blocked["cap"] == 1.0
+    disk = load_envelope()
+    assert disk["auto_reload"]["enabled"] is True
+    assert disk["last_reload"]["charged"] is False
+
+
+def test_month_key_rolls_spent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    july = datetime(2026, 7, 31, 23, 0, tzinfo=timezone.utc)
+    apply_settings({"cap": 20.0}, now=july)
+    observe_spend(4.0, now=july)
+    stored = load_envelope(now=july)
+    assert stored["month_key"] == "2026-07"
+    assert stored["spent_usd"] == 4.0
+
+    august = datetime(2026, 8, 1, 0, 1, tzinfo=timezone.utc)
+    rolled = load_envelope(now=august)
+    assert rolled["month_key"] == "2026-08"
+    assert rolled["spent_usd"] == 0.0
+    assert rolled["cap"] == 20.0

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.302"
+version = "0.9.304"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.302",
+  "version": "0.9.304",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.302",
+      "version": "0.9.304",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.302",
+  "version": "0.9.304",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Monthly billing envelope (cap, spent, remaining, optional auto-reload intent).
- GET /api/usage works with no live turn and includes the envelope.
- POST /api/usage sets cap / auto-reload. No card charge. Pin still `puppetmaster-ai==1.22.28`.
- Parallel to #148 (0.9.303); rebase after 303 merges.

## Test plan
- [x] hermetic `tests/test_billing_envelope.py`
- [ ] CI green