### PR TITLE
Marionette v0.9.321 — openai responses api_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.318, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.321, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.318"
+__version__ = "0.9.321"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/providers.py
+++ b/harness/providers.py
@@ -71,7 +71,7 @@ class Provider:
     name: str
     env_vars: tuple              # candidate API-key env vars, first match wins
     base_url: str
-    api_mode: str = "chat_completions"   # chat_completions | anthropic_messages
+    api_mode: str = "chat_completions"   # chat_completions | responses | codex_responses | anthropic_messages
     aliases: tuple = ()
     display_name: str = ""
     # curated pilot-capable models shown when a live catalog fetch isn't done.
@@ -197,7 +197,7 @@ PROVIDERS = (
         name="openai", aliases=("oai",),
         env_vars=("OPENAI_API_KEY",),
         base_url="https://api.openai.com/v1",
-        api_mode="chat_completions", display_name="OpenAI",
+        api_mode="responses", display_name="OpenAI",
         # GPT-5.6 Sol/Terra/Luna (GA 2026-07-09). Some accounts still see
         # limited-preview 404 until OpenAI finishes rollout; live probe
         # via model_fetch still wins when /v1/models lists them.
@@ -586,15 +586,21 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
         return _finalize_driver(
             BedrockDriver(name=spec, model=model, max_tokens=max_tokens)
         )
-    if provider.api_mode == "codex_responses":
+    if provider.api_mode in ("codex_responses", "responses"):
         from pmharness.drivers.codex_responses import CodexResponsesDriver
+        default_key_env = (
+            "OPENAI_CODEX_TOKEN"
+            if provider.api_mode == "codex_responses"
+            else "OPENAI_API_KEY"
+        )
         return _finalize_driver(
             CodexResponsesDriver(
                 name=spec,
                 model=model,
                 base_url=provider.base_url,
-                api_key_env=key_env or "OPENAI_CODEX_TOKEN",
+                api_key_env=key_env or default_key_env,
                 max_tokens=max_tokens,
+                chatgpt_backend=(provider.api_mode == "codex_responses"),
             )
         )
     if provider.api_mode == "cursor_cli":

--- a/harness/vision.py
+++ b/harness/vision.py
@@ -245,6 +245,7 @@ _NATIVE_IMAGE_API_MODES = frozenset({
     "chat_completions",
     "anthropic_messages",
     "codex_responses",
+    "responses",
     "gemini_native",
 })
 
@@ -371,7 +372,7 @@ def pilot_supports_native_images(
     # "fallback provider happens to declare a vision_model" as native — that
     # incorrectly skipped the sidecar for stub/fake pilots when
     # resolve_provider_for_spec fell through to openrouter.
-    if api_mode == "codex_responses":
+    if api_mode in ("codex_responses", "responses"):
         return True
     if api_mode in ("anthropic_messages", "gemini_generate") and model_id:
         return True

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -1029,6 +1029,12 @@ class CodexResponsesDriver:
         self._pool_provider: Optional[str] = None
         self._pool_entry_id: Optional[str] = None
 
+    def _billing_meta(self) -> Dict[str, str]:
+        """Receipt api_mode/billing derived from the host, not the driver class."""
+        if self.chatgpt_backend:
+            return {"api_mode": "codex_responses", "billing": "plan"}
+        return {"api_mode": "responses", "billing": "api"}
+
     def _key(self) -> str:
         self._pool_provider = None
         self._pool_entry_id = None
@@ -1274,9 +1280,8 @@ class CodexResponsesDriver:
             text = raw["output_text"]
         if finish == "content_filter":
             meta = {
-                "api_mode": "codex_responses",
+                **self._billing_meta(),
                 "finish_reason": "content_filter",
-                "billing": "plan",
                 "requested_model": self.model,
             }
             meta.update(_codex_stream_terminal_fields(raw, finish, _CONTENT_FILTER_MSG))
@@ -1297,8 +1302,7 @@ class CodexResponsesDriver:
             "tool_calls": tool_calls,
             "finish_reason": finish,
             "raw_usage": usage,
-            "api_mode": "codex_responses",
-            "billing": "plan",
+            **self._billing_meta(),
             "requested_model": self.model,
             "incomplete_retries": incomplete_retries,
         }
@@ -1459,8 +1463,7 @@ class CodexResponsesDriver:
                 base_meta: Optional[dict] = None,
             ) -> DriverResponse:
                 meta = {
-                    "api_mode": "codex_responses",
-                    "billing": "plan",
+                    **self._billing_meta(),
                     "requested_model": self.model,
                     # Prevent with_retry from replaying a body already mutated
                     # with continuation nudges as if it were the original turn.
@@ -1582,9 +1585,8 @@ class CodexResponsesDriver:
                     # post-increment sentinel that tripped exhaustion.
                     completed_retries = incomplete_retries - 1
                     meta = {
-                        "api_mode": "codex_responses",
+                        **self._billing_meta(),
                         "finish_reason": "incomplete",
-                        "billing": "plan",
                         "requested_model": self.model,
                     }
                     return _attach_request_cache_diagnostics(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.318"
+version = "0.9.321"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,7 +1,9 @@
 """Provider registry: detection from env keys, driver selection by api_mode,
 spec resolution, and MIT attribution presence. Data adapted from Hermes (MIT)."""
+import json
 import os
 import tempfile
+import urllib.request
 import pytest
 from harness import providers as prov
 
@@ -180,6 +182,92 @@ def test_build_pilot_selects_anthropic_driver(monkeypatch):
     assert d.model == "claude-opus-4-8"
 
 
+def test_build_pilot_selects_openai_responses_driver(monkeypatch):
+    """First-party openai: routes through CodexResponsesDriver (api.openai.com)."""
+    from pmharness.drivers.codex_responses import CodexResponsesDriver
+
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oai-test")
+    d = prov.build_pilot("openai:gpt-5.6-luna")
+    assert isinstance(d, CodexResponsesDriver)
+    assert d.base_url == "https://api.openai.com/v1"
+    assert d.api_key_env == "OPENAI_API_KEY"
+    assert d.chatgpt_backend is False
+    assert d.model == "gpt-5.6-luna"
+
+
+def test_build_pilot_openai_responses_wire(monkeypatch):
+    """openai:gpt-5.6-luna posts /v1/responses with reasoning + tools, not chat."""
+    from pmharness.drivers.codex_responses import CodexResponsesDriver
+
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oai-test")
+    monkeypatch.setenv("HARNESS_CODEX_REASONING_EFFORT", "max")
+    d = prov.build_pilot("openai:gpt-5.6-luna", max_tokens=8000)
+    assert isinstance(d, CodexResponsesDriver)
+
+    captured = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def __iter__(self):
+            return iter([
+                (
+                    b'data: {"type":"response.output_item.added","output_index":0,'
+                    b'"item":{"type":"function_call","id":"fc_1","name":"read_file",'
+                    b'"arguments":"{\\"path\\":\\"x\\"}"}}\n'
+                ),
+                (
+                    b'data: {"type":"response.output_item.done","output_index":0,'
+                    b'"item":{"type":"function_call","id":"fc_1","call_id":"fc_1",'
+                    b'"name":"read_file","arguments":"{\\"path\\":\\"x\\"}"}}\n'
+                ),
+                (
+                    b'data: {"type":"response.completed","response":{"status":"completed",'
+                    b'"usage":{"input_tokens":10,"output_tokens":5}}}\n'
+                ),
+            ])
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = {k.lower(): v for k, v in req.headers.items()}
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _Resp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    resp = d.chat(
+        [{"role": "user", "content": "hi"}],
+        tools=[{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }],
+    )
+
+    assert captured["url"] == "https://api.openai.com/v1/responses"
+    body = captured["body"]
+    assert body["reasoning"]["effort"] == "max"
+    assert body["reasoning"]["summary"] == "auto"
+    assert body.get("tools")
+    assert body.get("tool_choice") == "auto"
+    assert body.get("parallel_tool_calls") is True
+    assert body.get("max_output_tokens", 0) > 0
+    assert "reasoning_effort" not in body
+    assert "messages" not in body
+    assert "originator" not in captured["headers"]
+    assert resp.meta.get("billing") == "api"
+    assert resp.meta.get("api_mode") == "responses"
+    assert resp.meta.get("tool_calls")
+
+
 def test_build_pilot_selects_openai_compat(monkeypatch):
     from pmharness.drivers.openai_compat import OpenAICompatDriver
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-xxx")
@@ -225,6 +313,8 @@ def test_build_pilot_bare_gpt55_prefers_openai_codex(monkeypatch):
         d = prov.build_pilot("gpt-5.5")
         assert isinstance(d, CodexResponsesDriver)
         assert d.model == "gpt-5.5"
+        assert d.chatgpt_backend is True
+        assert d.api_key_env == "OPENAI_CODEX_TOKEN"
     finally:
         cp.clear_pools_for_tests()
 

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.318"
+version = "0.9.321"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.318",
+  "version": "0.9.321",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.318",
+      "version": "0.9.321",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.318",
+  "version": "0.9.321",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Re-implement Benton #164 on our ladder from `origin/main` (do **not** merge #164; it targets `dev`).
- First-party `openai:` now uses `api_mode=responses` and `build_pilot` constructs `CodexResponsesDriver` with `chatgpt_backend=False` (billing=`api`).
- `openai-codex:` stays OAuth/plan (`chatgpt_backend=True`, `api_mode=codex_responses`).
- Driver meta `api_mode`/`billing` follows that flag. No new driver, auth path, fallback, model branch, or registry.
- Provider-to-wire tests: Max + tools hit `/v1/responses`, no Completions fields, no originator header.
- Version 0.9.321; `puppetmaster-ai==1.22.28` unchanged.

## Test plan
- [x] `pytest tests/test_providers.py tests/test_codex_responses_driver.py tests/test_openai_compat_*.py tests/test_provider_capabilities.py` (128 passed)
- [x] `py_compile` on edited modules
- [ ] CI green on this PR before merge+tag
- [ ] After tag, close #164 as absorbed (not now)