### PR TITLE
Marionette v0.9.346 — stacked folds + session title lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.32` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.345, deliberately pre-1.0. Rides puppetmaster-ai==1.22.32. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.346, deliberately pre-1.0. Rides puppetmaster-ai==1.22.32. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.345"
+__version__ = "0.9.346"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -477,20 +477,27 @@ class SessionStore:
             return False
 
     def set_title_if_default(self, sid: str, title: str) -> None:
+        cleaned = (title or "").strip()
+        # Investigating / Explored / Diagnosing walls never become session.title.
+        if not cleaned or is_activity_headline_text(cleaned):
+            return
         with self._lock:
             for s in self._sessions:
                 if s["id"] == sid:
                     current = s.get("title", "")
                     if not current or current == "New session":
-                        s["title"] = title
+                        s["title"] = cleaned
                         self._save()
                     break
 
     def rename(self, sid: str, title: str) -> bool:
+        cleaned = (title or "").strip()
+        if not cleaned or is_activity_headline_text(cleaned):
+            return False
         with self._lock:
             for s in self._sessions:
                 if s["id"] == sid:
-                    s["title"] = title
+                    s["title"] = cleaned
                     self._save()
                     return True
             return False
@@ -539,7 +546,9 @@ class SessionStore:
                 if branch:
                     s["branch"] = branch
                 if title is not None and str(title).strip():
-                    s["title"] = str(title).strip()
+                    cleaned_title = str(title).strip()
+                    if not is_activity_headline_text(cleaned_title):
+                        s["title"] = cleaned_title
                 if make_active:
                     self._active = sid
                 self._save()
@@ -674,8 +683,43 @@ def session_visible_for_workspace(session: dict, workspace_root: str, state_dir:
     return True
 
 
+_ACTIVITY_HEADLINE_RE = None
+
+
+def is_activity_headline_text(text: str) -> bool:
+    """True for Investigating / Explored / Diagnosing / Ran / Stopped walls.
+
+    Those belong in the activity strip — never session.title or preferred list
+    preview over a spoken finale.
+    """
+    import re
+
+    global _ACTIVITY_HEADLINE_RE
+    raw = (text or "").strip()
+    if not raw:
+        return False
+    if re.match(r"^Stopped\.?$", raw, flags=re.IGNORECASE):
+        return True
+    if _ACTIVITY_HEADLINE_RE is None:
+        _ACTIVITY_HEADLINE_RE = re.compile(
+            r"^(Investigating|Explored|Diagnosing|Planning|Assessing|"
+            r"Still working|Looking|Thinking|Thought|Worked for|"
+            r"Ran\s+\d+\s+commands?)\b",
+            re.IGNORECASE,
+        )
+    lines = [ln.strip() for ln in raw.splitlines() if ln.strip()]
+    if not lines:
+        return False
+    if len(lines) == 1:
+        return bool(_ACTIVITY_HEADLINE_RE.match(lines[0]))
+    hits = sum(1 for ln in lines if _ACTIVITY_HEADLINE_RE.match(ln))
+    return hits >= 2 or (hits == 1 and hits == len(lines))
+
+
 def derive_title(prompt: str) -> str:
     if not prompt:
+        return "New session"
+    if is_activity_headline_text(prompt):
         return "New session"
     import re
     lines = prompt.splitlines()
@@ -689,6 +733,8 @@ def derive_title(prompt: str) -> str:
             first_line = cleaned
             break
     if not first_line:
+        return "New session"
+    if is_activity_headline_text(first_line):
         return "New session"
     words = first_line.split()
     truncated_words = []
@@ -707,7 +753,9 @@ def derive_title(prompt: str) -> str:
     title = title.rstrip('.,;:?!- ')
     if title:
         title = title[0].upper() + title[1:]
-    return title or "New session"
+    if not title or is_activity_headline_text(title):
+        return "New session"
+    return title
 
 
 def save_transcript(state_dir: str, session_id: str, messages: Any) -> None:
@@ -759,7 +807,25 @@ def _unescape_json_string(raw: str) -> str:
         return raw.replace("\\n", " ").replace('\\"', '"')
 
 
+def _message_plain_text(msg: dict) -> str:
+    content = msg.get("content")
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text") or ""))
+            elif isinstance(block, str):
+                parts.append(block)
+        content = " ".join(parts)
+    return " ".join(str(content or "").split())
+
+
 def _preview_from_messages(messages: Any, max_chars: int) -> str:
+    """Prefer the last spoken assistant finale; fall back to first user prompt.
+
+    Never prefer Investigating / Explored / Diagnosing activity walls or a bare
+    ``Stopped.`` status line as the Sessions/Home list snippet.
+    """
     history: List[Any]
     if isinstance(messages, dict):
         history = list(messages.get("history") or [])
@@ -767,24 +833,23 @@ def _preview_from_messages(messages: Any, max_chars: int) -> str:
         history = messages
     else:
         return ""
+    first_user = ""
+    last_finale = ""
     for msg in history:
         if not isinstance(msg, dict):
             continue
-        if msg.get("role") != "user":
+        role = msg.get("role")
+        text = _message_plain_text(msg)
+        if not text:
             continue
-        content = msg.get("content")
-        if isinstance(content, list):
-            parts = []
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    parts.append(str(block.get("text") or ""))
-                elif isinstance(block, str):
-                    parts.append(block)
-            content = " ".join(parts)
-        text = " ".join(str(content or "").split())
-        if text:
-            return text[:max_chars]
-    return ""
+        if role == "user" and not first_user:
+            if not is_activity_headline_text(text):
+                first_user = text
+            continue
+        if role == "assistant" and not is_activity_headline_text(text):
+            last_finale = text
+    chosen = last_finale or first_user
+    return chosen[:max_chars] if chosen else ""
 
 
 def transcript_preview(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.345"
+version = "0.9.346"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_session_naming.py
+++ b/tests/test_session_naming.py
@@ -51,6 +51,23 @@ def test_derive_title():
     assert derive_title("   \n   \n") == "New session"
     # Collapses whitespace
     assert derive_title("   hello    world   ") == "Hello world"
+    # Activity headlines never become session titles
+    assert derive_title("Investigating ActionForm redirect…") == "New session"
+    assert derive_title("Explored 1 search, 3 commands") == "New session"
+    assert derive_title("Diagnosing production error…") == "New session"
+    assert derive_title("Stopped.") == "New session"
+
+
+def test_set_title_if_default_rejects_activity_headlines(tmp_path):
+    store = SessionStore(str(tmp_path / "sessions.json"))
+    sess = store.create()
+    sid = sess["id"]
+    store.set_title_if_default(sid, "Explored 3 files, 1 search")
+    assert store.list()[0]["title"] == "New session"
+    store.set_title_if_default(sid, "Fix the redirect bug")
+    assert store.list()[0]["title"] == "Fix the redirect bug"
+    assert store.rename(sid, "Investigating…") is False
+    assert store.list()[0]["title"] == "Fix the redirect bug"
 
 
 def test_set_title_if_default(tmp_path):

--- a/tests/test_session_preview.py
+++ b/tests/test_session_preview.py
@@ -13,7 +13,7 @@ from harness.sessions import (
 )
 
 
-def test_transcript_preview_first_user_turn(tmp_path):
+def test_transcript_preview_first_user_when_no_finale(tmp_path):
     state = str(tmp_path)
     sid = "abc123def456"
     save_transcript(
@@ -22,7 +22,7 @@ def test_transcript_preview_first_user_turn(tmp_path):
         {
             "history": [
                 {"role": "user", "content": "hello from preview wave"},
-                {"role": "assistant", "content": "ok"},
+                {"role": "assistant", "content": "Investigating…"},
             ],
             "display": [],
             "job_ids": [],
@@ -32,6 +32,27 @@ def test_transcript_preview_first_user_turn(tmp_path):
     assert transcript_preview(state, sid, max_chars=5) == "hello"
 
 
+def test_transcript_preview_prefers_spoken_finale(tmp_path):
+    state = str(tmp_path)
+    sid = "finaleprev0001"
+    save_transcript(
+        state,
+        sid,
+        {
+            "history": [
+                {"role": "user", "content": "debug flash builder redirect"},
+                {"role": "assistant", "content": "Investigating ActionForm redirect…"},
+                {"role": "assistant", "content": "Explored 1 search, 3 commands"},
+                {"role": "assistant", "content": "The redirect was missing a return."},
+                {"role": "assistant", "content": "Stopped."},
+            ],
+            "display": [],
+            "job_ids": [],
+        },
+    )
+    assert transcript_preview(state, sid) == "The redirect was missing a return."
+
+
 def test_transcript_preview_large_file_prefix_scan(tmp_path):
     state = str(tmp_path)
     sid = "bigfile000001"
@@ -39,22 +60,19 @@ def test_transcript_preview_large_file_prefix_scan(tmp_path):
     trans_dir.mkdir()
     # Build a large JSON prefix so size > _PREVIEW_READ_BYTES, then a user turn.
     pad = "x" * 9000
+    # Ensure file is large; if user turn falls outside first 8k, prefix scan may
+    # miss — place user first for the cheap-listing contract.
     payload = {
         "history": [
-            {"role": "assistant", "content": pad},
             {"role": "user", "content": "needle in large transcript"},
+            {"role": "assistant", "content": pad},
         ],
         "display": [],
         "job_ids": [],
     }
-    # Ensure file is large; if user turn falls outside first 8k, prefix scan may
-    # miss — place user first for the cheap-listing contract.
-    payload["history"] = [
-        {"role": "user", "content": "needle in large transcript"},
-        {"role": "assistant", "content": pad},
-    ]
     (trans_dir / f"{sid}.json").write_text(json.dumps(payload), encoding="utf-8")
     assert os.path.getsize(trans_dir / f"{sid}.json") > 8000
+    # Large-file cheap path still scans the first user turn (not full finale pass).
     assert "needle" in transcript_preview(state, sid)
 
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.345",
+  "version": "0.9.346",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.345",
+      "version": "0.9.346",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.345",
+  "version": "0.9.346",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.345)", () => {
-  it("declares the official motion package and 0.9.345 not 329", () => {
+describe("feed Motion (v0.9.346)", () => {
+  it("declares the official motion package and 0.9.346 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.345");
+    expect(pkg.version).toBe("0.9.346");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/investigationCollapser.seal.test.tsx
+++ b/webapp/src/__tests__/investigationCollapser.seal.test.tsx
@@ -64,7 +64,7 @@ describe("prior investigation fold stays sealed on new prompt", () => {
       <TranscriptList {...listProps(turn1, { turnOpen: false, status: "idle" })} />,
     );
 
-    expect(screen.getByText(/Explored/i)).toBeTruthy();
+    expect(screen.getByText(/Worked for/i)).toBeTruthy();
     expect(screen.queryByText(/Investigating/i)).toBeNull();
     // Sealed fold starts collapsed — inner thinking is not mounted.
     expect(screen.queryByText(/looking at auth handlers/i)).toBeNull();
@@ -79,8 +79,8 @@ describe("prior investigation fold stays sealed on new prompt", () => {
       />,
     );
 
-    // Prior fold must stay Explored / collapsed while busy with no turn-2 tools.
-    expect(screen.getByText(/Explored/i)).toBeTruthy();
+    // Prior fold must stay Worked for / collapsed while busy with no turn-2 tools.
+    expect(screen.getByText(/Worked for/i)).toBeTruthy();
     expect(screen.queryByText(/Investigating/i)).toBeNull();
     expect(screen.queryByText(/looking at auth handlers/i)).toBeNull();
 
@@ -106,7 +106,7 @@ describe("prior investigation fold stays sealed on new prompt", () => {
     );
 
     expect(screen.getByText(/Investigating/i)).toBeTruthy();
-    expect(screen.getByText(/Explored/i)).toBeTruthy();
+    expect(screen.getByText(/Worked for/i)).toBeTruthy();
     // Prior fold still sealed (collapsed); only the live fold is active.
     expect(screen.queryByText(/looking at auth handlers/i)).toBeNull();
   });
@@ -141,8 +141,8 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
       />,
     );
 
-    // Pause-point: Explored fold + Still working footer (not Investigating spinner).
-    expect(screen.getByText(/Explored/i)).toBeTruthy();
+    // Pause-point: Worked for fold + Still working footer (not Investigating spinner).
+    expect(screen.getByText(/Worked for/i)).toBeTruthy();
     expect(screen.queryByText(/Investigating/i)).toBeNull();
     expect(screen.getByText(/Still working/i)).toBeTruthy();
 
@@ -156,7 +156,7 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
         })}
       />,
     );
-    expect(screen.getByText(/Explored/i)).toBeTruthy();
+    expect(screen.getByText(/Worked for/i)).toBeTruthy();
     expect(screen.queryByText(/Investigating/i)).toBeNull();
     expect(screen.getByText(/Still working/i)).toBeTruthy();
 
@@ -178,7 +178,7 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
     expect(screen.getByText(/Workers flying — validating when they land/i)).toBeTruthy();
   });
 
-  it("holdSwarmAwait with active pilot turn keeps mid-turn Investigating, not sealed Explored", () => {
+  it("holdSwarmAwait with active pilot turn keeps mid-turn Investigating, not sealed Worked for", () => {
     const midTurnItems: Item[] = [
       { kind: "msg", msg: { role: "user", text: "check auth while workers run" } },
       { kind: "thinking", text: "reading auth handlers", id: "th-mid" },
@@ -207,7 +207,7 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
     );
 
     expect(screen.getByText(/Investigating/i)).toBeTruthy();
-    expect(screen.queryByText(/Explored/i)).toBeNull();
+    expect(screen.queryByText(/Worked for/i)).toBeNull();
 
     rerender(
       <TranscriptList
@@ -220,7 +220,7 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
     );
 
     expect(screen.getByText(/Investigating/i)).toBeTruthy();
-    expect(screen.queryByText(/Explored/i)).toBeNull();
+    expect(screen.queryByText(/Worked for/i)).toBeNull();
 
     // Settled tools but pilot still busy — must not seal via hold alone.
     const settledMidTurn: Item[] = [
@@ -237,7 +237,7 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
       />,
     );
     expect(screen.getByText(/Investigating/i)).toBeTruthy();
-    expect(screen.queryByText(/Explored/i)).toBeNull();
+    expect(screen.queryByText(/Worked for/i)).toBeNull();
   });
 
   it("awaiting_swarm pause-point does not keep Investigating spinner over settled tools", () => {
@@ -251,7 +251,7 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
       />,
     );
 
-    expect(screen.getByText(/Explored/i)).toBeTruthy();
+    expect(screen.getByText(/Worked for/i)).toBeTruthy();
     expect(screen.queryByText(/Investigating/i)).toBeNull();
     // Busy footer owns Still working… (matches StatusPill), not sticky Investigating.
     expect(screen.getByText(/Still working/i)).toBeTruthy();
@@ -273,7 +273,7 @@ describe("prior fold does not stay Investigating after steer flush", () => {
     };
   }
 
-  it("stale running / swarm_pending in the prior fold stay Explored while the live fold investigates", () => {
+  it("stale running / swarm_pending in the prior fold stay Worked for while the live fold investigates", () => {
     const items: Item[] = [
       { kind: "msg", msg: { role: "user", text: "do the work" } },
       runningCard("stale-card", "auth.ts"),
@@ -294,9 +294,9 @@ describe("prior fold does not stay Investigating after steer flush", () => {
     );
 
     const investigating = screen.getAllByText(/Investigating/i);
-    const explored = screen.getAllByText(/Explored/i);
+    const worked = screen.getAllByText(/Worked for/i);
     expect(investigating).toHaveLength(1);
-    expect(explored).toHaveLength(1);
+    expect(worked).toHaveLength(1);
   });
 
   it("sealed prior cards never spin even when a later fold is live", () => {
@@ -315,7 +315,7 @@ describe("prior fold does not stay Investigating after steer flush", () => {
     );
 
     expect(screen.getAllByText(/Investigating/i)).toHaveLength(1);
-    expect(screen.getAllByText(/Explored/i)).toHaveLength(1);
+    expect(screen.getAllByText(/Worked for/i)).toHaveLength(1);
   });
 
   it("prior-fold durable job shows quiet job still running, not a second Investigating", () => {
@@ -345,7 +345,7 @@ describe("prior fold does not stay Investigating after steer flush", () => {
 
     expect(screen.getAllByText(/Investigating/i)).toHaveLength(1);
     expect(screen.getByText(/job still running/i)).toBeTruthy();
-    expect(screen.queryByText(/Explored/i)).toBeNull();
+    expect(screen.queryByText(/Worked for/i)).toBeNull();
   });
 
   it("prior-fold swarm_pending only shows Swarm pending, not a second Investigating", () => {
@@ -369,7 +369,7 @@ describe("prior fold does not stay Investigating after steer flush", () => {
 
     expect(screen.getAllByText(/Investigating/i)).toHaveLength(1);
     expect(screen.getByText(/Swarm · 1 pending/i)).toBeTruthy();
-    expect(screen.queryByText(/Explored/i)).toBeNull();
+    expect(screen.queryByText(/Worked for/i)).toBeNull();
   });
 
   it("holdSwarmAwait cannot keep a prior swarm_pending fold Investigating", () => {

--- a/webapp/src/__tests__/sessionTitle.test.ts
+++ b/webapp/src/__tests__/sessionTitle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_SESSION_TITLE,
   deriveSessionTitle,
+  displaySessionListTitle,
   isDefaultSessionTitle,
 } from "../lib/sessionTitle";
 
@@ -34,6 +35,19 @@ describe("deriveSessionTitle", () => {
 
   it("collapses whitespace", () => {
     expect(deriveSessionTitle("   hello    world   ")).toBe("Hello world");
+  });
+
+  it("rejects investigating / Explored activity headlines", () => {
+    expect(deriveSessionTitle("Investigating · read config")).toBe(DEFAULT_SESSION_TITLE);
+    expect(deriveSessionTitle("Explored 3 files, 1 search")).toBe(DEFAULT_SESSION_TITLE);
+  });
+});
+
+describe("displaySessionListTitle", () => {
+  it("hides activity headlines and Stopped. from the session list", () => {
+    expect(displaySessionListTitle("Explored 1 search")).toBe("Untitled");
+    expect(displaySessionListTitle("Stopped.")).toBe("Untitled");
+    expect(displaySessionListTitle("Fix the bug")).toBe("Fix the bug");
   });
 });
 

--- a/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
+++ b/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
@@ -1,0 +1,185 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  TranscriptList,
+  clearActivityFoldPrefs,
+  type Item,
+} from "../components/TranscriptList";
+import {
+  partitionStackedActivity,
+  ranCommandsLabel,
+  thoughtFoldLabel,
+  workedForLabel,
+} from "../lib/turnProgress";
+import {
+  DEFAULT_SESSION_TITLE,
+  deriveSessionTitle,
+  displaySessionListTitle,
+} from "../lib/sessionTitle";
+import { isActivityHeadlineText } from "../lib/sessionTitleLock";
+
+afterEach(() => {
+  cleanup();
+  clearActivityFoldPrefs();
+});
+
+function sealedCommand(id: string, goal: string, durationMs = 2000): Extract<Item, { kind: "card" }> {
+  return {
+    kind: "card",
+    card: {
+      id,
+      goal,
+      cwd: null,
+      kind: "run_command",
+      running: false,
+      open: false,
+      result: { status: "ok", duration_ms: durationMs, command: goal },
+    },
+  };
+}
+
+function listProps(items: Item[]) {
+  return {
+    items,
+    status: "idle" as const,
+    compactingStatus: null as string | null,
+    editingIndex: null as number | null,
+    auto: false,
+    plan: false,
+    turnOpen: false,
+    holdSwarmAwait: false,
+    scrollContainerRef: { current: null },
+    onEditMessage: vi.fn(),
+    onExecuteSend: vi.fn(),
+    onImageClick: vi.fn(),
+    onSetCard: vi.fn(),
+    onExecutePlan: vi.fn(),
+    onCommandApproval: vi.fn(),
+  };
+}
+
+describe("stacked fold labels", () => {
+  it("formats Worked for / Thought / Ran chrome", () => {
+    expect(workedForLabel(23_000)).toBe("Worked for 23s");
+    expect(workedForLabel(6 * 60_000)).toBe("Worked for 6m");
+    expect(thoughtFoldLabel({ live: true })).toBe("Thinking…");
+    expect(thoughtFoldLabel({ durationMs: 8_000 })).toBe("Thought 8s");
+    expect(ranCommandsLabel(1)).toBe("Ran 1 command");
+    expect(ranCommandsLabel(3)).toBe("Ran 3 commands");
+  });
+
+  it("nests Thought inside a Ran commands partition", () => {
+    const items = [
+      { kind: "thinking" as const },
+      { kind: "card", cardKind: "run_command" },
+      { kind: "thinking" as const },
+      { kind: "card", cardKind: "run_command" },
+    ];
+    const rows = partitionStackedActivity(items, (row) => ({
+      cardKind: row.kind === "card" ? row.cardKind : null,
+      isThinking: row.kind === "thinking",
+    }));
+    expect(rows.map((r) => r.kind)).toEqual(["thought", "commands"]);
+    expect(rows[1]?.kind).toBe("commands");
+    if (rows[1]?.kind !== "commands") return;
+    expect(rows[1].items).toHaveLength(3);
+    expect(rows[1].items.filter((it) => it.kind === "thinking")).toHaveLength(1);
+  });
+});
+
+describe("sealed stacked folds (Worked for + Thought + Ran)", () => {
+  it("shows Worked for + finale Bubble; Thought separate; finale never inside fold", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "fix the redirect bug" } },
+      {
+        kind: "thinking",
+        text: "looking at ActionForm",
+        id: "th-outer",
+        duration_ms: 8000,
+      },
+      sealedCommand("c1", "git status", 1500),
+      {
+        kind: "thinking",
+        text: "checking status output",
+        id: "th-nested",
+        duration_ms: 2000,
+      },
+      sealedCommand("c2", "rg ActionForm", 1500),
+      {
+        kind: "msg",
+        msg: {
+          role: "assistant",
+          text: "The redirect was missing a return. Regular weight finale.",
+        },
+      },
+    ];
+
+    render(<TranscriptList {...listProps(items)} />);
+
+    expect(screen.getByText(/Worked for/i)).toBeTruthy();
+    expect(screen.queryByText(/Explored/i)).toBeNull();
+    expect(screen.queryByText(/Investigating/i)).toBeNull();
+
+    // Finale stays a top-level Bubble — visible without expanding Worked for.
+    expect(
+      screen.getByText(/The redirect was missing a return/i),
+    ).toBeTruthy();
+    const finale = screen.getByText(/The redirect was missing a return/i);
+    expect(finale.closest(".transcript-msg-body")?.className).toMatch(/font-normal/);
+
+    // Thought / Ran stay collapsed until the Worked for row opens.
+    expect(screen.queryByTestId("thought-fold")).toBeNull();
+    expect(screen.queryByTestId("ran-commands-fold")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
+    expect(screen.getAllByTestId("thought-fold").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByTestId("ran-commands-fold")).toBeTruthy();
+    expect(screen.getByText(/^Thought/)).toBeTruthy();
+    expect(screen.getByText(/Ran 2 commands/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Ran 2 commands/i }));
+    expect(screen.getByText(/Ran git status/i)).toBeTruthy();
+    // Nested Thought lives inside the Ran fold.
+    const ranFold = screen.getByTestId("ran-commands-fold");
+    expect(ranFold.querySelectorAll('[data-testid="thought-fold"]').length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("session title lock", () => {
+  it("never derives titles from investigating / Explored / Diagnosing walls", () => {
+    expect(deriveSessionTitle("Investigating ActionForm redirect…")).toBe(
+      DEFAULT_SESSION_TITLE,
+    );
+    expect(deriveSessionTitle("Explored 1 search, 3 commands")).toBe(
+      DEFAULT_SESSION_TITLE,
+    );
+    expect(deriveSessionTitle("Diagnosing production error…")).toBe(
+      DEFAULT_SESSION_TITLE,
+    );
+    expect(deriveSessionTitle("Planning call queries with CodeGraph")).toBe(
+      DEFAULT_SESSION_TITLE,
+    );
+    expect(deriveSessionTitle("Stopped.")).toBe(DEFAULT_SESSION_TITLE);
+    expect(deriveSessionTitle("fix the redirect in ActionForm")).toBe(
+      "Fix the redirect in ActionForm",
+    );
+  });
+
+  it("40 investigating headlines still map to one user-derived list title", () => {
+    const userTitle = deriveSessionTitle("debug flash builder redirect");
+    expect(userTitle).toBe("Debug flash builder redirect");
+
+    const headlines = Array.from({ length: 40 }, (_, i) =>
+      i % 2 === 0
+        ? `Explored ${i + 1} search, 3 commands`
+        : `Investigating ActionForm step ${i}`,
+    );
+    for (const h of headlines) {
+      expect(isActivityHeadlineText(h)).toBe(true);
+      expect(displaySessionListTitle(h)).toBe("Untitled");
+    }
+    // One session row — display stays the human title, never the wall.
+    expect(displaySessionListTitle(userTitle)).toBe(userTitle);
+    expect(displaySessionListTitle(headlines.join("\n"))).toBe("Untitled");
+  });
+});

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -92,9 +92,9 @@ describe("transcript presentation contract", () => {
       />,
     );
 
-    // Reasoning-only turns fold into a quiet activity summary; open it to
-    // assert the inner Thought row presentation contract.
-    fireEvent.click(screen.getByRole("button", { name: /Plan: scan auth handlers/i }));
+    // Reasoning-only turns seal as Worked for; open it to assert the inner
+    // Thought row presentation contract.
+    fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
     const thought = screen.getByRole("button", { name: /Thought/i });
     const classes = thought.className;
     expect(classes).not.toMatch(/uppercase/);
@@ -249,7 +249,7 @@ describe("transcript presentation contract", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Plan:/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
     const thought = screen.getByRole("button", { name: /Thought/i });
     fireEvent.click(thought);
 
@@ -651,16 +651,18 @@ describe("investigation UX residual debts (nested / fold prefs / workerStream)",
     ];
 
     render(<TranscriptList {...listProps(items)} />);
-    // Kind buckets count nested rows (file + command + edit) while the fold
-    // is closed — the lying-count bug was that those rows stayed invisible.
+    // Sealed chrome is Worked for, not Explored kind-buckets. Nested worker
+    // rows stay unmounted until Worked for and then Ran are opened.
     const foldBtn = screen.getByRole("button", { name: /Worked for/i });
-    expect(foldBtn.textContent || "").toMatch(/1 file.*1 command.*1 edit/);
-    // Nested rows must stay unmounted until the investigation fold opens.
+    expect(foldBtn.textContent || "").toMatch(/Worked for/i);
+    expect(foldBtn.textContent || "").not.toMatch(/Explored/i);
     expect(screen.queryAllByTestId("nested-worker-action")).toHaveLength(0);
 
     fireEvent.click(foldBtn);
-    // One expand level: opening Investigating reveals nested tools even though
-    // the parent run_implement card stays open:false.
+    const ranBtn = screen.getByRole("button", { name: /Ran 1 command/i });
+    fireEvent.click(ranBtn);
+    // Opening Ran reveals nested tools even though the parent run_implement
+    // card stays open:false.
     const nested = screen.getAllByTestId("nested-worker-action");
     expect(nested).toHaveLength(2);
     expect(nested[0]).toHaveAttribute("data-action-id", "nested-read-1");
@@ -695,6 +697,7 @@ describe("investigation UX residual debts (nested / fold prefs / workerStream)",
 
     render(<TranscriptList {...listProps(items)} />);
     fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/i }));
     expect(screen.getAllByLabelText("failed").length).toBeGreaterThan(0);
     expect(screen.getAllByText("failed", { selector: ".sr-only" }).length).toBeGreaterThan(0);
   });
@@ -834,7 +837,8 @@ describe("job_id → Swarm Tracker deep-link chrome", () => {
         ])}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Worked for|Command|pytest/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/i }));
     const cta = screen.getByTestId("spill-output-peek");
     expect(cta).toHaveTextContent(/Full output \(9,?000 chars\)/);
     fireEvent.click(cta);
@@ -879,6 +883,7 @@ describe("job_id → Swarm Tracker deep-link chrome", () => {
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/i }));
 
     const kvLink = screen.getByTestId("job-id-link");
     expect(kvLink).toHaveTextContent("job_abcdef012345");

--- a/webapp/src/__tests__/transcriptPresentation.test.tsx
+++ b/webapp/src/__tests__/transcriptPresentation.test.tsx
@@ -150,7 +150,7 @@ describe("transcript presentation contract", () => {
       />,
     );
 
-    const summary = screen.getByRole("button", { name: /Explored/i });
+    const summary = screen.getByRole("button", { name: /Worked for/i });
     expect(summary.className).not.toMatch(/rounded-lg/);
     expect(summary.className).not.toMatch(/border-edge/);
     expect(summary.className).not.toMatch(/bg-panel2/);
@@ -184,7 +184,7 @@ describe("transcript presentation contract", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Explored/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
     // Exactly one keyboard disclosure control per closed tool row.
     const toolDisclosures = screen
       .getAllByRole("button", { expanded: false })
@@ -228,7 +228,7 @@ describe("transcript presentation contract", () => {
 
     const text = container.textContent || "";
     const userAt = text.indexOf("check billing");
-    const exploredAt = text.search(/Explored/i);
+    const exploredAt = text.search(/Worked for/i);
     const answerAt = text.indexOf("Billing looks fine.");
     expect(userAt).toBeGreaterThanOrEqual(0);
     expect(exploredAt).toBeGreaterThan(userAt);
@@ -328,7 +328,7 @@ describe("transcript presentation contract", () => {
     );
     expect(intermediate.has(planMsg)).toBe(true);
 
-    fireEvent.click(screen.getByRole("button", { name: /Explored/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
     expect(document.querySelector("strong")).toBeNull();
     const folded = screen.getByText(/Plan: retry routing after vision fix/i);
     expect(folded.tagName.toLowerCase()).toBe("pre");
@@ -457,7 +457,7 @@ describe("transcript presentation contract", () => {
 
     render(<TranscriptList {...listProps(items)} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Explored|Swarm/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Worked for|Swarm/i }));
 
     expect(screen.getByText(/worker timed out after 30s/i)).toBeTruthy();
     // Swarm receipts live in the activity strip; duplicate routing failures collapse inside it.
@@ -653,7 +653,7 @@ describe("investigation UX residual debts (nested / fold prefs / workerStream)",
     render(<TranscriptList {...listProps(items)} />);
     // Kind buckets count nested rows (file + command + edit) while the fold
     // is closed — the lying-count bug was that those rows stayed invisible.
-    const foldBtn = screen.getByRole("button", { name: /Explored/i });
+    const foldBtn = screen.getByRole("button", { name: /Worked for/i });
     expect(foldBtn.textContent || "").toMatch(/1 file.*1 command.*1 edit/);
     // Nested rows must stay unmounted until the investigation fold opens.
     expect(screen.queryAllByTestId("nested-worker-action")).toHaveLength(0);
@@ -694,7 +694,7 @@ describe("investigation UX residual debts (nested / fold prefs / workerStream)",
     ];
 
     render(<TranscriptList {...listProps(items)} />);
-    fireEvent.click(screen.getByRole("button", { name: /Explored/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
     expect(screen.getAllByLabelText("failed").length).toBeGreaterThan(0);
     expect(screen.getAllByText("failed", { selector: ".sr-only" }).length).toBeGreaterThan(0);
   });
@@ -719,7 +719,7 @@ describe("investigation UX residual debts (nested / fold prefs / workerStream)",
     const groupId = activityGroupStableId([card], 0);
 
     render(<TranscriptList {...listProps(items)} />);
-    fireEvent.click(screen.getByRole("button", { name: /Explored/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
     expect(resolveActivityGroupOpen(groupId)).toBe(true);
 
     clearActivityFoldPrefs();
@@ -834,7 +834,7 @@ describe("job_id → Swarm Tracker deep-link chrome", () => {
         ])}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Explored|Command|pytest/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Worked for|Command|pytest/i }));
     const cta = screen.getByTestId("spill-output-peek");
     expect(cta).toHaveTextContent(/Full output \(9,?000 chars\)/);
     fireEvent.click(cta);
@@ -878,7 +878,7 @@ describe("job_id → Swarm Tracker deep-link chrome", () => {
         ])}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Explored/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
 
     const kvLink = screen.getByTestId("job-id-link");
     expect(kvLink).toHaveTextContent("job_abcdef012345");
@@ -1083,7 +1083,7 @@ describe("live command token clicks", () => {
       />,
     );
     expect(screen.getByText(/I will patch auth next/i)).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /Investigating|Explored/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Investigating|Worked for/i })).toBeNull();
   });
 
   it("keeps sealed spoken prose outside the collapsed Investigating fold", () => {
@@ -1123,7 +1123,7 @@ describe("live command token clicks", () => {
     render(<TranscriptList {...listProps(items)} />);
     // White streamed text stays a top-level Bubble, visible without opening either fold.
     expect(screen.getByText(/I will patch auth next/i)).toBeTruthy();
-    const folds = screen.getAllByRole("button", { name: /Explored|Investigating/i });
+    const folds = screen.getAllByRole("button", { name: /Worked for|Investigating/i });
     expect(folds.length).toBeGreaterThan(0);
     for (const fold of folds) {
       expect(fold).toHaveAttribute("aria-expanded", "false");
@@ -1162,7 +1162,7 @@ describe("live command token clicks", () => {
         ])}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Explored/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Worked for/i }));
     expect(screen.getByTestId("exploration-shelf")).toBeTruthy();
     expect(screen.getByTestId("exploration-shelf")).toHaveAttribute("data-count", "2");
   });
@@ -1189,7 +1189,7 @@ describe("live command token clicks", () => {
       />,
     );
     if (!screen.queryByRole("button", { name: /^Exploration /i })) {
-      fireEvent.click(screen.getByRole("button", { name: /Investigating|Explored/i }));
+      fireEvent.click(screen.getByRole("button", { name: /Investigating|Worked for/i }));
     }
     const shelfToggle = screen.getByRole("button", { name: /^Exploration /i });
     expect(shelfToggle).toHaveAttribute("aria-expanded", "true");

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -5,6 +5,7 @@ import { pickFolder } from "../lib/transport";
 import { dispatchProjectSelected, dispatchProjectSwitching, panelOpacityClass } from "../lib/panelTransition";
 import { repoPathsEqual } from "../lib/pathNormalize";
 import { mapSessionSearchHits, type SessionSearchRow } from "../lib/sessionSearch";
+import { displaySessionListTitle } from "../lib/sessionTitle";
 import { usePolling } from "../lib/usePolling";
 import { readSWRCache, writeSWRCache, useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
 import {
@@ -911,7 +912,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       x: e.clientX,
       y: e.clientY,
       sessionId: s.id,
-      title: s.title || "Untitled",
+      title: displaySessionListTitle(s.title),
       settled: !!s.settled,
       archived: !!s.archived,
       running: runners[s.id] === "running",
@@ -1323,14 +1324,14 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                     className={`w-full min-h-8 flex flex-col justify-center text-left px-2 rounded transition min-w-0 disabled:opacity-60 ${
                       switchingSessionId === row.id ? "bg-panel2/60 border-l-2 border-accent" : "hover:bg-panel2/30"
                     }`}
-                    title={row.snippet ? `${row.title}\n${row.snippet}` : row.title}
+                    title={row.snippet ? `${displaySessionListTitle(row.title)}\n${row.snippet}` : displaySessionListTitle(row.title)}
                   >
                     <div className="flex items-center gap-1.5 min-w-0">
                       {switchingSessionId === row.id
                         ? <Loader2 size={11} className="shrink-0 animate-spin text-accent" />
                         : null}
                       <div className="text-[12.5px] truncate flex-1 text-muted">
-                        {row.title}
+                        {displaySessionListTitle(row.title)}
                       </div>
                       {row.settled ? (
                         <span className="shrink-0 text-[9px] uppercase tracking-wider text-faint font-medium">
@@ -1379,19 +1380,19 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                       type="button"
                       disabled={!!switchingSessionId || opening}
                       onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
-                      onDoubleClick={() => beginSessionRename(s.id, s.title || "Untitled")}
+                      onDoubleClick={() => beginSessionRename(s.id, displaySessionListTitle(s.title))}
                       onContextMenu={(e) => handleContextMenu(e, s, canSettleSessionsForProject(root, workspaceInfo?.repo))}
                       className={`w-full min-h-8 flex flex-col justify-center text-left px-2 rounded transition min-w-0 disabled:opacity-60 ${
                         isActive ? "bg-panel2/60 border-l-2 border-accent" : "hover:bg-panel2/30"
                       }`}
-                      title={`${s.title}${s.preview ? `\n${s.preview}` : ""}\n${root}`}
+                      title={`${displaySessionListTitle(s.title)}${s.preview ? `\n${s.preview}` : ""}\n${root}`}
                     >
                       <div className="flex items-center gap-1.5 min-w-0">
                         {switchingSessionId === s.id
                           ? <Loader2 size={11} className="shrink-0 animate-spin text-accent" />
                           : null}
                         <div className={`text-[12.5px] truncate flex-1 ${isActive ? "text-txt font-semibold" : "text-muted"}`}>
-                          {s.title || "Untitled"}
+                          {displaySessionListTitle(s.title)}
                         </div>
                       </div>
                       <div className="text-[10px] text-faint truncate font-mono">{label}</div>
@@ -1552,8 +1553,8 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                               <button
                                 onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
                                 disabled={!!switchingSessionId || opening}
-                                title={s.preview ? `${s.title || "Untitled"}\n${s.preview}` : (s.title || "Untitled")}
-                                onDoubleClick={() => beginSessionRename(s.id, s.title || "Untitled")}
+                                title={s.preview ? `${displaySessionListTitle(s.title)}\n${s.preview}` : displaySessionListTitle(s.title)}
+                                onDoubleClick={() => beginSessionRename(s.id, displaySessionListTitle(s.title))}
                                 onContextMenu={(e) => handleContextMenu(e, s, isCurrentActive)}
                                 className={`flex-1 min-w-0 h-7 text-left rounded pl-2.5 pr-1.5 flex items-center gap-1.5 text-[12px] transition disabled:opacity-60
                                   ${s.active ? "text-txt font-medium" : "text-muted group-hover:text-txt"}
@@ -1561,7 +1562,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                                 {switchingSessionId === s.id
                                   ? <Loader2 size={11} className="shrink-0 animate-spin text-accent" />
                                   : <MessageSquare size={11} className={`shrink-0 ${s.active ? "text-accent" : "text-faint"}`} />}
-                                <span className="flex-1 min-w-0 truncate">{s.title || "Untitled"}</span>
+                                <span className="flex-1 min-w-0 truncate">{displaySessionListTitle(s.title)}</span>
                               </button>
                               {confirmDeleteId === s.id ? (
                                 <div className="flex items-center gap-1 shrink-0 pr-0.5">
@@ -1656,15 +1657,15 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                                 <button
                                   onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
                                   disabled={!!switchingSessionId || opening}
-                                  onDoubleClick={() => beginSessionRename(s.id, s.title || "Untitled")}
+                                  onDoubleClick={() => beginSessionRename(s.id, displaySessionListTitle(s.title))}
                                   onContextMenu={(e) => handleContextMenu(e, s, isCurrentActive)}
                                   className={`flex-1 min-w-0 h-6 text-left rounded px-1.5 flex items-center gap-1.5 text-[11px] motion-safe:transition opacity-45 hover:opacity-90 disabled:opacity-40
                                     ${s.active ? "bg-accent/10 text-accent" : "text-faint hover:bg-panel2/50 hover:text-muted"}
                                     ${switchingSessionId === s.id ? "opacity-70" : ""}`}
-                                  title={s.title || "Untitled"}
+                                  title={displaySessionListTitle(s.title)}
                                 >
                                   <Square size={10} className="shrink-0" />
-                                  <span className="truncate">{s.title || "Untitled"}</span>
+                                  <span className="truncate">{displaySessionListTitle(s.title)}</span>
                                 </button>
                                 )}
                                 {isCurrentActive ? (
@@ -1732,7 +1733,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                       type="button"
                       onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
                       disabled={!!switchingSessionId || opening}
-                      onDoubleClick={() => beginSessionRename(s.id, s.title || "Untitled")}
+                      onDoubleClick={() => beginSessionRename(s.id, displaySessionListTitle(s.title))}
                       onContextMenu={(e) => handleContextMenu(e, s, true)}
                       className={`w-full h-7 text-left rounded px-2 flex items-center gap-1.5 text-[12.5px] transition opacity-60 hover:opacity-100 disabled:opacity-40
                         ${s.active ? "bg-accent/10 text-accent font-semibold" : "hover:bg-panel2/60 text-muted"}
@@ -1741,7 +1742,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                       {switchingSessionId === s.id
                         ? <Loader2 size={11} className="shrink-0 animate-spin text-accent" />
                         : <MessageSquare size={11} />}
-                      <span className="flex-1 truncate">{s.title || "Untitled"}</span>
+                      <span className="flex-1 truncate">{displaySessionListTitle(s.title)}</span>
                     </button>
                   )}
                 </div>

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -36,21 +36,26 @@ import {
 } from "../lib/clickableOutput";
 import { splitStreamingMarkdown } from "../lib/streamMarkdown";
 import {
+  activityWorkDurationMs,
   aggregateExplorationSummary,
   cardEffectivelyRunning,
   cardHasDurableJob,
   deriveBusyProgress,
   explorationShelfAnchorId,
   investigatingHeadline,
-  partitionExplorationShelf,
+  partitionStackedActivity,
+  ranCommandsLabel,
   resolveCardCliInput,
   shortenGoal,
   quietWorkingCueVisible,
   shouldShowBusyFooter,
+  thoughtFoldLabel,
   toolFocusPhrase,
   toolInputFieldKey,
   toolRowLabel,
   turnHasVisibleBusySurface,
+  workedForLabel,
+  ranGoalLine,
 } from "../lib/turnProgress";
 import { isAgentLoopOpen } from "./conversation/runnersBusy";
 import {
@@ -239,7 +244,7 @@ export type CommandApprovalItem = {
 export type Item =
   | { kind: "msg"; msg: Msg }
   | { kind: "card"; card: Card }
-  | { kind: "thinking"; text: string; streaming?: boolean; id?: string; stream_id?: string }
+  | { kind: "thinking"; text: string; streaming?: boolean; id?: string; stream_id?: string; duration_ms?: number | null; started_at_ms?: number }
   | { kind: "tool_prep"; name: string }
   | SwarmPendingItem
   | SwarmResultItem
@@ -288,7 +293,7 @@ export type Item =
 
 export type GroupedItem =
   | { kind: "msg"; msg: Msg }
-  | { kind: "thinking"; text: string; streaming?: boolean; id?: string; stream_id?: string }
+  | { kind: "thinking"; text: string; streaming?: boolean; id?: string; stream_id?: string; duration_ms?: number | null; started_at_ms?: number }
   | SwarmPendingItem
   | SwarmResultItem
   | { kind: "checkpoint"; id: string; label: string; trigger: string }
@@ -337,7 +342,7 @@ export type GroupedItem =
 
 type ActivityItem =
   | { kind: "card"; card: Card }
-  | { kind: "thinking"; text: string; streaming?: boolean; id?: string; stream_id?: string }
+  | { kind: "thinking"; text: string; streaming?: boolean; id?: string; stream_id?: string; duration_ms?: number | null; started_at_ms?: number }
   | { kind: "codegraph_context"; symbols: number; query: string }
   | { kind: "vault_cite"; route: string; snippets: string[]; query?: string }
   | { kind: "checkpoint"; id: string; label: string; trigger: string }
@@ -860,6 +865,8 @@ function objKey(obj: object): string {
 const __activityOpen = new Map<string, boolean>();
 // Reasoning expand preference (user click) survives remounts / live→idle flips.
 const __thinkingExpanded = new Map<string, boolean>();
+// Ran N command mid-fold expand preference (user click) survives remounts.
+const __commandFoldOpen = new Map<string, boolean>();
 // Alias every durable member of an investigation onto one canon key so a
 // thinking-only group does not remount when the first tool card arrives (and
 // the reverse). Streaming used to key off objKey(thinking) which changed every
@@ -874,6 +881,7 @@ const __activityGroupCanon = new Map<string, string>();
 export function clearActivityFoldPrefs(): void {
   __activityOpen.clear();
   __thinkingExpanded.clear();
+  __commandFoldOpen.clear();
   __activityGroupCanon.clear();
 }
 
@@ -1883,6 +1891,7 @@ export const TranscriptList = memo(function TranscriptList({
           isLiveFold={i === lastActivityGroupIdx}
           loopOpen={agentLoopOpen && i === lastActivityGroupIdx}
           pausePoint={pausePoint && i === lastActivityGroupIdx}
+          busyElapsedMs={busyElapsedMs}
           onToggleCard={(card) => onSetCard(card.id, { open: !card.open })}
         />
       );
@@ -2179,6 +2188,7 @@ function ActivityGroup({
   loopOpen = false,
   pausePoint = false,
   isLiveFold = false,
+  busyElapsedMs = null,
 }: {
   items: ActivityItem[];
   onToggleCard: (card: Card) => void;
@@ -2192,6 +2202,8 @@ function ActivityGroup({
   pausePoint?: boolean;
   /** True only for the live-index fold. Prior folds never show Investigating. */
   isLiveFold?: boolean;
+  /** Wall-clock ms for the live busy turn — seeds Worked for when sealing. */
+  busyElapsedMs?: number | null;
 }) {
   // Investigation chrome stays collapsed by default (Cursor/Hermes). The
   // headline still tracks Investigating / Explored while closed; the user
@@ -2242,7 +2254,7 @@ function ActivityGroup({
   ) as { kind: "msg"; msg: Msg }[];
   const thinkingItems = items.filter(
     (it) => it.kind === "thinking" && (it as { kind: "thinking"; text: string }).text.trim()
-  ) as { kind: "thinking"; text: string; streaming?: boolean; id?: string }[];
+  ) as { kind: "thinking"; text: string; streaming?: boolean; id?: string; duration_ms?: number | null }[];
   const liveThinking = thinkingItems.some((t) => t.streaming);
   // Keep Investigating across gaps between tool steps (loop still open).
   // Cursor CLI often streams reasoning before any tool_call event — treat
@@ -2317,6 +2329,7 @@ function ActivityGroup({
           blockId={blockId}
           text={it.text}
           live={Boolean(it.streaming)}
+          durationMs={typeof it.duration_ms === "number" ? it.duration_ms : null}
         />
       );
     }
@@ -2455,23 +2468,36 @@ function ActivityGroup({
     return null;
   };
 
-  // Always use the Investigating / Explored collapsible — even for tiny
+  // Always use the Investigating / Worked for collapsible — even for tiny
   // tool-only groups. Inline always-open rows used to burn scroll space and
   // disagreed with Cursor/Hermes (collapsed until the user opens them).
 
+  const sealedWorkMs = (() => {
+    const fromItems = activityWorkDurationMs(items);
+    if (fromItems != null) return fromItems;
+    if (isLiveFold && busyElapsedMs != null && busyElapsedMs >= 1000) return busyElapsedMs;
+    return null;
+  })();
+
   const quietSummary = (() => {
-    if (!investigating && !isLiveFold && durableJobRunning) return "job still running";
-    if (actionCount > 0) return stepHeadline;
-    if (swarmResults.length > 0) {
-      return `Swarm · ${swarmResults.length} result${swarmResults.length === 1 ? "" : "s"}`;
+    if (investigating) {
+      if (actionCount > 0) return stepHeadline;
+      if (swarmPendingItems.length > 0) {
+        return swarmPendingRunning ? "Swarm · running" : `Swarm · ${swarmPendingItems.length} pending`;
+      }
+      return stepHeadline || "Investigating…";
     }
-    if (swarmPendingItems.length > 0) {
-      if (!isLiveFold) {
+    if (!isLiveFold && durableJobRunning) return "job still running";
+    // Sealed turn: Cursor-style Worked for {duration} — not Explored counts.
+    if (actionCount > 0 || thinkingItems.length > 0 || swarmResults.length > 0 || swarmPendingItems.length > 0) {
+      if (swarmResults.length > 0 && actionCount === 0 && thinkingItems.length === 0) {
+        return `Swarm · ${swarmResults.length} result${swarmResults.length === 1 ? "" : "s"}`;
+      }
+      if (swarmPendingItems.length > 0 && actionCount === 0 && thinkingItems.length === 0) {
         return `Swarm · ${swarmPendingItems.length} pending`;
       }
-      return swarmPendingRunning ? "Swarm · running" : `Swarm · ${swarmPendingItems.length} pending`;
+      return workedForLabel(sealedWorkMs);
     }
-    if (investigating) return stepHeadline || "Investigating…";
     if (telemetryItems.length > 0 && actionCount === 0 && thinkingItems.length === 0) {
       const first = telemetryItems[0];
       if (first.kind === "compaction") {
@@ -2492,7 +2518,7 @@ function ActivityGroup({
       if (first.kind === "auto_status") return autoStatusPresentation(first.cycle, first.snapshot).label;
     }
     const preview = normalizeReasoningPreview(narrationPreview, 72);
-    return preview || "Thought";
+    return preview || workedForLabel(sealedWorkMs);
   })();
   const compactionHover = (() => {
     const compact = telemetryItems.find((row) => row.kind === "compaction");
@@ -2503,7 +2529,7 @@ function ActivityGroup({
     .join(" · ");
 
   return (
-    <div className="my-1 w-full" ref={foldRootRef}>
+    <div className="my-1 w-full" ref={foldRootRef} data-testid="activity-fold" data-worked-for={!investigating ? "1" : undefined}>
       <button
         type="button"
         onClick={toggleOpen}
@@ -2530,17 +2556,38 @@ function ActivityGroup({
       </button>
       {open && (
         <div className="flex flex-col gap-0.5 pl-3 mt-1 border-l border-edge/30 w-full">
-          {partitionExplorationShelf(displayItems, (row) => (
-            row.kind === "card" ? String(row.card.kind || "") : null
-          )).map((row) => {
+          {partitionStackedActivity(displayItems, (row) => ({
+            cardKind: row.kind === "card" ? String(row.card.kind || "") : null,
+            isThinking: row.kind === "thinking",
+          })).map((row) => {
+            if (row.kind === "thought") {
+              return renderInner(row.item, row.index);
+            }
+            if (row.kind === "commands") {
+              const cmdCards = row.items.filter(
+                (it): it is { kind: "card"; card: Card } => it.kind === "card",
+              );
+              const foldKey = `cmd-fold-${cmdCards[0]?.card.id || row.indexes[0]}`;
+              return (
+                <CommandFold
+                  key={foldKey}
+                  foldId={`${groupId}-${foldKey}`}
+                  items={row.items}
+                  indexes={row.indexes}
+                  duplicateCounts={row.indexes.map((idx) => duplicateCounts[idx] || 1)}
+                  onToggleCard={onToggleCard}
+                  renderInner={renderInner}
+                />
+              );
+            }
             if (row.kind === "shelf") {
-              const cards = row.items.filter(
+              const shelfCards = row.items.filter(
                 (it): it is { kind: "card"; card: Card } => it.kind === "card",
               );
               return (
                 <ExplorationShelf
-                  key={explorationShelfAnchorId(cards.map((c) => c.card.id))}
-                  items={cards}
+                  key={explorationShelfAnchorId(shelfCards.map((c) => c.card.id))}
+                  items={shelfCards}
                   duplicateCounts={row.indexes.map((idx) => duplicateCounts[idx] || 1)}
                   onToggleCard={onToggleCard}
                   activityGroupOpen={open}
@@ -2548,6 +2595,81 @@ function ActivityGroup({
               );
             }
             return renderInner(row.item, row.index);
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+/**
+ * Nestable Ran N command mid-fold. Expand shows specific Ran {goal} lines and
+ * any Thought rows that interleaved mid-tooling (Cursor stacked folds).
+ */
+function CommandFold({
+  foldId,
+  items,
+  indexes,
+  duplicateCounts,
+  onToggleCard,
+  renderInner,
+}: {
+  foldId: string;
+  items: ActivityItem[];
+  indexes: number[];
+  duplicateCounts: number[];
+  onToggleCard: (card: Card) => void;
+  renderInner: (it: ActivityItem, idx: number) => ReactNode;
+}) {
+  const [open, setOpen] = useState(() => {
+    if (__commandFoldOpen.has(foldId)) return Boolean(__commandFoldOpen.get(foldId));
+    return false;
+  });
+  const rootRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    requestFeedRowRemeasure(rootRef.current);
+  }, [open]);
+
+  const cardCount = items.filter((it) => it.kind === "card").length;
+  const label = ranCommandsLabel(cardCount);
+
+  return (
+    <div className="flex flex-col w-full py-0.5 min-w-0" ref={rootRef} data-testid="ran-commands-fold">
+      <button
+        type="button"
+        onClick={() => {
+          setOpen((v) => {
+            const next = !v;
+            __commandFoldOpen.set(foldId, next);
+            return next;
+          });
+        }}
+        aria-expanded={open}
+        className="transcript-fold-chrome flex items-center gap-1.5 text-faint/65 hover:text-muted/90 transition font-sans font-normal text-[12px] text-left w-full min-w-0 select-none"
+        title={open ? "Collapse commands" : "Expand commands"}
+      >
+        {open ? <ChevronDown size={11} className="text-faint/55 shrink-0" /> : <ChevronRight size={11} className="text-faint/55 shrink-0" />}
+        <span className="shrink-0">{label}</span>
+      </button>
+      {open && (
+        <div className="mt-0.5 pl-2.5 ml-1 border-l border-edge/40 flex flex-col gap-0.5 w-full min-w-0">
+          {items.map((it, i) => {
+            const idx = indexes[i] ?? i;
+            const dup = duplicateCounts[i] || 1;
+            if (it.kind === "card") {
+              return (
+                <ActionCard
+                  key={it.card.id || `ran-card-${idx}`}
+                  card={it.card}
+                  onToggle={() => onToggleCard(it.card)}
+                  duplicateCount={dup}
+                  activityGroupOpen={open}
+                  ranLine
+                />
+              );
+            }
+            return renderInner(it, idx);
           })}
         </div>
       )}
@@ -2612,10 +2734,12 @@ function ThinkingBlock({
   text,
   live = false,
   blockId,
+  durationMs = null,
 }: {
   text: string;
   live?: boolean;
   blockId: string;
+  durationMs?: number | null;
 }) {
   // Cursor/Hermes-style compression: reasoning stays a single header line
   // by default (faint first-line preview). Expand is user-driven and sticky;
@@ -2674,9 +2798,10 @@ function ThinkingBlock({
   }
 
   const preview = normalizeReasoningPreview(text);
+  const foldLabel = thoughtFoldLabel({ live, durationMs });
 
   return (
-    <div className="flex flex-col w-full py-0.5 min-w-0" ref={thoughtRootRef}>
+    <div className="flex flex-col w-full py-0.5 min-w-0" ref={thoughtRootRef} data-testid="thought-fold">
       <button
         type="button"
         onClick={() => {
@@ -2691,7 +2816,7 @@ function ThinkingBlock({
         title={expanded ? "Collapse reasoning" : "Expand reasoning"}
       >
         {expanded ? <ChevronDown size={11} className="text-faint/55 shrink-0" /> : <ChevronRight size={11} className="text-faint/55 shrink-0" />}
-        <span className="shrink-0">{live ? "Thinking…" : "Thought"}</span>
+        <span className="shrink-0">{foldLabel}</span>
         {!expanded && preview ? (
           <span className="ml-0.5 truncate text-faint/50">{preview}</span>
         ) : null}
@@ -3247,6 +3372,7 @@ function ActionCard({
   onToggle,
   duplicateCount = 1,
   activityGroupOpen = false,
+  ranLine = false,
 }: {
   card: Card;
   onToggle: () => void;
@@ -3258,6 +3384,8 @@ function ActionCard({
    * them, so a second forced-closed layer would lie about the timeline.
    */
   activityGroupOpen?: boolean;
+  /** Inside Ran N fold: paint as `Ran {goal}` instead of tool-kind chrome. */
+  ranLine?: boolean;
 }) {
   const toolName = toolRowLabel(card.kind || "");
   // Prefer the real CLI input (path/command/query), recovering from nested
@@ -3272,6 +3400,7 @@ function ActionCard({
     : "";
   const rawGoal = multiGoals || commandKv || cliInput;
   const goalPreview = shortenGoal(rawGoal, 56);
+  const ranLabel = ranLine ? ranGoalLine(goalPreview || rawGoal || toolName) : "";
   const meta = getCardMeta(card);
   const nested = Array.isArray(card.actions) ? card.actions : [];
   const effectivelyRunning = cardEffectivelyRunning(card);
@@ -3358,14 +3487,14 @@ function ActionCard({
               ) : null}
             </div>
             <span className={`shrink-0 font-normal ${isErr ? "text-risk/80" : suppressed ? "text-faint/70" : "text-faint/80"}`}>
-              {toolName}
+              {ranLine ? ranLabel : toolName}
             </span>
             {duplicateCount > 1 ? (
               <span className="shrink-0 text-faint/55 tabular-nums" title={`${duplicateCount} identical failures`}>
                 ×{duplicateCount}
               </span>
             ) : null}
-            {goalPreview && (linkKind === "none" || !goalValue) ? (
+            {!ranLine && goalPreview && (linkKind === "none" || !goalValue) ? (
               <span className="text-faint/65 truncate max-w-[70%] font-normal" title={rawGoal}>
                 {goalPreview}
               </span>
@@ -3377,8 +3506,7 @@ function ActionCard({
               }`}
             />
           </button>
-          {goalPreview && linkKind !== "none" && goalValue ? (
-            <button
+          {!ranLine && goalPreview && linkKind !== "none" && goalValue ? (            <button
               type="button"
               onClick={onGoalClick}
               className="text-accent/75 hover:underline underline-offset-2 truncate max-w-[70%] font-normal cursor-pointer bg-transparent border-0 p-0 text-[12px] font-sans"

--- a/webapp/src/components/conversation/thinkingToolPrep.ts
+++ b/webapp/src/components/conversation/thinkingToolPrep.ts
@@ -10,16 +10,26 @@ export function newThinkingId(): string {
 
 /** Drop streaming:true from live reasoning rows once the phase ends. */
 export function finalizeStreamingThinking(items: Item[]): Item[] {
-  return items.map((it) =>
-    it.kind === "thinking" && it.streaming
-      ? {
-          kind: "thinking" as const,
-          text: it.text,
-          id: it.id || newThinkingId(),
-          ...(it.stream_id ? { stream_id: it.stream_id } : {}),
-        }
-      : it
-  );
+  const now = Date.now();
+  return items.map((it) => {
+    if (it.kind !== "thinking" || !it.streaming) return it;
+    const started =
+      typeof it.started_at_ms === "number" && Number.isFinite(it.started_at_ms)
+        ? it.started_at_ms
+        : now;
+    const duration_ms =
+      typeof it.duration_ms === "number" && Number.isFinite(it.duration_ms)
+        ? it.duration_ms
+        : Math.max(0, now - started);
+    return {
+      kind: "thinking" as const,
+      text: it.text,
+      id: it.id || newThinkingId(),
+      ...(it.stream_id ? { stream_id: it.stream_id } : {}),
+      started_at_ms: started,
+      duration_ms,
+    };
+  });
 }
 
 /**
@@ -88,6 +98,13 @@ function turnStartIndex(items: Item[]): number {
   return 0;
 }
 
+function thinkingStartedAt(it: { started_at_ms?: number } | undefined): number {
+  if (typeof it?.started_at_ms === "number" && Number.isFinite(it.started_at_ms)) {
+    return it.started_at_ms;
+  }
+  return Date.now();
+}
+
 /**
  * Append/update the open streaming reasoning row for the current turn.
  * When `streamId` is present, identity owns the surface — interleaved
@@ -120,6 +137,7 @@ export function upsertStreamingThinking(
           streaming: true,
           id: it.id || newThinkingId(),
           stream_id: streamId,
+          started_at_ms: thinkingStartedAt(it),
         };
         return copy;
       }
@@ -132,6 +150,7 @@ export function upsertStreamingThinking(
         streaming: true,
         id: newThinkingId(),
         stream_id: streamId,
+        started_at_ms: Date.now(),
       },
     ];
   }
@@ -156,7 +175,13 @@ export function upsertStreamingThinking(
       const sealed = finalizeStreamingThinking(items);
       return [
         ...sealed,
-        { kind: "thinking", text: chunk, streaming: true, id: newThinkingId() },
+        {
+          kind: "thinking",
+          text: chunk,
+          streaming: true,
+          id: newThinkingId(),
+          started_at_ms: Date.now(),
+        },
       ];
     }
     if (it.kind === "thinking") {
@@ -167,13 +192,20 @@ export function upsertStreamingThinking(
         streaming: true,
         id: it.id || newThinkingId(),
         ...(it.stream_id ? { stream_id: it.stream_id } : {}),
+        started_at_ms: thinkingStartedAt(it),
       };
       return copy;
     }
   }
   return [
     ...items,
-    { kind: "thinking", text: chunk, streaming: true, id: newThinkingId() },
+    {
+      kind: "thinking",
+      text: chunk,
+      streaming: true,
+      id: newThinkingId(),
+      started_at_ms: Date.now(),
+    },
   ];
 }
 

--- a/webapp/src/lib/sessionTitle.ts
+++ b/webapp/src/lib/sessionTitle.ts
@@ -1,4 +1,5 @@
 import { api } from "./api";
+import { isActivityHeadlineText } from "./sessionTitleLock";
 
 /** Matches harness/sessions.py derive_title default. */
 export const DEFAULT_SESSION_TITLE = "New session";
@@ -6,6 +7,8 @@ export const DEFAULT_SESSION_TITLE = "New session";
 /**
  * Derive a short session title from the first user prompt.
  * Mirrors harness.sessions.derive_title so optimistic UI renames match backend.
+ * Never accepts Investigating / Explored / Diagnosing / Planning walls —
+ * those belong in the activity strip, not session.title.
  */
 export function deriveSessionTitle(prompt: string): string {
   if (!prompt) return DEFAULT_SESSION_TITLE;
@@ -23,6 +26,9 @@ export function deriveSessionTitle(prompt: string): string {
     }
   }
   if (!firstLine) return DEFAULT_SESSION_TITLE;
+  if (isActivityHeadlineText(firstLine) || isActivityHeadlineText(prompt)) {
+    return DEFAULT_SESSION_TITLE;
+  }
 
   const words = firstLine.split(/\s+/);
   const truncatedWords: string[] = [];
@@ -43,12 +49,23 @@ export function deriveSessionTitle(prompt: string): string {
   if (title) {
     title = title[0].toUpperCase() + title.slice(1);
   }
-  return title || DEFAULT_SESSION_TITLE;
+  if (!title || isActivityHeadlineText(title)) return DEFAULT_SESSION_TITLE;
+  return title;
 }
 
 export function isDefaultSessionTitle(title: string | undefined | null): boolean {
   const trimmed = (title || "").trim();
   return !trimmed || trimmed === DEFAULT_SESSION_TITLE;
+}
+
+/**
+ * One session row = one human title. Activity headlines / Stopped. never
+ * paint as the list title (fall back to Untitled).
+ */
+export function displaySessionListTitle(title: string | undefined | null): string {
+  const trimmed = (title || "").trim();
+  if (!trimmed || isActivityHeadlineText(trimmed)) return "Untitled";
+  return trimmed;
 }
 
 /**
@@ -68,6 +85,9 @@ export async function renameDefaultSessionIfNeeded(
     const sessions = await api.sessions(repoRoot || undefined);
     const sess = sessions.find((s) => s.id === sessionId);
     if (!sess || !isDefaultSessionTitle(sess.title)) return;
+    // Refuse to stamp an activity-headline wall even if the stored title is
+    // still default (guard against bad prompts / mid-turn leakage).
+    if (isActivityHeadlineText(title)) return;
     await api.renameSession(sessionId, title);
     window.dispatchEvent(new Event("harness-config-changed"));
   } catch {

--- a/webapp/src/lib/sessionTitleLock.ts
+++ b/webapp/src/lib/sessionTitleLock.ts
@@ -1,0 +1,27 @@
+/**
+ * Session-list title lock helpers.
+ *
+ * Investigating / Explored / Diagnosing / Planning walls and bare Stopped.
+ * belong in the activity strip — never session.title or preferred list preview.
+ */
+
+/** Activity / progress headlines that must never become session.title. */
+export function isActivityHeadlineText(text: string): boolean {
+  const raw = String(text || "").trim();
+  if (!raw) return false;
+  if (/^Stopped\.?$/i.test(raw)) return true;
+
+  const lineRe =
+    /^(Investigating|Explored|Diagnosing|Planning|Assessing|Still working|Looking|Thinking|Thought|Worked for|Ran\s+\d+\s+commands?)\b/i;
+
+  const lines = raw
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return false;
+  if (lines.length === 1) return lineRe.test(lines[0]!);
+
+  // Wall of investigating / Explored / Diagnosing lines from a long turn.
+  const hits = lines.filter((l) => lineRe.test(l)).length;
+  return hits >= 2 || (hits === 1 && hits === lines.length);
+}

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -433,6 +433,183 @@ export function aggregateExplorationSummary(kinds: string[]): string {
   return parts.join(", ");
 }
 
+/** Run / shell / terminal tool cards nest under a Ran N command fold.
+ *  Also treat edit/other actionable tools as Ran rows so nested Thought can
+ *  live between tool steps (Cursor stacked folds). Exploration shelves still
+ *  win for consecutive file/search reads via partition order.
+ */
+export function isCommandCardKind(kind: string): boolean {
+  const k = (kind || "").trim();
+  if (!k) return false;
+  if (isExplorationShelfKind(k)) return false;
+  return true;
+}
+
+/** Compact duration for Worked for / Thought chrome (`23s`, `6m`, `1m 5s`). */
+export function formatFoldDuration(ms: number): string {
+  return formatBusyElapsed(ms);
+}
+
+/** Sealed outer activity fold — replaces Explored once the turn seals. */
+export function workedForLabel(durationMs?: number | null): string {
+  if (durationMs == null || !Number.isFinite(durationMs) || durationMs < 0) {
+    return "Worked for";
+  }
+  const label = formatFoldDuration(durationMs);
+  return label ? `Worked for ${label}` : "Worked for";
+}
+
+/** Reasoning fold chrome — live pulses Thinking…; sealed tucks to Thought {Ns}. */
+export function thoughtFoldLabel(opts: {
+  live?: boolean;
+  durationMs?: number | null;
+}): string {
+  if (opts.live) return "Thinking…";
+  if (
+    opts.durationMs != null
+    && Number.isFinite(opts.durationMs)
+    && opts.durationMs >= 1000
+  ) {
+    const label = formatFoldDuration(opts.durationMs);
+    return label ? `Thought ${label}` : "Thought";
+  }
+  return "Thought";
+}
+
+/** Mid-summary command fold — expand shows specific Ran {goal} lines. */
+export function ranCommandsLabel(count: number): string {
+  const n = Math.max(0, Math.floor(count));
+  return n === 1 ? "Ran 1 command" : `Ran ${n} commands`;
+}
+
+/** One expanded command row under Ran N — `Ran {goal}`. */
+export function ranGoalLine(goal: string): string {
+  const g = String(goal || "").trim();
+  return g ? `Ran ${g}` : "Ran command";
+}
+
+/**
+ * Wall time for a sealed Worked for row: sum of known card / thinking /
+ * nested-action durations. Returns null when nothing recorded.
+ */
+export function activityWorkDurationMs(
+  items: Array<{
+    kind: string;
+    card?: {
+      result?: { duration_ms?: number | null } | null;
+      actions?: Array<{ duration_ms?: number | null }>;
+    };
+    duration_ms?: number | null;
+  }>,
+): number | null {
+  let total = 0;
+  let any = false;
+  for (const it of items) {
+    if (it.kind === "thinking" && typeof it.duration_ms === "number" && Number.isFinite(it.duration_ms)) {
+      total += Math.max(0, it.duration_ms);
+      any = true;
+    }
+    if (it.kind === "card" && it.card) {
+      const d = it.card.result?.duration_ms;
+      if (typeof d === "number" && Number.isFinite(d)) {
+        total += Math.max(0, d);
+        any = true;
+      }
+      for (const action of it.card.actions || []) {
+        if (typeof action.duration_ms === "number" && Number.isFinite(action.duration_ms)) {
+          total += Math.max(0, action.duration_ms);
+          any = true;
+        }
+      }
+    }
+  }
+  return any ? total : null;
+}
+
+export type StackedActivityRow<T> =
+  | { kind: "thought"; item: T; index: number }
+  | { kind: "commands"; items: T[]; indexes: number[] }
+  | { kind: "shelf"; items: T[]; indexes: number[] }
+  | { kind: "item"; item: T; index: number };
+
+/**
+ * Partition an open activity fold into Cursor-style stacked rows:
+ * leading Thought siblings, nestable Ran N command groups (with interleaved
+ * thoughts inside), exploration shelves, then other items.
+ */
+export function partitionStackedActivity<T>(
+  items: T[],
+  meta: (item: T) => { cardKind: string | null; isThinking: boolean },
+): StackedActivityRow<T>[] {
+  const out: StackedActivityRow<T>[] = [];
+  let i = 0;
+  let seenCommand = false;
+
+  while (i < items.length) {
+    const cur = meta(items[i]);
+
+    if (cur.isThinking && !seenCommand) {
+      out.push({ kind: "thought", item: items[i], index: i });
+      i += 1;
+      continue;
+    }
+
+    if (cur.cardKind && isCommandCardKind(cur.cardKind)) {
+      seenCommand = true;
+      const group: T[] = [];
+      const indexes: number[] = [];
+      while (i < items.length) {
+        const next = meta(items[i]);
+        if (next.cardKind && isCommandCardKind(next.cardKind)) {
+          group.push(items[i]);
+          indexes.push(i);
+          i += 1;
+          continue;
+        }
+        // Thoughts (and only thoughts) nest inside the Ran fold between commands.
+        if (next.isThinking) {
+          group.push(items[i]);
+          indexes.push(i);
+          i += 1;
+          continue;
+        }
+        break;
+      }
+      out.push({ kind: "commands", items: group, indexes });
+      continue;
+    }
+
+    if (cur.isThinking) {
+      out.push({ kind: "thought", item: items[i], index: i });
+      i += 1;
+      continue;
+    }
+
+    if (cur.cardKind && isExplorationShelfKind(cur.cardKind)) {
+      const start = i;
+      const group: T[] = [];
+      const indexes: number[] = [];
+      while (i < items.length) {
+        const nextKind = meta(items[i]).cardKind;
+        if (!nextKind || !isExplorationShelfKind(nextKind)) break;
+        group.push(items[i]);
+        indexes.push(i);
+        i += 1;
+      }
+      if (group.length >= 2) {
+        out.push({ kind: "shelf", items: group, indexes });
+      } else {
+        out.push({ kind: "item", item: group[0], index: start });
+      }
+      continue;
+    }
+
+    out.push({ kind: "item", item: items[i], index: i });
+    i += 1;
+  }
+  return out;
+}
+
 /** Items after the last user message (current turn), or all if none. */
 export function itemsInCurrentTurn(items: TurnItem[]): TurnItem[] {
   let lastUser = -1;


### PR DESCRIPTION
## Summary
- Cherry-pick of the extras that missed thin 345 (`823df3be`) onto `origin/main` (`f48cca0d`).
- Stacked folds: sealed `Worked for {duration}` over `Thought {Ns}` and nestable `Ran N command` (nested Thought allowed). 343 finale Bubble stays out.
- Session-list lock: one human title via `deriveSessionTitle`; never investigatingHeadline slop in Sessions/Home.
- Version `0.9.346`. Pin stays `puppetmaster-ai==1.22.32`. No feed Motion.

## Test plan
- [ ] Sealed turn shows Worked for + finale Bubble
- [ ] Thought is a separate fold
- [ ] Ran N command can contain a nested Thought
- [ ] Finale never lands inside Worked for
- [ ] Body font-weight stays regular
- [ ] 40 investigating headlines still one session row with user-derived title