### PR TITLE
Marionette v0.9.333 — APFS journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.29` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.332, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.333, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.332"
+__version__ = "0.9.333"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/sqlite_journal.py
+++ b/harness/sqlite_journal.py
@@ -33,7 +33,8 @@ _LINUX_NETWORK_FSTYPES = frozenset(
     }
 )
 
-_DARWIN_NETWORK_FSTYPES = frozenset({6, 13, 26, 28})  # NFS, AFP, NETFS, SMBFS
+# 26 is APFS (local). Including it forced TRUNCATE on every Mac local DB (v0.9.316).
+_DARWIN_NETWORK_FSTYPES = frozenset({6, 13, 28})  # NFS, AFP, SMBFS
 
 
 def _linux_mount_is_network(path: str) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.332"
+version = "0.9.333"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_sqlite_journal.py
+++ b/tests/test_sqlite_journal.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import os
 import sqlite3
+import sys
 from pathlib import Path
 
 import pytest
 
 from harness.sqlite_journal import (
+    _DARWIN_NETWORK_FSTYPES,
+    _LINUX_NETWORK_FSTYPES,
     configure_sqlite_connection,
     host_scoped_state_path,
     is_network_filesystem,
@@ -116,3 +120,89 @@ def test_host_scoped_paths_under_state_and_root(path_suffix, tmp_path, monkeypat
     scoped = host_scoped_state_path(base, statfs=_network_on)
     assert "hosts" in scoped.parts
     assert scoped.name == Path(path_suffix).name
+
+
+def test_darwin_network_fstypes_exclude_local_apfs():
+    """f_type 26 is APFS (local). 316 treated it as NETFS and forced TRUNCATE."""
+    assert 26 not in _DARWIN_NETWORK_FSTYPES
+    assert _DARWIN_NETWORK_FSTYPES == frozenset({6, 13, 28})
+
+
+def _fstype_from_proc_mounts(path: str):
+    target = os.path.realpath(path)
+    best_len = -1
+    best = None
+    with open("/proc/mounts", encoding="utf-8") as mounts:
+        for raw_line in mounts:
+            parts = raw_line.split()
+            if len(parts) < 3:
+                continue
+            mount_point = parts[1].replace("\\040", " ")
+            mount_point = mount_point.rstrip("/") or "/"
+            if target == mount_point or (
+                mount_point != "/" and target.startswith(mount_point + os.sep)
+            ):
+                if len(mount_point) > best_len:
+                    best_len = len(mount_point)
+                    best = parts[2]
+    return best
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="real Darwin APFS/HFS detector")
+def test_darwin_local_disk_is_not_network_uses_wal(tmp_path):
+    """Real detector (no injected statfs): local APFS/HFS is not network."""
+    assert is_network_filesystem(tmp_path) is False
+    db = tmp_path / "local.sqlite"
+    conn = sqlite3.connect(str(db))
+    try:
+        mode = configure_sqlite_connection(conn, db)
+        assert mode == "wal"
+        row = conn.execute("PRAGMA journal_mode").fetchone()
+        assert row is not None
+        assert row[0].lower() == "wal"
+    finally:
+        conn.close()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="real Linux /proc/mounts detector")
+def test_linux_real_proc_mounts_cwd_and_tmp(tmp_path):
+    """Real detector agrees with /proc/mounts for cwd and a temp dir."""
+    for probe in (os.getcwd(), str(tmp_path)):
+        fstype = _fstype_from_proc_mounts(probe)
+        expected_network = False
+        if fstype is not None:
+            base = fstype.split(".", 1)[0].lower()
+            expected_network = (
+                base in _LINUX_NETWORK_FSTYPES
+                or fstype.lower() in _LINUX_NETWORK_FSTYPES
+            )
+        assert is_network_filesystem(probe) is expected_network
+        mode = journal_mode_for(Path(probe) / "probe.sqlite")
+        assert mode == ("truncate" if expected_network else "wal")
+    if not is_network_filesystem(tmp_path):
+        db = tmp_path / "local.sqlite"
+        conn = sqlite3.connect(str(db))
+        try:
+            mode = configure_sqlite_connection(conn, db)
+            assert mode == "wal"
+            row = conn.execute("PRAGMA journal_mode").fetchone()
+            assert row is not None
+            assert row[0].lower() == "wal"
+        finally:
+            conn.close()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="real Win32 drive-type detector")
+def test_win32_local_temp_is_not_network(tmp_path):
+    """Real detector: a local temp dir is not DRIVE_REMOTE / UNC."""
+    assert is_network_filesystem(tmp_path) is False
+    db = tmp_path / "local.sqlite"
+    conn = sqlite3.connect(str(db))
+    try:
+        mode = configure_sqlite_connection(conn, db)
+        assert mode == "wal"
+        row = conn.execute("PRAGMA journal_mode").fetchone()
+        assert row is not None
+        assert row[0].lower() == "wal"
+    finally:
+        conn.close()

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.332"
+version = "0.9.333"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.332",
+  "version": "0.9.333",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.332",
+      "version": "0.9.333",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.332",
+  "version": "0.9.333",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.332)", () => {
-  it("declares the official motion package and 0.9.332 not 329", () => {
+describe("feed Motion (v0.9.333)", () => {
+  it("declares the official motion package and 0.9.333 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.332");
+    expect(pkg.version).toBe("0.9.333");
     expect(pkg.version).not.toBe("0.9.329");
   });
 


### PR DESCRIPTION
## Summary
- Darwin `statfs` f_type 26 is local APFS, not a network filesystem. v0.9.316 listed it as NETFS, so every Mac local DB was forced into TRUNCATE.
- Keep 6/13/28 (NFS, AFP, SMBFS). Local APFS/HFS now uses WAL.
- Add a real-platform journal test (Darwin local disk; Linux `/proc/mounts` for cwd; Win32 local temp) in addition to the existing stubs.
- Bump product version to 0.9.333. Pin stays `puppetmaster-ai==1.22.29`.

## Test plan
- [ ] `pytest tests/test_sqlite_journal.py`
- [ ] On a Mac: local `~/.pmharness` SQLite DBs use WAL, not TRUNCATE solely because f_type==26
- [ ] Network mounts (NFS/AFP/SMB) still select TRUNCATE