### PR TITLE
Marionette v0.9.347 — live fold labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.32` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.346, deliberately pre-1.0. Rides puppetmaster-ai==1.22.32. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.347, deliberately pre-1.0. Rides puppetmaster-ai==1.22.32. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.346"
+__version__ = "0.9.347"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/text_clean.py
+++ b/harness/text_clean.py
@@ -64,6 +64,11 @@ def is_pollution_line(line: str) -> bool:
         return True
     return False
 
+def is_working_ellipsis_fallback(text: str) -> bool:
+    """Spoken-prose empty fallback. Fold chrome must never adopt this string."""
+    return bool(re.match(r"^Working\.\.\.?$", (text or "").strip(), re.I))
+
+
 def get_first_sentence(text: str) -> str:
     for line in text.splitlines():
         if is_pollution_line(line):
@@ -170,8 +175,12 @@ def clean_say(text: str) -> str:
     # 6. Fallback if empty or near-empty — prefer a real first sentence, else
     # leave empty. Never substitute "Working..." (fold chrome must stay
     # Investigating… / Thinking… / Ran, not the spoken-prose placeholder).
+    if is_working_ellipsis_fallback(result):
+        return ""
     if len(result.strip()) < 5:
         fallback = get_first_sentence(text)
+        if is_working_ellipsis_fallback(fallback):
+            return ""
         return fallback if len(fallback.strip()) >= 5 else ""
         
     return result

--- a/harness/text_clean.py
+++ b/harness/text_clean.py
@@ -75,7 +75,9 @@ def get_first_sentence(text: str) -> str:
             if match and match[0]:
                 return match[0]
             return s
-    return "Working..."
+    # Empty after pollution strip — never invent "Working...". That string
+    # poisoned live fold chrome when empty crumbs hit the transcript.
+    return ""
 
 def clean_say(text: str) -> str:
     if not text:
@@ -165,9 +167,11 @@ def clean_say(text: str) -> str:
     # Note: 3+ blank lines means 4+ consecutive newlines, we collapse to 2 newlines (1 blank line)
     result = re.sub(r'\n{3,}', '\n\n', result)
     
-    # 6. Fallback if empty or near-empty
+    # 6. Fallback if empty or near-empty — prefer a real first sentence, else
+    # leave empty. Never substitute "Working..." (fold chrome must stay
+    # Investigating… / Thinking… / Ran, not the spoken-prose placeholder).
     if len(result.strip()) < 5:
         fallback = get_first_sentence(text)
-        return fallback if len(fallback.strip()) >= 5 else "Working..."
+        return fallback if len(fallback.strip()) >= 5 else ""
         
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.346"
+version = "0.9.347"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_say_clean.py
+++ b/tests/test_say_clean.py
@@ -113,3 +113,10 @@ def test_clean_say_collapses_newlines():
     text = "Line 1\n\n\n\nLine 2\n\n\nLine 3"
     expected = "Line 1\n\nLine 2\n\nLine 3"
     assert clean_say(text) == expected
+
+
+def test_clean_say_working_ellipsis_is_empty():
+    # The old empty fallback was stored as transcript text. It is not spoken prose.
+    assert clean_say("Working...") == ""
+    assert clean_say("Working..") == ""
+    assert clean_say("working...") == ""

--- a/tests/test_say_clean.py
+++ b/tests/test_say_clean.py
@@ -98,16 +98,16 @@ def test_clean_say_keeps_backticks_intact():
     assert clean_say(polluted) == polluted
 
 def test_clean_say_fallback():
-    # If the text has only pollution
+    # If the text has only pollution — empty after strip (never "Working...")
     polluted = "USER: (run_command 'x' completed with exit code 1)"
-    assert clean_say(polluted) == "Working..."
+    assert clean_say(polluted) == ""
     
     polluted_with_traceback = (
         "Traceback (most recent call last):\n"
         "  File \"harness/server.py\", line 12\n"
         "IndexError: list index out of range"
     )
-    assert clean_say(polluted_with_traceback) == "Working..."
+    assert clean_say(polluted_with_traceback) == ""
 
 def test_clean_say_collapses_newlines():
     text = "Line 1\n\n\n\nLine 2\n\n\nLine 3"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.346"
+version = "0.9.347"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.346",
+  "version": "0.9.347",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.346",
+      "version": "0.9.347",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.346",
+  "version": "0.9.347",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/emptySession.repro.test.tsx
+++ b/webapp/src/__tests__/emptySession.repro.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  TranscriptList,
+  clearActivityFoldPrefs,
+  type Item,
+} from "../components/TranscriptList";
+
+afterEach(() => {
+  cleanup();
+  clearActivityFoldPrefs();
+});
+
+function listProps(items: Item[]) {
+  return {
+    items,
+    status: "idle" as const,
+    compactingStatus: null as string | null,
+    editingIndex: null as number | null,
+    auto: false,
+    plan: false,
+    turnOpen: false,
+    holdSwarmAwait: false,
+    scrollContainerRef: { current: null },
+    onEditMessage: vi.fn(),
+    onExecuteSend: vi.fn(),
+    onImageClick: vi.fn(),
+    onSetCard: vi.fn(),
+    onExecutePlan: vi.fn(),
+    onCommandApproval: vi.fn(),
+  };
+}
+
+function expectEmptyFeed() {
+  expect(screen.queryByText("Working...")).toBeNull();
+  expect(screen.queryByText(/Working\.\.\.?/i)).toBeNull();
+  expect(screen.queryByTestId("activity-fold")).toBeNull();
+  expect(screen.queryByTestId("thought-fold")).toBeNull();
+  expect(screen.queryByTestId("ran-commands-fold")).toBeNull();
+}
+
+describe("empty session folds", () => {
+  it("empty items → zero Working... and zero fold chrome", () => {
+    render(<TranscriptList {...listProps([])} />);
+    expectEmptyFeed();
+  });
+
+  it("Working... assistant crumb stays hidden and mounts no folds", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "assistant", text: "Working..." } },
+    ];
+    render(<TranscriptList {...listProps(items)} />);
+    expectEmptyFeed();
+  });
+
+  it("three Working... assistant crumbs still paint nothing", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "assistant", text: "Working..." } },
+      { kind: "msg", msg: { role: "assistant", text: "Working.." } },
+      { kind: "msg", msg: { role: "assistant", text: "working..." } },
+    ];
+    render(<TranscriptList {...listProps(items)} />);
+    expectEmptyFeed();
+  });
+});

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.346)", () => {
-  it("declares the official motion package and 0.9.346 not 329", () => {
+describe("feed Motion (v0.9.347)", () => {
+  it("declares the official motion package and 0.9.347 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.346");
+    expect(pkg.version).toBe("0.9.347");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
+++ b/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
@@ -9,7 +9,9 @@ import {
   partitionStackedActivity,
   ranCommandsLabel,
   thoughtFoldLabel,
+  workFoldLabel,
   workedForLabel,
+  isWorkingEllipsisFallback,
 } from "../lib/turnProgress";
 import {
   DEFAULT_SESSION_TITLE,
@@ -68,6 +70,18 @@ describe("stacked fold labels", () => {
     expect(ranCommandsLabel(3)).toBe("Ran 3 commands");
   });
 
+  it("work fold never falls through to spoken-prose Working...", () => {
+    expect(isWorkingEllipsisFallback("Working...")).toBe(true);
+    expect(isWorkingEllipsisFallback("Working..")).toBe(true);
+    expect(workFoldLabel({ live: true })).toBe("Investigating…");
+    expect(workFoldLabel({ live: true, headline: "Working..." })).toBe("Investigating…");
+    expect(workFoldLabel({ live: true, headline: "Investigating · git status" })).toBe(
+      "Investigating · git status",
+    );
+    expect(workFoldLabel({ live: true, pausePoint: true })).toBe("Still working…");
+    expect(workFoldLabel({ live: false, durationMs: 12_000 })).toBe("Worked for 12s");
+  });
+
   it("nests Thought inside a Ran commands partition", () => {
     const items = [
       { kind: "thinking" as const },
@@ -84,6 +98,75 @@ describe("stacked fold labels", () => {
     if (rows[1]?.kind !== "commands") return;
     expect(rows[1].items).toHaveLength(3);
     expect(rows[1].items.filter((it) => it.kind === "thinking")).toHaveLength(1);
+  });
+});
+
+describe("live stacked folds (Investigating + Thinking + Ran)", () => {
+  it("shows three distinct live labels and never Working...", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "debug the redirect" } },
+      {
+        kind: "thinking",
+        text: "Working...", // spoken-prose fallback must not become Thought chrome
+        id: "th-live",
+        streaming: true,
+      },
+      {
+        kind: "card",
+        card: {
+          id: "c-live-1",
+          goal: "git status",
+          cwd: null,
+          kind: "run_command",
+          running: true,
+          open: false,
+        },
+      },
+      {
+        kind: "card",
+        card: {
+          id: "c-live-2",
+          goal: "rg ActionForm",
+          cwd: null,
+          kind: "run_command",
+          running: true,
+          open: false,
+        },
+      },
+    ];
+
+    render(
+      <TranscriptList
+        {...listProps(items)}
+        status="executing"
+        turnOpen
+      />,
+    );
+
+    // Outer work fold is live Investigating (not Working...).
+    const workChrome = screen.getByRole("button", { name: /Investigating/i });
+    expect(workChrome.textContent || "").not.toMatch(/Working\.\.\./i);
+    expect(screen.queryByText("Working...")).toBeNull();
+
+    fireEvent.click(workChrome);
+
+    const thought = screen.getByTestId("thought-fold");
+    const ran = screen.getByTestId("ran-commands-fold");
+    const thoughtLabel = thought.querySelector(".transcript-fold-chrome")?.textContent || "";
+    const ranLabel = ran.querySelector(".transcript-fold-chrome")?.textContent || "";
+    const workLabel = workChrome.textContent || "";
+
+    expect(thoughtLabel).toMatch(/Thinking/);
+    expect(ranLabel).toMatch(/Ran 2 commands/i);
+    expect(workLabel).toMatch(/Investigating/);
+
+    const labels = [workLabel, thoughtLabel, ranLabel].map((l) => l.trim());
+    // Three distinct chrome strings; none equal the spoken-prose fallback.
+    expect(new Set(labels).size).toBe(3);
+    for (const label of labels) {
+      expect(label).not.toBe("Working...");
+      expect(label).not.toMatch(/^Working\.\.\.?$/i);
+    }
   });
 });
 

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -47,6 +47,7 @@ import {
   ranCommandsLabel,
   resolveCardCliInput,
   shortenGoal,
+  isWorkingEllipsisFallback,
   quietWorkingCueVisible,
   shouldShowBusyFooter,
   thoughtFoldLabel,
@@ -54,6 +55,7 @@ import {
   toolInputFieldKey,
   toolRowLabel,
   turnHasVisibleBusySurface,
+  workFoldLabel,
   workedForLabel,
   ranGoalLine,
 } from "../lib/turnProgress";
@@ -2072,7 +2074,9 @@ function cleanAssistantText(text: string): string {
 
   let result = cleaned.join("\n").trim();
   result = result.replace(/\n{3,}/g, "\n\n");
-  return result || "Working...";
+  // Empty after strip — never paint the spoken-prose "Working..." fallback
+  // (that string poisoned fold chrome when empty crumbs landed in the feed).
+  return result;
 }
 
 function isGateSuppressed(card: Card): boolean {
@@ -2481,11 +2485,11 @@ function ActivityGroup({
 
   const quietSummary = (() => {
     if (investigating) {
-      if (actionCount > 0) return stepHeadline;
-      if (swarmPendingItems.length > 0) {
+      if (swarmPendingItems.length > 0 && actionCount === 0) {
         return swarmPendingRunning ? "Swarm · running" : `Swarm · ${swarmPendingItems.length} pending`;
       }
-      return stepHeadline || "Investigating…";
+      // Work-fold chrome owns Investigating… — never spoken-prose Working...
+      return workFoldLabel({ live: true, headline: stepHeadline });
     }
     if (!isLiveFold && durableJobRunning) return "job still running";
     // Sealed turn: Cursor-style Worked for {duration} — not Explored counts.
@@ -2496,7 +2500,7 @@ function ActivityGroup({
       if (swarmPendingItems.length > 0 && actionCount === 0 && thinkingItems.length === 0) {
         return `Swarm · ${swarmPendingItems.length} pending`;
       }
-      return workedForLabel(sealedWorkMs);
+      return workFoldLabel({ live: false, durationMs: sealedWorkMs });
     }
     if (telemetryItems.length > 0 && actionCount === 0 && thinkingItems.length === 0) {
       const first = telemetryItems[0];
@@ -2518,13 +2522,21 @@ function ActivityGroup({
       if (first.kind === "auto_status") return autoStatusPresentation(first.cycle, first.snapshot).label;
     }
     const preview = normalizeReasoningPreview(narrationPreview, 72);
-    return preview || workedForLabel(sealedWorkMs);
+    // Never let clean_say / Bubble "Working..." leach into fold chrome.
+    if (preview && !isWorkingEllipsisFallback(preview)) return preview;
+    return workFoldLabel({ live: false, durationMs: sealedWorkMs });
   })();
   const compactionHover = (() => {
     const compact = telemetryItems.find((row) => row.kind === "compaction");
     return compact && compact.kind === "compaction" ? compactionRowChrome(compact).title : "";
   })();
-  const foldTitle = [investigating ? (runningCard?.goal || quietSummary) : quietSummary, compactionHover]
+  const liveGoal = String(runningCard?.goal || "").trim();
+  const foldTitle = [
+    investigating
+      ? (liveGoal && !isWorkingEllipsisFallback(liveGoal) ? liveGoal : quietSummary)
+      : quietSummary,
+    compactionHover,
+  ]
     .filter(Boolean)
     .join(" · ");
 
@@ -2797,7 +2809,9 @@ function ThinkingBlock({
     return null;
   }
 
-  const preview = normalizeReasoningPreview(text);
+  const previewRaw = normalizeReasoningPreview(text);
+  // Spoken-prose Working... must never appear as Thought chrome or preview.
+  const preview = isWorkingEllipsisFallback(previewRaw) ? "" : previewRaw;
   const foldLabel = thoughtFoldLabel({ live, durationMs });
 
   return (
@@ -3309,6 +3323,9 @@ function Bubble({
   // `return null`) is exactly what made streamed text vanish the moment a tool
   // fired. We keep the full text -> tool -> text -> tool thought chain on screen;
   // `isIntermediate` now only tones styling down slightly, never hides.
+  // Empty / pollution-only assistant crumbs stay hidden — never "Working...".
+  if (!displayedText.trim()) return null;
+
   const showExecuteButton = msg.isPlan && !executed && onExecutePlan;
 
   return (

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -56,7 +56,6 @@ import {
   toolRowLabel,
   turnHasVisibleBusySurface,
   workFoldLabel,
-  workedForLabel,
   ranGoalLine,
 } from "../lib/turnProgress";
 import { isAgentLoopOpen } from "./conversation/runnersBusy";
@@ -726,6 +725,11 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
     if (item.kind === "tool_prep") continue;
 
     if (item.kind === "msg") {
+      // Spoken-prose "Working..." fallback is not a message. Empty session
+      // used to paint three of these as stacked Bubbles.
+      if (item.msg.role === "assistant" && isWorkingEllipsisFallback(item.msg.text)) {
+        continue;
+      }
       // Post-tool micro-narration folds into the investigation box. Pre-tool
       // assistant bubbles stay standalone permanently (no look-ahead reparent).
       if (item.msg.role === "assistant" && intermediateItems.has(item)) {
@@ -2074,8 +2078,10 @@ function cleanAssistantText(text: string): string {
 
   let result = cleaned.join("\n").trim();
   result = result.replace(/\n{3,}/g, "\n\n");
-  // Empty after strip — never paint the spoken-prose "Working..." fallback
-  // (that string poisoned fold chrome when empty crumbs landed in the feed).
+  // Empty after strip, or the spoken-prose "Working..." placeholder itself —
+  // never paint that string (it leaked as three stacked Bubbles on a fresh
+  // idle session when crumbs already held the fallback).
+  if (!result || isWorkingEllipsisFallback(result)) return "";
   return result;
 }
 

--- a/webapp/src/components/conversation/transcriptRowHeight.ts
+++ b/webapp/src/components/conversation/transcriptRowHeight.ts
@@ -127,7 +127,9 @@ export function assistantTextForMeasure(raw: string): string {
 
   let result = cleaned.join("\n").trim();
   result = result.replace(/\n{3,}/g, "\n\n");
-  return result || "Working...";
+  // Match Bubble cleanAssistantText — empty after strip stays empty (never
+  // "Working...", which must not leak into fold chrome or height placeholders).
+  return result;
 }
 
 function isPlanOrProgressAssistant(msg: Msg): boolean {

--- a/webapp/src/components/conversation/transcriptRowHeight.ts
+++ b/webapp/src/components/conversation/transcriptRowHeight.ts
@@ -9,6 +9,7 @@
 
 import { layout, prepare, type PreparedText } from "@chenglou/pretext";
 import type { GroupedItem, Msg } from "../TranscriptList";
+import { isWorkingEllipsisFallback } from "../../lib/turnProgress";
 
 /** Canvas font strings synced with TranscriptList bubble typography. */
 export const TRANSCRIPT_USER_FONT =
@@ -127,8 +128,9 @@ export function assistantTextForMeasure(raw: string): string {
 
   let result = cleaned.join("\n").trim();
   result = result.replace(/\n{3,}/g, "\n\n");
-  // Match Bubble cleanAssistantText — empty after strip stays empty (never
-  // "Working...", which must not leak into fold chrome or height placeholders).
+  // Match Bubble cleanAssistantText — empty after strip, or the Working...
+  // placeholder itself, stays empty (never leak into fold chrome / heights).
+  if (!result || isWorkingEllipsisFallback(result)) return "";
   return result;
 }
 

--- a/webapp/src/lib/sessionTitleLock.ts
+++ b/webapp/src/lib/sessionTitleLock.ts
@@ -12,7 +12,7 @@ export function isActivityHeadlineText(text: string): boolean {
   if (/^Stopped\.?$/i.test(raw)) return true;
 
   const lineRe =
-    /^(Investigating|Explored|Diagnosing|Planning|Assessing|Still working|Looking|Thinking|Thought|Worked for|Ran\s+\d+\s+commands?)\b/i;
+    /^(Investigating|Explored|Diagnosing|Planning|Assessing|Still working|Looking|Thinking|Thought|Worked for|Ran\s+\d+\s+commands?|Working\.\.\.?)\b/i;
 
   const lines = raw
     .split(/\r?\n/)

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -459,6 +459,35 @@ export function workedForLabel(durationMs?: number | null): string {
   return label ? `Worked for ${label}` : "Worked for";
 }
 
+/**
+ * Spoken-prose empty fallback (`clean_say` / Bubble `cleanAssistantText`).
+ * Fold chrome must never adopt this string as a live/sealed title.
+ */
+export function isWorkingEllipsisFallback(text: string): boolean {
+  return /^Working\.\.\.?$/i.test(String(text || "").trim());
+}
+
+/**
+ * Outer work-fold chrome — live Investigating… / Still working…; sealed Worked for.
+ * Never returns the spoken-prose "Working..." fallback.
+ */
+export function workFoldLabel(opts: {
+  live?: boolean;
+  /** Swarm/hold pause — StatusPill-aligned cue instead of Investigating… */
+  pausePoint?: boolean;
+  durationMs?: number | null;
+  /** Live investigatingHeadline (focus / kind counts); ignored when empty or Working... */
+  headline?: string | null;
+}): string {
+  if (opts.live) {
+    if (opts.pausePoint) return "Still working…";
+    const headline = String(opts.headline || "").trim();
+    if (headline && !isWorkingEllipsisFallback(headline)) return headline;
+    return "Investigating…";
+  }
+  return workedForLabel(opts.durationMs);
+}
+
 /** Reasoning fold chrome — live pulses Thinking…; sealed tucks to Thought {Ns}. */
 export function thoughtFoldLabel(opts: {
   live?: boolean;


### PR DESCRIPTION
## Summary
- Live stacked folds use distinct chrome: Investigating… / Thinking… / Ran N command. Never the spoken-prose `Working...` fallback.
- Sealed: Worked for {duration} / Thought / Ran. Finale Bubble stays out (343).
- Version bump 0.9.346 → 0.9.347. Pin stays `puppetmaster-ai==1.22.32`.
- No feed Motion. No tag writes.

## Test plan
- [ ] live 3-row stack has three different labels and none equal `Working...`
- [ ] required CI green