### PR TITLE
Marionette v0.9.329

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.28` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.322, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.329, deliberately pre-1.0. Rides puppetmaster-ai==1.22.28. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.322"
+__version__ = "0.9.329"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.322"
+version = "0.9.329"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.322"
+version = "0.9.329"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.322",
+  "version": "0.9.329",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.322",
+      "version": "0.9.329",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.322",
+  "version": "0.9.329",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -1,18 +1,36 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import column from "../components/conversation/ConversationChatColumn.tsx?raw";
 import helpers from "../components/conversation/feedMotion.tsx?raw";
 import list from "../components/TranscriptList.tsx?raw";
 import pkgJson from "../../package.json?raw";
 import { TranscriptList, type Item } from "../components/TranscriptList";
-import { feedLayoutMotionEnabled } from "../components/conversation/feedMotion";
+import {
+  feedLayoutMotionEnabled,
+  VIRTUAL_ROW_LAYOUT_ENABLED,
+} from "../components/conversation/feedMotion";
 
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
-function listProps(items: Item[]) {
+function listProps(
+  items: Item[],
+  scrollContainerRef: RefObject<HTMLDivElement | null> = { current: null },
+) {
   return {
     items,
     status: "done" as const,
@@ -21,7 +39,7 @@ function listProps(items: Item[]) {
     auto: false,
     plan: false,
     turnOpen: false,
-    scrollContainerRef: { current: null },
+    scrollContainerRef,
     onEditMessage: vi.fn(),
     onExecuteSend: vi.fn(),
     onImageClick: vi.fn(),
@@ -31,13 +49,130 @@ function listProps(items: Item[]) {
   };
 }
 
-describe("feed Motion (v0.9.318)", () => {
+function longTranscript(count: number): Item[] {
+  const items: Item[] = [];
+  for (let i = 0; i < count; i++) {
+    items.push({
+      kind: "msg",
+      msg: { role: "user", text: `user turn ${i}` },
+    });
+    items.push({
+      kind: "msg",
+      msg: { role: "assistant", text: `assistant reply ${i}` },
+    });
+  }
+  return items;
+}
+
+/** TanStack reads offsetHeight first, then RO borderBoxSize — feed both. */
+class SizedResizeObserver {
+  private readonly callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+  observe(target: Element) {
+    const box = { inlineSize: 600, blockSize: 360 };
+    const rect = {
+      x: 0,
+      y: 0,
+      width: 600,
+      height: 360,
+      top: 0,
+      left: 0,
+      bottom: 360,
+      right: 600,
+      toJSON() {
+        return this;
+      },
+    };
+    this.callback(
+      [
+        {
+          target,
+          contentRect: rect as DOMRectReadOnly,
+          borderBoxSize: [box],
+          contentBoxSize: [box],
+          devicePixelContentBoxSize: [box],
+        } as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver,
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+function sizeFeedElement(el: HTMLDivElement) {
+  Object.defineProperty(el, "offsetHeight", {
+    configurable: true,
+    get: () => 360,
+  });
+  Object.defineProperty(el, "offsetWidth", {
+    configurable: true,
+    get: () => 600,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    get: () => 360,
+  });
+  Object.defineProperty(el, "clientWidth", {
+    configurable: true,
+    get: () => 600,
+  });
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    get: () => 80 * 72,
+  });
+  el.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      width: 600,
+      height: 360,
+      top: 0,
+      left: 0,
+      bottom: 360,
+      right: 600,
+      toJSON() {
+        return this;
+      },
+    }) as DOMRect;
+}
+
+function VirtualFeedHarness({ items }: { items: Item[] }) {
+  const feedRef = useRef<HTMLDivElement>(null);
+  const [, setReady] = useState(0);
+  useLayoutEffect(() => {
+    const el = feedRef.current;
+    if (!el) return;
+    sizeFeedElement(el);
+    setReady((n) => n + 1);
+  }, []);
+  return (
+    <div
+      ref={feedRef}
+      data-testid="virtual-feed"
+      style={{ height: 360, overflow: "auto" }}
+    >
+      <TranscriptList {...listProps(items, feedRef)} />
+    </div>
+  );
+}
+
+function parseTranslateY(transform: string): number | null {
+  const match = /translateY\(([-\d.]+)px\)/.exec(transform);
+  return match ? Number(match[1]) : null;
+}
+
+describe("feed Motion (v0.9.329)", () => {
   it("declares the official motion package in webapp dependencies", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
+      version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
+    expect(pkg.version).toBe("0.9.329");
   });
 
   it("mounts transcript rows inside motion layout shells", () => {
@@ -60,14 +195,40 @@ describe("feed Motion (v0.9.318)", () => {
     expect(feedLayoutMotionEnabled(null)).toBe(true);
   });
 
-  it("keeps layoutScroll on the feed scrollport and popLayout on list presence", () => {
+  it("keeps layoutScroll on the feed scrollport and popLayout on in-flow presence", () => {
     expect(column).toContain("layoutScroll");
     expect(column).toContain("[overflow-anchor:auto]");
     expect(column).toContain("[scroll-padding-bottom:var(--feed-chrome-clearance");
     expect(column).not.toContain("overflow-anchor:none");
     expect(helpers).toContain('mode="popLayout"');
+    expect(helpers).toContain("VIRTUAL_ROW_LAYOUT_ENABLED = false");
+    expect(VIRTUAL_ROW_LAYOUT_ENABLED).toBe(false);
     expect(list).toContain("FeedMotionPresence");
+    expect(list).toContain("VIRTUAL_ROW_LAYOUT_ENABLED");
     expect(list).toContain("useVirtualizer");
+    expect(list).toContain("transcript-live-tail");
+    expect(list).not.toMatch(
+      /useVirtualWindow[\s\S]*<FeedMotionPresence>[\s\S]*virtualItems\.map/,
+    );
+    expect(list).not.toMatch(/from ["']node:/);
     expect(list).not.toMatch(/@stylexjs|create\(|stylex\./);
+    expect(helpers).not.toMatch(/from ["']node:/);
+  });
+
+  it("keeps distinct virtualizer translateY while feed layout is on", async () => {
+    expect(feedLayoutMotionEnabled(false)).toBe(true);
+    vi.stubGlobal("ResizeObserver", SizedResizeObserver);
+    render(<VirtualFeedHarness items={longTranscript(40)} />);
+
+    await waitFor(() => {
+      const rows = screen.getAllByTestId("transcript-virtual-row");
+      expect(rows.length).toBeGreaterThan(1);
+    });
+
+    const rows = screen.getAllByTestId("transcript-virtual-row");
+    const ys = rows.map((row) => parseTranslateY((row as HTMLElement).style.transform));
+    expect(ys.every((y) => y != null)).toBe(true);
+    expect(new Set(ys).size).toBe(ys.length);
+    expect(ys.some((y) => y !== 0)).toBe(true);
   });
 });

--- a/webapp/src/__tests__/transcriptVirtualizer.test.tsx
+++ b/webapp/src/__tests__/transcriptVirtualizer.test.tsx
@@ -19,7 +19,13 @@ import {
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
+
+function parseTranslateY(transform: string): number | null {
+  const match = transform.match(/translateY\(([-\d.]+)px\)/);
+  return match ? Number(match[1]) : null;
+}
 
 function listProps(
   items: Item[],
@@ -179,6 +185,24 @@ describe("transcript feed virtualizer", () => {
 
     expect(screen.queryByRole("button", { name: /Show earlier messages/i })).toBeNull();
     expect(screen.getByTestId("transcript-virtual-list")).toBeTruthy();
+  });
+
+  it("keeps distinct translateY positions on virtual rows when feed layout motion is on", async () => {
+    vi.stubGlobal("ResizeObserver", SizedResizeObserver);
+
+    render(<VirtualFeedHarness items={longTranscript(60)} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("transcript-virtual-row").length).toBeGreaterThan(1);
+    });
+
+    const translateYs = screen
+      .getAllByTestId("transcript-virtual-row")
+      .map((row) => parseTranslateY(row.style.transform))
+      .filter((value): value is number => value !== null);
+
+    expect(translateYs.length).toBeGreaterThan(1);
+    expect(new Set(translateYs).size).toBeGreaterThan(1);
   });
 
   it("keeps the virtual window after the scroll parent reports 0 height", async () => {

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -98,6 +98,7 @@ import {
 import {
   FeedMotionPresence,
   FeedMotionRow,
+  VIRTUAL_ROW_LAYOUT_ENABLED,
   useFeedLayoutMotion,
 } from "./conversation/feedMotion";
 
@@ -1008,7 +1009,6 @@ const VirtualTranscriptRow = memo(
     item: GroupedItem;
     rowId: string;
     feedSettled: boolean;
-    feedLayout: boolean;
     measureDom: (element: HTMLElement) => void;
     children: ReactNode;
   }>(function VirtualTranscriptRow(
@@ -1018,7 +1018,6 @@ const VirtualTranscriptRow = memo(
       item,
       rowId,
       feedSettled,
-      feedLayout,
       measureDom,
       children,
     },
@@ -1065,7 +1064,7 @@ const VirtualTranscriptRow = memo(
   return (
     <FeedMotionRow
       ref={attachDom && mountSettled ? setRowRef : forwardedRef}
-      layoutEnabled={feedLayout}
+      layoutEnabled={VIRTUAL_ROW_LAYOUT_ENABLED}
       data-index={virtualRow.index}
       data-testid="transcript-virtual-row"
       data-dom-measure={attachDom ? "1" : "0"}
@@ -1830,15 +1829,13 @@ export const TranscriptList = memo(function TranscriptList({
   });
   const feedLayout = useFeedLayoutMotion();
   const list = useVirtualWindow ? (
-    <motion.div
+    <div
       ref={listAnchorRef}
       data-testid="transcript-virtual-list"
       className="relative w-full"
       style={{ height: rowVirtualizer.getTotalSize() }}
-      layout={feedLayout}
     >
-      <FeedMotionPresence>
-        {virtualItems.map((virtualRow) => {
+      {virtualItems.map((virtualRow) => {
           const item = virtualGrouped[virtualRow.index]!;
           const rowId = stableItemKey(item, virtualRow.index);
           return (
@@ -1849,15 +1846,13 @@ export const TranscriptList = memo(function TranscriptList({
               item={item}
               rowId={rowId}
               feedSettled={feedSettled}
-              feedLayout={feedLayout}
               measureDom={measureVirtualRowDom}
             >
               {renderGroupedItem(virtualRow.index)}
             </VirtualTranscriptRow>
           );
         })}
-      </FeedMotionPresence>
-    </motion.div>
+    </div>
   ) : (
     <motion.div
       ref={listAnchorRef}

--- a/webapp/src/components/conversation/feedMotion.tsx
+++ b/webapp/src/components/conversation/feedMotion.tsx
@@ -1,6 +1,8 @@
 /**
- * Feed-only Motion helpers (v0.9.318). Transcript enter/exit + layout polish;
- * not used app-wide. Respects prefers-reduced-motion via Motion's hook.
+ * Feed-only Motion helpers (v0.9.318 / v0.9.329). Transcript enter/exit +
+ * layout polish on in-flow rows; not used app-wide. Virtual window rows must
+ * never take a Motion layout transform — TanStack owns translateY.
+ * prefers-reduced-motion stays off (animations run unless the user opted out).
  */
 
 import { forwardRef, memo, type CSSProperties, type ReactNode } from "react";
@@ -16,11 +18,17 @@ export function useFeedLayoutMotion(): boolean {
   return feedLayoutMotionEnabled(useReducedMotion());
 }
 
+/**
+ * Virtual window rows are `absolute top-0` + virtualizer translateY.
+ * Motion `layout` / popLayout write `transform` and stack every row at y=0.
+ */
+export const VIRTUAL_ROW_LAYOUT_ENABLED = false;
+
 type FeedMotionPresenceProps = {
   children: ReactNode;
 };
 
-/** popLayout wrapper for transcript rows — virtual window, fallback, live tail. */
+/** popLayout wrapper for in-flow transcript rows (fallback list + live tail). */
 export const FeedMotionPresence = memo(function FeedMotionPresence({
   children,
 }: FeedMotionPresenceProps) {
@@ -41,7 +49,7 @@ type FeedMotionRowProps = {
   "data-dom-measure"?: string;
 };
 
-/** One feed row shell: motion.div layout for popLayout reflow. */
+/** One feed row shell: motion.div layout only when layoutEnabled. */
 export const FeedMotionRow = memo(
   forwardRef<HTMLDivElement, FeedMotionRowProps>(function FeedMotionRow(
     {


### PR DESCRIPTION
## Summary
- Virtual window rows no longer take Motion `layout` / popLayout transforms; TanStack `translateY` is the only row transform so rows do not stack at y=0.
- `layoutScroll` stays on the feed scrollport only. popLayout remains on the unvirtualized fallback list and live tail (normal flow).
- prefers-reduced-motion stays off unless the user opted out. Pretext, overflow-anchor, activity strip, and OverlayPortal are unchanged.
- Package version 0.9.329 (skip 323–328). Pin remains `puppetmaster-ai==1.22.28`.

## Test plan
- [x] `vitest` feedMotion + transcriptVirtualizer (distinct translateY with feed layout on)
- [ ] CI on this PR