### PR TITLE
Marionette v0.9.331 — drop remaining feed Motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.29` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.330, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.331, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.330"
+__version__ = "0.9.331"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.330"
+version = "0.9.331"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.330"
+version = "0.9.331"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.330",
+  "version": "0.9.331",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.330",
+      "version": "0.9.331",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.330",
+  "version": "0.9.331",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,18 +164,19 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.330)", () => {
-  it("declares the official motion package in webapp dependencies", () => {
+describe("feed Motion (v0.9.331)", () => {
+  it("declares the official motion package and 0.9.331 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.330");
+    expect(pkg.version).toBe("0.9.331");
+    expect(pkg.version).not.toBe("0.9.329");
   });
 
-  it("mounts transcript rows inside motion layout shells", () => {
+  it("mounts transcript rows in plain in-flow divs", () => {
     render(
       <TranscriptList
         {...listProps([
@@ -195,27 +196,33 @@ describe("feed Motion (v0.9.330)", () => {
     expect(feedLayoutMotionEnabled(null)).toBe(true);
   });
 
-  it("keeps layoutScroll on the feed scrollport and popLayout on in-flow presence", () => {
+  it("drops Motion layout on live tail and fallback; keeps Pretext overflow-anchor", () => {
     expect(column).toContain("layoutScroll");
     expect(column).toContain("[overflow-anchor:auto]");
     expect(column).toContain("[scroll-padding-bottom:var(--feed-chrome-clearance");
     expect(column).not.toContain("overflow-anchor:none");
-    expect(helpers).toContain('mode="popLayout"');
     expect(helpers).toContain("VIRTUAL_ROW_LAYOUT_ENABLED = false");
     expect(VIRTUAL_ROW_LAYOUT_ENABLED).toBe(false);
-    expect(list).toContain("FeedMotionPresence");
-    expect(list).toContain("VIRTUAL_ROW_LAYOUT_ENABLED");
+    expect(helpers).not.toContain('mode="popLayout"');
+    expect(helpers).not.toContain("AnimatePresence");
+    expect(list).not.toContain("FeedMotionPresence");
+    expect(list).not.toContain("FeedMotionRow");
+    expect(list).not.toContain("useFeedLayoutMotion");
+    expect(list).not.toMatch(/from ["']motion\/react["']/);
+    expect(list).not.toContain("layout={true}");
+    expect(list).not.toContain("layoutEnabled={true}");
+    expect(list).not.toContain("layout={feedLayout}");
+    expect(list).not.toContain("layoutEnabled={feedLayout}");
+    const tailSrc = list.split("transcript-live-tail")[1] ?? "";
+    expect(tailSrc).not.toMatch(/layout(?:Enabled)?=\{(?:true|feedLayout)\}/);
     expect(list).toContain("useVirtualizer");
     expect(list).toContain("transcript-live-tail");
-    expect(list).not.toMatch(
-      /useVirtualWindow[\s\S]*<FeedMotionPresence>[\s\S]*virtualItems\.map/,
-    );
     expect(list).not.toMatch(/from ["']node:/);
     expect(list).not.toMatch(/@stylexjs|create\(|stylex\./);
     expect(helpers).not.toMatch(/from ["']node:/);
   });
 
-  it("keeps distinct virtualizer translateY while feed layout is on", async () => {
+  it("keeps distinct virtualizer translateY", async () => {
     expect(feedLayoutMotionEnabled(false)).toBe(true);
     vi.stubGlobal("ResizeObserver", SizedResizeObserver);
     render(<VirtualFeedHarness items={longTranscript(40)} />);

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback, useDeferredValue, useSyncExternalStore, useMemo, memo, forwardRef, type ReactNode } from "react";
-import { motion } from "motion/react";
 import { useVirtualizer, type VirtualItem } from "@tanstack/react-virtual";
 import { ChevronRight, Loader2, ChevronDown, ChevronUp, Play, Copy, Check, Pencil, RefreshCw, History, Share2, CheckCircle2, XCircle, Eye, Shield } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -95,12 +94,6 @@ import {
   focusReviewTabAndRefresh,
   vaultCiteChipLabel,
 } from "./conversation/streamApply";
-import {
-  FeedMotionPresence,
-  FeedMotionRow,
-  VIRTUAL_ROW_LAYOUT_ENABLED,
-  useFeedLayoutMotion,
-} from "./conversation/feedMotion";
 
 export type Msg = {
   role: "user" | "assistant";
@@ -1062,9 +1055,8 @@ const VirtualTranscriptRow = memo(
   );
 
   return (
-    <FeedMotionRow
+    <div
       ref={attachDom && mountSettled ? setRowRef : forwardedRef}
-      layoutEnabled={VIRTUAL_ROW_LAYOUT_ENABLED}
       data-index={virtualRow.index}
       data-testid="transcript-virtual-row"
       data-dom-measure={attachDom ? "1" : "0"}
@@ -1074,7 +1066,7 @@ const VirtualTranscriptRow = memo(
       }}
     >
       {children}
-    </FeedMotionRow>
+    </div>
   );
   }),
 );
@@ -1827,7 +1819,6 @@ export const TranscriptList = memo(function TranscriptList({
     scrollParentSized,
     alreadyVirtualized: virtualizedOnceRef.current,
   });
-  const feedLayout = useFeedLayoutMotion();
   const list = useVirtualWindow ? (
     <div
       ref={listAnchorRef}
@@ -1854,42 +1845,36 @@ export const TranscriptList = memo(function TranscriptList({
         })}
     </div>
   ) : (
-    <motion.div
+    <div
       ref={listAnchorRef}
       data-testid="transcript-virtual-list"
       className="relative flex flex-col gap-1 w-full"
-      layout={feedLayout}
     >
-      <FeedMotionPresence>
-        {grouped.map((_, i) => {
-          const key = stableItemKey(grouped[i]!, i);
-          return (
-            <FeedMotionRow key={key} layoutEnabled={feedLayout} className="pb-1">
-              {renderGroupedItem(i)}
-            </FeedMotionRow>
-          );
-        })}
-      </FeedMotionPresence>
-    </motion.div>
+      {grouped.map((_, i) => {
+        const key = stableItemKey(grouped[i]!, i);
+        return (
+          <div key={key} className="pb-1">
+            {renderGroupedItem(i)}
+          </div>
+        );
+      })}
+    </div>
   );
   const liveTailList = useVirtualWindow && liveTailGrouped.length > 0 ? (
-    <motion.div
+    <div
       data-testid="transcript-live-tail"
       className="relative flex flex-col gap-1 w-full"
-      layout={feedLayout}
     >
-      <FeedMotionPresence>
-        {liveTailGrouped.map((_, i) => {
-          const idx = tailStartIndex + i;
-          const key = stableItemKey(grouped[idx]!, idx);
-          return (
-            <FeedMotionRow key={key} layoutEnabled={feedLayout} className="pb-1">
-              {renderGroupedItem(idx)}
-            </FeedMotionRow>
-          );
-        })}
-      </FeedMotionPresence>
-    </motion.div>
+      {liveTailGrouped.map((_, i) => {
+        const idx = tailStartIndex + i;
+        const key = stableItemKey(grouped[idx]!, idx);
+        return (
+          <div key={key} className="pb-1">
+            {renderGroupedItem(idx)}
+          </div>
+        );
+      })}
+    </div>
   ) : null;
 
   const busyProgress = deriveBusyProgress(items, status, busyElapsedMs);

--- a/webapp/src/components/conversation/feedMotion.tsx
+++ b/webapp/src/components/conversation/feedMotion.tsx
@@ -1,12 +1,12 @@
 /**
- * Feed-only Motion helpers (v0.9.318 / v0.9.329). Transcript enter/exit +
- * layout polish on in-flow rows; not used app-wide. Virtual window rows must
+ * Feed Motion leftovers (v0.9.331). Live tail + fallback are plain divs —
+ * no motion.div layout and no popLayout presence wrapper. Virtual window rows
  * never take a Motion layout transform — TanStack owns translateY.
- * prefers-reduced-motion stays off (animations run unless the user opted out).
+ * ConversationChatColumn still uses layoutScroll on the Pretext / overflow-anchor
+ * scrollport. prefers-reduced-motion stays off (animations run unless opted out).
  */
 
-import { forwardRef, memo, type CSSProperties, type ReactNode } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useReducedMotion } from "motion/react";
 
 /** Whether feed layout/presence animations should run. */
 export function feedLayoutMotionEnabled(reducedMotion: boolean | null): boolean {
@@ -21,61 +21,6 @@ export function useFeedLayoutMotion(): boolean {
 /**
  * Virtual window rows are `absolute top-0` + virtualizer translateY.
  * Motion `layout` / popLayout write `transform` and stack every row at y=0.
+ * Kept false: do not re-enable layout on virtual rows.
  */
 export const VIRTUAL_ROW_LAYOUT_ENABLED = false;
-
-type FeedMotionPresenceProps = {
-  children: ReactNode;
-};
-
-/** popLayout wrapper for in-flow transcript rows (fallback list + live tail). */
-export const FeedMotionPresence = memo(function FeedMotionPresence({
-  children,
-}: FeedMotionPresenceProps) {
-  return (
-    <AnimatePresence mode="popLayout" initial={false}>
-      {children}
-    </AnimatePresence>
-  );
-});
-
-type FeedMotionRowProps = {
-  layoutEnabled: boolean;
-  className?: string;
-  style?: CSSProperties;
-  children: ReactNode;
-  "data-index"?: number;
-  "data-testid"?: string;
-  "data-dom-measure"?: string;
-};
-
-/** One feed row shell: motion.div layout only when layoutEnabled. */
-export const FeedMotionRow = memo(
-  forwardRef<HTMLDivElement, FeedMotionRowProps>(function FeedMotionRow(
-    {
-      layoutEnabled,
-      className,
-      style,
-      children,
-      "data-index": dataIndex,
-      "data-testid": testId,
-      "data-dom-measure": domMeasure,
-    },
-    ref,
-  ) {
-    return (
-      <motion.div
-        ref={ref}
-        layout={layoutEnabled}
-        initial={false}
-        className={className}
-        style={style}
-        data-index={dataIndex}
-        data-testid={testId}
-        data-dom-measure={domMeasure}
-      >
-        {children}
-      </motion.div>
-    );
-  }),
-);


### PR DESCRIPTION
## Summary
- Drop remaining feed Motion on LIVE TAIL and fallback: plain divs, no layout, no popLayout, no motion.div.
- Drop FeedMotion from TranscriptList. Virtual rows stay VIRTUAL_ROW_LAYOUT_ENABLED=false with distinct TanStack translateY.
- Keep Pretext + TanStack + overflow-anchor. Activity/Investigating/collapse use in-flow own row heights (no stretch/rubber-band).
- Version 0.9.331 (not 329). Pin remains puppetmaster-ai==1.22.29.
- Not onboarding / not 323. Does not edit .github. Does not rewrite v0.9.329 or v0.9.330 tags.

## Test plan
- [x] npx vitest run src/__tests__/feedMotion.test.tsx
- [ ] CI tests matrix