### PR TITLE
Marionette v0.9.317 — overflow-anchor feed pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.316, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.317, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.316"
+__version__ = "0.9.317"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.316"
+version = "0.9.317"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.316"
+version = "0.9.317"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.316",
+  "version": "0.9.317",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.316",
+      "version": "0.9.317",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.316",
+  "version": "0.9.317",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/feedScroll.test.ts
+++ b/webapp/src/__tests__/feedScroll.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  FEED_CHROME_CLEARANCE_VAR,
   FEED_GESTURE_IDLE_MS,
   FEED_REPIN_THRESHOLD_PX,
+  FEED_SCROLLPORT_OVERFLOW_ANCHOR,
   FEED_TAIL_EPSILON_PX,
   chooseFeedFollowFlush,
   feedBottomClearancePx,
@@ -741,6 +743,24 @@ describe("feedScroll layout contracts", () => {
         userGestureActive: false,
       }),
     ).toEqual({ pinned: false, releasedByGesture: true });
+  });
+
+  it("feed scrollport uses overflow-anchor auto with scroll-padding clearance from composer chrome", () => {
+    expect(FEED_SCROLLPORT_OVERFLOW_ANCHOR).toBe("auto");
+    expect(FEED_SCROLLPORT_OVERFLOW_ANCHOR).not.toBe("none");
+    const composerHeight = 156;
+    const clearancePx = feedBottomClearancePx(composerHeight);
+    expect(clearancePx).toBe(composerHeight);
+    const scroller = document.createElement("div");
+    scroller.style.overflow = "auto";
+    scroller.style.overflowAnchor = FEED_SCROLLPORT_OVERFLOW_ANCHOR;
+    scroller.style.setProperty(FEED_CHROME_CLEARANCE_VAR, `${clearancePx}px`);
+    scroller.style.scrollPaddingBottom = `var(${FEED_CHROME_CLEARANCE_VAR}, clamp(72px, 12vh, 144px))`;
+    expect(scroller.style.overflowAnchor).toBe("auto");
+    expect(scroller.style.scrollPaddingBottom).toBe(
+      `var(${FEED_CHROME_CLEARANCE_VAR}, clamp(72px, 12vh, 144px))`,
+    );
+    expect(scroller.style.getPropertyValue(FEED_CHROME_CLEARANCE_VAR)).toBe(`${clearancePx}px`);
   });
 
   it("DOM scroller grows last row in normal flow while pinned at tail", () => {

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -3,7 +3,7 @@
  * Conversation owns all state; this is a presentational peel.
  */
 
-import { useLayoutEffect, useRef, useState, type MutableRefObject, type ReactNode, type RefObject } from "react";
+import { useLayoutEffect, useRef, useState, type CSSProperties, type MutableRefObject, type ReactNode, type RefObject } from "react";
 import { ChevronDown } from "lucide-react";
 import { panelOpacityClass } from "../../lib/panelTransition";
 import { feedBottomClearancePx, FEED_CHROME_CLEARANCE_VAR } from "./feedScroll";
@@ -89,7 +89,7 @@ export default function ConversationChatColumn({
   return (
     <div
       className="chat-column flex flex-col flex-1 min-h-0 min-w-0"
-      style={{ [FEED_CHROME_CLEARANCE_VAR]: `${clearancePx}px` }}
+      style={{ [FEED_CHROME_CLEARANCE_VAR]: `${clearancePx}px` } as CSSProperties}
     >
       <div className="relative flex-1 min-h-0 flex flex-col">
         <div

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -6,7 +6,7 @@
 import { useLayoutEffect, useRef, useState, type MutableRefObject, type ReactNode, type RefObject } from "react";
 import { ChevronDown } from "lucide-react";
 import { panelOpacityClass } from "../../lib/panelTransition";
-import { feedBottomClearancePx } from "./feedScroll";
+import { feedBottomClearancePx, FEED_CHROME_CLEARANCE_VAR } from "./feedScroll";
 import {
   TranscriptList,
   type Card,
@@ -89,18 +89,17 @@ export default function ConversationChatColumn({
   return (
     <div
       className="chat-column flex flex-col flex-1 min-h-0 min-w-0"
-      style={{ ["--feed-chrome-clearance" as string]: `${clearancePx}px` }}
+      style={{ [FEED_CHROME_CLEARANCE_VAR]: `${clearancePx}px` }}
     >
       <div className="relative flex-1 min-h-0 flex flex-col">
         <div
           ref={feedRef}
-          className={`flex-1 min-h-0 overflow-y-auto overscroll-contain [overflow-anchor:none] [scrollbar-gutter:stable] [scroll-padding-bottom:var(--feed-chrome-clearance,clamp(72px,12vh,144px))] ${panelOpacityClass(transcriptStale)}`}
+          className={`flex-1 min-h-0 overflow-y-auto overscroll-contain [overflow-anchor:auto] [scrollbar-gutter:stable] [scroll-padding-bottom:var(--feed-chrome-clearance,clamp(72px,12vh,144px))] ${panelOpacityClass(transcriptStale)}`}
         >
-        {/* overflow-anchor:none — the virtualizer unmounts off-screen rows, so
-            auto-anchor would snap to the first remaining node (top of history)
-            on alt-tab / compositor restore. feedScroll pin/unpin owns stick.
-            scrollbar-gutter avoids a 15px jump when the bar appears.
-            overscroll-contain stops rubber-band from yanking the window.
+        {/* overflow-anchor:auto — browser tail anchoring during growth; scroll-padding-bottom
+            tracks composer chrome via --feed-chrome-clearance (ResizeObserver). nextFeedPinState
+            hysteresis still owns stick/unstick. scrollbar-gutter avoids a 15px jump when the bar
+            appears. overscroll-contain stops rubber-band from yanking the window.
             Composer sits outside this scrollport; do not move it inside. */}
         <div
           ref={feedContentRef}

--- a/webapp/src/components/conversation/feedScroll.ts
+++ b/webapp/src/components/conversation/feedScroll.ts
@@ -37,6 +37,12 @@ export function chooseFeedFollowFlush(): "before_paint" {
   return "before_paint";
 }
 
+/** Feed scrollport overflow-anchor — auto; pin hysteresis owns unstick (never "none"). */
+export const FEED_SCROLLPORT_OVERFLOW_ANCHOR = "auto" as const;
+
+/** CSS custom property on the chat column; drives scroll-padding-bottom on the feed scrollport. */
+export const FEED_CHROME_CLEARANCE_VAR = "--feed-chrome-clearance";
+
 /** Bottom spacer so the last stream line sits above the composer/status stack. */
 export function feedBottomClearancePx(chromeHeight: number): number {
   if (!Number.isFinite(chromeHeight) || chromeHeight <= 0) return 96;


### PR DESCRIPTION
## Summary
- Feed scrollport uses `overflow-anchor: auto` (never `none`) so the browser can keep the tail anchored during growth.
- `scroll-padding-bottom` tracks sticky composer height via `--feed-chrome-clearance` from ResizeObserver / `feedBottomClearancePx`.
- Keeps `nextFeedPinState` hysteresis, Pretext hybrid transcript heights, and TanStack virtual list from 314.
- Version 0.9.317; `puppetmaster-ai==1.22.28` unchanged.

## Test plan
- [x] `npx vitest run src/__tests__/feedScroll.test.ts` (42 passed)
- [ ] Stream tokens at the tail and confirm no jump to history top
- [ ] Grow/shrink the composer and confirm last line stays above the dock
- [ ] Trackpad unpin still holds; re-pin only after idle + tight threshold