### PR TITLE
Marionette v0.9.307 — diag + state backup bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.305, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.307, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.305"
+__version__ = "0.9.307"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/doctor.py
+++ b/harness/api/doctor.py
@@ -135,3 +135,45 @@ def get_diagnostics(svc: DoctorServices) -> tuple[int, JsonPayload]:
         "checks": checks,
         "diagnostic": diagnostic,
     }
+
+
+def get_diagnostics_bundle(
+    sessions: Optional[str],
+    svc: DoctorServices,
+) -> tuple[int, JsonPayload]:
+    """GET /api/diagnostics/bundle — write redacted zip; return path + manifest."""
+    from ..diag_bundle import DEFAULT_SESSION_LIMIT, write_diag_bundle
+
+    limit = DEFAULT_SESSION_LIMIT
+    raw = (sessions or "").strip() if sessions is not None else ""
+    if raw:
+        try:
+            limit = max(0, int(raw))
+        except ValueError:
+            return 400, {
+                "ok": False,
+                "error": "sessions must be an integer",
+                "correlation_id": get_correlation_id(),
+            }
+
+    checks = _build_checks(svc)
+    try:
+        zip_path, manifest = write_diag_bundle(
+            session_limit=limit,
+            get_driver=svc.get_driver,
+            get_reach=svc.get_reach,
+            get_repo=svc.get_repo,
+            checks=checks,
+        )
+    except Exception as exc:
+        return 500, {
+            "ok": False,
+            "error": f"bundle write failed: {exc}",
+            "correlation_id": get_correlation_id(),
+        }
+    return 200, {
+        "ok": True,
+        "path": zip_path,
+        "manifest": manifest,
+        "correlation_id": get_correlation_id(),
+    }

--- a/harness/diag_bundle.py
+++ b/harness/diag_bundle.py
@@ -1,0 +1,356 @@
+"""Redacted diagnostics / state-backup archive for bug reports.
+
+Shared by ``harness doctor --bundle`` and ``GET /api/diagnostics/bundle``.
+Reuses ``harness.api.doctor._build_checks`` — does not invent a second health
+engine. Secrets are stripped via ``harness.api.redaction`` before anything is
+written into the archive or manifest.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+DEFAULT_SESSION_LIMIT = 20
+PIN_FALLBACK = "puppetmaster-ai==1.22.28"
+_PIN_RE = re.compile(r"puppetmaster-ai==[0-9]+(?:\.[0-9]+)*")
+_SECRET_KEY_FRAGMENTS = (
+    "api_key",
+    "apikey",
+    "password",
+    "secret",
+    "token",
+    "authorization",
+    "bearer",
+    "credential",
+)
+
+
+def _state_root() -> str:
+    override = (os.environ.get("HARNESS_STATE_DIR") or "").strip()
+    if override:
+        return override
+    return os.path.join(os.path.expanduser("~"), ".pmharness")
+
+
+def resolve_puppetmaster_pin() -> str:
+    """Installed package version, else a pin string from repo docs, else fallback."""
+    try:
+        import importlib.metadata as metadata
+
+        ver = str(metadata.version("puppetmaster-ai") or "").strip()
+        if ver:
+            return f"puppetmaster-ai=={ver}"
+    except Exception:
+        pass
+    try:
+        import puppetmaster
+
+        ver = str(getattr(puppetmaster, "__version__", "") or "").strip()
+        if ver:
+            return f"puppetmaster-ai=={ver}"
+    except Exception:
+        pass
+    for rel in ("CONTRIBUTING.md", "README.md"):
+        path = Path(__file__).resolve().parents[1] / rel
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        match = _PIN_RE.search(text)
+        if match:
+            return match.group(0)
+    return PIN_FALLBACK
+
+
+def collect_os_info() -> dict[str, str]:
+    return {
+        "platform": platform.platform(),
+        "system": platform.system(),
+        "release": platform.release(),
+    }
+
+
+def _is_secret_key(key: str) -> bool:
+    lowered = str(key or "").strip().lower().replace("-", "_")
+    if not lowered:
+        return False
+    if lowered in ("has_api_key", "api_key_masked", "key_env_var", "masked"):
+        return False
+    return any(frag in lowered for frag in _SECRET_KEY_FRAGMENTS)
+
+
+def strip_secrets(value: Any) -> Any:
+    """Drop secret-shaped keys and redact remaining string values."""
+    from harness.api.redaction import redact_api_secrets, redact_secret_text
+
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key, item in value.items():
+            if _is_secret_key(str(key)):
+                continue
+            if key in ("env", "headers") and isinstance(item, dict):
+                out[key] = {k: "REDACTED" for k in item}
+            else:
+                out[key] = strip_secrets(item)
+        return redact_api_secrets(out)
+    if isinstance(value, list):
+        return [strip_secrets(item) for item in value]
+    if isinstance(value, str):
+        return redact_secret_text(value)
+    return value
+
+
+def collect_public_settings() -> dict[str, Any]:
+    """Config/settings public shape with secrets stripped."""
+    snapshot: dict[str, Any] = {}
+    try:
+        from harness.config import HarnessConfig
+
+        cfg = HarnessConfig.from_env()
+        snapshot = {
+            "driver": cfg.driver,
+            "reach": cfg.reach,
+            "budget": cfg.budget,
+            "state_dir": cfg.state_dir,
+            "repo": cfg.repo,
+            "swarm_adapter": cfg.swarm_adapter,
+            "wiki_auto": cfg.wiki_auto,
+            "auto_verify": cfg.auto_verify,
+            "verify_command": cfg.verify_command,
+            "edit_engine": os.environ.get("HARNESS_EDIT_ENGINE", ""),
+            "max_pilot_steps": os.environ.get("HARNESS_MAX_PILOT_STEPS", ""),
+            "command_timeout": os.environ.get("HARNESS_COMMAND_TIMEOUT", ""),
+        }
+    except Exception as exc:
+        snapshot = {"error": f"settings unavailable: {exc.__class__.__name__}"}
+    return strip_secrets(snapshot)
+
+
+def collect_plugins() -> list[dict[str, Any]]:
+    """Plugin names/ids/enabled only — no package paths or digests."""
+    try:
+        from harness.plugin_registry import discover_plugins, plugin_record_to_dict
+
+        rows = []
+        for record in discover_plugins():
+            full = plugin_record_to_dict(record)
+            rows.append(
+                {
+                    "id": full.get("id") or getattr(record, "id", ""),
+                    "name": full.get("name") or getattr(record, "name", ""),
+                    "enabled": bool(full.get("enabled", getattr(record, "enabled", False))),
+                }
+            )
+        return rows
+    except Exception:
+        return []
+
+
+def collect_session_rows(
+    limit: int = DEFAULT_SESSION_LIMIT,
+    *,
+    state_dir: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Last N sessions: id + title/mtime only (no transcripts)."""
+    root = (state_dir or "").strip() or _state_root()
+    path = os.path.join(root, "harness_sessions.json")
+    try:
+        from harness.sessions import SessionStore
+
+        store = SessionStore(path)
+        rows = store.list(include_preview=False)
+    except Exception:
+        rows = []
+    # Newest first when created is present.
+    def _sort_key(row: dict[str, Any]) -> float:
+        try:
+            return float(row.get("created") or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    rows = sorted(rows, key=_sort_key, reverse=True)[: max(0, int(limit))]
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        created = row.get("created")
+        try:
+            mtime = float(created) if created is not None else None
+        except (TypeError, ValueError):
+            mtime = None
+        out.append(
+            {
+                "id": str(row.get("id") or ""),
+                "title": str(row.get("title") or ""),
+                "mtime": mtime,
+            }
+        )
+    return out
+
+
+def _candidate_log_paths(state_dir: Optional[str] = None) -> list[Path]:
+    root = Path((state_dir or "").strip() or _state_root())
+    names = (
+        "diagnostics.log",
+        "electron.log",
+        "backend.log",
+        "harness.log",
+    )
+    paths = [root / name for name in names]
+    paths.append(root / "state" / "codegraph-index.log")
+    return paths
+
+
+def collect_recent_logs(
+    *,
+    state_dir: Optional[str] = None,
+    max_bytes_per_file: int = 256_000,
+) -> dict[str, str]:
+    """Recent log tails, redacted. Missing files are omitted."""
+    from harness.api.redaction import redact_secret_text
+
+    out: dict[str, str] = {}
+    for path in _candidate_log_paths(state_dir):
+        try:
+            if not path.is_file():
+                continue
+            raw = path.read_bytes()
+            if len(raw) > max_bytes_per_file:
+                raw = raw[-max_bytes_per_file:]
+            text = raw.decode("utf-8", errors="replace")
+            out[path.name] = redact_secret_text(text)
+        except OSError:
+            continue
+    return out
+
+
+def collect_doctor_checks(
+    *,
+    get_driver: Optional[Callable[[], str]] = None,
+    get_reach: Optional[Callable[[], str]] = None,
+    get_repo: Optional[Callable[[], str]] = None,
+) -> list[dict[str, str]]:
+    """Reuse the HTTP diagnostics check engine (single health source)."""
+    from harness.api.doctor import DoctorServices, _build_checks
+
+    def _driver() -> str:
+        if get_driver is not None:
+            return get_driver()
+        return (os.environ.get("HARNESS_DRIVER") or "").strip() or "unknown"
+
+    def _reach() -> str:
+        if get_reach is not None:
+            return get_reach()
+        return (os.environ.get("HARNESS_REACH") or "").strip()
+
+    def _repo() -> str:
+        if get_repo is not None:
+            return get_repo()
+        return (os.environ.get("HARNESS_REPO") or "").strip()
+
+    svc = DoctorServices(get_driver=_driver, get_reach=_reach, get_repo=_repo)
+    return _build_checks(svc)
+
+
+def build_manifest(
+    *,
+    session_limit: int = DEFAULT_SESSION_LIMIT,
+    state_dir: Optional[str] = None,
+    get_driver: Optional[Callable[[], str]] = None,
+    get_reach: Optional[Callable[[], str]] = None,
+    get_repo: Optional[Callable[[], str]] = None,
+    checks: Optional[list[dict[str, str]]] = None,
+) -> dict[str, Any]:
+    from harness import __version__
+
+    sessions = collect_session_rows(session_limit, state_dir=state_dir)
+    if checks is None:
+        checks = collect_doctor_checks(
+            get_driver=get_driver,
+            get_reach=get_reach,
+            get_repo=get_repo,
+        )
+    plugins = collect_plugins()
+    return strip_secrets(
+        {
+            "version": str(__version__),
+            "os": collect_os_info(),
+            "pin": resolve_puppetmaster_pin(),
+            "plugins": plugins,
+            "session_ids": [s["id"] for s in sessions if s.get("id")],
+            "sessions": sessions,
+            "checks": checks,
+            "doctor": {"checks": checks},
+            "settings": collect_public_settings(),
+            "created_at": int(time.time()),
+        }
+    )
+
+
+def _default_outdir() -> str:
+    root = _state_root()
+    out = os.path.join(root, "diag-bundles")
+    try:
+        os.makedirs(out, exist_ok=True)
+        return out
+    except OSError:
+        return tempfile.gettempdir()
+
+
+def write_diag_bundle(
+    outdir: Optional[str] = None,
+    *,
+    session_limit: int = DEFAULT_SESSION_LIMIT,
+    state_dir: Optional[str] = None,
+    get_driver: Optional[Callable[[], str]] = None,
+    get_reach: Optional[Callable[[], str]] = None,
+    get_repo: Optional[Callable[[], str]] = None,
+    checks: Optional[list[dict[str, str]]] = None,
+) -> tuple[str, dict[str, Any]]:
+    """Write ``*.zip`` + sibling ``*.manifest.json``. Returns (zip_path, manifest)."""
+    dest = (outdir or "").strip() or _default_outdir()
+    os.makedirs(dest, exist_ok=True)
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    base = f"marionette-diag-{stamp}"
+    zip_path = os.path.join(dest, f"{base}.zip")
+    manifest_path = os.path.join(dest, f"{base}.manifest.json")
+
+    root = (state_dir or "").strip() or _state_root()
+    manifest = build_manifest(
+        session_limit=session_limit,
+        state_dir=root,
+        get_driver=get_driver,
+        get_reach=get_reach,
+        get_repo=get_repo,
+        checks=checks,
+    )
+    logs = collect_recent_logs(state_dir=root)
+    settings = manifest.get("settings") or collect_public_settings()
+
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "manifest.json",
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        )
+        zf.writestr(
+            "settings.json",
+            json.dumps(settings, indent=2, sort_keys=True) + "\n",
+        )
+        zf.writestr(
+            "checks.json",
+            json.dumps(manifest.get("checks") or [], indent=2) + "\n",
+        )
+        for name, body in logs.items():
+            zf.writestr(f"logs/{name}", body if body.endswith("\n") else body + "\n")
+
+    with open(manifest_path, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+    return zip_path, manifest

--- a/harness/doctor.py
+++ b/harness/doctor.py
@@ -25,6 +25,21 @@ def run_doctor(argv) -> int:
     ap = argparse.ArgumentParser(prog="harness doctor")
     ap.add_argument("--ping", action="store_true",
                     help="also make a live 1-token call to the driver (costs a fraction of a cent)")
+    ap.add_argument(
+        "--bundle",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="OUTDIR",
+        help="write a redacted diagnostics zip + manifest (default outdir: state/diag-bundles)",
+    )
+    ap.add_argument(
+        "--sessions",
+        type=int,
+        default=20,
+        metavar="N",
+        help="with --bundle, include last N session ids (default 20)",
+    )
     args = ap.parse_args(argv)
 
     from .config import HarnessConfig
@@ -207,6 +222,26 @@ def run_doctor(argv) -> int:
     print()
     if hard_fail:
         _line("fail", "result", "one or more hard failures -- fix before running tasks")
-        return 1
-    _line("ok", "result", "harness ready")
-    return 0
+    else:
+        _line("ok", "result", "harness ready")
+
+    if args.bundle is not None:
+        try:
+            from .diag_bundle import write_diag_bundle
+
+            outdir = (args.bundle or "").strip() or None
+            zip_path, _manifest = write_diag_bundle(
+                outdir,
+                session_limit=max(0, int(args.sessions)),
+                state_dir=cfg.state_dir or None,
+                get_driver=lambda: cfg.driver,
+                get_reach=lambda: cfg.reach,
+                get_repo=lambda: cfg.repo,
+            )
+            print(f"diagnostics bundle: {zip_path}")
+            return 0
+        except Exception as e:
+            _line("fail", "bundle", f"could not write diagnostics archive: {e}")
+            return 1
+
+    return 1 if hard_fail else 0

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -685,6 +685,19 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
             _settings_api.get_config, services=svc.settings_services),
         "/api/diagnostics": get_json(
             _doctor_api.get_diagnostics, services=svc.doctor_services),
+        "/api/diagnostics/bundle": get_json(
+            _doctor_api.get_diagnostics_bundle,
+            services=svc.doctor_services,
+            qs_arg="sessions",
+            empty_as_none=True,
+        ),
+        # Cheap alias — preferred path is /api/diagnostics/bundle.
+        "/api/diag/bundle": get_json(
+            _doctor_api.get_diagnostics_bundle,
+            services=svc.doctor_services,
+            qs_arg="sessions",
+            empty_as_none=True,
+        ),
         "/api/wiki/config": get_json(_wiki_api.get_wiki_config_payload),
         "/api/bedrock": get_json(_plat_api.get_bedrock),
         "/api/auth/pools": _get_auth_pools,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.305"
+version = "0.9.307"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_diag_bundle.py
+++ b/tests/test_diag_bundle.py
@@ -1,0 +1,185 @@
+"""Diagnostics bundle: redacted zip + manifest for bug reports (hermetic)."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from harness.api.doctor import DoctorServices, get_diagnostics_bundle
+from harness.diag_bundle import build_manifest, write_diag_bundle
+from harness import cli
+
+
+PLANTED_SK = "sk-plantedsecretvalue99999999"
+PLANTED_GHP = "ghp_plantedGitHubPatXXXXXXXX"
+PLANTED_BEARER = "Bearer planted_bearer_token_abcdef"
+
+
+def _stub_plugins(monkeypatch):
+    from harness import plugin_registry as pr
+
+    class _Rec:
+        id = "demo-plugin"
+        name = "Demo Plugin"
+        enabled = True
+
+    monkeypatch.setattr(pr, "discover_plugins", lambda: [_Rec()])
+    monkeypatch.setattr(
+        pr,
+        "plugin_record_to_dict",
+        lambda r: {"id": r.id, "name": r.name, "enabled": r.enabled, "path": "/secret/path"},
+    )
+
+
+def _seed_state(tmp_path: Path) -> Path:
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "diagnostics.log").write_text(
+        f"boot ok api_key={PLANTED_SK} token={PLANTED_GHP} auth={PLANTED_BEARER}\n",
+        encoding="utf-8",
+    )
+    sessions = {
+        "active": "sess-2",
+        "sessions": [
+            {"id": "sess-1", "title": "Old", "created": 100.0},
+            {"id": "sess-2", "title": "New", "created": 200.0},
+            {"id": "sess-3", "title": "Mid", "created": 150.0},
+        ],
+    }
+    (state / "harness_sessions.json").write_text(json.dumps(sessions), encoding="utf-8")
+    return state
+
+
+def test_write_diag_bundle_manifest_and_redaction(tmp_path, monkeypatch):
+    state = _seed_state(tmp_path)
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(state))
+    monkeypatch.setenv("HARNESS_DRIVER", "stub-oracle-v2")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    _stub_plugins(monkeypatch)
+
+    outdir = tmp_path / "out"
+    zip_path, manifest = write_diag_bundle(
+        str(outdir),
+        session_limit=2,
+        state_dir=str(state),
+        get_driver=lambda: "stub-oracle-v2",
+        get_reach=lambda: "local",
+        get_repo=lambda: "",
+    )
+
+    assert Path(zip_path).is_file()
+    manifest_sidecars = list(outdir.glob("*.manifest.json"))
+    assert len(manifest_sidecars) == 1
+
+    for key in ("version", "os", "pin", "plugins", "session_ids", "checks"):
+        assert key in manifest
+    assert manifest["pin"].startswith("puppetmaster-ai==")
+    assert manifest["session_ids"] == ["sess-2", "sess-3"]
+    assert manifest["plugins"] == [
+        {"id": "demo-plugin", "name": "Demo Plugin", "enabled": True}
+    ]
+    assert isinstance(manifest["checks"], list)
+    assert manifest["checks"]
+    assert "doctor" in manifest and "checks" in manifest["doctor"]
+
+    blob = Path(zip_path).read_bytes()
+    assert PLANTED_SK.encode() not in blob
+    assert PLANTED_GHP.encode() not in blob
+    assert b"planted_bearer_token_abcdef" not in blob
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = set(zf.namelist())
+        assert "manifest.json" in names
+        assert "settings.json" in names
+        assert "logs/diagnostics.log" in names
+        log = zf.read("logs/diagnostics.log").decode("utf-8")
+        assert PLANTED_SK not in log
+        assert "REDACTED" in log
+        inner = json.loads(zf.read("manifest.json"))
+        packed = json.dumps(inner)
+        assert PLANTED_SK not in packed
+        assert PLANTED_GHP not in packed
+
+
+def test_build_manifest_strips_secret_settings(monkeypatch, tmp_path):
+    state = _seed_state(tmp_path)
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(state))
+    monkeypatch.setenv("HARNESS_DRIVER", "stub-oracle-v2")
+    _stub_plugins(monkeypatch)
+
+    # Plant a secret-shaped value into the public settings path via env that
+    # collect_public_settings does not normally emit — exercise strip_secrets.
+    from harness import diag_bundle as db
+
+    monkeypatch.setattr(
+        db,
+        "collect_public_settings",
+        lambda: db.strip_secrets(
+            {
+                "driver": "stub-oracle-v2",
+                "api_key": PLANTED_SK,
+                "note": f"key={PLANTED_SK}",
+            }
+        ),
+    )
+    manifest = build_manifest(
+        session_limit=1,
+        state_dir=str(state),
+        get_driver=lambda: "stub-oracle-v2",
+        get_reach=lambda: "local",
+        get_repo=lambda: "",
+        checks=[{"status": "ok", "name": "result", "detail": "harness ready"}],
+    )
+    packed = json.dumps(manifest)
+    assert "api_key" not in manifest.get("settings", {})
+    assert PLANTED_SK not in packed
+
+
+def test_cli_doctor_bundle_writes_file(tmp_path, monkeypatch, capsys):
+    state = _seed_state(tmp_path)
+    outdir = tmp_path / "cli-out"
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(state))
+    monkeypatch.setenv("HARNESS_DRIVER", "stub-oracle-v2")
+    _stub_plugins(monkeypatch)
+
+    code = cli.main(["doctor", "--bundle", str(outdir), "--sessions", "1"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "diagnostics bundle:" in out
+    zips = list(outdir.glob("*.zip"))
+    assert len(zips) == 1
+    assert zips[0].is_file()
+
+
+def test_get_diagnostics_bundle_api(tmp_path, monkeypatch):
+    state = _seed_state(tmp_path)
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(state))
+    monkeypatch.setenv("HARNESS_DRIVER", "stub-oracle-v2")
+    _stub_plugins(monkeypatch)
+
+    # Force default outdir under tmp so we never write into a real home.
+    from harness import diag_bundle as db
+
+    outdir = tmp_path / "api-out"
+    monkeypatch.setattr(db, "_default_outdir", lambda: str(outdir))
+
+    svc = DoctorServices(
+        get_driver=lambda: "stub-oracle-v2",
+        get_reach=lambda: "local",
+        get_repo=lambda: "",
+    )
+    with __import__("harness.correlation", fromlist=["correlation_scope"]).correlation_scope(
+        "diag-bundle-test",
+    ):
+        status, payload = get_diagnostics_bundle("2", svc)
+
+    assert status == 200
+    assert payload["ok"] is True
+    assert Path(payload["path"]).is_file()
+    assert "manifest" in payload
+    for key in ("version", "os", "pin", "plugins", "session_ids", "checks"):
+        assert key in payload["manifest"]
+    packed = json.dumps(payload)
+    assert PLANTED_SK not in packed
+    assert PLANTED_GHP not in packed

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.305"
+version = "0.9.307"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.305",
+  "version": "0.9.307",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.305",
+      "version": "0.9.307",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.305",
+  "version": "0.9.307",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- One-command redacted diagnostics + state backup for bug reports, extending the existing harness doctor (not a second health system).
- `harness doctor --bundle [outdir]` writes a zip + sidecar manifest; GET `/api/diagnostics/bundle` (alias `/api/diag/bundle`) returns `{ok, path, manifest}`.
- Bundle collects version, OS, `puppetmaster-ai` pin, redacted recent logs, settings without secrets, plugin id/name/enabled, last N session ids, and doctor `_build_checks`. Pin stays `puppetmaster-ai==1.22.28`. Version 0.9.304 → 0.9.307 from current main (305/306 still open).

## Test plan
- [x] `pytest tests/test_diag_bundle.py tests/test_doctor.py tests/test_api_diagnostics.py` (13 passed, hermetic)
- [ ] `harness doctor --bundle /tmp/marionette-diag` writes a zip; confirm planted secrets do not appear in the archive
- [ ] GET `/api/diagnostics/bundle` returns 200 + path + manifest keys (`version`, `os`, `pin`, `plugins`, `session_ids`, `checks`)