### PR TITLE
Marionette v0.9.337 — plugin source URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.29` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.336, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.337, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.336"
+__version__ = "0.9.337"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/plugins.py
+++ b/harness/api/plugins.py
@@ -10,7 +10,7 @@ from ..plugin_registry import (
     disable_plugin,
     enable_plugin,
     discover_plugins,
-    install_from_path,
+    install_from_source,
     namespaced_mcp_ids_for_plugin,
     plugin_record_to_dict,
 )
@@ -37,12 +37,20 @@ def get_plugins(svc: PluginServices) -> Tuple[int, JsonPayload]:
     return 200, {"plugins": [plugin_record_to_dict(r) for r in records]}
 
 
+def _install_source_from_body(body: dict) -> object:
+    """Accept path, source string, or a resolved source object."""
+    source = body.get("source")
+    if isinstance(source, dict) or (isinstance(source, str) and source.strip()):
+        return source
+    return (body.get("path") or "").strip()
+
+
 def post_plugins_install(body: dict, svc: PluginServices) -> Tuple[int, JsonPayload]:
-    """POST /api/plugins/install — copy absolute path; remains disabled."""
+    """POST /api/plugins/install — path or resolved git/https/github source."""
     del svc
-    path = (body.get("path") or "").strip()
+    source = _install_source_from_body(body)
     try:
-        record = install_from_path(path)
+        record = install_from_source(source)
     except AgentPluginError as exc:
         return 400, {"ok": False, "error": str(exc)}
     except Exception as exc:

--- a/harness/plugin_registry.py
+++ b/harness/plugin_registry.py
@@ -1,8 +1,9 @@
 """Installed Agent Plugins v1 packages under ~/.pmharness/plugins.
 
-Discover, install-from-path, and enable/disable portable packages. Default is
-disabled until explicitly enabled. Skills and MCP configs are namespaced so
-they never overwrite SkillStore files or collide with native mcp.json.
+Discover, install-from-path or resolved git/https/github sources, and
+enable/disable portable packages. Default is disabled until explicitly
+enabled. Skills and MCP configs are namespaced so they never overwrite
+SkillStore files or collide with native mcp.json.
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import json
 import os
 import re
 import shutil
+import tempfile
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -25,6 +27,12 @@ from .agent_plugins import (
     compute_package_sha256,
     load_agent_plugin,
     read_agent_plugin_manifest,
+)
+from .plugin_source_urls import (
+    ResolvedPluginSource,
+    coerce_plugin_source,
+    git_clone_plugin_source,
+    resolve_plugin_source,
 )
 from .secure_files import restrict_to_owner
 from .diag import note as _diag
@@ -331,17 +339,44 @@ def discover_plugins() -> List[PluginRecord]:
     return records
 
 
-def install_from_path(source: str) -> PluginRecord:
-    """Copy an absolute plugin package path into the plugins dir (disabled)."""
-    raw = (source or "").strip()
-    if not raw:
-        raise AgentPluginError("install path is required")
-    src = Path(raw).expanduser()
-    if not src.is_absolute():
-        raise AgentPluginError("install path must be absolute")
-    if not src.exists() or not src.is_dir():
-        raise AgentPluginError("install path must be an existing directory")
-    # Validate before copying so a bad package never lands in the registry.
+def _clone_resolved_source(resolved: ResolvedPluginSource, dest: Path) -> None:
+    """Clone a remote plugin source into ``dest`` (git / https / github)."""
+    url = (resolved.clone_url or "").strip()
+    if not url:
+        raise AgentPluginError("plugin source clone URL is required")
+    git_clone_plugin_source(url, dest, ref=(resolved.ref or None))
+
+
+def _materialize_source(source: object, *, clone_fn=None) -> Tuple[Path, Optional[Path]]:
+    resolved = coerce_plugin_source(source)
+    if resolved.kind == "path":
+        src = Path(os.path.expanduser(resolved.path or resolved.raw)).expanduser()
+        if not src.is_absolute():
+            raise AgentPluginError("install path must be absolute")
+        if not src.exists() or not src.is_dir():
+            raise AgentPluginError("install path must be an existing directory")
+        return src, None
+    tmp = Path(tempfile.mkdtemp(prefix="marionette-plugin-src-"))
+    shutil.rmtree(tmp, ignore_errors=True)
+    try:
+        cloner = clone_fn or _clone_resolved_source
+        cloner(resolved, tmp)
+        root = tmp
+        if resolved.subdir:
+            root = tmp / resolved.subdir
+            try:
+                root.resolve().relative_to(tmp.resolve())
+            except ValueError as exc:
+                raise AgentPluginError("plugin subdir escapes source checkout") from exc
+            if not root.is_dir():
+                raise AgentPluginError("plugin subdir not found in source")
+        return root, tmp
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+
+
+def _install_materialized(src: Path) -> PluginRecord:
     staging_ns = portable_skill_namespace("_install_probe")
     package = load_agent_plugin(src, plugin_data_root() / staging_ns)
     install_id = _sanitize_install_id(package.name)
@@ -355,7 +390,6 @@ def install_from_path(source: str) -> PluginRecord:
         except OSError as exc:
             raise AgentPluginError(f"failed to install plugin: {exc}") from exc
         digest = write_integrity_stamp(dest)
-        # Ensure default-disabled: remove from enabled if somehow present.
         enabled = [x for x in _read_enabled() if x != install_id]
         _write_enabled(enabled)
     namespace = portable_skill_namespace(install_id)
@@ -364,6 +398,26 @@ def install_from_path(source: str) -> PluginRecord:
     return _record_from_package(
         install_id, loaded, enabled=False, digest=digest, stamp_ok=True
     )
+
+
+def install_from_path(source: str, *, clone_fn=None) -> PluginRecord:
+    """Copy a local dir or git / https / github source into plugins (disabled)."""
+    src, cleanup = _materialize_source(source, clone_fn=clone_fn)
+    try:
+        return _install_materialized(src)
+    finally:
+        if cleanup is not None:
+            shutil.rmtree(cleanup, ignore_errors=True)
+
+
+def install_from_source(source: object, *, clone_fn=None) -> PluginRecord:
+    """Install from a path string, source URL, or resolved source mapping."""
+    src, cleanup = _materialize_source(source, clone_fn=clone_fn)
+    try:
+        return _install_materialized(src)
+    finally:
+        if cleanup is not None:
+            shutil.rmtree(cleanup, ignore_errors=True)
 
 
 def enable_plugin(plugin_id: str) -> PluginRecord:

--- a/harness/plugin_source_urls.py
+++ b/harness/plugin_source_urls.py
@@ -1,0 +1,193 @@
+"""Resolve Agent Plugin install sources: local path, git, https, github."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+from urllib.parse import unquote, urlparse
+
+from .agent_plugins import AgentPluginError
+
+SourceKind = str  # "path" | "git" | "https" | "github"
+
+_WINDOWS_ABS = re.compile(r"^[A-Za-z]:[\\/]")
+_GIT_SSH = re.compile(r"^(?:git@|ssh://git@|git://)", re.IGNORECASE)
+_GITHUB_HOST = re.compile(r"^(?:www\.)?github\.com$", re.IGNORECASE)
+_GITHUB_SHORTHAND = re.compile(
+    r"^(?:github:)?([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)/"
+    r"([A-Za-z0-9._-]+?)(?:\.git)?(?:[@#](.+))?$"
+)
+_CLONE_TIMEOUT_SEC = 120
+
+
+@dataclass(frozen=True)
+class ResolvedPluginSource:
+    kind: SourceKind
+    raw: str
+    path: str = ""
+    clone_url: str = ""
+    owner: str = ""
+    repo: str = ""
+    ref: str = ""
+    subdir: str = ""
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "ResolvedPluginSource":
+        kind = str(data.get("kind") or "").strip()
+        raw = str(data.get("raw") or data.get("cloneUrl") or data.get("clone_url") or "")
+        if kind not in {"path", "git", "https", "github"}:
+            raise AgentPluginError("unsupported plugin source")
+        clone_url = str(data.get("cloneUrl") or data.get("clone_url") or "")
+        path = str(data.get("path") or "")
+        return cls(
+            kind=kind,
+            raw=raw,
+            path=path,
+            clone_url=clone_url,
+            owner=str(data.get("owner") or ""),
+            repo=str(data.get("repo") or ""),
+            ref=str(data.get("ref") or ""),
+            subdir=str(data.get("subdir") or ""),
+        )
+
+
+def is_absolute_plugin_path(value: str) -> bool:
+    raw = (value or "").strip()
+    return raw.startswith("/") or _WINDOWS_ABS.match(raw) is not None
+
+
+def _parse_git_remote(clone_url: str) -> tuple[str, str]:
+    match = re.search(
+        r"(?:[:/])([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?$",
+        clone_url.rstrip("/"),
+    )
+    if not match:
+        return "", ""
+    return match.group(1), re.sub(r"\.git$", "", match.group(2), flags=re.IGNORECASE)
+
+
+def _split_hash_ref(raw: str) -> tuple[str, str]:
+    hash_at = raw.rfind("#")
+    if hash_at <= 0:
+        return raw, ""
+    return raw[:hash_at], unquote(raw[hash_at + 1 :])
+
+
+def resolve_plugin_source(source: str) -> ResolvedPluginSource:
+    """Classify an absolute path or git / https / github source URL."""
+    raw = (source or "").strip()
+    if not raw:
+        raise AgentPluginError("plugin source is required")
+    scheme = raw.split(":", 1)[0].lower()
+    if scheme in {"file", "javascript", "data", "ftp"}:
+        raise AgentPluginError("unsupported plugin source scheme")
+    if is_absolute_plugin_path(raw):
+        return ResolvedPluginSource(kind="path", raw=raw, path=raw)
+    if _GIT_SSH.match(raw):
+        base, ref = _split_hash_ref(raw)
+        owner, repo = _parse_git_remote(base)
+        return ResolvedPluginSource(
+            kind="git", raw=raw, clone_url=base, owner=owner, repo=repo, ref=ref
+        )
+    if re.match(r"^https?://", raw, re.IGNORECASE):
+        return _resolve_http_source(raw)
+    if "\\" in raw or raw.startswith(".") or raw.count("/") != 1:
+        raise AgentPluginError(
+            "plugin source must be an absolute path, git URL, https URL, or GitHub source"
+        )
+    match = _GITHUB_SHORTHAND.match(raw)
+    if match is None:
+        raise AgentPluginError(
+            "plugin source must be an absolute path, git URL, https URL, or GitHub source"
+        )
+    owner = match.group(1)
+    repo = re.sub(r"\.git$", "", match.group(2), flags=re.IGNORECASE)
+    ref = match.group(3) or ""
+    return ResolvedPluginSource(
+        kind="github",
+        raw=raw,
+        owner=owner,
+        repo=repo,
+        ref=ref,
+        clone_url=f"https://github.com/{owner}/{repo}.git",
+    )
+
+
+def _resolve_http_source(raw: str) -> ResolvedPluginSource:
+    parsed = urlparse(raw)
+    if parsed.scheme not in {"http", "https"}:
+        raise AgentPluginError("unsupported plugin source scheme")
+    host = (parsed.hostname or "").lower()
+    ref_from_hash = unquote((parsed.fragment or "").lstrip("#"))
+    if _GITHUB_HOST.match(host or ""):
+        parts = [p for p in (parsed.path or "").strip("/").split("/") if p]
+        if len(parts) < 2:
+            raise AgentPluginError("GitHub source must be owner/repo")
+        owner = parts[0]
+        repo = re.sub(r"\.git$", "", parts[1], flags=re.IGNORECASE)
+        ref = ref_from_hash
+        if len(parts) >= 4 and parts[2] in {"tree", "commit"}:
+            ref = ref or parts[3]
+        return ResolvedPluginSource(
+            kind="github",
+            raw=raw,
+            owner=owner,
+            repo=repo,
+            ref=ref,
+            clone_url=f"https://github.com/{owner}/{repo}.git",
+        )
+    path = (parsed.path or "").lower()
+    kind = "git" if path.endswith(".git") else "https"
+    location = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+    if parsed.query:
+        location = f"{location}?{parsed.query}"
+    owner, repo = _parse_git_remote(f"{parsed.scheme}://{parsed.netloc}{parsed.path}")
+    return ResolvedPluginSource(
+        kind=kind,
+        raw=raw,
+        clone_url=location,
+        ref=ref_from_hash,
+        owner=owner,
+        repo=repo,
+    )
+
+
+def git_clone_plugin_source(
+    url: str, dest: Path, *, ref: Optional[str] = None
+) -> None:
+    """Shallow-clone ``url`` into ``dest`` (must not already exist)."""
+    dest = Path(dest)
+    if dest.exists():
+        dest.mkdir(parents=True, exist_ok=True)
+    cmd = ["git", "clone", "--depth", "1"]
+    if ref:
+        cmd.extend(["--branch", ref])
+    cmd.extend(["--", url, str(dest)])
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_CLONE_TIMEOUT_SEC,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise AgentPluginError(f"failed to clone plugin source: {exc}") from exc
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "git clone failed").strip()
+        raise AgentPluginError(f"failed to clone plugin source: {detail}")
+
+
+def coerce_plugin_source(source: object) -> ResolvedPluginSource:
+    """Accept a URL string or a resolved mapping from the web client."""
+    if isinstance(source, ResolvedPluginSource):
+        return source
+    if isinstance(source, Mapping):
+        return ResolvedPluginSource.from_mapping(source)
+    return resolve_plugin_source(str(source or ""))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.336"
+version = "0.9.337"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_plugin_source_urls.py
+++ b/tests/test_plugin_source_urls.py
@@ -1,0 +1,167 @@
+"""Plugin source URL resolve + install (git / https / github)."""
+
+from __future__ import annotations
+
+pytest_plugins = ["tests.test_agent_plugins"]
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from harness.agent_plugins import AgentPluginError
+from harness.api.plugins import PluginServices, post_plugins_install
+from harness.plugin_registry import (
+    install_from_path,
+    install_from_source,
+    plugins_dir,
+    resolve_plugin_source,
+)
+from tests.test_agent_plugins import _valid_package
+
+
+def test_resolve_absolute_path() -> None:
+    src = resolve_plugin_source("/abs/plugin")
+    assert src.kind == "path"
+    assert src.path == "/abs/plugin"
+
+
+def test_resolve_github_https_and_shorthand() -> None:
+    https = resolve_plugin_source("https://github.com/acme/widget")
+    assert https.kind == "github"
+    assert https.owner == "acme"
+    assert https.repo == "widget"
+    assert https.clone_url == "https://github.com/acme/widget.git"
+
+    tagged = resolve_plugin_source("https://github.com/acme/widget.git#v1")
+    assert tagged.kind == "github"
+    assert tagged.ref == "v1"
+
+    short = resolve_plugin_source("acme/widget@main")
+    assert short.kind == "github"
+    assert short.ref == "main"
+    assert short.clone_url == "https://github.com/acme/widget.git"
+
+    prefixed = resolve_plugin_source("github:acme/widget")
+    assert prefixed.kind == "github"
+    assert prefixed.clone_url == "https://github.com/acme/widget.git"
+
+
+def test_resolve_git_and_https() -> None:
+    git = resolve_plugin_source("git@github.com:acme/widget.git")
+    assert git.kind == "git"
+    assert git.clone_url == "git@github.com:acme/widget.git"
+    assert git.owner == "acme"
+    assert git.repo == "widget"
+
+    git_https = resolve_plugin_source("https://gitlab.example/acme/widget.git")
+    assert git_https.kind == "git"
+    assert git_https.clone_url == "https://gitlab.example/acme/widget.git"
+
+    https = resolve_plugin_source("https://example.test/plugins/widget")
+    assert https.kind == "https"
+    assert https.clone_url == "https://example.test/plugins/widget"
+
+
+def test_resolve_rejects_relative_and_file() -> None:
+    with pytest.raises(AgentPluginError, match="plugin source"):
+        resolve_plugin_source("")
+    with pytest.raises(AgentPluginError, match="absolute path|git URL|https URL|GitHub"):
+        resolve_plugin_source("src-plugin")
+    with pytest.raises(AgentPluginError, match="unsupported"):
+        resolve_plugin_source("file:///tmp/plugin")
+
+
+def _stub_clone(package: Path):
+    def _clone(resolved, dest: Path) -> None:
+        shutil.copytree(str(package), str(dest))
+
+    return _clone
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "git@github.com:acme/widget.git",
+        "https://example.test/plugins/widget",
+        "https://github.com/acme/widget",
+        "acme/widget",
+        {"kind": "github", "raw": "https://github.com/acme/widget", "cloneUrl": "https://github.com/acme/widget.git"},
+    ],
+)
+def test_install_accepts_git_https_github(
+    plugins_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: object,
+) -> None:
+    del plugins_home
+    package = _valid_package(tmp_path / "src-plugin")
+    shutil.rmtree(plugins_dir(), ignore_errors=True)
+    monkeypatch.setattr(
+        "harness.plugin_registry._clone_resolved_source", _stub_clone(package)
+    )
+    record = install_from_source(source)
+    assert record.name == "portable.test"
+    assert record.enabled is False
+
+
+def test_install_from_path_accepts_git_https_github(
+    plugins_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del plugins_home
+    package = _valid_package(tmp_path / "src-plugin")
+    monkeypatch.setattr(
+        "harness.plugin_registry._clone_resolved_source", _stub_clone(package)
+    )
+    for source in (
+        "git@github.com:acme/widget.git",
+        "https://example.test/plugins/widget",
+        "https://github.com/acme/widget",
+        "github:acme/widget",
+    ):
+        shutil.rmtree(plugins_dir(), ignore_errors=True)
+        record = install_from_path(source)
+        assert record.name == "portable.test"
+        assert record.enabled is False
+
+
+def test_post_install_accepts_resolved_git_https_github(
+    plugins_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del plugins_home
+    package = _valid_package(tmp_path / "src-plugin")
+    monkeypatch.setattr(
+        "harness.plugin_registry._clone_resolved_source", _stub_clone(package)
+    )
+    svc = PluginServices()
+    for body in (
+        {"source": "git@github.com:acme/widget.git"},
+        {"source": "https://example.test/plugins/widget"},
+        {
+            "source": {
+                "kind": "github",
+                "raw": "https://github.com/acme/widget",
+                "cloneUrl": "https://github.com/acme/widget.git",
+            }
+        },
+    ):
+        shutil.rmtree(plugins_dir(), ignore_errors=True)
+        status, payload = post_plugins_install(body, svc)
+        assert status == 200, payload
+        assert payload["ok"] is True
+        assert payload["plugin"]["name"] == "portable.test"
+
+
+def test_post_install_still_accepts_path(
+    plugins_home: Path, tmp_path: Path
+) -> None:
+    del plugins_home
+    package = _valid_package(tmp_path / "src-plugin")
+    status, payload = post_plugins_install({"path": str(package)}, PluginServices())
+    assert status == 200, payload
+    assert payload["ok"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.336"
+version = "0.9.337"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.336",
+  "version": "0.9.337",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.336",
+      "version": "0.9.337",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.336",
+  "version": "0.9.337",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.336)", () => {
-  it("declares the official motion package and 0.9.336 not 329", () => {
+describe("feed Motion (v0.9.337)", () => {
+  it("declares the official motion package and 0.9.337 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.336");
+    expect(pkg.version).toBe("0.9.337");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/pluginSourceUrls.test.ts
+++ b/webapp/src/__tests__/pluginSourceUrls.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  PluginSourceError,
+  pluginInstallPayload,
+  resolvePluginSource,
+} from "../lib/pluginSourceUrls";
+
+describe("pluginSourceUrls", () => {
+  it("resolves absolute paths", () => {
+    expect(resolvePluginSource("/abs/plugin")).toEqual({
+      kind: "path",
+      raw: "/abs/plugin",
+      path: "/abs/plugin",
+    });
+    expect(resolvePluginSource("C:\\Users\\p\\plugin").kind).toBe("path");
+  });
+
+  it("resolves github https, shorthand, and github: sources", () => {
+    expect(resolvePluginSource("https://github.com/acme/widget")).toEqual({
+      kind: "github",
+      raw: "https://github.com/acme/widget",
+      owner: "acme",
+      repo: "widget",
+      ref: "",
+      cloneUrl: "https://github.com/acme/widget.git",
+    });
+    expect(resolvePluginSource("https://github.com/acme/widget.git#v1")).toMatchObject({
+      kind: "github",
+      owner: "acme",
+      repo: "widget",
+      ref: "v1",
+      cloneUrl: "https://github.com/acme/widget.git",
+    });
+    expect(resolvePluginSource("acme/widget@main")).toMatchObject({
+      kind: "github",
+      owner: "acme",
+      repo: "widget",
+      ref: "main",
+      cloneUrl: "https://github.com/acme/widget.git",
+    });
+    expect(resolvePluginSource("github:acme/widget")).toMatchObject({
+      kind: "github",
+      cloneUrl: "https://github.com/acme/widget.git",
+    });
+  });
+
+  it("resolves git and https remotes", () => {
+    expect(resolvePluginSource("git@github.com:acme/widget.git")).toMatchObject({
+      kind: "git",
+      cloneUrl: "git@github.com:acme/widget.git",
+      owner: "acme",
+      repo: "widget",
+    });
+    expect(resolvePluginSource("https://gitlab.example/acme/widget.git")).toMatchObject({
+      kind: "git",
+      cloneUrl: "https://gitlab.example/acme/widget.git",
+    });
+    expect(resolvePluginSource("https://example.test/plugins/widget")).toMatchObject({
+      kind: "https",
+      cloneUrl: "https://example.test/plugins/widget",
+    });
+  });
+
+  it("rejects empty, relative, and unsupported schemes", () => {
+    expect(() => resolvePluginSource("")).toThrow(PluginSourceError);
+    expect(() => resolvePluginSource("src-plugin")).toThrow(/absolute path|git URL|https URL|GitHub/);
+    expect(() => resolvePluginSource("file:///tmp/plugin")).toThrow(/unsupported/);
+    expect(() => resolvePluginSource("javascript:alert(1)")).toThrow(/unsupported/);
+  });
+
+  it("builds install payloads for path vs remote sources", () => {
+    expect(pluginInstallPayload("/abs/plugin")).toEqual({
+      source: { kind: "path", raw: "/abs/plugin", path: "/abs/plugin" },
+      path: "/abs/plugin",
+    });
+    expect(pluginInstallPayload("https://github.com/acme/widget").path).toBeUndefined();
+    expect(pluginInstallPayload("https://github.com/acme/widget").source.kind).toBe("github");
+  });
+});

--- a/webapp/src/components/PluginsPane.tsx
+++ b/webapp/src/components/PluginsPane.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { Puzzle, Power, PowerOff, FolderPlus } from "lucide-react";
 import { api, type AgentPlugin } from "../lib/api";
+import { PluginSourceError, resolvePluginSource } from "../lib/pluginSourceUrls";
 import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 
-/** Minimal Agent Plugins v1 Settings pane: list, enable/disable, install path. */
+/** Minimal Agent Plugins v1 Settings pane: list, enable/disable, install path or URL. */
 export default function PluginsPane({ embedded = false }: { embedded?: boolean }) {
   const [plugins, setPlugins] = useState<AgentPlugin[]>([]);
   const [busy, setBusy] = useState("");
@@ -50,20 +51,23 @@ export default function PluginsPane({ embedded = false }: { embedded?: boolean }
   };
 
   const install = async () => {
-    const path = installPath.trim();
-    if (!path) {
-      setError("Absolute package path is required");
+    const raw = installPath.trim();
+    if (!raw) {
+      setError("Plugin source path, git URL, https URL, or GitHub repo is required");
       return;
     }
-    if (!path.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(path)) {
-      setError("Install path must be absolute");
+    try {
+      resolvePluginSource(raw);
+    } catch (err) {
+      setError(err instanceof PluginSourceError ? err.message : "Invalid plugin source");
       return;
     }
     setBusy("install");
     setError("");
     setMsg("");
     try {
-      const res = await api.pluginInstall(path);
+      const res = await api.pluginInstall(raw);
+
       if (!res.ok) {
         setError(res.error || "install failed");
         return;
@@ -92,7 +96,7 @@ export default function PluginsPane({ embedded = false }: { embedded?: boolean }
           type="text"
           value={installPath}
           onChange={(e) => setInstallPath(e.target.value)}
-          placeholder="/absolute/path/to/plugin"
+          placeholder="/absolute/path or https://github.com/owner/repo"
           className="flex-1 min-w-0 px-2 py-1.5 rounded-md bg-panel2 border border-edge/50 text-[12px] text-txt placeholder:text-faint"
           data-testid="plugins-install-path"
         />

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -18,6 +18,7 @@ import {
   type SessionSearchHit,
 } from "./sessionSearch";
 import type { SessionExportPayload } from "./sessionExport";
+import { pluginInstallPayload } from "./pluginSourceUrls";
 
 export type { ChatEventFrame, StoreEvent } from "./transport";
 export type { SessionSearchHit } from "./sessionSearch";
@@ -1485,8 +1486,11 @@ export const api = {
   mcpRefresh: (name: string) =>
     postJSON<{ ok: boolean; tools?: number; error?: string }>("/api/mcp/refresh", { name }),
   plugins: () => getJSON<{ plugins: AgentPlugin[]; error?: string }>("/api/plugins"),
-  pluginInstall: (path: string) =>
-    postJSON<{ ok: boolean; plugin?: AgentPlugin; error?: string }>("/api/plugins/install", { path }),
+  pluginInstall: (source: string) =>
+    postJSON<{ ok: boolean; plugin?: AgentPlugin; error?: string }>(
+      "/api/plugins/install",
+      pluginInstallPayload(source),
+    ),
   pluginEnable: (id: string) =>
     postJSON<{ ok: boolean; plugin?: AgentPlugin; error?: string }>("/api/plugins/enable", { id }),
   pluginDisable: (id: string) =>

--- a/webapp/src/lib/pluginSourceUrls.ts
+++ b/webapp/src/lib/pluginSourceUrls.ts
@@ -1,0 +1,138 @@
+/** Resolve Agent Plugin install sources: absolute path, git, https, or GitHub. */
+
+export type PluginSourceKind = "path" | "git" | "https" | "github";
+
+export type ResolvedPluginSource = {
+  kind: PluginSourceKind;
+  raw: string;
+  path?: string;
+  cloneUrl?: string;
+  owner?: string;
+  repo?: string;
+  ref?: string;
+};
+
+export class PluginSourceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PluginSourceError";
+  }
+}
+
+const WINDOWS_ABS = /^[A-Za-z]:[\\/]/;
+const GIT_SSH = /^(?:git@|ssh:\/\/git@|git:\/\/)/i;
+const GITHUB_HOST = /^(?:www\.)?github\.com$/i;
+const GITHUB_SHORTHAND =
+  /^(?:github:)?([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\/([A-Za-z0-9._-]+?)(?:\.git)?(?:[@#](.+))?$/;
+
+export function isAbsolutePluginPath(value: string): boolean {
+  const raw = (value || "").trim();
+  return raw.startsWith("/") || WINDOWS_ABS.test(raw);
+}
+
+function parseGitRemote(cloneUrl: string): { owner?: string; repo?: string } {
+  const match = /(?:[:/])([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/.exec(
+    cloneUrl.replace(/\/+$/, ""),
+  );
+  if (!match) return {};
+  return { owner: match[1], repo: match[2].replace(/\.git$/i, "") };
+}
+
+function splitHashRef(raw: string): { base: string; ref: string } {
+  const hash = raw.lastIndexOf("#");
+  if (hash <= 0) return { base: raw, ref: "" };
+  return { base: raw.slice(0, hash), ref: decodeURIComponent(raw.slice(hash + 1)) };
+}
+
+export function resolvePluginSource(input: string): ResolvedPluginSource {
+  const raw = (input || "").trim();
+  if (!raw) {
+    throw new PluginSourceError("plugin source is required");
+  }
+  const scheme = raw.split(":", 1)[0]?.toLowerCase() || "";
+  if (scheme === "file" || scheme === "javascript" || scheme === "data" || scheme === "ftp") {
+    throw new PluginSourceError("unsupported plugin source scheme");
+  }
+  if (isAbsolutePluginPath(raw)) {
+    return { kind: "path", raw, path: raw };
+  }
+  if (GIT_SSH.test(raw)) {
+    const { base, ref } = splitHashRef(raw);
+    return { kind: "git", raw, cloneUrl: base, ref, ...parseGitRemote(base) };
+  }
+  if (/^https?:\/\//i.test(raw)) {
+    return resolveHttpSource(raw);
+  }
+  if (raw.includes("\\") || raw.startsWith(".") || raw.split("/").length !== 2) {
+    throw new PluginSourceError(
+      "plugin source must be an absolute path, git URL, https URL, or GitHub source",
+    );
+  }
+  const gh = raw.match(GITHUB_SHORTHAND);
+  if (!gh) {
+    throw new PluginSourceError(
+      "plugin source must be an absolute path, git URL, https URL, or GitHub source",
+    );
+  }
+  const owner = gh[1];
+  const repo = gh[2].replace(/\.git$/i, "");
+  const ref = gh[3] || "";
+  return {
+    kind: "github",
+    raw,
+    owner,
+    repo,
+    ref,
+    cloneUrl: `https://github.com/${owner}/${repo}.git`,
+  };
+}
+
+function resolveHttpSource(raw: string): ResolvedPluginSource {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new PluginSourceError("invalid plugin source URL");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new PluginSourceError("unsupported plugin source scheme");
+  }
+  const refFromHash = decodeURIComponent((url.hash || "").replace(/^#/, ""));
+  if (GITHUB_HOST.test(url.hostname)) {
+    const parts = url.pathname.replace(/^\/+|\/+$/g, "").split("/").filter(Boolean);
+    if (parts.length < 2) {
+      throw new PluginSourceError("GitHub source must be owner/repo");
+    }
+    const owner = parts[0];
+    const repo = parts[1].replace(/\.git$/i, "");
+    let ref = refFromHash;
+    if ((parts[2] === "tree" || parts[2] === "commit") && parts[3]) {
+      ref = ref || parts[3];
+    }
+    return {
+      kind: "github",
+      raw,
+      owner,
+      repo,
+      ref,
+      cloneUrl: `https://github.com/${owner}/${repo}.git`,
+    };
+  }
+  const path = url.pathname.toLowerCase();
+  const kind = path.endsWith(".git") ? "git" : "https";
+  return {
+    kind,
+    raw,
+    cloneUrl: `${url.origin}${url.pathname}${url.search}`,
+    ref: refFromHash,
+    ...parseGitRemote(`${url.origin}${url.pathname}`),
+  };
+}
+
+export function pluginInstallPayload(input: string): {
+  source: ResolvedPluginSource;
+  path?: string;
+} {
+  const source = resolvePluginSource(input);
+  return source.kind === "path" ? { source, path: source.path } : { source };
+}


### PR DESCRIPTION
## Summary
- Resolve Agent Plugin install sources: absolute path, git, https, and GitHub
- `POST /api/plugins/install` accepts a path, source URL, or resolved source object
- Plugin registry clones remote sources; packages stay default-disabled
- Agent plugins only (no marketplace, no contrib store)

## Test plan
- [x] URL resolve (path / git / https / github)
- [x] install accepts git / https / github (hermetic clone stub)
- [x] POST /api/plugins/install accepts resolved sources
- [ ] Do not merge until CI is green