### PR TITLE
Marionette v0.9.316 — NFS-safe SQLite journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.315, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.316, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.315"
+__version__ = "0.9.316"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/memory_graph.py
+++ b/harness/memory_graph.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from .memory_store import MemoryEntry, MemoryStore
+from .sqlite_journal import configure_sqlite_connection, host_scoped_state_path
 
 DEFAULT_SQLITE_PATH = Path(os.path.expanduser("~/.pmharness/memory_graph.sqlite"))
 DEFAULT_JOURNAL_PATH = Path(os.path.expanduser("~/.pmharness/memory_graph.jsonl"))
@@ -44,7 +45,9 @@ def default_graph_paths() -> Tuple[Path, Path]:
     if pytest_test:
         return _pytest_graph_paths(pytest_test)
 
-    return DEFAULT_SQLITE_PATH, DEFAULT_JOURNAL_PATH
+    sqlite_path = host_scoped_state_path(DEFAULT_SQLITE_PATH)
+    journal_path = host_scoped_state_path(DEFAULT_JOURNAL_PATH)
+    return sqlite_path, journal_path
 
 
 def _entry_to_node(entry: MemoryEntry) -> Dict[str, Any]:
@@ -100,8 +103,7 @@ class MemoryGraph:
         )
         self._conn.row_factory = sqlite3.Row
         with self._lock:
-            self._conn.execute("PRAGMA journal_mode=WAL")
-            self._conn.execute("PRAGMA busy_timeout=5000")
+            configure_sqlite_connection(self._conn, self.sqlite_path)
             self._init_db()
 
     def _init_db(self) -> None:

--- a/harness/schedule_store.py
+++ b/harness/schedule_store.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 from .schedule_core import SCHEDULE_FIELDS, Schedule
+from .sqlite_journal import configure_sqlite_connection, host_scoped_state_path
 
 DEFAULT_LEASE_SECONDS = 3600
 # Headroom beyond an explicit run ceiling so a short max_seconds cannot shrink
@@ -146,7 +147,9 @@ def default_db_path() -> Path:
     if pytest_test:
         return _pytest_test_db_path(pytest_test)
 
-    new_default = Path.home() / ".pmharness" / "state" / "schedules.sqlite"
+    new_default = host_scoped_state_path(
+        Path.home() / ".pmharness" / "state" / "schedules.sqlite",
+    )
     legacy = Path.home() / ".harness" / "schedules.sqlite"
     if not new_default.exists() and legacy.is_file():
         _migrate_legacy_db(legacy, new_default)
@@ -184,8 +187,7 @@ class ScheduleStore:
         )
         self._conn.row_factory = sqlite3.Row
         with self._lock:
-            self._conn.execute("PRAGMA journal_mode=WAL")
-            self._conn.execute("PRAGMA busy_timeout=5000")
+            configure_sqlite_connection(self._conn, self.path)
             self._init_db()
 
     def _init_db(self) -> None:

--- a/harness/sqlite_journal.py
+++ b/harness/sqlite_journal.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+"""SQLite journal selection for network filesystems.
+
+WAL mode relies on shared-memory sidecars that break on NFS and similar remote
+mounts. Call ``configure_sqlite_connection`` after ``sqlite3.connect`` so local
+disks keep WAL while network paths fall back to TRUNCATE.
+
+When ``Path.home()`` is on a network filesystem, ``host_scoped_state_path``
+rewrites default ``~/.pmharness/...`` locations under a per-host subdirectory
+so concurrent machines do not share one WAL set.
+"""
+
+import os
+import socket
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Callable, Optional, Union
+
+PathLike = Union[str, Path]
+StatfsFn = Callable[[str], bool]
+
+_LINUX_NETWORK_FSTYPES = frozenset(
+    {
+        "nfs",
+        "nfs4",
+        "cifs",
+        "smb3",
+        "fuse.sshfs",
+        "afs",
+        "ncpfs",
+    }
+)
+
+_DARWIN_NETWORK_FSTYPES = frozenset({6, 13, 26, 28})  # NFS, AFP, NETFS, SMBFS
+
+
+def _linux_mount_is_network(path: str) -> bool:
+    try:
+        target = os.path.realpath(path)
+        best_len = -1
+        best_fstype: Optional[str] = None
+        with open("/proc/mounts", encoding="utf-8") as mounts:
+            for raw_line in mounts:
+                parts = raw_line.split()
+                if len(parts) < 3:
+                    continue
+                mount_point = parts[1].replace("\\040", " ")
+                mount_point = mount_point.rstrip("/") or "/"
+                if target == mount_point or (
+                    mount_point != "/"
+                    and target.startswith(mount_point + os.sep)
+                ):
+                    if len(mount_point) > best_len:
+                        best_len = len(mount_point)
+                        best_fstype = parts[2]
+        if best_fstype is None:
+            return False
+        base = best_fstype.split(".", 1)[0].lower()
+        return base in _LINUX_NETWORK_FSTYPES or best_fstype.lower() in _LINUX_NETWORK_FSTYPES
+    except OSError:
+        return False
+
+
+def _darwin_mount_is_network(path: str) -> bool:
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL("libc.dylib", use_errno=True)
+
+        class Statfs(ctypes.Structure):
+            _fields_ = [
+                ("f_bsize", ctypes.c_uint32),
+                ("f_iosize", ctypes.c_uint32),
+                ("f_blocks", ctypes.c_uint64),
+                ("f_bfree", ctypes.c_uint64),
+                ("f_bavail", ctypes.c_uint64),
+                ("f_files", ctypes.c_uint64),
+                ("f_ffree", ctypes.c_uint64),
+                ("f_fsid", ctypes.c_int32 * 2),
+                ("f_owner", ctypes.c_uint32),
+                ("f_type", ctypes.c_uint32),
+                ("f_flags", ctypes.c_uint32),
+                ("f_fssubtype", ctypes.c_uint32),
+                ("f_fstypename", ctypes.c_char * 16),
+                ("f_mntonname", ctypes.c_char * 1024),
+                ("f_mntfromname", ctypes.c_char * 1024),
+                ("f_flags_ext", ctypes.c_uint32),
+                ("f_reserved", ctypes.c_uint32 * 7),
+            ]
+
+        buf = Statfs()
+        if libc.statfs(path.encode("utf-8"), ctypes.byref(buf)) != 0:
+            err = ctypes.get_errno()
+            raise OSError(err, os.strerror(err), path)
+        return int(buf.f_type) in _DARWIN_NETWORK_FSTYPES
+    except OSError:
+        return False
+
+
+def _win32_mount_is_network(path: str) -> bool:
+    normalized = os.path.abspath(path)
+    if normalized.startswith("\\\\"):
+        return True
+    if len(normalized) >= 2 and normalized[1] == ":":
+        try:
+            import ctypes
+
+            kernel32 = ctypes.windll.kernel32
+            drive_type = kernel32.GetDriveTypeW(normalized[:3])
+            return drive_type == 4  # DRIVE_REMOTE
+        except (AttributeError, OSError):
+            return False
+    return False
+
+
+def _platform_is_network_fs(path: str) -> bool:
+    if sys.platform == "linux":
+        return _linux_mount_is_network(path)
+    if sys.platform == "darwin":
+        return _darwin_mount_is_network(path)
+    if sys.platform == "win32":
+        return _win32_mount_is_network(path)
+    return False
+
+
+def is_network_filesystem(
+    path: PathLike,
+    *,
+    statfs: Optional[StatfsFn] = None,
+) -> bool:
+    """Return True when ``path`` lives on a network / remote filesystem."""
+    checker = statfs or _platform_is_network_fs
+    try:
+        resolved = str(Path(path).resolve())
+    except OSError:
+        resolved = str(path)
+    return bool(checker(resolved))
+
+
+def journal_mode_for(
+    path: PathLike,
+    *,
+    statfs: Optional[StatfsFn] = None,
+) -> str:
+    """WAL on local disks; TRUNCATE when the DB directory is network-backed."""
+    return "truncate" if is_network_filesystem(path, statfs=statfs) else "wal"
+
+
+def configure_sqlite_connection(
+    conn: sqlite3.Connection,
+    db_path: PathLike,
+    *,
+    busy_timeout_ms: int = 5000,
+    statfs: Optional[StatfsFn] = None,
+) -> str:
+    """Apply busy_timeout and a filesystem-appropriate journal mode."""
+    mode = journal_mode_for(db_path, statfs=statfs)
+    conn.execute(f"PRAGMA journal_mode={mode}")
+    conn.execute(f"PRAGMA busy_timeout={int(busy_timeout_ms)}")
+    return mode
+
+
+def _hostname_token() -> str:
+    host = (socket.gethostname() or "localhost").split(".", 1)[0].strip()
+    safe = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in host)
+    return safe or "localhost"
+
+
+def host_scoped_state_path(
+    path: PathLike,
+    *,
+    statfs: Optional[StatfsFn] = None,
+) -> Path:
+    """When HOME is network-backed, scope default pmharness files per host."""
+    candidate = Path(path)
+    home = Path.home()
+    if not is_network_filesystem(home, statfs=statfs):
+        return candidate
+    try:
+        home_res = home.resolve()
+        resolved = candidate.resolve()
+    except OSError:
+        return candidate
+    pm_root = home_res / ".pmharness"
+    try:
+        rel = resolved.relative_to(pm_root)
+    except ValueError:
+        return candidate
+    host = _hostname_token()
+    parts = list(rel.parts)
+    if parts and parts[0] == "state":
+        scoped = Path("state", "hosts", host, *parts[1:])
+    else:
+        scoped = Path("hosts", host, *parts)
+    return pm_root / scoped

--- a/harness/tool_output_savings.py
+++ b/harness/tool_output_savings.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional
 
+from .sqlite_journal import configure_sqlite_connection
+
 # Same crude chars→tokens ratio used by ConversationalSession context estimates.
 CHARS_PER_TOKEN = 4
 
@@ -194,7 +196,7 @@ class ToolOutputSavingsLedger:
             return
         os.makedirs(self.state_dir, exist_ok=True)
         self._conn = sqlite3.connect(self._db_path, timeout=30.0, check_same_thread=False)
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        configure_sqlite_connection(self._conn, self._db_path)
         self._conn.executescript(_SCHEMA)
         self._migrate_schema()
         self._conn.commit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.315"
+version = "0.9.316"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_sqlite_journal.py
+++ b/tests/test_sqlite_journal.py
@@ -1,0 +1,118 @@
+"""NFS-safe SQLite journal helper."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from harness.sqlite_journal import (
+    configure_sqlite_connection,
+    host_scoped_state_path,
+    is_network_filesystem,
+    journal_mode_for,
+)
+
+
+def _network_on(path: str) -> bool:
+    return True
+
+
+def _network_off(path: str) -> bool:
+    return False
+
+
+def test_journal_mode_wal_on_local_fs(tmp_path):
+    db = tmp_path / "local.sqlite"
+    assert journal_mode_for(db, statfs=_network_off) == "wal"
+
+
+def test_journal_mode_truncate_on_network_fs(tmp_path):
+    db = tmp_path / "remote.sqlite"
+    assert journal_mode_for(db, statfs=_network_on) == "truncate"
+
+
+def test_configure_sqlite_connection_applies_mode(tmp_path):
+    db = tmp_path / "mode.sqlite"
+    conn = sqlite3.connect(str(db))
+    try:
+        mode = configure_sqlite_connection(conn, db, statfs=_network_on)
+        assert mode == "truncate"
+        row = conn.execute("PRAGMA journal_mode").fetchone()
+        assert row is not None
+        assert row[0].lower() == "truncate"
+    finally:
+        conn.close()
+
+
+def test_configure_sqlite_connection_busy_timeout(tmp_path):
+    db = tmp_path / "busy.sqlite"
+    conn = sqlite3.connect(str(db))
+    try:
+        configure_sqlite_connection(conn, db, busy_timeout_ms=1234, statfs=_network_off)
+        row = conn.execute("PRAGMA busy_timeout").fetchone()
+        assert row == (1234,)
+    finally:
+        conn.close()
+
+
+def test_is_network_filesystem_uses_injected_statfs(tmp_path):
+    path = tmp_path / "probe"
+    path.mkdir()
+    assert is_network_filesystem(path, statfs=_network_on) is True
+    assert is_network_filesystem(path, statfs=_network_off) is False
+
+
+def test_host_scoped_state_path_unchanged_on_local_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    base = Path.home() / ".pmharness" / "state" / "schedules.sqlite"
+    assert host_scoped_state_path(base, statfs=_network_off) == base
+
+
+def test_host_scoped_state_path_adds_host_dir_on_network_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    base = Path.home() / ".pmharness" / "state" / "schedules.sqlite"
+    scoped = host_scoped_state_path(base, statfs=_network_on)
+    assert scoped.parent.name  # hostname token directory
+    assert scoped.name == "schedules.sqlite"
+    assert scoped.parts[-3:-1] == ("hosts", scoped.parts[-2])
+
+
+def test_host_scoped_state_path_non_pmharness_path_unchanged(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    other = Path.home() / "Documents" / "data.sqlite"
+    assert host_scoped_state_path(other, statfs=_network_on) == other
+
+
+def test_schedule_store_uses_journal_helper(tmp_path, monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    db = tmp_path / "schedules.sqlite"
+    from harness.schedule_store import ScheduleStore
+
+    store = ScheduleStore(str(db))
+    try:
+        row = store._conn.execute("PRAGMA journal_mode").fetchone()
+        assert row is not None
+        assert row[0].lower() in {"wal", "truncate"}
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize(
+    "path_suffix",
+    [
+        "state/schedules.sqlite",
+        "memory_graph.sqlite",
+    ],
+)
+def test_host_scoped_paths_under_state_and_root(path_suffix, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    base = Path.home() / ".pmharness" / path_suffix
+    scoped = host_scoped_state_path(base, statfs=_network_on)
+    assert "hosts" in scoped.parts
+    assert scoped.name == Path(path_suffix).name

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.315"
+version = "0.9.316"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.315",
+  "version": "0.9.316",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.315",
+      "version": "0.9.316",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.315",
+  "version": "0.9.316",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Add a small SQLite journal helper that uses injected/platform `statfs` (or `/proc/mounts` on Linux) so network filesystems get `TRUNCATE` instead of `WAL`.
- Wire it into existing sqlite connects (`schedule_store`, `memory_graph`, `tool_output_savings`) without rewriting those stores; host-scope default `~/.pmharness` paths when HOME is remote.
- Tests cover fake `statfs`, journal mode, busy_timeout, and host-scoped paths. Version is 0.9.316; pin remains `puppetmaster-ai==1.22.28`. No `.github` or Pretext/314 changes.

## Test plan
- [x] `pytest tests/test_sqlite_journal.py tests/test_schedule_store.py`
- [ ] CI green on this PR