### PR TITLE
Marionette v0.9.315 — Agent vs External hunk attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.314, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.315, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.314"
+__version__ = "0.9.315"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/checkpoints.py
+++ b/harness/api/checkpoints.py
@@ -93,3 +93,51 @@ def get_checkpoints_diff(checkpoint_id: str, svc: CheckpointServices) -> tuple[i
     if result.get("ok"):
         return 200, result
     return 400, {"error": result.get("error", "Diff generation failed")}
+
+
+def get_checkpoints_hunks(svc: CheckpointServices) -> tuple[int, JsonPayload]:
+    """GET /api/checkpoints/hunks — live hunks with Agent vs External attribution."""
+    repo, err = _repo_or_error(svc)
+    if err is not None:
+        return err
+    from ..checkpoints import CheckpointStore
+    active_sid = svc.get_active_session_id() or ""
+    store = CheckpointStore(repo, session_id=active_sid or None)
+    result = store.hunk_tracker(session_id=active_sid or None).recompute()
+    if result.get("ok"):
+        return 200, result
+    return 400, {"error": result.get("error", "Hunk recompute failed")}
+
+
+def post_checkpoints_hunks_accept(body: dict, svc: CheckpointServices) -> tuple[int, JsonPayload]:
+    """POST /api/checkpoints/hunks/accept."""
+    repo, err = _repo_or_error(svc)
+    if err is not None:
+        return err
+    hunk_id = (body.get("hunk_id") or body.get("id") or "").strip()
+    if not hunk_id:
+        return 400, {"error": "Missing hunk id"}
+    from ..checkpoints import CheckpointStore
+    active_sid = svc.get_active_session_id() or ""
+    store = CheckpointStore(repo, session_id=active_sid or None)
+    result = store.hunk_tracker(session_id=active_sid or None).accept_hunk(hunk_id)
+    if result.get("ok"):
+        return 200, result
+    return 400, {"error": result.get("error", "Accept failed")}
+
+
+def post_checkpoints_hunks_revert(body: dict, svc: CheckpointServices) -> tuple[int, JsonPayload]:
+    """POST /api/checkpoints/hunks/revert."""
+    repo, err = _repo_or_error(svc)
+    if err is not None:
+        return err
+    hunk_id = (body.get("hunk_id") or body.get("id") or "").strip()
+    if not hunk_id:
+        return 400, {"error": "Missing hunk id"}
+    from ..checkpoints import CheckpointStore
+    active_sid = svc.get_active_session_id() or ""
+    store = CheckpointStore(repo, session_id=active_sid or None)
+    result = store.hunk_tracker(session_id=active_sid or None).revert_hunk(hunk_id)
+    if result.get("ok"):
+        return 200, result
+    return 400, {"error": result.get("error", "Revert failed")}

--- a/harness/api/files.py
+++ b/harness/api/files.py
@@ -153,9 +153,9 @@ def post_file_write(body: dict, svc: FileServices) -> tuple[int, dict]:
         msg = str(e)
         return _mutate_path_error_status(msg), {"error": msg}
     try:
+        active_sid = svc.sessions.active or ""
         try:
             from ..checkpoints import CheckpointStore
-            active_sid = svc.sessions.active or ""
             store = CheckpointStore(repo, session_id=active_sid or None)
             store.snapshot(
                 label=f"before manual edit {rel_posix or rel_path}",
@@ -178,6 +178,11 @@ def post_file_write(body: dict, svc: FileServices) -> tuple[int, dict]:
                 os.remove(temp_path)
             raise e
         bytes_written = len(content.encode("utf-8"))
+        try:
+            from ..checkpoint_hunks import fs_notify
+            fs_notify(repo, rel_posix, session_id=active_sid or None)
+        except Exception:
+            pass
         return 200, {"ok": True, "bytes": bytes_written}
     except Exception as e:
         return 500, {"error": f"Failed to write file: {e}"}
@@ -208,6 +213,12 @@ def post_file_delete(body: dict, svc: FileServices) -> tuple[int, dict]:
             _shutil.rmtree(target_path)
         else:
             os.remove(target_path)
+        try:
+            active_sid = svc.sessions.active or ""
+            from ..checkpoint_hunks import fs_notify
+            fs_notify(repo, rel_posix, session_id=active_sid or None)
+        except Exception:
+            pass
         return 200, {"ok": True, "path": rel_posix}
     except Exception as e:
         return 500, {"error": f"Failed to delete: {e}"}

--- a/harness/checkpoint_hunks.py
+++ b/harness/checkpoint_hunks.py
@@ -1,0 +1,603 @@
+"""Live per-hunk Agent vs External attribution anchored to CheckpointStore."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from .checkpoints import CHECKPOINT_GIT_TIMEOUT, CheckpointStore, _within
+from .diffreview import parse_unified_diff
+
+logger = logging.getLogger("pmharness.checkpoint_hunks")
+
+SourceKind = Literal["agent", "external"]
+HunkKind = Literal["added", "removed", "modified"]
+DecisionKind = Literal["pending", "accepted", "reverted"]
+
+
+def _parse_hunk_header(header: str) -> Optional[dict[str, int]]:
+    import re
+
+    m = re.match(r"^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s@@", header.strip())
+    if not m:
+        return None
+    old_start = int(m.group(1))
+    old_count = int(m.group(2) or "1")
+    new_start = int(m.group(3))
+    new_count = int(m.group(4) or "1")
+    return {
+        "old_start": old_start,
+        "old_count": old_count,
+        "new_start": new_start,
+        "new_count": new_count,
+    }
+
+
+def _hunk_kind(hunk: dict[str, Any]) -> HunkKind:
+    has_add = False
+    has_del = False
+    for line in hunk.get("lines") or []:
+        if line.startswith("+"):
+            has_add = True
+        elif line.startswith("-"):
+            has_del = True
+    if has_add and not has_del:
+        return "added"
+    if has_del and not has_add:
+        return "removed"
+    return "modified"
+
+
+def _hunk_new_line_numbers(hunk: dict[str, Any]) -> list[int]:
+    header = _parse_hunk_header(hunk.get("header") or "")
+    if not header:
+        return []
+    nums: list[int] = []
+    cursor = header["new_start"]
+    for line in hunk.get("lines") or []:
+        if line.startswith("+"):
+            nums.append(cursor)
+            cursor += 1
+        elif line.startswith(" "):
+            nums.append(cursor)
+            cursor += 1
+        elif line.startswith("-"):
+            continue
+    return nums
+
+
+def _classify_source(
+    path: str,
+    hunk: dict[str, Any],
+    line_authorship: dict[str, dict[str, str]],
+    write_sources: dict[str, str],
+) -> SourceKind:
+    path_map = line_authorship.get(path) or {}
+    nums = _hunk_new_line_numbers(hunk)
+    if nums:
+        agent_hits = sum(1 for n in nums if path_map.get(str(n)) == "agent")
+        external_hits = sum(1 for n in nums if path_map.get(str(n)) == "external")
+        if agent_hits and not external_hits:
+            return "agent"
+        if external_hits and not agent_hits:
+            return "external"
+        if agent_hits >= external_hits and agent_hits:
+            return "agent"
+        if external_hits:
+            return "external"
+    kind = _hunk_kind(hunk)
+    if kind == "removed":
+        src = write_sources.get(path)
+        if src in ("agent", "external"):
+            return src  # type: ignore[return-value]
+    src = write_sources.get(path)
+    if src == "agent":
+        return "agent"
+    return "external"
+
+
+def _update_line_authorship(
+    old_text: str,
+    new_text: str,
+    source: SourceKind,
+    existing: dict[str, str],
+) -> dict[str, str]:
+    old_lines = old_text.splitlines()
+    new_lines = new_text.splitlines()
+    out = dict(existing)
+    import difflib
+
+    matcher = difflib.SequenceMatcher(None, old_lines, new_lines)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag in ("replace", "insert"):
+            for j in range(j1, j2):
+                out[str(j + 1)] = source
+        elif tag == "delete":
+            # Drop authorship for deleted new-side lines above the deletion.
+            for key in list(out.keys()):
+                try:
+                    ln = int(key)
+                except ValueError:
+                    continue
+                if ln > j1:
+                    out.pop(key, None)
+    # Re-index after structural edits so line numbers stay aligned with file.
+    if old_lines != new_lines:
+        remapped: dict[str, str] = {}
+        for j, line in enumerate(new_lines):
+            ln = j + 1
+            if str(ln) in out:
+                remapped[str(ln)] = out[str(ln)]
+            elif j < len(old_lines) and old_lines[j] == line and str(ln) in existing:
+                remapped[str(ln)] = existing[str(ln)]
+        # Preserve explicit marks from this write on changed rows.
+        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+            if tag in ("replace", "insert"):
+                for j in range(j1, j2):
+                    remapped[str(j + 1)] = source
+        out = remapped
+    return out
+
+
+def _read_repo_file(repo: str, rel_path: str) -> str:
+    abs_path = os.path.join(repo, rel_path)
+    if not os.path.isfile(abs_path):
+        return ""
+    with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+def _git_show_file(repo: str, commit_sha: str, rel_path: str) -> Optional[str]:
+    try:
+        res = subprocess.run(
+            ["git", "show", f"{commit_sha}:{rel_path}"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=CHECKPOINT_GIT_TIMEOUT,
+        )
+        if res.returncode == 0:
+            return res.stdout
+    except Exception:
+        pass
+    return None
+
+
+def _revert_hunk_in_text(current: str, hunk: dict[str, Any]) -> str:
+    header = _parse_hunk_header(hunk.get("header") or "")
+    if not header:
+        return current
+    lines = current.splitlines()
+    old_chunk: list[str] = []
+    for raw in hunk.get("lines") or []:
+        if not raw:
+            continue
+        if raw.startswith("-") or raw.startswith(" "):
+            old_chunk.append(raw[1:].rstrip("\n"))
+        elif raw.startswith("+"):
+            continue
+    start = max(0, header["new_start"] - 1)
+    end = start + header["new_count"]
+    new_lines = lines[:start] + old_chunk + lines[end:]
+    trailing_newline = current.endswith("\n")
+    out = "\n".join(new_lines)
+    if trailing_newline:
+        out += "\n"
+    return out
+
+
+class CheckpointHunkTracker:
+    """Track live unified-diff hunks vs a checkpoint baseline with authorship."""
+
+    _lock = threading.Lock()
+
+    def __init__(self, store: CheckpointStore, session_id: Optional[str] = None):
+        self._store = store
+        self._session_id = (session_id or store.session_id or "").strip() or None
+        self._repo = store.repo
+        self._enabled = bool(store._enabled and self._repo)
+        self._meta_file: Optional[Path] = None
+        if self._enabled and store._repo_hash:
+            sid = self._session_id or "default"
+            meta_dir = Path.home() / ".pmharness" / "checkpoints"
+            self._meta_file = meta_dir / f"{store._repo_hash}_{sid}_hunks.json"
+
+    def _default_state(self) -> dict[str, Any]:
+        return {
+            "baseline_id": None,
+            "snapshots": {},
+            "write_sources": {},
+            "line_authorship": {},
+            "decisions": {},
+            "updated_at": int(time.time()),
+        }
+
+    def _load_state(self) -> dict[str, Any]:
+        if not self._meta_file or not self._meta_file.exists():
+            return self._default_state()
+        try:
+            with open(self._meta_file, "r", encoding="utf-8", errors="replace") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                base = self._default_state()
+                base.update(data)
+                return base
+        except Exception:
+            pass
+        return self._default_state()
+
+    def _save_state(self, state: dict[str, Any]) -> None:
+        if not self._meta_file:
+            return
+        try:
+            self._meta_file.parent.mkdir(parents=True, exist_ok=True)
+            state["updated_at"] = int(time.time())
+            temp = str(self._meta_file) + ".tmp"
+            with open(temp, "w", encoding="utf-8", newline="\n") as f:
+                json.dump(state, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp, self._meta_file)
+        except Exception as exc:
+            logger.warning("failed to save hunk tracker state: %s", exc)
+
+    def ensure_baseline(self) -> Optional[str]:
+        if not self._enabled:
+            return None
+        with self._lock:
+            state = self._load_state()
+            if state.get("baseline_id"):
+                return str(state["baseline_id"])
+            listed = self._store.list(session_id=self._session_id)
+            if listed:
+                cp_id = str(listed[-1]["id"])
+                state["baseline_id"] = cp_id
+                self._save_state(state)
+                return cp_id
+            cp_id = self._store.snapshot(
+                label="Live hunk baseline",
+                trigger="hunk_baseline",
+                session_id=self._session_id,
+            )
+            if cp_id:
+                state["baseline_id"] = cp_id
+                self._save_state(state)
+            return cp_id
+
+    def _record_write(self, rel_path: str, source: SourceKind) -> None:
+        if not self._enabled or not rel_path:
+            return
+        rel = rel_path.replace("\\", "/").lstrip("./")
+        repo = self._repo
+        if not repo:
+            return
+        abs_path = os.path.realpath(os.path.join(repo, rel))
+        if not _within(repo, abs_path):
+            return
+        self.ensure_baseline()
+        new_text = _read_repo_file(repo, rel)
+        with self._lock:
+            state = self._load_state()
+            snapshots: dict[str, str] = state.setdefault("snapshots", {})
+            old_text = snapshots.get(rel, _git_show_file(repo, str(state.get("baseline_id")), rel) or "")
+            line_auth: dict[str, dict[str, str]] = state.setdefault("line_authorship", {})
+            line_auth[rel] = _update_line_authorship(
+                old_text,
+                new_text,
+                source,
+                line_auth.get(rel) or {},
+            )
+            snapshots[rel] = new_text
+            write_sources: dict[str, str] = state.setdefault("write_sources", {})
+            write_sources[rel] = source
+            self._save_state(state)
+
+    def record_agent_write(self, rel_path: str) -> None:
+        """Mark a workspace write as agent-authored."""
+        self._record_write(rel_path, "agent")
+
+    def fs_notify(self, rel_path: str) -> None:
+        """Mark an external filesystem change (manual editor save, etc.)."""
+        self._record_write(rel_path, "external")
+
+    def recompute(self) -> dict[str, Any]:
+        if not self._enabled:
+            return {"ok": False, "error": "Hunk tracker disabled: not a git worktree"}
+        baseline_id = self.ensure_baseline()
+        if not baseline_id:
+            return {"ok": False, "error": "Failed to establish hunk baseline checkpoint"}
+        repo = self._repo
+        assert repo is not None
+        try:
+            diff_res = subprocess.run(
+                ["git", "diff", baseline_id, "--", "."],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=CHECKPOINT_GIT_TIMEOUT,
+            )
+            diff_text = diff_res.stdout or ""
+        except Exception as exc:
+            return {"ok": False, "error": f"Failed to diff baseline: {exc}"}
+
+        state = self._load_state()
+        line_auth = state.get("line_authorship") or {}
+        write_sources = state.get("write_sources") or {}
+        decisions: dict[str, str] = state.get("decisions") or {}
+
+        files_out: list[dict[str, Any]] = []
+        parsed = parse_unified_diff(diff_text)
+        for f in parsed:
+            path = f.get("path") or ""
+            if not path:
+                continue
+            hunks_out: list[dict[str, Any]] = []
+            for h in f.get("hunks") or []:
+                hid = str(h.get("id") or "")
+                status = decisions.get(hid, "pending")
+                if status == "reverted":
+                    continue
+                source = _classify_source(path, h, line_auth, write_sources)
+                hunks_out.append(
+                    {
+                        "id": hid,
+                        "header": h.get("header") or "",
+                        "lines": h.get("lines") or [],
+                        "kind": _hunk_kind(h),
+                        "source": source,
+                        "status": status,
+                    }
+                )
+            if hunks_out:
+                files_out.append({"path": path, "hunks": hunks_out})
+
+        # Whole-file adds/removes not represented as hunks still surface via diff names.
+        try:
+            names_res = subprocess.run(
+                ["git", "diff", "--name-status", baseline_id, "--", "."],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=CHECKPOINT_GIT_TIMEOUT,
+            )
+        except Exception:
+            names_res = None
+        listed_paths = {f["path"] for f in files_out}
+        if names_res and names_res.returncode == 0:
+            file_index = len(parsed)
+            hunk_index = 0
+            for line in names_res.stdout.splitlines():
+                parts = line.split("\t", 1)
+                if len(parts) != 2:
+                    continue
+                code, path = parts[0].strip(), parts[1].strip()
+                if path in listed_paths:
+                    continue
+                if code.startswith("A"):
+                    hid = f"{file_index}:{hunk_index}"
+                    file_index += 1
+                    source = write_sources.get(path, "external")
+                    if (line_auth.get(path) or {}) and all(
+                        v == "agent" for v in (line_auth.get(path) or {}).values()
+                    ):
+                        source = "agent"
+                    status = decisions.get(hid, "pending")
+                    if status != "reverted":
+                        files_out.append(
+                            {
+                                "path": path,
+                                "hunks": [
+                                    {
+                                        "id": hid,
+                                        "header": "@@ file added @@",
+                                        "lines": [],
+                                        "kind": "added",
+                                        "source": source,
+                                        "status": status,
+                                    }
+                                ],
+                            }
+                        )
+                elif code.startswith("D"):
+                    hid = f"{file_index}:{hunk_index}"
+                    file_index += 1
+                    source = write_sources.get(path, "external")
+                    status = decisions.get(hid, "pending")
+                    if status != "reverted":
+                        files_out.append(
+                            {
+                                "path": path,
+                                "hunks": [
+                                    {
+                                        "id": hid,
+                                        "header": "@@ file removed @@",
+                                        "lines": [],
+                                        "kind": "removed",
+                                        "source": source,
+                                        "status": status,
+                                    }
+                                ],
+                            }
+                        )
+
+        files_out.sort(key=lambda row: row.get("path") or "")
+        # Untracked adds do not appear in `git diff <commit>` — surface them explicitly.
+        try:
+            status_res = subprocess.run(
+                ["git", "status", "--porcelain", "-u", "--", "."],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=CHECKPOINT_GIT_TIMEOUT,
+            )
+        except Exception:
+            status_res = None
+        listed_paths = {f["path"] for f in files_out}
+        if status_res and status_res.returncode == 0:
+            file_index = len(parsed) + len(listed_paths)
+            hunk_index = 0
+            for line in status_res.stdout.splitlines():
+                if not line.startswith("?? "):
+                    continue
+                path = line[3:].strip()
+                if not path or path in listed_paths:
+                    continue
+                hid = f"{file_index}:{hunk_index}"
+                file_index += 1
+                source = write_sources.get(path, "external")
+                path_lines = line_auth.get(path) or {}
+                if path_lines and all(v == "agent" for v in path_lines.values()):
+                    source = "agent"
+                status = decisions.get(hid, "pending")
+                if status == "reverted":
+                    continue
+                files_out.append(
+                    {
+                        "path": path,
+                        "hunks": [
+                            {
+                                "id": hid,
+                                "header": "@@ file added @@",
+                                "lines": [],
+                                "kind": "added",
+                                "source": source,
+                                "status": status,
+                            }
+                        ],
+                    }
+                )
+                listed_paths.add(path)
+
+        files_out.sort(key=lambda row: row.get("path") or "")
+        return {
+            "ok": True,
+            "baseline_id": baseline_id,
+            "files": files_out,
+            "diff": diff_text,
+        }
+
+    def accept_hunk(self, hunk_id: str) -> dict[str, Any]:
+        if not self._enabled:
+            return {"ok": False, "error": "Hunk tracker disabled"}
+        hid = (hunk_id or "").strip()
+        if not hid:
+            return {"ok": False, "error": "Missing hunk id"}
+        with self._lock:
+            state = self._load_state()
+            decisions: dict[str, str] = state.setdefault("decisions", {})
+            decisions[hid] = "accepted"
+            self._save_state(state)
+        return {"ok": True, "hunk_id": hid, "status": "accepted"}
+
+    def revert_hunk(self, hunk_id: str) -> dict[str, Any]:
+        if not self._enabled:
+            return {"ok": False, "error": "Hunk tracker disabled"}
+        hid = (hunk_id or "").strip()
+        if not hid:
+            return {"ok": False, "error": "Missing hunk id"}
+        live = self.recompute()
+        if not live.get("ok"):
+            return live
+        target: Optional[dict[str, Any]] = None
+        target_path = ""
+        for f in live.get("files") or []:
+            for h in f.get("hunks") or []:
+                if h.get("id") == hid:
+                    target = h
+                    target_path = f.get("path") or ""
+                    break
+            if target:
+                break
+        if target is None or not target_path:
+            return {"ok": False, "error": f"Hunk {hid} not found"}
+
+        repo = self._repo
+        assert repo is not None
+        baseline_id = str(live.get("baseline_id") or "")
+        kind = target.get("kind")
+        try:
+            if kind == "added":
+                abs_path = os.path.join(repo, target_path)
+                if _within(repo, abs_path) and os.path.isfile(abs_path):
+                    os.unlink(abs_path)
+            elif kind == "removed":
+                baseline_text = _git_show_file(repo, baseline_id, target_path)
+                if baseline_text is None:
+                    return {"ok": False, "error": "Baseline file missing for revert"}
+                abs_path = os.path.join(repo, target_path)
+                if not _within(repo, abs_path):
+                    return {"ok": False, "error": "Path escapes workspace"}
+                os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+                with open(abs_path, "w", encoding="utf-8", newline="\n") as f:
+                    f.write(baseline_text)
+            else:
+                current = _read_repo_file(repo, target_path)
+                baseline_text = _git_show_file(repo, baseline_id, target_path) or ""
+                if target.get("header") == "@@ file added @@":
+                    abs_path = os.path.join(repo, target_path)
+                    if _within(repo, abs_path) and os.path.isfile(abs_path):
+                        os.unlink(abs_path)
+                else:
+                    reverted = _revert_hunk_in_text(current, target)
+                    abs_path = os.path.join(repo, target_path)
+                    if not _within(repo, abs_path):
+                        return {"ok": False, "error": "Path escapes workspace"}
+                    with open(abs_path, "w", encoding="utf-8", newline="\n") as f:
+                        f.write(reverted)
+                # Refresh snapshot cache for subsequent attribution.
+                with self._lock:
+                    state = self._load_state()
+                    snapshots: dict[str, str] = state.setdefault("snapshots", {})
+                    snapshots[target_path] = _read_repo_file(repo, target_path)
+                    self._save_state(state)
+        except Exception as exc:
+            return {"ok": False, "error": f"Revert failed: {exc}"}
+
+        with self._lock:
+            state = self._load_state()
+            decisions: dict[str, str] = state.setdefault("decisions", {})
+            decisions[hid] = "reverted"
+            self._save_state(state)
+        return {"ok": True, "hunk_id": hid, "status": "reverted", "path": target_path}
+
+
+def hunk_tracker_for_store(
+    store: CheckpointStore,
+    session_id: Optional[str] = None,
+) -> CheckpointHunkTracker:
+    sid = session_id if session_id is not None else store.session_id
+    return CheckpointHunkTracker(store, session_id=sid)
+
+
+def record_agent_write(repo: Optional[str], rel_path: str, session_id: Optional[str] = None) -> None:
+    if not repo or not rel_path:
+        return
+    try:
+        store = CheckpointStore(repo, session_id=session_id)
+        hunk_tracker_for_store(store, session_id=session_id).record_agent_write(rel_path)
+    except Exception as exc:
+        logger.debug("record_agent_write skipped: %s", exc)
+
+
+def fs_notify(repo: Optional[str], rel_path: str, session_id: Optional[str] = None) -> None:
+    if not repo or not rel_path:
+        return
+    try:
+        store = CheckpointStore(repo, session_id=session_id)
+        hunk_tracker_for_store(store, session_id=session_id).fs_notify(rel_path)
+    except Exception as exc:
+        logger.debug("fs_notify skipped: %s", exc)

--- a/harness/checkpoints.py
+++ b/harness/checkpoints.py
@@ -627,3 +627,9 @@ class CheckpointStore:
                     break
             except Exception:
                 break
+
+    def hunk_tracker(self, session_id: Optional[str] = None) -> Any:
+        """Live per-hunk Agent vs External attribution for this store."""
+        from .checkpoint_hunks import CheckpointHunkTracker
+
+        return CheckpointHunkTracker(self, session_id=session_id)

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -3467,6 +3467,18 @@ class ConversationalSession(
 
         files = payload.get("files") or []
 
+        def _record_patch_agent_writes() -> None:
+            try:
+                from harness.checkpoint_hunks import record_agent_write
+                for rel_path in files:
+                    record_agent_write(
+                        repo_root,
+                        rel_path,
+                        session_id=self.harness_session_id or None,
+                    )
+            except Exception:
+                pass
+
         # Write diff to a temporary file. Binary mode: Windows text mode would
         # rewrite \n as \r\n, corrupting the unified diff before git apply sees it.
         fd, temp_path = tempfile.mkstemp(suffix=".patch")
@@ -3547,6 +3559,7 @@ class ConversationalSession(
                 )
                 if apply_p.returncode == 0:
                     self._last_checkpoint_id = checkpoint_id
+                    _record_patch_agent_writes()
                     return True, files, "applied cleanly"
                 else:
                     err_msg = apply_p.stderr.strip() or "git apply failed"
@@ -3578,6 +3591,7 @@ class ConversationalSession(
                 )
                 if three_way_p.returncode == 0:
                     self._last_checkpoint_id = checkpoint_id
+                    _record_patch_agent_writes()
                     return True, files, "applied with 3way merge"
 
                 # --3way failed: a genuine content conflict. Restore every target

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -136,6 +136,10 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             _ckpt_api.post_checkpoints_restore, services=svc.checkpoint_services),
         "/api/checkpoints/snapshot": post_json(
             _ckpt_api.post_checkpoints_snapshot, services=svc.checkpoint_services),
+        "/api/checkpoints/hunks/accept": post_json(
+            _ckpt_api.post_checkpoints_hunks_accept, services=svc.checkpoint_services),
+        "/api/checkpoints/hunks/revert": post_json(
+            _ckpt_api.post_checkpoints_hunks_revert, services=svc.checkpoint_services),
         "/api/codegraph/reindex": post_json(
             _cg_api.post_codegraph_reindex, services=svc.codegraph_services,
             needs_body=False),
@@ -668,6 +672,8 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         "/api/checkpoints/diff": get_json(
             _ckpt_api.get_checkpoints_diff, services=svc.checkpoint_services,
             qs_arg="id", empty_as_none=True),
+        "/api/checkpoints/hunks": get_json(
+            _ckpt_api.get_checkpoints_hunks, services=svc.checkpoint_services),
         "/api/mcp": get_json(_mcp_api.get_mcp, services=svc.mcp_services),
         "/api/mcp/catalog": get_json(_mcp_api.get_mcp_catalog),
         "/api/plugins": get_json(

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -2998,6 +2998,15 @@ def dispatch_local_action(
             })
             session._append_action_result(act, aid, f"(write_file {act.path} successfully wrote {bytes_written} bytes)", is_native)
             maybe_refresh_workspace_rules(session, act.path)
+            try:
+                from harness.checkpoint_hunks import record_agent_write
+                record_agent_write(
+                    session.config.repo,
+                    act.path,
+                    session_id=session.harness_session_id or None,
+                )
+            except Exception:
+                pass
             turn_changed_files.append(target_path)
             yield from _yield_task_profile_escalation(session, turn_changed_files)
         except Exception as e:
@@ -3057,6 +3066,15 @@ def dispatch_local_action(
             })
             session._append_action_result(act, aid, f"(edit_file {act.path} successfully edited: {headline})", is_native)
             maybe_refresh_workspace_rules(session, act.path)
+            try:
+                from harness.checkpoint_hunks import record_agent_write
+                record_agent_write(
+                    session.config.repo,
+                    act.path,
+                    session_id=session.harness_session_id or None,
+                )
+            except Exception:
+                pass
             turn_changed_files.append(target_path)
             yield from _yield_task_profile_escalation(session, turn_changed_files)
         except Exception as e:
@@ -3123,6 +3141,15 @@ def dispatch_local_action(
             yield ConvEvent("action_result", hash_edit_result)
             session._append_action_result(act, aid, f"(hash_edit {act.path} successfully applied: {headline})", is_native)
             maybe_refresh_workspace_rules(session, act.path)
+            try:
+                from harness.checkpoint_hunks import record_agent_write
+                record_agent_write(
+                    session.config.repo,
+                    act.path,
+                    session_id=session.harness_session_id or None,
+                )
+            except Exception:
+                pass
             turn_changed_files.append(target_path)
             yield from _yield_task_profile_escalation(session, turn_changed_files)
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.314"
+version = "0.9.315"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_checkpoint_hunks.py
+++ b/tests/test_checkpoint_hunks.py
@@ -1,0 +1,235 @@
+"""Hermetic tests for live checkpoint hunk attribution (Agent vs External)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+from harness.checkpoint_hunks import CheckpointHunkTracker, fs_notify, record_agent_write
+from harness.checkpoints import CheckpointStore
+
+
+@pytest.fixture
+def temp_git_repo():
+    temp_dir = tempfile.mkdtemp()
+    try:
+        subprocess.run(["git", "init"], cwd=temp_dir, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], cwd=temp_dir, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=temp_dir, check=True)
+        file1 = os.path.join(temp_dir, "file1.txt")
+        with open(file1, "w", encoding="utf-8") as f:
+            f.write("line one\nline two\n")
+        subprocess.run(["git", "add", "file1.txt"], cwd=temp_dir, check=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=temp_dir, check=True)
+        yield temp_dir
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _tracker(repo: str, session_id: str = "sess-hunks") -> CheckpointHunkTracker:
+    store = CheckpointStore(repo, session_id=session_id)
+    return store.hunk_tracker(session_id=session_id)
+
+
+def test_hunk_tracker_baseline_and_agent_attribution(temp_git_repo):
+    repo = temp_git_repo
+    tracker = _tracker(repo)
+
+    baseline = tracker.ensure_baseline()
+    assert baseline
+
+    path = os.path.join(repo, "file1.txt")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("line one\nagent line\n")
+    tracker.record_agent_write("file1.txt")
+
+    live = tracker.recompute()
+    assert live["ok"] is True
+    assert live["baseline_id"] == baseline
+    assert live["files"]
+    file_row = live["files"][0]
+    assert file_row["path"] == "file1.txt"
+    assert file_row["hunks"]
+    hunk = file_row["hunks"][0]
+    assert hunk["source"] == "agent"
+    assert hunk["kind"] == "modified"
+    assert hunk["status"] == "pending"
+
+
+def test_hunk_tracker_external_attribution(temp_git_repo):
+    repo = temp_git_repo
+    tracker = _tracker(repo)
+    tracker.ensure_baseline()
+
+    path = os.path.join(repo, "file1.txt")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("line one\nexternal line\n")
+    tracker.fs_notify("file1.txt")
+
+    live = tracker.recompute()
+    assert live["ok"] is True
+    hunk = live["files"][0]["hunks"][0]
+    assert hunk["source"] == "external"
+
+
+def test_record_agent_write_and_fs_notify_helpers(temp_git_repo):
+    repo = temp_git_repo
+    session = "helper-session"
+    store = CheckpointStore(repo, session_id=session)
+    store.snapshot(label="pre-helper", trigger="test", session_id=session)
+
+    path = os.path.join(repo, "file1.txt")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("line one\nhelper agent\n")
+    record_agent_write(repo, "file1.txt", session_id=session)
+
+    live = store.hunk_tracker(session_id=session).recompute()
+    assert live["files"][0]["hunks"][0]["source"] == "agent"
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("line one\nhelper external\n")
+    fs_notify(repo, "file1.txt", session_id=session)
+    live2 = store.hunk_tracker(session_id=session).recompute()
+    assert live2["files"][0]["hunks"][0]["source"] == "external"
+
+
+def test_accept_hunk_marks_status_without_file_change(temp_git_repo):
+    repo = temp_git_repo
+    tracker = _tracker(repo)
+    tracker.ensure_baseline()
+
+    path = os.path.join(repo, "file1.txt")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("line one\naccepted line\n")
+    tracker.record_agent_write("file1.txt")
+
+    live = tracker.recompute()
+    hunk_id = live["files"][0]["hunks"][0]["id"]
+    res = tracker.accept_hunk(hunk_id)
+    assert res["ok"] is True
+    assert res["status"] == "accepted"
+
+    after = tracker.recompute()
+    hunk = after["files"][0]["hunks"][0]
+    assert hunk["status"] == "accepted"
+    with open(path, "r", encoding="utf-8") as f:
+        assert "accepted line" in f.read()
+
+
+def test_revert_hunk_restores_baseline_content(temp_git_repo):
+    repo = temp_git_repo
+    tracker = _tracker(repo)
+    tracker.ensure_baseline()
+
+    path = os.path.join(repo, "file1.txt")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("line one\nagent edit\n")
+    tracker.record_agent_write("file1.txt")
+
+    live = tracker.recompute()
+    hunk_id = live["files"][0]["hunks"][0]["id"]
+    res = tracker.revert_hunk(hunk_id)
+    assert res["ok"] is True
+    assert res["status"] == "reverted"
+
+    with open(path, "r", encoding="utf-8") as f:
+        assert f.read() == "line one\nline two\n"
+
+    after = tracker.recompute()
+    assert after["files"] == []
+
+
+def test_added_file_hunk_revert_deletes_file(temp_git_repo):
+    repo = temp_git_repo
+    tracker = _tracker(repo)
+    tracker.ensure_baseline()
+
+    new_path = os.path.join(repo, "brand_new.txt")
+    with open(new_path, "w", encoding="utf-8") as f:
+        f.write("fresh\n")
+    tracker.record_agent_write("brand_new.txt")
+
+    live = tracker.recompute()
+    assert any(f["path"] == "brand_new.txt" for f in live["files"])
+    file_row = next(f for f in live["files"] if f["path"] == "brand_new.txt")
+    hunk_id = file_row["hunks"][0]["id"]
+    assert file_row["hunks"][0]["kind"] == "added"
+
+    res = tracker.revert_hunk(hunk_id)
+    assert res["ok"] is True
+    assert not os.path.exists(new_path)
+
+
+def test_removed_file_hunk_is_external_or_agent(temp_git_repo):
+    repo = temp_git_repo
+    tracker = _tracker(repo)
+    tracker.ensure_baseline()
+
+    os.remove(os.path.join(repo, "file1.txt"))
+    tracker.fs_notify("file1.txt")
+
+    live = tracker.recompute()
+    assert live["ok"] is True
+    file_row = next(f for f in live["files"] if f["path"] == "file1.txt")
+    hunk = file_row["hunks"][0]
+    assert hunk["kind"] == "removed"
+    assert hunk["source"] == "external"
+
+    res = tracker.revert_hunk(hunk["id"])
+    assert res["ok"] is True
+    with open(os.path.join(repo, "file1.txt"), "r", encoding="utf-8") as f:
+        assert "line two" in f.read()
+
+
+def test_api_checkpoints_hunks_endpoints(temp_git_repo):
+    from types import SimpleNamespace
+
+    from harness.api.checkpoints import (
+        CheckpointServices,
+        get_checkpoints_hunks,
+        post_checkpoints_hunks_accept,
+        post_checkpoints_hunks_revert,
+    )
+
+    repo = temp_git_repo
+    svc = CheckpointServices(
+        cfg=SimpleNamespace(repo=repo),
+        get_active_session_id=lambda: "sess-hunks",
+    )
+
+    path = os.path.join(repo, "file1.txt")
+    tracker = _tracker(repo)
+    tracker.ensure_baseline()
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("line one\napi agent\n")
+    record_agent_write(repo, "file1.txt", session_id="sess-hunks")
+
+    code, payload = get_checkpoints_hunks(svc)
+    assert code == 200
+    assert payload["ok"] is True
+    assert payload["files"]
+    hunk_id = payload["files"][0]["hunks"][0]["id"]
+    assert payload["files"][0]["hunks"][0]["source"] == "agent"
+
+    code, accept = post_checkpoints_hunks_accept({"hunk_id": hunk_id}, svc)
+    assert code == 200
+    assert accept["status"] == "accepted"
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("line one\napi external\n")
+    fs_notify(repo, "file1.txt", session_id="sess-hunks")
+    code, payload2 = get_checkpoints_hunks(svc)
+    assert code == 200
+    ext_hunk = payload2["files"][0]["hunks"][0]
+    assert ext_hunk["source"] == "external"
+
+    code, revert = post_checkpoints_hunks_revert({"hunk_id": ext_hunk["id"]}, svc)
+    assert code == 200
+    assert revert["status"] == "reverted"
+
+    code, missing = post_checkpoints_hunks_accept({}, svc)
+    assert code == 400

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.314"
+version = "0.9.315"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.314",
+  "version": "0.9.315",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.314",
+      "version": "0.9.315",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.314",
+  "version": "0.9.315",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Live per-hunk Agent vs External attribution on the existing checkpoints path (no second engine).
- Watch agent writes and file changes, recompute hunks, and emit added/removed with authorship.
- Per-hunk accept/revert, hermetic tests, version 0.9.315, pin puppetmaster-ai==1.22.28.

## Test plan
- [x] `pytest tests/test_checkpoint_hunks.py`
- [ ] Checkpoints pane: agent edit vs external save show Agent/External
- [ ] Accept leaves disk; revert restores baseline hunk