### PR TITLE
Marionette v0.9.344 — tracker and chrome polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.31` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.343, deliberately pre-1.0. Rides puppetmaster-ai==1.22.31. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.344, deliberately pre-1.0. Rides puppetmaster-ai==1.22.31. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.343"
+__version__ = "0.9.344"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/pilot_guards.py
+++ b/harness/pilot_guards.py
@@ -890,6 +890,13 @@ def normalize_action_args(kind: str, act: Any) -> str:
             payload["max_results"] = _norm_optional_int(args.get("max_results"))
         if kind == "search_codegraph":
             payload["kind_arg"] = (args.get("kind") or "search").strip().lower()
+        if kind == "search_tools":
+            activate = args.get("activate") or []
+            if isinstance(activate, str):
+                activate = [activate]
+            payload["activate"] = sorted(
+                str(x).strip() for x in activate if str(x or "").strip()
+            )
     elif kind == "query_wiki":
         payload["question"] = _norm_whitespace(args.get("question", "") or "")
     elif kind in ("run_swarm", "run_implement"):

--- a/harness/pilot_tool_recovery.py
+++ b/harness/pilot_tool_recovery.py
@@ -21,6 +21,7 @@ from .pilot import (
     strip_inline_tool_calls,
     tool_names_from_schema,
 )
+from .tool_discovery import is_lazy_activatable_name
 
 INVALID_ONLY_HALT_REASON = (
     "Stopped: 3 consecutive provider steps produced only "
@@ -111,6 +112,58 @@ def assign_missing_native_tool_call_ids(
     return copied
 
 
+
+def _tool_call_names(tool_calls: Any, content: str = "") -> list[str]:
+    names: list[str] = []
+    if isinstance(tool_calls, list):
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function") or {}
+            raw = fn.get("name") if isinstance(fn, dict) else None
+            if isinstance(raw, str) and raw.strip():
+                names.append(raw.strip())
+    text = content or ""
+    if text:
+        import re
+        for match in re.finditer(
+            r"<(?:function|tool_call)\s*=\s*([A-Za-z0-9_]+)", text
+        ):
+            names.append(match.group(1))
+        for match in re.finditer(r'"name"\s*:\s*"([A-Za-z0-9_]+)"', text):
+            names.append(match.group(1))
+    out: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        if name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
+
+
+def expand_allowed_names_for_lazy_activate(
+    allowed_names: Optional[list],
+    called_names: Any,
+    catalog: Any = None,
+) -> Optional[list]:
+    """Allow first-call web_search / web_fetch / browser_* without schema exposure.
+
+    Hidden tools stay out of the schema. search_tools activate is applied on
+    the catalog (never cached as a no-op). ``allowed_names is None`` already
+    means the full native set.
+    """
+    called = [str(n).strip() for n in (called_names or []) if str(n).strip()]
+    lazy = [n for n in called if is_lazy_activatable_name(n)]
+    if catalog is not None and lazy:
+        catalog.try_lazy_activate(lazy)
+    if allowed_names is None or not lazy:
+        return allowed_names
+    extra = [n for n in lazy if n not in allowed_names]
+    if not extra:
+        return allowed_names
+    return list(allowed_names) + extra
+
+
 def parse_native_tool_turn(
     pure_content: str,
     tool_calls: list,
@@ -132,6 +185,12 @@ def parse_native_tool_turn(
         tool_names_from_schema(schema)
         if schema is not None
         else None
+    )
+    catalog = getattr(session, "_tool_catalog", None) if session is not None else None
+    allowed_names = expand_allowed_names_for_lazy_activate(
+        allowed_names,
+        _tool_call_names(tool_calls, pure_content),
+        catalog,
     )
     used = _history_tool_call_ids(
         getattr(session, "_history", None) if session is not None else None

--- a/harness/tool_discovery.py
+++ b/harness/tool_discovery.py
@@ -121,6 +121,24 @@ def core_visible_names(
 CORE_PILOT: Set[str] = CORE_ALWAYS | _PILOT_EXTRAS
 CORE_WORKER: Set[str] = CORE_ALWAYS | _WORKER_EXTRAS
 
+# Hidden built-ins the model may still name on the first call. Activate then
+# dispatch instead of INVALID TOOL CALL. They must not appear in the schema
+# until activated (search_tools or this first-call path).
+LAZY_ACTIVATE_NAMES: Set[str] = {
+    "web_search",
+    "web_fetch",
+}
+
+
+def is_lazy_activatable_name(name: str) -> bool:
+    """True for web_search / web_fetch / browser_* first-call activation."""
+    key = (name or "").strip()
+    if not key:
+        return False
+    if key in LAZY_ACTIVATE_NAMES:
+        return True
+    return key.startswith("browser_")
+
 
 def discovery_enabled() -> bool:
     """Return False when ``HARNESS_TOOL_DISCOVERY=0|false|no``."""
@@ -350,26 +368,62 @@ class ToolCatalog:
         return hits[:limit]
 
     def resolve_activation_keys(self, keys: Iterable[str]) -> List[str]:
-        """Map user-supplied names/ids to canonical tool_ids."""
+        """Map user-supplied names/ids to canonical tool_ids.
+
+        Materialize ``keys`` first so a one-shot iterator cannot be consumed
+        as an empty repeat. Refresh if the catalog is empty so a real first
+        key (web_search / web_fetch / browser_*) does not resolve to [].
+        """
+        materialized = [str(raw or "").strip() for raw in keys]
+        if not self._entries:
+            try:
+                self.refresh()
+            except Exception as exc:
+                _diag_note("tool_discovery.resolve_refresh", exc)
         resolved: List[str] = []
         by_name = {e.name: e.tool_id for e in self._entries.values()}
+        by_name_l = {e.name.lower(): e.tool_id for e in self._entries.values()}
         by_qualified = {e.qualified: e.tool_id for e in self._entries.values()}
-        for raw in keys:
-            key = (raw or "").strip()
+        by_qualified_l = {e.qualified.lower(): e.tool_id for e in self._entries.values()}
+        for key in materialized:
             if not key:
                 continue
             if key in self._entries:
                 resolved.append(key)
                 continue
+            bare = key[8:] if key.startswith("builtin:") else key
             if key in by_name:
                 resolved.append(by_name[key])
+                continue
+            if bare in by_name:
+                resolved.append(by_name[bare])
                 continue
             if key in by_qualified:
                 resolved.append(by_qualified[key])
                 continue
+            if bare in by_qualified:
+                resolved.append(by_qualified[bare])
+                continue
+            low = key.lower()
+            bare_l = bare.lower()
+            if low in by_name_l:
+                resolved.append(by_name_l[low])
+                continue
+            if bare_l in by_name_l:
+                resolved.append(by_name_l[bare_l])
+                continue
+            if low in by_qualified_l:
+                resolved.append(by_qualified_l[low])
+                continue
+            if bare_l in by_qualified_l:
+                resolved.append(by_qualified_l[bare_l])
+                continue
             # Accept mcp_server_tool without prefix.
             if key.startswith("mcp_") and key in by_name:
                 resolved.append(by_name[key])
+                continue
+            if is_lazy_activatable_name(bare):
+                resolved.append(f"builtin:{bare}")
         # Stable dedupe
         out: List[str] = []
         seen: Set[str] = set()
@@ -380,9 +434,42 @@ class ToolCatalog:
         return out
 
     def activate(self, keys: Iterable[str]) -> List[str]:
-        activated = self.resolve_activation_keys(keys)
+        """Mark tools visible. Never a cached no-op: every call updates the set
+        and returns the resolved ids, including already-activated keys.
+        """
+        activated = self.resolve_activation_keys(list(keys or []))
         self._activated.update(activated)
         return activated
+
+    def try_lazy_activate(self, keys: Iterable[str]) -> List[str]:
+        """Activate hidden web/browser built-ins on first call.
+
+        Unknown names are ignored. Known lazy names that are not yet in the
+        catalog (browser off) are still marked activated so parse can dispatch
+        instead of INVALID TOOL CALL; they stay out of the schema until an
+        entry exists.
+        """
+        newly: List[str] = []
+        for raw in keys:
+            name = (raw or "").strip()
+            if not is_lazy_activatable_name(name):
+                continue
+            resolved = self.resolve_activation_keys([name])
+            if resolved:
+                self._activated.update(resolved)
+                newly.extend(resolved)
+                continue
+            tid = f"builtin:{name}"
+            self._activated.add(tid)
+            newly.append(tid)
+        # Stable dedupe
+        out: List[str] = []
+        seen: Set[str] = set()
+        for tid in newly:
+            if tid not in seen:
+                seen.add(tid)
+                out.append(tid)
+        return out
 
     def is_visible(self, tool_id: str) -> bool:
         if not discovery_enabled():
@@ -435,7 +522,9 @@ class ToolCatalog:
         activate: Optional[Sequence[str]] = None,
     ) -> str:
         """Stable-size JSON payload for ``search_tools`` results."""
-        newly = self.activate(activate or [])
+        if not self._entries:
+            self.refresh()
+        newly = self.activate(list(activate or []))
         hits = self.search(query, limit=limit)
         rows = []
         for hit in hits:

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -1112,6 +1112,8 @@ class ToolDispatchMixin:
         if isinstance(activate, str):
             activate = [activate]
         try:
+            # Always run activate on this catalog. Never treat search_tools
+            # activate as a cached no-op even when the query repeats.
             text = catalog.format_search_response(query, limit=limit, activate=activate)
             self._tool_catalog = catalog
             return True, "success", text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.343"
+version = "0.9.344"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_pilot_guards.py
+++ b/tests/test_pilot_guards.py
@@ -538,6 +538,25 @@ def test_normalize_near_identical_paths():
     assert normalize_action_args("read_file", a) == normalize_action_args("read_file", b)
 
 
+def test_search_tools_activate_is_not_a_repeat_of_search_only():
+    """Query-only search_tools must not cache-replay a later activate of the same query."""
+    search_only = _Act(kind="search_tools", query="web", arguments={"query": "web"})
+    activate = _Act(
+        kind="search_tools",
+        query="web",
+        arguments={"query": "web", "activate": ["web_search", "web_fetch"]},
+    )
+    assert normalize_action_args("search_tools", search_only) != normalize_action_args(
+        "search_tools", activate
+    )
+    state = new_turn_guard_state()
+    record_action_execution(state, "search_tools", search_only)
+    from harness.pilot_guards import record_successful_result
+    record_successful_result(state, "search_tools", search_only, '{"query":"web","activated":[]}')
+    verdict = check_loop_guard(state, "search_tools", activate)
+    assert verdict.suppress is False
+
+
 def test_loop_suppresses_identical_repeat():
     """Without a cached successful result, an identical repeat still hard-suppresses.
 

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -11,13 +11,15 @@ import pytest
 from harness.config import HarnessConfig
 from harness.conversation import ConversationalSession, ConvEvent
 from harness.mcp_client import McpTool
-from harness.pilot import build_tools_schema, parse_tool_calls
+from harness.pilot import build_tools_schema, is_invalid_action, parse_tool_calls
+from harness.pilot_tool_recovery import parse_native_tool_turn
 from harness.tool_discovery import (
     ToolCatalog,
     CORE_PILOT,
     CORE_WORKER,
     _normalize_path_text,
     discovery_enabled,
+    is_lazy_activatable_name,
 )
 
 
@@ -311,3 +313,136 @@ def test_core_always_survives_hash_edit_import_failure(monkeypatch):
     core = td._core_always()
     assert "read_file" in core
     assert "hash_edit" not in core
+
+
+def _fn_names(schema):
+    return {t["function"]["name"] for t in schema}
+
+
+def _tc(name, args=None, tc_id="tc_lazy"):
+    return {
+        "id": tc_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": json.dumps(args if args is not None else {"query": "marionette"}),
+        },
+    }
+
+
+class _CatalogSession:
+    def __init__(self, catalog):
+        self._tool_catalog = catalog
+        self._history = []
+        self._synthetic_tool_call_seq = 0
+
+
+def test_hidden_web_and_browser_not_in_visible_schema(monkeypatch):
+    monkeypatch.setattr(
+        "harness.browser.standalone_browser_available", lambda **_k: True,
+    )
+    catalog = ToolCatalog()
+    catalog.refresh(browser_enabled=True)
+    names = _fn_names(catalog.visible_schema(browser_enabled=True))
+    assert "web_search" not in names
+    assert "web_fetch" not in names
+    assert not any(n.startswith("browser_") for n in names)
+    assert is_lazy_activatable_name("web_search")
+    assert is_lazy_activatable_name("web_fetch")
+    assert is_lazy_activatable_name("browser_navigate")
+    assert not is_lazy_activatable_name("read_file")
+
+
+def test_first_activate_resolves_on_empty_catalog(monkeypatch):
+    """A real first key must not resolve to [] before refresh (repeat no-op bug)."""
+    monkeypatch.setattr(
+        "harness.browser.standalone_browser_available", lambda **_k: True,
+    )
+    catalog = ToolCatalog()
+    activated = catalog.activate(["web_search"])
+    assert "builtin:web_search" in activated
+    assert "web_search" in _fn_names(catalog.visible_schema())
+
+
+def test_search_tools_activate_is_not_a_noop(monkeypatch):
+    monkeypatch.setattr(
+        "harness.browser.standalone_browser_available", lambda **_k: True,
+    )
+    catalog = ToolCatalog()
+    catalog.refresh(browser_enabled=True)
+    assert "web_search" not in _fn_names(catalog.visible_schema())
+    first = catalog.format_search_response("", activate=["web_search"])
+    payload = json.loads(first)
+    assert "builtin:web_search" in payload["activated"]
+    assert "web_search" in _fn_names(catalog.visible_schema())
+    # Second activate must still resolve and keep the tool visible (not a cache no-op).
+    second = catalog.activate(["web_search"])
+    assert "builtin:web_search" in second
+    assert "web_search" in _fn_names(catalog.visible_schema())
+    third = catalog.format_search_response("web", activate=["web_fetch"])
+    payload3 = json.loads(third)
+    assert "builtin:web_fetch" in payload3["activated"]
+    assert "web_fetch" in _fn_names(catalog.visible_schema())
+
+
+def test_lazy_activate_first_call_is_not_invalid_tool(monkeypatch):
+    monkeypatch.setattr(
+        "harness.browser.standalone_browser_available", lambda **_k: True,
+    )
+    catalog = ToolCatalog()
+    catalog.refresh(browser_enabled=True)
+    schema = catalog.visible_schema(browser_enabled=True)
+    assert "web_search" not in _fn_names(schema)
+    session = _CatalogSession(catalog)
+    turn, _calls, _content = parse_native_tool_turn(
+        "",
+        [_tc("web_search", {"query": "marionette tracker"}, tc_id="tc_web")],
+        "",
+        schema,
+        session=session,
+    )
+    assert len(turn.actions) == 1
+    assert turn.actions[0].kind == "web_search"
+    assert not is_invalid_action(turn.actions[0])
+    assert "web_search" in _fn_names(catalog.visible_schema())
+
+    schema2 = catalog.visible_schema()
+    # web_fetch still hidden until first call / activate
+    assert "web_fetch" not in _fn_names(schema2)
+    turn2, _, _ = parse_native_tool_turn(
+        "",
+        [_tc("web_fetch", {"url": "https://example.com"}, tc_id="tc_fetch")],
+        "",
+        schema2,
+        session=session,
+    )
+    assert turn2.actions[0].kind == "web_fetch"
+    assert not is_invalid_action(turn2.actions[0])
+
+    schema3 = catalog.visible_schema(browser_enabled=True)
+    assert "browser_navigate" not in _fn_names(schema3)
+    turn3, _, _ = parse_native_tool_turn(
+        "",
+        [_tc("browser_navigate", {"url": "https://example.com"}, tc_id="tc_b")],
+        "",
+        schema3,
+        session=session,
+    )
+    assert turn3.actions[0].kind == "browser_navigate"
+    assert not is_invalid_action(turn3.actions[0])
+
+
+def test_unknown_hidden_name_stays_invalid_tool():
+    catalog = ToolCatalog()
+    catalog.refresh()
+    schema = catalog.visible_schema()
+    session = _CatalogSession(catalog)
+    turn, _, _ = parse_native_tool_turn(
+        "",
+        [_tc("not_a_real_tool", {"q": 1}, tc_id="tc_bad")],
+        "",
+        schema,
+        session=session,
+    )
+    assert is_invalid_action(turn.actions[0])
+    assert "INVALID TOOL CALL" in (turn.actions[0].content or "")

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.343"
+version = "0.9.344"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/electron/link-menu.test.cjs
+++ b/webapp/electron/link-menu.test.cjs
@@ -1,0 +1,34 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+describe("v0.9.344 link menu and Cmd+W intercept", () => {
+  it("main.cjs builds a linkURL context menu with the three polish items", () => {
+    const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+    assert.match(main, /params\.linkURL/);
+    assert.match(main, /Open in system browser/);
+    assert.match(main, /Open in-app browser/);
+    assert.match(main, /Copy link/);
+    assert.match(main, /wireLinkContextMenu/);
+    assert.match(main, /browser:openInApp/);
+  });
+
+  it("main.cjs intercepts Cmd\/Ctrl+W so Close Window is not first", () => {
+    const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+    assert.match(main, /wireCloseTabShortcut/);
+    assert.match(main, /app:closeTab/);
+    assert.match(main, /before-input-event/);
+    assert.match(main, /window:close/);
+    assert.match(main, /event\.preventDefault\(\)/);
+  });
+
+  it("preload exposes close-tab and in-app open listeners", () => {
+    const preload = fs.readFileSync(path.join(__dirname, "preload.cjs"), "utf8");
+    assert.match(preload, /onCloseTab/);
+    assert.match(preload, /app:closeTab/);
+    assert.match(preload, /onOpenInApp/);
+    assert.match(preload, /browser:openInApp/);
+    assert.match(preload, /window:close/);
+  });
+});

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -7,7 +7,7 @@
 // The renderer is the SAME React app as the web build; only the transport
 // implementation differs (IPC here vs fetch/SSE on the web).
 
-const { app, BrowserWindow, ipcMain, dialog, shell, session, nativeTheme } = require("electron");
+const { app, BrowserWindow, ipcMain, dialog, shell, session, nativeTheme, Menu, clipboard } = require("electron");
 app.name = "Marionette";
 const { spawn } = require("node:child_process");
 const http = require("node:http");
@@ -1502,6 +1502,63 @@ function setupRequestInterception() {
   );
 }
 
+
+function linkContextMenuTemplate(url) {
+  return [
+    {
+      label: "Open in system browser",
+      click: () => {
+        if (!isAllowedBrowserUrl(url)) return;
+        Promise.resolve(shell.openExternal(url)).catch(() => {});
+      },
+    },
+    {
+      label: "Open in-app browser",
+      click: () => {
+        if (win && !win.isDestroyed() && win.webContents && !win.webContents.isDestroyed()) {
+          win.webContents.send("browser:openInApp", url);
+        }
+      },
+    },
+    {
+      label: "Copy link",
+      click: () => {
+        try { clipboard.writeText(url); } catch {}
+      },
+    },
+  ];
+}
+
+function wireLinkContextMenu(contents) {
+  if (!contents || contents.isDestroyed()) return;
+  contents.on("context-menu", (_e, params) => {
+    const url = params && params.linkURL;
+    if (!url || !isAllowedBrowserUrl(url)) return;
+    const owner = (win && !win.isDestroyed()) ? win : BrowserWindow.fromWebContents(contents);
+    try {
+      Menu.buildFromTemplate(linkContextMenuTemplate(url)).popup({ window: owner || undefined });
+    } catch (err) {
+      logMain(`link context-menu failed: ${err && err.message ? err.message : err}`);
+    }
+  });
+}
+
+function wireCloseTabShortcut(contents) {
+  if (!contents || contents.isDestroyed()) return;
+  contents.on("before-input-event", (event, input) => {
+    try {
+      if (!input || input.type !== "keyDown") return;
+      const mod = process.platform === "darwin" ? input.meta : input.control;
+      if (!mod || input.shift || input.alt) return;
+      if (String(input.key).toLowerCase() !== "w") return;
+      event.preventDefault();
+      if (win && !win.isDestroyed() && win.webContents && !win.webContents.isDestroyed()) {
+        win.webContents.send("app:closeTab");
+      }
+    } catch {}
+  });
+}
+
 function createWindow() {
   const saved = loadWindowState();
   win = new BrowserWindow({
@@ -1551,6 +1608,8 @@ function createWindow() {
   }
   trackWindowState(win);
   loadRenderer();
+  wireLinkContextMenu(win.webContents);
+  wireCloseTabShortcut(win.webContents);
 
   // Drop the reference when the window is closed so a reopen builds a clean one
   // (and a failed renderer load doesn't leave a half-dead window bound to `win`).
@@ -1901,6 +1960,8 @@ app.on("web-contents-created", (_e, contents) => {
   if (type === "webview") {
     applyChromeFingerprint(contents);
     wireWikiConnectNavigation(contents);
+    wireLinkContextMenu(contents);
+    wireCloseTabShortcut(contents);
     logMain(`[browser] webview contents created; UA applied`);
     contents.setWindowOpenHandler(() => {
       return {
@@ -2032,6 +2093,12 @@ ipcMain.handle("browser:openExternal", async (_e, url) => {
     return { ok: false, error: String(e && e.message ? e.message : e) };
   }
 });
+
+ipcMain.handle("window:close", () => {
+  if (win && !win.isDestroyed()) win.close();
+  return { ok: true };
+});
+
 
 app.whenReady().then(async () => {
   if (!gotSingleInstanceLock) return; // a prior instance owns the backend

--- a/webapp/electron/preload.cjs
+++ b/webapp/electron/preload.cjs
@@ -12,6 +12,17 @@ contextBridge.exposeInMainWorld("harnessIPC", {
   popoutBrowser: (url) => ipcRenderer.invoke("browser:popout", url),
   // Open a URL in the OS default browser (escape hatch when in-app Google OAuth rejects).
   openExternal: (url) => ipcRenderer.invoke("browser:openExternal", url),
+  closeWindow: () => ipcRenderer.invoke("window:close"),
+  onCloseTab: (cb) => {
+    const handler = () => { try { cb(); } catch (_) {} };
+    ipcRenderer.on("app:closeTab", handler);
+    return () => ipcRenderer.removeListener("app:closeTab", handler);
+  },
+  onOpenInApp: (cb) => {
+    const handler = (_e, url) => { try { cb(url); } catch (_) {} };
+    ipcRenderer.on("browser:openInApp", handler);
+    return () => ipcRenderer.removeListener("browser:openInApp", handler);
+  },
   uploadFile: (payload) => ipcRenderer.invoke("harness:uploadFile", payload),
   // Electron no longer sets File.path; this is the supported drop-path API.
   pathForFile: (file) => {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.343",
+  "version": "0.9.344",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.343",
+      "version": "0.9.344",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.343",
+  "version": "0.9.344",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -22,7 +22,8 @@ import {
   droppedPathIsDirectory,
   resolveDroppedOsPath,
 } from "./components/conversation/composerInput";
-import { openAgentWorkspace } from "./lib/agentLinks";
+import { openAgentUrl, openAgentWorkspace } from "./lib/agentLinks";
+import { isCloseTabKey, requestCloseFocusedTab } from "./lib/closeTabShortcut";
 import { reclampRailWidths } from "./lib/railLayout";
 import {
   setConfigured,
@@ -286,6 +287,15 @@ export default function App() {
         if (k === "j") { e.preventDefault(); openRightTo("settings"); }
         return;
       }
+      if (isCloseTabKey(e)) {
+        e.preventDefault();
+        const closed = requestCloseFocusedTab();
+        if (closed === "none") {
+          const ipc = (window as unknown as { harnessIPC?: { closeWindow?: () => void } }).harnessIPC;
+          if (ipc && typeof ipc.closeWindow === "function") ipc.closeWindow();
+        }
+        return;
+      }
       switch (k) {
         case "b": e.preventDefault(); setLeftOpen((v) => !v); break;        // toggle sessions panel
         case "j": e.preventDefault(); toggleRight(); break;       // toggle right pane
@@ -301,6 +311,27 @@ export default function App() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [toggleRight]);
+
+  useEffect(() => {
+    const ipc = (window as unknown as {
+      harnessIPC?: {
+        onCloseTab?: (cb: () => void) => () => void;
+        onOpenInApp?: (cb: (url: string) => void) => () => void;
+        closeWindow?: () => void;
+      };
+    }).harnessIPC;
+    const unsubs: Array<() => void> = [];
+    if (ipc && typeof ipc.onCloseTab === "function") {
+      unsubs.push(ipc.onCloseTab(() => {
+        const closed = requestCloseFocusedTab();
+        if (closed === "none" && typeof ipc.closeWindow === "function") ipc.closeWindow();
+      }));
+    }
+    if (ipc && typeof ipc.onOpenInApp === "function") {
+      unsubs.push(ipc.onOpenInApp((url) => { if (url) openAgentUrl(url); }));
+    }
+    return () => { for (const u of unsubs) u(); };
+  }, []);
 
   return (
     <div className="h-full flex flex-col bg-[var(--shell-chrome)]">

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -1193,7 +1193,8 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
     expect(screen.getByText(/1 failed/)).toBeInTheDocument();
     fireEvent.click(screen.getByText("Finished"));
     fireEvent.click(await screen.findByText("Timed-out command"));
-    expect(screen.getByText("1/1 · 1 failed")).toBeInTheDocument();
+    expect(screen.getByLabelText("Workers")).toHaveTextContent("1/1");
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     expect(screen.getByTitle("Dismiss from tracker (stays in Puppetmaster history)")).toBeInTheDocument();
   });
 
@@ -1840,8 +1841,10 @@ describe("SwarmPane worker progress", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Workers (3)")).toBeInTheDocument();
-      expect(screen.getByText("2/3 · 1 failed")).toBeInTheDocument();
+      expect(screen.getByLabelText("Workers")).toHaveTextContent("2/3");
     });
+    expect(screen.getByRole("button", { name: /b, failed/i })).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
   });
 });
 
@@ -1912,8 +1915,8 @@ describe("SwarmPane worker outcome hierarchy", () => {
     expect(worker.getAttribute("aria-label") || "").toMatch(/degraded/i);
     expect(worker).toHaveTextContent("degraded");
     expect(worker.querySelector(".text-good")).toBeNull();
-    expect(screen.getByText("1/1 · 1 degraded")).toBeInTheDocument();
-    expect(screen.getByLabelText(/1 of 1 workers finished, 0 failed, 1 degraded/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Workers")).toHaveTextContent("1/1");
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     expect(container.querySelector('[style*="width: 220px"]')).toBeTruthy();
 
     fireEvent.click(worker);
@@ -1944,7 +1947,7 @@ describe("SwarmPane worker outcome hierarchy", () => {
 
     expect(screen.getByText("Workers (3)")).toBeInTheDocument();
     expect(screen.getByLabelText("Workers")).toHaveTextContent("3/3");
-    expect(screen.getByLabelText(/3 of 3 workers finished, 0 failed, 0 degraded/)).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
   });
 
   it("keeps x/N and failed count on mixed 2/3 terminal progress", async () => {
@@ -1964,9 +1967,10 @@ describe("SwarmPane worker outcome hierarchy", () => {
     render(<SwarmPane />);
     await expandVisibleJobs();
     await waitFor(() => {
-      expect(screen.getByText("2/3 · 1 failed")).toBeInTheDocument();
+      expect(screen.getByLabelText("Workers")).toHaveTextContent("2/3");
     });
-    expect(screen.getByLabelText(/2 of 3 workers finished, 1 failed, 0 degraded/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /fail-b/ }).getAttribute("aria-label") || "").toMatch(/failed/i);
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
   });
 
   it("keeps x/N during active 1/3 progress", async () => {
@@ -1985,9 +1989,9 @@ describe("SwarmPane worker outcome hierarchy", () => {
 
     render(<SwarmPane />);
     await expandVisibleJobs();
-    const progress = await screen.findByLabelText(/1 of 3 workers finished, 0 failed, 0 degraded/);
+    await waitFor(() => expect(screen.getByLabelText("Workers")).toHaveTextContent("1/3"));
     expect(screen.getByText("Workers (3)")).toBeInTheDocument();
-    expect(progress).toHaveTextContent("1/3");
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
   });
 
   it("does not mark any worker degraded from unmatched verification without task_id", async () => {
@@ -3088,5 +3092,47 @@ describe("SwarmPane command vs swarm split", () => {
     expect(await screen.findByText("No swarm jobs yet")).toBeInTheDocument();
     expect(screen.queryByText("sleep 999")).not.toBeInTheDocument();
     expect(screen.getByText("Swarm Tracker").parentElement).not.toHaveTextContent("(1)");
+  });
+});
+
+describe("SwarmPane v0.9.344 density", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    clearSWRCache();
+    mockArtifacts.mockResolvedValue([]);
+    mockSwarmLive.mockResolvedValue({
+      session: { tokens_used: 12, est_cost_usd: 0.01 },
+      jobs: [
+        {
+          id: "job-live",
+          goal: "Live audit",
+          status: "running",
+          tokens: 12,
+          est_cost_usd: 0.01,
+          created_at: "2026-03-01T00:00:00Z",
+        },
+        {
+          id: "job-done",
+          goal: "Finished review",
+          status: "complete",
+          tokens: 8,
+          est_cost_usd: 0.002,
+          created_at: "2026-02-01T00:00:00Z",
+        },
+      ],
+    });
+  });
+
+  it("keeps status, title, and spend without per-card progress bars or card borders", async () => {
+    render(<SwarmPane />);
+    expect(await screen.findByText("Live audit")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Finished"));
+    expect(await screen.findByText("Finished review")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    const live = screen.getByText("Live audit").closest("[data-job-id]");
+    expect(live?.className || "").not.toMatch(/rounded-md/);
+    expect(live?.className || "").not.toMatch(/\bborder\b/);
   });
 });

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -1080,7 +1080,7 @@ describe("SwarmPane mid-run job-row meters", () => {
     // over router) so the worker owns model/policy and no unmatched note.
     mockSwarmLive.mockResolvedValue(
       liveJob({
-        id: "local-1",
+        id: "local-swarm-1",
         status: "running",
         artifacts_complete: true,
         artifacts: [
@@ -1107,7 +1107,7 @@ describe("SwarmPane mid-run job-row meters", () => {
         ],
         tasks: [
           {
-            id: "local-1-w0",
+            id: "local-swarm-1-w0",
             status: "running",
             role: "implement (agentic)",
             instruction: "",
@@ -1174,14 +1174,14 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
         id: "job-timeout",
         goal: "Timed-out command",
         status: "timeout",
-        adapter: "command",
+        adapter: "agentic",
         tasks: [
           {
             id: "job-timeout-w0",
             status: "timeout",
-            role: "command",
+            role: "worker",
             instruction: "pytest",
-            adapter: "command",
+            adapter: "agentic",
           },
         ],
       }),
@@ -1203,6 +1203,7 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
       id: "job-truncated",
       goal: "Truncated command",
       status: "truncated",
+      job_kind: "run_swarm",
       adapter: "command",
       tasks: [
         { id: "job-truncated-w0", status: "truncated", role: "command", instruction: "cat", adapter: "command" },
@@ -1212,6 +1213,7 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
       id: "job-interrupted",
       goal: "Interrupted command",
       status: "interrupted",
+      job_kind: "run_swarm",
       adapter: "command",
       tasks: [
         { id: "job-interrupted-w0", status: "interrupted", role: "command", instruction: "sleep", adapter: "command" },
@@ -3092,6 +3094,42 @@ describe("SwarmPane command vs swarm split", () => {
     expect(await screen.findByText("No swarm jobs yet")).toBeInTheDocument();
     expect(screen.queryByText("sleep 999")).not.toBeInTheDocument();
     expect(screen.getByText("Swarm Tracker").parentElement).not.toHaveTextContent("(1)");
+  });
+
+  it("hides the wave parent and still shows hired children", async () => {
+    mockSwarmLive.mockResolvedValue({
+      session: { tokens_used: 0, est_cost_usd: 0 },
+      jobs: [
+        {
+          id: "local-wave-call_00_ET_S8G91HzE94famGY0TK0Q8637",
+          goal: "Parallel wave (2 jobs)",
+          status: "running",
+          job_kind: "parallel_wave",
+          role: "parallel_wave",
+          adapter: "parallel_wave",
+          source: "harness",
+        },
+        {
+          id: "job_abc123def456",
+          goal: "run_swarm audit",
+          status: "running",
+          job_kind: "run_swarm",
+          source: "harness",
+        },
+        {
+          id: "local-impl-1",
+          goal: "run_implement fix",
+          status: "running",
+          job_kind: "run_implement",
+          source: "harness",
+        },
+      ],
+    });
+    render(<SwarmPane />);
+    expect(await screen.findByText("run_swarm audit")).toBeInTheDocument();
+    expect(screen.getByText("run_implement fix")).toBeInTheDocument();
+    expect(screen.queryByText("Parallel wave (2 jobs)")).not.toBeInTheDocument();
+    expect(screen.getByText("Swarm Tracker").parentElement).toHaveTextContent("(2)");
   });
 });
 

--- a/webapp/src/__tests__/agentLinks.test.ts
+++ b/webapp/src/__tests__/agentLinks.test.ts
@@ -490,4 +490,20 @@ describe("openAgentLink events", () => {
     expect(out).not.toContain("](job_");
     expect(out).not.toContain("](local-");
   });
+
+  it("Cmd/middle-click opens the system browser instead of the in-app pane", () => {
+    const openExternal = vi.fn();
+    const prev = (window as any).harnessIPC;
+    (window as any).harnessIPC = { openExternal };
+    const spy = vi.spyOn(window, "dispatchEvent");
+    openAgentLink("https://example.com/cmd", { preventDefault: vi.fn(), metaKey: true });
+    openAgentLink("https://example.com/mid", { preventDefault: vi.fn(), button: 1 });
+    const types = spy.mock.calls.map((c) => (c[0] as CustomEvent).type);
+    expect(types).not.toContain("harness-open-url");
+    expect(openExternal).toHaveBeenCalledWith("https://example.com/cmd");
+    expect(openExternal).toHaveBeenCalledWith("https://example.com/mid");
+    if (prev === undefined) delete (window as any).harnessIPC;
+    else (window as any).harnessIPC = prev;
+  });
 });
+

--- a/webapp/src/__tests__/chromeSelect.test.tsx
+++ b/webapp/src/__tests__/chromeSelect.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRef } from "react";
+import { TranscriptList, type Item } from "../components/TranscriptList";
+import css from "../index.css?raw";
+import column from "../components/conversation/ConversationChatColumn.tsx?raw";
+
+afterEach(() => cleanup());
+
+describe("feed selection chrome", () => {
+  it("CSS keeps message body selectable and fold/virtual chrome unselectable", () => {
+    expect(css).toMatch(/\.transcript-msg-body\s*\{[^}]*user-select:\s*text/);
+    expect(css).toMatch(/\[data-testid="transcript-virtual-row"\][^{]*\{[^}]*user-select:\s*none/);
+    expect(css).toMatch(/\.transcript-fold-chrome[^{]*\{[^}]*user-select:\s*none/);
+    expect(column).toMatch(/data-testid="composer-chrome"/);
+    expect(column).toMatch(/data-testid="jump-to-latest"/);
+  });
+
+  it("message body is select-text and virtual wrappers are select-none", () => {
+    const items: Item[] = [{ kind: "msg", msg: { role: "user", text: "hello range" } }];
+    render(
+      <TranscriptList
+        items={items}
+        status="done"
+        compactingStatus={null}
+        editingIndex={null}
+        auto={false}
+        plan={false}
+        turnOpen={false}
+        scrollContainerRef={createRef<HTMLDivElement>()}
+        onEditMessage={vi.fn()}
+        onExecuteSend={vi.fn()}
+        onImageClick={vi.fn()}
+        onSetCard={vi.fn()}
+        onExecutePlan={vi.fn()}
+        onCommandApproval={vi.fn()}
+      />,
+    );
+    const body = document.querySelector(".transcript-msg-body");
+    expect(body).toBeTruthy();
+    expect(body).toHaveClass("select-text");
+    expect(screen.getByText("hello range")).toBeTruthy();
+    const wrappers = document.querySelectorAll("[data-testid='transcript-virtual-row'], .transcript-virtual-row");
+    expect(wrappers.length).toBeGreaterThan(0);
+    wrappers.forEach((node) => {
+      expect(node.className).toMatch(/select-none/);
+    });
+  });
+});

--- a/webapp/src/__tests__/closeTabShortcut.test.ts
+++ b/webapp/src/__tests__/closeTabShortcut.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyCloseTabTarget,
+  focusedCloseSurface,
+  isCloseTabKey,
+} from "../lib/closeTabShortcut";
+
+describe("close-tab shortcut classifier", () => {
+  it("recognizes Cmd/Ctrl+W and ignores shifted/alted variants", () => {
+    expect(isCloseTabKey({ key: "w", metaKey: true, ctrlKey: false })).toBe(true);
+    expect(isCloseTabKey({ key: "W", metaKey: false, ctrlKey: true })).toBe(true);
+    expect(isCloseTabKey({ key: "w", metaKey: true, ctrlKey: false, shiftKey: true })).toBe(false);
+    expect(isCloseTabKey({ key: "w", metaKey: false, ctrlKey: false })).toBe(false);
+  });
+
+  it("closes the focused editor tab first", () => {
+    expect(
+      classifyCloseTabTarget({
+        activeEditorTab: "src/App.tsx",
+        focusedSelector: "editor",
+      }),
+    ).toEqual({ kind: "editor", path: "src/App.tsx" });
+  });
+
+  it("closes an extra in-app browser tab, or the browser card when it is the last tab", () => {
+    expect(
+      classifyCloseTabTarget({
+        activeEditorTab: "chat",
+        focusedSelector: "browser",
+        browserTabCount: 3,
+      }),
+    ).toEqual({ kind: "browser-tab" });
+    expect(
+      classifyCloseTabTarget({
+        activeEditorTab: "chat",
+        focusedSelector: "browser",
+        browserTabCount: 1,
+      }),
+    ).toEqual({ kind: "right-card", tab: "browser" });
+  });
+
+  it("closes the focused right-pane card", () => {
+    expect(
+      classifyCloseTabTarget({
+        activeEditorTab: "chat",
+        focusedSelector: "right-card",
+        focusedRightCard: "swarm",
+      }),
+    ).toEqual({ kind: "right-card", tab: "swarm" });
+  });
+
+  it("does not close the window target while a file tab is showing", () => {
+    expect(
+      classifyCloseTabTarget({
+        activeEditorTab: "README.md",
+        focusedSelector: "other",
+      }),
+    ).toEqual({ kind: "editor", path: "README.md" });
+  });
+
+  it("returns none when chat is focused and no tab can close", () => {
+    expect(
+      classifyCloseTabTarget({
+        activeEditorTab: "chat",
+        focusedSelector: "other",
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("reads editor / browser / right-card surfaces from the focused node", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `
+      <div data-close-surface="editor" id="ed"></div>
+      <div data-close-surface="browser" data-browser-tab-count="2" id="br"></div>
+      <section id="right-pane-card-terminal"></section>
+    `;
+    document.body.appendChild(root);
+    expect(focusedCloseSurface(root.querySelector("#ed"))).toEqual({ selector: "editor" });
+    expect(focusedCloseSurface(root.querySelector("#br"))).toEqual({
+      selector: "browser",
+      browserTabCount: 2,
+    });
+    expect(focusedCloseSurface(root.querySelector("#right-pane-card-terminal"))).toEqual({
+      selector: "right-card",
+      rightCard: "terminal",
+    });
+    root.remove();
+  });
+});

--- a/webapp/src/__tests__/composerStatusStack.test.ts
+++ b/webapp/src/__tests__/composerStatusStack.test.ts
@@ -157,9 +157,9 @@ describe("composerStatusStack", () => {
     }
   });
 
-  it("keeps command-adapter swarm workers without job_kind as swarm", () => {
+  it("hides command-stamped non-hires and wave parents from the swarm stack", () => {
     const now = Date.parse("2026-08-23T12:00:00Z");
-    const job = {
+    const commandStamp = {
       id: "job-timeout",
       goal: "Timed-out command",
       source: "harness",
@@ -168,8 +168,36 @@ describe("composerStatusStack", () => {
       adapter: "command",
       role: "command",
     } as any;
-    expect(visibleSwarmJob(job, now)?.kind).toBe("swarm");
-    expect(visibleCommandJob(job, now)).toBeNull();
+    expect(visibleSwarmJob(commandStamp, now)).toBeNull();
+    expect(visibleCommandJob(commandStamp, now)).toBeNull();
+    const wave = {
+      id: "local-wave-call_00_ET_S8G91HzE94famGY0TK0Q8637",
+      goal: "Parallel wave (2 jobs)",
+      source: "harness",
+      status: "running",
+      updated_at: now - 1000,
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+      job_kind: "parallel_wave",
+    } as any;
+    expect(visibleSwarmJob(wave, now)).toBeNull();
+    expect(visibleCommandJob(wave, now)).toBeNull();
+  });
+
+  it("keeps a command-adapter hire on the swarm stack", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const hire = {
+      id: "job_abc123def456",
+      goal: "run_implement fix",
+      source: "harness",
+      status: "running",
+      updated_at: now - 1000,
+      job_kind: "run_implement",
+      adapter: "command",
+      role: "command",
+    } as any;
+    expect(visibleSwarmJob(hire, now)?.kind).toBe("swarm");
+    expect(visibleCommandJob(hire, now)).toBeNull();
   });
 
   it("keeps run_swarm / run_implement / run_parallel as swarm", () => {

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.343)", () => {
-  it("declares the official motion package and 0.9.343 not 329", () => {
+describe("feed Motion (v0.9.344)", () => {
+  it("declares the official motion package and 0.9.344 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.343");
+    expect(pkg.version).toBe("0.9.344");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/jobClassification.test.ts
+++ b/webapp/src/__tests__/jobClassification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isCommandJob } from "../lib/jobClassification";
+import { isCommandJob, isSwarmTrackerJob, isTrackerHire, isWaveCoordinator } from "../lib/jobClassification";
 
 describe("isCommandJob", () => {
   it("matches job_kind and local-cmd id prefixes", () => {
@@ -22,5 +22,66 @@ describe("isCommandJob", () => {
     expect(isCommandJob({ job_kind: "run_swarm" })).toBe(false);
     expect(isCommandJob({ job_kind: "run_parallel" })).toBe(false);
     expect(isCommandJob({ id: "job-timeout", adapter: "command", role: "command" })).toBe(false);
+  });
+});
+
+describe("isWaveCoordinator", () => {
+  it("matches local-wave ids, job_kind, and role/adapter parallel_wave", () => {
+    expect(isWaveCoordinator({
+      id: "local-wave-call_00_ET_S8G91HzE94famGY0TK0Q8637",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+      job_kind: "parallel_wave",
+    })).toBe(true);
+    expect(isWaveCoordinator({ id: "local-wave-abc" })).toBe(true);
+    expect(isWaveCoordinator({ job_kind: "parallel_wave" })).toBe(true);
+    expect(isWaveCoordinator({ role: "parallel_wave" })).toBe(true);
+    expect(isWaveCoordinator({ adapter: "parallel_wave" })).toBe(true);
+  });
+
+  it("does not hide real hires", () => {
+    expect(isWaveCoordinator({ id: "job_abc123def456" })).toBe(false);
+    expect(isWaveCoordinator({ id: "local-swarm-1", job_kind: "run_swarm" })).toBe(false);
+    expect(isWaveCoordinator({ id: "local-impl-1", job_kind: "run_implement" })).toBe(false);
+    expect(isWaveCoordinator({ job_kind: "run_parallel" })).toBe(false);
+  });
+});
+
+describe("isSwarmTrackerJob allowlist", () => {
+  it("shows real hires only", () => {
+    expect(isSwarmTrackerJob({ job_kind: "run_swarm" })).toBe(true);
+    expect(isSwarmTrackerJob({ job_kind: "run_implement" })).toBe(true);
+    expect(isSwarmTrackerJob({ id: "job_abc123def456" })).toBe(true);
+    expect(isSwarmTrackerJob({ id: "local-swarm-1", role: "worker", adapter: "agentic" })).toBe(true);
+    expect(isSwarmTrackerJob({ id: "local-impl-1", job_kind: "run_implement" })).toBe(true);
+    expect(isSwarmTrackerJob({
+      id: "job_hire",
+      job_kind: "run_implement",
+      adapter: "command",
+      role: "command",
+    })).toBe(true);
+  });
+
+  it("hides command jobs, wave parents, and command/wave role stamps", () => {
+    expect(isSwarmTrackerJob({
+      id: "local-cmd-e35cf193",
+      job_kind: "run_command",
+      role: "command",
+      adapter: "command",
+    })).toBe(false);
+    expect(isSwarmTrackerJob({
+      id: "local-wave-call_00_ET_S8G91HzE94famGY0TK0Q8637",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+      job_kind: "parallel_wave",
+    })).toBe(false);
+    expect(isSwarmTrackerJob({ id: "job-timeout", adapter: "command", role: "command" })).toBe(false);
+    expect(isSwarmTrackerJob({ id: "local-cmdbatch-aa11bb22", job_kind: "run_command_batch" })).toBe(false);
+  });
+
+  it("keeps unnamed store-shaped swarm rows that are not coordinators", () => {
+    expect(isSwarmTrackerJob({ id: "job-live", goal: "Live audit" } as any)).toBe(true);
+    expect(isSwarmTrackerJob({ id: "job_par", goal: "run_parallel wave" })).toBe(true);
+    expect(isTrackerHire({ job_kind: "run_swarm" })).toBe(true);
   });
 });

--- a/webapp/src/__tests__/turnTerminal.wave3.test.ts
+++ b/webapp/src/__tests__/turnTerminal.wave3.test.ts
@@ -28,8 +28,10 @@ import { staleLocalStreamTickDecision } from "../components/conversation/runners
 import { isTerminalStreamKind } from "../components/conversation/chatEvents";
 import {
   CONTINUE_PROMPT,
+  DIRTY_FINISH_BANNER,
   canonicalizeTerminalCause,
   composerBusyDuringSwitch,
+  dirtyFinishExplanation,
   hasPartialAssistantAnswer,
   latestUserAsk,
   recoveryControlsAvailable,
@@ -454,7 +456,8 @@ describe("Wave 3 last-mile: fail-closed empty assistant_done", () => {
     expect(state.settle?.lifecycle).toBe("settled_incomplete");
     expect(state.settle?.cause).toBe("unspecified");
     expect(state.settle?.lifecycle).not.toBe("settled_complete");
-    expect(terminalChip(state.items)?.cause).toBe("unspecified");
+    expect(state.settle?.explanation).toBeNull();
+    expect(terminalChip(state.items)).toBeUndefined();
   });
 });
 
@@ -712,3 +715,47 @@ describe("Wave 3 last-mile: auto_halt and onDone-after-error", () => {
   });
 });
 
+
+describe("dirty-finish chrome decision", () => {
+  it("does not paint CAUSE_UNSPECIFIED as the dirty-finish banner", () => {
+    expect(terminalCauseCopy("unspecified")).toBe(DIRTY_FINISH_BANNER);
+    expect(dirtyFinishExplanation({ cause: "unspecified" })).toBeNull();
+    expect(dirtyFinishExplanation({ cause: "unspecified", finishReason: "stop" })).toBeNull();
+    expect(dirtyFinishExplanation({ cause: "unspecified", finishReason: "tool_calls" })).toBeNull();
+    expect(dirtyFinishExplanation({ cause: "length" })).toMatch(/length/i);
+  });
+
+  it("keeps unspecified fail-closed and stays quiet or Continue on stop/tool_calls", () => {
+    for (const wire of ["stop", "tool_calls"] as const) {
+      const settle = settleFromAssistantDone({
+        stopCause: "unspecified",
+        finishReason: wire,
+      });
+      expect(settle.cause).toBe("unspecified");
+      expect(settle.lifecycle).toBe("settled_incomplete");
+      expect(settle.lifecycle).not.toBe("settled_complete");
+      expect(settle.explanation).toBeNull();
+      expect(settle.explanation).not.toBe(DIRTY_FINISH_BANNER);
+      expect(recoveryControlsAvailable(settle.lifecycle)).toBe(true);
+    }
+    const blank = settleFromAssistantDone({ stopCause: "", finishReason: "stop" });
+    expect(blank.cause).toBe("unspecified");
+    expect(blank.explanation).toBeNull();
+    expect(recoveryControlsAvailable(blank.lifecycle)).toBe(true);
+  });
+
+  it("assistant_done with wire stop/tool_calls does not paint the banner", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({ kind: "message_delta", data: { text: "Working" } });
+    apply({
+      kind: "assistant_done",
+      data: { stop_cause: "unspecified", finish_reason: "stop" },
+    });
+    expect(state.settle?.cause).toBe("unspecified");
+    expect(state.settle?.lifecycle).toBe("settled_incomplete");
+    expect(state.settle?.explanation).toBeNull();
+    expect(terminalChip(state.items)).toBeUndefined();
+    const itemsText = state.items.map((it) => ("text" in it ? String(it.text || "") : "")).join(" ");
+    expect(itemsText).not.toContain(DIRTY_FINISH_BANNER);
+  });
+});

--- a/webapp/src/components/BrowserPane.tsx
+++ b/webapp/src/components/BrowserPane.tsx
@@ -246,8 +246,14 @@ export default function BrowserPane() {
     });
   };
 
+  useEffect(() => {
+    const onClose = () => { closeTab(activeTabId); };
+    window.addEventListener("harness-close-browser-tab", onClose);
+    return () => window.removeEventListener("harness-close-browser-tab", onClose);
+  }, [activeTabId, tabs]);
+
   return (
-    <div className="flex flex-col h-full bg-transparent">
+    <div data-close-surface="browser" data-browser-tab-count={tabs.length} className="flex flex-col h-full bg-transparent">
       {/* Tab strip */}
       <div className="flex items-center gap-1 px-2 pt-1.5 bg-transparent border-b border-[var(--shell-panel-border)] select-none overflow-x-auto scrollbar-none">
         {tabs.map((tab) => {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -420,6 +420,16 @@ export default function Conversation({
     };
   }, [tabContextMenu]);
 
+  useEffect(() => {
+    const onClose = (e: Event) => {
+      const path = (e as CustomEvent<{ path?: string }>).detail?.path;
+      if (!path) return;
+      handleCloseTab(path);
+    };
+    window.addEventListener("harness-close-editor-tab", onClose as EventListener);
+    return () => window.removeEventListener("harness-close-editor-tab", onClose as EventListener);
+  }, [openTabs, activeTab]);
+
   const [input, setInput] = useState("");
   // Live composer text for per-session draft cache across useSessionSwitch.
   const composerInputRef = useRef("");
@@ -3528,7 +3538,7 @@ export default function Conversation({
   );
 
   return (
-    <main className="flex flex-col h-full min-w-0 bg-transparent">
+    <main className="flex flex-col h-full min-w-0 bg-transparent" data-active-editor-tab={activeTab}>
       {/* Brand + idle share equal inset so they line up with the floating dock. */}
       <ConversationHeader
         pillStatus={pillStatus}
@@ -3716,6 +3726,7 @@ export default function Conversation({
         />
       </div>
       {!isChatColumnActive(activeTab) ? (
+    <div data-close-surface="editor" className="flex-1 min-h-0 min-w-0 flex flex-col">
     <FileEditorPane
       path={activeTab}
       line={openTabs.find((t) => t.path === activeTab)?.line}
@@ -3723,6 +3734,7 @@ export default function Conversation({
       onClose={() => handleCloseTab(activeTab)}
       onDirtyChange={(dirty) => handleTabDirtyChange(activeTab, dirty)}
     />
+    </div>
       ) : null}
       </div>
 

--- a/webapp/src/components/FileEditorPane.tsx
+++ b/webapp/src/components/FileEditorPane.tsx
@@ -491,7 +491,7 @@ export default function FileEditorPane({ path, line, col, onClose, onDirtyChange
 
   if (loading) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center bg-bg">
+      <div data-close-surface="editor" className="flex-1 flex flex-col items-center justify-center bg-bg">
         <Loader2 className="animate-spin text-accent mb-2" size={24} />
         <span className="text-[12px] text-muted">Reading file...</span>
       </div>
@@ -500,7 +500,7 @@ export default function FileEditorPane({ path, line, col, onClose, onDirtyChange
 
   if (notice && kind !== "binary" && kind !== "pdf" && kind !== "image") {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center bg-bg px-6 text-center">
+      <div data-close-surface="editor" className="flex-1 flex flex-col items-center justify-center bg-bg px-6 text-center">
         <span className="text-risk font-semibold text-[13px] mb-2">{notice}</span>
         <button
           onClick={onClose}

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -336,6 +336,20 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
     persistBoard(tabOrder, nextOpenCards);
   };
 
+  useEffect(() => {
+    const onClose = (e: Event) => {
+      const tab = (e as CustomEvent<{ tab?: Tab }>).detail?.tab;
+      if (!tab) return;
+      if (tab === PINNED_LAST) {
+        closeSettings();
+        return;
+      }
+      if (openCards.includes(tab)) removeCard(tab);
+    };
+    window.addEventListener("harness-close-right-card", onClose as EventListener);
+    return () => window.removeEventListener("harness-close-right-card", onClose as EventListener);
+  }, [closeSettings, openCards, tabOrder]);
+
   const persistCardLayouts = useCallback((nextLayouts: CardLayouts) => {
     cardLayoutsRef.current = nextLayouts;
     setCardLayouts(nextLayouts);

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -958,11 +958,6 @@ export function SavingsChip({ parts, className }: { parts: SavingsParts; classNa
   );
 }
 
-// The four visible phases of a swarm's life. A job advances left-to-right; the
-// strip fills behind the active phase so a running swarm reads as *moving*
-// instead of a static spinner. "failed" paints the reached phase red.
-const PHASES = ["dispatched", "routing", "workers", "done"] as const;
-
 function jobPhase(j: Job): { key: string; label: string; index: number; failed: boolean } {
   const st = jobStatus(j);
   const tasks = j.tasks || [];
@@ -984,99 +979,6 @@ function jobPhase(j: Job): { key: string; label: string; index: number; failed: 
   if (total > 0) return { key: "workers", label: `${total} worker${total > 1 ? "s" : ""}`, index: 2, failed: false };
   if (hasRouting) return { key: "routing", label: "routing", index: 1, failed: false };
   return { key: "dispatched", label: "dispatched", index: 0, failed: false };
-}
-
-function PhaseStrip({ job, phase }: { job: Job; phase?: ReturnType<typeof jobPhase> }) {
-  const { index, failed, key } = phase ?? jobPhase(job);
-  const warning = jobStatus(job) === "completed" && job.outcome?.trustworthy === false;
-  const active = key !== "done" && !failed;
-  return (
-    <div
-      className="flex items-center gap-0.5"
-      role="progressbar"
-      aria-label={`Swarm phase: ${key}`}
-      aria-valuemin={0}
-      aria-valuemax={PHASES.length - 1}
-      aria-valuenow={index}
-    >
-      {PHASES.map((_, i) => {
-        const reached = i <= index;
-        const isActiveSeg = i === index && active;
-        const color = failed && i === index
-          ? (key === "cancelled" ? "bg-muted" : "bg-risk")
-          : warning && reached
-          ? "bg-warn"
-          : reached
-          ? (key === "done" ? "bg-good" : "bg-accent")
-          : "bg-edge/60";
-        return (
-          <div
-            key={i}
-            className={`h-px flex-1 transition-all ${color} ${isActiveSeg ? "animate-pulse" : ""}`}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-function WorkerProgress({
-  tasks,
-  failureForTask,
-}: {
-  tasks: Task[];
-  failureForTask: Map<string, Artifact>;
-}) {
-  const total = tasks.length;
-  if (total === 0) return null;
-  let ok = 0;
-  let degraded = 0;
-  let failed = 0;
-  for (const t of tasks) {
-    const outcome = workerOutcome(t, failureForTask.get(t.id));
-    if (outcome === "ok") ok += 1;
-    else if (outcome === "degraded") degraded += 1;
-    else if (outcome === "failed") failed += 1;
-  }
-  const finished = ok + degraded + failed;
-  const okPct = Math.round((ok / total) * 100);
-  const degradedPct = Math.round((degraded / total) * 100);
-  const failedPct = Math.round((failed / total) * 100);
-  const allOk = ok === total;
-  const countText = [
-    `${finished}/${total}`,
-    failed > 0 ? `${failed} failed` : "",
-    degraded > 0 ? `${degraded} degraded` : "",
-  ].filter(Boolean).join(" · ");
-  return (
-    <div
-      className="flex items-center gap-2"
-      role="progressbar"
-      aria-label={`${finished} of ${total} workers finished, ${failed} failed, ${degraded} degraded`}
-      aria-valuemin={0}
-      aria-valuemax={total}
-      aria-valuenow={finished}
-    >
-      <div className="flex-1 h-px bg-edge/50 overflow-hidden flex">
-        {okPct > 0 && (
-          <div className="h-full bg-good transition-all duration-500" style={{ width: `${okPct}%` }} />
-        )}
-        {degradedPct > 0 && (
-          <div className="h-full bg-warn transition-all duration-500" style={{ width: `${degradedPct}%` }} />
-        )}
-        {failedPct > 0 && (
-          <div className="h-full bg-risk transition-all duration-500" style={{ width: `${failedPct}%` }} />
-        )}
-      </div>
-      {!allOk && (
-        <span className={`text-[9px] tabular-nums shrink-0 ${
-          failed > 0 ? "text-risk/80" : degraded > 0 ? "text-warn/80" : "text-faint"
-        }`}>
-          {countText}
-        </span>
-      )}
-    </div>
-  );
 }
 
 function WorkerModelSlot({
@@ -1622,19 +1524,7 @@ export default function SwarmPane() {
         // collapsed and clipped its own findings instead of pushing the list into
         // overflow. Pinning shrink-0 keeps the card at full content height so the
         // list actually scrolls.
-        className={`shrink-0 rounded-md border bg-panel2/20 flex flex-col overflow-hidden transition-colors ${
-          st === "in_progress"
-            ? "border-accent/30"
-            : st === "failed"
-            ? "border-risk/25"
-            : outcomeWarning
-            ? "border-warn/35"
-            : st === "completed"
-            ? "border-good/25"
-            : st === "cancelled"
-            ? "border-muted/40"
-            : "border-edge"
-        }`}
+        className="shrink-0 flex flex-col"
       >
         {/* Header row. A div (not a button) so the dismiss control can be a real
             nested button without invalid button-in-button markup. */}
@@ -1645,7 +1535,7 @@ export default function SwarmPane() {
           aria-label={`${j.goal || "Swarm job"}, ${phase.label}`}
           onClick={toggle}
           onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); } }}
-          className={`w-full flex flex-col gap-0 p-2 hover:bg-panel2/35 text-left transition-colors select-none cursor-pointer ${DISCLOSURE_FOCUS}`}
+          className={`w-full flex flex-col gap-0 py-1 px-1.5 hover:bg-panel2/25 text-left transition-colors select-none cursor-pointer ${DISCLOSURE_FOCUS}`}
         >
           <div className="flex items-center justify-between w-full gap-2">
             <div className="flex items-center gap-2 min-w-0 flex-1">
@@ -1683,6 +1573,19 @@ export default function SwarmPane() {
                 {jobIdentifier(j.id)}
               </button>
             </div>
+            <span className={`text-[9px] font-medium tabular-nums shrink-0 ${
+              phase.key === "cancelled"
+                ? "text-muted"
+                : phase.failed
+                ? "text-risk/80"
+                : outcomeWarning
+                ? "text-warn/80"
+                : phase.key === "done"
+                ? "text-faint"
+                : "text-accent/80"
+            }`}>
+              {phase.label}
+            </span>
             <div className="flex items-center gap-2 shrink-0 text-[10px]">
               {/* Kill: running jobs only. Best-effort cooperative cancel on the
                   backend. Shows 'cancelling...' until the next poll flips the job
@@ -1885,23 +1788,6 @@ export default function SwarmPane() {
             </div>
           ) : null}
 
-          {/* Phase strip + label -- the at-a-glance "where is this swarm". */}
-          <div className="flex items-center gap-2 pl-6 pr-1 mt-2">
-            <div className="flex-1"><PhaseStrip job={j} phase={phase} /></div>
-            <span className={`text-[9px] font-medium tabular-nums shrink-0 ${
-              phase.key === "cancelled"
-                ? "text-muted"
-                : phase.failed
-                ? "text-risk/80"
-                : outcomeWarning
-                ? "text-warn/80"
-                : phase.key === "done"
-                ? "text-good/80"
-                : "text-accent/80"
-            }`}>
-              {phase.label}
-            </span>
-          </div>
 
           {/* Last activity supplies motion without repeating the receipt. */}
           {st === "in_progress" && (() => {
@@ -1927,7 +1813,6 @@ export default function SwarmPane() {
                 <div className="flex items-center justify-between">
                   <span className="text-[8.5px] uppercase tracking-[0.14em] text-faint font-medium">Workers ({tasks.length})</span>
                 </div>
-                <WorkerProgress tasks={tasks} failureForTask={failureForTask} />
                 <div className="flex flex-col divide-y divide-edge/20 mt-0.5">
                   {tasks.map((task) => {
                     const tExpanded = !!expandedTasks[task.id];
@@ -2163,7 +2048,7 @@ export default function SwarmPane() {
                   Findings ({countLabel})
                 </button>
                 {sectionOpen && (
-                <div className="pr-1 flex flex-col gap-1 border border-edge/40 rounded p-1.5 bg-panel2/20">
+                <div className="pr-1 flex flex-col gap-1">
                   {findingRows.map(({ art, count, artifactIds }, idx: number) => {
                     const fid = art.id || `f${idx}`;
                     const fExpanded = !!expandedFindings[fid];
@@ -2333,7 +2218,7 @@ export default function SwarmPane() {
           in a flex-col defaults to min-height:auto, refuses to shrink below its
           content, grows past the panel, and the root's overflow-hidden clips it
           -- so overflow-y-auto never engages and the list can't scroll. */}
-      <div className="flex-1 min-h-0 overflow-y-auto p-2 flex flex-col gap-2">
+      <div className="flex-1 min-h-0 overflow-y-auto px-2 py-1 flex flex-col gap-0.5">
         {visibleJobs.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-48 text-center px-6 gap-2">
             <Network size={20} className="text-faint/50" />
@@ -2377,7 +2262,7 @@ export default function SwarmPane() {
             {/* Finished runs folded into a collapsible section so a long session
                 stays a short list. Non-destructive: "Clear" only hides. */}
             {finished.length > 0 && (
-              <div className="shrink-0 flex flex-col gap-2">
+              <div className="shrink-0 flex flex-col gap-0">
                 <div className="swarm-finished-head flex items-center justify-between px-1 pt-0.5">
                   <button
                     onClick={() => setFinishedOpen((o) => !o)}

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -11,7 +11,7 @@ import {
 } from "../lib/pendingSwarmOpenJob";
 import { useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
 import { filterJobsByScope, loadJobScope, saveJobScope, type JobScope } from "../lib/jobScope";
-import { isCommandJob } from "../lib/jobClassification";
+import { isTrackerJob } from "../lib/jobClassification";
 import { jobHeadlineTotal } from "./EconomicsDurable";
 
 // A clean, self-contained hover tooltip. The native `title=` tooltip renders as a
@@ -1381,7 +1381,7 @@ export default function SwarmPane() {
   }, [scopedRepo, applyLive]);
 
   const allJobs = filterJobsByScope(data?.jobs || [], jobScope, activeSessionId).filter(
-    (job) => !isCommandJob(job),
+    (job) => isTrackerJob(job),
   );
   // Clear/dismiss is archive chrome for finished runs only. Live (and pending)
   // jobs must stay visible even if their id was previously dismissed — otherwise

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -1148,7 +1148,7 @@ const VirtualTranscriptRow = memo(
       data-index={virtualRow.index}
       data-testid="transcript-virtual-row"
       data-dom-measure={attachDom ? "1" : "0"}
-      className="absolute top-0 left-0 w-full pb-1"
+      className="transcript-virtual-row absolute top-0 left-0 w-full pb-1 select-none"
       style={{
         transform: `translateY(${virtualRow.start - scrollMargin}px)`,
       }}
@@ -1941,7 +1941,7 @@ export const TranscriptList = memo(function TranscriptList({
       {grouped.map((_, i) => {
         const key = stableItemKey(grouped[i]!, i);
         return (
-          <div key={key} className="pb-1">
+          <div key={key} className="transcript-virtual-row pb-1 select-none">
             {renderGroupedItem(i)}
           </div>
         );
@@ -2508,7 +2508,7 @@ function ActivityGroup({
         type="button"
         onClick={toggleOpen}
         aria-expanded={open}
-        className="flex items-center gap-1.5 py-0.5 text-[12px] font-sans font-normal text-faint/75 hover:text-muted transition w-fit max-w-full select-none"
+        className="transcript-fold-chrome flex items-center gap-1.5 py-0.5 text-[12px] font-sans font-normal text-faint/75 hover:text-muted transition w-fit max-w-full select-none"
       >
         {open ? <ChevronDown size={11} className="text-faint/55 shrink-0" /> : <ChevronRight size={11} className="text-faint/55 shrink-0" />}
         {investigating ? <Loader2 size={11} className="animate-spin text-faint/60 shrink-0" /> : null}
@@ -2686,7 +2686,7 @@ function ThinkingBlock({
             return next;
           });
         }}
-        className="flex items-center gap-1.5 text-faint/65 hover:text-muted/90 transition font-sans font-normal text-[12px] text-left w-full min-w-0 select-none"
+        className="transcript-fold-chrome flex items-center gap-1.5 text-faint/65 hover:text-muted/90 transition font-sans font-normal text-[12px] text-left w-full min-w-0 select-none"
         aria-expanded={expanded}
         title={expanded ? "Collapse reasoning" : "Expand reasoning"}
       >
@@ -2878,6 +2878,7 @@ const PrettyMarkdown = memo(function PrettyMarkdown({ text }: { text: string }) 
             <a
               href={href}
               onClick={(e) => openMarkdownHref(href, e)}
+              onAuxClick={(e) => { if (e.button === 1) openMarkdownHref(href, e); }}
               className="text-accent/90 no-underline hover:underline underline-offset-2 decoration-accent/40 cursor-pointer break-words"
             >
               {children}
@@ -3131,7 +3132,7 @@ function Bubble({
               <Pencil size={12} />
             </button>
           )}
-          <div className={`rounded-xl px-3 py-1 text-[13px] leading-relaxed whitespace-pre-wrap break-words border transition-all ${
+          <div className={`transcript-msg-body select-text rounded-xl px-3 py-1 text-[13px] leading-relaxed whitespace-pre-wrap break-words border transition-all ${
             isEditing
               ? "bg-accent/10 text-txt border-accent"
               : "bg-accent2 text-txt border-edge/30"
@@ -3190,7 +3191,7 @@ function Bubble({
       {showLabel && (
         <span className="text-[10px] uppercase tracking-wider text-faint px-0.5 select-none font-semibold mt-1">pilot</span>
       )}
-      <div className={`text-[0.8125rem] leading-[1.7] break-words max-w-[95%] py-0.5 w-full relative pr-14 ${isIntermediate ? "text-txt/75" : "text-txt/95"}`}>
+      <div className={`transcript-msg-body select-text text-[0.8125rem] leading-[1.7] break-words max-w-[95%] py-0.5 w-full relative pr-14 ${isIntermediate ? "text-txt/75" : "text-txt/95"}`}>
         {/* Plan/progress stays ordinary text; final answers keep Markdown
             so code fences / lists render for the user-facing reply. */}
         {isPlanOrProgressAssistant(msg) ? (

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -147,14 +147,14 @@ export default function ConversationChatColumn({
           title="Jump to latest"
           aria-label="Jump to latest"
           onClick={onJumpToBottom}
-          className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full border border-edge2 text-muted hover:text-txt hover:bg-panel2/80 transition-colors"
+          className="transcript-fold-chrome select-none absolute bottom-3 left-1/2 -translate-x-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full border border-edge2 text-muted hover:text-txt hover:bg-panel2/80 transition-colors"
           style={{ backgroundColor: "#0f1113" }}
         >
           <ChevronDown size={16} />
         </button>
       ) : null}
       </div>
-      <div ref={chromeRef} className="shrink-0 min-w-0" data-testid="composer-chrome">
+      <div ref={chromeRef} className="transcript-fold-chrome select-none shrink-0 min-w-0" data-testid="composer-chrome">
         {composerDock}
       </div>
     </div>

--- a/webapp/src/components/conversation/EditorTabStrip.tsx
+++ b/webapp/src/components/conversation/EditorTabStrip.tsx
@@ -46,7 +46,7 @@ export default function EditorTabStrip({
   return (
     <>
       {openTabs.length > 0 && (
-        <div className="flex items-center gap-1 px-4 bg-panel border-b border-edge h-9 shrink-0 overflow-x-auto scrollbar-none select-none">
+        <div data-close-surface="editor" className="flex items-center gap-1 px-4 bg-panel border-b border-edge h-9 shrink-0 overflow-x-auto scrollbar-none select-none">
           <button
             onClick={() => onSelectTab("chat")}
             className={`flex items-center h-full px-3 text-[12px] font-medium transition-colors border-b-2 ${

--- a/webapp/src/components/conversation/composerStatusStackData.ts
+++ b/webapp/src/components/conversation/composerStatusStackData.ts
@@ -1,6 +1,6 @@
 import type { Job } from "../../lib/api";
 import type { AgentCommandSession } from "../../lib/agentCommandIndex";
-import { isCommandJob } from "../../lib/jobClassification";
+import { isCommandJob, isTrackerJob } from "../../lib/jobClassification";
 
 export type ComposerStatusStackKind = "swarm" | "terminal";
 export type ComposerStatusStackState = "running" | "done" | "failed";
@@ -86,7 +86,7 @@ function lingerAllows(state: ComposerStatusStackState, updatedAt: number | null,
 /** Accounting-owned provider swarm only. Command jobs return null (reclassify as terminal). */
 export function visibleSwarmJob(job: Job, nowMs: number): ComposerStatusStackRow | null {
   if (!jobAccountingOwned(job)) return null;
-  if (isCommandJob(job)) return null;
+  if (!isTrackerJob(job)) return null;
   const state = normalizeState(job.status);
   const updatedAt = jobUpdatedAt(job);
   if (!lingerAllows(state, updatedAt, nowMs, SWARM_SUCCESS_LINGER_MS, SWARM_FAILURE_LINGER_MS)) return null;

--- a/webapp/src/components/conversation/streamApply.ts
+++ b/webapp/src/components/conversation/streamApply.ts
@@ -38,6 +38,7 @@ import {
   normalizeNestedActionStatus,
 } from "./nestedActionBounds";
 import { normalizeToolKind } from "../../lib/turnProgress";
+import { suppressUnspecifiedDirtyFinish } from "../../lib/turnTerminal";
 
 export {
   boundActionField,
@@ -1800,6 +1801,7 @@ export function appendTurnTerminal(
 ): Item[] {
   const text = String(data.text || "").trim();
   if (!text) return items;
+  if (suppressUnspecifiedDirtyFinish(data.cause, text)) return items;
   const last = items[items.length - 1];
   const next: Extract<Item, { kind: "turn_terminal" }> = {
     kind: "turn_terminal",

--- a/webapp/src/components/conversation/transcriptItems.ts
+++ b/webapp/src/components/conversation/transcriptItems.ts
@@ -15,6 +15,7 @@ import {
   normalizeNestedActionStatus,
 } from "./nestedActionBounds";
 import { hoistCardsBeforeTrailingFinals } from "./thinkingToolPrep";
+import { suppressUnspecifiedDirtyFinish } from "../../lib/turnTerminal";
 
 /** Same SHA-256 hex gate as SSE ``appendCommandApproval`` (streamApply). */
 const COMMAND_HASH_HEX = /^[0-9a-f]{64}$/;
@@ -463,6 +464,7 @@ export function transcriptResponseToItems(res: {
       } else if (m.type === "turn_terminal") {
         const text = String(m.text || "").trim();
         if (!text) return [];
+        if (suppressUnspecifiedDirtyFinish(m.cause, text)) return [];
         const id = String(m.id || "").trim();
         return [{
           kind: "turn_terminal" as const,

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -562,3 +562,16 @@ body.is-row-resizing iframe {
 .scrollbar-none::-webkit-scrollbar {
   display: none;
 }
+
+
+/* Feed selection: highlight a clean text range, not fold chrome. */
+.transcript-msg-body {
+  user-select: text;
+}
+[data-testid="transcript-virtual-row"],
+.transcript-virtual-row,
+.transcript-fold-chrome,
+.chat-column [data-testid="jump-to-latest"],
+.chat-column [data-testid="composer-chrome"] {
+  user-select: none;
+}

--- a/webapp/src/lib/agentLinks.ts
+++ b/webapp/src/lib/agentLinks.ts
@@ -422,6 +422,21 @@ export function openAgentUrl(url: string): void {
   }
 }
 
+/** Cmd/Ctrl+click or middle-click: system browser, not the in-app pane. */
+export function openAgentUrlExternal(url: string): void {
+  if (!url || !isExternalUrl(url)) return;
+  const ipc = (window as unknown as { harnessIPC?: { openExternal?: (href: string) => void } }).harnessIPC;
+  if (ipc && typeof ipc.openExternal === "function") {
+    try { ipc.openExternal(url); return; } catch { /* fall through */ }
+  }
+  try { window.open(url, "_blank", "noopener,noreferrer"); } catch { /* ignore */ }
+}
+
+function wantsSystemBrowser(e?: { metaKey?: boolean; ctrlKey?: boolean; button?: number }): boolean {
+  if (!e) return false;
+  return Boolean(e.metaKey || e.ctrlKey || e.button === 1);
+}
+
 export function openAgentFile(pathOrHref: string, line?: number, col?: number): void {
   const parsed = parseFileHref(pathOrHref) || (looksLikeFilePath(pathOrHref)
     ? { path: pathOrHref.trim(), line, col }
@@ -578,7 +593,7 @@ export function syncAgentCommandOutput(id: string, output: string): void {
 }
 
 /** Route a markdown href click (or synthetic open). */
-export function openAgentLink(href: string, e?: { preventDefault(): void }): void {
+export function openAgentLink(href: string, e?: { preventDefault(): void; metaKey?: boolean; ctrlKey?: boolean; button?: number }): void {
   if (!href) return;
   const target = classifyTranscriptTarget(href);
   if (target.kind === "none") {
@@ -587,7 +602,8 @@ export function openAgentLink(href: string, e?: { preventDefault(): void }): voi
   }
   e?.preventDefault();
   if (target.kind === "url") {
-    openAgentUrl(target.href);
+    if (wantsSystemBrowser(e)) openAgentUrlExternal(target.href);
+    else openAgentUrl(target.href);
     return;
   }
   if (target.kind === "spill") {

--- a/webapp/src/lib/closeTabShortcut.ts
+++ b/webapp/src/lib/closeTabShortcut.ts
@@ -1,0 +1,103 @@
+/**
+ * Cmd/Ctrl+W: close the focused editor tab, in-app browser tab, or
+ * right-pane card. Never treat the default Electron Close Window as the
+ * first action while one of those can still close.
+ */
+
+export type CloseTabKind = "editor" | "browser-tab" | "right-card" | "none";
+
+export type CloseTabTarget =
+  | { kind: "editor"; path: string }
+  | { kind: "browser-tab" }
+  | { kind: "right-card"; tab: string }
+  | { kind: "none" };
+
+export type CloseSurface = "editor" | "browser" | "right-card" | "other";
+
+export function isCloseTabKey(e: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+}): boolean {
+  if (e.altKey || e.shiftKey) return false;
+  if (!(e.metaKey || e.ctrlKey)) return false;
+  return e.key.toLowerCase() === "w";
+}
+
+export function classifyCloseTabTarget(input: {
+  activeEditorTab: string;
+  focusedSelector: CloseSurface;
+  focusedRightCard?: string | null;
+  browserTabCount?: number;
+}): CloseTabTarget {
+  const editorPath = (input.activeEditorTab || "").trim();
+  const editorOpen = editorPath !== "" && editorPath !== "chat";
+
+  if (input.focusedSelector === "editor" && editorOpen) {
+    return { kind: "editor", path: editorPath };
+  }
+  if (input.focusedSelector === "browser") {
+    if ((input.browserTabCount ?? 1) > 1) return { kind: "browser-tab" };
+    return { kind: "right-card", tab: "browser" };
+  }
+  if (input.focusedSelector === "right-card" && input.focusedRightCard) {
+    return { kind: "right-card", tab: input.focusedRightCard };
+  }
+  if (editorOpen) return { kind: "editor", path: editorPath };
+  return { kind: "none" };
+}
+
+export function focusedCloseSurface(el: Element | null): {
+  selector: CloseSurface;
+  rightCard?: string;
+  browserTabCount?: number;
+} {
+  if (!el || typeof el.closest !== "function") return { selector: "other" };
+  const editor = el.closest("[data-close-surface='editor']");
+  if (editor) return { selector: "editor" };
+  const browser = el.closest("[data-close-surface='browser']");
+  if (browser) {
+    const raw = browser.getAttribute("data-browser-tab-count");
+    const n = raw ? Number(raw) : 1;
+    return { selector: "browser", browserTabCount: Number.isFinite(n) ? n : 1 };
+  }
+  const card = el.closest("[id^='right-pane-card-']");
+  if (card && card.id) {
+    return { selector: "right-card", rightCard: card.id.slice("right-pane-card-".length) };
+  }
+  return { selector: "other" };
+}
+
+export function readActiveEditorTab(root: ParentNode | null = typeof document !== "undefined" ? document : null): string {
+  const node = root?.querySelector?.("[data-active-editor-tab]");
+  const value = node?.getAttribute?.("data-active-editor-tab") || "";
+  return value.trim() || "chat";
+}
+
+export function requestCloseFocusedTab(
+  root: ParentNode | null = typeof document !== "undefined" ? document : null,
+): CloseTabKind {
+  const active = typeof document !== "undefined" ? document.activeElement : null;
+  const surface = focusedCloseSurface(active instanceof Element ? active : null);
+  const target = classifyCloseTabTarget({
+    activeEditorTab: readActiveEditorTab(root),
+    focusedSelector: surface.selector,
+    focusedRightCard: surface.rightCard,
+    browserTabCount: surface.browserTabCount,
+  });
+  if (target.kind === "editor") {
+    window.dispatchEvent(new CustomEvent("harness-close-editor-tab", { detail: { path: target.path } }));
+    return "editor";
+  }
+  if (target.kind === "browser-tab") {
+    window.dispatchEvent(new Event("harness-close-browser-tab"));
+    return "browser-tab";
+  }
+  if (target.kind === "right-card") {
+    window.dispatchEvent(new CustomEvent("harness-close-right-card", { detail: { tab: target.tab } }));
+    return "right-card";
+  }
+  return "none";
+}

--- a/webapp/src/lib/jobClassification.ts
+++ b/webapp/src/lib/jobClassification.ts
@@ -1,12 +1,21 @@
-/** Classify /api/swarm/live rows as terminal command vs provider swarm.
+/** Classify /api/swarm/live rows for Swarm Tracker vs terminal chrome.
  *
- * Background run_command / run_command_batch jobs ride the same live feed as
- * swarms (local-job projection) but must never paint Swarm Tracker chrome.
- * job_kind and local-cmd* ids are the seam. role/adapter "command" is
- * corroborating, not sufficient — swarm workers can use adapter=command.
+ * 342 hid run_command / local-cmd-* only. Wave parents still leaked
+ * (local-wave-* / role+adapter parallel_wave) beside their hired children.
+ * Tracker allowlist: real hires only.
+ *
+ * Show: run_swarm, run_implement, remote job_*, unnamed non-coordinator rows.
+ * Hide: role/adapter command AND parallel_wave; ids local-wave-* and local-cmd-*.
+ * Do not show the wave parent alongside its children.
+ *
+ * isCommandJob stays the terminal-reclassify seam. role/adapter "command" is
+ * still not sufficient there — a hire (run_swarm / run_implement / job_*)
+ * still paints even when the worker adapter is command.
  */
 
 const COMMAND_JOB_KINDS = new Set(["run_command", "run_command_batch"]);
+const HIRE_JOB_KINDS = new Set(["run_swarm", "run_implement"]);
+const EXCLUDED_STAMPS = new Set(["command", "command_batch", "parallel_wave"]);
 
 export type CommandJobSignals = {
   id?: string | null;
@@ -15,15 +24,64 @@ export type CommandJobSignals = {
   adapter?: string | null;
 };
 
+function norm(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
 function commandId(id: string): boolean {
   return id.startsWith("local-cmd-") || id.startsWith("local-cmdbatch-");
 }
 
+function waveId(id: string): boolean {
+  return id.startsWith("local-wave-");
+}
+
+/** True for the run_parallel wave parent, never its hired children. */
+export function isWaveCoordinator(job: CommandJobSignals): boolean {
+  const id = norm(job.id);
+  if (waveId(id)) return true;
+  return (
+    norm(job.job_kind) === "parallel_wave"
+    || norm(job.role) === "parallel_wave"
+    || norm(job.adapter) === "parallel_wave"
+  );
+}
+
 /** True for background command / command-batch jobs. */
 export function isCommandJob(job: CommandJobSignals): boolean {
-  const kind = String(job.job_kind || "").trim().toLowerCase();
+  const kind = norm(job.job_kind);
   if (COMMAND_JOB_KINDS.has(kind)) return true;
-  const id = String(job.id || "").trim().toLowerCase();
+  const id = norm(job.id);
   if (commandId(id)) return true;
   return false;
 }
+
+/** True for run_swarm / run_implement / remote job_* / local-swarm|impl. */
+export function isTrackerHire(job: CommandJobSignals): boolean {
+  const kind = norm(job.job_kind);
+  if (HIRE_JOB_KINDS.has(kind)) return true;
+  const id = String(job.id || "").trim();
+  const idLower = id.toLowerCase();
+  if (id.startsWith("job_")) return true;
+  if (idLower.startsWith("local-swarm-") || idLower.startsWith("local-impl-")) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Tracker allowlist. Wave parent never sits beside children. Command-stamped
+ * non-hires are excluded; command-adapter hires and unnamed store rows stay.
+ */
+export function isSwarmTrackerJob(job: CommandJobSignals): boolean {
+  if (isWaveCoordinator(job)) return false;
+  if (isCommandJob(job)) return false;
+  if (isTrackerHire(job)) return true;
+  const role = norm(job.role);
+  const adapter = norm(job.adapter);
+  if (EXCLUDED_STAMPS.has(role) || EXCLUDED_STAMPS.has(adapter)) return false;
+  return true;
+}
+
+/** Alias used by SwarmPane / composer stack. */
+export const isTrackerJob = isSwarmTrackerJob;

--- a/webapp/src/lib/turnTerminal.ts
+++ b/webapp/src/lib/turnTerminal.ts
@@ -128,6 +128,8 @@ export function canonicalizeTerminalCause(raw: unknown): TerminalCause {
  * Truthful chip copy. Never mentions context % unless the backend named
  * context overflow as the cause.
  */
+export const DIRTY_FINISH_BANNER = "Turn ended without a clean finish.";
+
 export function terminalCauseCopy(cause: TerminalCause): string {
   switch (cause) {
     case CAUSE_NATURAL:
@@ -164,8 +166,40 @@ export function terminalCauseCopy(cause: TerminalCause): string {
       return "Turn ended during tool use.";
     case CAUSE_UNSPECIFIED:
     default:
-      return "Turn ended without a clean finish.";
+      return DIRTY_FINISH_BANNER;
   }
+}
+
+const QUIET_UNSPECIFIED_WIRE = new Set(["stop", "tool_calls"]);
+
+export function lastWireFinishReason(raw: unknown): string {
+  return String(raw || "").trim().toLowerCase();
+}
+
+/**
+ * Chrome decision for a settled turn. Fail-closed internally (caller keeps
+ * CAUSE_UNSPECIFIED). If the last wire reason was stop or tool_calls, stay
+ * quiet so Continue can show without a dirty-finish banner.
+ */
+export function dirtyFinishExplanation(opts: {
+  cause: TerminalCause;
+  finishReason?: unknown;
+}): string | null {
+  if (opts.cause !== CAUSE_UNSPECIFIED) {
+    const copy = terminalCauseCopy(opts.cause);
+    return copy || null;
+  }
+  // Fail-closed internally (caller keeps unspecified). Never paint the crash
+  // banner for stop / tool_calls / blank wire — stay quiet so Continue shows.
+  const wire = lastWireFinishReason(opts.finishReason);
+  if (QUIET_UNSPECIFIED_WIRE.has(wire) || !wire) return null;
+  return null;
+}
+
+/** Gate boxed turn_terminal chrome: unspecified crash copy stays unpainted. */
+export function suppressUnspecifiedDirtyFinish(cause: unknown, text: unknown): boolean {
+  if (canonicalizeTerminalCause(cause) !== CAUSE_UNSPECIFIED) return false;
+  return String(text || "").trim() === DIRTY_FINISH_BANNER;
 }
 
 export function isNaturalStopCause(cause: TerminalCause): boolean {
@@ -250,7 +284,9 @@ export function settleFromAssistantDone(opts: {
       cause: isNaturalStopCause(cause) ? CAUSE_NATURAL : cause,
       status: "awaiting_swarm",
       turnOpen: false,
-      explanation: isNaturalStopCause(cause) ? null : terminalCauseCopy(cause),
+      explanation: isNaturalStopCause(cause)
+        ? null
+        : dirtyFinishExplanation({ cause, finishReason: opts.finishReason }),
     };
   }
   if (isNaturalStopCause(cause)) {
@@ -269,7 +305,7 @@ export function settleFromAssistantDone(opts: {
     cause,
     status: "done",
     turnOpen: false,
-    explanation: terminalCauseCopy(cause),
+    explanation: dirtyFinishExplanation({ cause, finishReason: opts.finishReason }),
   };
 }
 


### PR DESCRIPTION
Tracker and chrome polish on v0.9.343 (e0e1a55f). Pin stays puppetmaster-ai==1.22.31.

- Swarm Tracker: flat rows (status dot, title, tokens/cost pills, status word). No per-card progress bars or nested card borders. Finished is a quiet list.
- Feed selection: user-select:text on message bodies; user-select:none on fold chrome, buttons, and virtual row wrappers.
- Link right-click: Open in system browser, Open in-app browser, Copy link. Cmd/middle-click opens the system browser.
- Cmd+W / Ctrl+W closes the focused editor tab, in-app browser tab, or right-pane card. Does not close the app while a tab can close.