### PR TITLE
Marionette v0.9.332 — chat UX stream remasure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.29` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.331, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.332, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.331"
+__version__ = "0.9.332"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.331"
+version = "0.9.332"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.331"
+version = "0.9.332"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.331",
+  "version": "0.9.332",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.331",
+      "version": "0.9.332",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.331",
+  "version": "0.9.332",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.331)", () => {
-  it("declares the official motion package and 0.9.331 not 329", () => {
+describe("feed Motion (v0.9.332)", () => {
+  it("declares the official motion package and 0.9.332 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.331");
+    expect(pkg.version).toBe("0.9.332");
     expect(pkg.version).not.toBe("0.9.329");
   });
 
@@ -197,7 +197,9 @@ describe("feed Motion (v0.9.331)", () => {
   });
 
   it("drops Motion layout on live tail and fallback; keeps Pretext overflow-anchor", () => {
-    expect(column).toContain("layoutScroll");
+    expect(column).not.toContain("layoutScroll");
+    expect(column).not.toContain("motion.div");
+    expect(column).not.toContain('from "motion/react"');
     expect(column).toContain("[overflow-anchor:auto]");
     expect(column).toContain("[scroll-padding-bottom:var(--feed-chrome-clearance");
     expect(column).not.toContain("overflow-anchor:none");
@@ -218,6 +220,10 @@ describe("feed Motion (v0.9.331)", () => {
     expect(list).toContain("useVirtualizer");
     expect(list).toContain("FEED_ROW_REMEASURE_EVENT");
     expect(list).toContain("requestFeedRowRemeasure");
+    expect(list).toContain("rowMeasureSignal");
+    expect(list).toContain("shouldRemeasureImmediately");
+    expect(list).toContain("measureSignal");
+    expect(list).toMatch(/Collapse \/ expand must remasure/);
     expect(list).toContain("transcript-live-tail");
     expect(list).not.toMatch(/from ["']node:/);
     expect(list).not.toMatch(/@stylexjs|create\(|stylex\./);

--- a/webapp/src/__tests__/transcriptRowHeight.test.ts
+++ b/webapp/src/__tests__/transcriptRowHeight.test.ts
@@ -6,9 +6,11 @@ import {
   hasMarkdownCodeFence,
   hasMarkdownImage,
   hasMermaidFence,
+  rowMeasureSignal,
   rowNeedsDomMeasure,
   rowPretextSpec,
   shouldAttachDomMeasure,
+  shouldRemeasureImmediately,
   stripMarkdownForPretext,
   transcriptBubbleMaxWidth,
   transcriptFeedInnerWidth,
@@ -141,5 +143,21 @@ describe("transcriptRowHeight", () => {
     expect(shouldAttachDomMeasure(rich, false)).toBe(false);
     expect(shouldAttachDomMeasure(rich, true)).toBe(true);
     expect(shouldAttachDomMeasure(msg("user", "plain"), true)).toBe(false);
+    const fold: GroupedItem = { kind: "activity_group", items: [] };
+    expect(shouldAttachDomMeasure(fold, false)).toBe(true);
+    expect(shouldAttachDomMeasure(fold, true)).toBe(true);
+    expect(shouldRemeasureImmediately(fold)).toBe(true);
+    expect(shouldRemeasureImmediately(msg("user", "plain"))).toBe(false);
+    const streaming: GroupedItem = {
+      kind: "msg",
+      msg: { role: "assistant", text: "Hel", streaming: true },
+    };
+    const grown: GroupedItem = {
+      kind: "msg",
+      msg: { role: "assistant", text: "Hello there", streaming: true },
+    };
+    expect(shouldRemeasureImmediately(streaming)).toBe(true);
+    expect(shouldAttachDomMeasure(streaming, false)).toBe(true);
+    expect(rowMeasureSignal(streaming)).not.toBe(rowMeasureSignal(grown));
   });
 });

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -84,7 +84,9 @@ import {
 } from "./conversation/transcriptVirtualWindow";
 import {
   createTranscriptRowHeightCache,
+  rowMeasureSignal,
   shouldAttachDomMeasure,
+  shouldRemeasureImmediately,
   transcriptFeedInnerWidth,
   TRANSCRIPT_ROW_FALLBACK_PX,
 } from "./conversation/transcriptRowHeight";
@@ -1029,11 +1031,18 @@ const VirtualTranscriptRow = memo(
   const rowRef = useRef<HTMLDivElement>(null);
   const [mountSettled, setMountSettled] = useState(false);
   const attachDom = shouldAttachDomMeasure(item, feedSettled);
-  const keepMeasure = attachDom || item.kind === "activity_group";
+  const remasureNow = shouldRemeasureImmediately(item);
+  const measureSignal = rowMeasureSignal(item);
+  const keepMeasure = attachDom || remasureNow || item.kind === "activity_group";
 
   useLayoutEffect(() => {
     if (!keepMeasure) {
       setMountSettled(false);
+      return;
+    }
+    // Stream tokens + Investigating collapse must remasure this frame.
+    if (remasureNow) {
+      setMountSettled(true);
       return;
     }
     setMountSettled(false);
@@ -1048,22 +1057,28 @@ const VirtualTranscriptRow = memo(
     };
     const outer = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(outer);
-  }, [keepMeasure, rowId]);
+  }, [keepMeasure, remasureNow, rowId]);
 
   useLayoutEffect(() => {
     const el = rowRef.current;
     if (!el) return;
+    // Collapse / expand must remasure so the fold pushes following rows
+    // (TanStack translateY uses the last measured height until remasure).
+    // Every stream token height change also remasures via measureSignal.
     const onRemeasure = () => {
       measureDom(el);
     };
     el.addEventListener(FEED_ROW_REMEASURE_EVENT, onRemeasure);
-    if (keepMeasure && (mountSettled || item.kind === "activity_group")) {
+    if (keepMeasure && (mountSettled || remasureNow)) {
       measureDom(el);
     }
+    const ro = typeof ResizeObserver !== "undefined" ? new ResizeObserver(onRemeasure) : null;
+    ro?.observe(el);
     return () => {
       el.removeEventListener(FEED_ROW_REMEASURE_EVENT, onRemeasure);
+      ro?.disconnect();
     };
-  }, [keepMeasure, mountSettled, measureDom, rowId, item.kind]);
+  }, [keepMeasure, remasureNow, mountSettled, measureDom, rowId, measureSignal]);
 
   const setRowRef = useCallback(
     (el: HTMLDivElement | null) => {

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -4,7 +4,6 @@
  */
 
 import { useLayoutEffect, useRef, useState, type CSSProperties, type MutableRefObject, type ReactNode, type RefObject } from "react";
-import { motion } from "motion/react";
 import { ChevronDown } from "lucide-react";
 import { panelOpacityClass } from "../../lib/panelTransition";
 import { feedBottomClearancePx, FEED_CHROME_CLEARANCE_VAR } from "./feedScroll";
@@ -93,9 +92,8 @@ export default function ConversationChatColumn({
       style={{ [FEED_CHROME_CLEARANCE_VAR]: `${clearancePx}px` } as CSSProperties}
     >
       <div className="relative flex-1 min-h-0 flex flex-col">
-        <motion.div
+        <div
           ref={feedRef}
-          layoutScroll
           className={`flex-1 min-h-0 overflow-y-auto overscroll-contain [overflow-anchor:auto] [scrollbar-gutter:stable] [scroll-padding-bottom:var(--feed-chrome-clearance,clamp(72px,12vh,144px))] ${panelOpacityClass(transcriptStale)}`}
         >
         {/* overflow-anchor:auto — browser tail anchoring during growth; scroll-padding-bottom
@@ -141,7 +139,7 @@ export default function ConversationChatColumn({
             onAuthFailureRetry={onAuthFailureRetry}
           />
         </div>
-      </motion.div>
+      </div>
       {showJumpToBottom ? (
         <button
           type="button"

--- a/webapp/src/components/conversation/feedMotion.tsx
+++ b/webapp/src/components/conversation/feedMotion.tsx
@@ -2,8 +2,8 @@
  * Feed Motion leftovers (v0.9.331). Live tail + fallback are plain divs —
  * no motion.div layout and no popLayout presence wrapper. Virtual window rows
  * never take a Motion layout transform — TanStack owns translateY.
- * ConversationChatColumn still uses layoutScroll on the Pretext / overflow-anchor
- * scrollport. prefers-reduced-motion stays off (animations run unless opted out).
+ * ConversationChatColumn scrollport is a plain div (no layoutScroll) with
+ * Pretext + overflow-anchor. prefers-reduced-motion stays off (animations run unless opted out).
  */
 
 import { useReducedMotion } from "motion/react";

--- a/webapp/src/components/conversation/transcriptRowHeight.ts
+++ b/webapp/src/components/conversation/transcriptRowHeight.ts
@@ -331,10 +331,35 @@ export function createTranscriptRowHeightCache(): TranscriptRowHeightCache {
   };
 }
 
+/** Signal that changes on every stream token / fold membership so rows remasure. */
+export function rowMeasureSignal(item: GroupedItem): string {
+  switch (item.kind) {
+    case "msg":
+      return `msg:${item.msg.streaming ? 1 : 0}:${item.msg.workerStream ? 1 : 0}:${item.msg.text.length}:${item.msg.text.slice(-32)}`;
+    case "thinking":
+      return `think:${item.streaming ? 1 : 0}:${item.text.length}:${item.text.slice(-32)}`;
+    case "activity_group":
+      return `fold:${item.items.length}`;
+    default:
+      return item.kind;
+  }
+}
+
+/** Immediate attach — skip the 2-rAF settle so tokens / folds remasure this frame. */
+export function shouldRemeasureImmediately(item: GroupedItem): boolean {
+  if (item.kind === "activity_group" || item.kind === "thinking") return true;
+  if (item.kind === "msg" && (item.msg.streaming || item.msg.workerStream)) return true;
+  return false;
+}
+
 /** Whether DOM measureElement may attach for this row (after mount settle). */
 export function shouldAttachDomMeasure(
   item: GroupedItem,
   feedSettled: boolean,
 ): boolean {
+  // Investigating / Explored folds and live stream rows change height in place.
+  // Attach measureElement even before feed settle so tokens / expand cannot
+  // paint over the next virtual row.
+  if (shouldRemeasureImmediately(item)) return true;
   return feedSettled && rowNeedsDomMeasure(item);
 }


### PR DESCRIPTION
## Summary
- Remasure live stream tokens (and keep fold remasure) so the virtual tail cannot overlay the next row.
- Drop leftover `layoutScroll` / `motion.div` on the ConversationChatColumn scrollport (plain `div` + Pretext overflow-anchor).
- Bump product version to 0.9.332. Pin stays `puppetmaster-ai==1.22.29`.

## Test plan
- [ ] `webapp` transcriptRowHeight + feedMotion tests
- [ ] Stream a long assistant reply and confirm the live tail does not paint over the following row
- [ ] Collapse / expand Investigating fold still pushes following rows