### PR TITLE
Release v0.9.313

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.312, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.313, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.312"
+__version__ = "0.9.313"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/session_control.py
+++ b/harness/api/session_control.py
@@ -518,6 +518,11 @@ def post_session_interrupt(
     body: dict, session_id: str, svc: SessionControlServices
 ) -> tuple[int, JsonPayload]:
     """POST /api/session/interrupt."""
+    if svc is None:
+        # Route-table rebuild tests may pass None; Stop must still cancel the
+        # live server pilot instead of AttributeError on get_pilot().
+        from .. import server as _srv
+        svc = _srv._session_control_services()
     sid = (session_id or body.get("session_id") or "").strip()
     target = None
     if sid:

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -126,7 +126,7 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
         "/api/session/persist": post_json(
             _sc_api.post_session_persist, services=svc.session_control_services,
             needs_body=False),
-        "/api/restart": _post_restart,
+        "/api/restart": _bind_post_restart(svc),
         "/api/session/compact": post_json(
             _sc_api.post_session_compact_routed, services=svc.session_control_services),
         "/api/session/snapcompact": post_json(
@@ -241,7 +241,7 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             _skills_api.post_memory_propose_dismiss, services=svc.skills_services),
         "/api/sessions/create": post_json(
             _sessions_api.post_sessions_create, services=svc.session_services),
-        "/api/sessions/relocate": _post_session_relocate,
+        "/api/sessions/relocate": _bind_post_session_relocate(svc),
         "/api/sessions/switch": post_json(
             _sessions_api.post_sessions_switch, services=svc.session_services),
         "/api/sessions/delete": post_json(
@@ -257,7 +257,7 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             _sessions_api.post_sessions_rename, services=svc.session_services),
         "/api/chat/stash": post_json(
             _sc_api.post_chat_stash, services=svc.session_control_services),
-        "/api/session/interrupt": _post_session_interrupt,
+        "/api/session/interrupt": _bind_post_session_interrupt(svc),
         "/api/session/rewind": post_json(
             _sc_api.post_session_rewind, services=svc.session_control_services),
         "/api/session/rewind/restore": post_json(
@@ -315,7 +315,7 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             _auth_api.post_auth_cursor_cli_logout, needs_body=False),
         "/api/auth/cursor-cli/models": post_json(
             _auth_api.post_auth_cursor_cli_models, needs_body=False),
-        "/api/wiki/handoff": _post_wiki_handoff,
+        "/api/wiki/handoff": _bind_post_wiki_handoff(svc),
         "/api/git/connect": post_json(_git_api.post_git_connect),
         "/api/git/device/poll": post_json(_git_api.post_git_device_poll),
         "/api/git/disconnect": post_json(
@@ -357,57 +357,64 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
         "/api/metaharness/score": post_json(_mh_api.post_metaharness_score),
         "/api/metaharness/heartbeat": post_json(_mh_api.post_metaharness_heartbeat),
     }
-    # Attach relocate helper + host_ok/diag via closure attrs on module-level fns.
-    _post_session_relocate._svc = svc  # type: ignore[attr-defined]
-    _post_session_interrupt._svc = svc  # type: ignore[attr-defined]
-    _post_wiki_handoff._svc = svc  # type: ignore[attr-defined]
-    _post_restart._svc = svc  # type: ignore[attr-defined]
-    _post_restart._mcp = svc.mcp_services  # type: ignore[attr-defined]
     return routes
 
 
-def _post_session_relocate(handler: Any, body: dict) -> Any:
-    status, payload = _post_session_relocate._svc.handle_session_relocate(body)  # type: ignore[attr-defined]
-    return send_json(handler, status, payload)
+def _bind_post_session_relocate(svc: Any) -> PostHandler:
+    def handle(handler: Any, body: dict) -> Any:
+        status, payload = svc.handle_session_relocate(body)
+        return send_json(handler, status, payload)
+    return handle
 
 
-def _post_session_interrupt(handler: Any, body: dict) -> Any:
-    from .api import session_control as _sc_api
-    from . import server as _srv
-    sid = (body.get("session_id") or "").strip()
-    if not sid:
-        try:
-            qs = parse_qs(urlparse(handler.path).query)
-            sid = (qs.get("session_id") or [""])[0].strip()
-        except Exception:
-            sid = ""
-    # Resolve live session services at call time. Route-table rebuild tests
-    # (e.g. metaharness wiring) may overwrite _svc with stubs while the lazy
-    # POST table stays cached — Stop must still reach the real pilot.
-    status, payload = _sc_api.post_session_interrupt(
-        body, sid, _srv._session_control_services())
-    return send_json(handler, status, payload)
+def _bind_post_session_interrupt(svc: Any) -> PostHandler:
+    """Close over this table's svc. Never store it on a module-level fn.
+
+    ``build_post_json_routes`` is called from characterization tests with
+    mock factories that return None. Mutating ``_post_session_interrupt._svc``
+    used to clobber the live cached Stop handler (Windows shard shift after
+    v0.9.312 metaharness route wiring).
+    """
+    def handle(handler: Any, body: dict) -> Any:
+        from .api import session_control as _sc_api
+        sid = (body.get("session_id") or "").strip()
+        if not sid:
+            try:
+                qs = parse_qs(urlparse(handler.path).query)
+                sid = (qs.get("session_id") or [""])[0].strip()
+            except Exception:
+                sid = ""
+        status, payload = _sc_api.post_session_interrupt(
+            body, sid, svc.session_control_services())
+        return send_json(handler, status, payload)
+    return handle
 
 
-def _post_wiki_handoff(handler: Any, body: dict) -> Any:
-    from .api import wiki as _wiki_api
-    svc = _post_wiki_handoff._svc  # type: ignore[attr-defined]
-    host = handler.headers.get("Host", "") or ""
-    if not svc.host_ok(host):
-        return send_json(handler, 400, {"error": "bad host"})
-    status, payload = _wiki_api.post_wiki_handoff(host)
-    return send_json(handler, status, payload)
+def _bind_post_wiki_handoff(svc: Any) -> PostHandler:
+    def handle(handler: Any, body: dict) -> Any:
+        from .api import wiki as _wiki_api
+        host = handler.headers.get("Host", "") or ""
+        if not svc.host_ok(host):
+            return send_json(handler, 400, {"error": "bad host"})
+        status, payload = _wiki_api.post_wiki_handoff(host)
+        return send_json(handler, status, payload)
+    return handle
 
 
-def _post_restart(handler: Any, body: dict) -> Any:
+def _bind_post_restart(svc: Any) -> PostHandler:
+    def handle(handler: Any, body: dict) -> Any:
+        return _post_restart(handler, body, svc, svc.mcp_services)
+    return handle
+
+
+def _post_restart(handler: Any, body: dict, svc: Any, mcp_factory: Any) -> Any:
     from .api import session_control as _sc_api
     from .backend_restart_signal import write_intentional_restart_signal
-    svc = _post_restart._svc  # type: ignore[attr-defined]
     ok, err = _sc_api.prepare_session_restart(svc.session_control_services())
     if not ok:
         svc.diag("server.self_edit_restart_persist", Exception(err or "persist failed"))
     try:
-        mcp_svc = _post_restart._mcp()  # type: ignore[attr-defined]
+        mcp_svc = mcp_factory()
         mcp_svc.mcp.stop_all()
     except Exception as exc:
         svc.diag("server.self_edit_restart_mcp", exc)

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -373,7 +373,7 @@ def _post_session_relocate(handler: Any, body: dict) -> Any:
 
 def _post_session_interrupt(handler: Any, body: dict) -> Any:
     from .api import session_control as _sc_api
-    svc = _post_session_interrupt._svc  # type: ignore[attr-defined]
+    from . import server as _srv
     sid = (body.get("session_id") or "").strip()
     if not sid:
         try:
@@ -381,8 +381,11 @@ def _post_session_interrupt(handler: Any, body: dict) -> Any:
             sid = (qs.get("session_id") or [""])[0].strip()
         except Exception:
             sid = ""
+    # Resolve live session services at call time. Route-table rebuild tests
+    # (e.g. metaharness wiring) may overwrite _svc with stubs while the lazy
+    # POST table stays cached — Stop must still reach the real pilot.
     status, payload = _sc_api.post_session_interrupt(
-        body, sid, svc.session_control_services())
+        body, sid, _srv._session_control_services())
     return send_json(handler, status, payload)
 
 

--- a/harness/pilot.py
+++ b/harness/pilot.py
@@ -255,6 +255,10 @@ class PilotAction:
     # swarm retains its compatibility demotion for unknown pilot-session ids.
     # Prompt text alone never pins.
     model: str = ""
+    # run_swarm only: explicit Orchestrator worker_mode. Empty means unspecified
+    # so the product path keeps its inline default (env key wiring). Never
+    # inferred from goal prose.
+    worker_mode: str = ""
     # Optional explicit acceptance criteria for swarm/parallel analysis.
     # Never inferred from goal prose — only an explicit list/string field.
     acceptance_criteria: list = field(default_factory=list)
@@ -481,6 +485,19 @@ class PilotError(ValueError):
     """Raised when a pilot envelope cannot be parsed/validated."""
 
 
+_SWARM_WORKER_MODES = ("subprocess", "inline", "daemon")
+
+
+def _coerce_swarm_worker_mode(raw: Optional[dict], arguments: Optional[dict]) -> str:
+    """Explicit run_swarm worker_mode only. Invalid or missing becomes empty."""
+    blob = raw if isinstance(raw, dict) else {}
+    args = arguments if isinstance(arguments, dict) else {}
+    cand = str(blob.get("worker_mode") or args.get("worker_mode") or "").strip().lower()
+    if cand in _SWARM_WORKER_MODES:
+        return cand
+    return ""
+
+
 def from_wire(
     kind: str,
     raw: Optional[dict] = None,
@@ -677,6 +694,9 @@ def from_wire(
             or arguments.get("model")
             or ""
         ).strip()
+    worker_mode = ""
+    if kind == "run_swarm":
+        worker_mode = _coerce_swarm_worker_mode(raw, arguments)
 
     memory_action = ""
     memory_content = ""
@@ -758,6 +778,7 @@ def from_wire(
         direction=(raw.get("direction") or "").strip(),
         repo=str(repo_arg),
         model=str(model),
+        worker_mode=str(worker_mode),
         acceptance_criteria=list(acceptance_criteria),
         start_line=_optional_int(raw.get("start_line")),
         limit=_optional_int(raw.get("limit")),
@@ -1312,7 +1333,11 @@ def build_tools_schema(
                         "worker_mode": {
                             "type": "string",
                             "enum": ["subprocess", "inline", "daemon"],
-                            "description": "Optional worker process mode"
+                            "description": (
+                                "Optional Orchestrator worker process mode. Omit for the "
+                                "product default (inline, so env keys wire). Pass "
+                                "subprocess only when isolated workers are required."
+                            ),
                         },
                         "model": {
                             "type": "string",

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -402,6 +402,59 @@ def _resolved_swarm_model(result: Any, arts: Optional[list] = None) -> str:
     return model_id
 
 
+_SWARM_WORKER_MODES = ("subprocess", "inline", "daemon")
+_DEFAULT_NO_TOOL_CALLS_NOTE = (
+    "worker failed to call tools (no_tool_calls after 3 turns)"
+)
+
+
+def _explicit_swarm_worker_mode(act) -> str:
+    """Return a valid run_swarm worker_mode, or empty when unspecified."""
+    wm = str(getattr(act, "worker_mode", "") or "").strip().lower()
+    if wm in _SWARM_WORKER_MODES:
+        return wm
+    args = getattr(act, "arguments", None)
+    if isinstance(args, dict):
+        wm = str(args.get("worker_mode") or "").strip().lower()
+        if wm in _SWARM_WORKER_MODES:
+            return wm
+    return ""
+
+
+def _intent_worker_kwargs(act) -> dict:
+    wm = _explicit_swarm_worker_mode(act)
+    return {"worker_mode": wm} if wm else {}
+
+
+def _no_tool_calls_degrade_note(arts) -> str:
+    """Human note when workers died on the no_tool_calls fail-fast.
+
+    Empty when the run is not a no_tool_calls degrade. Prefer an artifact
+    headline that already names the streak; otherwise the default copy.
+    """
+    for a in arts or []:
+        if not isinstance(a, dict):
+            continue
+        fail = str(a.get("failure") or "").strip().lower()
+        head = str(a.get("headline") or "").strip()
+        body = str(a.get("body") or "").strip()
+        blob = f"{head}\n{body}".lower()
+        tagged = fail.startswith("no_tool_calls") or "no_tool_calls" in blob or (
+            "never called any tool" in blob
+        )
+        if not tagged:
+            continue
+        if "no_tool_calls" in head.lower() or "never called any tool" in head.lower():
+            return head
+        if "no_tool_calls" in body.lower() or "never called any tool" in body.lower():
+            # Keep it one line for the badge.
+            line = body.splitlines()[0].strip() if body else ""
+            if line:
+                return line[:160]
+        return _DEFAULT_NO_TOOL_CALLS_NOTE
+    return ""
+
+
 def _is_substantive_artifact(a: dict) -> bool:
     """True when a FINDING/RISK/DECISION carries real analysis, not a stub.
 
@@ -533,6 +586,7 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         model=(act.model or '').strip() or None,
         acceptance_criteria=_acceptance_criteria or None,
         repo=_swarm_repo or None,
+        **_intent_worker_kwargs(act),
     )
     _non_git = _non_git_workspace_error(_swarm_repo)
     if _non_git:
@@ -689,6 +743,7 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             model=(act.model or '').strip() or None,
             acceptance_criteria=_narrow_criteria or None,
             repo=_swarm_repo or None,
+            **_intent_worker_kwargs(act),
         )
     elif (
         _reuse_decision is not None
@@ -705,6 +760,7 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             model=(act.model or '').strip() or None,
             acceptance_criteria=list(_acceptance_criteria) or None,
             repo=_swarm_repo or None,
+            **_intent_worker_kwargs(act),
         )
     try:
         session._register_local_job(
@@ -771,9 +827,11 @@ Yields the same ConvEvent stream. Generator return value is ``None``
     import queue as _queue
     import threading as _threading
     _delta_q: '_queue.Queue' = _queue.Queue()
+    _explicit_wm = _explicit_swarm_worker_mode(act) or None
     _swarm_thread = _threading.Thread(
         target=stream_swarm,
         args=(session, intent, _delta_q, aid),
+        kwargs={"worker_mode": _explicit_wm} if _explicit_wm else {},
         daemon=True,
     )
     _swarm_thread.start()
@@ -929,11 +987,19 @@ Yields the same ConvEvent stream. Generator return value is ``None``
     # on the goal used to read as a clean "N findings" success.
     _substantive = [a for a in _signal if _is_substantive_artifact(a)]
     _swarm_ok = bool(_substantive) and (not auth_failure) and (not _demo_refused)
+    _ntc_note = "" if _demo_refused or auth_failure else (
+        _no_tool_calls_degrade_note(ordered) or _no_tool_calls_degrade_note(_all_arts)
+    )
     if _demo_refused:
         _badge_summary = 'refused: demo substrate (not real codebase analysis)'
     elif auth_failure:
         # Lead with the provider/key note, never a generic "no findings" badge.
         _badge_summary = auth_failure[:160] if len(auth_failure) > 20 else 'auth failure'
+    elif _ntc_note and not _substantive:
+        _badge_summary = (
+            _ntc_note if _ntc_note.lower().startswith('degraded:')
+            else f'degraded: {_ntc_note}'
+        )
     elif _substantive:
         _badge_summary = f'{len(_signal)} findings via {_ui_adapter} ({_ui_num} artifacts)'
     elif _has_signal:
@@ -945,7 +1011,8 @@ Yields the same ConvEvent stream. Generator return value is ``None``
     _badge_error = (
         'demo substrate -- not real codebase analysis' if _demo_refused
         else auth_failure or (
-            None if _swarm_ok
+            _ntc_note if (_ntc_note and not _swarm_ok)
+            else None if _swarm_ok
             else 'swarm findings are thin/generic (no file-backed substance)' if _has_signal
             else 'swarm produced no FINDING/RISK/DECISION artifacts' if _ui_num
             else 'swarm produced no artifacts'))
@@ -1108,6 +1175,14 @@ Yields the same ConvEvent stream. Generator return value is ``None``
         stall = '\n(NOTE: swarm hit the DEMO substrate and was refused -- Marionette never treats demo findings as real analysis. Do NOT retry or cite those findings. Tell the user analysis needs HARNESS_SWARM_ADAPTER=agentic and a provider key, then stop.)'
     if auth_failure:
         stall = f'\n(PROVIDER AUTH FAILURE -- {auth_failure} This is a dead/revoked/wrong API key, NOT a weak model or bad prompt. Do NOT re-run the swarm; tell the user to fix the named key, then stop.)' + stall
+    elif _ntc_note:
+        stall = (
+            '\n(NO_TOOL_CALLS — workers reasoned but never called tools '
+            f'({_ntc_note}). This is the kernel fail-fast on a reasoner-only '
+            'pin, not a routing/provider outage and not thin findings. Do NOT '
+            're-dispatch the same pinned model expecting tools; auto-route or '
+            'pin a tool-using model, then stop.)'
+        ) + stall
     elif not _has_signal:
         stall = (
             '\n(DEGRADED SWARM — only routing/verification plumbing, no '

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -1066,12 +1066,16 @@ def stream_swarm(
     intent: Any,
     delta_q: Any,
     dispatch_id: str = "",
+    worker_mode: Any = None,
 ) -> None:
     """Background target: execute_intent with on_delta → delta_q (delta/done/error).
 
     The intent's validated subject repo wins over the session workspace so an
     explicit ``run_swarm(repo=...)`` audit reads that checkout instead of the
     open project. Passed per call, never via the process-global env pointer.
+
+    ``worker_mode`` is the explicit tool-call override (subprocess/inline/daemon).
+    Omit it so execute_intent keeps the product inline default for LLM adapters.
     """
     try:
         from .repo_resolve import resolve_effective_repo
@@ -1087,6 +1091,7 @@ def stream_swarm(
             dispatch_id=dispatch_id,
             cwd=_cwd,
             repo=_cwd,
+            worker_mode=worker_mode,
             on_delta=lambda wid, kind, text: delta_q.put(
                 ("delta", (wid, kind, text))
             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.312"
+version = "0.9.313"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_bridge_agentic_swarm_routing.py
+++ b/tests/test_bridge_agentic_swarm_routing.py
@@ -47,6 +47,7 @@ class _FakeOrchestrator:
         self.store = store
 
     def run(self, goal: str, specs=None, worker_mode=None, label=None):
+        type(self).last_worker_mode = worker_mode
         return _FakeResult()
 
 
@@ -88,6 +89,49 @@ def test_agentic_swarm_pins_allowed_adapters(monkeypatch, tmp_path):
     assert payload.get("prefer_plan_billed") is False
     assert payload.get("token_budget") == 250000
     assert _CapturingWorkerSpec._last_captured[0].adapter == "agentic"
+
+
+def test_execute_intent_explicit_subprocess_reaches_orchestrator(monkeypatch, tmp_path):
+    _CapturingWorkerSpec._last_captured = []
+    _FakeOrchestrator.last_worker_mode = "unset"
+    monkeypatch.setenv("HARNESS_SWARM_ADAPTER", "agentic")
+    monkeypatch.setenv("HARNESS_REPO", str(tmp_path))
+    _pin_agentic_only_allowlist(monkeypatch)
+    monkeypatch.setattr("puppetmaster.workers.WorkerSpec", _CapturingWorkerSpec)
+    monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _FakeOrchestrator)
+    monkeypatch.setattr(bridge, "_warn_if_unindexed", lambda *_a, **_k: None)
+
+    intent = DriverIntent(
+        action="run_swarm",
+        goal="Trace the live scoring pipeline for a points flicker",
+        roles=["pipeline-mapper"],
+    )
+    result = bridge.execute_intent(
+        intent, state_dir=str(tmp_path / "state"), worker_mode="subprocess",
+    )
+    assert result is not None
+    assert _FakeOrchestrator.last_worker_mode == "subprocess"
+
+
+def test_execute_intent_omitted_worker_mode_stays_inline(monkeypatch, tmp_path):
+    _CapturingWorkerSpec._last_captured = []
+    _FakeOrchestrator.last_worker_mode = "unset"
+    monkeypatch.setenv("HARNESS_SWARM_ADAPTER", "agentic")
+    monkeypatch.setenv("HARNESS_REPO", str(tmp_path))
+    _pin_agentic_only_allowlist(monkeypatch)
+    monkeypatch.setattr("puppetmaster.workers.WorkerSpec", _CapturingWorkerSpec)
+    monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _FakeOrchestrator)
+    monkeypatch.setattr(bridge, "_warn_if_unindexed", lambda *_a, **_k: None)
+
+    intent = DriverIntent(
+        action="run_swarm",
+        goal="Trace the live scoring pipeline for a points flicker",
+        roles=["pipeline-mapper"],
+        worker_mode="subprocess",
+    )
+    result = bridge.execute_intent(intent, state_dir=str(tmp_path / "state"))
+    assert result is not None
+    assert _FakeOrchestrator.last_worker_mode == "inline"
 
 
 def test_swarm_allowed_adapters_includes_cursor_when_settings_enable_it(

--- a/tests/test_http_routes_restart.py
+++ b/tests/test_http_routes_restart.py
@@ -36,12 +36,9 @@ def test_post_restart_stops_mcp_before_exit(monkeypatch, tmp_path):
     # Avoid spawning a real self-terminate thread against the test process.
     monkeypatch.setattr(routes.threading, "Thread", lambda *a, **k: SimpleNamespace(start=lambda: None))
 
-    routes._post_restart._svc = svc  # type: ignore[attr-defined]
-    routes._post_restart._mcp = svc.mcp_services  # type: ignore[attr-defined]
-
     handler = MagicMock()
 
-    routes._post_restart(handler, {})
+    routes._post_restart(handler, {}, svc, svc.mcp_services)
 
     assert stopped == ["yes"]
     assert written, "must write intentional restart signal for Electron"

--- a/tests/test_pilot_arg_coerce_and_dispatch_errors.py
+++ b/tests/test_pilot_arg_coerce_and_dispatch_errors.py
@@ -445,6 +445,26 @@ def test_top_level_repo_wins_over_nested_arguments(tmp_path):
     assert act.repo == str(a.resolve())
 
 
+def test_run_swarm_from_wire_copies_worker_mode():
+    act = from_wire(
+        "run_swarm",
+        {"goal": "audit auth", "worker_mode": "subprocess"},
+    )
+    assert act.worker_mode == "subprocess"
+    nested = from_wire(
+        "run_swarm",
+        {"goal": "audit auth", "arguments": {"worker_mode": "inline"}},
+    )
+    assert nested.worker_mode == "inline"
+    bad = from_wire(
+        "run_swarm",
+        {"goal": "audit auth", "worker_mode": "threads"},
+    )
+    assert bad.worker_mode == ""
+    omitted = from_wire("run_swarm", {"goal": "audit auth"})
+    assert omitted.worker_mode == ""
+
+
 def test_run_parallel_schema_states_goals_array_contract():
     schema = build_tools_schema(no_delegation=False)
     parallel = next(

--- a/tests/test_send_loop_dispatch.py
+++ b/tests/test_send_loop_dispatch.py
@@ -745,6 +745,119 @@ def test_dispatch_swarm_does_not_register_durable_job_in_sidecar(monkeypatch):
     assert finished == ["local-swarm-call_abc"]
 
 
+def test_dispatch_swarm_forwards_explicit_worker_mode(monkeypatch):
+    """run_swarm(worker_mode=subprocess) must reach stream_swarm, not drop."""
+    act = PilotAction(
+        kind="run_swarm",
+        goal="audit routing",
+        roles=["explore"],
+        worker_mode="subprocess",
+    )
+    session = SimpleNamespace(
+        config=SimpleNamespace(repo="/repo"),
+        _session_job_ids=[],
+        _register_local_job=MagicMock(),
+        _finish_local_job=MagicMock(),
+        _append_action_result=MagicMock(),
+        _display_transcript=[],
+    )
+    import harness.send_loop_dispatch as dispatch
+
+    monkeypatch.delenv("HARNESS_ALLOW_DEMO_SWARM", raising=False)
+    monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda *_a, **_k: None)
+    captured = {}
+
+    result = SimpleNamespace(
+        job_id="job_wm",
+        adapter="agentic",
+        mode="swarm",
+        artifacts=[{
+            "type": "finding",
+            "headline": "CSRF missing in harness/auth.py:42",
+            "body": "Auth middleware does not check CSRF on POST /api/session.",
+        }],
+        artifact_types=["finding"],
+        num_artifacts=1,
+        auth_failure="",
+        summary="one finding",
+        applied=True,
+        files=[],
+        error=None,
+    )
+
+    def fake_stream(session, intent, q, dispatch_id, worker_mode=None):
+        captured["worker_mode"] = worker_mode
+        captured["intent_mode"] = getattr(intent, "worker_mode", None)
+        q.put(("done", result))
+
+    monkeypatch.setattr(dispatch, "stream_swarm", fake_stream)
+    list(
+        dispatch_swarm_action(
+            session,
+            act,
+            "call_wm",
+            True,
+            counters={"swarms": 0, "demo_swarms": 0},
+            turn_findings=[],
+        )
+    )
+    assert captured["worker_mode"] == "subprocess"
+    assert captured["intent_mode"] == "subprocess"
+
+
+def test_dispatch_swarm_omitted_worker_mode_does_not_force_subprocess(monkeypatch):
+    """Unspecified tool arg must not pass worker_mode, so product stays inline."""
+    act = PilotAction(kind="run_swarm", goal="audit routing", roles=["explore"])
+    session = SimpleNamespace(
+        config=SimpleNamespace(repo="/repo"),
+        _session_job_ids=[],
+        _register_local_job=MagicMock(),
+        _finish_local_job=MagicMock(),
+        _append_action_result=MagicMock(),
+        _display_transcript=[],
+    )
+    import harness.send_loop_dispatch as dispatch
+
+    monkeypatch.delenv("HARNESS_ALLOW_DEMO_SWARM", raising=False)
+    monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda *_a, **_k: None)
+    captured = {}
+
+    result = SimpleNamespace(
+        job_id="job_default",
+        adapter="agentic",
+        mode="swarm",
+        artifacts=[{
+            "type": "finding",
+            "headline": "CSRF missing in harness/auth.py:42",
+            "body": "Auth middleware does not check CSRF on POST /api/session.",
+        }],
+        artifact_types=["finding"],
+        num_artifacts=1,
+        auth_failure="",
+        summary="one finding",
+        applied=True,
+        files=[],
+        error=None,
+    )
+
+    def fake_stream(session, intent, q, dispatch_id, worker_mode=None):
+        captured["worker_mode"] = worker_mode
+        q.put(("done", result))
+
+    monkeypatch.setattr(dispatch, "stream_swarm", fake_stream)
+    list(
+        dispatch_swarm_action(
+            session,
+            act,
+            "call_default",
+            True,
+            counters={"swarms": 0, "demo_swarms": 0},
+            turn_findings=[],
+        )
+    )
+    assert captured["worker_mode"] is None
+
+
 def test_is_untracked_pm_start_tool():
     assert is_untracked_pm_start_tool("puppetmaster_start_cursor_swarm")
     assert is_untracked_pm_start_tool("user-puppetmaster/start_implement")

--- a/tests/test_sse_detach.py
+++ b/tests/test_sse_detach.py
@@ -148,6 +148,29 @@ def test_auto_stream_client_disconnect_does_not_cancel_turn():
             httpd.shutdown()
 
 
+def test_explicit_interrupt_survives_mock_route_rebuild():
+    """Characterization rebuilds must not clobber the live Stop handler.
+
+    v0.9.312 ``test_routes_are_wired`` calls ``build_post_json_routes`` with a
+    mock whose factories return None. That used to mutate
+    ``_post_session_interrupt._svc`` and 500 the next /api/session/interrupt
+    (Windows shard 3 after 313 shifted collection order).
+    """
+    import harness.http_routes as http_routes
+    import harness.server as srv
+
+    srv._POST_JSON_ROUTES = None
+    srv._GET_ROUTES = None
+    srv._post_json_routes()
+
+    class _Svc:
+        def __getattr__(self, name):
+            return lambda: None
+
+    http_routes.build_post_json_routes(_Svc())
+    test_explicit_interrupt_still_cancels()
+
+
 def test_explicit_interrupt_still_cancels():
     """Stop button path: /api/session/interrupt must still cancel the pilot."""
     httpd, port, srv = _server()

--- a/tests/test_swarm_surfaced_honesty.py
+++ b/tests/test_swarm_surfaced_honesty.py
@@ -339,3 +339,74 @@ def test_pilot_result_is_bounded_to_current_job_evidence(monkeypatch):
     assert "not verified, never as a defect" in text
     assert "Never carry earlier issue examples forward" in text
     assert "blend prior findings" not in text
+
+
+def test_no_tool_calls_badge_names_the_fail_fast(monkeypatch):
+    """Reasoner-killed workers must not hide behind generic thin-findings copy."""
+    result = SimpleNamespace(
+        job_id="job_ntc",
+        adapter="agentic",
+        mode="swarm",
+        num_artifacts=1,
+        artifact_types=["verification"],
+        artifacts=[{
+            "type": "verification",
+            "headline": "no_tool_calls after 3 turns",
+            "body": "worker never called any tool",
+            "failure": "no_tool_calls",
+        }],
+        auth_failure="",
+        summary="no structured findings",
+    )
+
+    session, events = _run_dispatch(monkeypatch, result)
+    badge = next(e for e in events if e.kind == "swarm_result").data["result"]
+    assert badge["applied"] is False
+    summary = (badge.get("summary") or "").lower()
+    error = (badge.get("error") or "").lower()
+    assert "no_tool_calls" in summary
+    assert "failed to call tools" in summary or "no_tool_calls" in summary
+    assert "thin findings" not in summary
+    assert "no_tool_calls" in error
+    assert "thin/generic" not in error
+    stall = _pilot_text(session).lower()
+    assert "no_tool_calls" in stall
+    assert "thin swarm findings" not in stall
+    assert "reasoner-only pin" in stall
+
+
+def test_no_tool_calls_stall_wins_over_thin_finding_stubs(monkeypatch):
+    """Stub FINDING rows must not relabel a no_tool_calls fail-fast as thin."""
+    result = SimpleNamespace(
+        job_id="job_ntc_thin",
+        adapter="agentic",
+        mode="swarm",
+        num_artifacts=2,
+        artifact_types=["finding", "verification"],
+        artifacts=[
+            {
+                "type": "finding",
+                "headline": "Looks incomplete",
+                "body": "ok",
+            },
+            {
+                "type": "verification",
+                "headline": "never called any tool",
+                "body": "no_tool_calls after 3 turns",
+                "failure": "no_tool_calls",
+            },
+        ],
+        auth_failure="",
+        summary="thin findings",
+    )
+
+    session, events = _run_dispatch(monkeypatch, result)
+    badge = next(e for e in events if e.kind == "swarm_result").data["result"]
+    summary = (badge.get("summary") or "").lower()
+    error = (badge.get("error") or "").lower()
+    assert "no_tool_calls" in summary or "never called any tool" in summary
+    assert "thin findings" not in summary
+    assert "no_tool_calls" in error or "never called any tool" in error
+    stall = _pilot_text(session).lower()
+    assert "no_tool_calls" in stall
+    assert "thin swarm findings" not in stall

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.312"
+version = "0.9.313"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.312",
+  "version": "0.9.313",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.312",
+      "version": "0.9.313",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.312",
+  "version": "0.9.313",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CheckpointsPane.test.tsx
+++ b/webapp/src/__tests__/CheckpointsPane.test.tsx
@@ -63,6 +63,14 @@ describe("CheckpointsPane diff badges", () => {
     render(<CheckpointsPane />);
 
     await screen.findByText("before edits");
+    // refreshScope sets activeSessionId after first paint; that changes
+    // scopeKey and clearLocalState() wipes expanded diffs. Click Diff only
+    // after the second checkpoints fetch.
+    await waitFor(() => {
+      expect(apiMocks.sessions).toHaveBeenCalled();
+      expect(apiMocks.getCheckpoints.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+    await screen.findByText("before edits");
     fireEvent.click(screen.getByTitle("View diff"));
 
     await waitFor(() => {

--- a/webapp/src/__tests__/CheckpointsPane.test.tsx
+++ b/webapp/src/__tests__/CheckpointsPane.test.tsx
@@ -63,16 +63,21 @@ describe("CheckpointsPane diff badges", () => {
     render(<CheckpointsPane />);
 
     await screen.findByText("before edits");
-    fireEvent.click(screen.getByText("Diff"));
+    fireEvent.click(screen.getByTitle("View diff"));
 
     await waitFor(() => {
       expect(apiMocks.getCheckpointDiff).toHaveBeenCalledWith("cp-1");
     });
-    expect(await screen.findByText("src/new.ts")).toBeTruthy();
-    expect(screen.getByText("added")).toBeTruthy();
+
+    const addedBadge = await screen.findByLabelText("added: src/new.ts");
+    const modifiedBadge = await screen.findByLabelText("modified: src/old.ts");
+    const removedBadge = await screen.findByLabelText("removed: src/gone.ts");
+
+    expect(addedBadge).toHaveTextContent("added");
+    expect(modifiedBadge).toHaveTextContent("modified");
+    expect(removedBadge).toHaveTextContent("removed");
+    expect(screen.getByText("src/new.ts")).toBeTruthy();
     expect(screen.getByText("src/old.ts")).toBeTruthy();
-    expect(screen.getByText("modified")).toBeTruthy();
     expect(screen.getByText("src/gone.ts")).toBeTruthy();
-    expect(screen.getByText("removed")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Thread explicit `run_swarm(..., worker_mode=...)` through `PilotAction` → `DriverIntent` → `execute_intent` so it actually reaches `Orchestrator.run`. Unspecified product swarms stay `inline`.
- Surface Puppetmaster `no_tool_calls` fail-fast on the swarm badge and pilot stall instead of generic thin findings. Pinned reasoners that never drive tools are named as such; the kernel fail-fast is unchanged.

## Test plan
- [ ] `tests` workflow green: Python 3.9, 3.11, Windows, frontend-build
- [ ] Local: `tests/test_send_loop_dispatch.py`, `tests/test_swarm_surfaced_honesty.py`, `tests/test_bridge_agentic_swarm_routing.py`, `tests/test_version_consistency.py`