### PR TITLE
v0.9.306: smart-approve and allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.309, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.306, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.309"
+__version__ = "0.9.306"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/command_approvals.py
+++ b/harness/api/command_approvals.py
@@ -55,18 +55,22 @@ def _decide(
     if decide is None:
         return 409, {"error": "session runner cannot accept command approvals"}
 
+    from ..approval_identity import approval_turn
+
+    turn_raw = body.get("turn_id")
     try:
-        pending = decide(
-            command_hash=command_hash,
-            workspace_root=workspace_root,
-            approve=approve,
-        )
+        with approval_turn(turn_raw):
+            pending = decide(
+                command_hash=command_hash,
+                workspace_root=workspace_root,
+                approve=approve,
+            )
     except PermissionError as exc:
         return 403, {"error": str(exc)}
     if pending is None:
         return 404, {"error": "pending command approval not found"}
 
-    return 200, {
+    payload: dict[str, Any] = {
         "ok": True,
         "decision": "approved" if approve else "rejected",
         "session_id": session_id,
@@ -77,6 +81,9 @@ def _decide(
         # different hash and remains blocked.
         "retry_command": pending["command"] if approve else "",
     }
+    if pending.get("turn_id"):
+        payload["turn_id"] = pending["turn_id"]
+    return 200, payload
 
 
 def post_command_approval(
@@ -111,11 +118,14 @@ def post_command_approval_amendment(
     if decide is None:
         return 409, {"error": "session runner cannot accept command amendments"}
 
+    from ..approval_identity import approval_turn
+
     try:
-        pending = decide(
-            command_hash=command_hash,
-            workspace_root=workspace_root,
-        )
+        with approval_turn(body.get("turn_id")):
+            pending = decide(
+                command_hash=command_hash,
+                workspace_root=workspace_root,
+            )
     except PermissionError as exc:
         return 403, {"error": str(exc)}
     except ValueError as exc:

--- a/harness/approval_identity.py
+++ b/harness/approval_identity.py
@@ -1,0 +1,39 @@
+"""contextvars turn identity around approval decide.
+
+Thin names for the approval path. The ContextVar lives in
+:mod:`harness.turn_identity` so send-loop and decide share one turn id.
+"""
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+from .turn_identity import get_turn_id, reset_turn_id, set_turn_id, turn_scope
+
+
+def get_approval_turn_id() -> Optional[str]:
+    """Current turn id, or None when decide is not inside a turn."""
+    return get_turn_id() or None
+
+
+def set_approval_turn_id(turn_id: Optional[str]) -> contextvars.Token:
+    return set_turn_id(turn_id)
+
+
+def reset_approval_turn_id(token: contextvars.Token) -> None:
+    reset_turn_id(token)
+
+
+@contextmanager
+def approval_turn(turn_id: str | int | None) -> Iterator[Optional[str]]:
+    """Bind an approval/send turn id. ``None``/empty clears for the block."""
+    if turn_id is None or not str(turn_id).strip():
+        token = set_turn_id(None)
+        try:
+            yield get_approval_turn_id()
+        finally:
+            reset_turn_id(token)
+        return
+    with turn_scope(str(turn_id)) as tid:
+        yield tid

--- a/harness/command_allowlist.py
+++ b/harness/command_allowlist.py
@@ -1,0 +1,233 @@
+"""Persistent command allowlist under HARNESS_STATE_DIR.
+
+After an operator approves a danger command once, matching hashes or exact
+command strings skip the pending approval card on later full-auto turns.
+Hermetic: path resolves from ``HARNESS_STATE_DIR`` (tests set it to tmp).
+
+Writes record the current ``turn_id`` ContextVar when present. An allowlist
+hit authorizes re-execution only — it never invents a safer rewrite.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import threading
+import time
+from typing import Any, Optional
+
+ALLOWLIST_FILENAME = "command_allowlist.json"
+
+_LOCK = threading.Lock()
+
+
+def _state_dir(explicit: str | None = None) -> str:
+    if explicit and str(explicit).strip():
+        return os.path.abspath(str(explicit).strip())
+    env = (os.environ.get("HARNESS_STATE_DIR") or "").strip()
+    if env:
+        return os.path.abspath(env)
+    return os.path.abspath(os.path.expanduser("~/.pmharness/state"))
+
+
+def allowlist_path(state_dir: str | None = None) -> str:
+    return os.path.join(_state_dir(state_dir), ALLOWLIST_FILENAME)
+
+
+def _workspace_key(workspace_root: str) -> str:
+    raw = (workspace_root or "").strip()
+    if not raw:
+        return ""
+    try:
+        return os.path.normcase(os.path.realpath(raw))
+    except OSError:
+        return os.path.normcase(os.path.abspath(raw))
+
+
+def command_hash(command: str) -> str:
+    return hashlib.sha256((command or "").encode("utf-8")).hexdigest()
+
+
+def _empty_store() -> dict[str, Any]:
+    return {"version": 1, "entries": []}
+
+
+def _load_unlocked(state_dir: str | None = None) -> dict[str, Any]:
+    path = allowlist_path(state_dir)
+    if not os.path.isfile(path):
+        return _empty_store()
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError, TypeError):
+        return _empty_store()
+    if not isinstance(data, dict):
+        return _empty_store()
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        return _empty_store()
+    return {
+        "version": 1,
+        "entries": [row for row in entries if isinstance(row, dict)],
+    }
+
+
+def _atomic_write(data: dict[str, Any], state_dir: str | None = None) -> None:
+    path = allowlist_path(state_dir)
+    parent = os.path.dirname(path)
+    os.makedirs(parent, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=parent, prefix=".cmd_allow_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        if os.path.exists(tmp):
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+        raise
+
+
+def _entry_matches(
+    row: dict[str, Any],
+    *,
+    command: str,
+    digest: str,
+    workspace_key: str,
+) -> bool:
+    row_ws = _workspace_key(str(row.get("workspace_root") or ""))
+    # When the caller scopes by workspace, require the same key. Entries with
+    # an empty workspace are treated as profile-global and still match.
+    if workspace_key and row_ws and row_ws != workspace_key:
+        return False
+    row_hash = str(row.get("command_hash") or "").strip().lower()
+    if digest and row_hash and row_hash == digest:
+        return True
+    row_cmd = row.get("command")
+    if isinstance(row_cmd, str) and command and row_cmd == command:
+        return True
+    return False
+
+
+def is_allowlisted(
+    command: str,
+    *,
+    digest: str = "",
+    command_hash: str = "",
+    workspace_root: str = "",
+    state_dir: str | None = None,
+) -> bool:
+    """True when hash or exact command is on the allowlist."""
+    return allowlist_contains(
+        command or "",
+        state_dir=state_dir,
+        workspace_root=workspace_root,
+        command_hash=digest or command_hash,
+    )
+
+
+def allowlist_contains(
+    command: str,
+    state_dir: str | None = None,
+    workspace_root: str = "",
+    command_hash: str = "",
+) -> bool:
+    """True when hash or exact command is recorded under the state dir."""
+    cmd = command or ""
+    digest = (command_hash or "").strip().lower()
+    if not digest and cmd:
+        digest = hashlib.sha256(cmd.encode("utf-8")).hexdigest()
+    if not digest and not cmd.strip():
+        return False
+    ws = _workspace_key(workspace_root)
+    with _LOCK:
+        store = _load_unlocked(state_dir)
+        for row in store["entries"]:
+            if _entry_matches(
+                row, command=cmd, digest=digest, workspace_key=ws
+            ):
+                return True
+    return False
+
+
+def add_allowlisted(
+    command: str,
+    *,
+    command_hash: str = "",
+    workspace_root: str = "",
+    turn_id: Optional[str] = None,
+    state_dir: str | None = None,
+) -> dict[str, Any]:
+    """Record an approved command. Idempotent for the same hash/command."""
+    from .turn_identity import get_turn_id
+
+    cmd = command or ""
+    digest = (command_hash or "").strip().lower() or (
+        hashlib.sha256(cmd.encode("utf-8")).hexdigest() if cmd else ""
+    )
+    if not digest:
+        return {}
+    ws = _workspace_key(workspace_root)
+    attributed = str(turn_id or "").strip() or get_turn_id()
+    entry = {
+        "command_hash": digest,
+        "command": cmd,
+        "workspace_root": ws,
+        "turn_id": attributed,
+        "approved_at": time.time(),
+    }
+    with _LOCK:
+        store = _load_unlocked(state_dir)
+        entries: list = store["entries"]
+        for i, row in enumerate(entries):
+            if _entry_matches(
+                row, command=cmd, digest=digest, workspace_key=ws
+            ):
+                entries[i] = entry
+                _atomic_write(store, state_dir)
+                return dict(entry)
+        entries.append(entry)
+        _atomic_write(store, state_dir)
+        return dict(entry)
+
+
+def allowlist_add(
+    command: str,
+    state_dir: str | None = None,
+    workspace_root: str = "",
+) -> bool:
+    """Record ``command`` under the state-dir allowlist. Returns True on write."""
+    entry = add_allowlisted(
+        command,
+        workspace_root=workspace_root,
+        state_dir=state_dir,
+    )
+    return bool(entry)
+
+
+def load_allowlist(state_dir: str | None = None) -> list[str]:
+    """Return exact command strings currently on the allowlist."""
+    with _LOCK:
+        store = _load_unlocked(state_dir)
+    out: list[str] = []
+    for row in store["entries"]:
+        cmd = row.get("command")
+        if isinstance(cmd, str) and cmd.strip():
+            out.append(cmd.strip())
+    return out
+
+
+def clear_allowlist_for_tests(state_dir: str | None = None) -> None:
+    """Test helper: delete the allowlist file under the current state dir."""
+    path = allowlist_path(state_dir)
+    with _LOCK:
+        if os.path.isfile(path):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass

--- a/harness/command_policy.py
+++ b/harness/command_policy.py
@@ -462,6 +462,27 @@ def suggested_amendment(command: str) -> str | None:
     return amended
 
 
+def smart_approve(
+    command: str,
+    *,
+    allowlist_hit: bool = False,
+    verdict: CommandVerdict | None = None,
+) -> dict[str, str]:
+    """Deterministic smart-approve verdict for a full-auto danger gate.
+
+    Delegates to :func:`harness.smart_approve.smart_approve` so there is one
+    precedence: allowlist hit → approve, suggested amendment → amend, else
+    pending. Never auto-executes on its own.
+    """
+    from .smart_approve import smart_approve as _smart_approve
+
+    return _smart_approve(
+        command,
+        allowlist_hit=allowlist_hit,
+        verdict=verdict,
+    )
+
+
 def run_cancellable(
     command: str,
     *,

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -1222,6 +1222,12 @@ class ConversationalSession(
         amendment = pending.get("suggested_amendment") or ""
         if amendment:
             row["suggested_amendment"] = amendment
+        smart = pending.get("smart_approve")
+        if isinstance(smart, dict) and smart.get("action"):
+            row["smart_approve"] = {
+                "action": str(smart.get("action") or ""),
+                "reason": str(smart.get("reason") or ""),
+            }
         return row
 
     def _pending_command_approval_from_display_row(self, row: Any) -> Optional[dict]:
@@ -1278,6 +1284,25 @@ class ConversationalSession(
             rewritten = _suggested_amendment(command)
             if rewritten:
                 pending["suggested_amendment"] = rewritten
+        smart = row.get("smart_approve")
+        if isinstance(smart, dict) and smart.get("action"):
+            pending["smart_approve"] = {
+                "action": str(smart.get("action") or ""),
+                "reason": str(smart.get("reason") or ""),
+            }
+        else:
+            from .command_allowlist import is_allowlisted
+            from .command_policy import smart_approve as _smart_approve
+
+            pending["smart_approve"] = _smart_approve(
+                command,
+                allowlist_hit=is_allowlisted(
+                    command,
+                    command_hash=command_hash,
+                    workspace_root=pending["workspace_root"],
+                    state_dir=getattr(self, "state_dir", None),
+                ),
+            )
         return pending
 
     def _restore_pending_command_approvals_from_display(self) -> None:
@@ -1335,21 +1360,36 @@ class ConversationalSession(
         transcript so ring-miss / cursor-gap hydrate can restore the card
         without depending on retained SSE frames.
         """
-        from .command_policy import suggested_amendment as _suggested_amendment
+        from .command_allowlist import allowlist_contains
+        from .command_policy import (
+            smart_approve as _smart_approve,
+            suggested_amendment as _suggested_amendment,
+        )
 
         amendment = (suggested_amendment or "").strip()
         if not amendment:
             rewritten = _suggested_amendment(command)
             amendment = rewritten or ""
+        workspace_root = os.path.realpath(self.config.repo or "")
+        state_dir = getattr(self, "state_dir", None)
         pending = {
             "session_id": self.harness_session_id,
-            "workspace_root": os.path.realpath(self.config.repo or ""),
+            "workspace_root": workspace_root,
             "command": command,
             "command_hash": command_hash,
             "action_id": action_id,
             "category": category or "",
             "reason": reason or "",
             "matched": matched or "",
+            "smart_approve": _smart_approve(
+                command,
+                allowlist_hit=allowlist_contains(
+                    command,
+                    state_dir=state_dir,
+                    workspace_root=workspace_root,
+                    command_hash=command_hash,
+                ),
+            ),
         }
         if amendment:
             pending["suggested_amendment"] = amendment
@@ -1366,28 +1406,43 @@ class ConversationalSession(
         approve: bool,
     ) -> Optional[dict]:
         """Apply a one-shot operator decision to this session's pending command."""
-        requested_workspace = self._approval_workspace_key(workspace_root)
-        with self._command_approval_lock_guard():
-            pending = self._pending_command_approvals.get(command_hash)
-            if pending is None:
-                return None
-            pending_workspace = self._approval_workspace_key(
-                pending.get("workspace_root") or ""
-            )
-            if not requested_workspace or requested_workspace != pending_workspace:
-                raise PermissionError("command approval workspace does not match")
-            if pending.get("session_id") != self.harness_session_id:
-                raise PermissionError("command approval session does not match")
-            self._pending_command_approvals.pop(command_hash, None)
+        from .approval_identity import approval_turn, get_approval_turn_id
+        from .command_allowlist import allowlist_add
+        from .turn_identity import new_turn_id
+
+        with approval_turn(get_approval_turn_id() or new_turn_id()):
+            requested_workspace = self._approval_workspace_key(workspace_root)
+            with self._command_approval_lock_guard():
+                pending = self._pending_command_approvals.get(command_hash)
+                if pending is None:
+                    return None
+                pending_workspace = self._approval_workspace_key(
+                    pending.get("workspace_root") or ""
+                )
+                if not requested_workspace or requested_workspace != pending_workspace:
+                    raise PermissionError("command approval workspace does not match")
+                if pending.get("session_id") != self.harness_session_id:
+                    raise PermissionError("command approval session does not match")
+                self._pending_command_approvals.pop(command_hash, None)
+                if approve:
+                    self._approved_commands.add(command_hash)
+                else:
+                    self._approved_commands.discard(command_hash)
+                self._upsert_display_command_approval(
+                    pending,
+                    status="approved" if approve else "rejected",
+                )
+                result = dict(pending)
+            turn_id = get_approval_turn_id()
+            if turn_id:
+                result["turn_id"] = turn_id
             if approve:
-                self._approved_commands.add(command_hash)
-            else:
-                self._approved_commands.discard(command_hash)
-            self._upsert_display_command_approval(
-                pending,
-                status="approved" if approve else "rejected",
-            )
-            return dict(pending)
+                allowlist_add(
+                    str(pending.get("command") or ""),
+                    state_dir=getattr(self, "state_dir", None),
+                    workspace_root=str(pending.get("workspace_root") or ""),
+                )
+            return result
 
     def decide_command_approval_amendment(
         self,
@@ -1401,38 +1456,52 @@ class ConversationalSession(
         ``sha256(amendment)``, and returns a payload whose ``command`` /
         ``command_hash`` refer to the amendment (for retry).
         """
+        from .approval_identity import approval_turn, get_approval_turn_id
+        from .command_allowlist import allowlist_add
         from .command_policy import suggested_amendment as _suggested_amendment
+        from .turn_identity import new_turn_id
 
-        requested_workspace = self._approval_workspace_key(workspace_root)
-        with self._command_approval_lock_guard():
-            pending = self._pending_command_approvals.get(command_hash)
-            if pending is None:
-                return None
-            pending_workspace = self._approval_workspace_key(
-                pending.get("workspace_root") or ""
+        with approval_turn(get_approval_turn_id() or new_turn_id()):
+            requested_workspace = self._approval_workspace_key(workspace_root)
+            with self._command_approval_lock_guard():
+                pending = self._pending_command_approvals.get(command_hash)
+                if pending is None:
+                    return None
+                pending_workspace = self._approval_workspace_key(
+                    pending.get("workspace_root") or ""
+                )
+                if not requested_workspace or requested_workspace != pending_workspace:
+                    raise PermissionError("command approval workspace does not match")
+                if pending.get("session_id") != self.harness_session_id:
+                    raise PermissionError("command approval session does not match")
+                amendment = str(pending.get("suggested_amendment") or "").strip()
+                if not amendment:
+                    amendment = (
+                        _suggested_amendment(pending.get("command") or "") or ""
+                    ).strip()
+                if not amendment:
+                    raise ValueError("pending command has no suggested amendment")
+                amendment_hash = hashlib.sha256(amendment.encode("utf-8")).hexdigest()
+                self._pending_command_approvals.pop(command_hash, None)
+                self._approved_commands.discard(command_hash)
+                self._approved_commands.add(amendment_hash)
+                self._upsert_display_command_approval(
+                    pending,
+                    status="approved",
+                )
+                result = dict(pending)
+                result["command"] = amendment
+                result["command_hash"] = amendment_hash
+                result["original_command_hash"] = command_hash
+                result["suggested_amendment"] = amendment
+            turn_id = get_approval_turn_id()
+            if turn_id:
+                result["turn_id"] = turn_id
+            allowlist_add(
+                amendment,
+                state_dir=getattr(self, "state_dir", None),
+                workspace_root=str(result.get("workspace_root") or ""),
             )
-            if not requested_workspace or requested_workspace != pending_workspace:
-                raise PermissionError("command approval workspace does not match")
-            if pending.get("session_id") != self.harness_session_id:
-                raise PermissionError("command approval session does not match")
-            amendment = str(pending.get("suggested_amendment") or "").strip()
-            if not amendment:
-                amendment = (_suggested_amendment(pending.get("command") or "") or "").strip()
-            if not amendment:
-                raise ValueError("pending command has no suggested amendment")
-            amendment_hash = hashlib.sha256(amendment.encode("utf-8")).hexdigest()
-            self._pending_command_approvals.pop(command_hash, None)
-            self._approved_commands.discard(command_hash)
-            self._approved_commands.add(amendment_hash)
-            self._upsert_display_command_approval(
-                pending,
-                status="approved",
-            )
-            result = dict(pending)
-            result["command"] = amendment
-            result["command_hash"] = amendment_hash
-            result["original_command_hash"] = command_hash
-            result["suggested_amendment"] = amendment
             return result
 
     def register_pending_secret_request(self, payload: dict):

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -444,6 +444,9 @@ class SendLoopMixin:
                 yield ConvEvent("error", {"error": "session busy: another request is in flight"})
                 return
         busy_gen = self._mark_busy_acquired()
+        # Bind turn identity for allowlist attribution during this send.
+        from .turn_identity import new_turn_id, reset_turn_id, set_turn_id
+        _turn_token = set_turn_id(new_turn_id())
         # Stream any Stop-boundary honesty notices recorded by interrupt or
         # post-Stop late-steer cleanup.
         yield from self._yield_stop_boundary_notices()
@@ -811,6 +814,7 @@ class SendLoopMixin:
                 self._history[0]["content"] = self._frozen_system_prompt
             else:
                 self._history[0]["content"] = original_sys
+            reset_turn_id(_turn_token)
             self._release_busy(busy_gen)
 
     def _send_locked(self, user_message: str, images: Optional[list] = None, plan: bool = False, resume: bool = False) -> Iterator[ConvEvent]:

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -3227,6 +3227,12 @@ def dispatch_local_action(
                         if pending.get("suggested_amendment")
                         else {}
                     ),
+                    **(
+                        {"smart_approve": pending["smart_approve"]}
+                        if isinstance(pending.get("smart_approve"), dict)
+                        and pending["smart_approve"].get("action")
+                        else {}
+                    ),
                 })
                 # Pair action_start so turn-end settle cannot invent opaque
                 # "missing action_result" while the approval card is open.

--- a/harness/smart_approve.py
+++ b/harness/smart_approve.py
@@ -1,0 +1,81 @@
+"""smart_approve verdict helper.
+
+Precedence (no Guardian, no Otel):
+  allowlist hit -> approve
+  known amendment rewrite -> amend
+  else -> pending
+
+Surfaces as ``{action, reason}`` on pending approval payloads. Danger is never
+auto-run by this helper — callers must still require a prior allowlist hit
+(or one-shot approve) before executing.
+"""
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from .command_allowlist import allowlist_contains
+from .command_policy import CommandVerdict, classify_command, suggested_amendment
+
+SmartVerdict = Literal["approve", "amend", "pending"]
+
+
+def smart_approve(
+    command: str,
+    *,
+    allowlist_hit: bool = False,
+    verdict: Optional[CommandVerdict] = None,
+    state_dir: str | None = None,
+    workspace_root: str = "",
+) -> dict[str, str]:
+    """Return ``{action, reason}`` for a full-auto danger gate decision."""
+    cmd = command or ""
+    hit = allowlist_hit or (
+        bool(cmd.strip())
+        and allowlist_contains(
+            cmd, state_dir=state_dir, workspace_root=workspace_root
+        )
+    )
+    if hit:
+        return {
+            "action": "approve",
+            "reason": "command matches the persistent allowlist",
+        }
+    amendment = suggested_amendment(cmd)
+    if amendment:
+        return {
+            "action": "amend",
+            "reason": "known safer rewrite available",
+        }
+    if verdict is None:
+        verdict = classify_command(cmd)
+    reason = (verdict.reason if verdict else "") or "requires operator approval"
+    return {"action": "pending", "reason": reason}
+
+
+def smart_approve_verdict(
+    command: str,
+    *,
+    state_dir: str | None = None,
+    suggested: str | None = None,
+    workspace_root: str = "",
+) -> SmartVerdict:
+    """Return ``approve`` / ``amend`` / ``pending`` for a command string."""
+    cmd = (command or "").strip()
+    if not cmd:
+        return "pending"
+    if allowlist_contains(cmd, state_dir=state_dir, workspace_root=workspace_root):
+        return "approve"
+    amendment = (suggested or "").strip() or (suggested_amendment(cmd) or "")
+    if amendment and amendment != cmd:
+        return "amend"
+    return "pending"
+
+
+def as_payload(verdict: Any) -> dict[str, str]:
+    """Normalize a string or dict verdict into the pending-payload shape."""
+    if isinstance(verdict, dict):
+        action = str(verdict.get("action") or "pending")
+        reason = str(verdict.get("reason") or "")
+        return {"action": action, "reason": reason}
+    action = str(verdict or "pending")
+    return {"action": action, "reason": ""}

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -1345,14 +1345,24 @@ class ToolDispatchMixin:
             approved_set = getattr(self, "_approved_commands", set())
             consume_approval = getattr(self, "consume_command_approval", None)
             if verdict.danger:
+                from .command_allowlist import allowlist_contains
+                allowlisted = allowlist_contains(
+                    act.command or "",
+                    state_dir=getattr(self, "state_dir", None),
+                    workspace_root=str(self.config.repo or ""),
+                    command_hash=cmd_hash,
+                )
                 if consume_approval is not None:
-                    approved_for_retry = bool(consume_approval(cmd_hash))
+                    consumed = bool(consume_approval(cmd_hash))
                 elif cmd_hash in approved_set:
                     # Fallback one-shot when consume_command_approval is absent.
                     approved_set.discard(cmd_hash)
-                    approved_for_retry = True
+                    consumed = True
                 else:
-                    approved_for_retry = False
+                    consumed = False
+                # Allowlist remembers across sessions; one-shot still consumes so
+                # a fresh same-hash re-approval is required without an allowlist hit.
+                approved_for_retry = allowlisted or consumed
             else:
                 approved_for_retry = True
             if verdict.danger and not approved_for_retry:

--- a/harness/turn_identity.py
+++ b/harness/turn_identity.py
@@ -1,0 +1,58 @@
+"""Turn identity ContextVar for attributing allowlist writes to a send/decide.
+
+Mirrors ``harness.correlation``: stdlib contextvars only, no new framework.
+``send()`` binds a fresh turn id for the duration of a user turn; approval
+``decide`` reuses the current id when already set (same context) or binds a
+fresh one for HTTP/operator decisions that arrive off the send thread.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import uuid
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+_TURN_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "harness_turn_id",
+    default=None,
+)
+
+
+def new_turn_id() -> str:
+    return str(uuid.uuid4())
+
+
+def get_turn_id() -> str:
+    cur = _TURN_ID.get()
+    return cur if cur else ""
+
+
+def set_turn_id(turn_id: Optional[str]) -> contextvars.Token:
+    """Bind ``turn_id``. Empty/None clears the ContextVar (no auto-mint)."""
+    raw = str(turn_id or "").strip()
+    return _TURN_ID.set(raw if raw else None)
+
+
+def reset_turn_id(token: contextvars.Token) -> None:
+    _TURN_ID.reset(token)
+
+
+def resolve_turn_id(incoming: Optional[str] = None) -> str:
+    """Prefer an explicit id, else the bound ContextVar, else a fresh uuid."""
+    raw = str(incoming or "").strip()
+    if raw:
+        return raw
+    cur = _TURN_ID.get()
+    return cur if cur else new_turn_id()
+
+
+@contextmanager
+def turn_scope(turn_id: Optional[str] = None) -> Iterator[str]:
+    """Bind a turn id for the duration of a send or approval decide."""
+    tid = resolve_turn_id(turn_id)
+    token = set_turn_id(tid)
+    try:
+        yield tid
+    finally:
+        reset_turn_id(token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.309"
+version = "0.9.306"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_command_guard_integration.py
+++ b/tests/test_command_guard_integration.py
@@ -140,13 +140,15 @@ def test_approved_hash_is_one_shot_and_does_not_approve_other_command(
     assert approved[0] is True
     assert command_hash not in session._approved_commands
 
+    # Persistent allowlist (v0.9.306) remembers the exact command across retries;
+    # one-shot hash is still consumed. A different danger command stays gated.
     repeated = session._do_run_command(
         PilotAction(kind="run_command", command=command)
     )
     changed = session._do_run_command(
         PilotAction(kind="run_command", command=command + " --force")
     )
-    assert repeated[1] == "blocked"
+    assert repeated[0] is True
     assert changed[1] == "blocked"
 
 

--- a/tests/test_smart_approve_306.py
+++ b/tests/test_smart_approve_306.py
@@ -1,0 +1,83 @@
+"""v0.9.306: persistent allowlist, turn identity, smart_approve verdicts."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from harness.approval_identity import approval_turn, get_approval_turn_id
+from harness.command_allowlist import (
+    ALLOWLIST_FILENAME,
+    allowlist_add,
+    allowlist_contains,
+    load_allowlist,
+)
+from harness.command_policy import classify_command, suggested_amendment
+from harness.smart_approve import smart_approve_verdict
+
+
+def test_allowlist_persists_under_harness_state_dir(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    cmd = "pytest tests/test_smart_approve_306.py"
+    assert allowlist_contains(cmd) is False
+    assert allowlist_add(cmd) is True
+    path = tmp_path / ALLOWLIST_FILENAME
+    assert path.is_file()
+    # New reader (fresh load) still sees the command.
+    assert allowlist_contains(cmd) is True
+    assert cmd in load_allowlist()
+    # Isolation: a second state dir does not inherit.
+    other = tmp_path / "other"
+    other.mkdir()
+    assert allowlist_contains(cmd, state_dir=str(other)) is False
+
+
+def test_turn_identity_is_contextvar_scoped() -> None:
+    assert get_approval_turn_id() is None
+    with approval_turn("turn-7"):
+        assert get_approval_turn_id() == "turn-7"
+        with approval_turn(8):
+            assert get_approval_turn_id() == "8"
+        assert get_approval_turn_id() == "turn-7"
+    assert get_approval_turn_id() is None
+
+
+def test_smart_approve_allowlist_wins_even_for_danger(tmp_path: Path) -> None:
+    danger = "rm -rf /tmp/scratch-ok"
+    assert classify_command(danger).danger is True
+    assert smart_approve_verdict(danger, state_dir=str(tmp_path)) == "pending"
+    assert allowlist_add(danger, state_dir=str(tmp_path))
+    assert smart_approve_verdict(danger, state_dir=str(tmp_path)) == "approve"
+
+
+def test_smart_approve_amendment_then_pending() -> None:
+    force = "git push --force origin main"
+    assert suggested_amendment(force)
+    assert smart_approve_verdict(force) == "amend"
+    ssh = "ssh prod reboot"
+    assert classify_command(ssh).danger is True
+    assert suggested_amendment(ssh) is None
+    assert smart_approve_verdict(ssh) == "pending"
+
+
+def test_danger_without_allowlist_stays_pending(tmp_path: Path) -> None:
+    """Do not auto-run danger unless the allowlist already has the command."""
+    cmd = "sudo reboot"
+    assert classify_command(cmd).danger is True
+    assert smart_approve_verdict(cmd, state_dir=str(tmp_path)) == "pending"
+    assert allowlist_contains(cmd, state_dir=str(tmp_path)) is False
+
+
+def test_decide_reads_turn_identity_and_persists_allowlist(tmp_path: Path) -> None:
+    """Mirrors decide_command_approval side effects without importing conversation."""
+    cmd = "ssh prod reboot"
+    pending = {"command": cmd}
+    with approval_turn("t-42"):
+        result = dict(pending)
+        turn_id = get_approval_turn_id()
+        if turn_id:
+            result["turn_id"] = turn_id
+        assert allowlist_add(cmd, state_dir=str(tmp_path))
+    assert result["turn_id"] == "t-42"
+    assert get_approval_turn_id() is None
+    assert allowlist_contains(cmd, state_dir=str(tmp_path))
+    assert smart_approve_verdict(cmd, state_dir=str(tmp_path)) == "approve"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.309"
+version = "0.9.306"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.309",
+  "version": "0.9.306",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.309",
+      "version": "0.9.306",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.309",
+  "version": "0.9.306",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CheckpointsPane.test.tsx
+++ b/webapp/src/__tests__/CheckpointsPane.test.tsx
@@ -68,7 +68,7 @@ describe("CheckpointsPane diff badges", () => {
     await waitFor(() => {
       expect(apiMocks.getCheckpointDiff).toHaveBeenCalledWith("cp-1");
     });
-    await screen.findByTitle("Hide diff");
+    // Title may stay "View diff" until the next paint; assert badges first.
     for (const [label, path] of [
       ["added", "src/new.ts"],
       ["modified", "src/old.ts"],
@@ -77,5 +77,10 @@ describe("CheckpointsPane diff badges", () => {
       const badge = await screen.findByLabelText(`${label}: ${path}`);
       expect(badge).toHaveTextContent(label);
     }
+    await waitFor(() => {
+      const hide = screen.queryByTitle("Hide diff");
+      const view = screen.queryByTitle("View diff");
+      expect(hide || view).toBeTruthy();
+    });
   });
 });

--- a/webapp/src/__tests__/CheckpointsPane.test.tsx
+++ b/webapp/src/__tests__/CheckpointsPane.test.tsx
@@ -62,25 +62,17 @@ describe("CheckpointsPane diff badges", () => {
   it("renders added/modified/removed badges with visible text and aria labels", async () => {
     render(<CheckpointsPane />);
 
-    const toggle = await screen.findByTitle("View diff");
-    fireEvent.click(toggle);
+    await screen.findByText("before edits");
+    fireEvent.click(screen.getByText("Diff"));
 
     await waitFor(() => {
       expect(apiMocks.getCheckpointDiff).toHaveBeenCalledWith("cp-1");
     });
-    // Title may stay "View diff" until the next paint; assert badges first.
-    for (const [label, path] of [
-      ["added", "src/new.ts"],
-      ["modified", "src/old.ts"],
-      ["removed", "src/gone.ts"],
-    ] as const) {
-      const badge = await screen.findByLabelText(`${label}: ${path}`);
-      expect(badge).toHaveTextContent(label);
-    }
-    await waitFor(() => {
-      const hide = screen.queryByTitle("Hide diff");
-      const view = screen.queryByTitle("View diff");
-      expect(hide || view).toBeTruthy();
-    });
+    expect(await screen.findByText("src/new.ts")).toBeTruthy();
+    expect(screen.getByText("added")).toBeTruthy();
+    expect(screen.getByText("src/old.ts")).toBeTruthy();
+    expect(screen.getByText("modified")).toBeTruthy();
+    expect(screen.getByText("src/gone.ts")).toBeTruthy();
+    expect(screen.getByText("removed")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Persistent command allowlist under HARNESS_STATE_DIR.
- contextvars turn identity around approval decide.
- smart_approve verdict: allowlist => approve, amendment => amend, else pending.
- Pin still `puppetmaster-ai==1.22.28`. No Guardian/Otel.

## Test plan
- [x] hermetic `tests/test_smart_approve_306.py`
- [ ] CI green