### PR TITLE
Marionette v0.9.309 — snapcompact

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.307, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.309, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.307"
+__version__ = "0.9.309"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/session_control.py
+++ b/harness/api/session_control.py
@@ -201,6 +201,91 @@ def _compaction_error_message(reason: str) -> str:
     return "no compaction occurred (history too small or summary rejected)"
 
 
+
+def _hot_context_messages(pilot: Any) -> list:
+    """User/tool/assistant turns from the live pilot. Fail closed to []."""
+    try:
+        data = pilot.export_transcript_data()
+    except Exception:
+        data = None
+    if isinstance(data, dict):
+        history = data.get("history")
+        if isinstance(history, list) and history:
+            return [m for m in history if isinstance(m, dict)]
+    raw = getattr(pilot, "_history", None) or []
+    msgs = [m for m in raw if isinstance(m, dict)]
+    if msgs and str(msgs[0].get("role") or "") == "system":
+        return msgs[1:]
+    return msgs
+
+
+def post_session_snapcompact(
+    svc: SessionControlServices,
+    body: Optional[dict] = None,
+) -> tuple[int, JsonPayload]:
+    """POST /api/session/snapcompact (also ``POST /api/session/compact`` op=snap).
+
+    One-shot compact-to-snapshot on the existing vault/archive/journal path.
+    """
+    not_ready = svc.gate_active_pilot_ready()
+    if not_ready is not None:
+        return 409, not_ready
+    body = body or {}
+    pilot = svc.get_pilot()
+    sessions = svc.get_sessions() if svc.get_sessions is not None else None
+    sid = (
+        str(body.get("session_id") or "").strip()
+        or getattr(sessions, "active", None)
+        or getattr(pilot, "harness_session_id", None)
+        or "default"
+    )
+    messages = _hot_context_messages(pilot)
+    state_dir = getattr(svc.cfg, "state_dir", None) or _tf.gettempdir()
+    from ..compaction_vault import snap_compact
+
+    result = snap_compact(state_dir, str(sid), messages)
+    if not result.get("ok"):
+        reason = str(result.get("reason") or "no_compactable_history")
+        return 409, {
+            **result,
+            "compacted": False,
+            "error": _compaction_error_message(reason),
+        }
+    if sessions is not None and sessions.active and svc.save_transcript is not None:
+        try:
+            svc.save_transcript(
+                state_dir,
+                sessions.active,
+                pilot.export_transcript_data(),
+            )
+        except Exception:
+            pass
+    return 200, {
+        **result,
+        "compacted": True,
+        "op": "snap",
+    }
+
+
+def post_session_compact_routed(
+    body: dict,
+    svc: SessionControlServices,
+) -> tuple[int, JsonPayload]:
+    """Route compact POSTs; ``op=snap`` is snapcompact, else Compact Now."""
+    op = str((body or {}).get("op") or "").strip().lower()
+    if op in ("snap", "snapcompact"):
+        return post_session_snapcompact(svc, body)
+    return post_session_compact(svc)
+
+
+def post_session_snapcompact_routed(
+    body: dict,
+    svc: SessionControlServices,
+) -> tuple[int, JsonPayload]:
+    """POST /api/session/snapcompact with optional JSON body."""
+    return post_session_snapcompact(svc, body)
+
+
 def post_session_compact(svc: SessionControlServices) -> tuple[int, JsonPayload]:
     """POST /api/session/compact.
 

--- a/harness/compaction_vault.py
+++ b/harness/compaction_vault.py
@@ -7,9 +7,11 @@ dump-and-query plane: compact writes the middle here, later turns retrieve
 matching slices the way wiki grounding retrieves pages. Never raises.
 """
 
+import hashlib
 import os
 import re
 import sqlite3
+import time
 from typing import Any, List
 
 from harness.api.redaction import redact_secret_text
@@ -496,3 +498,78 @@ def build_turn_vault_section(
 ) -> str:
     """Wiki-style inject for the current user ask. Never raises."""
     return str(build_turn_vault_cite(state_dir, session_id, user_message).get("section") or "")
+
+
+def snap_compact(
+    state_dir: str,
+    session_id: str,
+    messages: Any,
+    *,
+    snapshot_id: str = "",
+) -> dict:
+    """One-shot compact-to-snapshot via archive + vault + journal. Never raises.
+
+    Folds hot context into the existing compaction archive sidecar, FTS vault,
+    and history journal. Does not invent a second engine or rewrite live
+    history — Compact Now still owns the LLM residual path.
+    """
+    empty = {
+        "ok": False,
+        "snapshot_id": "",
+        "session_id": "",
+        "archived": False,
+        "archived_messages": 0,
+        "vault_chunks": 0,
+        "chars_before": 0,
+        "reason": "no_compactable_history",
+    }
+    try:
+        sid = _safe_session_id(session_id)
+        copied = [m for m in (messages or []) if isinstance(m, dict)]
+        if not state_dir or not sid or not copied:
+            empty["session_id"] = sid
+            return empty
+        chars_before = sum(len(str(m.get("content") or "")) for m in copied)
+        if not snapshot_id:
+            digest = hashlib.sha256()
+            digest.update(sid.encode("utf-8"))
+            digest.update(str(len(copied)).encode("ascii"))
+            digest.update(str(time.time()).encode("ascii"))
+            snapshot_id = "snap-" + digest.hexdigest()[:16]
+        from harness.compaction_archive import (
+            append_compaction_archive,
+            load_compaction_archive_messages,
+        )
+        from harness.history_compaction_journal import (
+            EVENT_COMPACT,
+            record_history_compaction,
+        )
+
+        archived = bool(append_compaction_archive(state_dir, sid, copied))
+        vault_chunks = int(index_elided_messages(state_dir, sid, copied) or 0)
+        record_history_compaction(
+            state_dir,
+            sid,
+            len(copied),
+            chars_before,
+            0,
+            f"snapcompact {snapshot_id}",
+            event_kind=EVENT_COMPACT,
+            compact_policy="snap",
+        )
+        archived_messages = (
+            len(load_compaction_archive_messages(state_dir, sid)) if archived else 0
+        )
+        return {
+            "ok": True,
+            "snapshot_id": snapshot_id,
+            "session_id": sid,
+            "archived": archived,
+            "archived_messages": archived_messages,
+            "vault_chunks": vault_chunks,
+            "chars_before": chars_before,
+            "reason": "ok",
+        }
+    except Exception:
+        return empty
+

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -122,8 +122,10 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             needs_body=False),
         "/api/restart": _post_restart,
         "/api/session/compact": post_json(
-            _sc_api.post_session_compact, services=svc.session_control_services,
-            needs_body=False),
+            _sc_api.post_session_compact_routed, services=svc.session_control_services),
+        "/api/session/snapcompact": post_json(
+            _sc_api.post_session_snapcompact_routed,
+            services=svc.session_control_services),
         "/api/checkpoints/restore": post_json(
             _ckpt_api.post_checkpoints_restore, services=svc.checkpoint_services),
         "/api/checkpoints/snapshot": post_json(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.307"
+version = "0.9.309"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_http_routes_table.py
+++ b/tests/test_http_routes_table.py
@@ -49,6 +49,7 @@ _SAMPLE_GUARDED_POST = (
     "/api/restart",
     "/api/session/interrupt",
     "/api/session/compact",
+    "/api/session/snapcompact",
     "/api/mcp/refresh",
 )
 

--- a/tests/test_snapcompact.py
+++ b/tests/test_snapcompact.py
@@ -1,0 +1,142 @@
+"""Hermetic snapcompact: archive + vault + journal on the existing path."""
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+from harness.api.session_control import (
+    SessionControlServices,
+    post_session_compact_routed,
+    post_session_snapcompact,
+)
+from harness.compaction_archive import load_compaction_archive_messages
+from harness.compaction_vault import retrieve_vault_chunks, snap_compact
+from harness.history_compaction_journal import DB_FILENAME
+
+
+NONCE = "omega-snap-token-9f3a"
+
+
+def _messages():
+    return [
+        {"role": "user", "content": "Run the snapcompact probe."},
+        {
+            "role": "assistant",
+            "content": f"Probe finished with measurement {NONCE}.",
+        },
+    ]
+
+
+def test_snap_compact_writes_archive_vault_and_journal(tmp_path):
+    result = snap_compact(str(tmp_path), "sess-snap", _messages())
+    assert result["ok"] is True
+    assert result["snapshot_id"].startswith("snap-")
+    assert result["session_id"] == "sess-snap"
+    assert result["archived"] is True
+    assert result["archived_messages"] >= 2
+    assert result["vault_chunks"] >= 1
+    assert result["chars_before"] > 0
+
+    archived = load_compaction_archive_messages(str(tmp_path), "sess-snap")
+    assert any(NONCE in str(row.get("content") or "") for row in archived)
+
+    hits = retrieve_vault_chunks(
+        str(tmp_path),
+        "sess-snap",
+        "What snapcompact probe measurement token was returned?",
+    )
+    assert any(NONCE in hit for hit in hits)
+
+    conn = sqlite3.connect(str(tmp_path / DB_FILENAME))
+    try:
+        rows = conn.execute(
+            "SELECT summary_preview, compact_policy, messages_compacted "
+            "FROM compactions"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows
+    preview, policy, count = rows[-1]
+    assert result["snapshot_id"] in str(preview)
+    assert policy == "snap"
+    assert int(count) >= 2
+
+
+def test_snap_compact_empty_history_is_noop(tmp_path):
+    result = snap_compact(str(tmp_path), "sess-empty", [])
+    assert result["ok"] is False
+    assert result["reason"] == "no_compactable_history"
+    assert result["snapshot_id"] == ""
+    assert load_compaction_archive_messages(str(tmp_path), "sess-empty") == []
+
+
+def _svc(tmp_path, pilot, sessions=None, not_ready=None):
+    return SessionControlServices(
+        cfg=SimpleNamespace(driver="m1", state_dir=str(tmp_path), max_context_tokens=96000),
+        get_pilot=lambda: pilot,
+        get_runners=lambda: SimpleNamespace(
+            get=lambda sid: None,
+            statuses=lambda: {},
+            active_view_id="v1",
+        ),
+        gate_active_pilot_ready=lambda: not_ready,
+        stash_put=lambda msg, imgs: "mid1",
+        save_active_transcript=lambda: None,
+        upload_dir="/uploads",
+        diag=lambda *a: None,
+        get_sessions=lambda: sessions or SimpleNamespace(active="sess-snap"),
+        save_transcript=lambda *a, **k: None,
+        set_resume_latch=lambda *a, **k: None,
+        persist_boot_usage=lambda **k: None,
+        peek_resume_pending=lambda idle, session_id="": False,
+        consume_resume_pending=lambda idle, session_id="": False,
+        checkpoint_transcript=lambda: None,
+        context_at=lambda *a: None,
+    )
+
+
+class _SnapPilot:
+    harness_session_id = "sess-snap"
+
+    def export_transcript_data(self):
+        return {"history": _messages(), "display": [], "job_ids": []}
+
+
+def test_post_session_snapcompact_returns_snapshot_id(tmp_path):
+    svc = _svc(tmp_path, _SnapPilot())
+    code, payload = post_session_snapcompact(svc)
+    assert code == 200
+    assert payload["ok"] is True
+    assert payload["compacted"] is True
+    assert payload["op"] == "snap"
+    assert str(payload["snapshot_id"]).startswith("snap-")
+    assert payload["archived_messages"] >= 2
+    assert payload["vault_chunks"] >= 1
+
+
+def test_post_session_compact_op_snap_uses_snapcompact(tmp_path):
+    svc = _svc(tmp_path, _SnapPilot())
+    code, payload = post_session_compact_routed({"op": "snap"}, svc)
+    assert code == 200
+    assert payload["op"] == "snap"
+    assert payload["snapshot_id"]
+    archived = load_compaction_archive_messages(str(tmp_path), "sess-snap")
+    assert any(NONCE in str(row.get("content") or "") for row in archived)
+
+
+def test_snapcompact_route_is_registered():
+    import harness.http_routes as http_routes
+    import harness.server as srv
+
+    svc = srv._route_services()
+    post = http_routes.build_post_json_routes(svc)
+    assert "/api/session/snapcompact" in post
+    assert "/api/session/compact" in post
+    assert callable(post["/api/session/snapcompact"])
+
+
+def test_snapcompact_respects_pilot_gate(tmp_path):
+    svc = _svc(tmp_path, _SnapPilot(), not_ready={"error": "busy"})
+    code, payload = post_session_snapcompact(svc)
+    assert code == 409
+    assert payload["error"] == "busy"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.307"
+version = "0.9.309"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.307",
+  "version": "0.9.309",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.307",
+      "version": "0.9.309",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.307",
+  "version": "0.9.309",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- One-shot snapcompact on the existing compaction vault/archive/journal path (not a second compaction engine).
- `snap_compact()` folds hot context into the archive sidecar + FTS vault index + history journal (`compact_policy=snap`).
- `POST /api/session/snapcompact` and `POST /api/session/compact` with `op=snap` return snapshot id + counts.
- Version 0.9.307 → 0.9.309. Pin stays `puppetmaster-ai==1.22.28`.

## Test plan
- [x] `pytest tests/test_snapcompact.py tests/test_http_routes_table.py tests/test_api_session_control_peel.py tests/test_compaction_vault.py` (43 passed, hermetic)
- [ ] POST `/api/session/snapcompact` on a live session returns `snapshot_id` + `archived_messages` / `vault_chunks`
- [ ] POST `/api/session/compact` with `{op: snap}` hits the same path; empty history returns 409