### PR TITLE
Marionette v0.9.314 — Pretext hybrid transcript heights

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.313, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.314, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.313"
+__version__ = "0.9.314"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.313"
+version = "0.9.314"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.313"
+version = "0.9.314"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "pm-harness",
-  "version": "0.9.313",
+  "version": "0.9.314",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.313",
+      "version": "0.9.314",
       "dependencies": {
+        "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.11",
         "@codemirror/lang-javascript": "^6.2.5",
@@ -454,6 +455,11 @@
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.8.tgz",
+      "integrity": "sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA=="
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.3",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.313",
+  "version": "0.9.314",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -17,6 +17,7 @@
     "make-icon": "node scripts/make_icon.mjs"
   },
   "dependencies": {
+    "@chenglou/pretext": "^0.0.8",
     "@codemirror/lang-css": "^6.3.1",
     "@codemirror/lang-html": "^6.4.11",
     "@codemirror/lang-javascript": "^6.2.5",

--- a/webapp/src/__tests__/transcriptRowHeight.test.ts
+++ b/webapp/src/__tests__/transcriptRowHeight.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { GroupedItem } from "../components/TranscriptList";
+import {
+  assistantTextForMeasure,
+  createTranscriptRowHeightCache,
+  hasMarkdownCodeFence,
+  hasMarkdownImage,
+  hasMermaidFence,
+  rowNeedsDomMeasure,
+  rowPretextSpec,
+  shouldAttachDomMeasure,
+  stripMarkdownForPretext,
+  transcriptBubbleMaxWidth,
+  transcriptFeedInnerWidth,
+  transcriptRowCacheKey,
+  TRANSCRIPT_ROW_FALLBACK_PX,
+  TRANSCRIPT_USER_CLAMP_PX,
+} from "../components/conversation/transcriptRowHeight";
+
+vi.mock("@chenglou/pretext", () => ({
+  prepare: vi.fn((text: string, _font: string, opts?: { whiteSpace?: string }) => ({
+    text,
+    whiteSpace: opts?.whiteSpace ?? "normal",
+  })),
+  layout: vi.fn((handle: { text: string }, maxWidth: number, lineHeight: number) => {
+    const charsPerLine = Math.max(8, Math.floor(maxWidth / 7));
+    const lineCount = Math.max(1, Math.ceil(handle.text.length / charsPerLine));
+    return { height: lineCount * lineHeight, lineCount };
+  }),
+}));
+
+function msg(
+  role: "user" | "assistant",
+  text: string,
+  extra: Partial<{ images: { path: string; name: string; previewUrl: string }[]; workerStream: boolean }> = {},
+): GroupedItem {
+  return {
+    kind: "msg",
+    msg: { role, text, ...extra },
+  };
+}
+
+describe("transcriptRowHeight", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("computes feed inner width from the scroll parent", () => {
+    expect(transcriptFeedInnerWidth(1200)).toBe(720);
+    expect(transcriptFeedInnerWidth(400)).toBe(352);
+    expect(transcriptFeedInnerWidth(200)).toBe(240);
+  });
+
+  it("applies role-specific bubble width ratios", () => {
+    expect(transcriptBubbleMaxWidth(600, "user")).toBe(510);
+    expect(transcriptBubbleMaxWidth(600, "assistant")).toBe(570);
+  });
+
+  it("builds stable cache keys from row id, text, and font", () => {
+    const a = transcriptRowCacheKey("row-1", "hello", "13px Inter");
+    const b = transcriptRowCacheKey("row-1", "hello", "13px Inter");
+    const c = transcriptRowCacheKey("row-1", "hello!", "13px Inter");
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+
+  it("detects markdown features that require DOM measurement", () => {
+    expect(hasMarkdownCodeFence("plain")).toBe(false);
+    expect(hasMarkdownCodeFence("```ts\nx\n```")).toBe(true);
+    expect(hasMermaidFence("```mermaid\ngraph TD\n```")).toBe(true);
+    expect(hasMarkdownImage("![alt](https://x/y.png)")).toBe(true);
+  });
+
+  it("classifies rows for Pretext vs DOM settle", () => {
+    expect(rowNeedsDomMeasure(msg("user", "short note"))).toBe(false);
+    expect(rowNeedsDomMeasure(msg("assistant", "```py\nprint(1)\n```"))).toBe(true);
+    expect(rowNeedsDomMeasure(msg("user", "pic", {
+      images: [{ path: "/a.png", name: "a", previewUrl: "blob:x" }],
+    }))).toBe(true);
+    expect(rowNeedsDomMeasure({ kind: "activity_group", items: [] })).toBe(true);
+    expect(rowNeedsDomMeasure({ kind: "turn_terminal", cause: "x", state: "y", text: "done" })).toBe(false);
+  });
+
+  it("strips fenced markdown before Pretext prose measurement", () => {
+    const stripped = stripMarkdownForPretext("# Title\n\nHello **world**\n\n```js\nx\n```");
+    expect(stripped).not.toContain("```");
+    expect(stripped).toContain("Hello world");
+  });
+
+  it("cleans assistant traceback noise for measurement", () => {
+    const raw = "Traceback (most recent call last):\n  File x\nValueError: bad\n\nActual answer.";
+    expect(assistantTextForMeasure(raw)).toBe("Actual answer.");
+  });
+
+  it("estimates prose height via cached prepare+layout", () => {
+    const cache = createTranscriptRowHeightCache();
+    const item = msg("user", "line one\nline two\nline three");
+    const h1 = cache.estimateRowHeight(item, "u-1", 600);
+    const h2 = cache.estimateRowHeight(item, "u-1", 600);
+    expect(h1).toBeGreaterThan(24);
+    expect(h2).toBe(h1);
+  });
+
+  it("caps long user messages at the clamp budget", () => {
+    const cache = createTranscriptRowHeightCache();
+    const wall = "word ".repeat(400);
+    const item = msg("user", wall);
+    const height = cache.estimateRowHeight(item, "u-wall", 600);
+    expect(height).toBeLessThanOrEqual(TRANSCRIPT_USER_CLAMP_PX + 40);
+  });
+
+  it("returns fixed heights for chip rows", () => {
+    const cache = createTranscriptRowHeightCache();
+    const chip: GroupedItem = {
+      kind: "turn_terminal",
+      cause: "stop",
+      state: "done",
+      text: "Stopped",
+    };
+    expect(cache.estimateRowHeight(chip, "t-1", 600)).toBe(36);
+  });
+
+  it("falls back when Pretext spec is missing for complex rows", () => {
+    const cache = createTranscriptRowHeightCache();
+    const row: GroupedItem = { kind: "activity_group", items: [] };
+    expect(cache.estimateRowHeight(row, "ag-1", 600)).toBe(TRANSCRIPT_ROW_FALLBACK_PX * 2);
+  });
+
+  it("builds Pretext specs for user and assistant bubbles", () => {
+    const userSpec = rowPretextSpec(msg("user", "hi"), 600);
+    expect(userSpec?.whiteSpace).toBe("pre-wrap");
+    expect(userSpec?.maxProsePx).toBe(TRANSCRIPT_USER_CLAMP_PX);
+
+    const assistantSpec = rowPretextSpec(msg("assistant", "Hello **there**"), 600);
+    expect(assistantSpec?.whiteSpace).toBe("normal");
+    expect(assistantSpec?.text).toContain("Hello there");
+  });
+
+  it("gates DOM measureElement until feed settle for rich rows", () => {
+    const rich = msg("assistant", "```js\n1\n```");
+    expect(shouldAttachDomMeasure(rich, false)).toBe(false);
+    expect(shouldAttachDomMeasure(rich, true)).toBe(true);
+    expect(shouldAttachDomMeasure(msg("user", "plain"), true)).toBe(false);
+  });
+});

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -1105,6 +1105,7 @@ export default function Conversation({
   // scrolling to bottom until height stabilizes (or wall-clock timeout).
   // onScroll still tracks real geometry so keyboard/scrollbar unpin is not swallowed.
   const scrollSettlingRef = useRef(false);
+  const [feedSettled, setFeedSettled] = useState(true);
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
   const scrollFeedToEndRef = useRef<(() => void) | null>(null);
   const publishJumpVisibilityRef = useRef(() => {});
@@ -1332,6 +1333,7 @@ export default function Conversation({
     scrollReleasedByGestureRef.current = false;
     prevFeedScrollTopRef.current = null;
     scrollSettlingRef.current = true;
+    setFeedSettled(false);
     setShowJumpToBottom(false);
     const scrollToEnd = scrollFeedToEndRef.current;
     if (scrollToEnd) {
@@ -1350,6 +1352,7 @@ export default function Conversation({
       const node = feedRef.current;
       if (!node) {
         scrollSettlingRef.current = false;
+        setFeedSettled(true);
         return;
       }
       if (!scrollSettlingRef.current || scrollReleasedByGestureRef.current) {
@@ -1378,6 +1381,7 @@ export default function Conversation({
       pinnedToBottomRef.current = true;
       if (step.done) {
         scrollSettlingRef.current = false;
+        setFeedSettled(true);
         publishJumpVisibilityRef.current();
         return;
       }
@@ -1387,6 +1391,7 @@ export default function Conversation({
     return () => {
       cancelAnimationFrame(rafId);
       scrollSettlingRef.current = false;
+      setFeedSettled(true);
     };
   }, [activeSessionId]);
 
@@ -3593,6 +3598,7 @@ export default function Conversation({
           busyElapsedMs={busyElapsedMs}
           turnOpen={turnOpen}
           holdSwarmAwait={holdSwarmAwait}
+          feedSettled={feedSettled}
           scrollToEndRef={scrollFeedToEndRef}
           onEditMessage={stableEditMessage}
           onExecuteSend={stableExecuteSend}

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, useSyncExternalStore, useMemo, memo } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, useSyncExternalStore, useMemo, memo, type ReactNode } from "react";
+import { useVirtualizer, type VirtualItem } from "@tanstack/react-virtual";
 import { ChevronRight, Loader2, ChevronDown, ChevronUp, Play, Copy, Check, Pencil, RefreshCw, History, Share2, CheckCircle2, XCircle, Eye, Shield } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -82,6 +82,12 @@ import {
   isOccludedScrollParentSize,
   shouldUseVirtualTranscriptWindow,
 } from "./conversation/transcriptVirtualWindow";
+import {
+  createTranscriptRowHeightCache,
+  shouldAttachDomMeasure,
+  transcriptFeedInnerWidth,
+  TRANSCRIPT_ROW_FALLBACK_PX,
+} from "./conversation/transcriptRowHeight";
 import {
   compactionKeptDroppedLine,
   compactionSuccessLabel,
@@ -982,12 +988,75 @@ export function stableItemKey(it: GroupedItem, i: number): string {
 // PERF: Long sessions grow the transcript without bound, and every displayed
 // group is an expensive subtree (markdown + syntax highlight + tool cards).
 // Virtualize the muted four-surface feed (msg / question / file / activity fold)
-// with @tanstack/react-virtual + measureElement so only the viewport (plus
-// overscan) stays mounted. Parent stick-to-bottom (nextFeedPinState hysteresis
-// in Conversation) still owns pin/unpin — this list only reports real total
-// height via the spacer; it never fakes a 40-row render cap.
-const FEED_ROW_ESTIMATE_PX = 72;
+// with @tanstack/react-virtual. Pretext (prepare once per row id+text+font,
+// layout per width) sizes prose without DOM reflow; measureElement runs only
+// after mount settle for code/images/mermaid Pretext cannot model. Parent
+// stick-to-bottom (nextFeedPinState hysteresis in Conversation) still owns
+// pin/unpin — this list only reports total height via the spacer.
 const FEED_VIRTUAL_OVERSCAN = 8;
+
+/** One virtual row: Pretext estimate always; DOM measure only after settle. */
+const VirtualTranscriptRow = memo(function VirtualTranscriptRow({
+  virtualRow,
+  scrollMargin,
+  item,
+  rowId,
+  feedSettled,
+  measureDom,
+  children,
+}: {
+  virtualRow: VirtualItem;
+  scrollMargin: number;
+  item: GroupedItem;
+  rowId: string;
+  feedSettled: boolean;
+  measureDom: (element: HTMLElement) => void;
+  children: ReactNode;
+}) {
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [mountSettled, setMountSettled] = useState(false);
+  const attachDom = shouldAttachDomMeasure(item, feedSettled);
+
+  useLayoutEffect(() => {
+    if (!attachDom) {
+      setMountSettled(false);
+      return;
+    }
+    setMountSettled(false);
+    let inner = 0;
+    const tick = () => {
+      inner += 1;
+      if (inner >= 2) {
+        setMountSettled(true);
+        return;
+      }
+      requestAnimationFrame(tick);
+    };
+    const outer = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(outer);
+  }, [attachDom, rowId]);
+
+  useLayoutEffect(() => {
+    if (!attachDom || !mountSettled) return;
+    const el = rowRef.current;
+    if (el) measureDom(el);
+  }, [attachDom, mountSettled, measureDom, rowId]);
+
+  return (
+    <div
+      data-index={virtualRow.index}
+      ref={attachDom && mountSettled ? rowRef : undefined}
+      data-testid="transcript-virtual-row"
+      data-dom-measure={attachDom ? "1" : "0"}
+      className="absolute top-0 left-0 w-full pb-1"
+      style={{
+        transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+      }}
+    >
+      {children}
+    </div>
+  );
+});
 
 /** Bind run_command cards even when Investigating is collapsed (Hermes procId). */
 function indexCardCommandSession(card: Card): void {
@@ -1121,6 +1190,8 @@ export type TranscriptListProps = {
    * absorption / footer match StatusPill through idle flaps / switch rearm.
    */
   holdSwarmAwait?: boolean;
+  /** When false, rich rows defer measureElement until session/scroll settle glue ends. */
+  feedSettled?: boolean;
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   /** Conversation jump-to-latest / stick-to-bottom: virtualizer-aware end scroll. */
   scrollToEndRef?: React.MutableRefObject<(() => void) | null>;
@@ -1145,6 +1216,7 @@ export const TranscriptList = memo(function TranscriptList({
   busyElapsedMs = null,
   turnOpen = false,
   holdSwarmAwait = false,
+  feedSettled = true,
   scrollContainerRef,
   scrollToEndRef,
   onEditMessage,
@@ -1225,19 +1297,31 @@ export const TranscriptList = memo(function TranscriptList({
     return () => ro?.disconnect();
   }, [scrollContainerRef, grouped.length, scrollEpoch]);
 
+  const rowHeightCacheRef = useRef(createTranscriptRowHeightCache());
+  const feedInnerWidth = useMemo(() => {
+    const w = scrollContainerRef.current?.clientWidth ?? 600;
+    return transcriptFeedInnerWidth(w);
+  }, [scrollContainerRef, scrollEpoch]);
+
   const rowVirtualizer = useVirtualizer({
     count: virtualGrouped.length,
     getScrollElement: () => scrollContainerRef.current,
-    estimateSize: () => FEED_ROW_ESTIMATE_PX,
+    estimateSize: (index) => {
+      const item = virtualGrouped[index];
+      if (!item) return TRANSCRIPT_ROW_FALLBACK_PX;
+      const rowId = stableItemKey(item, index);
+      return rowHeightCacheRef.current.estimateRowHeight(item, rowId, feedInnerWidth);
+    },
     overscan: FEED_VIRTUAL_OVERSCAN,
     scrollMargin,
     getItemKey: (index) => stableItemKey(virtualGrouped[index]!, index),
-    measureElement:
-      typeof window !== "undefined" &&
-      !/firefox/i.test(window.navigator.userAgent)
-        ? (element) => element.getBoundingClientRect().height
-        : undefined,
   });
+  const measureVirtualRowDom = useCallback(
+    (element: HTMLElement) => {
+      rowVirtualizer.measureElement(element);
+    },
+    [rowVirtualizer],
+  );
   const scrollToEnd = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
@@ -1729,20 +1813,23 @@ export const TranscriptList = memo(function TranscriptList({
       className="relative w-full"
       style={{ height: rowVirtualizer.getTotalSize() }}
     >
-      {virtualItems.map((virtualRow) => (
-        <div
-          key={virtualRow.key}
-          data-index={virtualRow.index}
-          ref={rowVirtualizer.measureElement}
-          data-testid="transcript-virtual-row"
-          className="absolute top-0 left-0 w-full pb-1"
-          style={{
-            transform: `translateY(${virtualRow.start - scrollMargin}px)`,
-          }}
-        >
-          {renderGroupedItem(virtualRow.index)}
-        </div>
-      ))}
+      {virtualItems.map((virtualRow) => {
+        const item = virtualGrouped[virtualRow.index]!;
+        const rowId = stableItemKey(item, virtualRow.index);
+        return (
+          <VirtualTranscriptRow
+            key={virtualRow.key}
+            virtualRow={virtualRow}
+            scrollMargin={scrollMargin}
+            item={item}
+            rowId={rowId}
+            feedSettled={feedSettled}
+            measureDom={measureVirtualRowDom}
+          >
+            {renderGroupedItem(virtualRow.index)}
+          </VirtualTranscriptRow>
+        );
+      })}
     </div>
   ) : (
     <div ref={listAnchorRef} data-testid="transcript-virtual-list" className="flex flex-col gap-1 w-full">

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -29,6 +29,7 @@ export default function ConversationChatColumn({
   busyElapsedMs,
   turnOpen,
   holdSwarmAwait = false,
+  feedSettled = true,
   scrollToEndRef,
   onEditMessage,
   onExecuteSend,
@@ -56,6 +57,8 @@ export default function ConversationChatColumn({
   turnOpen: boolean;
   /** Same hold as Conversation — pending jobs keep transcript latch through idle flaps. */
   holdSwarmAwait?: boolean;
+  /** Defer DOM row measurement while session-switch settle glue runs. */
+  feedSettled?: boolean;
   scrollToEndRef?: MutableRefObject<(() => void) | null>;
   onEditMessage: (idx: number, text: string) => void;
   onExecuteSend: (msg: string, useAuto: boolean, usePlan?: boolean) => void;
@@ -91,7 +94,7 @@ export default function ConversationChatColumn({
       <div className="relative flex-1 min-h-0 flex flex-col">
         <div
           ref={feedRef}
-          className={`flex-1 min-h-0 overflow-y-auto overscroll-contain [overflow-anchor:none] [scrollbar-gutter:stable] ${panelOpacityClass(transcriptStale)}`}
+          className={`flex-1 min-h-0 overflow-y-auto overscroll-contain [overflow-anchor:none] [scrollbar-gutter:stable] [scroll-padding-bottom:var(--feed-chrome-clearance,clamp(72px,12vh,144px))] ${panelOpacityClass(transcriptStale)}`}
         >
         {/* overflow-anchor:none — the virtualizer unmounts off-screen rows, so
             auto-anchor would snap to the first remaining node (top of history)
@@ -124,6 +127,7 @@ export default function ConversationChatColumn({
             busyElapsedMs={busyElapsedMs}
             turnOpen={turnOpen}
             holdSwarmAwait={holdSwarmAwait}
+            feedSettled={feedSettled}
             scrollContainerRef={feedRef}
             scrollToEndRef={scrollToEndRef}
             onEditMessage={onEditMessage}

--- a/webapp/src/components/conversation/transcriptRowHeight.ts
+++ b/webapp/src/components/conversation/transcriptRowHeight.ts
@@ -1,0 +1,340 @@
+/**
+ * Pretext-backed row height estimates for the virtual transcript feed.
+ *
+ * prepare(text, font) once per row id+text+font; layout(prepared, maxWidth,
+ * lineHeight) is the cheap streaming ruler. Rows with code/images/mermaid
+ * still get a DOM measureElement pass after mount settle — Pretext cannot
+ * know fenced blocks or media chrome.
+ */
+
+import { layout, prepare, type PreparedText } from "@chenglou/pretext";
+import type { GroupedItem, Msg } from "../TranscriptList";
+
+/** Canvas font strings synced with TranscriptList bubble typography. */
+export const TRANSCRIPT_USER_FONT =
+  'normal 13px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+export const TRANSCRIPT_ASSISTANT_FONT =
+  'normal 13px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+export const TRANSCRIPT_CHIP_FONT =
+  'normal 10.5px ui-monospace, SFMono-Regular, Menlo, monospace';
+
+export const TRANSCRIPT_USER_LINE_HEIGHT_PX = 21;
+export const TRANSCRIPT_ASSISTANT_LINE_HEIGHT_PX = 22;
+export const TRANSCRIPT_CHIP_LINE_HEIGHT_PX = 16;
+
+/** Cursor-style clamp for long pasted user messages (matches Bubble). */
+export const TRANSCRIPT_USER_CLAMP_PX = 160;
+
+/** Fallback when Pretext or extraction cannot run (jsdom without canvas). */
+export const TRANSCRIPT_ROW_FALLBACK_PX = 72;
+
+const FEED_COLUMN_MAX_PX = 768;
+const FEED_HORIZONTAL_PADDING_PX = 48;
+
+/** Fixed chrome for chip / status rows that never use Pretext body text. */
+const FIXED_ROW_HEIGHT_PX: Partial<Record<GroupedItem["kind"], number>> = {
+  codegraph_context: 28,
+  vault_cite: 36,
+  command_blocked: 32,
+  auto_status: 32,
+  auto_halt: 32,
+  verifying: 32,
+  auto_verify: 32,
+  verification: 32,
+  quality_gate: 32,
+  turn_terminal: 36,
+  steer: 28,
+  checkpoint: 32,
+  pending_review: 40,
+  compaction: 36,
+};
+
+export type TranscriptRowPretextSpec = {
+  text: string;
+  font: string;
+  lineHeight: number;
+  maxWidth: number;
+  whiteSpace?: "normal" | "pre-wrap";
+  /** Extra pixels beyond layout height (label, padding, buttons). */
+  chromePx: number;
+  /** Cap prose height (user clamp). */
+  maxProsePx?: number;
+};
+
+export function transcriptFeedInnerWidth(scrollClientWidth: number): number {
+  const column = Math.min(FEED_COLUMN_MAX_PX, scrollClientWidth) - FEED_HORIZONTAL_PADDING_PX;
+  return Math.max(240, column);
+}
+
+export function transcriptBubbleMaxWidth(
+  feedInnerWidth: number,
+  role: Msg["role"],
+): number {
+  const ratio = role === "user" ? 0.85 : 0.95;
+  return Math.floor(feedInnerWidth * ratio);
+}
+
+export function transcriptRowCacheKey(
+  rowId: string,
+  text: string,
+  font: string,
+  whiteSpace: "normal" | "pre-wrap" = "normal",
+): string {
+  return `${rowId}\0${font}\0${whiteSpace}\0${text}`;
+}
+
+export function hasMarkdownCodeFence(text: string): boolean {
+  return /```/.test(text);
+}
+
+export function hasMermaidFence(text: string): boolean {
+  return /```\s*mermaid/i.test(text);
+}
+
+export function hasMarkdownImage(text: string): boolean {
+  return /!\[[^\]]*\]\([^)]+\)/.test(text);
+}
+
+/** Strip assistant traceback noise — mirrors Bubble's cleanAssistantText (height-only). */
+export function assistantTextForMeasure(raw: string): string {
+  const lines = raw.split("\n");
+  const cleaned: string[] = [];
+  let inTraceback = false;
+
+  for (const line of lines) {
+    const stripped = line.trim();
+    if (stripped.startsWith("USER: (") || stripped.includes("completed with exit code")) {
+      continue;
+    }
+    if (/^\s*Traceback\s*\(most\s+recent\s+call\s+last\):/i.test(stripped)) {
+      inTraceback = true;
+      continue;
+    }
+    if (inTraceback) {
+      if (stripped === "") continue;
+      if (line.startsWith(" ") || line.startsWith("\t")) continue;
+      inTraceback = false;
+      continue;
+    }
+    if (
+      stripped.includes("During handling of the above exception")
+      || stripped.includes("The above exception was the direct cause")
+    ) {
+      continue;
+    }
+    cleaned.push(line);
+  }
+
+  let result = cleaned.join("\n").trim();
+  result = result.replace(/\n{3,}/g, "\n\n");
+  return result || "Working...";
+}
+
+function isPlanOrProgressAssistant(msg: Msg): boolean {
+  return Boolean(msg.isPlan) || msg.channel === "progress";
+}
+
+/**
+ * Rows Pretext cannot fully model — these get measureElement after mount settle.
+ */
+export function rowNeedsDomMeasure(item: GroupedItem): boolean {
+  switch (item.kind) {
+    case "msg": {
+      const msg = item.msg;
+      if (msg.images?.length) return true;
+      if (msg.workerStream) return true;
+      const text =
+        msg.role === "user" ? msg.text : assistantTextForMeasure(msg.text);
+      if (hasMarkdownCodeFence(text)) return true;
+      if (hasMermaidFence(text)) return true;
+      if (hasMarkdownImage(text)) return true;
+      return false;
+    }
+    case "activity_group":
+      return true;
+    case "command_approval":
+    case "secret_request":
+    case "auth_failure":
+    case "swarm_pending":
+    case "swarm_result":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function rowPretextSpec(
+  item: GroupedItem,
+  feedInnerWidth: number,
+): TranscriptRowPretextSpec | null {
+  switch (item.kind) {
+    case "msg": {
+      const msg = item.msg;
+      if (msg.workerStream) {
+        return {
+          text: msg.role === "user" ? msg.text : assistantTextForMeasure(msg.text),
+          font: TRANSCRIPT_CHIP_FONT,
+          lineHeight: 19,
+          maxWidth: transcriptBubbleMaxWidth(feedInnerWidth, "assistant"),
+          whiteSpace: "pre-wrap",
+          chromePx: 56,
+        };
+      }
+      if (msg.role === "user") {
+        const imageExtra = (msg.images?.length ?? 0) * 88;
+        return {
+          text: msg.text,
+          font: TRANSCRIPT_USER_FONT,
+          lineHeight: TRANSCRIPT_USER_LINE_HEIGHT_PX,
+          maxWidth: transcriptBubbleMaxWidth(feedInnerWidth, "user"),
+          whiteSpace: "pre-wrap",
+          chromePx: 28 + imageExtra,
+          maxProsePx: TRANSCRIPT_USER_CLAMP_PX,
+        };
+      }
+      const text = assistantTextForMeasure(msg.text);
+      if (isPlanOrProgressAssistant(msg)) {
+        return {
+          text,
+          font: TRANSCRIPT_ASSISTANT_FONT,
+          lineHeight: TRANSCRIPT_ASSISTANT_LINE_HEIGHT_PX,
+          maxWidth: transcriptBubbleMaxWidth(feedInnerWidth, "assistant"),
+          whiteSpace: "pre-wrap",
+          chromePx: 24,
+        };
+      }
+      // Markdown prose: measure stripped inline text; fenced blocks use DOM settle.
+      const proseOnly = stripMarkdownForPretext(text);
+      return {
+        text: proseOnly,
+        font: TRANSCRIPT_ASSISTANT_FONT,
+        lineHeight: TRANSCRIPT_ASSISTANT_LINE_HEIGHT_PX,
+        maxWidth: transcriptBubbleMaxWidth(feedInnerWidth, "assistant"),
+        whiteSpace: "normal",
+        chromePx: 24,
+      };
+    }
+    case "thinking": {
+      const preview = item.text.split("\n").find((ln) => ln.trim())?.trim() ?? "";
+      return {
+        text: preview,
+        font: TRANSCRIPT_ASSISTANT_FONT,
+        lineHeight: 20,
+        maxWidth: feedInnerWidth,
+        whiteSpace: "normal",
+        chromePx: 20,
+      };
+    }
+    case "auth_failure":
+      return {
+        text: item.message,
+        font: TRANSCRIPT_ASSISTANT_FONT,
+        lineHeight: TRANSCRIPT_ASSISTANT_LINE_HEIGHT_PX,
+        maxWidth: feedInnerWidth,
+        whiteSpace: "pre-wrap",
+        chromePx: 56,
+      };
+    case "steer":
+      return {
+        text: item.text,
+        font: TRANSCRIPT_ASSISTANT_FONT,
+        lineHeight: TRANSCRIPT_ASSISTANT_LINE_HEIGHT_PX,
+        maxWidth: feedInnerWidth,
+        whiteSpace: "pre-wrap",
+        chromePx: 16,
+      };
+    default:
+      return null;
+  }
+}
+
+/** Remove fenced blocks and most markdown chrome so Pretext measures prose only. */
+export function stripMarkdownForPretext(text: string): string {
+  let out = text.replace(/```[\s\S]*?```/g, " ");
+  out = out.replace(/!\[[^\]]*\]\([^)]+\)/g, " ");
+  out = out.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+  out = out.replace(/^#{1,6}\s+/gm, "");
+  out = out.replace(/(\*\*|__|\*|_|~~|`)/g, "");
+  out = out.replace(/\n{3,}/g, "\n\n");
+  return out.trim() || " ";
+}
+
+export type TranscriptRowHeightCache = {
+  estimateRowHeight: (
+    item: GroupedItem,
+    rowId: string,
+    feedInnerWidth: number,
+  ) => number;
+  clear: () => void;
+};
+
+export function createTranscriptRowHeightCache(): TranscriptRowHeightCache {
+  const preparedByKey = new Map<string, PreparedText>();
+
+  function layoutHeight(
+    rowId: string,
+    spec: TranscriptRowPretextSpec,
+  ): number {
+    const cacheKey = transcriptRowCacheKey(
+      rowId,
+      spec.text,
+      spec.font,
+      spec.whiteSpace ?? "normal",
+    );
+    let handle = preparedByKey.get(cacheKey);
+    if (!handle) {
+      try {
+        handle = prepare(spec.text, spec.font, {
+          whiteSpace: spec.whiteSpace ?? "normal",
+        });
+        preparedByKey.set(cacheKey, handle);
+      } catch {
+        return TRANSCRIPT_ROW_FALLBACK_PX;
+      }
+    }
+    try {
+      const { height, lineCount } = layout(handle, spec.maxWidth, spec.lineHeight);
+      const prose =
+        lineCount === 0
+          ? spec.lineHeight
+          : Math.max(height, spec.lineHeight);
+      const capped =
+        spec.maxProsePx != null
+          ? Math.min(prose, spec.maxProsePx)
+          : prose;
+      return Math.max(24, Math.ceil(capped + spec.chromePx));
+    } catch {
+      return TRANSCRIPT_ROW_FALLBACK_PX;
+    }
+  }
+
+  function estimateRowHeight(
+    item: GroupedItem,
+    rowId: string,
+    feedInnerWidth: number,
+  ): number {
+    const fixed = FIXED_ROW_HEIGHT_PX[item.kind];
+    if (fixed != null) return fixed;
+
+    const spec = rowPretextSpec(item, feedInnerWidth);
+    if (!spec) {
+      return rowNeedsDomMeasure(item)
+        ? TRANSCRIPT_ROW_FALLBACK_PX * 2
+        : TRANSCRIPT_ROW_FALLBACK_PX;
+    }
+    return layoutHeight(rowId, spec);
+  }
+
+  return {
+    estimateRowHeight,
+    clear: () => preparedByKey.clear(),
+  };
+}
+
+/** Whether DOM measureElement may attach for this row (after mount settle). */
+export function shouldAttachDomMeasure(
+  item: GroupedItem,
+  feedSettled: boolean,
+): boolean {
+  return feedSettled && rowNeedsDomMeasure(item);
+}


### PR DESCRIPTION
## Summary
- Size streaming transcript rows with public `@chenglou/pretext` (`prepare` once per row id+text+font, cheap `layout` for height) on top of `@tanstack/react-virtual` and existing `feedScroll`/`nextFeedPinState`.
- Hybrid: Pretext for prose; `measureElement` only after feed/mount settle for images, mermaid, and code. No per-token DOM measure.
- Bump to 0.9.314 (README, harness, pyproject, webapp + lock). Pin stays `puppetmaster-ai==1.22.28`. Overflow-anchor and scroll-padding-bottom kept.

## Test plan
- [x] `cd webapp && npx vitest run src/__tests__/transcriptRowHeight.test.ts` (13 passed)
- [ ] Stream a long assistant reply and confirm the feed stays pinned without jump on each token
- [ ] Rows with fenced code / mermaid / images still settle to the measured height
- [ ] Session switch still settles then re-enables DOM measure for rich rows