### PR TITLE
Marionette v0.9.336 — provider config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.29` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.335, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.336, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.335"
+__version__ = "0.9.336"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.335"
+version = "0.9.336"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.335"
+version = "0.9.336"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.335",
+  "version": "0.9.336",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.335",
+      "version": "0.9.336",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.335",
+  "version": "0.9.336",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/ProviderConfigModal.test.tsx
+++ b/webapp/src/__tests__/ProviderConfigModal.test.tsx
@@ -1,0 +1,124 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ProviderConfigModal from "../components/ProviderConfigModal";
+import {
+  changedProviderFields,
+  emptyProviderConfig,
+  providerConfigFromInfo,
+} from "../lib/providerConfig";
+
+afterEach(() => {
+  cleanup();
+});
+
+const provider = {
+  name: "openrouter",
+  display_name: "OpenRouter",
+  env_var: "OPENROUTER_API_KEY",
+  base_url: "https://openrouter.ai/api/v1",
+  api_mode: "chat_completions",
+  has_key: true,
+  masked: "sk-or-••••abcd",
+};
+
+function renderModal(overrides: Partial<ComponentProps<typeof ProviderConfigModal>> = {}) {
+  const onClose = vi.fn();
+  const onSubmit = vi.fn().mockResolvedValue(undefined);
+  const result = render(
+    <ProviderConfigModal
+      open
+      provider={provider}
+      onClose={onClose}
+      onSubmit={onSubmit}
+      {...overrides}
+    />,
+  );
+  return { ...result, onClose, onSubmit };
+}
+
+describe("changedProviderFields", () => {
+  it("submits only edited fields", () => {
+    const original = providerConfigFromInfo(provider);
+    const draft = { ...original, display_name: "OR" };
+    expect(changedProviderFields(original, draft)).toEqual({ display_name: "OR" });
+  });
+
+  it("omits an untouched secret and includes it only after retype", () => {
+    const original = providerConfigFromInfo(provider);
+    expect(original.api_key).toBe("");
+    expect(changedProviderFields(original, original, { maskedSecret: provider.masked })).toEqual({});
+    expect(
+      changedProviderFields(
+        original,
+        { ...original, api_key: provider.masked },
+        { maskedSecret: provider.masked },
+      ),
+    ).toEqual({});
+    expect(
+      changedProviderFields(
+        original,
+        { ...original, api_key: "sk-retyped" },
+        { maskedSecret: provider.masked },
+      ),
+    ).toEqual({ api_key: "sk-retyped" });
+  });
+});
+
+describe("ProviderConfigModal", () => {
+  it("renders grouped fields and seeds secrets blank", async () => {
+    renderModal();
+    expect(await screen.findByTestId("provider-config-modal")).toBeTruthy();
+    expect(screen.getByText("Identity")).toBeTruthy();
+    expect(screen.getByText("Credentials")).toBeTruthy();
+    expect(screen.getByText("Connection")).toBeTruthy();
+    expect((screen.getByTestId("provider-config-field-name") as HTMLInputElement).value).toBe(
+      "openrouter",
+    );
+    expect((screen.getByTestId("provider-config-field-api_key") as HTMLInputElement).value).toBe("");
+    expect(screen.getByPlaceholderText("sk-or-••••abcd")).toBeTruthy();
+  });
+
+  it("submits only edited fields", async () => {
+    const { onSubmit } = renderModal();
+    const display = await screen.findByTestId("provider-config-field-display_name");
+    fireEvent.change(display, { target: { value: "OR" } });
+    fireEvent.click(screen.getByTestId("provider-config-submit"));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ display_name: "OR" }));
+  });
+
+  it("omits an untouched secret and includes it only after retype", async () => {
+    const { onSubmit } = renderModal();
+    const url = await screen.findByTestId("provider-config-field-base_url");
+    fireEvent.change(url, { target: { value: "https://example.test/v1" } });
+    fireEvent.click(screen.getByTestId("provider-config-submit"));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({ base_url: "https://example.test/v1" }),
+    );
+    onSubmit.mockClear();
+
+    fireEvent.change(screen.getByTestId("provider-config-field-api_key"), {
+      target: { value: "sk-retyped" },
+    });
+    fireEvent.click(screen.getByTestId("provider-config-submit"));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({
+        api_key: "sk-retyped",
+        base_url: "https://example.test/v1",
+      }),
+    );
+  });
+
+  it("opens Add provider with manual=true and empty identity", async () => {
+    renderModal({ manual: true, provider: null });
+    const dialog = await screen.findByRole("dialog", { name: "Add provider" });
+    expect(dialog.getAttribute("data-manual")).toBe("true");
+    expect((screen.getByTestId("provider-config-field-name") as HTMLInputElement).value).toBe("");
+    expect(emptyProviderConfig().api_key).toBe("");
+  });
+
+  it("renders nothing while closed", () => {
+    renderModal({ open: false });
+    expect(screen.queryByTestId("provider-config-modal")).toBeNull();
+  });
+});

--- a/webapp/src/__tests__/SettingsPane.providerConfig.test.tsx
+++ b/webapp/src/__tests__/SettingsPane.providerConfig.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SettingsPane, { clearSettingsSnapshot } from "../components/SettingsPane";
+import { api } from "../lib/api";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    settings: vi.fn().mockResolvedValue({
+      driver: "cursor",
+      reach: "repo",
+      budget: 100,
+      models: [],
+      auto_distill: false,
+      state_dir: "/tmp/state",
+      repo: "/tmp/repo",
+      has_api_key: false,
+    }),
+    updateSettings: vi.fn(),
+    getUsage: vi.fn().mockResolvedValue(null),
+    getWikiConfig: vi.fn().mockResolvedValue({ api_base: "", has_token: false }),
+    getHooks: vi.fn().mockResolvedValue({ hooks: [], events: [] }),
+    providers: vi.fn(),
+    authPools: vi.fn().mockResolvedValue({ pools: [] }),
+    getAuthPools: vi.fn().mockResolvedValue({ pools: [] }),
+    bedrockStatus: vi.fn().mockResolvedValue(null),
+    getBedrockStatus: vi.fn().mockResolvedValue(null),
+    cursorCliStatus: vi.fn().mockResolvedValue(null),
+    getCursorCliStatus: vi.fn().mockResolvedValue(null),
+    gitStatus: vi.fn().mockResolvedValue(null),
+    platformAdapters: vi.fn().mockResolvedValue([]),
+    setProviderKey: vi.fn().mockResolvedValue({ ok: true, provider: "openrouter", has_key: true, masked: "sk-…" }),
+    clearProviderKey: vi.fn().mockResolvedValue({ ok: true }),
+    setProviderEnabled: vi.fn().mockResolvedValue({ ok: true }),
+  },
+}));
+
+vi.mock("../components/SkillsPane", () => ({ default: () => <div /> }));
+vi.mock("../components/MemoryPane", () => ({ default: () => <div /> }));
+vi.mock("../components/SchedulesPane", () => ({ default: () => <div /> }));
+
+const row = {
+  name: "openrouter",
+  display_name: "OpenRouter",
+  env_var: "OPENROUTER_API_KEY",
+  base_url: "https://openrouter.ai/api/v1",
+  api_mode: "chat_completions",
+  has_key: true,
+  masked: "sk-or-••••abcd",
+  worker_capability: "full_stack" as const,
+  worker_capability_label: "Full stack",
+};
+
+describe("SettingsPane Accounts provider config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearSettingsSnapshot();
+    vi.mocked(api.providers).mockResolvedValue([row]);
+  });
+
+  it("opens Add provider with manual=true", async () => {
+    render(<SettingsPane onOpenWizard={vi.fn()} section="providers" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("add-provider")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("add-provider"));
+    const dialog = await screen.findByRole("dialog", { name: "Add provider" });
+    expect(dialog.getAttribute("data-manual")).toBe("true");
+  });
+
+  it("drills down into an existing provider from Accounts", async () => {
+    render(<SettingsPane onOpenWizard={vi.fn()} section="providers" />);
+    const name = await screen.findByTestId("provider-account-drilldown");
+    fireEvent.click(name);
+    const dialog = await screen.findByRole("dialog", { name: /Configure OpenRouter/ });
+    expect(dialog.getAttribute("data-manual")).toBe("false");
+    expect((screen.getByTestId("provider-config-field-name") as HTMLInputElement).value).toBe("openrouter");
+  });
+});

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.335)", () => {
-  it("declares the official motion package and 0.9.335 not 329", () => {
+describe("feed Motion (v0.9.336)", () => {
+  it("declares the official motion package and 0.9.336 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.335");
+    expect(pkg.version).toBe("0.9.336");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/components/ProviderConfigModal.tsx
+++ b/webapp/src/components/ProviderConfigModal.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { X } from "lucide-react";
+import type { ProviderInfo } from "../lib/api";
+import { OverlayPortal } from "../lib/overlayPortal";
+import {
+  PROVIDER_CONFIG_GROUPS,
+  PROVIDER_CONFIG_LABELS,
+  SECRET_FIELD_IDS,
+  changedProviderFields,
+  emptyProviderConfig,
+  providerConfigFromInfo,
+  type ProviderConfigFieldId,
+  type ProviderConfigValues,
+} from "../lib/providerConfig";
+
+export type ProviderConfigModalProps = {
+  open: boolean;
+  /** Add-provider path: name is editable and fields start empty. */
+  manual?: boolean;
+  provider?: Partial<ProviderInfo> | null;
+  busy?: boolean;
+  onClose: () => void;
+  onSubmit: (changed: Partial<ProviderConfigValues>) => void | Promise<void>;
+};
+
+export default function ProviderConfigModal({
+  open,
+  manual = false,
+  provider = null,
+  busy = false,
+  onClose,
+  onSubmit,
+}: ProviderConfigModalProps) {
+  const original = useMemo(
+    () => (manual ? emptyProviderConfig() : providerConfigFromInfo(provider)),
+    [manual, provider],
+  );
+  const [draft, setDraft] = useState<ProviderConfigValues>(original);
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) setDraft(original);
+  }, [open, original]);
+
+  const changed = useMemo(
+    () => changedProviderFields(original, draft, { maskedSecret: provider?.masked }),
+    [original, draft, provider?.masked],
+  );
+  const canSubmit = Object.keys(changed).length > 0 && !busy;
+  const title = manual
+    ? "Add provider"
+    : `Configure ${provider?.display_name || provider?.name || "provider"}`;
+
+  const setField = (id: ProviderConfigFieldId, value: string) => {
+    setDraft((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    await onSubmit(changed);
+  };
+
+  return (
+    <OverlayPortal
+      open={open}
+      onClose={onClose}
+      testId="provider-config-modal"
+      className="fixed inset-0 z-[90] bg-black/50 flex items-center justify-center p-4"
+      initialFocusRef={firstFieldRef}
+      onBackdropClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        data-manual={manual ? "true" : "false"}
+        onSubmit={handleSubmit}
+        className="w-full max-w-md rounded-lg border border-edge bg-bg shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-edge/40">
+          <h2 className="text-[13px] font-semibold text-txt">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            title="Close"
+            className="p-1 rounded-md text-muted hover:text-txt hover:bg-panel2"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="px-4 py-3 space-y-4 max-h-[70vh] overflow-y-auto">
+          {PROVIDER_CONFIG_GROUPS.map((group) => (
+            <fieldset
+              key={group.id}
+              data-testid={`provider-config-group-${group.id}`}
+              className="space-y-2"
+            >
+              <legend className="text-[10px] uppercase tracking-wide text-muted font-medium">
+                {group.label}
+              </legend>
+              {group.fields.map((id) => {
+                const secret = SECRET_FIELD_IDS.has(id);
+                const locked = id === "name" && !manual;
+                const placeholder = secret
+                  ? provider?.has_key
+                    ? provider.masked || "Retype to replace"
+                    : PROVIDER_CONFIG_LABELS[id]
+                  : PROVIDER_CONFIG_LABELS[id];
+                return (
+                  <label key={id} className="block space-y-1">
+                    <span className="text-[11px] text-muted">{PROVIDER_CONFIG_LABELS[id]}</span>
+                    <input
+                      ref={id === "name" ? firstFieldRef : undefined}
+                      data-testid={`provider-config-field-${id}`}
+                      type={secret ? "password" : "text"}
+                      name={id}
+                      autoComplete={secret ? "off" : "off"}
+                      value={draft[id]}
+                      onChange={(e) => setField(id, e.target.value)}
+                      disabled={busy || locked}
+                      placeholder={placeholder}
+                      readOnly={locked}
+                      className="w-full bg-panel2 border border-edge rounded px-2 py-1 text-txt text-[11px] font-mono focus:outline-none focus:border-accent disabled:opacity-50"
+                    />
+                    {secret && provider?.has_key ? (
+                      <span className="block text-[10px] text-faint">
+                        Leave blank to keep the current key. Retype to replace.
+                      </span>
+                    ) : null}
+                  </label>
+                );
+              })}
+            </fieldset>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-edge/40">
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted hover:text-txt border border-edge rounded px-2.5 py-1 text-[11px]"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-testid="provider-config-submit"
+            disabled={!canSubmit}
+            className="bg-accent/15 hover:bg-accent/25 text-accent border border-accent/30 rounded px-2.5 py-1 text-[11px] font-medium disabled:opacity-30"
+          >
+            Save
+          </button>
+        </div>
+      </form>
+    </OverlayPortal>
+  );
+}

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -22,6 +22,8 @@ import {
 import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 import { SettingsCollapse } from "./SettingsCollapse";
 import WindowGlassSettings from "./WindowGlassSettings";
+import ProviderConfigModal from "./ProviderConfigModal";
+import type { ProviderConfigValues } from "../lib/providerConfig";
 
 export type SettingsSection = "general" | "safety" | "providers" | "notifications" | "plugins" | "advanced";
 
@@ -90,6 +92,9 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
   const [keyBootstrapIssues, setKeyBootstrapIssues] = useState<NonNullable<Config["key_bootstrap_issues"]>>([]);
   const [provKeyInput, setProvKeyInput] = useState<Record<string, string>>({});
   const [provBusy, setProvBusy] = useState<string>("");
+  const [providerConfig, setProviderConfig] = useState<
+    { manual: true } | { manual: false; provider: ProviderInfo } | null
+  >(null);
 
   // Hermes-style credential pools (multi-key / rotate on plan limit)
   const [authPools, setAuthPools] = useState<AuthPoolsResponse | null>(null);
@@ -835,6 +840,28 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
     }
   };
 
+  const handleProviderConfigSubmit = async (changed: Partial<ProviderConfigValues>) => {
+    const name = (
+      changed.name
+      || (providerConfig && !providerConfig.manual ? providerConfig.provider.name : "")
+      || ""
+    ).trim();
+    if (changed.api_key && name) {
+      setProvBusy(name);
+      try {
+        await api.setProviderKey(name, changed.api_key);
+        setProvKeyInput((p) => ({ ...p, [name]: "" }));
+        await refreshProviders();
+        window.dispatchEvent(new Event("harness-config-changed"));
+      } catch (e) {
+        console.error("Failed to set provider key", e);
+      } finally {
+        setProvBusy("");
+      }
+    }
+    setProviderConfig(null);
+  };
+
   const handleSetProviderKey = async (name: string) => {
     const val = (provKeyInput[name] || "").trim();
     if (!val) return;
@@ -1361,7 +1388,15 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex items-center gap-2 min-w-0">
                     <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${connected ? "bg-good" : "bg-faint"}`} />
-                    <span className="text-txt font-medium text-[11px]">{p.display_name || p.name}</span>
+                    <button
+                      type="button"
+                      data-testid="provider-account-drilldown"
+                      data-provider={p.name}
+                      onClick={() => setProviderConfig({ manual: false, provider: p })}
+                      className="text-txt font-medium text-[11px] hover:text-accent text-left"
+                    >
+                      {p.display_name || p.name}
+                    </button>
                     {p.worker_capability_label ? (
                       <span
                         title={p.worker_capability_hint || undefined}
@@ -1440,7 +1475,26 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
               );
             })}
           </div>
+          <button
+            type="button"
+            data-testid="add-provider"
+            onClick={() => setProviderConfig({ manual: true })}
+            className="flex items-center gap-1 text-accent hover:text-accent/80 text-[11px] font-medium"
+          >
+            <Plus size={12} />
+            Add provider
+          </button>
         </SettingsCollapse>
+        {providerConfig ? (
+          <ProviderConfigModal
+            open
+            manual={providerConfig.manual}
+            provider={providerConfig.manual ? null : providerConfig.provider}
+            busy={!!provBusy}
+            onClose={() => setProviderConfig(null)}
+            onSubmit={handleProviderConfigSubmit}
+          />
+        ) : null}
 
         </>)}
 

--- a/webapp/src/lib/providerConfig.ts
+++ b/webapp/src/lib/providerConfig.ts
@@ -1,0 +1,84 @@
+import type { ProviderInfo } from "./api";
+
+export const PROVIDER_CONFIG_FIELD_IDS = [
+  "name",
+  "display_name",
+  "api_key",
+  "base_url",
+  "api_mode",
+] as const;
+
+export type ProviderConfigFieldId = (typeof PROVIDER_CONFIG_FIELD_IDS)[number];
+
+export type ProviderConfigValues = Record<ProviderConfigFieldId, string>;
+
+export type ProviderConfigGroup = {
+  id: string;
+  label: string;
+  fields: ProviderConfigFieldId[];
+};
+
+export const PROVIDER_CONFIG_GROUPS: ProviderConfigGroup[] = [
+  { id: "identity", label: "Identity", fields: ["name", "display_name"] },
+  { id: "credentials", label: "Credentials", fields: ["api_key"] },
+  { id: "connection", label: "Connection", fields: ["base_url", "api_mode"] },
+];
+
+export const SECRET_FIELD_IDS = new Set<ProviderConfigFieldId>(["api_key"]);
+
+export const PROVIDER_CONFIG_LABELS: Record<ProviderConfigFieldId, string> = {
+  name: "Provider",
+  display_name: "Display name",
+  api_key: "API key",
+  base_url: "Base URL",
+  api_mode: "API mode",
+};
+
+export function emptyProviderConfig(): ProviderConfigValues {
+  return {
+    name: "",
+    display_name: "",
+    api_key: "",
+    base_url: "",
+    api_mode: "",
+  };
+}
+
+/** Never prefill secrets — the user must retype to replace. */
+export function providerConfigFromInfo(
+  provider?: Partial<ProviderInfo> | null,
+): ProviderConfigValues {
+  return {
+    name: provider?.name || "",
+    display_name: provider?.display_name || "",
+    api_key: "",
+    base_url: provider?.base_url || "",
+    api_mode: provider?.api_mode || "",
+  };
+}
+
+export function isSecretRetyped(draftSecret: string, masked?: string): boolean {
+  const typed = (draftSecret || "").trim();
+  if (!typed) return false;
+  if (masked && typed === masked.trim()) return false;
+  return true;
+}
+
+/** Submit payload: only fields the user changed. Secrets only if retyped. */
+export function changedProviderFields(
+  original: ProviderConfigValues,
+  draft: ProviderConfigValues,
+  opts?: { maskedSecret?: string },
+): Partial<ProviderConfigValues> {
+  const out: Partial<ProviderConfigValues> = {};
+  for (const id of PROVIDER_CONFIG_FIELD_IDS) {
+    const next = (draft[id] ?? "").trim();
+    const prev = (original[id] ?? "").trim();
+    if (SECRET_FIELD_IDS.has(id)) {
+      if (isSecretRetyped(next, opts?.maskedSecret)) out[id] = next;
+      continue;
+    }
+    if (next !== prev) out[id] = next;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- ProviderConfigModal with grouped Identity / Credentials / Connection fields
- Secret retype: existing keys are not submitted unless the user types a new one
- Submit sends only changed fields
- Settings Accounts drill-down plus Add provider (`manual=true`), wired into the existing Settings pane

## Test plan
- [x] ProviderConfigModal submit-only-changed
- [x] ProviderConfigModal secret retype
- [x] Settings Accounts Add provider + drill-down
- [ ] Do not merge until CI is green