### PR TITLE
Marionette v0.9.342 — command vs swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.31` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.341, deliberately pre-1.0. Rides puppetmaster-ai==1.22.31. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.342, deliberately pre-1.0. Rides puppetmaster-ai==1.22.31. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.341"
+__version__ = "0.9.342"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.341"
+version = "0.9.342"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.341"
+version = "0.9.342"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.341",
+  "version": "0.9.342",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.341",
+      "version": "0.9.342",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.341",
+  "version": "0.9.342",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -3003,3 +3003,90 @@ describe("swarm tracker usage pills (0.9.300)", () => {
     expect(screen.queryByText(/Findings \(2 of/)).toBeNull();
   });
 });
+
+
+describe("SwarmPane command vs swarm split", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    clearSWRCache();
+    mockArtifacts.mockResolvedValue([]);
+    mockSwarmCancel.mockResolvedValue({ ok: true } as any);
+  });
+
+  it("excludes run_command jobs from tracker count and cards", async () => {
+    mockSwarmLive.mockResolvedValue({
+      session: { tokens_used: 0, est_cost_usd: 0 },
+      jobs: [
+        {
+          id: "local-cmd-e35cf193",
+          goal: "sleep 999",
+          status: "running",
+          job_kind: "run_command",
+          role: "command",
+          adapter: "command",
+          command_preview: "sleep 999",
+          source: "harness",
+        },
+        {
+          id: "job_abc123def456",
+          goal: "Audit auth flow",
+          status: "running",
+          source: "harness",
+        },
+      ],
+    });
+    render(<SwarmPane />);
+    expect(await screen.findByText("Audit auth flow")).toBeInTheDocument();
+    expect(screen.queryByText("sleep 999")).not.toBeInTheDocument();
+    expect(screen.getByText("Swarm Tracker").parentElement).toHaveTextContent("(1)");
+  });
+
+  it("still shows run_swarm / run_implement / run_parallel cards", async () => {
+    mockSwarmLive.mockResolvedValue({
+      session: { tokens_used: 0, est_cost_usd: 0 },
+      jobs: [
+        { id: "job_swarm", goal: "run_swarm audit", status: "running", source: "harness" },
+        { id: "job_impl", goal: "run_implement fix", status: "running", source: "harness", role: "implementer", adapter: "agentic" },
+        { id: "job_par", goal: "run_parallel wave", status: "running", source: "harness" },
+        {
+          id: "local-cmdbatch-aa11bb22",
+          goal: "echo batch",
+          status: "running",
+          job_kind: "run_command_batch",
+          role: "command_batch",
+          adapter: "command_batch",
+          source: "harness",
+        },
+      ],
+    });
+    render(<SwarmPane />);
+    expect(await screen.findByText("run_swarm audit")).toBeInTheDocument();
+    expect(screen.getByText("run_implement fix")).toBeInTheDocument();
+    expect(screen.getByText("run_parallel wave")).toBeInTheDocument();
+    expect(screen.queryByText("echo batch")).not.toBeInTheDocument();
+    expect(screen.getByText("Swarm Tracker").parentElement).toHaveTextContent("(3)");
+  });
+
+  it("does not count a lone command job as Swarm Tracker (1)", async () => {
+    mockSwarmLive.mockResolvedValue({
+      session: { tokens_used: 0, est_cost_usd: 0 },
+      jobs: [
+        {
+          id: "local-cmd-e35cf193",
+          goal: "sleep 999",
+          status: "running",
+          job_kind: "run_command",
+          role: "command",
+          adapter: "command",
+          source: "harness",
+        },
+      ],
+    });
+    render(<SwarmPane />);
+    expect(await screen.findByText("No swarm jobs yet")).toBeInTheDocument();
+    expect(screen.queryByText("sleep 999")).not.toBeInTheDocument();
+    expect(screen.getByText("Swarm Tracker").parentElement).not.toHaveTextContent("(1)");
+  });
+});

--- a/webapp/src/__tests__/composerStatusStack.test.ts
+++ b/webapp/src/__tests__/composerStatusStack.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildComposerStatusStackRows } from "../components/conversation/composerStatusStackData";
+import {
+  buildComposerStatusStackRows,
+  visibleCommandJob,
+  visibleSwarmJob,
+} from "../components/conversation/composerStatusStackData";
 
 describe("composerStatusStack", () => {
   it("filters to owned jobs and hides stale terminal rows", () => {
@@ -64,6 +68,151 @@ describe("composerStatusStack", () => {
       kind: "terminal",
       state: "running",
       label: "pytest -q",
+    });
+  });
+
+
+  it("reclassifies run_command live jobs as terminal, not swarm", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const commandJob = {
+      id: "local-cmd-e35cf193",
+      goal: "sleep 999",
+      source: "harness",
+      status: "running",
+      updated_at: now - 1000,
+      job_kind: "run_command",
+      role: "command",
+      adapter: "command",
+      command_preview: "sleep 999",
+    } as any;
+    const swarmJob = {
+      id: "job_abc123def456",
+      goal: "Audit composer stack",
+      source: "harness",
+      status: "running",
+      updated_at: now - 1000,
+    } as any;
+    expect(visibleSwarmJob(commandJob, now)).toBeNull();
+    expect(visibleCommandJob(commandJob, now)).toMatchObject({
+      id: "local-cmd-e35cf193",
+      kind: "terminal",
+      command: "sleep 999",
+      state: "running",
+    });
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [commandJob, swarmJob],
+      commandSessions: [],
+    });
+    expect(rows.map((row) => ({ id: row.id, kind: row.kind }))).toEqual([
+      { id: "job_abc123def456", kind: "swarm" },
+      { id: "local-cmd-e35cf193", kind: "terminal" },
+    ]);
+  });
+
+
+  it("classifies run_command_batch and local-cmd* ids as terminal", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const cases = [
+      {
+        id: "job_batch",
+        goal: "echo a",
+        source: "harness",
+        status: "running",
+        updated_at: now - 1000,
+        job_kind: "run_command_batch",
+        role: "command_batch",
+        adapter: "command_batch",
+        command_preview: "echo a",
+      },
+      {
+        id: "job_role_only",
+        goal: "sleep 1",
+        source: "harness",
+        status: "running",
+        updated_at: now - 1000,
+        job_kind: "run_command",
+        role: "command",
+        adapter: "command",
+      },
+      {
+        id: "local-cmd-deadbeef",
+        goal: "sleep 1",
+        source: "harness",
+        status: "running",
+        updated_at: now - 1000,
+      },
+      {
+        id: "local-cmdbatch-aa11bb22",
+        goal: "echo batch",
+        source: "harness",
+        status: "running",
+        updated_at: now - 1000,
+        command_preview: "echo batch",
+      },
+    ] as any[];
+    for (const job of cases) {
+      expect(visibleSwarmJob(job, now), job.id).toBeNull();
+      expect(visibleCommandJob(job, now)?.kind, job.id).toBe("terminal");
+    }
+  });
+
+  it("keeps command-adapter swarm workers without job_kind as swarm", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const job = {
+      id: "job-timeout",
+      goal: "Timed-out command",
+      source: "harness",
+      status: "timeout",
+      updated_at: now - 1000,
+      adapter: "command",
+      role: "command",
+    } as any;
+    expect(visibleSwarmJob(job, now)?.kind).toBe("swarm");
+    expect(visibleCommandJob(job, now)).toBeNull();
+  });
+
+  it("keeps run_swarm / run_implement / run_parallel as swarm", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const jobs = [
+      { id: "job_swarm", goal: "run_swarm audit", source: "harness", status: "running", updated_at: now - 1000 },
+      { id: "job_impl", goal: "run_implement fix", source: "harness", status: "running", updated_at: now - 1000, role: "implementer", adapter: "agentic" },
+      { id: "job_par", goal: "run_parallel wave", source: "harness", status: "running", updated_at: now - 1000 },
+    ] as any[];
+    for (const job of jobs) {
+      expect(visibleSwarmJob(job, now)?.kind, job.id).toBe("swarm");
+      expect(visibleCommandJob(job, now), job.id).toBeNull();
+    }
+  });
+
+  it("dedupes a live command job against the same command-session id", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [{
+        id: "local-cmd-e35cf193",
+        goal: "sleep 999",
+        source: "harness",
+        status: "running",
+        updated_at: now - 1000,
+        job_kind: "run_command",
+        role: "command",
+        adapter: "command",
+        command_preview: "sleep 999",
+      } as any],
+      commandSessions: [{
+        id: "local-cmd-e35cf193",
+        command: "sleep 999",
+        output: "still running",
+        state: "running",
+        updatedAt: now - 200,
+      }],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "local-cmd-e35cf193",
+      kind: "terminal",
+      output: "still running",
     });
   });
 });

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.341)", () => {
-  it("declares the official motion package and 0.9.341 not 329", () => {
+describe("feed Motion (v0.9.342)", () => {
+  it("declares the official motion package and 0.9.342 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.341");
+    expect(pkg.version).toBe("0.9.342");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/jobClassification.test.ts
+++ b/webapp/src/__tests__/jobClassification.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isCommandJob } from "../lib/jobClassification";
+
+describe("isCommandJob", () => {
+  it("matches job_kind and local-cmd id prefixes", () => {
+    expect(isCommandJob({ job_kind: "run_command" })).toBe(true);
+    expect(isCommandJob({ job_kind: "run_command_batch" })).toBe(true);
+    expect(isCommandJob({ id: "local-cmd-e35cf193" })).toBe(true);
+    expect(isCommandJob({ id: "local-cmdbatch-aa11bb22" })).toBe(true);
+    expect(isCommandJob({
+      id: "local-cmd-e35cf193",
+      job_kind: "run_command",
+      role: "command",
+      adapter: "command",
+    })).toBe(true);
+  });
+
+  it("does not treat provider swarm / command-adapter workers as command jobs", () => {
+    expect(isCommandJob({ id: "job_abc123def456" })).toBe(false);
+    expect(isCommandJob({ id: "local-swarm-1", role: "worker", adapter: "agentic" })).toBe(false);
+    expect(isCommandJob({ id: "local-impl-1", job_kind: "run_implement" })).toBe(false);
+    expect(isCommandJob({ job_kind: "run_swarm" })).toBe(false);
+    expect(isCommandJob({ job_kind: "run_parallel" })).toBe(false);
+    expect(isCommandJob({ id: "job-timeout", adapter: "command", role: "command" })).toBe(false);
+  });
+});

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -11,6 +11,7 @@ import {
 } from "../lib/pendingSwarmOpenJob";
 import { useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
 import { filterJobsByScope, loadJobScope, saveJobScope, type JobScope } from "../lib/jobScope";
+import { isCommandJob } from "../lib/jobClassification";
 import { jobHeadlineTotal } from "./EconomicsDurable";
 
 // A clean, self-contained hover tooltip. The native `title=` tooltip renders as a
@@ -1477,7 +1478,9 @@ export default function SwarmPane() {
     };
   }, [scopedRepo, applyLive]);
 
-  const allJobs = filterJobsByScope(data?.jobs || [], jobScope, activeSessionId);
+  const allJobs = filterJobsByScope(data?.jobs || [], jobScope, activeSessionId).filter(
+    (job) => !isCommandJob(job),
+  );
   // Clear/dismiss is archive chrome for finished runs only. Live (and pending)
   // jobs must stay visible even if their id was previously dismissed — otherwise
   // a CLI-started swarm looks "gone" while workers are still running, and pilots

--- a/webapp/src/components/conversation/composerStatusStackData.ts
+++ b/webapp/src/components/conversation/composerStatusStackData.ts
@@ -1,5 +1,6 @@
 import type { Job } from "../../lib/api";
 import type { AgentCommandSession } from "../../lib/agentCommandIndex";
+import { isCommandJob } from "../../lib/jobClassification";
 
 export type ComposerStatusStackKind = "swarm" | "terminal";
 export type ComposerStatusStackState = "running" | "done" | "failed";
@@ -75,13 +76,20 @@ function jobUpdatedAt(job: Job): number | null {
   return timestampMs(job.updated_at ?? job.created_at ?? null);
 }
 
-function visibleSwarmJob(job: Job, nowMs: number): ComposerStatusStackRow | null {
+function lingerAllows(state: ComposerStatusStackState, updatedAt: number | null, nowMs: number, successMs: number, failureMs: number): boolean {
+  if (state !== "running" && updatedAt == null) return false;
+  if (state === "done" && updatedAt != null && nowMs - updatedAt > successMs) return false;
+  if (state === "failed" && updatedAt != null && nowMs - updatedAt > failureMs) return false;
+  return true;
+}
+
+/** Accounting-owned provider swarm only. Command jobs return null (reclassify as terminal). */
+export function visibleSwarmJob(job: Job, nowMs: number): ComposerStatusStackRow | null {
   if (!jobAccountingOwned(job)) return null;
+  if (isCommandJob(job)) return null;
   const state = normalizeState(job.status);
   const updatedAt = jobUpdatedAt(job);
-  if (state !== "running" && updatedAt == null) return null;
-  if (state === "done" && updatedAt != null && nowMs - updatedAt > SWARM_SUCCESS_LINGER_MS) return null;
-  if (state === "failed" && updatedAt != null && nowMs - updatedAt > SWARM_FAILURE_LINGER_MS) return null;
+  if (!lingerAllows(state, updatedAt, nowMs, SWARM_SUCCESS_LINGER_MS, SWARM_FAILURE_LINGER_MS)) return null;
   const id = String(job.id || "").trim();
   if (!id) return null;
   const label = String(job.goal || job.role || job.id || "").trim() || id;
@@ -92,6 +100,31 @@ function visibleSwarmJob(job: Job, nowMs: number): ComposerStatusStackRow | null
     state,
     updatedAt: updatedAt ?? nowMs,
     title: label,
+  };
+}
+
+/** Live command / command-batch rows from /api/swarm/live, painted as terminal. */
+export function visibleCommandJob(job: Job, nowMs: number): ComposerStatusStackRow | null {
+  if (!jobAccountingOwned(job)) return null;
+  if (!isCommandJob(job)) return null;
+  const state = normalizeState(job.status);
+  const updatedAt = jobUpdatedAt(job);
+  if (!lingerAllows(state, updatedAt, nowMs, COMMAND_SUCCESS_LINGER_MS, COMMAND_FAILURE_LINGER_MS)) return null;
+  const id = String(job.id || "").trim();
+  if (!id) return null;
+  const command = String(job.command_preview || job.goal || "").trim();
+  const label = command || String(job.role || job.id || "").trim() || id;
+  const receipt = job.terminal_receipt;
+  const output = receipt && typeof receipt.summary === "string" ? receipt.summary : undefined;
+  return {
+    id,
+    kind: "terminal",
+    label,
+    state,
+    updatedAt: updatedAt ?? nowMs,
+    title: label,
+    command: command || label,
+    output,
   };
 }
 
@@ -122,15 +155,25 @@ export function buildComposerStatusStackRows(
 ): ComposerStatusStackRow[] {
   const nowMs = source.nowMs ?? Date.now();
   const rows: ComposerStatusStackRow[] = [];
+  const seen = new Set<string>();
 
-  for (const job of source.swarmJobs) {
-    const row = visibleSwarmJob(job, nowMs);
-    if (row) rows.push(row);
-  }
-
+  // Sessions first: they carry live stdout for the existing openAgentCommand path.
   for (const session of source.commandSessions) {
     const row = visibleCommandSession(session, nowMs);
-    if (row) rows.push(row);
+    if (row) {
+      rows.push(row);
+      seen.add(row.id);
+    }
+  }
+
+  for (const job of source.swarmJobs) {
+    const id = String(job.id || "").trim();
+    if (id && seen.has(id)) continue;
+    const row = visibleSwarmJob(job, nowMs) ?? visibleCommandJob(job, nowMs);
+    if (row) {
+      rows.push(row);
+      seen.add(row.id);
+    }
   }
 
   return rows.sort((a, b) => {

--- a/webapp/src/lib/jobClassification.ts
+++ b/webapp/src/lib/jobClassification.ts
@@ -1,0 +1,29 @@
+/** Classify /api/swarm/live rows as terminal command vs provider swarm.
+ *
+ * Background run_command / run_command_batch jobs ride the same live feed as
+ * swarms (local-job projection) but must never paint Swarm Tracker chrome.
+ * job_kind and local-cmd* ids are the seam. role/adapter "command" is
+ * corroborating, not sufficient — swarm workers can use adapter=command.
+ */
+
+const COMMAND_JOB_KINDS = new Set(["run_command", "run_command_batch"]);
+
+export type CommandJobSignals = {
+  id?: string | null;
+  job_kind?: string | null;
+  role?: string | null;
+  adapter?: string | null;
+};
+
+function commandId(id: string): boolean {
+  return id.startsWith("local-cmd-") || id.startsWith("local-cmdbatch-");
+}
+
+/** True for background command / command-batch jobs. */
+export function isCommandJob(job: CommandJobSignals): boolean {
+  const kind = String(job.job_kind || "").trim().toLowerCase();
+  if (COMMAND_JOB_KINDS.has(kind)) return true;
+  const id = String(job.id || "").trim().toLowerCase();
+  if (commandId(id)) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary

- Background `run_command` / `run_command_batch` jobs (job_kind, or `local-cmd-*` / `local-cmdbatch-*` ids) were painted as Swarm Tracker cards and composer Puppetmaster / Open swarm rows.
- Frontend classification only: `/api/swarm/live` already stamps command jobs correctly. `isCommandJob` filters them out of Swarm Tracker and reclassifies them as composer Terminal / Term / Open terminal (existing `openAgentCommand` path).
- Real `run_swarm` / `run_implement` / `run_parallel` stay swarm. Pin stays `puppetmaster-ai==1.22.31`. Version 0.9.342.

## Test plan

- [x] `vitest` `jobClassification` / `composerStatusStack` / `SwarmPane` (105 passed)
- [ ] Confirm a live background `run_command` (`local-cmd-*`) shows Terminal / Open terminal, not Swarm Tracker (1)
- [ ] Confirm a live `run_swarm` still shows as swarm