### PR TITLE
Marionette v0.9.312 — metaharness scoring and leader election

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.311, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.312, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 
@@ -101,8 +101,6 @@ The cost thesis is measured, not asserted:
 | **Cost transparency** | The status bar shows **process-wide** spend (pilot plus every delegated swarm/worker job in this backend process), priced at each job's actual model rate when usage is known. Unknown models fall back to the live OpenRouter price map (public `/models` feed, disk-cached), then to the router's pre-flight estimate -- never silently $0. The Swarm pane shows **per-repo session** spend on each job card (scoped to the active workspace), not a second copy of the status-bar total. |
 | **Full-auto mode** | Unattended objective pursuit bounded by an AutoBudget governor (max swarms / tokens / seconds / idle), with a non-bypassable command safety guard. |
 | **Scheduled autonomy** | `harness schedule` provides cron-backed local unattended runs with transactional cross-process claims, restart recovery, cooperative cancellation, truthful run history, and workspace safety. Fire times are host-local. HTTP + Settings UI can list/mutate/run-now/history (poll-first); the local daemon is still required for unattended cron fire. Per-schedule IANA timezone and schedule SSE remain deferred. |
-| **Chrome browser relay** | Unpacked Chrome extension / native-host message posts tab URL, title, and optional page text to `POST /api/browser/relay`. Off by default (`PM_BROWSER_RELAY=1`). Extends the existing CDP browser stack; not a second engine, marketplace listing, or telemetry sink. |
-| **Collab web presence** | Who is in the session: peer id, label, and last_seen. Heartbeat POST refreshes a peer; GET lists live peers and expires stale ones. In-process stdlib store -- no marketplace, Sentry/Otel, or Guardian. |
 | **Command safety guard** | In full-auto, irreversible/remote/escalating shell commands (recursive deletes, ssh/scp, curl-pipe-to-shell, force-push, sudo, disk writes, key exfil) are screened and blocked; interactive co-working is untouched. Configurable per-command timeout (default 120s; 0/off = unbounded for long sessions). |
 
 ## Architecture

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.311"
+__version__ = "0.9.312"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/metaharness.py
+++ b/harness/api/metaharness.py
@@ -1,0 +1,43 @@
+"""Authenticated metaharness scoring / leader-election HTTP handlers."""
+from __future__ import annotations
+
+from typing import Any, Union
+
+from ..metaharness import ScoreError, get_latch, score_report
+
+JsonPayload = Union[dict, list]
+
+
+def get_metaharness_status() -> tuple[int, JsonPayload]:
+    """GET /api/metaharness/status — current leader latch."""
+    return 200, get_latch().status()
+
+
+def post_metaharness_score(body: dict) -> tuple[int, JsonPayload]:
+    """POST /api/metaharness/score — report a peer score (also a heartbeat)."""
+    if not isinstance(body, dict):
+        return 400, {"ok": False, "error": "body must be an object"}
+    try:
+        value = score_report(body)
+        snap = get_latch().report_score(body.get("peer_id") or body.get("id"), value)
+    except ScoreError as exc:
+        return 400, {"ok": False, "error": str(exc)}
+    return 200, snap
+
+
+def post_metaharness_heartbeat(body: dict) -> tuple[int, JsonPayload]:
+    """POST /api/metaharness/heartbeat — refresh liveness, optional new score."""
+    if not isinstance(body, dict):
+        return 400, {"ok": False, "error": "body must be an object"}
+    peer_id = body.get("peer_id") or body.get("id")
+    score: Any = None
+    if "score" in body or "ok" in body or "success" in body:
+        try:
+            score = score_report(body)
+        except ScoreError as exc:
+            return 400, {"ok": False, "error": str(exc)}
+    try:
+        snap = get_latch().heartbeat(peer_id, score)
+    except ScoreError as exc:
+        return 400, {"ok": False, "error": str(exc)}
+    return 200, snap

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -111,6 +111,7 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
     from .api import workspace as _ws_api
     from .api import worktrees as _wt_api
     from .api import collab_presence as _collab_presence_api
+    from .api import metaharness as _mh_api
 
     routes: dict[str, PostHandler] = {
         "/api/browser/relay": post_json(_browser_api.post_browser_relay),
@@ -353,6 +354,8 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
         "/api/schedules/disable": post_json(_sched_api.post_schedules_disable),
         "/api/schedules/remove": post_json(_sched_api.post_schedules_remove),
         "/api/schedules/run-now": post_json(_sched_api.post_schedules_run_now),
+        "/api/metaharness/score": post_json(_mh_api.post_metaharness_score),
+        "/api/metaharness/heartbeat": post_json(_mh_api.post_metaharness_heartbeat),
     }
     # Attach relocate helper + host_ok/diag via closure attrs on module-level fns.
     _post_session_relocate._svc = svc  # type: ignore[attr-defined]
@@ -462,6 +465,7 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
     from .api import workspace as _ws_api
     from .api import worktrees as _wt_api
     from .api import collab_presence as _collab_presence_api
+    from .api import metaharness as _mh_api
 
     def _get_git_diff(handler: Any, u: Any, qs: dict) -> Any:
         staged = qs.get("staged", ["0"])[0].strip().lower() in ("1", "true", "yes")
@@ -775,4 +779,5 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         "/api/auto": _get_auto,
         "/api/collab/presence": get_json(
             _collab_presence_api.get_presence, pass_qs=True),
+        "/api/metaharness/status": get_json(_mh_api.get_metaharness_status),
     }

--- a/harness/metaharness.py
+++ b/harness/metaharness.py
@@ -1,0 +1,164 @@
+"""In-process metaharness scoring and leader election.
+
+Peers report a numeric score (and optional heartbeat). One leader is
+elected: highest live score, ties broken stably by peer id
+(lexicographically smallest). No marketplace, Sentry, or Guardian.
+"""
+from __future__ import annotations
+
+import math
+import threading
+import time
+from typing import Any, Callable, Optional
+
+
+DEFAULT_TTL_SECONDS = 30.0
+
+
+class ScoreError(ValueError):
+    """Reported score could not be accepted."""
+
+
+def score_value(raw: Any) -> float:
+    """Normalize a reported score to a finite float."""
+    if raw is None or isinstance(raw, bool):
+        raise ScoreError("score must be a finite number")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ScoreError("score must be a finite number") from exc
+    if not math.isfinite(value):
+        raise ScoreError("score must be a finite number")
+    return value
+
+
+def score_report(payload: dict) -> float:
+    """Score a peer report.
+
+    Prefer an explicit ``score``. Otherwise derive a small composite from
+    ``ok`` / ``success`` plus optional ``latency_ms`` (lower is better).
+    """
+    if not isinstance(payload, dict):
+        raise ScoreError("report must be an object")
+    if "score" in payload and payload["score"] is not None:
+        return score_value(payload["score"])
+    ok_raw = payload.get("ok", payload.get("success"))
+    if ok_raw is None:
+        raise ScoreError("score or ok/success is required")
+    ok = bool(ok_raw)
+    latency_raw = payload.get("latency_ms", 0)
+    if latency_raw in (None, ""):
+        latency_raw = 0
+    try:
+        latency = float(latency_raw)
+    except (TypeError, ValueError) as exc:
+        raise ScoreError("latency_ms must be a number") from exc
+    if not math.isfinite(latency) or latency < 0:
+        raise ScoreError("latency_ms must be a non-negative finite number")
+    # Success is the bulk of the score; latency is a small tie-breaker.
+    return (1.0 if ok else 0.0) + (1.0 / (1.0 + latency))
+
+
+class LeaderLatch:
+    """Thread-safe in-process peer score table + leader latch."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._ttl = float(ttl_seconds)
+        self._clock = clock or time.monotonic
+        self._lock = threading.Lock()
+        self._peers: dict[str, dict[str, Any]] = {}
+
+    def reset(self) -> None:
+        with self._lock:
+            self._peers.clear()
+
+    def report_score(self, peer_id: str, score: Any) -> dict[str, Any]:
+        pid = _require_peer_id(peer_id)
+        value = score_value(score)
+        now = self._clock()
+        with self._lock:
+            self._peers[pid] = {"id": pid, "score": value, "seen_at": now}
+            return self._snapshot_locked(now)
+
+    def heartbeat(self, peer_id: str, score: Any = None) -> dict[str, Any]:
+        pid = _require_peer_id(peer_id)
+        now = self._clock()
+        with self._lock:
+            prev = self._peers.get(pid)
+            if score is None:
+                if prev is None:
+                    raise ScoreError("heartbeat without a prior score requires score")
+                value = float(prev["score"])
+            else:
+                value = score_value(score)
+            self._peers[pid] = {"id": pid, "score": value, "seen_at": now}
+            return self._snapshot_locked(now)
+
+    def status(self) -> dict[str, Any]:
+        now = self._clock()
+        with self._lock:
+            return self._snapshot_locked(now)
+
+    def _live_peers(self, now: float) -> list[dict[str, Any]]:
+        live: list[dict[str, Any]] = []
+        stale: list[str] = []
+        for pid, rec in self._peers.items():
+            age = now - float(rec["seen_at"])
+            if age > self._ttl:
+                stale.append(pid)
+                continue
+            live.append({"id": rec["id"], "score": rec["score"]})
+        for pid in stale:
+            self._peers.pop(pid, None)
+        live.sort(key=lambda p: (-float(p["score"]), str(p["id"])))
+        return live
+
+    def _elect(self, live: list[dict[str, Any]]) -> Optional[dict[str, Any]]:
+        if not live:
+            return None
+        return {"id": live[0]["id"], "score": live[0]["score"]}
+
+    def _snapshot_locked(self, now: float) -> dict[str, Any]:
+        live = self._live_peers(now)
+        leader = self._elect(live)
+        return {
+            "ok": True,
+            "leader": leader,
+            "elected": leader is not None,
+            "peers": live,
+            "ttl_seconds": self._ttl,
+        }
+
+
+_LATCH: Optional[LeaderLatch] = None
+_LATCH_LOCK = threading.Lock()
+
+
+def get_latch() -> LeaderLatch:
+    global _LATCH
+    with _LATCH_LOCK:
+        if _LATCH is None:
+            _LATCH = LeaderLatch()
+        return _LATCH
+
+
+def reset_latch() -> LeaderLatch:
+    """Replace the process latch (tests)."""
+    global _LATCH
+    with _LATCH_LOCK:
+        _LATCH = LeaderLatch()
+        return _LATCH
+
+
+def _require_peer_id(peer_id: Any) -> str:
+    pid = str(peer_id or "").strip()
+    if not pid:
+        raise ScoreError("peer_id is required")
+    if len(pid) > 128:
+        raise ScoreError("peer_id is too long")
+    return pid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.311"
+version = "0.9.312"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_metaharness_election.py
+++ b/tests/test_metaharness_election.py
@@ -1,0 +1,125 @@
+"""Hermetic metaharness scoring and leader-election tests."""
+from __future__ import annotations
+
+import pytest
+
+from harness.api import metaharness as api
+from harness import metaharness as mh
+
+
+@pytest.fixture(autouse=True)
+def _fresh_latch():
+    mh.reset_latch()
+    yield
+    mh.reset_latch()
+
+
+def test_highest_score_wins():
+    latch = mh.LeaderLatch(ttl_seconds=30, clock=lambda: 0.0)
+    latch.report_score("b", 1.0)
+    latch.report_score("a", 2.5)
+    snap = latch.status()
+    assert snap["elected"] is True
+    assert snap["leader"] == {"id": "a", "score": 2.5}
+    assert [p["id"] for p in snap["peers"]] == ["a", "b"]
+
+
+def test_tie_breaks_stably_by_id():
+    latch = mh.LeaderLatch(ttl_seconds=30, clock=lambda: 0.0)
+    latch.report_score("zeta", 10)
+    latch.report_score("alpha", 10)
+    latch.report_score("mu", 10)
+    assert latch.status()["leader"]["id"] == "alpha"
+    # Re-report in a different order; leader must stay alpha.
+    latch.report_score("mu", 10)
+    latch.report_score("zeta", 10)
+    assert latch.status()["leader"]["id"] == "alpha"
+
+
+def test_stale_peer_loses_election():
+    now = [0.0]
+
+    def clock() -> float:
+        return now[0]
+
+    latch = mh.LeaderLatch(ttl_seconds=5, clock=clock)
+    latch.report_score("old", 99)
+    now[0] = 6.0
+    latch.report_score("new", 1)
+    snap = latch.status()
+    assert snap["leader"]["id"] == "new"
+    assert [p["id"] for p in snap["peers"]] == ["new"]
+
+
+def test_score_value_rejects_non_finite():
+    with pytest.raises(mh.ScoreError):
+        mh.score_value(float("nan"))
+    with pytest.raises(mh.ScoreError):
+        mh.score_value(float("inf"))
+    with pytest.raises(mh.ScoreError):
+        mh.score_value("nope")
+    with pytest.raises(mh.ScoreError):
+        mh.score_value(True)
+
+
+def test_derived_score_from_ok_and_latency():
+    good = mh.score_report({"ok": True, "latency_ms": 0})
+    slow = mh.score_report({"success": True, "latency_ms": 100})
+    bad = mh.score_report({"ok": False, "latency_ms": 0})
+    assert good > slow > bad
+    assert good == pytest.approx(2.0)
+
+
+def test_api_score_heartbeat_and_status():
+    st, body = api.get_metaharness_status()
+    assert st == 200
+    assert body["leader"] is None
+    assert body["peers"] == []
+
+    st, body = api.post_metaharness_score({"peer_id": "p2", "score": 3})
+    assert st == 200
+    assert body["leader"]["id"] == "p2"
+
+    st, body = api.post_metaharness_score({"id": "p1", "score": 3})
+    assert st == 200
+    assert body["leader"]["id"] == "p1"  # same score, smaller id
+
+    st, body = api.post_metaharness_heartbeat({"peer_id": "p2"})
+    assert st == 200
+    assert body["leader"]["id"] == "p1"
+    assert {p["id"] for p in body["peers"]} == {"p1", "p2"}
+
+    st, status = api.get_metaharness_status()
+    assert st == 200
+    assert status["leader"]["id"] == "p1"
+
+
+def test_api_rejects_bad_payloads():
+    st, body = api.post_metaharness_score({"peer_id": "x"})
+    assert st == 400
+    assert body["ok"] is False
+
+    st, body = api.post_metaharness_heartbeat({"peer_id": "ghost"})
+    assert st == 400
+
+    st, body = api.post_metaharness_score({"peer_id": "", "score": 1})
+    assert st == 400
+
+
+class _Svc:
+    def __getattr__(self, name):
+        return lambda: None
+
+
+def test_routes_are_wired():
+    import harness.http_routes as http_routes
+
+    svc = _Svc()
+    post = http_routes.build_post_json_routes(svc)
+    get = http_routes.build_get_routes(svc)
+    assert "/api/metaharness/status" in get
+    assert "/api/metaharness/score" in post
+    assert "/api/metaharness/heartbeat" in post
+    assert callable(get["/api/metaharness/status"])
+    assert callable(post["/api/metaharness/score"])
+    assert callable(post["/api/metaharness/heartbeat"])

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.311"
+version = "0.9.312"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.311",
+  "version": "0.9.312",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.311",
+      "version": "0.9.312",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.311",
+  "version": "0.9.312",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- In-process metaharness scorer + leader latch: peers report a score, one leader is elected (highest score, stable lexicographic id tie-break).
- GET `/api/metaharness/status`, POST `/api/metaharness/score` and POST `/api/metaharness/heartbeat`.
- Version bump to 0.9.312; remains on puppetmaster-ai==1.22.28. Hermetic tests only.

## Test plan
- [x] `uv run --extra dev pytest tests/test_metaharness_election.py tests/test_version_consistency.py`
- [ ] CI green on the PR