### PR TITLE
Marionette v0.9.334 — onboarding store

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.29` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.333, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.334, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.333"
+__version__ = "0.9.334"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.333"
+version = "0.9.334"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.333"
+version = "0.9.334"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.333",
+  "version": "0.9.334",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.333",
+      "version": "0.9.334",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.333",
+  "version": "0.9.334",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -23,6 +23,11 @@ import {
 } from "./components/conversation/composerInput";
 import { openAgentWorkspace } from "./lib/agentLinks";
 import { reclampRailWidths } from "./lib/railLayout";
+import {
+  setConfigured,
+  setManual,
+  shouldAutoOpenOnboardingWizard,
+} from "./state/onboardingStore";
 
 const LS = {
   left: "pmharness.leftW",
@@ -188,25 +193,19 @@ export default function App() {
     };
   }, []);
 
-  // First-run behavior checking
+  // First-run gate: onboarding store decides whether to auto-open RegistryWizard.
   useEffect(() => {
     const checkSetupStatus = async () => {
-      const seen = localStorage.getItem("pmharness.wizardSeen");
-      if (seen === "1") return;
+      if (!shouldAutoOpenOnboardingWizard()) return;
 
       try {
         const provs = await api.providers();
         const hasAnyKey = provs.some((p) => p.has_key);
-        // Only auto-open the setup wizard when there is genuinely NO provider key
-        // configured (real first-run onboarding). Previously `seen === null` also
-        // forced it open, so it popped up on EVERY launch even with keys already
-        // set, until the user manually dismissed it. If a key already exists,
-        // mark the wizard as seen so it never nags again.
-        if (!hasAnyKey) {
-          setShowWizard(true);
-        } else {
-          localStorage.setItem("pmharness.wizardSeen", "1");
+        if (hasAnyKey) {
+          setConfigured(true);
+          return;
         }
+        setShowWizard(true);
       } catch (err) {
         console.error("Failed to check provider setup", err);
         // On a status-check failure, do NOT force the wizard open -- an API hiccup
@@ -314,7 +313,10 @@ export default function App() {
               ? "workers"
               : "keyless"
           }
-          onAddKey={() => setShowWizard(true)}
+          onAddKey={() => {
+            setManual(true);
+            setShowWizard(true);
+          }}
         />
       )}
       {config?.key_bootstrap_issues && config.key_bootstrap_issues.length > 0 && !showWizard && (
@@ -407,7 +409,10 @@ export default function App() {
               <RightPane
                 visible={rightOpen}
                 artifacts={artifacts}
-                onOpenWizard={() => setShowWizard(true)}
+                onOpenWizard={() => {
+                  setManual(true);
+                  setShowWizard(true);
+                }}
                 initialTab={pendingRightTab.current}
                 onEmpty={closeEmptyRightPane}
                 onRequestMinWidth={requestRightMinWidth}
@@ -423,7 +428,7 @@ export default function App() {
           onOpenEconomics={() => openRightTo("economics")} />
       </div>
 
-      {showWizard && <RegistryWizard onClose={() => { localStorage.setItem("pmharness.wizardSeen", "1"); setShowWizard(false); }} />}
+      {showWizard && <RegistryWizard onClose={() => setShowWizard(false)} />}
 
       <CommandPalette
         onToggleLeft={() => setLeftOpen((v) => !v)}

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.333)", () => {
-  it("declares the official motion package and 0.9.333 not 329", () => {
+describe("feed Motion (v0.9.334)", () => {
+  it("declares the official motion package and 0.9.334 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.333");
+    expect(pkg.version).toBe("0.9.334");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/components/RegistryWizard.tsx
+++ b/webapp/src/components/RegistryWizard.tsx
@@ -8,16 +8,17 @@ import {
   openOnboardingKeyUrl,
 } from "../lib/onboardingProviders";
 import { usePanelNotice } from "../lib/useOperationalDiagnostic";
+import { setConfigured, skipFirstRun } from "../state/onboardingStore";
 
 interface RegistryWizardProps {
   onClose: () => void;
 }
 
-function markWizardSeen(): void {
-  try {
-    localStorage.setItem("pmharness.wizardSeen", "1");
-  } catch {
-    // Private mode / quota — closing still works.
+function dismissWizard(configured = false): void {
+  if (configured) {
+    setConfigured(true);
+  } else {
+    skipFirstRun();
   }
 }
 
@@ -38,7 +39,7 @@ export default function RegistryWizard({ onClose }: RegistryWizardProps) {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        markWizardSeen();
+        dismissWizard();
         onClose();
       }
     };
@@ -70,7 +71,7 @@ export default function RegistryWizard({ onClose }: RegistryWizardProps) {
   }, []);
 
   const skip = () => {
-    markWizardSeen();
+    dismissWizard();
     onClose();
   };
 
@@ -85,7 +86,7 @@ export default function RegistryWizard({ onClose }: RegistryWizardProps) {
         throw new Error("Could not save that key.");
       }
       window.dispatchEvent(new Event("harness-config-changed"));
-      markWizardSeen();
+      dismissWizard(true);
       onClose();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Could not save that key.";

--- a/webapp/src/state/onboardingStore.test.ts
+++ b/webapp/src/state/onboardingStore.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getOnboardingState,
+  resetOnboardingForTests,
+  setConfigured,
+  setFlow,
+  setLocalEndpoint,
+  setManual,
+  setMode,
+  setProviderStatus,
+  shouldAutoOpenOnboardingWizard,
+  skipFirstRun,
+  subscribeOnboarding,
+} from "./onboardingStore";
+
+describe("onboardingStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetOnboardingForTests(false);
+  });
+
+  afterEach(() => {
+    resetOnboardingForTests(true);
+  });
+
+  it("starts with unknown configured and idle flow", () => {
+    expect(getOnboardingState()).toMatchObject({
+      configured: null,
+      flow: "idle",
+      mode: "apikey",
+      firstRunSkipped: false,
+      manual: false,
+      localEndpoint: "",
+      providerStatusByModel: {},
+    });
+  });
+
+  it("seeds configured from localStorage", () => {
+    localStorage.setItem("pmharness.onboarding.configured", "1");
+    resetOnboardingForTests(false);
+    expect(getOnboardingState().configured).toBe(true);
+  });
+
+  it("seeds firstRunSkipped from localStorage", () => {
+    localStorage.setItem("pmharness.onboarding.firstRunSkipped", "1");
+    resetOnboardingForTests(false);
+    expect(getOnboardingState().firstRunSkipped).toBe(true);
+  });
+
+  it("migrates legacy pmharness.wizardSeen into configured and firstRunSkipped", () => {
+    localStorage.setItem("pmharness.wizardSeen", "1");
+    resetOnboardingForTests(false);
+    const state = getOnboardingState();
+    expect(state.configured).toBe(true);
+    expect(state.firstRunSkipped).toBe(true);
+  });
+
+  it("persists skipFirstRun and blocks auto-open", () => {
+    skipFirstRun();
+    expect(getOnboardingState().firstRunSkipped).toBe(true);
+    expect(localStorage.getItem("pmharness.onboarding.firstRunSkipped")).toBe("1");
+    expect(localStorage.getItem("pmharness.wizardSeen")).toBe("1");
+    expect(shouldAutoOpenOnboardingWizard()).toBe(false);
+  });
+
+  it("persists setConfigured and blocks auto-open", () => {
+    setConfigured(true);
+    expect(getOnboardingState().configured).toBe(true);
+    expect(localStorage.getItem("pmharness.onboarding.configured")).toBe("1");
+    expect(localStorage.getItem("pmharness.wizardSeen")).toBe("1");
+    expect(shouldAutoOpenOnboardingWizard()).toBe(false);
+  });
+
+  it("setConfigured(false) records explicit not-configured", () => {
+    setConfigured(false);
+    expect(getOnboardingState().configured).toBe(false);
+    expect(localStorage.getItem("pmharness.onboarding.configured")).toBe("0");
+    expect(shouldAutoOpenOnboardingWizard()).toBe(true);
+  });
+
+  it("setManual blocks auto-open for the session", () => {
+    setManual(true);
+    expect(getOnboardingState().manual).toBe(true);
+    expect(shouldAutoOpenOnboardingWizard()).toBe(false);
+  });
+
+  it("auto-opens when unconfigured and not skipped", () => {
+    expect(shouldAutoOpenOnboardingWizard()).toBe(true);
+  });
+
+  it("updates flow and mode", () => {
+    setFlow("polling");
+    setMode("oauth");
+    expect(getOnboardingState()).toMatchObject({
+      flow: "polling",
+      mode: "oauth",
+    });
+    setFlow("confirming_model");
+    expect(getOnboardingState().flow).toBe("confirming_model");
+  });
+
+  it("tracks localEndpoint and provider status by model", () => {
+    setLocalEndpoint("http://127.0.0.1:11434");
+    setProviderStatus("llama3", { ready: true });
+    setProviderStatus("mistral", { ready: false });
+    expect(getOnboardingState().localEndpoint).toBe("http://127.0.0.1:11434");
+    expect(getOnboardingState().providerStatusByModel).toEqual({
+      llama3: { ready: true },
+      mistral: { ready: false },
+    });
+  });
+
+  it("notifies subscribers on patch", () => {
+    const listener = vi.fn();
+    const unsub = subscribeOnboarding(listener);
+    expect(listener).toHaveBeenCalledWith(getOnboardingState());
+
+    setFlow("submitting");
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.lastCall?.[0].flow).toBe("submitting");
+
+    unsub();
+    setFlow("success");
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("resetOnboardingForTests clears storage and rehydrates", () => {
+    setConfigured(true);
+    skipFirstRun();
+    setFlow("error");
+    setLocalEndpoint("http://example.test");
+
+    resetOnboardingForTests(true);
+    expect(localStorage.getItem("pmharness.onboarding.configured")).toBeNull();
+    expect(getOnboardingState()).toMatchObject({
+      configured: null,
+      flow: "idle",
+      firstRunSkipped: false,
+      localEndpoint: "",
+    });
+  });
+});

--- a/webapp/src/state/onboardingStore.ts
+++ b/webapp/src/state/onboardingStore.ts
@@ -1,0 +1,177 @@
+/**
+ * First-run onboarding state. Persists gate decisions to localStorage so reload
+ * keeps the wizard from nagging after skip or successful provider setup.
+ */
+
+const LS_CONFIGURED = "pmharness.onboarding.configured";
+const LS_FIRST_RUN_SKIPPED = "pmharness.onboarding.firstRunSkipped";
+const LS_WIZARD_SEEN = "pmharness.wizardSeen";
+
+export type OnboardingFlow =
+  | "idle"
+  | "starting"
+  | "awaiting_user"
+  | "polling"
+  | "external_pending"
+  | "submitting"
+  | "success"
+  | "confirming_model"
+  | "error";
+
+export type OnboardingMode = "apikey" | "oauth";
+
+export type OnboardingState = {
+  configured: boolean | null;
+  flow: OnboardingFlow;
+  mode: OnboardingMode;
+  firstRunSkipped: boolean;
+  manual: boolean;
+  localEndpoint: string;
+  providerStatusByModel: Record<string, unknown>;
+};
+
+type Listener = (state: OnboardingState) => void;
+
+function readConfigured(): boolean | null {
+  try {
+    const raw = localStorage.getItem(LS_CONFIGURED);
+    if (raw === "1") return true;
+    if (raw === "0") return false;
+    // Migrate legacy wizard-dismissed flag as "already handled".
+    if (localStorage.getItem(LS_WIZARD_SEEN) === "1") return true;
+  } catch {
+    // Private mode / quota — treat as unknown.
+  }
+  return null;
+}
+
+function readFirstRunSkipped(): boolean {
+  try {
+    if (localStorage.getItem(LS_FIRST_RUN_SKIPPED) === "1") return true;
+    if (localStorage.getItem(LS_WIZARD_SEEN) === "1") return true;
+  } catch {
+    // ignore
+  }
+  return false;
+}
+
+function persistConfigured(value: boolean): void {
+  try {
+    localStorage.setItem(LS_CONFIGURED, value ? "1" : "0");
+    if (value) localStorage.setItem(LS_WIZARD_SEEN, "1");
+  } catch {
+    // ignore
+  }
+}
+
+function persistFirstRunSkipped(): void {
+  try {
+    localStorage.setItem(LS_FIRST_RUN_SKIPPED, "1");
+    localStorage.setItem(LS_WIZARD_SEEN, "1");
+  } catch {
+    // ignore
+  }
+}
+
+let state: OnboardingState = {
+  configured: readConfigured(),
+  flow: "idle",
+  mode: "apikey",
+  firstRunSkipped: readFirstRunSkipped(),
+  manual: false,
+  localEndpoint: "",
+  providerStatusByModel: {},
+};
+
+const listeners = new Set<Listener>();
+
+function emit(): void {
+  for (const listener of listeners) listener(state);
+}
+
+function patch(partial: Partial<OnboardingState>): void {
+  state = { ...state, ...partial };
+  emit();
+}
+
+function rehydrateFromStorage(): void {
+  state = {
+    configured: readConfigured(),
+    flow: "idle",
+    mode: "apikey",
+    firstRunSkipped: readFirstRunSkipped(),
+    manual: false,
+    localEndpoint: "",
+    providerStatusByModel: {},
+  };
+}
+
+export function getOnboardingState(): OnboardingState {
+  return state;
+}
+
+export function subscribeOnboarding(listener: Listener): () => void {
+  listeners.add(listener);
+  listener(state);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** True when the first-run wizard should auto-open on launch. */
+export function shouldAutoOpenOnboardingWizard(
+  s: OnboardingState = state,
+): boolean {
+  if (s.firstRunSkipped || s.manual) return false;
+  if (s.configured === true) return false;
+  return true;
+}
+
+export function setConfigured(configured: boolean): void {
+  persistConfigured(configured);
+  patch({ configured });
+}
+
+export function setFlow(flow: OnboardingFlow): void {
+  patch({ flow });
+}
+
+export function setMode(mode: OnboardingMode): void {
+  patch({ mode });
+}
+
+export function skipFirstRun(): void {
+  persistFirstRunSkipped();
+  patch({ firstRunSkipped: true });
+}
+
+export function setManual(manual: boolean): void {
+  patch({ manual });
+}
+
+export function setLocalEndpoint(localEndpoint: string): void {
+  patch({ localEndpoint });
+}
+
+export function setProviderStatus(
+  model: string,
+  status: unknown,
+): void {
+  patch({
+    providerStatusByModel: { ...state.providerStatusByModel, [model]: status },
+  });
+}
+
+export function resetOnboardingForTests(clearStorage = true): void {
+  if (clearStorage) {
+    try {
+      localStorage.removeItem(LS_CONFIGURED);
+      localStorage.removeItem(LS_FIRST_RUN_SKIPPED);
+      localStorage.removeItem(LS_WIZARD_SEEN);
+    } catch {
+      // ignore
+    }
+  }
+  rehydrateFromStorage();
+  emit();
+}

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/__tests__/setup.ts"],
     css: true,
-    include: ["src/__tests__/**/*.{test,spec}.{ts,tsx}"],
+    include: [
+      "src/__tests__/**/*.{test,spec}.{ts,tsx}",
+      "src/state/**/*.test.ts",
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- Add a Marionette-sized onboarding store (`configured`, flow, mode, firstRunSkipped, manual, localEndpoint, providerStatusByModel) with localStorage seed and store-transition tests.
- Gate first-run `RegistryWizard` on the store (`configured` / `firstRunSkipped` / `manual`) instead of `!hasAnyKey` + `pmharness.wizardSeen`. Wizard stays mounted; overlay is 335.
- Bump product version to 0.9.334 (including feedMotion version assert). Pin stays `puppetmaster-ai==1.22.29`.

## Test plan
- [ ] Store tests: seed from localStorage, migrate `wizardSeen`, skip / configured / manual block auto-open, flow/mode/status transitions
- [ ] First-run with no key still opens `RegistryWizard`
- [ ] Existing key or prior skip does not nag
- [ ] Manual open from key banner / right pane still works
- [ ] frontend-build: feedMotion asserts 0.9.334