### PR TITLE
fix: honor OpenAI API reasoning with tools

### DIFF
--- a/harness/providers.py
+++ b/harness/providers.py
@@ -71,7 +71,7 @@ class Provider:
     name: str
     env_vars: tuple              # candidate API-key env vars, first match wins
     base_url: str
-    api_mode: str = "chat_completions"   # chat_completions | anthropic_messages
+    api_mode: str = "chat_completions"   # chat_completions | responses | anthropic_messages
     aliases: tuple = ()
     display_name: str = ""
     # curated pilot-capable models shown when a live catalog fetch isn't done.
@@ -197,7 +197,7 @@ PROVIDERS = (
         name="openai", aliases=("oai",),
         env_vars=("OPENAI_API_KEY",),
         base_url="https://api.openai.com/v1",
-        api_mode="chat_completions", display_name="OpenAI",
+        api_mode="responses", display_name="OpenAI",
         # GPT-5.6 Sol/Terra/Luna (GA 2026-07-09). Some accounts still see
         # limited-preview 404 until OpenAI finishes rollout; live probe
         # via model_fetch still wins when /v1/models lists them.
@@ -586,7 +586,7 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
         return _finalize_driver(
             BedrockDriver(name=spec, model=model, max_tokens=max_tokens)
         )
-    if provider.api_mode == "codex_responses":
+    if provider.api_mode in ("codex_responses", "responses"):
         from pmharness.drivers.codex_responses import CodexResponsesDriver
         return _finalize_driver(
             CodexResponsesDriver(
@@ -595,6 +595,7 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
                 base_url=provider.base_url,
                 api_key_env=key_env or "OPENAI_CODEX_TOKEN",
                 max_tokens=max_tokens,
+                chatgpt_backend=(provider.api_mode == "codex_responses"),
             )
         )
     if provider.api_mode == "cursor_cli":

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -1026,6 +1026,8 @@ class CodexResponsesDriver:
         # Responses host (e.g. OpenCode Go's /v1/responses) rejects those
         # extras as unknown parameters, so they are opt-out per host.
         self.chatgpt_backend = chatgpt_backend
+        self.api_mode = "codex_responses" if chatgpt_backend else "responses"
+        self.billing = "plan" if chatgpt_backend else "api"
         self._pool_provider: Optional[str] = None
         self._pool_entry_id: Optional[str] = None
 
@@ -1274,9 +1276,9 @@ class CodexResponsesDriver:
             text = raw["output_text"]
         if finish == "content_filter":
             meta = {
-                "api_mode": "codex_responses",
+                "api_mode": self.api_mode,
                 "finish_reason": "content_filter",
-                "billing": "plan",
+                "billing": self.billing,
                 "requested_model": self.model,
             }
             meta.update(_codex_stream_terminal_fields(raw, finish, _CONTENT_FILTER_MSG))
@@ -1297,8 +1299,8 @@ class CodexResponsesDriver:
             "tool_calls": tool_calls,
             "finish_reason": finish,
             "raw_usage": usage,
-            "api_mode": "codex_responses",
-            "billing": "plan",
+            "api_mode": self.api_mode,
+            "billing": self.billing,
             "requested_model": self.model,
             "incomplete_retries": incomplete_retries,
         }
@@ -1459,8 +1461,8 @@ class CodexResponsesDriver:
                 base_meta: Optional[dict] = None,
             ) -> DriverResponse:
                 meta = {
-                    "api_mode": "codex_responses",
-                    "billing": "plan",
+                    "api_mode": self.api_mode,
+                    "billing": self.billing,
                     "requested_model": self.model,
                     # Prevent with_retry from replaying a body already mutated
                     # with continuation nudges as if it were the original turn.
@@ -1582,9 +1584,9 @@ class CodexResponsesDriver:
                     # post-increment sentinel that tripped exhaustion.
                     completed_retries = incomplete_retries - 1
                     meta = {
-                        "api_mode": "codex_responses",
+                        "api_mode": self.api_mode,
                         "finish_reason": "incomplete",
-                        "billing": "plan",
+                        "billing": self.billing,
                         "requested_model": self.model,
                     }
                     return _attach_request_cache_diagnostics(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,7 +1,9 @@
 """Provider registry: detection from env keys, driver selection by api_mode,
 spec resolution, and MIT attribution presence. Data adapted from Hermes (MIT)."""
+import json
 import os
 import tempfile
+import urllib.request
 import pytest
 from harness import providers as prov
 
@@ -188,6 +190,82 @@ def test_build_pilot_selects_openai_compat(monkeypatch):
     assert "openrouter.ai" in d.base_url
 
 
+def test_openai_gpt56_api_key_uses_standard_responses_driver(monkeypatch):
+    from pmharness.drivers.codex_responses import CodexResponsesDriver
+
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oai-test")
+
+    driver = prov.build_pilot("openai:gpt-5.6-luna")
+
+    assert isinstance(driver, CodexResponsesDriver)
+    assert driver.base_url == "https://api.openai.com/v1"
+    assert driver.api_key_env == "OPENAI_API_KEY"
+    assert driver.chatgpt_backend is False
+
+
+def test_openai_gpt56_api_key_sends_max_reasoning_with_tools(monkeypatch):
+    from pmharness.drivers.codex_responses import CodexResponsesDriver
+
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oai-test")
+    monkeypatch.setenv("HARNESS_CODEX_REASONING_EFFORT", "max")
+    captured = {}
+
+    class SuccessfulResponsesStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def __iter__(self):
+            return iter([
+                b'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"noop","arguments":"{}"}}\n',
+                b'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}\n',
+            ])
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        assert req.full_url == "https://api.openai.com/v1/responses"
+        return SuccessfulResponsesStream()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    driver = prov.build_pilot("openai:gpt-5.6-luna")
+    assert isinstance(driver, CodexResponsesDriver)
+    response = driver.chat_stream(
+        [{"role": "user", "content": "Call noop."}],
+        tools=[{
+            "type": "function",
+            "function": {
+                "name": "noop",
+                "description": "No operation",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }],
+        on_delta=lambda _event: None,
+        session_id="api-reasoning-red",
+    )
+
+    body = captured["body"]
+    assert response.error is None
+    assert response.meta["billing"] == "api"
+    assert response.meta["api_mode"] == "responses"
+    assert len(response.meta["tool_calls"]) == 1
+    assert body["reasoning"] == {"effort": "max", "summary": "auto"}
+    assert body["tools"]
+    assert body["tool_choice"] == "auto"
+    assert body["parallel_tool_calls"] is True
+    assert body["max_output_tokens"] > 0
+    assert "reasoning_effort" not in body
+    assert "messages" not in body
+    assert "originator" not in {
+        key.lower(): value for key, value in captured["headers"].items()
+    }
+
+
 def test_build_pilot_no_key_raises(monkeypatch):
     _clear_provider_env(monkeypatch)
     try:
@@ -225,6 +303,8 @@ def test_build_pilot_bare_gpt55_prefers_openai_codex(monkeypatch):
         d = prov.build_pilot("gpt-5.5")
         assert isinstance(d, CodexResponsesDriver)
         assert d.model == "gpt-5.5"
+        assert d.api_key_env == "OPENAI_CODEX_TOKEN"
+        assert d.chatgpt_backend is True
     finally:
         cp.clear_pools_for_tests()
 


### PR DESCRIPTION
## Problem

Direct OpenAI GPT-5 pilots currently use Chat Completions. In #1, I fixed invalid GPT-5 request fields by making tool-enabled turns send `reasoning_effort: none`. That restored working chat, but I generalized the constraint too far: the OpenAI Responses API supports reasoning and tools together.

As a result, Marionette can display a selected reasoning effort such as Max while the direct OpenAI tool request disables reasoning.

## Change

- Route the first-party `openai:` provider through Marionette's existing Responses transport.
- Keep `openai-codex:` on its existing ChatGPT Codex OAuth behavior.
- Mark standard OpenAI Responses usage as `billing=api` / `api_mode=responses`; retain `billing=plan` / `api_mode=codex_responses` for ChatGPT Codex.
- Test the public provider-to-wire boundary, including Max reasoning with function tools and standard API headers.

This adds no driver, auth path, fallback, model-specific branch, or registry.

## Verification

- `222 passed, 1 skipped` across the focused provider, Responses, Settings, model-visibility, OpenCode, and prompt-cache suites.
- `py_compile` and `git diff --check` passed.
- A bounded live request through `openai:gpt-5.6-luna` reached `https://api.openai.com/v1/responses` with Max reasoning and one function tool:
  - `error=none`
  - `tool_calls=1`
  - `served_model=gpt-5.6-luna`
  - `billing=api`
  - `api_mode=responses`
  - `tokens_in=319`, `tokens_out=216`

This keeps the valid compatibility work from #1 while correcting the assumption that direct OpenAI tool use required reasoning to be disabled.
