### PR TITLE
Marionette v0.9.318 — feed-only Motion layoutScroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.317, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.318, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.317"
+__version__ = "0.9.318"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.317"
+version = "0.9.318"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.317"
+version = "0.9.318"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.317",
+  "version": "0.9.318",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.317",
+      "version": "0.9.318",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",
@@ -23,6 +23,7 @@
         "@xterm/xterm": "^6.0.0",
         "electron-updater": "^6.3.9",
         "lucide-react": "^1.21.0",
+        "motion": "^12.43.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
@@ -6554,6 +6555,32 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
+      "dependencies": {
+        "motion-dom": "^12.43.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -9459,6 +9486,44 @@
         "node": ">=10"
       }
     },
+    "node_modules/motion": {
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.43.0.tgz",
+      "integrity": "sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==",
+      "dependencies": {
+        "framer-motion": "^12.43.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11923,7 +11988,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-fest": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.317",
+  "version": "0.9.318",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -32,6 +32,7 @@
     "@xterm/xterm": "^6.0.0",
     "electron-updater": "^6.3.9",
     "lucide-react": "^1.21.0",
+    "motion": "^12.43.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -1,12 +1,11 @@
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import column from "../components/conversation/ConversationChatColumn.tsx?raw";
+import helpers from "../components/conversation/feedMotion.tsx?raw";
+import list from "../components/TranscriptList.tsx?raw";
+import pkgJson from "../../package.json?raw";
 import { TranscriptList, type Item } from "../components/TranscriptList";
 import { feedLayoutMotionEnabled } from "../components/conversation/feedMotion";
-
-const webappRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
 afterEach(() => {
   cleanup();
@@ -34,9 +33,9 @@ function listProps(items: Item[]) {
 
 describe("feed Motion (v0.9.318)", () => {
   it("declares the official motion package in webapp dependencies", () => {
-    const pkg = JSON.parse(
-      readFileSync(join(webappRoot, "package.json"), "utf8"),
-    ) as { dependencies?: Record<string, string> };
+    const pkg = JSON.parse(pkgJson) as {
+      dependencies?: Record<string, string>;
+    };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
   });
@@ -62,18 +61,6 @@ describe("feed Motion (v0.9.318)", () => {
   });
 
   it("keeps layoutScroll on the feed scrollport and popLayout on list presence", () => {
-    const column = readFileSync(
-      join(webappRoot, "src/components/conversation/ConversationChatColumn.tsx"),
-      "utf8",
-    );
-    const helpers = readFileSync(
-      join(webappRoot, "src/components/conversation/feedMotion.tsx"),
-      "utf8",
-    );
-    const list = readFileSync(
-      join(webappRoot, "src/components/TranscriptList.tsx"),
-      "utf8",
-    );
     expect(column).toContain("layoutScroll");
     expect(column).toContain("[overflow-anchor:auto]");
     expect(column).toContain("[scroll-padding-bottom:var(--feed-chrome-clearance");

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TranscriptList, type Item } from "../components/TranscriptList";
+import { feedLayoutMotionEnabled } from "../components/conversation/feedMotion";
+
+const webappRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function listProps(items: Item[]) {
+  return {
+    items,
+    status: "done" as const,
+    compactingStatus: null as string | null,
+    editingIndex: null as number | null,
+    auto: false,
+    plan: false,
+    turnOpen: false,
+    scrollContainerRef: { current: null },
+    onEditMessage: vi.fn(),
+    onExecuteSend: vi.fn(),
+    onImageClick: vi.fn(),
+    onSetCard: vi.fn(),
+    onExecutePlan: vi.fn(),
+    onCommandApproval: vi.fn(),
+  };
+}
+
+describe("feed Motion (v0.9.318)", () => {
+  it("declares the official motion package in webapp dependencies", () => {
+    const pkg = JSON.parse(
+      readFileSync(join(webappRoot, "package.json"), "utf8"),
+    ) as { dependencies?: Record<string, string> };
+    expect(pkg.dependencies?.motion).toBeTruthy();
+    expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
+  });
+
+  it("mounts transcript rows inside motion layout shells", () => {
+    render(
+      <TranscriptList
+        {...listProps([
+          { kind: "msg", msg: { role: "user", text: "hello" } },
+          { kind: "msg", msg: { role: "assistant", text: "hi there" } },
+        ])}
+      />,
+    );
+    expect(screen.getByTestId("transcript-virtual-list")).toBeTruthy();
+    expect(screen.getByText("hello")).toBeTruthy();
+    expect(screen.getByText("hi there")).toBeTruthy();
+  });
+
+  it("disables feed layout motion when prefers-reduced-motion is set", () => {
+    expect(feedLayoutMotionEnabled(true)).toBe(false);
+    expect(feedLayoutMotionEnabled(false)).toBe(true);
+    expect(feedLayoutMotionEnabled(null)).toBe(true);
+  });
+
+  it("keeps layoutScroll on the feed scrollport and popLayout on list presence", () => {
+    const column = readFileSync(
+      join(webappRoot, "src/components/conversation/ConversationChatColumn.tsx"),
+      "utf8",
+    );
+    const helpers = readFileSync(
+      join(webappRoot, "src/components/conversation/feedMotion.tsx"),
+      "utf8",
+    );
+    const list = readFileSync(
+      join(webappRoot, "src/components/TranscriptList.tsx"),
+      "utf8",
+    );
+    expect(column).toContain("layoutScroll");
+    expect(column).toContain("[overflow-anchor:auto]");
+    expect(column).toContain("[scroll-padding-bottom:var(--feed-chrome-clearance");
+    expect(column).not.toContain("overflow-anchor:none");
+    expect(helpers).toContain('mode="popLayout"');
+    expect(list).toContain("FeedMotionPresence");
+    expect(list).toContain("useVirtualizer");
+    expect(list).not.toMatch(/@stylexjs|create\(|stylex\./);
+  });
+});

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, useSyncExternalStore, useMemo, memo, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, useSyncExternalStore, useMemo, memo, forwardRef, type ReactNode } from "react";
+import { motion } from "motion/react";
 import { useVirtualizer, type VirtualItem } from "@tanstack/react-virtual";
 import { ChevronRight, Loader2, ChevronDown, ChevronUp, Play, Copy, Check, Pencil, RefreshCw, History, Share2, CheckCircle2, XCircle, Eye, Shield } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -94,6 +95,11 @@ import {
   focusReviewTabAndRefresh,
   vaultCiteChipLabel,
 } from "./conversation/streamApply";
+import {
+  FeedMotionPresence,
+  FeedMotionRow,
+  useFeedLayoutMotion,
+} from "./conversation/feedMotion";
 
 export type Msg = {
   role: "user" | "assistant";
@@ -996,23 +1002,29 @@ export function stableItemKey(it: GroupedItem, i: number): string {
 const FEED_VIRTUAL_OVERSCAN = 8;
 
 /** One virtual row: Pretext estimate always; DOM measure only after settle. */
-const VirtualTranscriptRow = memo(function VirtualTranscriptRow({
-  virtualRow,
-  scrollMargin,
-  item,
-  rowId,
-  feedSettled,
-  measureDom,
-  children,
-}: {
-  virtualRow: VirtualItem;
-  scrollMargin: number;
-  item: GroupedItem;
-  rowId: string;
-  feedSettled: boolean;
-  measureDom: (element: HTMLElement) => void;
-  children: ReactNode;
-}) {
+const VirtualTranscriptRow = memo(
+  forwardRef<HTMLDivElement, {
+    virtualRow: VirtualItem;
+    scrollMargin: number;
+    item: GroupedItem;
+    rowId: string;
+    feedSettled: boolean;
+    feedLayout: boolean;
+    measureDom: (element: HTMLElement) => void;
+    children: ReactNode;
+  }>(function VirtualTranscriptRow(
+    {
+      virtualRow,
+      scrollMargin,
+      item,
+      rowId,
+      feedSettled,
+      feedLayout,
+      measureDom,
+      children,
+    },
+    forwardedRef,
+  ) {
   const rowRef = useRef<HTMLDivElement>(null);
   const [mountSettled, setMountSettled] = useState(false);
   const attachDom = shouldAttachDomMeasure(item, feedSettled);
@@ -1042,10 +1054,20 @@ const VirtualTranscriptRow = memo(function VirtualTranscriptRow({
     if (el) measureDom(el);
   }, [attachDom, mountSettled, measureDom, rowId]);
 
+  const setRowRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      rowRef.current = el;
+      if (typeof forwardedRef === "function") forwardedRef(el);
+      else if (forwardedRef) forwardedRef.current = el;
+    },
+    [forwardedRef],
+  );
+
   return (
-    <div
+    <FeedMotionRow
+      ref={attachDom && mountSettled ? setRowRef : forwardedRef}
+      layoutEnabled={feedLayout}
       data-index={virtualRow.index}
-      ref={attachDom && mountSettled ? rowRef : undefined}
       data-testid="transcript-virtual-row"
       data-dom-measure={attachDom ? "1" : "0"}
       className="absolute top-0 left-0 w-full pb-1"
@@ -1054,9 +1076,10 @@ const VirtualTranscriptRow = memo(function VirtualTranscriptRow({
       }}
     >
       {children}
-    </div>
+    </FeedMotionRow>
   );
-});
+  }),
+);
 
 /** Bind run_command cards even when Investigating is collapsed (Hermes procId). */
 function indexCardCommandSession(card: Card): void {
@@ -1806,43 +1829,73 @@ export const TranscriptList = memo(function TranscriptList({
     scrollParentSized,
     alreadyVirtualized: virtualizedOnceRef.current,
   });
+  const feedLayout = useFeedLayoutMotion();
   const list = useVirtualWindow ? (
-    <div
+    <motion.div
       ref={listAnchorRef}
       data-testid="transcript-virtual-list"
       className="relative w-full"
       style={{ height: rowVirtualizer.getTotalSize() }}
+      layout={feedLayout}
     >
-      {virtualItems.map((virtualRow) => {
-        const item = virtualGrouped[virtualRow.index]!;
-        const rowId = stableItemKey(item, virtualRow.index);
-        return (
-          <VirtualTranscriptRow
-            key={virtualRow.key}
-            virtualRow={virtualRow}
-            scrollMargin={scrollMargin}
-            item={item}
-            rowId={rowId}
-            feedSettled={feedSettled}
-            measureDom={measureVirtualRowDom}
-          >
-            {renderGroupedItem(virtualRow.index)}
-          </VirtualTranscriptRow>
-        );
-      })}
-    </div>
+      <FeedMotionPresence>
+        {virtualItems.map((virtualRow) => {
+          const item = virtualGrouped[virtualRow.index]!;
+          const rowId = stableItemKey(item, virtualRow.index);
+          return (
+            <VirtualTranscriptRow
+              key={virtualRow.key}
+              virtualRow={virtualRow}
+              scrollMargin={scrollMargin}
+              item={item}
+              rowId={rowId}
+              feedSettled={feedSettled}
+              feedLayout={feedLayout}
+              measureDom={measureVirtualRowDom}
+            >
+              {renderGroupedItem(virtualRow.index)}
+            </VirtualTranscriptRow>
+          );
+        })}
+      </FeedMotionPresence>
+    </motion.div>
   ) : (
-    <div ref={listAnchorRef} data-testid="transcript-virtual-list" className="flex flex-col gap-1 w-full">
-      {grouped.map((_, i) => renderGroupedItem(i))}
-    </div>
+    <motion.div
+      ref={listAnchorRef}
+      data-testid="transcript-virtual-list"
+      className="relative flex flex-col gap-1 w-full"
+      layout={feedLayout}
+    >
+      <FeedMotionPresence>
+        {grouped.map((_, i) => {
+          const key = stableItemKey(grouped[i]!, i);
+          return (
+            <FeedMotionRow key={key} layoutEnabled={feedLayout} className="pb-1">
+              {renderGroupedItem(i)}
+            </FeedMotionRow>
+          );
+        })}
+      </FeedMotionPresence>
+    </motion.div>
   );
   const liveTailList = useVirtualWindow && liveTailGrouped.length > 0 ? (
-    <div
+    <motion.div
       data-testid="transcript-live-tail"
-      className="flex flex-col gap-1 w-full"
+      className="relative flex flex-col gap-1 w-full"
+      layout={feedLayout}
     >
-      {liveTailGrouped.map((_, i) => renderGroupedItem(tailStartIndex + i))}
-    </div>
+      <FeedMotionPresence>
+        {liveTailGrouped.map((_, i) => {
+          const idx = tailStartIndex + i;
+          const key = stableItemKey(grouped[idx]!, idx);
+          return (
+            <FeedMotionRow key={key} layoutEnabled={feedLayout} className="pb-1">
+              {renderGroupedItem(idx)}
+            </FeedMotionRow>
+          );
+        })}
+      </FeedMotionPresence>
+    </motion.div>
   ) : null;
 
   const busyProgress = deriveBusyProgress(items, status, busyElapsedMs);

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useLayoutEffect, useRef, useState, type CSSProperties, type MutableRefObject, type ReactNode, type RefObject } from "react";
+import { motion } from "motion/react";
 import { ChevronDown } from "lucide-react";
 import { panelOpacityClass } from "../../lib/panelTransition";
 import { feedBottomClearancePx, FEED_CHROME_CLEARANCE_VAR } from "./feedScroll";
@@ -92,8 +93,9 @@ export default function ConversationChatColumn({
       style={{ [FEED_CHROME_CLEARANCE_VAR]: `${clearancePx}px` } as CSSProperties}
     >
       <div className="relative flex-1 min-h-0 flex flex-col">
-        <div
+        <motion.div
           ref={feedRef}
+          layoutScroll
           className={`flex-1 min-h-0 overflow-y-auto overscroll-contain [overflow-anchor:auto] [scrollbar-gutter:stable] [scroll-padding-bottom:var(--feed-chrome-clearance,clamp(72px,12vh,144px))] ${panelOpacityClass(transcriptStale)}`}
         >
         {/* overflow-anchor:auto — browser tail anchoring during growth; scroll-padding-bottom
@@ -139,7 +141,7 @@ export default function ConversationChatColumn({
             onAuthFailureRetry={onAuthFailureRetry}
           />
         </div>
-      </div>
+      </motion.div>
       {showJumpToBottom ? (
         <button
           type="button"

--- a/webapp/src/components/conversation/feedMotion.tsx
+++ b/webapp/src/components/conversation/feedMotion.tsx
@@ -1,0 +1,73 @@
+/**
+ * Feed-only Motion helpers (v0.9.318). Transcript enter/exit + layout polish;
+ * not used app-wide. Respects prefers-reduced-motion via Motion's hook.
+ */
+
+import { forwardRef, memo, type CSSProperties, type ReactNode } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+
+/** Whether feed layout/presence animations should run. */
+export function feedLayoutMotionEnabled(reducedMotion: boolean | null): boolean {
+  return !reducedMotion;
+}
+
+/** Whether feed layout/presence animations should run. */
+export function useFeedLayoutMotion(): boolean {
+  return feedLayoutMotionEnabled(useReducedMotion());
+}
+
+type FeedMotionPresenceProps = {
+  children: ReactNode;
+};
+
+/** popLayout wrapper for transcript rows — virtual window, fallback, live tail. */
+export const FeedMotionPresence = memo(function FeedMotionPresence({
+  children,
+}: FeedMotionPresenceProps) {
+  return (
+    <AnimatePresence mode="popLayout" initial={false}>
+      {children}
+    </AnimatePresence>
+  );
+});
+
+type FeedMotionRowProps = {
+  layoutEnabled: boolean;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+  "data-index"?: number;
+  "data-testid"?: string;
+  "data-dom-measure"?: string;
+};
+
+/** One feed row shell: motion.div layout for popLayout reflow. */
+export const FeedMotionRow = memo(
+  forwardRef<HTMLDivElement, FeedMotionRowProps>(function FeedMotionRow(
+    {
+      layoutEnabled,
+      className,
+      style,
+      children,
+      "data-index": dataIndex,
+      "data-testid": testId,
+      "data-dom-measure": domMeasure,
+    },
+    ref,
+  ) {
+    return (
+      <motion.div
+        ref={ref}
+        layout={layoutEnabled}
+        initial={false}
+        className={className}
+        style={style}
+        data-index={dataIndex}
+        data-testid={testId}
+        data-dom-measure={domMeasure}
+      >
+        {children}
+      </motion.div>
+    );
+  }),
+);

--- a/webapp/tsconfig.app.json
+++ b/webapp/tsconfig.app.json
@@ -21,5 +21,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }


### PR DESCRIPTION
## Summary
- Add Motion **only** on the transcript feed: `layoutScroll` on the feed scrollport plus `AnimatePresence` `popLayout` around virtual, fallback, and live-tail lists.
- Per-row `motion.div layout` via `FeedMotionRow`; respects `prefers-reduced-motion`.
- Does **not** introduce StyleX or app-wide Motion (no App/chrome/composer/overlay/sidebar).
- Keeps 314 Pretext + TanStack virtualizer + `feedScroll` hysteresis, and 317 `overflow-anchor: auto` (never `none`) + `scroll-padding-bottom = --feed-chrome-clearance`.
- Version 0.9.318; `puppetmaster-ai==1.22.28` unchanged.

## Test plan
- [x] `npx vitest run` feedMotion + transcriptVirtualizer + transcriptPresentation + transcriptVirtualWindow + feedScroll + motionPolicy (6 files, 90 passed)
- [ ] Stream a new assistant bubble and confirm enter/layout does not yank the virtual window
- [ ] Reduced-motion: no layout/presence animation
- [ ] Composer grow/shrink still keeps last line above the dock (317 clearance)