### PR TITLE
fix: feedMotion version assert for 0.9.330

### DIFF
--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,7 +164,7 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.329)", () => {
+describe("feed Motion (v0.9.330)", () => {
   it("declares the official motion package in webapp dependencies", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
@@ -172,7 +172,7 @@ describe("feed Motion (v0.9.329)", () => {
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.329");
+    expect(pkg.version).toBe("0.9.330");
   });
 
   it("mounts transcript rows inside motion layout shells", () => {


### PR DESCRIPTION
## Summary
- `feedMotion.test.tsx` still expected package version `0.9.329` after the v0.9.330 pin cut; frontend-build failed on #172 after merge.
- Bump the assert (and describe label) to `0.9.330`. No product change.

## Test plan
- [ ] CI `frontend-build` green