### PR TITLE
Marionette v0.9.339 — settings opt-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.29` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.338, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.339, deliberately pre-1.0. Rides puppetmaster-ai==1.22.29. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.338"
+__version__ = "0.9.339"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.338"
+version = "0.9.339"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.338"
+version = "0.9.339"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.338",
+  "version": "0.9.339",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.338",
+      "version": "0.9.339",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.338",
+  "version": "0.9.339",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SettingsOptIns.test.tsx
+++ b/webapp/src/__tests__/SettingsOptIns.test.tsx
@@ -79,7 +79,7 @@ describe("SettingsOptIns", () => {
     expect(src).not.toMatch(/hermes/i);
     expect(src).not.toMatch(/flag platform|featureFlag|feature_flag/i);
     expect(paneSrc).toMatch(/<SettingsOptIns /);
-    expect(paneSrc).toMatch(/onUpdate=\{update\}/);
+    expect(paneSrc).toMatch(/onUpdate=\{\(partial\) => \{ void update\(partial\); \}\}/);
     expect(shellSrc).not.toMatch(/SettingsOptIns|opt-ins|marketplace/i);
   });
 });

--- a/webapp/src/__tests__/SettingsOptIns.test.tsx
+++ b/webapp/src/__tests__/SettingsOptIns.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import SettingsOptIns, {
+  SETTINGS_OPT_IN_KEYS,
+  settingsOptInOn,
+} from "../components/SettingsOptIns";
+import src from "../components/SettingsOptIns.tsx?raw";
+import paneSrc from "../components/SettingsPane.tsx?raw";
+import shellSrc from "../components/SettingsShell.tsx?raw";
+import type { Settings } from "../lib/api";
+
+const sample: Settings = {
+  driver: "cursor",
+  reach: "repo",
+  budget: 10,
+  models: [],
+  auto_distill: false,
+  hash_edit_enabled: false,
+  reviewEditsBeforeApply: false,
+  autoVerify: true,
+  state_dir: "/tmp/state",
+  repo: "/tmp/repo",
+};
+
+describe("SettingsOptIns", () => {
+  it("renders existing Settings keys only", () => {
+    render(<SettingsOptIns settings={sample} onUpdate={vi.fn()} />);
+    expect(screen.getByTestId("settings-opt-ins")).toBeTruthy();
+    expect(screen.getByText("Opt-ins")).toBeTruthy();
+    for (const key of SETTINGS_OPT_IN_KEYS) {
+      expect(screen.getByTestId(`settings-opt-in-${key}`)).toBeTruthy();
+    }
+    expect([...SETTINGS_OPT_IN_KEYS]).toEqual([
+      "auto_distill",
+      "hash_edit_enabled",
+      "reviewEditsBeforeApply",
+      "autoVerify",
+    ]);
+  });
+
+  it("reads existing keys and writes the same keys only", () => {
+    const onUpdate = vi.fn();
+    render(<SettingsOptIns settings={sample} onUpdate={onUpdate} />);
+    expect(screen.getByTestId("settings-opt-in-auto_distill").textContent).toMatch(/off/i);
+    expect(screen.getByTestId("settings-opt-in-autoVerify").textContent).toMatch(/on/i);
+
+    fireEvent.click(screen.getByTestId("settings-opt-in-auto_distill"));
+    expect(onUpdate).toHaveBeenCalledWith({ auto_distill: true });
+    fireEvent.click(screen.getByTestId("settings-opt-in-reviewEditsBeforeApply"));
+    expect(onUpdate).toHaveBeenCalledWith({ reviewEditsBeforeApply: true });
+    fireEvent.click(screen.getByTestId("settings-opt-in-hash_edit_enabled"));
+    expect(onUpdate).toHaveBeenCalledWith({ hash_edit_enabled: true });
+    fireEvent.click(screen.getByTestId("settings-opt-in-autoVerify"));
+    expect(onUpdate).toHaveBeenCalledWith({ autoVerify: false });
+
+    for (const call of onUpdate.mock.calls) {
+      const keys = Object.keys(call[0]);
+      expect(keys).toHaveLength(1);
+      expect(SETTINGS_OPT_IN_KEYS).toContain(keys[0]);
+    }
+  });
+
+  it("honors defaults when a key is omitted", () => {
+    const thin: Settings = {
+      driver: "cursor",
+      reach: "repo",
+      budget: 10,
+      models: [],
+      auto_distill: false,
+      state_dir: "/tmp/state",
+      repo: "/tmp/repo",
+    };
+    expect(settingsOptInOn(thin, "hash_edit_enabled", false)).toBe(false);
+    expect(settingsOptInOn(thin, "autoVerify", true)).toBe(true);
+  });
+
+  it("stays a Settings section: no new keys, marketplace, Hermes copy, or flag platform", () => {
+    expect(src).not.toMatch(/marketplace/i);
+    expect(src).not.toMatch(/hermes/i);
+    expect(src).not.toMatch(/flag platform|featureFlag|feature_flag/i);
+    expect(paneSrc).toMatch(/<SettingsOptIns /);
+    expect(paneSrc).toMatch(/onUpdate=\{update\}/);
+    expect(shellSrc).not.toMatch(/SettingsOptIns|opt-ins|marketplace/i);
+  });
+});

--- a/webapp/src/__tests__/SettingsPane.optIns.test.tsx
+++ b/webapp/src/__tests__/SettingsPane.optIns.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SettingsPane, { writeSettingsSnapshot } from "../components/SettingsPane";
+import { api, type Settings } from "../lib/api";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    settings: vi.fn(),
+    updateSettings: vi.fn(),
+    getUsage: vi.fn().mockResolvedValue(null),
+    getWikiConfig: vi.fn().mockResolvedValue({ api_base: "", has_token: false }),
+    getHooks: vi.fn().mockResolvedValue({ hooks: [], events: [] }),
+    providers: vi.fn().mockResolvedValue([]),
+    authPools: vi.fn().mockResolvedValue({ pools: [] }),
+    bedrockStatus: vi.fn().mockResolvedValue(null),
+    cursorCliStatus: vi.fn().mockResolvedValue(null),
+    gitStatus: vi.fn().mockResolvedValue(null),
+    platformAdapters: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../components/SkillsPane", () => ({ default: () => <div /> }));
+vi.mock("../components/MemoryPane", () => ({ default: () => <div /> }));
+vi.mock("../components/SchedulesPane", () => ({ default: () => <div /> }));
+
+const mockSettings = vi.mocked(api.settings);
+const mockUpdate = vi.mocked(api.updateSettings);
+
+const sampleSettings: Settings = {
+  driver: "cursor",
+  reach: "repo",
+  budget: 10,
+  models: ["anthropic/claude-sonnet"],
+  auto_distill: false,
+  reviewEditsBeforeApply: false,
+  hash_edit_enabled: false,
+  autoVerify: true,
+  compactionResidual: "catalog",
+  state_dir: "/tmp/state",
+  repo: "/tmp/repo",
+};
+
+describe("SettingsPane Opt-ins section", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeSettingsSnapshot(sampleSettings);
+    mockSettings.mockResolvedValue(sampleSettings);
+    mockUpdate.mockImplementation(async (partial) => ({ ...sampleSettings, ...partial }));
+  });
+
+  it("wires Opt-ins into existing Settings and writes existing keys", async () => {
+    render(<SettingsPane onOpenWizard={vi.fn()} section="general" />);
+
+    expect(await screen.findByTestId("settings-opt-ins")).toBeTruthy();
+    expect(screen.getByText("Opt-ins")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("settings-opt-in-auto_distill"));
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith({ auto_distill: true });
+    });
+
+    fireEvent.click(screen.getByTestId("settings-opt-in-reviewEditsBeforeApply"));
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith({ reviewEditsBeforeApply: true });
+    });
+  });
+});

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.338)", () => {
-  it("declares the official motion package and 0.9.338 not 329", () => {
+describe("feed Motion (v0.9.339)", () => {
+  it("declares the official motion package and 0.9.339 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.338");
+    expect(pkg.version).toBe("0.9.339");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/components/SettingsOptIns.tsx
+++ b/webapp/src/components/SettingsOptIns.tsx
@@ -1,0 +1,110 @@
+import type { Settings } from "../lib/api";
+
+/** Existing Settings keys surfaced by the Opt-ins section. No new flags. */
+export const SETTINGS_OPT_IN_KEYS = [
+  "auto_distill",
+  "hash_edit_enabled",
+  "reviewEditsBeforeApply",
+  "autoVerify",
+] as const;
+
+export type SettingsOptInKey = (typeof SETTINGS_OPT_IN_KEYS)[number];
+
+type OptInRow = {
+  key: SettingsOptInKey;
+  label: string;
+  summary: string;
+  help: string;
+  defaultOn: boolean;
+};
+
+const OPT_INS: OptInRow[] = [
+  {
+    key: "auto_distill",
+    label: "Auto-Distill",
+    summary: "Propose skills/rules after task",
+    help: "When enabled, PM proposes pending skill/rule candidates automatically on task completion.",
+    defaultOn: false,
+  },
+  {
+    key: "hash_edit_enabled",
+    label: "Hash-Anchored Edits",
+    summary: "Hash-anchored edits (experimental)",
+    help: "When on, the agent may apply edits anchored by content hashes instead of line numbers.",
+    defaultOn: false,
+  },
+  {
+    key: "reviewEditsBeforeApply",
+    label: "Review Edits",
+    summary: "Review edits before applying",
+    help: "When on, agent edits are held for your per-hunk approval instead of auto-applying.",
+    defaultOn: false,
+  },
+  {
+    key: "autoVerify",
+    label: "Auto-Verify Edits",
+    summary: "Check edits and self-correct",
+    help: "After the agent edits files, run a fast project check (typecheck / syntax on the changed files) and let it self-correct in the same turn before handing back.",
+    defaultOn: true,
+  },
+];
+
+export function settingsOptInOn(
+  settings: Settings,
+  key: SettingsOptInKey,
+  defaultOn: boolean,
+): boolean {
+  const value = settings[key];
+  return typeof value === "boolean" ? value : defaultOn;
+}
+
+/** Settings Opt-ins: read/write existing keys only. No new settings backend. */
+export default function SettingsOptIns({
+  settings,
+  onUpdate,
+  saving = false,
+}: {
+  settings: Settings;
+  onUpdate: (partial: Partial<Settings>) => void | Promise<void>;
+  saving?: boolean;
+}) {
+  return (
+    <div className="space-y-3" data-testid="settings-opt-ins">
+      <div>
+        <label className="block uppercase tracking-wider text-[10px] text-faint font-semibold">
+          Opt-ins
+        </label>
+        <p className="text-[10px] text-muted">
+          Existing Settings switches. Writes the current keys only.
+        </p>
+      </div>
+      {OPT_INS.map((row) => {
+        const on = settingsOptInOn(settings, row.key, row.defaultOn);
+        return (
+          <div key={row.key} className="space-y-1.5">
+            <label className="block uppercase tracking-wider text-[10px] text-faint font-semibold">
+              {row.label}
+            </label>
+            <button
+              type="button"
+              data-testid={`settings-opt-in-${row.key}`}
+              onClick={() => onUpdate({ [row.key]: !on })}
+              disabled={saving}
+              className={`w-full flex items-center justify-between px-3 py-2 rounded border transition text-left ${
+                on
+                  ? "bg-accent/10 border-accent/30 text-accent"
+                  : "bg-panel2 border-edge text-muted"
+              } disabled:opacity-50`}
+            >
+              <span className="font-medium text-[11px]">{row.summary}</span>
+              <span className="text-[10px] uppercase font-bold tracking-wider">
+                {on ? "on" : "off"}
+              </span>
+            </button>
+            <p className="text-[10px] text-muted">{row.help}</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -23,6 +23,7 @@ import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 import { SettingsCollapse } from "./SettingsCollapse";
 import WindowGlassSettings from "./WindowGlassSettings";
 import ProviderConfigModal from "./ProviderConfigModal";
+import SettingsOptIns from "./SettingsOptIns";
 import type { ProviderConfigValues } from "../lib/providerConfig";
 
 export type SettingsSection = "general" | "safety" | "providers" | "notifications" | "plugins" | "advanced";
@@ -1078,58 +1079,9 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
         </div>
 
         </>)}
-        {gate("general", "auto-distill distillation toggle") && settings && (<>
-        {/* Auto Distill Toggle */}
-        <div className="space-y-1.5">
-          <label className="block uppercase tracking-wider text-[10px] text-faint font-semibold">
-            Auto-Distill
-          </label>
-          <button
-            onClick={() => update({ auto_distill: !settings.auto_distill })}
-            disabled={saving}
-            className={`w-full flex items-center justify-between px-3 py-2 rounded border transition text-left ${
-              settings.auto_distill
-                ? "bg-accent/10 border-accent/30 text-accent"
-                : "bg-panel2 border-edge text-muted"
-            } disabled:opacity-50`}
-          >
-            <span className="font-medium text-[11px]">Propose skills/rules after task</span>
-            <span className="text-[10px] uppercase font-bold tracking-wider">
-              {settings.auto_distill ? "on" : "off"}
-            </span>
-          </button>
-          <p className="text-[10px] text-muted">
-            When enabled, PM proposes pending skill/rule candidates automatically on task completion.
-          </p>
-        </div>
-
-        </>)}
-        {gate("general", "hash edit hash-anchored experimental") && settings && (<>
-        {/* Hash-anchored edits (experimental) */}
-        <div className="space-y-1.5">
-          <label className="block uppercase tracking-wider text-[10px] text-faint font-semibold">
-            Hash-Anchored Edits
-          </label>
-          <button
-            onClick={() => update({ hash_edit_enabled: !(settings.hash_edit_enabled ?? false) })}
-            disabled={saving}
-            className={`w-full flex items-center justify-between px-3 py-2 rounded border transition text-left ${
-              (settings.hash_edit_enabled ?? false)
-                ? "bg-accent/10 border-accent/30 text-accent"
-                : "bg-panel2 border-edge text-muted"
-            } disabled:opacity-50`}
-          >
-            <span className="font-medium text-[11px]">Hash-anchored edits (experimental)</span>
-            <span className="text-[10px] uppercase font-bold tracking-wider">
-              {(settings.hash_edit_enabled ?? false) ? "on" : "off"}
-            </span>
-          </button>
-          <p className="text-[10px] text-muted">
-            When on, the agent may apply edits anchored by content hashes instead of line numbers.
-          </p>
-        </div>
-
-        </>)}
+        {gate("general", "opt-ins optin auto-distill distillation toggle hash edit hash-anchored experimental review edits diff review toggle auto-verify edits typecheck syntax check self-correct diagnostics") && settings && (
+          <SettingsOptIns settings={settings} onUpdate={update} saving={saving} />
+        )}
         {gate("general", "compaction residual hybrid summary catalog vault compact handle index") && settings && (<>
         <div className="space-y-1.5">
           <label className="block uppercase tracking-wider text-[10px] text-faint font-semibold">
@@ -1172,59 +1124,6 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
             story after compact, then retrieve matching slices later.
             Hybrid adds a paid LLM paragraph on top. Summary is the paid
             paragraph alone.
-          </p>
-        </div>
-
-        </>)}
-        {gate("general", "review edits diff review toggle") && settings && (<>
-        {/* Diff Review Toggle */}
-        <div className="space-y-1.5">
-          <label className="block uppercase tracking-wider text-[10px] text-faint font-semibold">
-            Review Edits
-          </label>
-          <button
-            onClick={() => update({ reviewEditsBeforeApply: !settings.reviewEditsBeforeApply })}
-            disabled={saving}
-            className={`w-full flex items-center justify-between px-3 py-2 rounded border transition text-left ${
-              settings.reviewEditsBeforeApply
-                ? "bg-accent/10 border-accent/30 text-accent"
-                : "bg-panel2 border-edge text-muted"
-            } disabled:opacity-50`}
-          >
-            <span className="font-medium text-[11px]">Review edits before applying</span>
-            <span className="text-[10px] uppercase font-bold tracking-wider">
-              {settings.reviewEditsBeforeApply ? "on" : "off"}
-            </span>
-          </button>
-          <p className="text-[10px] text-muted">
-            When on, agent edits are held for your per-hunk approval instead of auto-applying.
-          </p>
-        </div>
-
-        </>)}
-        {gate("general", "auto-verify edits typecheck syntax check self-correct diagnostics") && settings && (<>
-        {/* Auto-Verify Edits Toggle */}
-        <div className="space-y-1.5">
-          <label className="block uppercase tracking-wider text-[10px] text-faint font-semibold">
-            Auto-Verify Edits
-          </label>
-          <button
-            onClick={() => update({ autoVerify: !(settings.autoVerify ?? true) })}
-            disabled={saving}
-            className={`w-full flex items-center justify-between px-3 py-2 rounded border transition text-left ${
-              (settings.autoVerify ?? true)
-                ? "bg-accent/10 border-accent/30 text-accent"
-                : "bg-panel2 border-edge text-muted"
-            } disabled:opacity-50`}
-          >
-            <span className="font-medium text-[11px]">Check edits and self-correct</span>
-            <span className="text-[10px] uppercase font-bold tracking-wider">
-              {(settings.autoVerify ?? true) ? "on" : "off"}
-            </span>
-          </button>
-          <p className="text-[10px] text-muted">
-            After the agent edits files, run a fast project check (typecheck / syntax on the
-            changed files) and let it self-correct in the same turn before handing back.
           </p>
         </div>
 

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -1080,7 +1080,7 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
 
         </>)}
         {gate("general", "opt-ins optin auto-distill distillation toggle hash edit hash-anchored experimental review edits diff review toggle auto-verify edits typecheck syntax check self-correct diagnostics") && settings && (
-          <SettingsOptIns settings={settings} onUpdate={update} saving={saving} />
+          <SettingsOptIns settings={settings} onUpdate={(partial) => { void update(partial); }} saving={saving} />
         )}
         {gate("general", "compaction residual hybrid summary catalog vault compact handle index") && settings && (<>
         <div className="space-y-1.5">


### PR DESCRIPTION
## Summary
- Settings Opt-ins section over existing Settings keys only (`auto_distill`, `hash_edit_enabled`, `reviewEditsBeforeApply`, `autoVerify`)
- Wired into existing SettingsPane; SettingsShell unchanged
- No new settings keys, flag platform, marketplace, Hermes copy, or `.github`
- Version 0.9.339; feedMotion assert 0.9.338 → 0.9.339; pin puppetmaster-ai==1.22.29

## Test plan
- [x] SettingsOptIns reads/writes existing keys only
- [x] SettingsPane general hosts the Opt-ins section
- [x] Compact Residual still cycles catalog → hybrid
- [x] feedMotion version assert is 0.9.339
- [ ] Do not merge until CI is green