### PR TITLE
Marionette v0.9.345 — pin 1.22.32 + regular-weight spoken text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.31"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.32"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.31` (desktop
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.32` (desktop
    bootstrap, install/doctor, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.31` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.32` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.344, deliberately pre-1.0. Rides puppetmaster-ai==1.22.31. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.345, deliberately pre-1.0. Rides puppetmaster-ai==1.22.32. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.31` (configurable default reviewer platform, shared `build_cost_report`, safely resumable jobs, honest delivery verdicts, Google Antigravity `agy` adapter, dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.32` (configurable default reviewer platform, shared `build_cost_report`, safely resumable jobs, honest delivery verdicts, Google Antigravity `agy` adapter, dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Durable memory graph** | Local durable facts/preferences (`MemoryStore`) plus optional relations via `MemoryGraph` (`GET /api/memory/graph`, shape `{nodes,edges}` like the wiki graph; sqlite + append-only jsonl). |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.344"
+__version__ = "0.9.345"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/diag_bundle.py
+++ b/harness/diag_bundle.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 DEFAULT_SESSION_LIMIT = 20
-PIN_FALLBACK = "puppetmaster-ai==1.22.31"
+PIN_FALLBACK = "puppetmaster-ai==1.22.32"
 _PIN_RE = re.compile(r"puppetmaster-ai==[0-9]+(?:\.[0-9]+)*")
 _SECRET_KEY_FRAGMENTS = (
     "api_key",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.344"
+version = "0.9.345"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.31" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.32" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.31"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.32"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.31" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.32" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.31}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.32}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.344"
+version = "0.9.345"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.31";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.32";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.31";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.32";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 const HARNESS_DIST_NAME = "pm-harness";
 
@@ -95,7 +95,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.31" }    -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.32" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -117,7 +117,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.31).
+ * to 1.22.32).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.344",
+  "version": "0.9.345",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.344",
+      "version": "0.9.345",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.344",
+  "version": "0.9.345",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/chromeSelect.test.tsx
+++ b/webapp/src/__tests__/chromeSelect.test.tsx
@@ -7,9 +7,27 @@ import column from "../components/conversation/ConversationChatColumn.tsx?raw";
 
 afterEach(() => cleanup());
 
+const listProps = (items: Item[]) => ({
+  items,
+  status: "done" as const,
+  compactingStatus: null,
+  editingIndex: null,
+  auto: false,
+  plan: false,
+  turnOpen: false,
+  scrollContainerRef: createRef<HTMLDivElement>(),
+  onEditMessage: vi.fn(),
+  onExecuteSend: vi.fn(),
+  onImageClick: vi.fn(),
+  onSetCard: vi.fn(),
+  onExecutePlan: vi.fn(),
+  onCommandApproval: vi.fn(),
+});
+
 describe("feed selection chrome", () => {
   it("CSS keeps message body selectable and fold/virtual chrome unselectable", () => {
     expect(css).toMatch(/\.transcript-msg-body\s*\{[^}]*user-select:\s*text/);
+    expect(css).toMatch(/\.transcript-msg-body\s*\{[^}]*font-weight:\s*400/);
     expect(css).toMatch(/\[data-testid="transcript-virtual-row"\][^{]*\{[^}]*user-select:\s*none/);
     expect(css).toMatch(/\.transcript-fold-chrome[^{]*\{[^}]*user-select:\s*none/);
     expect(column).toMatch(/data-testid="composer-chrome"/);
@@ -17,24 +35,8 @@ describe("feed selection chrome", () => {
   });
 
   it("message body is select-text and virtual wrappers are select-none", () => {
-    const items: Item[] = [{ kind: "msg", msg: { role: "user", text: "hello range" } }];
     render(
-      <TranscriptList
-        items={items}
-        status="done"
-        compactingStatus={null}
-        editingIndex={null}
-        auto={false}
-        plan={false}
-        turnOpen={false}
-        scrollContainerRef={createRef<HTMLDivElement>()}
-        onEditMessage={vi.fn()}
-        onExecuteSend={vi.fn()}
-        onImageClick={vi.fn()}
-        onSetCard={vi.fn()}
-        onExecutePlan={vi.fn()}
-        onCommandApproval={vi.fn()}
-      />,
+      <TranscriptList {...listProps([{ kind: "msg", msg: { role: "user", text: "hello range" } }])} />,
     );
     const body = document.querySelector(".transcript-msg-body");
     expect(body).toBeTruthy();
@@ -45,5 +47,40 @@ describe("feed selection chrome", () => {
     wrappers.forEach((node) => {
       expect(node.className).toMatch(/select-none/);
     });
+  });
+
+  it("spoken assistant body is regular weight (not semibold/bold on the wrapper)", () => {
+    render(
+      <TranscriptList
+        {...listProps([
+          { kind: "msg", msg: { role: "user", text: "ask" } },
+          {
+            kind: "msg",
+            msg: {
+              role: "assistant",
+              text: "Plain spoken answer with **emphasis** only where marked.",
+            },
+          },
+        ])}
+      />,
+    );
+    const bodies = document.querySelectorAll(".transcript-msg-body");
+    expect(bodies.length).toBeGreaterThanOrEqual(2);
+    const spoken = Array.from(bodies).find((el) =>
+      (el.textContent || "").includes("Plain spoken answer"),
+    );
+    expect(spoken).toBeTruthy();
+    expect(spoken!.className).toMatch(/font-normal/);
+    expect(spoken!.className).not.toMatch(/font-semibold/);
+    expect(spoken!.className).not.toMatch(/font-bold/);
+    expect(spoken!.className).not.toMatch(/font-medium/);
+    const para = spoken!.querySelector("p");
+    expect(para).toBeTruthy();
+    expect(para!.className).toMatch(/font-normal/);
+    expect(para!.className).not.toMatch(/font-semibold/);
+    expect(para!.className).not.toMatch(/font-bold/);
+    const strong = spoken!.querySelector("strong");
+    expect(strong).toBeTruthy();
+    expect(strong!.className).toMatch(/font-semibold/);
   });
 });

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.344)", () => {
-  it("declares the official motion package and 0.9.344 not 329", () => {
+describe("feed Motion (v0.9.345)", () => {
+  it("declares the official motion package and 0.9.345 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.344");
+    expect(pkg.version).toBe("0.9.345");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -2858,12 +2858,12 @@ const PrettyMarkdown = memo(function PrettyMarkdown({ text }: { text: string }) 
         h1: ({ children }: any) => <h1 className="text-sm font-semibold text-txt mt-3 mb-1.5 border-b border-edge pb-0.5">{children}</h1>,
         h2: ({ children }: any) => <h2 className="text-[0.8125rem] font-semibold text-txt mt-3 mb-1.5">{children}</h2>,
         h3: ({ children }: any) => <h3 className="text-[0.75rem] font-semibold text-muted mt-2 mb-1">{children}</h3>,
-        p: ({ children }: any) => <p className="text-[0.8125rem] leading-[1.7] my-2 first:mt-0 last:mb-0">{children}</p>,
+        p: ({ children }: any) => <p className="font-normal text-[0.8125rem] leading-[1.7] my-2 first:mt-0 last:mb-0">{children}</p>,
         strong: ({ children }: any) => <strong className="font-semibold text-txt">{children}</strong>,
         em: ({ children }: any) => <em className="italic text-txt/90">{children}</em>,
-        ul: ({ children }: any) => <ul className="list-disc pl-4 my-2 space-y-1 text-txt/90">{children}</ul>,
-        ol: ({ children }: any) => <ol className="list-decimal pl-4 my-2 space-y-1 text-txt/90">{children}</ol>,
-        li: ({ children }: any) => <li className="text-[0.8125rem] leading-[1.65]">{children}</li>,
+        ul: ({ children }: any) => <ul className="list-disc pl-4 my-2 space-y-1 text-txt/90 font-normal">{children}</ul>,
+        ol: ({ children }: any) => <ol className="list-decimal pl-4 my-2 space-y-1 text-txt/90 font-normal">{children}</ol>,
+        li: ({ children }: any) => <li className="font-normal text-[0.8125rem] leading-[1.65]">{children}</li>,
         blockquote: ({ children }: any) => (
           <blockquote className="border-l-2 border-edge pl-2.5 my-2 text-muted italic bg-panel2/30 rounded-r-sm py-1">
             {children}
@@ -3132,7 +3132,7 @@ function Bubble({
               <Pencil size={12} />
             </button>
           )}
-          <div className={`transcript-msg-body select-text rounded-xl px-3 py-1 text-[13px] leading-relaxed whitespace-pre-wrap break-words border transition-all ${
+          <div className={`transcript-msg-body select-text font-normal rounded-xl px-3 py-1 text-[13px] leading-relaxed whitespace-pre-wrap break-words border transition-all ${
             isEditing
               ? "bg-accent/10 text-txt border-accent"
               : "bg-accent2 text-txt border-edge/30"
@@ -3191,9 +3191,10 @@ function Bubble({
       {showLabel && (
         <span className="text-[10px] uppercase tracking-wider text-faint px-0.5 select-none font-semibold mt-1">pilot</span>
       )}
-      <div className={`transcript-msg-body select-text text-[0.8125rem] leading-[1.7] break-words max-w-[95%] py-0.5 w-full relative pr-14 ${isIntermediate ? "text-txt/75" : "text-txt/95"}`}>
+      <div className={`transcript-msg-body select-text font-normal text-[0.8125rem] leading-[1.7] break-words max-w-[95%] py-0.5 w-full relative pr-14 ${isIntermediate ? "text-txt/75" : "text-txt/95"}`}>
         {/* Plan/progress stays ordinary text; final answers keep Markdown
-            so code fences / lists render for the user-facing reply. */}
+            so code fences / lists render for the user-facing reply.
+            Explicit font-normal: spoken body must not inherit semibold from chrome. */}
         {isPlanOrProgressAssistant(msg) ? (
           <pre className="whitespace-pre-wrap font-sans font-normal text-[0.8125rem] leading-[1.7] m-0">
             {normalizePlainTextNarration(displayedText)}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -564,9 +564,11 @@ body.is-row-resizing iframe {
 }
 
 
-/* Feed selection: highlight a clean text range, not fold chrome. */
+/* Feed selection: highlight a clean text range, not fold chrome.
+   Spoken body stays regular weight (400); fold chrome / labels / strong keep their own. */
 .transcript-msg-body {
   user-select: text;
+  font-weight: 400;
 }
 [data-testid="transcript-virtual-row"],
 .transcript-virtual-row,


### PR DESCRIPTION
## Summary
- Pin `puppetmaster-ai==1.22.32` at runtime sites (README, CONTRIBUTING, FINDINGS, diag_bundle PIN_FALLBACK, install/doctor sh+ps1, bootstrap/update-pm DEFAULT). Package version 0.9.344 → 0.9.345.
- Spoken feed text is regular weight again: `.transcript-msg-body` is `font-weight: 400` / `font-normal`; Markdown `p`/`ul`/`ol`/`li` are `font-normal`. Fold chrome, labels, headings, and `strong` stay semibold. No feed Motion.

## Test plan
- [ ] `feedMotion.test.tsx` still asserts official version 0.9.345 and does not re-enable feed Motion
- [ ] `chromeSelect.test.tsx` asserts spoken body / Markdown `p` is `font-normal` and not semibold/bold; `strong` stays semibold
- [ ] Required CI green: pytest-linux, frontend-build, pmharness-units, pytest-windows
- [ ] Ignore release-build electron-zip / hosted-runner-lost-communication infra flakes