### PR TITLE
Marionette v0.9.335 — onboarding overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.29` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.334, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.335, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.334"
+__version__ = "0.9.335"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.334"
+version = "0.9.335"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.334"
+version = "0.9.335"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.334",
+  "version": "0.9.335",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.334",
+      "version": "0.9.335",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.334",
+  "version": "0.9.335",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -15,6 +15,7 @@ import KeyBootstrapBanner from "./components/KeyBootstrapBanner";
 import { focusSettingsPage } from "./components/SettingsShell";
 import Resizer from "./components/Resizer";
 import RegistryWizard from "./components/RegistryWizard";
+import OnboardingOverlay from "./components/OnboardingOverlay";
 import ErrorBoundary from "./components/ErrorBoundary";
 import CommandPalette from "./components/CommandPalette";
 import {
@@ -133,6 +134,7 @@ export default function App() {
   }, [leftOpen]);
 
   const [showWizard, setShowWizard] = useState(false);
+  const [showOverlay, setShowOverlay] = useState(false);
 
   const fetchConfig = () => {
     api.config().then(setConfig).catch(() => {});
@@ -193,7 +195,7 @@ export default function App() {
     };
   }, []);
 
-  // First-run gate: onboarding store decides whether to auto-open RegistryWizard.
+  // First-run gate: onboarding store decides whether to auto-open OnboardingOverlay.
   useEffect(() => {
     const checkSetupStatus = async () => {
       if (!shouldAutoOpenOnboardingWizard()) return;
@@ -205,7 +207,7 @@ export default function App() {
           setConfigured(true);
           return;
         }
-        setShowWizard(true);
+        setShowOverlay(true);
       } catch (err) {
         console.error("Failed to check provider setup", err);
         // On a status-check failure, do NOT force the wizard open -- an API hiccup
@@ -306,7 +308,7 @@ export default function App() {
       {/* Keyless nudge: agentic is the shipped default, so instead of a demo run
           we tell the user to plug in a key. Suppressed while the first-run wizard
           is up (it already covers key setup) to avoid stacking two prompts. */}
-      {config && (config.workers_ready ?? config.agentic_ready) === false && !showWizard && (
+      {config && (config.workers_ready ?? config.agentic_ready) === false && !showWizard && !showOverlay && (
         <ProviderKeyBanner
           variant={
             config.pilot_ready && (config.workers_ready ?? config.agentic_ready) === false
@@ -319,7 +321,7 @@ export default function App() {
           }}
         />
       )}
-      {config?.key_bootstrap_issues && config.key_bootstrap_issues.length > 0 && !showWizard && (
+      {config?.key_bootstrap_issues && config.key_bootstrap_issues.length > 0 && !showWizard && !showOverlay && (
         <KeyBootstrapBanner
           issues={config.key_bootstrap_issues}
           onOpenSettings={() => {
@@ -428,6 +430,7 @@ export default function App() {
           onOpenEconomics={() => openRightTo("economics")} />
       </div>
 
+      {showOverlay && <OnboardingOverlay onClose={() => setShowOverlay(false)} />}
       {showWizard && <RegistryWizard onClose={() => setShowWizard(false)} />}
 
       <CommandPalette

--- a/webapp/src/__tests__/OnboardingOverlay.test.tsx
+++ b/webapp/src/__tests__/OnboardingOverlay.test.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import OnboardingOverlay from "../components/OnboardingOverlay";
+import overlaySrc from "../components/OnboardingOverlay.tsx?raw";
+import apiSrc from "../lib/api.ts?raw";
+import { api } from "../lib/api";
+import { FEATURED_OAUTH_ORDER } from "../lib/onboardingProviders";
+import {
+  getOnboardingState,
+  resetOnboardingForTests,
+} from "../state/onboardingStore";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    providers: vi.fn(),
+    setProviderKey: vi.fn(),
+    startAuthOAuth: vi.fn(),
+    pollAuthOAuth: vi.fn(),
+    completeAuthOAuth: vi.fn(),
+    cancelAuthOAuth: vi.fn(),
+  },
+}));
+
+function provider(name: string, extra: Record<string, unknown> = {}) {
+  return {
+    name,
+    display_name: name,
+    env_var: `${name.toUpperCase()}_API_KEY`,
+    base_url: "",
+    has_key: false,
+    api_mode: "chat_completions",
+    worker_capability: "full_stack" as const,
+    ...extra,
+  };
+}
+
+const providers = [
+  provider("openrouter", { display_name: "OpenRouter", env_var: "OPENROUTER_API_KEY" }),
+  provider("anthropic", { display_name: "Anthropic", env_var: "ANTHROPIC_API_KEY" }),
+  provider("openai-codex", { display_name: "ChatGPT Codex (OAuth)", env_var: "OPENAI_CODEX_TOKEN" }),
+  provider("nous", { display_name: "Nous Portal (OAuth)", env_var: "NOUS_API_KEY" }),
+  provider("xai", { display_name: "xAI Grok", env_var: "XAI_API_KEY" }),
+  provider("qwen-oauth", { display_name: "Qwen OAuth" }),
+  provider("minimax-oauth", { display_name: "MiniMax OAuth" }),
+  provider("cursor-cli", { display_name: "Cursor CLI (plan)", worker_capability: "pilot_only" }),
+];
+
+describe("OnboardingOverlay featured vs key rows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("open", vi.fn());
+    localStorage.clear();
+    resetOnboardingForTests(true);
+    vi.mocked(api.providers).mockResolvedValue(providers);
+    vi.mocked(api.setProviderKey).mockResolvedValue({
+      ok: true,
+      provider: "openrouter",
+      has_key: true,
+      masked: "sk-or-…",
+    });
+    vi.mocked(api.startAuthOAuth).mockResolvedValue({
+      session_id: "sess-1",
+      provider: "openai-codex",
+      user_code: "ABCD-1234",
+      verification_uri: "https://example.test/device",
+    });
+    vi.mocked(api.pollAuthOAuth).mockResolvedValue({
+      status: "done",
+      provider: "openai-codex",
+      label: "chatgpt",
+    });
+    vi.mocked(api.completeAuthOAuth).mockResolvedValue({
+      status: "done",
+      provider: "anthropic",
+      label: "claude-max",
+    });
+    vi.mocked(api.cancelAuthOAuth).mockResolvedValue({ ok: true });
+  });
+
+  it("wires OAuth to existing /api/auth/oauth helpers, not /api/providers/oauth", () => {
+    expect(overlaySrc).toContain("startAuthOAuth");
+    expect(overlaySrc).toContain("pollAuthOAuth");
+    expect(overlaySrc).toContain("completeAuthOAuth");
+    expect(overlaySrc).toContain("cancelAuthOAuth");
+    expect(overlaySrc).not.toContain("/api/providers/oauth");
+    expect(apiSrc).toContain('"/api/auth/oauth/start"');
+    expect(apiSrc).toContain('"/api/auth/oauth/poll"');
+    expect(apiSrc).toContain('"/api/auth/oauth/complete"');
+    expect(apiSrc).toContain('"/api/auth/oauth/cancel"');
+    expect(apiSrc).not.toContain("/api/providers/oauth");
+    expect(overlaySrc).toContain("FeaturedProviderRow");
+    expect(overlaySrc).toContain("KeyProviderRow");
+  });
+
+  it("renders featured OAuth rows and key paste rows", async () => {
+    render(<OnboardingOverlay onClose={vi.fn()} />);
+    expect(await screen.findByTestId("onboarding-overlay")).toBeTruthy();
+
+    const featured = screen.getAllByTestId("featured-provider-row");
+    expect(featured.map((el) => el.getAttribute("data-provider"))).toEqual([
+      ...FEATURED_OAUTH_ORDER,
+    ]);
+    expect(screen.getByText("ChatGPT Codex")).toBeTruthy();
+    expect(screen.getByText("Claude Max")).toBeTruthy();
+    expect(screen.getByText("xAI SuperGrok")).toBeTruthy();
+    expect(screen.getByText("Nous Portal")).toBeTruthy();
+
+    const keys = screen.getAllByTestId("key-provider-row");
+    const keyNames = keys.map((el) => el.getAttribute("data-provider"));
+    expect(keyNames).toContain("openrouter");
+    expect(keyNames).toContain("xai");
+    expect(keyNames).not.toContain("anthropic");
+    expect(keyNames).not.toContain("openai-codex");
+    expect(keyNames).not.toContain("nous");
+    expect(keyNames).not.toContain("xai-oauth");
+    expect(featured.map((el) => el.getAttribute("data-provider"))).not.toContain("qwen-oauth");
+    expect(featured.map((el) => el.getAttribute("data-provider"))).not.toContain("minimax-oauth");
+    expect(screen.queryByText("Cursor CLI (plan)")).toBeNull();
+  });
+
+  it("skip sets firstRunSkipped and closes without saving", async () => {
+    const onClose = vi.fn();
+    render(<OnboardingOverlay onClose={onClose} />);
+    await screen.findByTestId("onboarding-overlay");
+    fireEvent.click(screen.getByRole("button", { name: /choose a provider later/i }));
+    expect(api.setProviderKey).not.toHaveBeenCalled();
+    expect(api.startAuthOAuth).not.toHaveBeenCalled();
+    expect(getOnboardingState().firstRunSkipped).toBe(true);
+    expect(localStorage.getItem("pmharness.onboarding.firstRunSkipped")).toBe("1");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("key row keeps the paste path via setProviderKey", async () => {
+    const onClose = vi.fn();
+    render(<OnboardingOverlay onClose={onClose} />);
+    await screen.findByTestId("onboarding-overlay");
+    fireEvent.change(screen.getByPlaceholderText("OPENROUTER_API_KEY"), {
+      target: { value: "sk-or-test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Connect/i }));
+    await waitFor(() => {
+      expect(api.setProviderKey).toHaveBeenCalledWith("openrouter", "sk-or-test");
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+    expect(getOnboardingState().configured).toBe(true);
+    expect(getOnboardingState().mode).toBe("apikey");
+  });
+
+  it("featured Sign in starts the existing auth oauth device flow", async () => {
+    const onClose = vi.fn();
+    render(<OnboardingOverlay onClose={onClose} />);
+    await screen.findByTestId("onboarding-overlay");
+    const rows = screen.getAllByTestId("featured-provider-row");
+    const codex = rows.find((el) => el.getAttribute("data-provider") === "openai-codex");
+    expect(codex).toBeTruthy();
+    fireEvent.click(codex!.querySelector("button") as HTMLButtonElement);
+    await waitFor(() => {
+      expect(api.startAuthOAuth).toHaveBeenCalledWith("openai-codex");
+      expect(api.pollAuthOAuth).toHaveBeenCalledWith("sess-1", "openai-codex");
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+    expect(getOnboardingState().configured).toBe(true);
+    expect(getOnboardingState().mode).toBe("oauth");
+  });
+});

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.334)", () => {
-  it("declares the official motion package and 0.9.334 not 329", () => {
+describe("feed Motion (v0.9.335)", () => {
+  it("declares the official motion package and 0.9.335 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.334");
+    expect(pkg.version).toBe("0.9.335");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/onboardingProviders.test.ts
+++ b/webapp/src/__tests__/onboardingProviders.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { ProviderInfo } from "../lib/api";
 import {
+  FEATURED_OAUTH,
+  FEATURED_OAUTH_ORDER,
   defaultOnboardingProvider,
+  featuredOnboardingProviders,
+  isFeaturedOAuth,
   isOnboardableProvider,
+  keyOnboardingProviders,
   onboardableProviders,
   onboardingCopy,
 } from "../lib/onboardingProviders";
@@ -55,5 +60,48 @@ describe("onboardingProviders", () => {
     expect(onboardingCopy("opencode-zen").keyUrl).toBe("https://opencode.ai/docs/zen/");
     expect(onboardingCopy("opencode-zen").tagline).toMatch(/ox alpha/i);
     expect(isOnboardableProvider(provider("opencode-zen"))).toBe(true);
+  });
+});
+
+describe("featured vs key onboarding rows", () => {
+  it("features only wired OAuth start handlers", () => {
+    expect([...FEATURED_OAUTH_ORDER]).toEqual([
+      "openai-codex",
+      "anthropic",
+      "xai-oauth",
+      "nous",
+    ]);
+    expect(isFeaturedOAuth("qwen-oauth")).toBe(false);
+    expect(isFeaturedOAuth("minimax-oauth")).toBe(false);
+    expect(FEATURED_OAUTH.has("qwen-oauth")).toBe(false);
+    expect(FEATURED_OAUTH.has("minimax-oauth")).toBe(false);
+  });
+
+  it("always lists the four featured rows, including synthetic xai-oauth", () => {
+    const featured = featuredOnboardingProviders([
+      provider("openrouter"),
+      provider("anthropic"),
+      provider("qwen-oauth"),
+      provider("minimax-oauth"),
+    ]);
+    expect(featured.map((p) => p.name)).toEqual([
+      "openai-codex",
+      "anthropic",
+      "xai-oauth",
+      "nous",
+    ]);
+    expect(featured.some((p) => p.name === "qwen-oauth")).toBe(false);
+  });
+
+  it("keeps paste-key rows out of featured OAuth names", () => {
+    const keys = keyOnboardingProviders([
+      provider("openrouter"),
+      provider("anthropic"),
+      provider("openai-codex"),
+      provider("nous"),
+      provider("xai"),
+      provider("qwen-oauth"),
+    ]);
+    expect(keys.map((p) => p.name)).toEqual(["openrouter", "xai", "qwen-oauth"]);
   });
 });

--- a/webapp/src/components/OnboardingOverlay.tsx
+++ b/webapp/src/components/OnboardingOverlay.tsx
@@ -1,0 +1,494 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ExternalLink, KeyRound, LogIn } from "lucide-react";
+import { api, type ProviderInfo } from "../lib/api";
+import {
+  FEATURED_LABELS,
+  featuredOnboardingProviders,
+  featuredOAuthKind,
+  keyOnboardingProviders,
+  onboardingCopy,
+  openOnboardingKeyUrl,
+  type FeaturedOAuthName,
+} from "../lib/onboardingProviders";
+import { usePanelNotice } from "../lib/useOperationalDiagnostic";
+import { setConfigured, setFlow, setMode, skipFirstRun } from "../state/onboardingStore";
+
+export type OnboardingOverlayProps = {
+  onClose: () => void;
+};
+
+function finishConfigured(onClose: () => void): void {
+  setFlow("success");
+  setConfigured(true);
+  window.dispatchEvent(new Event("harness-config-changed"));
+  onClose();
+}
+
+function finishSkip(onClose: () => void): void {
+  skipFirstRun();
+  onClose();
+}
+
+export type FeaturedProviderRowProps = {
+  provider: ProviderInfo;
+  busy: boolean;
+  hint: string;
+  error: string;
+  sessionId: string;
+  pasteCode: string;
+  onPasteCode: (value: string) => void;
+  onSignIn: () => void;
+  onComplete: () => void;
+  onCancel: () => void;
+};
+
+export function FeaturedProviderRow({
+  provider,
+  busy,
+  hint,
+  error,
+  sessionId,
+  pasteCode,
+  onPasteCode,
+  onSignIn,
+  onComplete,
+  onCancel,
+}: FeaturedProviderRowProps) {
+  const copy = onboardingCopy(provider.name);
+  const label =
+    FEATURED_LABELS[provider.name as FeaturedOAuthName] ||
+    provider.display_name ||
+    provider.name;
+  const pkce = featuredOAuthKind(provider.name) === "pkce";
+  const errorNotice = usePanelNotice(error || null);
+
+  return (
+    <div
+      data-testid="featured-provider-row"
+      data-provider={provider.name}
+      className="rounded-lg border border-edge/70 bg-panel2 px-3 py-2.5"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[13px] font-semibold text-txt leading-tight">{label}</div>
+          <div className="text-[11px] text-muted mt-0.5 leading-snug">{copy.tagline}</div>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          {busy || sessionId ? (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="text-[11px] text-muted hover:text-txt border border-edge rounded px-2 py-1"
+            >
+              Cancel
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={onSignIn}
+            disabled={busy}
+            className="inline-flex items-center gap-1 bg-good/10 hover:bg-good/20 text-good border border-good/30 rounded px-2.5 py-1 text-[11px] font-medium disabled:opacity-35"
+          >
+            <LogIn size={12} />
+            {busy ? (pkce ? "Waiting for code…" : "Waiting…") : "Sign in"}
+          </button>
+        </div>
+      </div>
+      {hint ? (
+        <p className="mt-1.5 text-[11px] text-accent font-mono leading-normal">{hint}</p>
+      ) : null}
+      {pkce && sessionId ? (
+        <div className="mt-2 flex items-center gap-2">
+          <input
+            type="text"
+            value={pasteCode}
+            onChange={(e) => onPasteCode(e.target.value)}
+            placeholder="paste authorization code#state"
+            className="flex-1 bg-bg border border-edge rounded-lg px-2.5 py-1.5 text-[12px] font-mono text-txt placeholder:text-faint focus:outline-none focus:border-accent"
+          />
+          <button
+            type="button"
+            onClick={onComplete}
+            disabled={busy || !pasteCode.trim()}
+            className="bg-accent/15 hover:bg-accent/25 text-accent border border-accent/30 rounded px-2.5 py-1 text-[11px] font-medium disabled:opacity-35"
+          >
+            Complete
+          </button>
+        </div>
+      ) : null}
+      {errorNotice ? (
+        <p className="mt-1.5 text-[11px] text-risk" role="alert">
+          {errorNotice}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export type KeyProviderRowProps = {
+  provider: ProviderInfo;
+  expanded: boolean;
+  onExpand: () => void;
+  disabled: boolean;
+  onConnected: () => void;
+};
+
+export function KeyProviderRow({
+  provider,
+  expanded,
+  onExpand,
+  disabled,
+  onConnected,
+}: KeyProviderRowProps) {
+  const [keyValue, setKeyValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const copy = onboardingCopy(provider.name);
+  const errorNotice = usePanelNotice(error || null);
+  const canConnect = Boolean(keyValue.trim()) && !saving && !disabled;
+
+  const connect = async () => {
+    const key = keyValue.trim();
+    if (!key) return;
+    setSaving(true);
+    setError("");
+    setMode("apikey");
+    setFlow("submitting");
+    try {
+      const res = await api.setProviderKey(provider.name, key);
+      if (!res?.ok) {
+        throw new Error("Could not save that key.");
+      }
+      onConnected();
+    } catch (err: unknown) {
+      setFlow("error");
+      setError(err instanceof Error ? err.message : "Could not save that key.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid="key-provider-row"
+      data-provider={provider.name}
+      className={`rounded-lg border px-3 py-2.5 ${
+        expanded ? "border-accent bg-accent/10" : "border-edge/70 bg-panel2"
+      }`}
+    >
+      <button
+        type="button"
+        onClick={onExpand}
+        disabled={disabled}
+        className="w-full text-left"
+      >
+        <div className="text-[13px] font-semibold text-txt leading-tight">
+          {provider.display_name || provider.name}
+        </div>
+        <div className="text-[11px] text-muted mt-0.5 leading-snug">{copy.tagline}</div>
+      </button>
+      {expanded ? (
+        <form
+          className="mt-2.5"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void connect();
+          }}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <p className="text-[12px] text-muted leading-relaxed">{copy.blurb}</p>
+            {copy.keyUrl ? (
+              <button
+                type="button"
+                onClick={() => openOnboardingKeyUrl(copy.keyUrl!)}
+                className="shrink-0 inline-flex items-center gap-1 text-[12px] text-accent hover:underline pt-0.5"
+              >
+                Get a key
+                <ExternalLink size={11} />
+              </button>
+            ) : null}
+          </div>
+          <input
+            type="password"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder={provider.env_var || "API key"}
+            value={keyValue}
+            onChange={(e) => setKeyValue(e.target.value)}
+            disabled={saving || disabled}
+            className="mt-2 w-full bg-bg border border-edge rounded-lg px-3 py-2 text-[13px] font-mono text-txt placeholder:text-faint focus:outline-none focus:border-accent disabled:opacity-50"
+          />
+          {errorNotice ? (
+            <p className="mt-2 text-[12px] text-risk" role="alert">
+              {errorNotice}
+            </p>
+          ) : null}
+          <div className="mt-2 flex justify-end">
+            <button
+              type="submit"
+              disabled={!canConnect}
+              className="inline-flex items-center gap-1.5 bg-accent text-panel font-semibold rounded-lg px-3.5 py-1.5 text-[12.5px] hover:brightness-110 disabled:opacity-35 disabled:hover:brightness-100 transition"
+            >
+              <KeyRound size={13} />
+              {saving ? "Connecting…" : "Connect"}
+            </button>
+          </div>
+        </form>
+      ) : null}
+    </div>
+  );
+}
+
+export default function OnboardingOverlay({ onClose }: OnboardingOverlayProps) {
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [selectedKey, setSelectedKey] = useState("");
+  const [oauthName, setOauthName] = useState("");
+  const [oauthBusy, setOauthBusy] = useState(false);
+  const [oauthHint, setOauthHint] = useState("");
+  const [oauthError, setOauthError] = useState("");
+  const [oauthSessionId, setOauthSessionId] = useState("");
+  const [oauthPasteCode, setOauthPasteCode] = useState("");
+  const abortRef = useRef(false);
+  const loadNotice = usePanelNotice(loadError || null);
+
+  const featured = useMemo(() => featuredOnboardingProviders(providers), [providers]);
+  const keyRows = useMemo(() => keyOnboardingProviders(providers), [providers]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") finishSkip(onClose);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setLoadError("");
+      try {
+        const list = await api.providers();
+        if (cancelled) return;
+        setProviders(list);
+        const keys = keyOnboardingProviders(list);
+        setSelectedKey(keys[0]?.name || "");
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err.message : "Failed to load providers.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current = true;
+    };
+  }, []);
+
+  const cancelOAuth = () => {
+    abortRef.current = true;
+    const sid = oauthSessionId;
+    const name = oauthName;
+    if (sid) {
+      api.cancelAuthOAuth(sid, name).catch(() => {
+        /* best-effort */
+      });
+    }
+    setOauthBusy(false);
+    setOauthSessionId("");
+    setOauthPasteCode("");
+    setOauthHint("Sign-in cancelled — click Sign in to try again.");
+    setFlow("idle");
+  };
+
+  const signInFeatured = async (provider: ProviderInfo) => {
+    abortRef.current = false;
+    setOauthName(provider.name);
+    setOauthBusy(true);
+    setOauthHint("");
+    setOauthError("");
+    setOauthSessionId("");
+    setOauthPasteCode("");
+    setMode("oauth");
+    setFlow("starting");
+    try {
+      const start = await api.startAuthOAuth(provider.name);
+      if (!start.session_id) {
+        throw new Error(start.error || "oauth start failed");
+      }
+      setOauthSessionId(start.session_id);
+      const kind = featuredOAuthKind(provider.name);
+      if (kind === "pkce") {
+        if (!start.auth_url) {
+          throw new Error(start.error || "oauth start failed");
+        }
+        setFlow("awaiting_user");
+        setOauthHint("Browser opened — authorize, then paste the code below (code#state).");
+        try {
+          openOnboardingKeyUrl(start.auth_url);
+        } catch {
+          setOauthHint(`Open ${start.auth_url} then paste the code below.`);
+        }
+        return;
+      }
+      if (!start.user_code) {
+        throw new Error(start.error || "oauth start failed");
+      }
+      setFlow("awaiting_user");
+      setOauthHint(`Enter code ${start.user_code} at ${start.verification_uri || "the login page"}`);
+      const verify = start.verification_uri_complete || start.verification_uri;
+      if (verify) {
+        try {
+          openOnboardingKeyUrl(verify);
+        } catch {
+          /* ignore */
+        }
+      }
+      setFlow("polling");
+      const deadline = Date.now() + (start.expires_in || 900) * 1000;
+      const intervalMs = Math.max(1, start.interval || 5) * 1000;
+      while (Date.now() < deadline) {
+        if (abortRef.current) {
+          setOauthHint("Sign-in cancelled — click Sign in to try again.");
+          setFlow("idle");
+          return;
+        }
+        const poll = await api.pollAuthOAuth(start.session_id, provider.name);
+        if (poll.status === "done") {
+          finishConfigured(onClose);
+          return;
+        }
+        if (poll.status === "error") {
+          throw new Error(poll.error || "oauth failed");
+        }
+        await new Promise((r) => setTimeout(r, intervalMs));
+      }
+      throw new Error("Login timed out — click Sign in to try again.");
+    } catch (err: unknown) {
+      setFlow("error");
+      setOauthError(err instanceof Error ? err.message : `${provider.name} sign-in failed`);
+      setOauthSessionId("");
+    } finally {
+      setOauthBusy(false);
+    }
+  };
+
+  const completeAnthropic = async () => {
+    const code = oauthPasteCode.trim();
+    if (!oauthSessionId || !code) return;
+    setOauthBusy(true);
+    setOauthError("");
+    setFlow("submitting");
+    try {
+      const res = await api.completeAuthOAuth(oauthSessionId, code, "anthropic");
+      if (res.status !== "done") {
+        throw new Error(res.error || "oauth complete failed");
+      }
+      finishConfigured(onClose);
+    } catch (err: unknown) {
+      setFlow("error");
+      setOauthError(err instanceof Error ? err.message : "Claude sign-in failed");
+    } finally {
+      setOauthBusy(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid="onboarding-overlay"
+      className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6"
+      style={{
+        background:
+          "radial-gradient(ellipse at 50% 38%, rgba(224,164,90,0.08) 0%, transparent 52%), #0f1113",
+      }}
+    >
+      <div className="onboarding-card w-full max-w-[36rem] max-h-full overflow-y-auto rounded-2xl border border-edge bg-panel px-7 py-8 shadow-[0_24px_80px_rgba(0,0,0,0.45)]">
+        <header className="text-center mb-6">
+          <h1 className="text-[1.45rem] font-semibold tracking-tight text-txt leading-tight">
+            Let&apos;s get you set up with Marionette
+          </h1>
+          <p className="mt-2 text-[13px] text-muted leading-relaxed">
+            Sign in with a plan or paste a Full stack key. One credential runs chat and swarms.
+          </p>
+        </header>
+
+        {loading ? (
+          <p className="text-center text-muted text-[13px] py-10">Loading providers…</p>
+        ) : (
+          <>
+            {loadNotice ? (
+              <p className="mb-4 text-center text-[12px] text-risk" role="alert">
+                {loadNotice}
+              </p>
+            ) : null}
+
+            <section aria-label="Featured plan sign-in">
+              <h2 className="text-[11px] font-semibold uppercase tracking-wide text-muted mb-2">
+                Sign in with a plan
+              </h2>
+              <div className="space-y-2">
+                {featured.map((p) => (
+                  <FeaturedProviderRow
+                    key={p.name}
+                    provider={p}
+                    busy={oauthBusy && oauthName === p.name}
+                    hint={oauthName === p.name ? oauthHint : ""}
+                    error={oauthName === p.name ? oauthError : ""}
+                    sessionId={oauthName === p.name ? oauthSessionId : ""}
+                    pasteCode={oauthName === p.name ? oauthPasteCode : ""}
+                    onPasteCode={setOauthPasteCode}
+                    onSignIn={() => void signInFeatured(p)}
+                    onComplete={() => void completeAnthropic()}
+                    onCancel={cancelOAuth}
+                  />
+                ))}
+              </div>
+            </section>
+
+            <section className="mt-6" aria-label="API key providers">
+              <h2 className="text-[11px] font-semibold uppercase tracking-wide text-muted mb-2">
+                Or paste an API key
+              </h2>
+              {keyRows.length === 0 ? (
+                <p className="text-center text-muted text-[13px] py-4">
+                  No key providers available. You can add a key later from Settings.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {keyRows.map((p) => (
+                    <KeyProviderRow
+                      key={p.name}
+                      provider={p}
+                      expanded={p.name === selectedKey}
+                      onExpand={() => setSelectedKey(p.name)}
+                      disabled={oauthBusy}
+                      onConnected={() => finishConfigured(onClose)}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          </>
+        )}
+
+        <div className="mt-6 text-center">
+          <button
+            type="button"
+            onClick={() => finishSkip(onClose)}
+            className="text-[12.5px] text-muted hover:text-txt transition-colors"
+          >
+            I&apos;ll choose a provider later
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/lib/onboardingProviders.ts
+++ b/webapp/src/lib/onboardingProviders.ts
@@ -52,6 +52,10 @@ export const ONBOARDING_COPY: Record<string, OnboardingCopy> = {
     blurb: "Direct xAI API. Grok for chat and agentic workers.",
     keyUrl: "https://console.x.ai/",
   },
+  "xai-oauth": {
+    tagline: "SuperGrok plan",
+    blurb: "Sign in with SuperGrok. Full stack Grok for chat and workers.",
+  },
   deepseek: {
     tagline: "DeepSeek models",
     blurb: "Direct DeepSeek API. Strong coding models at API rates.",
@@ -122,6 +126,93 @@ export function defaultOnboardingProvider(providers: ProviderInfo[]): string {
   const list = onboardableProviders(providers);
   if (list.some((p) => p.name === "openrouter")) return "openrouter";
   return list[0]?.name || "";
+}
+
+
+/** Wired OAuth start handlers in harness/api/providers.py. qwen/minimax stay out. */
+export const FEATURED_OAUTH_ORDER = [
+  "openai-codex",
+  "anthropic",
+  "xai-oauth",
+  "nous",
+] as const;
+
+export type FeaturedOAuthName = (typeof FEATURED_OAUTH_ORDER)[number];
+
+export const FEATURED_OAUTH = new Set<string>(FEATURED_OAUTH_ORDER);
+
+export const FEATURED_LABELS: Record<FeaturedOAuthName, string> = {
+  "openai-codex": "ChatGPT Codex",
+  anthropic: "Claude Max",
+  "xai-oauth": "xAI SuperGrok",
+  nous: "Nous Portal",
+};
+
+const FEATURED_SYNTH: Record<FeaturedOAuthName, Pick<ProviderInfo, "display_name" | "env_var" | "base_url" | "api_mode">> = {
+  "openai-codex": {
+    display_name: "ChatGPT Codex",
+    env_var: "OPENAI_CODEX_TOKEN",
+    base_url: "",
+    api_mode: "codex_responses",
+  },
+  anthropic: {
+    display_name: "Claude Max",
+    env_var: "ANTHROPIC_API_KEY",
+    base_url: "",
+    api_mode: "anthropic_messages",
+  },
+  "xai-oauth": {
+    display_name: "xAI SuperGrok",
+    env_var: "XAI_OAUTH_TOKEN",
+    base_url: "",
+    api_mode: "chat_completions",
+  },
+  nous: {
+    display_name: "Nous Portal",
+    env_var: "NOUS_API_KEY",
+    base_url: "",
+    api_mode: "chat_completions",
+  },
+};
+
+export function isFeaturedOAuth(name: string): name is FeaturedOAuthName {
+  return FEATURED_OAUTH.has(name);
+}
+
+export function featuredOAuthKind(name: string): "device" | "pkce" | null {
+  if (name === "anthropic") return "pkce";
+  if (isFeaturedOAuth(name)) return "device";
+  return null;
+}
+
+function syntheticFeatured(name: FeaturedOAuthName, providers: ProviderInfo[]): ProviderInfo {
+  const found = providers.find((p) => p.name === name);
+  if (found) {
+    return {
+      ...found,
+      display_name: FEATURED_LABELS[name] || found.display_name || found.name,
+    };
+  }
+  const meta = FEATURED_SYNTH[name];
+  return {
+    name,
+    display_name: meta.display_name,
+    env_var: meta.env_var,
+    base_url: meta.base_url,
+    has_key: false,
+    api_mode: meta.api_mode,
+    worker_capability: "full_stack",
+  };
+}
+
+/** Always the four wired OAuth providers. xai-oauth is a pool, not a GET /api/providers row. */
+export function featuredOnboardingProviders(providers: ProviderInfo[]): ProviderInfo[] {
+  return FEATURED_OAUTH_ORDER.map((name) => syntheticFeatured(name, providers));
+}
+
+/** Paste-key rows: onboardable providers that are not featured OAuth. */
+export function keyOnboardingProviders(providers: ProviderInfo[]): ProviderInfo[] {
+  return onboardableProviders(providers).filter((p) => !isFeaturedOAuth(p.name));
 }
 
 export function openOnboardingKeyUrl(url: string): void {


### PR DESCRIPTION
## Summary
- Replace first-run `RegistryWizard` with `OnboardingOverlay`: `FeaturedProviderRow` (OAuth) vs `KeyProviderRow` (paste).
- Featured OAuth is wired only for `openai-codex`, `anthropic`, `xai-oauth`, `nous` on existing `/api/auth/oauth/start|poll|complete|cancel`. No `/api/providers/oauth/*`.
- Skip writes `firstRunSkipped`. Key rows keep the current `setProviderKey` paste path. Reuses 334 `onboardingStore` and `ONBOARDING_ORDER`/`COPY`.
- Bump product version to 0.9.335 (including feedMotion version assert). Pin stays `puppetmaster-ai==1.22.29`.

## Test plan
- [ ] Featured rows are the four wired OAuth providers; qwen/minimax are not featured
- [ ] Key rows keep paste/`setProviderKey`; featured names stay out of the key list
- [ ] Skip sets `firstRunSkipped` and does not save a key
- [ ] Featured Sign in calls `startAuthOAuth` / existing `/api/auth/oauth/*` only
- [ ] frontend-build: feedMotion asserts 0.9.335