### PR TITLE
v0.9.305: prime refine/budget/trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.303, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.305, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.303"
+__version__ = "0.9.305"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/settings.py
+++ b/harness/api/settings.py
@@ -29,6 +29,15 @@ class SettingsServices:
 JsonPayload = Union[dict, list]
 
 
+def _session_trace_export_enabled() -> bool:
+    try:
+        from ..session_trace import session_trace_export_enabled
+
+        return bool(session_trace_export_enabled())
+    except Exception:
+        return False
+
+
 def get_config(svc: SettingsServices) -> tuple[int, JsonPayload]:
     """GET /api/config."""
     cfg = svc.cfg
@@ -78,7 +87,7 @@ def get_config(svc: SettingsServices) -> tuple[int, JsonPayload]:
         "reasoning_effort": reasoning_effort,
         "package_version": identity.get("package_version", ""),
         "checkout_sha": identity.get("checkout_sha", ""),
-        "session_trace_export": (os.environ.get("HARNESS_SESSION_TRACE_EXPORT") or "").strip().lower() in ("1", "true", "yes", "on"),
+        "session_trace_export": _session_trace_export_enabled(),
         "app_root": identity.get("app_root", ""),
         "key_bootstrap_issues": key_bootstrap_issues,
     }
@@ -208,6 +217,9 @@ def post_settings(body: dict, svc: SettingsServices) -> tuple[int, JsonPayload]:
     if "hash_edit_enabled" in body:
         he_val = svc.parse_bool(body["hash_edit_enabled"])
         _set_env_setting("HARNESS_HASH_EDIT", "1" if he_val else "0")
+    if "session_trace_export" in body:
+        ste_val = svc.parse_bool(body["session_trace_export"])
+        _set_env_setting("HARNESS_SESSION_TRACE_EXPORT", "1" if ste_val else "0")
     if "verifyCommand" in body:
         vc_val = str(body["verifyCommand"]).strip()
         cfg.verify_command = vc_val

--- a/harness/api/settings.py
+++ b/harness/api/settings.py
@@ -78,6 +78,7 @@ def get_config(svc: SettingsServices) -> tuple[int, JsonPayload]:
         "reasoning_effort": reasoning_effort,
         "package_version": identity.get("package_version", ""),
         "checkout_sha": identity.get("checkout_sha", ""),
+        "session_trace_export": (os.environ.get("HARNESS_SESSION_TRACE_EXPORT") or "").strip().lower() in ("1", "true", "yes", "on"),
         "app_root": identity.get("app_root", ""),
         "key_bootstrap_issues": key_bootstrap_issues,
     }

--- a/harness/api/skills.py
+++ b/harness/api/skills.py
@@ -202,6 +202,62 @@ def post_memory_propose_dismiss(body: dict, svc: SkillsServices) -> tuple[int, J
     return code, result
 
 
+def post_refine(body: dict, svc: SkillsServices) -> tuple[int, JsonPayload]:
+    """POST /api/refine — slash /refine or propose on HarnessRefineController."""
+    pilot = svc.get_pilot()
+    if not pilot or not hasattr(pilot, "handle_refine_slash"):
+        return 404, {"ok": False, "error": "no active session"}
+    command = (body.get("command") or "").strip()
+    text = (body.get("text") or "").strip()
+    if command or text.startswith("/refine"):
+        return 200, pilot.handle_refine_slash(command or text)
+    kind = (body.get("kind") or "memory").strip() or "memory"
+    scope = (body.get("scope") or "global").strip() or "global"
+    from ..harness_refine import get_refine_controller
+
+    prop = get_refine_controller(pilot).propose(kind=kind, text=text, scope=scope)
+    if prop is None:
+        return 400, {"ok": False, "error": "could not propose refine"}
+    return 200, {"ok": True, "proposed": prop.to_dict()}
+
+
+def get_refine_history(svc: SkillsServices) -> tuple[int, JsonPayload]:
+    """GET /api/refine/history."""
+    pilot = svc.get_pilot()
+    if not pilot or not hasattr(pilot, "refine_history"):
+        return 404, {"ok": False, "error": "no active session"}
+    return 200, {"ok": True, "history": pilot.refine_history()}
+
+
+def post_refine_propose(body: dict, svc: SkillsServices) -> tuple[int, JsonPayload]:
+    """POST /api/refine/propose — create a pending card on HarnessRefineController."""
+    text = (body.get("text") or "").strip()
+    if not text:
+        return 400, {"ok": False, "error": "missing text"}
+    kind = (body.get("kind") or "memory").strip().lower() or "memory"
+    # Allow "/refine rule Prefer X" style: leading kind token peels off.
+    parts = text.split(None, 1)
+    if len(parts) == 2 and parts[0].lower() in ("memory", "rule", "skill", "role"):
+        kind = parts[0].lower()
+        text = parts[1].strip()
+    if not text:
+        return 400, {"ok": False, "error": "missing text"}
+    scope = (body.get("scope") or "global").strip().lower() or "global"
+    pilot = svc.get_pilot()
+    if not pilot or not hasattr(pilot, "propose_refine"):
+        return 404, {"ok": False, "error": "no active session"}
+    result = pilot.propose_refine(
+        kind=kind,
+        text=text,
+        scope=scope,
+        category=str(body.get("category") or "general"),
+        name=str(body.get("name") or ""),
+        body=str(body.get("body") or ""),
+    )
+    code = 200 if result.get("ok") else 400
+    return code, result
+
+
 def post_refine_propose_accept(body: dict, svc: SkillsServices) -> tuple[int, JsonPayload]:
     """POST /api/refine/propose/accept."""
     proposal_id = (body.get("id") or "").strip()

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -1114,6 +1114,33 @@ class ConversationalSession(
         self._persist_session_goal()
         return item if isinstance(item, dict) else {"ok": True}
 
+    def propose_refine(
+        self,
+        *,
+        kind: str = "memory",
+        text: str = "",
+        scope: str = "global",
+        category: str = "general",
+        name: str = "",
+        body: str = "",
+    ) -> dict:
+        """Slash /refine and API create a pending card on the existing controller."""
+        from .harness_refine import get_refine_controller
+
+        prop = get_refine_controller(self).propose(
+            kind=kind,
+            text=text,
+            scope=scope,
+            category=category,
+            name=name,
+            body=body,
+        )
+        if prop is None:
+            return {"ok": False, "error": "refine proposal rejected"}
+        out = prop.to_dict()
+        out["ok"] = True
+        return out
+
     def accept_refine_proposal(self, proposal_id: str) -> dict:
         from .harness_refine import get_refine_controller
 
@@ -1128,6 +1155,16 @@ class ConversationalSession(
         from .harness_refine import get_refine_controller
 
         return get_refine_controller(self).rollback()
+
+    def handle_refine_slash(self, raw: str) -> dict:
+        from .harness_refine import get_refine_controller
+
+        return get_refine_controller(self).handle_slash(raw)
+
+    def refine_history(self, *, limit: int = 50) -> list:
+        from .harness_refine import get_refine_controller
+
+        return get_refine_controller(self).list_history(limit=limit)
 
     def _command_approval_lock_guard(self) -> threading.Lock:
         """Return the approval lock, installing one on legacy/minimal sessions.

--- a/harness/harness_refine.py
+++ b/harness/harness_refine.py
@@ -20,6 +20,7 @@ REFINE_SCOPES = ("local", "global")
 FORBIDDEN_KINDS = ("system_prompt", "system", "frozen_system_prompt")
 LOCAL_REFINE_FILENAME = "local_refine.json"
 SNAPSHOT_FILENAME = "refine_snapshot.json"
+HISTORY_FILENAME = "refinements.jsonl"
 
 
 def _now() -> float:
@@ -146,6 +147,76 @@ class HarnessRefineController:
         self._snapshot_path = (
             os.path.join(state_dir, SNAPSHOT_FILENAME) if state_dir else ""
         )
+
+
+    def _history_path(self) -> str:
+        state_dir = str(getattr(self.session, "state_dir", "") or "")
+        if not state_dir:
+            return ""
+        return os.path.join(state_dir, HISTORY_FILENAME)
+
+    def _append_history(self, event: str, payload: Dict[str, Any]) -> None:
+        path = self._history_path()
+        if not path:
+            return
+        rec = {"event": event, "ts": _now(), **dict(payload or {})}
+        try:
+            os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+            with open(path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        except Exception:
+            pass
+
+    def list_history(self, *, limit: int = 50) -> List[dict]:
+        """Read append-only applied-refine history (newest last)."""
+        path = self._history_path()
+        if not path or not os.path.isfile(path):
+            return []
+        out: List[dict] = []
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except Exception:
+                        continue
+                    if isinstance(rec, dict):
+                        out.append(rec)
+        except Exception:
+            return out
+        if limit and len(out) > int(limit):
+            return out[-int(limit):]
+        return out
+
+    def handle_slash(self, raw: str) -> Dict[str, Any]:
+        """Slash /refine on this controller — list history or propose."""
+        text = (raw or "").strip()
+        if text.lower().startswith("/refine"):
+            text = text[7:].strip()
+        if not text:
+            return {
+                "ok": True,
+                "history": self.list_history(),
+                "usage": "/refine [kind] [scope] <text>",
+            }
+        parts = text.split()
+        kind = "memory"
+        scope = "global"
+        rest = text
+        if parts and parts[0].lower() in REFINE_KINDS:
+            kind = parts[0].lower()
+            rest = " ".join(parts[1:])
+            more = rest.split()
+            if more and more[0].lower() in REFINE_SCOPES:
+                scope = more[0].lower()
+                rest = " ".join(more[1:])
+        prop = self.propose(kind=kind, text=rest, scope=scope)
+        if prop is None:
+            return {"ok": False, "error": "could not propose refine"}
+        return {"ok": True, "proposed": prop.to_dict()}
 
     @property
     def pending(self) -> Dict[str, RefineProposal]:
@@ -314,6 +385,7 @@ class HarnessRefineController:
         applied["id"] = prop.id
         applied["kind"] = prop.kind
         applied["scope"] = prop.scope
+        self._append_history("accept", {"id": prop.id, "kind": prop.kind, "scope": prop.scope, "text": prop.text})
         return applied
 
     def dismiss(self, proposal_id: str) -> Dict[str, Any]:
@@ -339,6 +411,7 @@ class HarnessRefineController:
             self._restore_snapshot(snap)
         except Exception as exc:
             return {"ok": False, "error": str(exc)}
+        self._append_history("rollback", {"ok": True})
         return {"ok": True, "rolled_back": True}
 
     def _apply(self, prop: RefineProposal) -> Dict[str, Any]:

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -262,6 +262,10 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             services=svc.session_control_services),
         "/api/session/goal": post_json(
             _sc_api.post_session_goal, services=svc.session_control_services),
+        "/api/refine": post_json(
+            _skills_api.post_refine, services=svc.skills_services),
+        "/api/refine/propose": post_json(
+            _skills_api.post_refine_propose, services=svc.skills_services),
         "/api/refine/propose/accept": post_json(
             _skills_api.post_refine_propose_accept, services=svc.skills_services),
         "/api/refine/propose/dismiss": post_json(
@@ -626,6 +630,8 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         "/api/session/events": _get_session_events,
         "/api/session/goal": get_json(
             _sc_api.get_session_goal, services=svc.session_control_services),
+        "/api/refine/history": get_json(
+            _skills_api.get_refine_history, services=svc.skills_services),
         "/api/session/context_at": _get_session_context_at,
         "/api/session/swarm-results": get_json(
             _sc_api.get_session_swarm_results,

--- a/harness/ipython_kernel.py
+++ b/harness/ipython_kernel.py
@@ -22,6 +22,8 @@ from typing import Any, Optional
 
 DEFAULT_TIMEOUT_SEC = 60.0
 DEFAULT_OUTPUT_CAP = 64 * 1024
+MAX_IPYTHON_DEPTH = 2
+_ipython_depth = threading.local()
 _INSTALL_HINT = (
     "IPython is not installed. For richer display/repr, run: "
     "pip install ipython  (stdlib fallback kernel is still active)"

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -743,15 +743,31 @@ class SendLoopMixin:
                                 )
                                 goal.record_turn_usage(tokens=tokens)
                                 self._persist_session_goal()
+                                if getattr(goal, "budget_exceeded", False):
+                                    yield ConvEvent("notice", {
+                                        "message": (
+                                            "Session goal paused: token_budget "
+                                            "reached (%s / %s)."
+                                            % (goal.token_count, goal.token_budget)
+                                        ),
+                                        "reason": "token_budget",
+                                    })
                                 auto_continue = bool(
                                     getattr(self.config, "goal_auto_continue", False)
                                 )
                                 if (
                                     auto_continue
                                     and not gate_blocks_idle
+                                    and not getattr(goal, "budget_exceeded", False)
                                     and hasattr(self, "enqueue_goal_continuation")
                                 ):
                                     self.enqueue_goal_continuation()
+                        except Exception:
+                            pass
+                        try:
+                            from .session_trace import maybe_export_session_trace
+
+                            maybe_export_session_trace(self)
                         except Exception:
                             pass
                         # Interactive mode: background the work to keep the UI

--- a/harness/server.py
+++ b/harness/server.py
@@ -2961,6 +2961,7 @@ def _settings_compaction_residual():
 def _get_settings_dict():
     from harness.hash_edit import hash_edit_enabled
     from harness.reasoning_effort import current_reasoning_effort
+    from harness.session_trace import session_trace_export_enabled
 
     reach = _cfg.reach
     status = get_api_key_status(reach)
@@ -2986,6 +2987,7 @@ def _get_settings_dict():
         "verifyCommand": getattr(_cfg, "verify_command", ""),
         "autoCommandGuard": getattr(_pilot, "_auto_command_guard", True),
         "hash_edit_enabled": hash_edit_enabled(),
+        "session_trace_export": session_trace_export_enabled(),
         "commandTimeout": (os.environ.get("HARNESS_COMMAND_TIMEOUT", "").strip() or "120"),
         "maxPilotSteps": (os.environ.get("HARNESS_MAX_PILOT_STEPS", "").strip() or "40"),
         "pilotToolBudget": (

--- a/harness/session_goal.py
+++ b/harness/session_goal.py
@@ -27,6 +27,7 @@ class SessionGoal:
     elapsed_seconds: float = 0.0
     continuation_count: int = 0
     token_budget: Optional[int] = None
+    budget_exceeded: bool = False
     # Wall-clock anchor for elapsed_seconds while status is active.
     _active_since: float = field(default=0.0, repr=False)
 
@@ -40,6 +41,7 @@ class SessionGoal:
             "elapsed_seconds": float(self.elapsed_seconds),
             "continuation_count": int(self.continuation_count),
             "token_budget": self.token_budget,
+            "budget_exceeded": bool(self.budget_exceeded),
         }
 
     @classmethod
@@ -67,6 +69,7 @@ class SessionGoal:
             elapsed_seconds=float(data.get("elapsed_seconds") or 0.0),
             continuation_count=int(data.get("continuation_count") or 0),
             token_budget=token_budget,
+            budget_exceeded=bool(data.get("budget_exceeded")),
             _active_since=float(data.get("_active_since") or 0.0),
         )
 
@@ -84,6 +87,7 @@ class SessionGoal:
             self.created_at = now
         self.updated_at = now
         self._active_since = now
+        self.budget_exceeded = False
         if token_budget is not None:
             try:
                 self.token_budget = int(token_budget)
@@ -145,6 +149,13 @@ class SessionGoal:
         if continuation:
             self.continuation_count = int(self.continuation_count) + 1
         self.updated_at = time.time()
+        if self.token_budget is not None:
+            try:
+                if int(self.token_count) >= int(self.token_budget):
+                    self.pause()
+                    self.budget_exceeded = True
+            except (TypeError, ValueError):
+                pass
         return self
 
     def continuation_prompt(self) -> str:

--- a/harness/session_trace.py
+++ b/harness/session_trace.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""Opt-in session trace export/upload. Default OFF. No Sentry/OTel."""
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+TRACE_FILENAME = "session_trace.json"
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def session_trace_export_enabled() -> bool:
+    return (os.environ.get("HARNESS_SESSION_TRACE_EXPORT") or "").strip().lower() in _TRUTHY
+
+
+def session_trace_upload_enabled() -> bool:
+    return (os.environ.get("HARNESS_SESSION_TRACE_UPLOAD") or "").strip().lower() in _TRUTHY
+
+
+def session_trace_upload_url() -> str:
+    return (os.environ.get("HARNESS_SESSION_TRACE_UPLOAD_URL") or "").strip()
+
+
+def _state_dir(session: Any) -> str:
+    explicit = str(getattr(session, "state_dir", "") or "")
+    if explicit:
+        return explicit
+    cfg = getattr(session, "config", None)
+    return str(getattr(cfg, "state_dir", "") or "")
+
+
+def build_session_trace(session: Any) -> Dict[str, Any]:
+    goal = getattr(session, "_session_goal", None)
+    goal_d = goal.to_dict() if goal is not None and hasattr(goal, "to_dict") else {}
+    history = getattr(session, "_history", None) or []
+    return {
+        "exported_at": time.time(),
+        "session_id": str(getattr(session, "session_id", "") or ""),
+        "goal": goal_d,
+        "history_len": len(history) if isinstance(history, list) else 0,
+        "tokens_used": int(getattr(session, "_tokens_used", 0) or 0),
+        "last_turn_tokens": int(
+            getattr(session, "_last_turn_tokens", 0)
+            or getattr(session, "_turn_output_tokens", 0)
+            or 0
+        ),
+    }
+
+
+def export_session_trace(session: Any) -> Optional[Dict[str, Any]]:
+    """Write state_dir/session_trace.json when export is opted in. Default no-op."""
+    if not session_trace_export_enabled():
+        return None
+    state_dir = _state_dir(session)
+    if not state_dir:
+        return None
+    payload = build_session_trace(session)
+    path = os.path.join(state_dir, TRACE_FILENAME)
+    try:
+        os.makedirs(state_dir, exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(json.dumps(payload, indent=2, ensure_ascii=False))
+        os.replace(tmp, path)
+    except Exception:
+        return None
+    uploaded = False
+    upload_error = ""
+    if session_trace_upload_enabled():
+        uploaded, upload_error = _upload_trace(path, payload)
+    return {
+        "ok": True,
+        "path": path,
+        "uploaded": uploaded,
+        "upload_error": upload_error,
+    }
+
+
+def _upload_trace(path: str, payload: Dict[str, Any]) -> tuple[bool, str]:
+    url = session_trace_upload_url()
+    if not url:
+        return False, "no upload url"
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            resp.read()
+        return True, ""
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return False, str(exc)
+
+
+def maybe_export_session_trace(session: Any) -> Optional[Dict[str, Any]]:
+    try:
+        return export_session_trace(session)
+    except Exception:
+        return None

--- a/harness/stream_performance_store.py
+++ b/harness/stream_performance_store.py
@@ -19,6 +19,7 @@ Path traversal is refused. Sink failures never raise to the chat hot path.
 from __future__ import annotations
 
 import contextlib
+import errno
 import json
 import math
 import os
@@ -198,6 +199,31 @@ def _lock_for(path: str) -> threading.Lock:
         return lock
 
 
+_LOCK_ACQUIRE_ATTEMPTS = 4
+_LOCK_ACQUIRE_RETRY_SEC = 0.05
+_REPLACE_ATTEMPTS = 8
+_REPLACE_RETRY_SEC = 0.05
+_WIN_SHARING_WINERRORS = frozenset({5, 32})  # ACCESS_DENIED, SHARING_VIOLATION
+
+
+def _is_windows_sharing_error(exc: BaseException) -> bool:
+    """True for replace/lock failures Windows raises while a file is still busy."""
+    if not isinstance(exc, OSError):
+        return False
+    winerror = getattr(exc, "winerror", None)
+    if winerror in _WIN_SHARING_WINERRORS:
+        return True
+    if isinstance(exc, PermissionError):
+        return True
+    return exc.errno in (
+        errno.EACCES,
+        errno.EPERM,
+        errno.EAGAIN,
+        getattr(errno, "EBUSY", errno.EACCES),
+        getattr(errno, "EWOULDBLOCK", errno.EAGAIN),
+    )
+
+
 def _acquire_os_lock(fd: int) -> str:
     try:
         import fcntl
@@ -207,16 +233,25 @@ def _acquire_os_lock(fd: int) -> str:
         pass
     try:
         import msvcrt
-        os.lseek(fd, 0, os.SEEK_SET)
-        try:
-            os.write(fd, b"\0")
-        except OSError:
-            pass
-        os.lseek(fd, 0, os.SEEK_SET)
-        msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
-        return "msvcrt"
-    except (ImportError, OSError, AttributeError):
+    except ImportError:
         return ""
+    delay = _LOCK_ACQUIRE_RETRY_SEC
+    for attempt in range(_LOCK_ACQUIRE_ATTEMPTS):
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            try:
+                os.write(fd, b"\0")
+            except OSError:
+                pass
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            return "msvcrt"
+        except (OSError, AttributeError):
+            if attempt + 1 >= _LOCK_ACQUIRE_ATTEMPTS:
+                return ""
+            time.sleep(delay)
+            delay = min(delay * 2, 0.4)
+    return ""
 
 
 def _release_os_lock(fd: int, kind: str) -> None:
@@ -691,7 +726,7 @@ def _atomic_write_json(path: str, data: Dict[str, Any]) -> None:
             json.dump(data, handle, ensure_ascii=False, indent=2, allow_nan=False)
         if _is_symlink(path) or _is_symlink(parent):
             raise OSError("refusing to replace a symlinked receipt path")
-        os.replace(tmp, path)
+        _replace_atomic(tmp, path)
     except Exception:
         try:
             if os.path.lexists(tmp):
@@ -699,6 +734,31 @@ def _atomic_write_json(path: str, data: Dict[str, Any]) -> None:
         except OSError:
             pass
         raise
+
+
+
+def _replace_atomic(src: str, dest: str) -> None:
+    """``os.replace`` with retries for Windows sharing / access-denied flakes.
+
+    Destination handles can stay busy briefly after a sibling process closes
+    the receipt file (or a scanner opens it). ``record`` swallows write
+    failures, so a one-shot PermissionError / WinError 5 or 32 drops the
+    receipt. Retry under the existing RMW lock instead of losing the row.
+    """
+    delay = _REPLACE_RETRY_SEC
+    last: Optional[OSError] = None
+    for attempt in range(_REPLACE_ATTEMPTS):
+        try:
+            os.replace(src, dest)
+            return
+        except OSError as exc:
+            last = exc
+            if attempt + 1 >= _REPLACE_ATTEMPTS or not _is_windows_sharing_error(exc):
+                raise
+            time.sleep(delay)
+            delay = min(delay * 2, 0.4)
+    if last is not None:
+        raise last
 
 
 def _load_document(path: str) -> List[Dict[str, Any]]:

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -1433,10 +1433,17 @@ class ToolDispatchMixin:
         code = (act.content or "").strip()
         if not code:
             return False, "error", "run_ipython requires non-empty code"
-        from .ipython_kernel import get_or_create_kernel
+        from .ipython_kernel import MAX_IPYTHON_DEPTH, _ipython_depth, get_or_create_kernel
 
-        kernel = get_or_create_kernel(self)
-        result = kernel.execute(code)
+        depth = int(getattr(_ipython_depth, "n", 0) or 0)
+        if depth >= MAX_IPYTHON_DEPTH:
+            return False, "error", "run_ipython depth limit reached"
+        _ipython_depth.n = depth + 1
+        try:
+            kernel = get_or_create_kernel(self)
+            result = kernel.execute(code)
+        finally:
+            _ipython_depth.n = depth
         payload = {
             "output": result.output,
             "backend": result.backend,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.303"
+version = "0.9.305"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_prime_305.py
+++ b/tests/test_prime_305.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from harness.harness_refine import HISTORY_FILENAME, HarnessRefineController
+from harness.ipython_kernel import MAX_IPYTHON_DEPTH, _ipython_depth
+from harness.session_goal import SessionGoal
+
+
+class _Sess:
+    def __init__(self, state_dir: str) -> None:
+        self.state_dir = state_dir
+        self._auto_mode = False
+        self._frozen_system_prompt = "frozen"
+
+
+def test_refine_history_jsonl(tmp_path: Path) -> None:
+    sess = _Sess(str(tmp_path))
+    ctl = HarnessRefineController(sess)
+    prop = ctl.propose(kind="memory", text="remember the latch", scope="local")
+    assert prop is not None
+    out = ctl.accept(prop.id)
+    assert out.get("ok") is True
+    path = tmp_path / HISTORY_FILENAME
+    rec = json.loads(path.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert rec["event"] == "accept"
+    rb = ctl.rollback()
+    assert rb.get("ok") is True
+    rec2 = json.loads(path.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert rec2["event"] == "rollback"
+
+
+def test_token_budget_pauses() -> None:
+    goal = SessionGoal()
+    goal.set("ship it", token_budget=10)
+    goal.record_turn_usage(tokens=4)
+    assert goal.status == "active"
+    goal.record_turn_usage(tokens=10)
+    assert goal.status == "paused"
+    assert goal.token_count >= 10
+
+
+def test_ipython_depth_cap() -> None:
+    assert MAX_IPYTHON_DEPTH >= 1
+    _ipython_depth.n = 0
+    _ipython_depth.n = MAX_IPYTHON_DEPTH
+    assert int(_ipython_depth.n) >= MAX_IPYTHON_DEPTH
+    _ipython_depth.n = 0
+
+
+def test_trace_export_off_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("HARNESS_SESSION_TRACE_EXPORT", raising=False)
+    flag = (os.environ.get("HARNESS_SESSION_TRACE_EXPORT") or "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    assert flag is False

--- a/tests/test_prime_305.py
+++ b/tests/test_prime_305.py
@@ -1,12 +1,21 @@
+"""v0.9.305: refine slash/history, SessionGoal budget pause, ipython depth, opt-in trace."""
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
+from types import SimpleNamespace
 
-from harness.harness_refine import HISTORY_FILENAME, HarnessRefineController
+from harness.harness_refine import HISTORY_FILENAME, HarnessRefineController, get_refine_controller
 from harness.ipython_kernel import MAX_IPYTHON_DEPTH, _ipython_depth
+from harness.pilot import PilotAction
 from harness.session_goal import SessionGoal
+from harness.session_trace import (
+    TRACE_FILENAME,
+    export_session_trace,
+    session_trace_export_enabled,
+    session_trace_upload_enabled,
+)
+from harness.tool_dispatch import ToolDispatchMixin
 
 
 class _Sess:
@@ -14,45 +23,106 @@ class _Sess:
         self.state_dir = state_dir
         self._auto_mode = False
         self._frozen_system_prompt = "frozen"
+        self.session_id = "s-test"
+        self._history = []
+        self._tokens_used = 0
+        self._last_turn_tokens = 0
 
 
-def test_refine_history_jsonl(tmp_path: Path) -> None:
+def test_refine_slash_proposes_on_existing_controller(tmp_path: Path) -> None:
     sess = _Sess(str(tmp_path))
-    ctl = HarnessRefineController(sess)
-    prop = ctl.propose(kind="memory", text="remember the latch", scope="local")
-    assert prop is not None
-    out = ctl.accept(prop.id)
-    assert out.get("ok") is True
+    ctl = get_refine_controller(sess)
+    listed = ctl.handle_slash("/refine")
+    assert listed["ok"] is True
+    assert listed["history"] == []
+    proposed = ctl.handle_slash("/refine memory local latch the door")
+    assert proposed["ok"] is True
+    assert proposed["proposed"]["kind"] == "memory"
+    assert proposed["proposed"]["scope"] == "local"
+    assert "latch" in proposed["proposed"]["text"]
+    assert (tmp_path / HISTORY_FILENAME).exists() is False
+    accepted = ctl.accept(proposed["proposed"]["id"])
+    assert accepted["ok"] is True
     path = tmp_path / HISTORY_FILENAME
     rec = json.loads(path.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert rec["event"] == "accept"
+    assert rec["text"] == "latch the door"
+
+
+def test_refine_history_jsonl_append_only(tmp_path: Path) -> None:
+    sess = _Sess(str(tmp_path))
+    ctl = HarnessRefineController(sess)
+    prop = ctl.propose(kind="memory", text="remember the latch")
+    assert prop is not None
+    assert ctl.accept(prop.id).get("ok") is True
+    path = tmp_path / HISTORY_FILENAME
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[-1])
     assert rec["event"] == "accept"
     rb = ctl.rollback()
     assert rb.get("ok") is True
     rec2 = json.loads(path.read_text(encoding="utf-8").strip().splitlines()[-1])
     assert rec2["event"] == "rollback"
+    assert len(path.read_text(encoding="utf-8").strip().splitlines()) == 2
 
 
-def test_token_budget_pauses() -> None:
+def test_token_budget_pauses_and_stops_continuation() -> None:
     goal = SessionGoal()
     goal.set("ship it", token_budget=10)
     goal.record_turn_usage(tokens=4)
     assert goal.status == "active"
+    assert goal.budget_exceeded is False
     goal.record_turn_usage(tokens=10)
     assert goal.status == "paused"
+    assert goal.budget_exceeded is True
     assert goal.token_count >= 10
+    assert not goal.is_active()
+    d = goal.to_dict()
+    assert d["budget_exceeded"] is True
+    restored = SessionGoal.from_dict(d)
+    assert restored.budget_exceeded is True
+    restored.set("new goal", token_budget=20)
+    assert restored.budget_exceeded is False
+    assert restored.status == "active"
 
 
-def test_ipython_depth_cap() -> None:
+def test_ipython_depth_guard_no_new_kernel(tmp_path: Path) -> None:
     assert MAX_IPYTHON_DEPTH >= 1
-    _ipython_depth.n = 0
-    _ipython_depth.n = MAX_IPYTHON_DEPTH
-    assert int(_ipython_depth.n) >= MAX_IPYTHON_DEPTH
-    _ipython_depth.n = 0
-
-
-def test_trace_export_off_by_default(monkeypatch) -> None:
-    monkeypatch.delenv("HARNESS_SESSION_TRACE_EXPORT", raising=False)
-    flag = (os.environ.get("HARNESS_SESSION_TRACE_EXPORT") or "").strip().lower() in (
-        "1", "true", "yes", "on",
+    session = SimpleNamespace(
+        config=SimpleNamespace(repo=str(tmp_path), state_dir=str(tmp_path)),
+        _ipython_kernel=None,
     )
-    assert flag is False
+    _ipython_depth.n = MAX_IPYTHON_DEPTH
+    try:
+        act = PilotAction(kind="run_ipython", content="1 + 1")
+        ok, status, val = ToolDispatchMixin._do_run_ipython(session, act)
+        assert ok is False
+        assert status == "error"
+        assert "depth" in str(val).lower()
+        assert session._ipython_kernel is None
+    finally:
+        _ipython_depth.n = 0
+
+
+def test_trace_export_off_by_default(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("HARNESS_SESSION_TRACE_EXPORT", raising=False)
+    monkeypatch.delenv("HARNESS_SESSION_TRACE_UPLOAD", raising=False)
+    assert session_trace_export_enabled() is False
+    assert session_trace_upload_enabled() is False
+    sess = _Sess(str(tmp_path))
+    assert export_session_trace(sess) is None
+    assert not (tmp_path / TRACE_FILENAME).exists()
+
+
+def test_trace_export_opt_in_no_upload(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HARNESS_SESSION_TRACE_EXPORT", "1")
+    monkeypatch.delenv("HARNESS_SESSION_TRACE_UPLOAD", raising=False)
+    sess = _Sess(str(tmp_path))
+    sess._session_goal = SessionGoal()
+    sess._session_goal.set("trace me", token_budget=5)
+    out = export_session_trace(sess)
+    assert out and out["ok"] is True
+    assert out["uploaded"] is False
+    data = json.loads((tmp_path / TRACE_FILENAME).read_text(encoding="utf-8"))
+    assert data["goal"]["text"] == "trace me"

--- a/tests/test_stream_performance_store.py
+++ b/tests/test_stream_performance_store.py
@@ -1235,6 +1235,31 @@ def test_multiprocess_rmw_preserves_all_receipts(tmp_path):
     assert sorted(r["provider_step"] for r in rows) == list(range(n))
 
 
+def test_atomic_replace_retries_windows_sharing_errors(tmp_path, monkeypatch):
+    """WinError 5/32 on os.replace must not drop a receipt (store retries)."""
+    import harness.stream_performance_store as store_mod
+
+    real_replace = store_mod.os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(src, dest):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            err = PermissionError(13, "Access is denied")
+            err.winerror = 5
+            raise err
+        return real_replace(src, dest)
+
+    monkeypatch.setattr(store_mod.os, "replace", flaky_replace)
+    sid = "sess-win-replace"
+    store = StreamPerformanceReceiptStore(str(tmp_path))
+    store.record(sid, _receipt(sid, provider_step=1))
+    store.record(sid, _receipt(sid, provider_step=2))
+    rows = store.list_receipts(sid)
+    assert [r["provider_step"] for r in rows] == [1, 2]
+    assert calls["n"] >= 3
+
+
 def test_deep_json_and_recursion_error_fail_soft_then_repair(tmp_path, monkeypatch):
     store = StreamPerformanceReceiptStore(str(tmp_path))
     sid = "sess-deep"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.303"
+version = "0.9.305"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.303",
+  "version": "0.9.305",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.303",
+      "version": "0.9.305",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.303",
+  "version": "0.9.305",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -3054,7 +3054,26 @@ export default function Conversation({
         ]);
         return;
       }
-      api.refinePropose?.({ text: refineText, kind: "memory" })
+      const command = msg.startsWith("/") ? msg : `/refine ${refineText}`;
+      void api.refinePropose({ command, text: refineText })
+        .then((res) => {
+          const prop = res?.proposed;
+          if (res?.ok && prop?.id && (prop.text || "").trim()) {
+            setMemoryProposals((prev) => (
+              prev.some((p) => p.id === prop.id)
+                ? prev
+                : [...prev, {
+                  id: prop.id,
+                  text: String(prop.text || "").trim(),
+                  category: prop.category || "general",
+                  refine: {
+                    kind: String(prop.kind || "memory"),
+                    scope: String(prop.scope || "global"),
+                  },
+                }]
+            ));
+          }
+        })
         .catch(() => undefined);
       setItems((p) => [
         ...p,

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -3042,6 +3042,27 @@ export default function Conversation({
       window.dispatchEvent(new Event("harness-new-session"));
       return;
     }
+    if (slash.kind === "refine") {
+      const refineText = slash.text || "";
+      setInput("");
+      setEditingIndex(null);
+      if (!refineText) {
+        setItems((p) => [
+          ...p,
+          { kind: "msg", msg: { role: "user", text: msg } },
+          { kind: "msg", msg: { role: "assistant", text: "Usage: /refine <memory|rule|skill|role text>. Accept/dismiss/rollback stay on the existing refine cards." } },
+        ]);
+        return;
+      }
+      api.refinePropose?.({ text: refineText, kind: "memory" })
+        .catch(() => undefined);
+      setItems((p) => [
+        ...p,
+        { kind: "msg", msg: { role: "user", text: msg } },
+        { kind: "msg", msg: { role: "assistant", text: "Queued refine proposal on the existing controller." } },
+      ]);
+      return;
+    }
     if (slash.kind === "compact") {
       // Local slash path: echo the command into the transcript so Send feels
       // like a normal prompt (compaction itself still bypasses the pilot loop).

--- a/webapp/src/components/conversation/composerSend.ts
+++ b/webapp/src/components/conversation/composerSend.ts
@@ -355,6 +355,7 @@ export type LocalSlashAction =
   | { kind: "clear" }
   | { kind: "new" }
   | { kind: "compact" }
+  | { kind: "refine"; text: string }
   | { kind: "model" }
   | { kind: "help" }
   | { kind: "swarm" }
@@ -421,6 +422,9 @@ export function classifyLocalSlashCommand(opts: {
   if (cmd === "/clear") return { kind: "clear" };
   if (cmd === "/new") return { kind: "new" };
   if (cmd === "/compact") return { kind: "compact" };
+  if (cmd === "/refine") {
+    return { kind: "refine", text: msg.substring(cmd.length).trim() };
+  }
   if (cmd === "/model") return { kind: "model" };
   if (cmd === "/help") return { kind: "help" };
   if (cmd === "/swarm") return { kind: "swarm" };

--- a/webapp/src/components/conversation/composerSend.ts
+++ b/webapp/src/components/conversation/composerSend.ts
@@ -70,7 +70,7 @@ export function formatHelpSlashReply(
   return (
     "Available Slash Commands:\n\n"
     + commands.map((s) => `* \`${s.cmd}\` - ${s.desc}`).join("\n")
-    + "\n\nLocal chrome (not sent to the model): `/swarm` `/terminal` `/settings` `/memory` `/mcp` `/files` `/state`."
+    + "\n\nLocal chrome (not sent to the model): `/swarm` `/terminal` `/settings` `/memory` `/mcp` `/files` `/state` `/refine`."
     + "\n\nType @ to list and mention files in your message context."
   );
 }

--- a/webapp/src/components/conversation/slashCommands.ts
+++ b/webapp/src/components/conversation/slashCommands.ts
@@ -2,6 +2,7 @@ export const SLASH_COMMANDS = [
   { cmd: "/clear", desc: "Clear visible transcript" },
   { cmd: "/new", desc: "Start a new session" },
   { cmd: "/compact", desc: "Trigger manual context compaction" },
+  { cmd: "/refine", desc: "Propose a harness refine (existing controller)" },
   { cmd: "/model", desc: "Focus model picker to switch models" },
   { cmd: "/swarm", desc: "Focus Swarm tab" },
   { cmd: "/terminal", desc: "Focus Terminal" },

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1226,6 +1226,27 @@ export const api = {
     postJSON<{ ok: boolean; goal: SessionGoal }>("/api/session/goal", { action: "complete" }),
   clearSessionGoal: () =>
     postJSON<{ ok: boolean; goal: SessionGoal }>("/api/session/goal", { action: "clear" }),
+  refinePropose: (body: {
+    text?: string;
+    kind?: string;
+    scope?: string;
+    command?: string;
+  }) =>
+    postJSON<{
+      ok: boolean;
+      proposed?: {
+        id: string;
+        text?: string;
+        kind?: string;
+        scope?: string;
+        category?: string;
+      };
+      history?: unknown[];
+      usage?: string;
+      error?: string;
+    }>("/api/refine", body),
+  refineHistory: () =>
+    getJSON<{ ok: boolean; history: unknown[] }>(withToken("/api/refine/history")),
   refineProposeAccept: (id: string) =>
     postJSON<{ ok: boolean; error?: string }>("/api/refine/propose/accept", { id }),
   refineProposeDismiss: (id: string) =>


### PR DESCRIPTION
## Summary
- Slash `/refine` + append-only `refinements.jsonl` on the existing HarnessRefineController.
- SessionGoal.token_budget now pauses the goal when token_count >= budget.
- Small run_ipython depth guard. No new kernel.
- Opt-in `HARNESS_SESSION_TRACE_EXPORT` (off by default). No Sentry/Otel.
- Pin still `puppetmaster-ai==1.22.28`. Parallel to #148 / #149.

## Test plan
- [x] hermetic `tests/test_prime_305.py`
- [ ] CI green