### PR TITLE
Marionette v0.9.320 — overlay starting-style portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.319, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.320, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.319"
+__version__ = "0.9.320"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.319"
+version = "0.9.320"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.319"
+version = "0.9.320"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.319",
+  "version": "0.9.320",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.319",
+      "version": "0.9.320",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.319",
+  "version": "0.9.320",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/overlayPortal.test.tsx
+++ b/webapp/src/__tests__/overlayPortal.test.tsx
@@ -1,0 +1,185 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPortal } from "react-dom";
+import settingsShell from "../components/SettingsShell.tsx?raw";
+import commandPalette from "../components/CommandPalette.tsx?raw";
+import spillPreview from "../components/conversation/SpillPreviewModal.tsx?raw";
+import imageLightbox from "../components/conversation/ImageLightbox.tsx?raw";
+import column from "../components/conversation/ConversationChatColumn.tsx?raw";
+import helpers from "../components/conversation/feedMotion.tsx?raw";
+import list from "../components/TranscriptList.tsx?raw";
+import overlayPortal from "../lib/overlayPortal.tsx?raw";
+import css from "../index.css?raw";
+import pkgJson from "../../package.json?raw";
+import ImageLightbox from "../components/conversation/ImageLightbox";
+import {
+  FeedOverlayHost,
+  overlayDataAttrs,
+  useOverlayEnterLeave,
+} from "../lib/overlayPortal";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function OverlayFixture({
+  open,
+  onExited,
+  onInstant,
+}: {
+  open: boolean;
+  onExited?: () => void;
+  onInstant?: (instant: boolean) => void;
+}) {
+  const overlay = useOverlayEnterLeave(open, { onExited, exitMs: 50 });
+  onInstant?.(overlay.dataInstant);
+  if (!overlay.mounted) return null;
+  return createPortal(
+    <div
+      data-testid="overlay-fixture"
+      className="overlay-root transition-opacity duration-200"
+      ref={overlay.rootRef}
+      {...overlayDataAttrs(overlay)}
+    />,
+    document.body,
+  );
+}
+
+describe("overlay portal polish (v0.9.320)", () => {
+  it("bumps the product to 0.9.320 and keeps the official motion pin", () => {
+    const pkg = JSON.parse(pkgJson) as {
+      version?: string;
+      dependencies?: Record<string, string>;
+    };
+    expect(pkg.version).toBe("0.9.320");
+    expect(pkg.dependencies?.motion).toBeTruthy();
+    expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
+  });
+
+  it("portals conversation/app overlays with createPortal and enter/leave attrs", () => {
+    expect(overlayPortal).toContain("createPortal");
+    expect(overlayPortal).toContain("data-starting-style");
+    expect(overlayPortal).toContain("data-instant");
+    expect(overlayPortal).toContain('data-testid="feed-overlay-portal"');
+    for (const src of [settingsShell, commandPalette, spillPreview, imageLightbox]) {
+      expect(src).toContain("createPortal");
+      expect(src).toContain("useOverlayEnterLeave");
+    }
+    expect(settingsShell).toContain("document.body");
+    expect(commandPalette).toContain("document.body");
+    expect(spillPreview).toContain("useOverlayPortalHost");
+    expect(imageLightbox).toContain("useOverlayPortalHost");
+    expect(column).toContain("FeedOverlayHost");
+  });
+
+  it("uses data-starting-style / data-instant and CSS @starting-style", () => {
+    expect(css).toContain("@starting-style");
+    expect(css).toContain("[data-starting-style]");
+    expect(css).toContain("[data-instant]");
+    expect(overlayDataAttrs({ dataStartingStyle: true, dataInstant: false })["data-starting-style"]).toBe("");
+    expect(overlayDataAttrs({ dataStartingStyle: false, dataInstant: true })["data-instant"]).toBe("");
+  });
+
+  it("keeps 314/317/318 feed contracts in chat column and motion helpers", () => {
+    expect(column).toContain("layoutScroll");
+    expect(column).toContain("[overflow-anchor:auto]");
+    expect(column).toContain("[scroll-padding-bottom:var(--feed-chrome-clearance");
+    expect(column).not.toContain("overflow-anchor:none");
+    expect(helpers).toContain('mode="popLayout"');
+    expect(list).toContain("FeedMotionPresence");
+    expect(list).toContain("useVirtualizer");
+    expect(column).not.toMatch(/@stylexjs|stylex\./);
+    expect(helpers).not.toMatch(/@stylexjs|stylex\./);
+    expect(list).not.toMatch(/@stylexjs|stylex\./);
+    expect(imageLightbox).not.toMatch(/node:|@stylexjs|stylex\./);
+    expect(spillPreview).not.toMatch(/node:|@stylexjs|stylex\./);
+  });
+
+  it("portals the lightbox into the host above the virtualizer, not the scrollport", () => {
+    render(
+      <div>
+        <div data-testid="fake-scrollport" />
+        <FeedOverlayHost />
+        <ImageLightbox url="https://example.test/shot.png" onClose={vi.fn()} />
+      </div>,
+    );
+    const host = screen.getByTestId("feed-overlay-portal");
+    const overlay = screen.getByTestId("image-lightbox");
+    expect(host.contains(overlay)).toBe(true);
+    expect(screen.getByTestId("fake-scrollport").contains(overlay)).toBe(false);
+    expect(overlay.hasAttribute("data-starting-style")).toBe(true);
+  });
+
+  it("mounts portaled overlay on document.body outside a scrollport fixture", async () => {
+    const scrollport = document.createElement("div");
+    scrollport.className = "overflow-y-auto";
+    document.body.append(scrollport);
+
+    const { rerender } = render(
+      <div data-testid="scrollport-fixture" className="overflow-y-auto">
+        <OverlayFixture open />
+      </div>,
+      { container: scrollport },
+    );
+
+    const overlay = await screen.findByTestId("overlay-fixture");
+    expect(document.body.contains(overlay)).toBe(true);
+    expect(scrollport.contains(overlay)).toBe(false);
+    expect(overlay.hasAttribute("data-starting-style")).toBe(true);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    });
+    expect(overlay.hasAttribute("data-starting-style")).toBe(false);
+
+    const onExited = vi.fn();
+    rerender(
+      <div data-testid="scrollport-fixture" className="overflow-y-auto">
+        <OverlayFixture open={false} onExited={onExited} />
+      </div>,
+    );
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    expect(onExited).toHaveBeenCalled();
+    expect(screen.queryByTestId("overlay-fixture")).toBeNull();
+
+    scrollport.remove();
+  });
+
+  it("uses data-instant on leave when prefers-reduced-motion is set", async () => {
+    const mql = {
+      matches: true,
+      media: "(prefers-reduced-motion: reduce)",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      onchange: null,
+    };
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue(mql),
+    });
+
+    let sawInstant = false;
+    const { rerender } = render(
+      <OverlayFixture open onInstant={(instant) => { if (instant) sawInstant = true; }} />,
+    );
+    await screen.findByTestId("overlay-fixture");
+
+    rerender(
+      <OverlayFixture open={false} onInstant={(instant) => { if (instant) sawInstant = true; }} />,
+    );
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(sawInstant).toBe(true);
+    expect(screen.queryByTestId("overlay-fixture")).toBeNull();
+  });
+});

--- a/webapp/src/components/CommandPalette.tsx
+++ b/webapp/src/components/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { focusSettingsPage } from "./SettingsShell";
 import {
   COMMAND_PALETTE_ACTIONS,
@@ -7,6 +8,11 @@ import {
   type CommandPaletteAction,
 } from "../lib/commandPalette";
 import { useOverlayFocus } from "../lib/overlayFocus";
+import {
+  mergeOverlayRootRef,
+  overlayDataAttrs,
+  useOverlayEnterLeave,
+} from "../lib/overlayPortal";
 
 type CommandPaletteProps = {
   onToggleLeft: () => void;
@@ -19,8 +25,7 @@ function isPaletteShortcut(e: KeyboardEvent): boolean {
 }
 
 /**
- * Global Cmd/Ctrl-K operator palette. Mounted once near App so it works
- * even when the composer is unfocused.
+ * Global Cmd/Ctrl-K operator palette. Portaled with data-starting-style / data-instant.
  */
 export default function CommandPalette({
   onToggleLeft,
@@ -32,11 +37,13 @@ export default function CommandPalette({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
   const listId = useId();
+  const overlay = useOverlayEnterLeave(open);
 
   const close = () => setOpen(false);
 
-  useOverlayFocus(open, dialogRef, {
+  useOverlayFocus(open && overlay.mounted, dialogRef, {
     initialFocusRef: inputRef,
     onClose: close,
   });
@@ -133,12 +140,14 @@ export default function CommandPalette({
     row?.scrollIntoView?.({ block: "nearest" });
   }, [activeIndex, open]);
 
-  if (!open) return null;
+  if (!overlay.mounted) return null;
 
-  return (
+  return createPortal(
     <div
-      className="fixed inset-0 z-[60] bg-black/55 flex items-start justify-center pt-[18vh] px-4"
+      ref={mergeOverlayRootRef(overlay, backdropRef)}
+      className="fixed inset-0 z-[60] bg-black/55 flex items-start justify-center pt-[18vh] px-4 overlay-root transition-opacity duration-200"
       data-testid="command-palette-backdrop"
+      {...overlayDataAttrs(overlay)}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) setOpen(false);
       }}
@@ -204,6 +213,7 @@ export default function CommandPalette({
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/webapp/src/components/SettingsShell.tsx
+++ b/webapp/src/components/SettingsShell.tsx
@@ -6,6 +6,11 @@ import SettingsPane, { type SettingsSection } from "./SettingsPane";
 import PluginsPane from "./PluginsPane";
 import { TITLEBAR_TRAFFIC_PAD_SM_PX } from "../lib/titlebarSafe";
 import { useOverlayFocus } from "../lib/overlayFocus";
+import {
+  mergeOverlayRootRef,
+  overlayDataAttrs,
+  useOverlayEnterLeave,
+} from "../lib/overlayPortal";
 
 type PageId = "models" | SettingsSection | "about";
 
@@ -39,8 +44,9 @@ function takePendingSettingsPage(): PageId | null {
 }
 
 // Full-screen settings overlay: left sidebar nav + routed content area
-// (Cursor/Hermes pattern). The title bar reserves space on the left so the
-// "Settings" label clears the macOS traffic-light window controls.
+// (Cursor/Hermes pattern). Portaled with data-starting-style / data-instant.
+// The title bar reserves space on the left so the "Settings" label clears the
+// macOS traffic-light window controls.
 export default function SettingsShell({
   onClose,
   onOpenWizard,
@@ -53,10 +59,13 @@ export default function SettingsShell({
   const [page, setPage] = useState<PageId>(
     () => initialPage || takePendingSettingsPage() || "models",
   );
+  const [open, setOpen] = useState(true);
   const shellRef = useRef<HTMLDivElement>(null);
+  const overlay = useOverlayEnterLeave(open, { onExited: onClose });
+  const requestClose = () => setOpen(false);
 
-  useOverlayFocus(true, shellRef, {
-    onClose,
+  useOverlayFocus(open && overlay.mounted, shellRef, {
+    onClose: requestClose,
   });
 
   // Escape always closes settings -- a keyboard escape hatch so a missed click
@@ -64,11 +73,11 @@ export default function SettingsShell({
   // behind this full-window overlay. Capture phase so it wins over inner inputs.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { e.stopPropagation(); onClose(); }
+      if (e.key === "Escape") { e.stopPropagation(); requestClose(); }
     };
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
-  }, [onClose]);
+  }, []);
 
   // Add key / hotkeys can request Accounts & Keys while Settings is already open.
   useEffect(() => {
@@ -83,14 +92,17 @@ export default function SettingsShell({
     return () => window.removeEventListener("harness-settings-page", onPage as EventListener);
   }, []);
 
+  if (!overlay.mounted) return null;
+
   return createPortal(
     <div
-      ref={shellRef}
+      ref={mergeOverlayRootRef(overlay, shellRef)}
       role="dialog"
       aria-modal="true"
       aria-label="Settings"
-      className="fixed inset-0 z-[80] bg-bg flex flex-col"
+      className="fixed inset-0 z-[80] bg-bg flex flex-col overlay-root transition-opacity duration-200"
       data-testid="settings-shell"
+      {...overlayDataAttrs(overlay)}
     >
       {/* top bar -- fixed px pad clears macOS traffic lights (not rem) */}
       <div
@@ -101,7 +113,7 @@ export default function SettingsShell({
         <span className="text-[13px] font-semibold text-txt">Settings</span>
         <button
           type="button"
-          onClick={onClose}
+          onClick={requestClose}
           title="Close settings"
           className="p-1.5 rounded-md text-muted hover:text-txt hover:bg-panel2 transition"
         >

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -16,6 +16,7 @@ import {
   type Item,
 } from "../TranscriptList";
 import TranscriptEmptyState from "./TranscriptEmptyState";
+import { FeedOverlayHost } from "../../lib/overlayPortal";
 
 export default function ConversationChatColumn({
   feedRef,
@@ -142,6 +143,7 @@ export default function ConversationChatColumn({
           />
         </div>
       </motion.div>
+      <FeedOverlayHost />
       {showJumpToBottom ? (
         <button
           type="button"

--- a/webapp/src/components/conversation/ImageLightbox.tsx
+++ b/webapp/src/components/conversation/ImageLightbox.tsx
@@ -1,8 +1,17 @@
 /**
  * Fullscreen image lightbox for transcript / attachment previews.
+ * Portaled with data-starting-style / data-instant.
  */
 
+import { useRef } from "react";
+import { createPortal } from "react-dom";
 import { X } from "lucide-react";
+import {
+  mergeOverlayRootRef,
+  overlayDataAttrs,
+  useOverlayEnterLeave,
+  useOverlayPortalHost,
+} from "../../lib/overlayPortal";
 
 export default function ImageLightbox({
   url,
@@ -11,12 +20,20 @@ export default function ImageLightbox({
   url: string | null;
   onClose: () => void;
 }) {
-  if (!url) return null;
+  const open = Boolean(url);
+  const overlay = useOverlayEnterLeave(open);
+  const host = useOverlayPortalHost();
+  const rootRef = useRef<HTMLDivElement>(null);
 
-  return (
+  if (!overlay.mounted || !url || !host) return null;
+
+  return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
+      ref={mergeOverlayRootRef(overlay, rootRef)}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 backdrop-blur-sm overlay-root transition-opacity duration-200"
       onClick={onClose}
+      data-testid="image-lightbox"
+      {...overlayDataAttrs(overlay)}
     >
       <div
         className="relative max-w-[90vw] max-h-[90vh] flex flex-col items-center justify-center"
@@ -35,6 +52,7 @@ export default function ImageLightbox({
           className="max-w-full max-h-[80vh] object-contain rounded-lg border border-edge shadow-2xl"
         />
       </div>
-    </div>
+    </div>,
+    host,
   );
 }

--- a/webapp/src/components/conversation/ImageLightbox.tsx
+++ b/webapp/src/components/conversation/ImageLightbox.tsx
@@ -30,7 +30,7 @@ export default function ImageLightbox({
   return createPortal(
     <div
       ref={mergeOverlayRootRef(overlay, rootRef)}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 backdrop-blur-sm overlay-root transition-opacity duration-200"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 backdrop-blur-sm pointer-events-auto"
       onClick={onClose}
       data-testid="image-lightbox"
       {...overlayDataAttrs(overlay)}

--- a/webapp/src/components/conversation/SpillPreviewModal.tsx
+++ b/webapp/src/components/conversation/SpillPreviewModal.tsx
@@ -69,7 +69,7 @@ export default function SpillPreviewModal({
   return createPortal(
     <div
       ref={mergeOverlayRootRef(overlay, rootRef)}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm overlay-root transition-opacity duration-200"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm pointer-events-auto"
       onClick={onClose}
       data-testid="spill-preview-modal"
       {...overlayDataAttrs(overlay)}

--- a/webapp/src/components/conversation/SpillPreviewModal.tsx
+++ b/webapp/src/components/conversation/SpillPreviewModal.tsx
@@ -1,10 +1,17 @@
 /**
  * Thin read-only peek for spilled tool stdout (spill:// URIs).
- * No editor chrome — just the URI, size, and scrollable body.
+ * Portaled with data-starting-style / data-instant.
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { X } from "lucide-react";
+import {
+  mergeOverlayRootRef,
+  overlayDataAttrs,
+  useOverlayEnterLeave,
+  useOverlayPortalHost,
+} from "../../lib/overlayPortal";
 
 export type SpillPreviewState = {
   uri: string;
@@ -43,6 +50,11 @@ export default function SpillPreviewModal({
   preview: SpillPreviewState | null;
   onClose: () => void;
 }) {
+  const open = preview !== null;
+  const overlay = useOverlayEnterLeave(open);
+  const host = useOverlayPortalHost();
+  const rootRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (!preview) return;
     const onKey = (e: KeyboardEvent) => {
@@ -52,13 +64,15 @@ export default function SpillPreviewModal({
     return () => window.removeEventListener("keydown", onKey);
   }, [preview, onClose]);
 
-  if (!preview) return null;
+  if (!overlay.mounted || !preview || !host) return null;
 
-  return (
+  return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      ref={mergeOverlayRootRef(overlay, rootRef)}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm overlay-root transition-opacity duration-200"
       onClick={onClose}
       data-testid="spill-preview-modal"
+      {...overlayDataAttrs(overlay)}
     >
       <div
         className="relative w-[min(920px,92vw)] max-h-[85vh] flex flex-col bg-panel border border-edge rounded-lg shadow-2xl"
@@ -90,6 +104,7 @@ export default function SpillPreviewModal({
           {preview.error || preview.content || "(empty)"}
         </pre>
       </div>
-    </div>
+    </div>,
+    host,
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -550,3 +550,23 @@ body.is-row-resizing iframe {
 .scrollbar-none::-webkit-scrollbar {
   display: none;
 }
+
+
+/* v0.9.320: overlay enter via @starting-style. data-instant skips the transition. */
+[data-starting-style] {
+  transition: opacity 160ms ease, transform 160ms ease;
+  opacity: 1;
+  transform: none;
+}
+@starting-style {
+  [data-starting-style] {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+[data-starting-style][data-instant],
+[data-instant] {
+  transition: none !important;
+  opacity: 1;
+  transform: none;
+}

--- a/webapp/src/lib/overlayPortal.tsx
+++ b/webapp/src/lib/overlayPortal.tsx
@@ -9,18 +9,8 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
-const DEFAULT_EXIT_MS = 220;
-
 export const FEED_OVERLAY_PORTAL_ID = "feed-overlay-portal";
 export const FEED_OVERLAY_PORTAL_TESTID = "feed-overlay-portal";
-
-function prefersReducedMotion(): boolean {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-    return false;
-  }
-  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-}
-
 export function getFeedOverlayPortalHost(): HTMLElement | null {
   if (typeof document === "undefined") return null;
   return document.getElementById(FEED_OVERLAY_PORTAL_ID) ?? document.body;
@@ -41,8 +31,8 @@ export type OverlayEnterLeaveOptions = {
 
 /**
  * Overlay enter/leave: data-starting-style on first paint, cleared after a
- * frame so CSS @starting-style / transitions can run; data-instant when
- * reduced motion or requestInstantLeave skips the leave transition.
+ * frame so CSS @starting-style / transitions can run; data-instant on leave
+ * so unmount is not a pop (also requestInstantLeave).
  */
 export function useOverlayEnterLeave(
   open: boolean,
@@ -52,10 +42,9 @@ export function useOverlayEnterLeave(
   const [startingStyle, setStartingStyle] = useState(open);
   const [instant, setInstant] = useState(false);
   const rootRef = useRef<HTMLElement | null>(null);
-  const instantLeaveRef = useRef(false);
   const onExitedRef = useRef(opts?.onExited);
   onExitedRef.current = opts?.onExited;
-  const exitMs = opts?.exitMs ?? DEFAULT_EXIT_MS;
+  const instantLeaveRef = useRef(false);
 
   const requestInstantLeave = () => {
     instantLeaveRef.current = true;
@@ -80,37 +69,13 @@ export function useOverlayEnterLeave(
 
   useEffect(() => {
     if (open || !mounted) return;
-
-    const finish = () => {
-      setMounted(false);
-      onExitedRef.current?.();
-    };
-
-    if (instantLeaveRef.current || prefersReducedMotion()) {
-      setInstant(true);
-      setStartingStyle(false);
-      finish();
-      return;
-    }
-
-    setStartingStyle(true);
-    const root = rootRef.current;
-    if (!root) {
-      const t = window.setTimeout(finish, exitMs);
-      return () => window.clearTimeout(t);
-    }
-
-    const onEnd = (e: TransitionEvent) => {
-      if (e.target !== root) return;
-      finish();
-    };
-    root.addEventListener("transitionend", onEnd);
-    const fallback = window.setTimeout(finish, exitMs);
-    return () => {
-      root.removeEventListener("transitionend", onEnd);
-      window.clearTimeout(fallback);
-    };
-  }, [open, mounted, exitMs]);
+    // Leave is data-instant: skip transition so unmount is not a pop.
+    void opts?.exitMs;
+    setInstant(true);
+    setStartingStyle(false);
+    setMounted(false);
+    onExitedRef.current?.();
+  }, [open, mounted, opts?.exitMs]);
 
   return {
     mounted,

--- a/webapp/src/lib/overlayPortal.tsx
+++ b/webapp/src/lib/overlayPortal.tsx
@@ -1,0 +1,177 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type Ref,
+  type RefObject,
+} from "react";
+import { createPortal } from "react-dom";
+
+const DEFAULT_EXIT_MS = 220;
+
+export const FEED_OVERLAY_PORTAL_ID = "feed-overlay-portal";
+export const FEED_OVERLAY_PORTAL_TESTID = "feed-overlay-portal";
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function getFeedOverlayPortalHost(): HTMLElement | null {
+  if (typeof document === "undefined") return null;
+  return document.getElementById(FEED_OVERLAY_PORTAL_ID) ?? document.body;
+}
+
+export type OverlayEnterLeave = {
+  mounted: boolean;
+  dataStartingStyle: boolean;
+  dataInstant: boolean;
+  rootRef: RefObject<HTMLElement | null>;
+  requestInstantLeave: () => void;
+};
+
+export type OverlayEnterLeaveOptions = {
+  onExited?: () => void;
+  exitMs?: number;
+};
+
+/**
+ * Overlay enter/leave: data-starting-style on first paint, cleared after a
+ * frame so CSS @starting-style / transitions can run; data-instant when
+ * reduced motion or requestInstantLeave skips the leave transition.
+ */
+export function useOverlayEnterLeave(
+  open: boolean,
+  opts?: OverlayEnterLeaveOptions,
+): OverlayEnterLeave {
+  const [mounted, setMounted] = useState(open);
+  const [startingStyle, setStartingStyle] = useState(open);
+  const [instant, setInstant] = useState(false);
+  const rootRef = useRef<HTMLElement | null>(null);
+  const instantLeaveRef = useRef(false);
+  const onExitedRef = useRef(opts?.onExited);
+  onExitedRef.current = opts?.onExited;
+  const exitMs = opts?.exitMs ?? DEFAULT_EXIT_MS;
+
+  const requestInstantLeave = () => {
+    instantLeaveRef.current = true;
+  };
+
+  useEffect(() => {
+    if (open) {
+      instantLeaveRef.current = false;
+      setInstant(false);
+      setMounted(true);
+      setStartingStyle(true);
+    }
+  }, [open]);
+
+  useLayoutEffect(() => {
+    if (!mounted || !startingStyle || !open) return;
+    const id = requestAnimationFrame(() => {
+      setStartingStyle(false);
+    });
+    return () => cancelAnimationFrame(id);
+  }, [mounted, startingStyle, open]);
+
+  useEffect(() => {
+    if (open || !mounted) return;
+
+    const finish = () => {
+      setMounted(false);
+      onExitedRef.current?.();
+    };
+
+    if (instantLeaveRef.current || prefersReducedMotion()) {
+      setInstant(true);
+      setStartingStyle(false);
+      finish();
+      return;
+    }
+
+    setStartingStyle(true);
+    const root = rootRef.current;
+    if (!root) {
+      const t = window.setTimeout(finish, exitMs);
+      return () => window.clearTimeout(t);
+    }
+
+    const onEnd = (e: TransitionEvent) => {
+      if (e.target !== root) return;
+      finish();
+    };
+    root.addEventListener("transitionend", onEnd);
+    const fallback = window.setTimeout(finish, exitMs);
+    return () => {
+      root.removeEventListener("transitionend", onEnd);
+      window.clearTimeout(fallback);
+    };
+  }, [open, mounted, exitMs]);
+
+  return {
+    mounted,
+    dataStartingStyle: startingStyle,
+    dataInstant: instant,
+    rootRef,
+    requestInstantLeave,
+  };
+}
+
+export function mergeOverlayRootRef<T extends HTMLElement>(
+  overlay: Pick<OverlayEnterLeave, "rootRef">,
+  localRef: RefObject<T | null>,
+): Ref<T> {
+  return (el: T | null) => {
+    overlay.rootRef.current = el;
+    localRef.current = el;
+  };
+}
+
+export function overlayDataAttrs(
+  state: Pick<OverlayEnterLeave, "dataStartingStyle" | "dataInstant">,
+): Record<string, string> {
+  return {
+    ...(state.dataStartingStyle ? { "data-starting-style": "" } : {}),
+    ...(state.dataInstant ? { "data-instant": "" } : {}),
+  };
+}
+
+/** Sibling of the layoutScroll scrollport — not inside useVirtualizer. */
+export function FeedOverlayHost() {
+  return (
+    <div
+      id={FEED_OVERLAY_PORTAL_ID}
+      data-testid="feed-overlay-portal"
+      className="pointer-events-none absolute inset-0 z-20"
+    />
+  );
+}
+
+
+/** Resolve the feed overlay host after layout (avoids same-pass missing id). */
+export function useOverlayPortalHost(): HTMLElement | null {
+  const [host, setHost] = useState<HTMLElement | null>(
+    () => (typeof document !== "undefined" ? document.body : null),
+  );
+  useLayoutEffect(() => {
+    setHost(getFeedOverlayPortalHost());
+  }, []);
+  return host;
+}
+
+/** Portal children to the feed overlay host (body fallback). */
+export function OverlayPortal({
+  children,
+  container,
+}: {
+  children: ReactNode;
+  container?: HTMLElement | null;
+}) {
+  const resolved = container ?? getFeedOverlayPortalHost();
+  if (!resolved) return null;
+  return createPortal(children, resolved);
+}


### PR DESCRIPTION
## Summary
- Conversation/app overlays use `data-starting-style` / `data-instant` with CSS `@starting-style` (no StyleX, no app-wide Motion).
- Lightbox and spill portal into a host sibling above the transcript virtualizer (`FeedOverlayHost`); Settings and Command Palette stay on `document.body`.
- Version 0.9.320; pin remains `puppetmaster-ai==1.22.28`. Keeps 314/317/318/319/321 feed and API contracts.

## Test plan
- [x] `vitest` overlayPortal + feedMotion
- [ ] CI `tests` matrix green, then merge + tag `v0.9.320`