### PR TITLE
Marionette v0.9.322

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.319, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.322, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.319"
+__version__ = "0.9.322"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.319"
+version = "0.9.322"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.319"
+version = "0.9.322"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.319",
+  "version": "0.9.322",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.319",
+      "version": "0.9.322",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.319",
+  "version": "0.9.322",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/commandPalette.test.tsx
+++ b/webapp/src/__tests__/commandPalette.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import CommandPalette from "../components/CommandPalette";
 import {
@@ -102,7 +102,7 @@ describe("CommandPalette UI", () => {
     }
   });
 
-  it("opens on Cmd/Ctrl-K and closes on Escape", () => {
+  it("opens on Cmd/Ctrl-K and closes on Escape", async () => {
     render(
       <CommandPalette onToggleLeft={() => {}} onToggleRight={() => {}} />,
     );
@@ -110,7 +110,9 @@ describe("CommandPalette UI", () => {
     pressPaletteShortcut();
     expect(screen.getByTestId("command-palette")).toBeTruthy();
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(screen.queryByTestId("command-palette")).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByTestId("command-palette")).toBeNull();
+    });
   });
 
   it("filters the list as the query narrows", () => {
@@ -124,7 +126,7 @@ describe("CommandPalette UI", () => {
     expect(screen.queryByTestId("command-palette-item-new-session")).toBeNull();
   });
 
-  it("selecting Clear does not createSession", () => {
+  it("selecting Clear does not createSession", async () => {
     const createSession = vi.fn();
     const onNew = () => {
       createSession();
@@ -144,20 +146,24 @@ describe("CommandPalette UI", () => {
       fireEvent.click(screen.getByTestId("command-palette-item-clear-transcript"));
       expect(cleared).toEqual(["clear"]);
       expect(createSession).not.toHaveBeenCalled();
-      expect(screen.queryByTestId("command-palette")).toBeNull();
+      await waitFor(() => {
+        expect(screen.queryByTestId("command-palette")).toBeNull();
+      });
     } finally {
       window.removeEventListener("harness-new-session", onNew);
       window.removeEventListener("harness-clear-transcript", onClear);
     }
   });
 
-  it("closes when clicking the backdrop", () => {
+  it("closes when clicking the backdrop", async () => {
     render(
       <CommandPalette onToggleLeft={() => {}} onToggleRight={() => {}} />,
     );
     pressPaletteShortcut();
     expect(screen.getByTestId("command-palette")).toBeTruthy();
     fireEvent.mouseDown(screen.getByTestId("command-palette-backdrop"));
-    expect(screen.queryByTestId("command-palette")).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByTestId("command-palette")).toBeNull();
+    });
   });
 });

--- a/webapp/src/__tests__/overlayPortal.test.tsx
+++ b/webapp/src/__tests__/overlayPortal.test.tsx
@@ -1,0 +1,123 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import column from "../components/conversation/ConversationChatColumn.tsx?raw";
+import spillSource from "../components/conversation/SpillPreviewModal.tsx?raw";
+import lightboxSource from "../components/conversation/ImageLightbox.tsx?raw";
+import paletteSource from "../components/CommandPalette.tsx?raw";
+import helperSource from "../lib/overlayPortal.tsx?raw";
+import cssSource from "../index.css?raw";
+import SpillPreviewModal from "../components/conversation/SpillPreviewModal";
+import ImageLightbox from "../components/conversation/ImageLightbox";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("overlay portal contract (v0.9.322)", () => {
+  it("portals conversation overlays to document.body via createPortal", () => {
+    expect(helperSource).toContain("createPortal");
+    expect(helperSource).toContain("document.body");
+    expect(spillSource).toContain("OverlayPortal");
+    expect(lightboxSource).toContain("OverlayPortal");
+    expect(paletteSource).toContain("OverlayPortal");
+    expect(helperSource).toContain("data-starting-style");
+    expect(helperSource).toContain("data-instant");
+  });
+
+  it("uses CSS attribute selectors for enter/leave without StyleX or Motion on overlays", () => {
+    for (const src of [spillSource, lightboxSource, helperSource, paletteSource]) {
+      expect(src).not.toMatch(/from\s+["']motion["']|from\s+["']framer-motion["']/);
+      expect(src).not.toMatch(/@stylexjs|stylex\./);
+      expect(src).not.toMatch(/node:/);
+    }
+    expect(cssSource).toContain("[data-starting-style]");
+    expect(cssSource).toContain("[data-instant]");
+  });
+
+  it("keeps feed scrollport overflow-anchor:auto and scroll-padding-bottom", () => {
+    expect(column).toContain("[overflow-anchor:auto]");
+    expect(column).toContain("[scroll-padding-bottom:var(--feed-chrome-clearance");
+    expect(column).not.toContain("overflow-anchor:none");
+  });
+
+  it("renders SpillPreviewModal backdrop as a document.body descendant outside the virtual list", async () => {
+    const virtualList = document.createElement("div");
+    virtualList.setAttribute("data-testid", "transcript-virtual-list");
+    document.body.append(virtualList);
+
+    render(
+      <SpillPreviewModal
+        preview={{
+          uri: "spill://stdout/abc",
+          content: "hello spill",
+          chars: 11,
+          truncated: false,
+        }}
+        onClose={() => {}}
+      />,
+    );
+
+    const modal = screen.getByTestId("spill-preview-modal");
+    expect(document.body.contains(modal)).toBe(true);
+    expect(virtualList.contains(modal)).toBe(false);
+    expect(modal).toHaveAttribute("data-starting-style");
+
+    await waitFor(() => {
+      expect(modal.hasAttribute("data-starting-style")).toBe(false);
+    });
+
+    virtualList.remove();
+  });
+
+  it("renders ImageLightbox as a body descendant and clears data-starting-style after enter", async () => {
+    const virtualList = document.createElement("div");
+    virtualList.setAttribute("data-testid", "transcript-virtual-list");
+    document.body.append(virtualList);
+
+    render(
+      <ImageLightbox url="blob:test-image" onClose={() => {}} />,
+    );
+
+    const backdrop = document.body.querySelector(".fixed.inset-0.z-50");
+    expect(backdrop).toBeTruthy();
+    expect(virtualList.contains(backdrop!)).toBe(false);
+    expect(backdrop).toHaveAttribute("data-starting-style");
+
+    await waitFor(() => {
+      expect(backdrop!.hasAttribute("data-starting-style")).toBe(false);
+    });
+
+    virtualList.remove();
+  });
+
+  it("sets data-instant on close so leave is not animated", async () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <SpillPreviewModal
+        preview={{
+          uri: "spill://stdout/xyz",
+          content: "body",
+          chars: 4,
+          truncated: false,
+        }}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByTestId("spill-preview-modal")).toBeTruthy();
+
+    await act(async () => {
+      rerender(
+        <SpillPreviewModal preview={null} onClose={onClose} />,
+      );
+    });
+
+    const instant = document.body.querySelector("[data-instant]");
+    expect(instant).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("spill-preview-modal")).toBeNull();
+    });
+  });
+});

--- a/webapp/src/components/CommandPalette.tsx
+++ b/webapp/src/components/CommandPalette.tsx
@@ -6,7 +6,7 @@ import {
   runCommandPaletteAction,
   type CommandPaletteAction,
 } from "../lib/commandPalette";
-import { useOverlayFocus } from "../lib/overlayFocus";
+import { OverlayPortal } from "../lib/overlayPortal";
 
 type CommandPaletteProps = {
   onToggleLeft: () => void;
@@ -35,11 +35,6 @@ export default function CommandPalette({
   const listId = useId();
 
   const close = () => setOpen(false);
-
-  useOverlayFocus(open, dialogRef, {
-    initialFocusRef: inputRef,
-    onClose: close,
-  });
 
   const actions = filterCommandPaletteActions(COMMAND_PALETTE_ACTIONS, query);
   const actionsRef = useRef(actions);
@@ -133,13 +128,15 @@ export default function CommandPalette({
     row?.scrollIntoView?.({ block: "nearest" });
   }, [activeIndex, open]);
 
-  if (!open) return null;
-
   return (
-    <div
-      className="fixed inset-0 z-[60] bg-black/55 flex items-start justify-center pt-[18vh] px-4"
-      data-testid="command-palette-backdrop"
-      onMouseDown={(e) => {
+    <OverlayPortal
+      open={open}
+      onClose={close}
+      focusRootRef={dialogRef}
+      initialFocusRef={inputRef}
+      testId="command-palette-backdrop"
+      className="fixed inset-0 z-[60] bg-black/55 flex items-start justify-center pt-[18vh] px-4 transition-opacity duration-150"
+      onBackdropMouseDown={(e) => {
         if (e.target === e.currentTarget) setOpen(false);
       }}
     >
@@ -204,6 +201,6 @@ export default function CommandPalette({
           )}
         </div>
       </div>
-    </div>
+    </OverlayPortal>
   );
 }

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -3726,9 +3726,7 @@ export default function Conversation({
       ) : null}
       </div>
 
-      {lightboxUrl && (
-        <ImageLightbox url={lightboxUrl} onClose={() => setLightboxUrl(null)} />
-      )}
+      <ImageLightbox url={lightboxUrl} onClose={() => setLightboxUrl(null)} />
 
       <SpillPreviewModal
         preview={spillPreview}

--- a/webapp/src/components/conversation/ImageLightbox.tsx
+++ b/webapp/src/components/conversation/ImageLightbox.tsx
@@ -2,7 +2,9 @@
  * Fullscreen image lightbox for transcript / attachment previews.
  */
 
+import { useRef } from "react";
 import { X } from "lucide-react";
+import { OverlayPortal } from "../../lib/overlayPortal";
 
 export default function ImageLightbox({
   url,
@@ -11,30 +13,39 @@ export default function ImageLightbox({
   url: string | null;
   onClose: () => void;
 }) {
-  if (!url) return null;
+  const panelRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
-      onClick={onClose}
+    <OverlayPortal
+      open={url !== null}
+      onClose={onClose}
+      focusRootRef={panelRef}
+      initialFocusRef={closeRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 backdrop-blur-sm transition-opacity duration-200"
+      onBackdropClick={onClose}
     >
-      <div
-        className="relative max-w-[90vw] max-h-[90vh] flex flex-col items-center justify-center"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <button
-          onClick={onClose}
-          className="absolute -top-10 right-0 p-1.5 text-faint hover:text-txt bg-panel border border-edge rounded-full transition-all focus:outline-none"
-          title="Close"
+      {url ? (
+        <div
+          ref={panelRef}
+          className="relative max-w-[90vw] max-h-[90vh] flex flex-col items-center justify-center"
+          onClick={(e) => e.stopPropagation()}
         >
-          <X size={16} />
-        </button>
-        <img
-          src={url}
-          alt="Enlarged screenshot"
-          className="max-w-full max-h-[80vh] object-contain rounded-lg border border-edge shadow-2xl"
-        />
-      </div>
-    </div>
+          <button
+            ref={closeRef}
+            onClick={onClose}
+            className="absolute -top-10 right-0 p-1.5 text-faint hover:text-txt bg-panel border border-edge rounded-full transition-all focus:outline-none"
+            title="Close"
+          >
+            <X size={16} />
+          </button>
+          <img
+            src={url}
+            alt="Enlarged screenshot"
+            className="max-w-full max-h-[80vh] object-contain rounded-lg border border-edge shadow-2xl"
+          />
+        </div>
+      ) : null}
+    </OverlayPortal>
   );
 }

--- a/webapp/src/components/conversation/SpillPreviewModal.tsx
+++ b/webapp/src/components/conversation/SpillPreviewModal.tsx
@@ -3,8 +3,9 @@
  * No editor chrome — just the URI, size, and scrollable body.
  */
 
-import { useEffect } from "react";
+import { useRef } from "react";
 import { X } from "lucide-react";
+import { OverlayPortal } from "../../lib/overlayPortal";
 
 export type SpillPreviewState = {
   uri: string;
@@ -43,53 +44,53 @@ export default function SpillPreviewModal({
   preview: SpillPreviewState | null;
   onClose: () => void;
 }) {
-  useEffect(() => {
-    if (!preview) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [preview, onClose]);
-
-  if (!preview) return null;
+  const panelRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
-      onClick={onClose}
-      data-testid="spill-preview-modal"
+    <OverlayPortal
+      open={preview !== null}
+      onClose={onClose}
+      focusRootRef={panelRef}
+      initialFocusRef={closeRef}
+      testId="spill-preview-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm transition-opacity duration-200"
+      onBackdropClick={onClose}
     >
-      <div
-        className="relative w-[min(920px,92vw)] max-h-[85vh] flex flex-col bg-panel border border-edge rounded-lg shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-edge/60">
-          <div className="min-w-0 flex-1">
-            <div className="font-mono text-[11px] text-accent/90 truncate" title={preview.uri}>
-              {preview.uri}
+      {preview ? (
+        <div
+          ref={panelRef}
+          className="relative w-[min(920px,92vw)] max-h-[85vh] flex flex-col bg-panel border border-edge rounded-lg shadow-2xl"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-edge/60">
+            <div className="min-w-0 flex-1">
+              <div className="font-mono text-[11px] text-accent/90 truncate" title={preview.uri}>
+                {preview.uri}
+              </div>
+              <div className="text-[10px] text-faint/70 tabular-nums">
+                {preview.error
+                  ? "Failed to load"
+                  : `${preview.chars.toLocaleString()} chars${
+                      preview.truncated ? " · preview truncated" : ""
+                    }`}
+              </div>
             </div>
-            <div className="text-[10px] text-faint/70 tabular-nums">
-              {preview.error
-                ? "Failed to load"
-                : `${preview.chars.toLocaleString()} chars${
-                    preview.truncated ? " · preview truncated" : ""
-                  }`}
-            </div>
+            <button
+              ref={closeRef}
+              type="button"
+              onClick={onClose}
+              className="p-1.5 text-faint hover:text-txt bg-transparent border border-edge/50 rounded-full transition-colors"
+              title="Close"
+            >
+              <X size={14} />
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="p-1.5 text-faint hover:text-txt bg-transparent border border-edge/50 rounded-full transition-colors"
-            title="Close"
-          >
-            <X size={14} />
-          </button>
+          <pre className="m-0 px-3 py-2 overflow-auto whitespace-pre-wrap break-all font-mono text-[11px] leading-snug text-txt/90 min-h-[12rem]">
+            {preview.error || preview.content || "(empty)"}
+          </pre>
         </div>
-        <pre className="m-0 px-3 py-2 overflow-auto whitespace-pre-wrap break-all font-mono text-[11px] leading-snug text-txt/90 min-h-[12rem]">
-          {preview.error || preview.content || "(empty)"}
-        </pre>
-      </div>
-    </div>
+      ) : null}
+    </OverlayPortal>
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -544,6 +544,18 @@ body.is-row-resizing iframe {
   animation: onboarding-rise 320ms ease-out;
 }
 
+/* Body-portaled overlays (conversation lightbox/spill, command palette).
+   data-starting-style: first paint at starting opacity (no pop-in).
+   data-instant: skip transition on close. Attribute selectors only. */
+[data-starting-style] {
+  opacity: 0;
+}
+[data-instant] {
+  transition: none !important;
+  animation: none !important;
+  opacity: 1;
+}
+
 .scrollbar-none {
   scrollbar-width: none;
 }

--- a/webapp/src/lib/overlayPortal.tsx
+++ b/webapp/src/lib/overlayPortal.tsx
@@ -1,0 +1,86 @@
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { createPortal } from "react-dom";
+import { useOverlayFocus } from "./overlayFocus";
+
+type OverlayPhase = "closed" | "enter" | "open" | "leave";
+
+export type OverlayPortalProps = {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  className?: string;
+  testId?: string;
+  /** Focus-trap root; defaults to the backdrop element. */
+  focusRootRef?: RefObject<HTMLElement | null>;
+  initialFocusRef?: RefObject<HTMLElement | null>;
+  restoreFocus?: boolean;
+  onBackdropClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onBackdropMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
+};
+
+/**
+ * Body-portaled overlay shell with first-paint and instant-leave attributes.
+ * Enter: data-starting-style for one frame so CSS can transition from a
+ * stable starting state (no pop). Leave: data-instant for one frame so close
+ * does not animate. No Motion — feed-only layout motion stays in the list.
+ */
+export function OverlayPortal({
+  open,
+  onClose,
+  children,
+  className,
+  testId,
+  focusRootRef,
+  initialFocusRef,
+  restoreFocus = true,
+  onBackdropClick,
+  onBackdropMouseDown,
+}: OverlayPortalProps) {
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const rootRef = focusRootRef ?? backdropRef;
+  const [phase, setPhase] = useState<OverlayPhase>(open ? "enter" : "closed");
+
+  useOverlayFocus(open, rootRef, {
+    initialFocusRef,
+    onClose,
+    restoreFocus,
+  });
+
+  useLayoutEffect(() => {
+    if (open) {
+      setPhase("enter");
+      const id = requestAnimationFrame(() => setPhase("open"));
+      return () => cancelAnimationFrame(id);
+    }
+    setPhase((prev) => (prev === "closed" ? "closed" : "leave"));
+  }, [open]);
+
+  useLayoutEffect(() => {
+    if (phase !== "leave") return;
+    const id = requestAnimationFrame(() => setPhase("closed"));
+    return () => cancelAnimationFrame(id);
+  }, [phase]);
+
+  if (phase === "closed") return null;
+
+  return createPortal(
+    <div
+      ref={backdropRef}
+      className={className}
+      data-testid={testId}
+      data-starting-style={phase === "enter" ? "" : undefined}
+      data-instant={phase === "leave" ? "" : undefined}
+      onClick={onBackdropClick}
+      onMouseDown={onBackdropMouseDown}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
## Summary
- Portal conversation overlays (spill peek, image lightbox) and the command palette to `document.body` so they are not trapped in the TanStack/Pretext feed scrollport.
- First paint uses `data-starting-style`; close uses `data-instant` (CSS attribute selectors only — no StyleX, no Motion on overlays).
- Package version 0.9.322 (monotonic after the v0.9.321 tag). Pin remains `puppetmaster-ai==1.22.28`.
- Keeps 314 Pretext + TanStack + feedScroll, 317 `overflow-anchor:auto` + scroll-padding-bottom, 318 feed-only Motion, 319 Item union, and 321 openai responses on main.

## Test plan
- [x] `vitest` overlayPortal + commandPalette + overlayFocus + feedMotion + SettingsShell.providersFocus
- [ ] CI on this PR