### PR TITLE
Marionette v0.9.319 — activity-strip item union

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.319, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.321, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.321, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.319, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.321"
+__version__ = "0.9.319"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.319"
+__version__ = "0.9.321"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.321"
+version = "0.9.319"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.319"
+version = "0.9.321"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.319"
+version = "0.9.321"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.321"
+version = "0.9.319"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.321",
+  "version": "0.9.319",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.321",
+      "version": "0.9.319",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.319",
+  "version": "0.9.321",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.319",
+      "version": "0.9.321",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.321",
+  "version": "0.9.319",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.319",
+  "version": "0.9.321",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/thinkingStreamUx.test.ts
+++ b/webapp/src/__tests__/thinkingStreamUx.test.ts
@@ -207,8 +207,8 @@ describe("upsertStreamingThinking preserves durable id", () => {
   });
 });
 
-describe("swarm terminal rows stay at the end of one investigation", () => {
-  it("lifts the durable receipt out of the fold and suppresses a duplicate terminal pill", () => {
+describe("swarm terminal rows stay inside the activity strip", () => {
+  it("folds the durable receipt into the investigation and suppresses a duplicate terminal pill", () => {
     const items: Item[] = [
       {
         kind: "card",
@@ -237,18 +237,12 @@ describe("swarm terminal rows stay at the end of one investigation", () => {
 
     const grouped = groupAgentActivity(items, new Set());
 
-    expect(grouped.map((row) => row.kind)).toEqual([
-      "activity_group",
-      "swarm_result",
-      "activity_group",
-    ]);
+    expect(grouped.map((row) => row.kind)).toEqual(["activity_group"]);
     expect(grouped[0].kind).toBe("activity_group");
     if (grouped[0].kind !== "activity_group") return;
-    expect(grouped[0].items.map((item) => item.kind)).toEqual(["card"]);
-    expect(grouped[1]).toMatchObject({ kind: "swarm_result", job_id: "job-1" });
-    expect(grouped[2].kind).toBe("activity_group");
-    if (grouped[2].kind !== "activity_group") return;
-    expect(grouped[2].items.map((item) => item.kind)).toEqual([
+    expect(grouped[0].items.map((item) => item.kind)).toEqual([
+      "card",
+      "swarm_result",
       "thinking",
       "card",
     ]);

--- a/webapp/src/__tests__/transcriptColumnRows.test.ts
+++ b/webapp/src/__tests__/transcriptColumnRows.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import {
+  columnRowKind,
+  columnRowKinds,
+  type TranscriptColumnRowKind,
+} from "../components/conversation/transcriptColumnRows";
+import {
+  groupAgentActivity,
+  type GroupedItem,
+  type Item,
+} from "../components/TranscriptList";
+
+const card: Item = {
+  kind: "card",
+  card: { id: "read-1", goal: "read file", running: false, open: false },
+};
+
+function activityInnerKinds(row: GroupedItem): string[] {
+  if (row.kind !== "activity_group") return [];
+  return row.items.map((item) => item.kind);
+}
+
+describe("columnRowKind presentation union (v0.9.319)", () => {
+  it("maps grouped rows to the four main-column kinds", () => {
+    const rows: GroupedItem[] = [
+      { kind: "msg", msg: { role: "user", text: "hi" } },
+      { kind: "activity_group", items: [card] },
+      { kind: "command_approval", id: "a", command: "x", commandHash: "h", sessionId: "s", workspaceRoot: "/", category: "c", reason: "r", matched: "m", status: "pending" },
+      { kind: "secret_request", id: "sr", label: "key", connector: "openai", field: "api_key", description: "", sessionId: "s", status: "pending" },
+      { kind: "pending_review", id: "pr", summary: "held" },
+      { kind: "steer", text: "try again" },
+      { kind: "auth_failure", message: "denied", id: "af" },
+      { kind: "turn_terminal", cause: "halt", state: "done", text: "stopped" },
+    ];
+    expect(columnRowKinds(rows)).toEqual([
+      "msg",
+      "activity",
+      "question",
+      "question",
+      "file",
+      "msg",
+      "activity",
+      "activity",
+    ] satisfies TranscriptColumnRowKind[]);
+  });
+
+  it("classifies inner telemetry variants as activity when folded", () => {
+    expect(
+      columnRowKind({
+        kind: "activity_group",
+        items: [
+          card,
+          { kind: "thinking", id: "t1", text: "reasoning" },
+          { kind: "checkpoint", id: "k1", label: "snap", trigger: "manual" },
+          {
+            kind: "swarm_pending",
+            job_ids: ["j1"],
+            objective: "audit",
+            status: "running",
+          },
+          {
+            kind: "swarm_result",
+            job_id: "j1",
+            applied: true,
+            files: [],
+            summary: "ok",
+            error: null,
+          },
+          { kind: "compaction", before_tokens: 100, after_tokens: 50 },
+          { kind: "quality_gate", outcome: "pass", passed: true },
+          { kind: "verifying", cmd: "pytest" },
+          { kind: "verification", passed: true, cmd: "pytest" },
+        ],
+      }),
+    ).toBe("activity");
+  });
+});
+
+describe("groupAgentActivity union collapse (v0.9.319)", () => {
+  it("folds thinking, cards, checkpoint, verify, and swarm into activity strips", () => {
+    const items: Item[] = [
+      card,
+      { kind: "checkpoint", id: "ck1", label: "before tools", trigger: "manual" },
+      { kind: "thinking", id: "think-1", text: "Checking routes." },
+      { kind: "compaction", before_tokens: 9000, after_tokens: 3000 },
+      { kind: "quality_gate", outcome: "pass", passed: true, cmd: "pytest" },
+      { kind: "verifying", cmd: "pytest" },
+      { kind: "verification", passed: true, cmd: "pytest", output: "ok" },
+      {
+        kind: "swarm_pending",
+        job_ids: ["job-live"],
+        objective: "audit",
+        status: "running",
+      },
+      {
+        kind: "swarm_result",
+        job_id: "job-live",
+        applied: false,
+        files: [],
+        summary: "",
+        error: "routing failed",
+        objective: "audit",
+      },
+    ];
+
+    const grouped = groupAgentActivity(items, new Set());
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].kind).toBe("activity_group");
+    expect(columnRowKind(grouped[0]!)).toBe("activity");
+    expect(activityInnerKinds(grouped[0]!)).toEqual([
+      "card",
+      "checkpoint",
+      "thinking",
+      "compaction",
+      "quality_gate",
+      "verifying",
+      "verification",
+      "swarm_pending",
+      "swarm_result",
+    ]);
+    expect(grouped.some((row) => row.kind === "swarm_result")).toBe(false);
+  });
+
+  it("keeps user and assistant messages as msg rows", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "fix the import" } },
+      card,
+      { kind: "msg", msg: { role: "assistant", text: "Updated the path." } },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    expect(columnRowKinds(grouped)).toEqual(["msg", "activity", "msg"]);
+  });
+
+  it("keeps command_approval and secret_request as question rows", () => {
+    const items: Item[] = [
+      card,
+      {
+        kind: "command_approval",
+        id: "appr-1",
+        command: "rm -rf /",
+        commandHash: "h",
+        sessionId: "s",
+        workspaceRoot: "/tmp",
+        category: "destructive",
+        reason: "needs a decision",
+        matched: "rm",
+        status: "pending",
+      },
+      {
+        kind: "secret_request",
+        id: "sec-1",
+        label: "OpenAI key",
+        connector: "openai",
+        field: "api_key",
+        description: "required",
+        sessionId: "s",
+        status: "pending",
+      },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    expect(columnRowKinds(grouped)).toEqual(["activity", "question", "question"]);
+  });
+
+  it("keeps pending_review as a file row", () => {
+    const items: Item[] = [
+      card,
+      { kind: "pending_review", id: "rev-1", summary: "2 files held" },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    expect(columnRowKinds(grouped)).toEqual(["activity", "file"]);
+  });
+
+  it("preserves chronological user → activity → answer ordering", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "audit screenshot" } },
+      {
+        kind: "card",
+        card: { id: "swarm-a", goal: "inspect", running: false, open: false },
+      },
+      {
+        kind: "swarm_result",
+        job_id: "job-1",
+        applied: true,
+        files: [],
+        summary: "complete",
+        error: null,
+      },
+      { kind: "msg", msg: { role: "assistant", text: "Found the regression." } },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    expect(columnRowKinds(grouped)).toEqual(["msg", "activity", "msg"]);
+    if (grouped[1]?.kind !== "activity_group") return;
+    expect(grouped[1].items.map((item) => item.kind)).toEqual([
+      "card",
+      "swarm_result",
+    ]);
+  });
+});

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -457,11 +457,13 @@ describe("transcript presentation contract", () => {
 
     render(<TranscriptList {...listProps(items)} />);
 
+    fireEvent.click(screen.getByRole("button", { name: /Explored|Swarm/i }));
+
     expect(screen.getByText(/worker timed out after 30s/i)).toBeTruthy();
-    // ActionCards are no longer terminal owners; each durable job result remains distinct.
+    // Swarm receipts live in the activity strip; duplicate routing failures collapse inside it.
     const failedLabels = screen.getAllByText(/swarm failed/i);
-    expect(failedLabels).toHaveLength(3);
-    expect(screen.getAllByText(/No model in registry has all required tags/i)).toHaveLength(2);
+    expect(failedLabels).toHaveLength(2);
+    expect(screen.getAllByText(/No model in registry has all required tags/i)).toHaveLength(1);
   });
 
   it("paints held_for_review and analysis_ok badges without applied/failed chrome", () => {
@@ -506,6 +508,8 @@ describe("transcript presentation contract", () => {
       />,
     );
 
+    fireEvent.click(screen.getByRole("button", { name: /Swarm · 3 results/i }));
+
     const cards = screen.getAllByTestId("swarm-result-card");
     const byOutcome = Object.fromEntries(
       cards.map((el) => [el.getAttribute("data-outcome"), el]),
@@ -536,6 +540,8 @@ describe("transcript presentation contract", () => {
         }])}
       />,
     );
+
+    fireEvent.click(screen.getByRole("button", { name: /Swarm · 1 result/i }));
 
     const card = screen.getByTestId("swarm-result-card");
     fireEvent.click(within(card).getByRole("button", { name: /swarm done/i }));
@@ -591,6 +597,8 @@ describe("transcript presentation contract", () => {
         ])}
       />,
     );
+
+    fireEvent.click(screen.getByRole("button", { name: /Swarm · 1 result/i }));
 
     const heldCard = screen.getByTestId("swarm-result-card");
     expect(heldCard).toHaveAttribute("data-outcome", "held");
@@ -948,6 +956,8 @@ describe("job_id → Swarm Tracker deep-link chrome", () => {
     const hydratedItems = JSON.parse(JSON.stringify(persistedItems)) as Item[];
 
     render(<TranscriptList {...listProps(hydratedItems)} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Swarm · 2 results/i }));
 
     screen.getAllByText("swarm done").forEach((label) => {
       fireEvent.click(label.closest("button")!);

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -642,10 +642,10 @@ export function collectIntermediateAssistantItems(
 }
 
 export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>): GroupedItem[] {
-  // The feed is a conversation, not an event log. Top-level rows are
-  // msg / steer, a question (command_approval), a file (pending_review),
-  // a loud auth failure, and one activity strip. Compaction, gates, verify,
-  // and auto receipts fold into that strip. Surfaces do not reclassify
+  // The feed is a conversation, not an event log. Top-level painted rows are
+  // msg / question (command_approval, secret_request) / file (pending_review) /
+  // activity strip. Thinking, tools, swarm, checkpoint, verify, compaction,
+  // gates, and auto receipts fold into that strip. Surfaces do not reclassify
   // after first paint.
   const grouped: GroupedItem[] = [];
   let currentGroup: ActivityItem[] = [];
@@ -684,10 +684,9 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
       flush();
       grouped.push(item);
     } else if (item.kind === "swarm_result") {
-      // The durable swarm receipt is the terminal owner; never bury it under an
-      // activity fold now that run_swarm ActionCards are intentionally absent.
-      flush();
-      grouped.push(item);
+      // Durable swarm receipts live inside the activity strip alongside tools
+      // and reasoning — same fold as swarm_pending / checkpoint / verify.
+      currentGroup.push(item);
     } else if (item.kind === "checkpoint") {
       currentGroup.push(item);
     } else if (item.kind === "pending_review") {

--- a/webapp/src/components/conversation/transcriptColumnRows.ts
+++ b/webapp/src/components/conversation/transcriptColumnRows.ts
@@ -1,0 +1,31 @@
+import type { GroupedItem } from "../TranscriptList";
+
+/** Main-column presentation kinds — the feed paints only these four row types. */
+export type TranscriptColumnRowKind = "msg" | "question" | "file" | "activity";
+
+/**
+ * Map a grouped transcript row to its main-column presentation kind.
+ * GroupedItem may retain inner variants (swarm_result, thinking, …) but the
+ * column paints only msg / question / file / activity strip.
+ */
+export function columnRowKind(row: GroupedItem): TranscriptColumnRowKind {
+  switch (row.kind) {
+    case "msg":
+    case "steer":
+      return "msg";
+    case "command_approval":
+    case "secret_request":
+      return "question";
+    case "pending_review":
+      return "file";
+    case "activity_group":
+      return "activity";
+    default:
+      return "activity";
+  }
+}
+
+/** Presentation kinds for every grouped row (same length as input). */
+export function columnRowKinds(rows: GroupedItem[]): TranscriptColumnRowKind[] {
+  return rows.map(columnRowKind);
+}


### PR DESCRIPTION
## Summary
- Paint the transcript Item union as four main-column row kinds: **msg / question / file / activity strip**.
- Fold thinking, tools, swarm (`swarm_pending` + `swarm_result`), checkpoint, and verify into the activity strip — they are not first-class column rows.
- `columnRowKind` maps grouped rows to the presentation union (`steer` → msg; `command_approval`/`secret_request` → question; `pending_review` → file).
- Keeps 314 Pretext + TanStack + `feedScroll`, 317 `overflow-anchor: auto` (never `none`) + `scroll-padding-bottom = --feed-chrome-clearance`, and 318 feed-only Motion `layoutScroll` + `AnimatePresence` `popLayout`.
- Version 0.9.319; `puppetmaster-ai==1.22.28` unchanged. No StyleX, no app-wide Motion, no overlay `data-starting-style` (320).

## Test plan
- [x] `npx vitest run` transcriptColumnRows + thinkingStreamUx + transcriptPresentation + feedMotion + feedScroll + transcriptRowHeight (6 files, 154 passed)
- [ ] Confirm a swarm receipt appears inside the activity strip (expand if collapsed), not as its own column row
- [ ] Confirm command approval stays a question row and pending review stays a file row
- [ ] Confirm feed pin / overflow-anchor / Motion layout still behave on a live stream