### PR TITLE
Marionette v0.9.343 — sealed prose bubble

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.31` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.342, deliberately pre-1.0. Rides puppetmaster-ai==1.22.31. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.343, deliberately pre-1.0. Rides puppetmaster-ai==1.22.31. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.342"
+__version__ = "0.9.343"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.342"
+version = "0.9.343"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.342"
+version = "0.9.343"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.342",
+  "version": "0.9.343",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.342",
+      "version": "0.9.343",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.342",
+  "version": "0.9.343",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.342)", () => {
-  it("declares the official motion package and 0.9.342 not 329", () => {
+describe("feed Motion (v0.9.343)", () => {
+  it("declares the official motion package and 0.9.343 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.342");
+    expect(pkg.version).toBe("0.9.343");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/investigationCollapser.seal.test.tsx
+++ b/webapp/src/__tests__/investigationCollapser.seal.test.tsx
@@ -160,7 +160,9 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
     expect(screen.queryByText(/Investigating/i)).toBeNull();
     expect(screen.getByText(/Still working/i)).toBeTruthy();
 
-    // Pilot busy (thinking): holdSwarmAwait must not seal — live swarm keeps Investigating.
+    // Pilot busy (thinking): holdSwarmAwait must not seal. Live chrome is
+    // Swarm · running + Still working… (not Investigating). Sealed cards
+    // stay Explored 2 files; spoken assistant prose stays a top-level Bubble.
     rerender(
       <TranscriptList
         {...listProps(pauseItems, {
@@ -170,9 +172,10 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
         })}
       />,
     );
-    expect(screen.getByText(/Investigating/i)).toBeTruthy();
-    // Finished cards + open loop: fold stays Investigating and the footer
-    // keeps Still working… so tool-batch gaps are not a dead log dump.
+    expect(screen.getByText(/Swarm · running/i)).toBeTruthy();
+    expect(screen.getByText(/Explored/i)).toBeTruthy();
+    expect(screen.queryByText(/Investigating/i)).toBeNull();
+    // Footer keeps Still working… so tool-batch gaps are not a dead log dump.
     expect(screen.getByText(/Still working/i)).toBeTruthy();
   });
 

--- a/webapp/src/__tests__/investigationCollapser.seal.test.tsx
+++ b/webapp/src/__tests__/investigationCollapser.seal.test.tsx
@@ -160,9 +160,7 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
     expect(screen.queryByText(/Investigating/i)).toBeNull();
     expect(screen.getByText(/Still working/i)).toBeTruthy();
 
-    // Pilot busy (thinking): holdSwarmAwait must not seal. Live chrome is
-    // Swarm · running + Still working… (not Investigating). Sealed cards
-    // stay Explored 2 files; spoken assistant prose stays a top-level Bubble.
+    // Pilot busy (thinking): holdSwarmAwait must not seal — live swarm keeps Investigating.
     rerender(
       <TranscriptList
         {...listProps(pauseItems, {
@@ -172,11 +170,12 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
         })}
       />,
     );
-    expect(screen.getByText(/Swarm · running/i)).toBeTruthy();
-    expect(screen.getByText(/Explored/i)).toBeTruthy();
-    expect(screen.queryByText(/Investigating/i)).toBeNull();
-    // Footer keeps Still working… so tool-batch gaps are not a dead log dump.
+    expect(screen.getByText(/Investigating/i)).toBeTruthy();
+    // Finished cards + open loop: fold stays Investigating and the footer
+    // keeps Still working… so tool-batch gaps are not a dead log dump.
     expect(screen.getByText(/Still working/i)).toBeTruthy();
+    // Spoken assistant prose stays a top-level Bubble after the fold.
+    expect(screen.getByText(/Workers flying — validating when they land/i)).toBeTruthy();
   });
 
   it("holdSwarmAwait with active pilot turn keeps mid-turn Investigating, not sealed Explored", () => {

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -1086,6 +1086,50 @@ describe("live command token clicks", () => {
     expect(screen.queryByRole("button", { name: /Investigating|Explored/i })).toBeNull();
   });
 
+  it("keeps sealed spoken prose outside the collapsed Investigating fold", () => {
+    const spoken: Item = {
+      kind: "msg",
+      msg: { role: "assistant", text: "I will patch auth next." },
+    };
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "fix auth" } },
+      {
+        kind: "card",
+        card: {
+          id: "c-pre",
+          goal: "auth.ts",
+          cwd: null,
+          kind: "read_file",
+          running: false,
+          open: false,
+          result: { status: "ok" },
+        },
+      },
+      spoken,
+      {
+        kind: "card",
+        card: {
+          id: "c-post",
+          goal: "apply patch",
+          cwd: null,
+          kind: "edit_file",
+          running: false,
+          open: false,
+          result: { status: "ok" },
+        },
+      },
+    ];
+    expect(collectIntermediateAssistantItems(items, false).has(spoken)).toBe(false);
+    render(<TranscriptList {...listProps(items)} />);
+    // White streamed text stays a top-level Bubble, visible without opening either fold.
+    expect(screen.getByText(/I will patch auth next/i)).toBeTruthy();
+    const folds = screen.getAllByRole("button", { name: /Explored|Investigating/i });
+    expect(folds.length).toBeGreaterThan(0);
+    for (const fold of folds) {
+      expect(fold).toHaveAttribute("aria-expanded", "false");
+    }
+  });
+
   it("groups consecutive read/search cards into one exploration shelf", () => {
     render(
       <TranscriptList

--- a/webapp/src/__tests__/transcriptSurfaceStability.test.ts
+++ b/webapp/src/__tests__/transcriptSurfaceStability.test.ts
@@ -315,7 +315,7 @@ describe("transcript surface stability (no mid-turn reclassification)", () => {
     expect(whenDone.has(finale)).toBe(false);
   });
 
-  it("sealed: planning before Thought+finale stays inside the fold (no PILOT split)", () => {
+  it("sealed unmarked planning stays a top-level Bubble (spoken prose, not fold)", () => {
     const card: Item = {
       kind: "card",
       card: {
@@ -355,9 +355,87 @@ describe("transcript surface stability (no mid-turn reclassification)", () => {
       finale,
     ];
     const whenDone = collectIntermediateAssistantItems(items, false);
-    expect(whenDone.has(planning)).toBe(true);
-    // True trailing finale still peels even when late Thought preceded it.
+    // Unmarked spoken prose is not foldable — only workerStream / isPlan / progress.
+    expect(whenDone.has(planning)).toBe(false);
     expect(whenDone.has(finale)).toBe(false);
+  });
+
+  it("sealed spoken prose stays top-level when a later card or swarm arrives", () => {
+    const firstCard: Item = {
+      kind: "card",
+      card: {
+        id: "c-pre",
+        goal: "auth.ts",
+        cwd: null,
+        kind: "read_file",
+        running: false,
+        open: false,
+        result: { status: "ok" },
+      },
+    };
+    const spoken: Item = {
+      kind: "msg",
+      msg: { role: "assistant", text: "I will patch auth next.", streaming: false },
+    };
+    const laterCard: Item = {
+      kind: "card",
+      card: {
+        id: "c-post",
+        goal: "apply patch",
+        cwd: null,
+        kind: "edit_file",
+        running: false,
+        open: false,
+        result: { status: "ok" },
+      },
+    };
+    const laterSwarm: Item = {
+      kind: "swarm_pending",
+      job_ids: ["job_sealed_prose"],
+      objective: "implement patch",
+      status: "running",
+    };
+    const withCard: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "fix auth" } },
+      firstCard,
+      spoken,
+      laterCard,
+    ];
+    const withSwarm: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "fix auth" } },
+      firstCard,
+      spoken,
+      laterSwarm,
+    ];
+    for (const open of [true, false]) {
+      expect(collectIntermediateAssistantItems(withCard, open).has(spoken)).toBe(false);
+      expect(collectIntermediateAssistantItems(withSwarm, open).has(spoken)).toBe(false);
+    }
+
+    const planMsg: Item = {
+      kind: "msg",
+      msg: { role: "assistant", text: "Planning the patch.", isPlan: true },
+    };
+    const progressMsg: Item = {
+      kind: "msg",
+      msg: { role: "assistant", text: "Retrying after routing error", channel: "progress" },
+    };
+    const worker: Item = {
+      kind: "msg",
+      msg: { role: "assistant", text: "worker tokens…", workerStream: true },
+    };
+    const foldables: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "fix auth" } },
+      firstCard,
+      planMsg,
+      progressMsg,
+      worker,
+      laterCard,
+    ];
+    const folded = collectIntermediateAssistantItems(foldables, false);
+    expect(folded.has(planMsg)).toBe(true);
+    expect(folded.has(progressMsg)).toBe(true);
+    expect(folded.has(worker)).toBe(true);
   });
 
   it("sealed: true finale before late thinking does not bury the answer", () => {

--- a/webapp/src/__tests__/turnTerminal.wave3.test.ts
+++ b/webapp/src/__tests__/turnTerminal.wave3.test.ts
@@ -312,6 +312,44 @@ describe("Wave 3: live answer stays outside the investigation fold", () => {
     const after: Item[] = [...items.slice(0, -1), sealed];
     expect(collectIntermediateAssistantItems(after, false).has(sealed)).toBe(false);
   });
+
+  it("does not reparent sealed spoken prose into the fold when a later card exists", () => {
+    const spoken: Item = {
+      kind: "msg",
+      msg: { role: "assistant", text: "Here is the patch.", streaming: false },
+    };
+    const items: Item[] = [
+      msg("user", "patch it"),
+      {
+        kind: "card",
+        card: {
+          id: "c1",
+          goal: "a.ts",
+          cwd: null,
+          kind: "read_file",
+          running: false,
+          open: false,
+          result: { status: "ok" },
+        },
+      },
+      spoken,
+      {
+        kind: "card",
+        card: {
+          id: "c2",
+          goal: "b.ts",
+          cwd: null,
+          kind: "edit_file",
+          running: false,
+          open: false,
+          result: { status: "ok" },
+        },
+      },
+    ];
+    expect(isLiveAnswerAssistant(spoken.msg)).toBe(false);
+    expect(collectIntermediateAssistantItems(items, true).has(spoken)).toBe(false);
+    expect(collectIntermediateAssistantItems(items, false).has(spoken)).toBe(false);
+  });
 });
 
 describe("Wave 3: Continue / Retry", () => {

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -638,6 +638,31 @@ export function collectIntermediateAssistantItems(
   return intermediateItems;
 }
 
+/**
+ * Spoken assistant prose stays a top-level Bubble and flushes the activity
+ * strip so it is never reparented into Investigating. Walk back across those
+ * bubbles to the same-turn fold they split — user / steer / questions are
+ * hard boundaries and must not resume a prior investigation.
+ */
+function activityGroupAcrossSpokenProse(grouped: GroupedItem[]): ActivityItem[] | null {
+  for (let k = grouped.length - 1; k >= 0; k--) {
+    const g = grouped[k];
+    if (g.kind === "msg" && g.msg.role === "assistant") continue;
+    if (g.kind === "activity_group") return g.items;
+    return null;
+  }
+  return null;
+}
+
+function isLiveInvestigationContinuity(item: Item): boolean {
+  if (item.kind === "card") return cardEffectivelyRunning(item.card);
+  if (item.kind === "swarm_pending") {
+    const status = item.status || (item.resolved ? "done" : "running");
+    return status === "running";
+  }
+  return false;
+}
+
 export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>): GroupedItem[] {
   // The feed is a conversation, not an event log. Top-level painted rows are
   // msg / question (command_approval, secret_request) / file (pending_review) /
@@ -647,6 +672,10 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
   const grouped: GroupedItem[] = [];
   let currentGroup: ActivityItem[] = [];
   let terminalSwarmItems: ActivityItem[] = [];
+  // After spoken prose flushes the strip, a later live swarm/card appends
+  // back onto the fold it split so Investigating cannot seal as Explored
+  // while that work is still running.
+  let bridgeTarget: ActivityItem[] | null = null;
   const resultJobIds = new Set(
     items
       .filter((item): item is Extract<Item, { kind: "swarm_result" }> => item.kind === "swarm_result")
@@ -660,6 +689,27 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
       currentGroup = [];
       terminalSwarmItems = [];
     }
+    bridgeTarget = null;
+  };
+
+  const pushActivity = (item: ActivityItem, live = false) => {
+    if (currentGroup.length > 0 || terminalSwarmItems.length > 0) {
+      currentGroup.push(item);
+      return;
+    }
+    if (bridgeTarget) {
+      bridgeTarget.push(item);
+      return;
+    }
+    if (live) {
+      const prior = activityGroupAcrossSpokenProse(grouped);
+      if (prior) {
+        prior.push(item);
+        bridgeTarget = prior;
+        return;
+      }
+    }
+    currentGroup.push(item);
   };
 
   for (let i = 0; i < items.length; i++) {
@@ -672,7 +722,7 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
       // Post-tool micro-narration folds into the investigation box. Pre-tool
       // assistant bubbles stay standalone permanently (no look-ahead reparent).
       if (item.msg.role === "assistant" && intermediateItems.has(item)) {
-        currentGroup.push(item);
+        pushActivity(item);
       } else {
         flush();
         grouped.push(item);
@@ -683,9 +733,9 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
     } else if (item.kind === "swarm_result") {
       // Durable swarm receipts live inside the activity strip alongside tools
       // and reasoning — same fold as swarm_pending / checkpoint / verify.
-      currentGroup.push(item);
+      pushActivity(item);
     } else if (item.kind === "checkpoint") {
-      currentGroup.push(item);
+      pushActivity(item);
     } else if (item.kind === "pending_review") {
       // Operator receipt for DiffReview hold — keep top-level so it is not
       // buried inside a collapsed investigation fold.
@@ -695,8 +745,9 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
       const status = item.status || (item.resolved ? "done" : "running");
       if (status === "running") {
         // Keep the live swarm pill inside the current Investigating fold with
-        // surrounding tool cards / reasoning — do not flush it top-level.
-        currentGroup.push(item);
+        // surrounding tool cards / reasoning — including across a top-level
+        // spoken Bubble that flushed the strip.
+        pushActivity(item, true);
         continue;
       }
       const uncoveredJobIds = (item.job_ids || []).filter((jobId) => !resultJobIds.has(jobId));
@@ -709,7 +760,7 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
           : { ...item, job_ids: uncoveredJobIds },
       );
     } else if (isActivityTelemetry(item)) {
-      currentGroup.push(item);
+      pushActivity(item);
     } else if (
       item.kind === "command_approval"
       || item.kind === "secret_request"
@@ -720,7 +771,8 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
       grouped.push(item);
     } else if (item.kind === "card" || item.kind === "thinking" || item.kind === "codegraph_context" || item.kind === "vault_cite") {
       // Cards, reasoning, codegraph/vault chips: all collect into the one box.
-      currentGroup.push(item);
+      // A later running card across spoken prose resumes the same fold.
+      pushActivity(item, isLiveInvestigationContinuity(item));
     }
   }
 

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -502,25 +502,29 @@ function VaultCiteChip({
 /**
  * Assistants that belong inside the investigation fold for this turn.
  *
- * Open-loop absorption (fold mid-turn narration once the turn has tools /
- * thinking) applies ONLY to the current turn — the span after the last user
- * message. Prior turns always use the sealed rule: fold only assistants that
- * still have a later tool card. Without that scope, a live turn would re-fold
- * every historical finale into its Explored group, then peel those finales
- * back out on seal (row remount churn / flicker in the virtualized feed).
+ * Fold only workerStream / isPlan / channel=progress. Spoken assistant
+ * prose (the white streamed answer) stays a top-level Bubble after seal —
+ * never reparented into the collapsed Investigating/tool fold once a later
+ * card or swarm exists.
  *
- * Current turn while open: fold worker/progress/plan narration and sealed
- * mid-turn text that still has later tools. Live answers stay top-level.
- * Current turn when closed / any prior turn: trailing final stands alone.
+ * Open-loop absorption applies ONLY to the current turn — the span after
+ * the last user message. Prior turns use the sealed rule for foldable
+ * narration that still has later investigation activity. Without that
+ * scope, a live turn would re-fold every historical finale into its
+ * Explored group, then peel those finales back out on seal.
  */
 function isPlanOrProgressAssistant(msg: Msg): boolean {
   return Boolean(msg.isPlan) || msg.channel === "progress";
 }
 
+/** Activity-strip narration only — never spoken assistant prose. */
+function isFoldableAssistantNarration(msg: Msg): boolean {
+  return Boolean(msg.workerStream) || isPlanOrProgressAssistant(msg);
+}
+
 /** Live/final answer stays a top-level Bubble — never absorbed into ActivityGroup. */
 export function isLiveAnswerAssistant(msg: Msg): boolean {
-  if (msg.workerStream) return false;
-  if (isPlanOrProgressAssistant(msg)) return false;
+  if (isFoldableAssistantNarration(msg)) return false;
   if (msg.channel === "answer") return true;
   return msg.streaming === true;
 }
@@ -583,9 +587,21 @@ export function collectIntermediateAssistantItems(
       continue;
     }
     if (item.kind !== "msg" || item.msg.role !== "assistant") continue;
-    // workerStream assistants fold into Investigating with other mid-turn
-    // narration. ActivityGroup renders them via Bubble's capped ticker (not
-    // muted <pre>) when the fold is open — never force-open for them.
+
+    // Spoken assistant prose stays a top-level Bubble after seal. The leak
+    // was the sealed rule reparenting white streamed text into Investigating
+    // once streaming=false and a later card/swarm existed.
+    if (!isFoldableAssistantNarration(item.msg)) {
+      continue;
+    }
+
+    // workerStream always belongs in the activity strip (open or sealed).
+    // ActivityGroup renders them via Bubble's capped ticker (not muted
+    // <pre>) when the fold is open — never force-open for them.
+    if (item.msg.workerStream) {
+      intermediateItems.add(item);
+      continue;
+    }
 
     const seenCardBefore = items
       .slice(turnStart, i)
@@ -594,21 +610,9 @@ export function collectIntermediateAssistantItems(
 
     // Open-loop absorption is current-turn only (see docstring).
     const openAbsorb = agentLoopOpen && i >= currentTurnStart;
-    if (openAbsorb) {
-      if (item.msg.workerStream) {
-        intermediateItems.add(item);
-        continue;
-      }
-      // Live answer / unmarked streaming stays a top-level Bubble so it
-      // cannot hide behind a collapsed fold or remount on terminal peel.
-      if (isLiveAnswerAssistant(item.msg)) {
-        continue;
-      }
-      if (isPlanOrProgressAssistant(item.msg) && (foldActivity || item.msg.streaming === true)) {
-        intermediateItems.add(item);
-        continue;
-      }
-      // Sealed mid-turn narration still uses the sealed rule below.
+    if (openAbsorb && (foldActivity || item.msg.streaming === true)) {
+      intermediateItems.add(item);
+      continue;
     }
 
     const later = laterInvestigationActivity(items, i);
@@ -617,15 +621,12 @@ export function collectIntermediateAssistantItems(
       // Sealed pre-tool sticky outside — except explicit plan/progress
       // narration, which folds into the investigation when tools/swarm/
       // thinking follow (Cursor-like chrome; final answers stay standalone).
-      if (
-        isPlanOrProgressAssistant(item.msg)
-        && (later.laterCardOrSwarm || later.laterThinking)
-      ) {
+      if (later.laterCardOrSwarm || later.laterThinking) {
         intermediateItems.add(item);
       }
       continue;
     }
-    // Sealed / prior turns: fold mid-turn narration when investigation still
+    // Sealed / prior turns: fold plan/progress when investigation still
     // continues after it. A later tool/swarm_result always counts. Later
     // thinking alone is not enough (Cursor late-reasoning after a true finale
     // must not bury the answer inside Explored) — but thinking PLUS a later


### PR DESCRIPTION
## Summary

- Spoken assistant prose disappeared after seal: `isLiveAnswerAssistant` already kept streaming text out of the activity strip, but `collectIntermediateAssistantItems`' sealed rule reparented white streamed text into the collapsed Investigating/tool fold once `streaming=false` and a later card/swarm existed.
- Fold only `workerStream` / `isPlan` / `channel=progress`. Spoken assistant prose stays a top-level Bubble after seal. Activity strip is tools, thinking, swarms only.
- 342 command-vs-swarm classification is untouched. Pin stays `puppetmaster-ai==1.22.31`. Version 0.9.343.

## Test plan

- [x] `vitest` `transcriptSurfaceStability` / `turnTerminal.wave3` / `transcriptPresentation` / `feedMotion` / `jobClassification` (100 passed)
- [ ] Confirm a live spoken answer stays a Bubble after seal when tools/swarm follow
- [ ] Confirm Investigating/Explored still folds workerStream / isPlan / progress, not white prose