### PR TITLE
v0.9.348: sidebar recover, empty-state, hide stale release branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.32` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.347, deliberately pre-1.0. Rides puppetmaster-ai==1.22.32. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.348, deliberately pre-1.0. Rides puppetmaster-ai==1.22.32. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.347"
+__version__ = "0.9.348"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/workspaces.py
+++ b/harness/workspaces.py
@@ -90,7 +90,56 @@ def list_workspaces(repo: str) -> list[dict]:
         if not row.get("worktree_path"):
             row.pop("worktree_path", None)
         rows.append(row)
-    return rows
+    remote = _origin_branch_names(repo)
+    return [row for row in rows if not _is_stale_local_release(row, remote)]
+
+
+def _origin_branch_names(repo: str) -> set[str]:
+    """Short names of origin/* heads (empty when origin is missing or unread)."""
+    rc, out, _ = _git(repo, "branch", "-r", "--format=%(refname:short)")
+    if rc != 0:
+        return set()
+    names: set[str] = set()
+    for line in out.splitlines():
+        name = line.strip()
+        if not name.startswith("origin/"):
+            continue
+        short = name[len("origin/"):]
+        if not short or short == "HEAD" or short.startswith("HEAD "):
+            continue
+        names.add(short)
+    return names
+
+
+def _is_live_worktree_path(path: str | None) -> bool:
+    if not path:
+        return False
+    try:
+        return os.path.isdir(path)
+    except Exception:
+        return False
+
+
+def _is_stale_local_release(row: dict, remote: set[str]) -> bool:
+    """True when BRANCHES should hide a leftover local release/v0.9.* head.
+
+    Origin already deleted these. Keep main/dev (not this prefix), the current
+    checkout, any still-on-origin release, and a *live* worktree checkout.
+    Do not delete the worktree — only hide the row.
+    """
+    name = str(row.get("name") or "")
+    if not name.startswith("release/v0.9."):
+        return False
+    if row.get("active"):
+        return False
+    if _is_live_worktree_path(row.get("worktree_path")):
+        return False
+    if name in remote:
+        return False
+    # No origin picture: do not hide (offline / no-remote test repos).
+    if not remote:
+        return False
+    return True
 
 
 def _worktree_holding_branch(repo: str, branch: str) -> Optional[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.347"
+version = "0.9.348"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_workspaces_unit.py
+++ b/tests/test_workspaces_unit.py
@@ -195,3 +195,58 @@ def test_switch_workspace_soft_refuses_branch_locked_in_worktree(tmp_path):
     listed = {r["name"]: r for r in list_workspaces(str(repo))}
     assert listed["pmedit-deadbeef"].get("worktree_path")
     assert "worktree_path" not in listed["main"]
+
+
+
+def test_list_workspaces_hides_stale_local_release_keeps_live(tmp_path):
+    """BRANCHES hides leftover local release/v0.9.* once origin deleted them.
+
+    Keep main, dev, the current checkout, origin-backed release heads, and a
+    live worktree. Do not delete the worktree.
+    """
+    repo = _init_repo(tmp_path, branch="main")
+    _git(repo, "branch", "dev")
+    _git(repo, "branch", "release/v0.9.286")
+    _git(repo, "branch", "release/v0.9.318")
+    _git(repo, "branch", "release/v0.9.348")
+    _git(repo, "branch", "feature")
+
+    remote = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True, capture_output=True)
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-q", "origin", "main", "dev", "release/v0.9.348")
+
+    wt = tmp_path / "wt-318"
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", str(wt), "release/v0.9.318"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    names = {r["name"] for r in list_workspaces(str(repo))}
+    assert "main" in names
+    assert "dev" in names
+    assert "feature" in names
+    assert "release/v0.9.348" in names  # still on origin
+    assert "release/v0.9.318" in names  # live worktree
+    assert "release/v0.9.286" not in names  # stale local-only leftover
+
+    listed = {r["name"]: r for r in list_workspaces(str(repo))}
+    assert listed["release/v0.9.318"].get("worktree_path")
+    assert Path(listed["release/v0.9.318"]["worktree_path"]).is_dir()
+
+
+def test_list_workspaces_keeps_current_release_checkout_even_if_local_only(tmp_path):
+    repo = _init_repo(tmp_path, branch="main")
+    _git(repo, "branch", "release/v0.9.331")
+    _git(repo, "checkout", "-q", "release/v0.9.331")
+    remote = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True, capture_output=True)
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-q", "origin", "main")
+
+    names = {r["name"] for r in list_workspaces(str(repo))}
+    assert "release/v0.9.331" in names
+    active = [r for r in list_workspaces(str(repo)) if r["active"]]
+    assert active and active[0]["name"] == "release/v0.9.331"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.347"
+version = "0.9.348"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.347",
+  "version": "0.9.348",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.347",
+      "version": "0.9.348",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.347",
+  "version": "0.9.348",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/LeftRail.sessions.test.ts
+++ b/webapp/src/__tests__/LeftRail.sessions.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { clearSWRCache, readSWRCache, writeSWRCache } from "../lib/useStaleWhileRevalidate";
 import { repoPathsEqual } from "../lib/pathNormalize";
-import { buildProjectsList, canSettleSessionsForProject, collectUnreadFinishedSessionIds, filterForgottenRecent, formatLeaseExhaustedMessage, isLeaseExhaustedError, isRailWideSwitching, jobsCacheKey, partitionProjectSessions, patchSessionArchivedInCaches, patchSessionSettledInCaches, patchSessionTitleInCaches, projectSessionsEmptyState, purgeSessionFromRootCaches, readSessionSettledFromCaches, SESSION_LEASE_EXHAUSTED_MESSAGE, shouldOfferBackgroundStop, workspacesCacheKey } from "../components/LeftRail";
+import {
+  clearTranscriptCache,
+  peekTranscriptCacheEntry,
+  writeTranscriptCache,
+} from "../components/conversation/transcriptCache";
+import { buildProjectsList, canSettleSessionsForProject, collectUnreadFinishedSessionIds, filterForgottenRecent, formatLeaseExhaustedMessage, isLeaseExhaustedError, isRailWideSwitching, jobsCacheKey, partitionProjectSessions, patchSessionArchivedInCaches, patchSessionSettledInCaches, patchSessionTitleInCaches, pickFallbackProjectAfterForget, projectSessionsEmptyState, purgeSessionFromRootCaches, readSessionSettledFromCaches, SESSION_LEASE_EXHAUSTED_MESSAGE, shouldOfferBackgroundStop, workspacesCacheKey } from "../components/LeftRail";
 import type { Session } from "../lib/api";
 
 /**
@@ -11,6 +16,7 @@ import type { Session } from "../lib/api";
 describe("LeftRail session list contracts", () => {
   afterEach(() => {
     clearSWRCache();
+    clearTranscriptCache();
   });
 
   it("purgeSessionFromRootCaches removes id from every root cache", () => {
@@ -100,17 +106,19 @@ describe("LeftRail session list contracts", () => {
   });
 
   it("maps runners statuses to session badge visibility", () => {
-    // Mirrors LeftRail RunnerStatusDot: only render when status is known.
-    const runners: Record<string, "running" | "idle"> = {
+    // Mirrors LeftRail RunnerStatusDot: unknown/missing default to idle dot.
+    const runners: Record<string, "running" | "idle" | "missing"> = {
       "sess-a": "running",
       "sess-b": "idle",
     };
-    const badgeFor = (sessionId: string): "running" | "idle" | null =>
-      runners[sessionId] ?? null;
+    const badgeFor = (sessionId: string): "running" | "idle" =>
+      runners[sessionId] && runners[sessionId] !== "missing"
+        ? runners[sessionId] as "running" | "idle"
+        : "idle";
 
     expect(badgeFor("sess-a")).toBe("running");
     expect(badgeFor("sess-b")).toBe("idle");
-    expect(badgeFor("sess-unknown")).toBeNull();
+    expect(badgeFor("sess-unknown")).toBe("idle");
   });
 
   it("project browsing toggles expansion without changing the active work target", () => {
@@ -306,6 +314,57 @@ describe("LeftRail session list contracts", () => {
     expect(createCalls).toBe(1);
   });
 
+  it("newSession seeds seededEmpty cache for workspace-created sessions", async () => {
+    // Mirrors LeftRail newSession: workspace/open auto-create must still seed
+    // [] + seededEmpty so Conversation never paints stale crumbs under the id.
+    const workspaceSid = "sess-workspace-new";
+    const createdSid = "sess-created-new";
+    const currentRepo = "C:\\Projects\\active";
+    const otherRepo = "C:\\Projects\\empty";
+
+    const handleOpenProject = async () => ({
+      ok: true,
+      created_session: true,
+      active_session: workspaceSid,
+    });
+    const createSession = async () => ({ id: createdSid });
+
+    const newSession = async (
+      inProjectPath: string | undefined,
+      selectedProjectPath: string,
+      current: string,
+    ) => {
+      const target = (inProjectPath || selectedProjectPath || "").trim();
+      let workspaceCreatedSession = false;
+      let newSessionId = "";
+      if (target && (!current || !repoPathsEqual(target, current))) {
+        const opened = await handleOpenProject();
+        if (!opened.ok) return;
+        workspaceCreatedSession = !!opened.created_session;
+        newSessionId = (opened.active_session || "").trim();
+      }
+      if (!workspaceCreatedSession) {
+        const created = await createSession();
+        newSessionId = (created?.id || "").trim();
+      }
+      if (newSessionId) {
+        writeTranscriptCache(newSessionId, [], { seededEmpty: true });
+      }
+    };
+
+    await newSession(otherRepo, otherRepo, currentRepo);
+    expect(peekTranscriptCacheEntry(workspaceSid)).toEqual({
+      items: [],
+      seededEmpty: true,
+    });
+
+    await newSession(undefined, currentRepo, currentRepo);
+    expect(peekTranscriptCacheEntry(createdSid)).toEqual({
+      items: [],
+      seededEmpty: true,
+    });
+  });
+
   it("openWorkspace does not reorder projects to put current first", () => {
     const recents = ["C:\\Projects\\alpha", "C:\\Projects\\beta", "C:\\Projects\\gamma"];
     // Opening beta (already in recents) must keep recents order -- beta stays
@@ -335,6 +394,19 @@ describe("LeftRail session list contracts", () => {
     expect(buildProjectsList("", filterForgottenRecent(recents, "C:\\Ashita\\Ashita"))).toEqual([
       "C:\\Projects\\other",
     ]);
+  });
+
+  it("pickFallbackProjectAfterForget lands on Home or the first remaining recent", () => {
+    const home = "C:\\Users\\me\\.pmharness\\home";
+    const active = "C:\\Projects\\authority-spoof-lab";
+    const other = "C:\\Projects\\marionette";
+    const recents = [active, other];
+
+    expect(pickFallbackProjectAfterForget(recents, active, home)).toBe(home);
+    expect(pickFallbackProjectAfterForget(recents, other, home)).toBe(home);
+    expect(pickFallbackProjectAfterForget([active], active, home)).toBe(home);
+    expect(pickFallbackProjectAfterForget([active, other], active)).toBe(other);
+    expect(pickFallbackProjectAfterForget([active], active)).toBe("");
   });
 
   it("buildProjectsList pins Home first and dedupes it from recents", () => {

--- a/webapp/src/__tests__/emptySession.repro.test.tsx
+++ b/webapp/src/__tests__/emptySession.repro.test.tsx
@@ -3,8 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   TranscriptList,
   clearActivityFoldPrefs,
+  countPaintableTranscriptItems,
   type Item,
 } from "../components/TranscriptList";
+import TranscriptEmptyState from "../components/conversation/TranscriptEmptyState";
 
 afterEach(() => {
   cleanup();
@@ -61,5 +63,34 @@ describe("empty session folds", () => {
     ];
     render(<TranscriptList {...listProps(items)} />);
     expectEmptyFeed();
+  });
+
+  it("countPaintableTranscriptItems treats Working... crumbs as empty", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "assistant", text: "Working..." } },
+      { kind: "msg", msg: { role: "assistant", text: "Working.." } },
+    ];
+    expect(countPaintableTranscriptItems(items)).toBe(0);
+    expect(countPaintableTranscriptItems([])).toBe(0);
+    expect(
+      countPaintableTranscriptItems([
+        { kind: "msg", msg: { role: "user", text: "hello" } },
+      ]),
+    ).toBe(1);
+  });
+
+  it("TranscriptEmptyState shows pilot copy when crumbs are paint-invisible", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "assistant", text: "Working..." } },
+    ];
+    render(
+      <TranscriptEmptyState
+        transcriptStale={false}
+        itemCount={countPaintableTranscriptItems(items)}
+      />,
+    );
+    expect(
+      screen.getByText("Message the pilot. It plans, investigates via swarms, and explains."),
+    ).toBeTruthy();
   });
 });

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.347)", () => {
-  it("declares the official motion package and 0.9.347 not 329", () => {
+describe("feed Motion (v0.9.348)", () => {
+  it("declares the official motion package and 0.9.348 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.347");
+    expect(pkg.version).toBe("0.9.348");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -27,6 +27,7 @@ export {
   formatLeaseExhaustedMessage,
   buildProjectsList,
   filterForgottenRecent,
+  pickFallbackProjectAfterForget,
   canSettleSessionsForProject,
   partitionProjectSessions,
   readSessionSettledFromCaches,
@@ -47,6 +48,7 @@ import {
   formatLeaseExhaustedMessage,
   buildProjectsList,
   filterForgottenRecent,
+  pickFallbackProjectAfterForget,
   canSettleSessionsForProject,
   partitionProjectSessions,
   readSessionSettledFromCaches,
@@ -412,16 +414,92 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     dispatchProjectSwitching(panelSwitching);
   }, [panelSwitching]);
 
+  const toast = (msg: string) => {
+    window.dispatchEvent(new CustomEvent("harness-toast", { detail: msg }));
+  };
+
+  const notifySessionActivationBlocked = (err: unknown): boolean => {
+    if (!isLeaseExhaustedError(err)) return false;
+    const msg = formatLeaseExhaustedMessage(err);
+    setSessionActivationNotice(msg);
+    toast(msg);
+    return true;
+  };
+
+  const openProjectWorkspace = useCallback(async (
+    path: string,
+    options?: { quiet?: boolean },
+  ): Promise<{ ok: boolean; created_session?: boolean; active_session?: string }> => {
+    if (!options?.quiet) setOpening(true);
+    try {
+      const res = await api.openWorkspace(path);
+      if (res.ok) {
+        if (res.codegraph) codegraphByRepoRef.current[res.repo] = res.codegraph;
+        mutateWorkspace({
+          repo: res.repo,
+          branch: res.branch,
+          is_git: res.is_git,
+          codegraph_status: res.codegraph,
+          recents: workspaceInfo?.recents,
+        });
+        // Hermes-style: land inside the opened project — expand + select so
+        // sessions are visible without an extra click.
+        setExpandedProjects((prev) => ({ ...prev, [res.repo]: true }));
+        setSelectedProjectPath(res.repo);
+        dispatchProjectSelected(res.repo);
+        await Promise.all([revalidateWorkspace(), revalidateWorkspaces(), revalidateSessions()]);
+        window.dispatchEvent(new Event("harness-config-changed"));
+        return {
+          ok: true,
+          created_session: res.created_session,
+          active_session: res.active_session,
+        };
+      }
+      if ((res as { code?: string }).code === "lease_exhausted") {
+        notifySessionActivationBlocked(res);
+      } else if (!options?.quiet) {
+        alert("Failed to open directory: " + (res as any).error);
+      }
+      return { ok: false };
+    } catch (err: any) {
+      if (!notifySessionActivationBlocked(err) && !options?.quiet) {
+        alert("Error opening directory: " + (err?.error || err?.message || err));
+      }
+      return { ok: false };
+    } finally {
+      if (!options?.quiet) setOpening(false);
+    }
+  }, [
+    mutateWorkspace,
+    notifySessionActivationBlocked,
+    revalidateSessions,
+    revalidateWorkspace,
+    revalidateWorkspaces,
+    workspaceInfo?.recents,
+  ]);
+
   const handleForgetProject = async (path: string) => {
     const previous = workspaceInfo;
     const forgettingActive = !!(previous?.repo && repoPathsEqual(previous.repo, path));
+    const nextRecents = previous ? filterForgottenRecent(previous.recents || [], path) : [];
+    const fallback = forgettingActive
+      ? pickFallbackProjectAfterForget(nextRecents, path, previous?.home)
+      : "";
     mutateWorkspace(previous
       ? {
           ...previous,
-          recents: filterForgottenRecent(previous.recents || [], path),
+          recents: nextRecents,
           // Drop active repo immediately so buildProjectsList cannot re-append
-          // the forgotten path as a phantom row.
-          ...(forgettingActive ? { repo: "", branch: "", is_git: false, codegraph_status: "none" } : {}),
+          // the forgotten path as a phantom row. When another project remains,
+          // land there optimistically so the rail never greys out on a stale cwd.
+          ...(forgettingActive
+            ? {
+                repo: fallback || "",
+                branch: "",
+                is_git: false,
+                codegraph_status: "none",
+              }
+            : {}),
         }
       : undefined);
     setExpandedProjects((prev) => {
@@ -438,7 +516,14 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       setSessionsCacheEpoch((n) => n + 1);
     } catch { /* best-effort */ }
     if (forgettingActive) {
-      setSelectedProjectPath("");
+      if (fallback) {
+        setExpandedProjects((prev) => ({ ...prev, [fallback]: true }));
+        setSelectedProjectPath(fallback);
+        dispatchProjectSelected(fallback);
+      } else {
+        setSelectedProjectPath("");
+        dispatchProjectSelected("");
+      }
     }
     try {
       const res = await api.forgetWorkspace(path);
@@ -446,13 +531,24 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
         ? {
             ...previous,
             recents: res.recents,
-            repo: res.cleared_active ? (res.repo || "") : previous.repo,
-            ...(res.cleared_active
-              ? { branch: "", is_git: false, codegraph_status: "none" }
-              : {}),
+            ...(forgettingActive
+              ? {
+                  repo: fallback || (res.cleared_active ? (res.repo || "") : previous.repo),
+                  branch: "",
+                  is_git: false,
+                  codegraph_status: "none",
+                }
+              : {
+                  repo: res.cleared_active ? (res.repo || "") : previous.repo,
+                  ...(res.cleared_active
+                    ? { branch: "", is_git: false, codegraph_status: "none" }
+                    : {}),
+                }),
           }
         : undefined);
-      if (res.cleared_active) {
+      if (forgettingActive && fallback) {
+        await openProjectWorkspace(fallback, { quiet: true });
+      } else if (res.cleared_active) {
         window.dispatchEvent(new Event("harness-config-changed"));
       }
     } catch (err) {
@@ -496,43 +592,10 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     return () => window.removeEventListener("focus", onFocus);
   }, [workspaceInfo?.codegraph_status, revalidateWorkspace]);
 
-  const handleOpenProject = async (path: string): Promise<{ ok: boolean; created_session?: boolean }> => {
-    setOpening(true);
-    try {
-      const res = await api.openWorkspace(path);
-      if (res.ok) {
-        if (res.codegraph) codegraphByRepoRef.current[res.repo] = res.codegraph;
-        mutateWorkspace({
-          repo: res.repo,
-          branch: res.branch,
-          is_git: res.is_git,
-          codegraph_status: res.codegraph,
-          recents: workspaceInfo?.recents,
-        });
-        // Hermes-style: land inside the opened project — expand + select so
-        // sessions are visible without an extra click.
-        setExpandedProjects((prev) => ({ ...prev, [res.repo]: true }));
-        setSelectedProjectPath(res.repo);
-        dispatchProjectSelected(res.repo);
-        await Promise.all([revalidateWorkspace(), revalidateWorkspaces(), revalidateSessions()]);
-        window.dispatchEvent(new Event("harness-config-changed"));
-        return { ok: true, created_session: res.created_session };
-      }
-      if ((res as { code?: string }).code === "lease_exhausted") {
-        notifySessionActivationBlocked(res);
-      } else {
-        alert("Failed to open directory: " + (res as any).error);
-      }
-      return { ok: false };
-    } catch (err: any) {
-      if (!notifySessionActivationBlocked(err)) {
-        alert("Error opening directory: " + (err?.error || err?.message || err));
-      }
-      return { ok: false };
-    } finally {
-      setOpening(false);
-    }
-  };
+  const handleOpenProject = async (
+    path: string,
+  ): Promise<{ ok: boolean; created_session?: boolean; active_session?: string }> =>
+    openProjectWorkspace(path);
 
   const handleOpenFolder = async () => {
     const picked = await pickFolder();
@@ -579,18 +642,6 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       window.removeEventListener("keydown", handleKeyDown);
     };
   }, [projectContextMenu]);
-
-  const toast = (msg: string) => {
-    window.dispatchEvent(new CustomEvent("harness-toast", { detail: msg }));
-  };
-
-  const notifySessionActivationBlocked = (err: unknown): boolean => {
-    if (!isLeaseExhaustedError(err)) return false;
-    const msg = formatLeaseExhaustedMessage(err);
-    setSessionActivationNotice(msg);
-    toast(msg);
-    return true;
-  };
 
   const openWorktreeBranch = async (name: string, worktreePath: string) => {
     setSwapping(name);
@@ -830,21 +881,24 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       const target = (inProjectPath || selectedProjectPath || "").trim();
       const current = (workspaceInfo?.repo || "").trim();
       let workspaceCreatedSession = false;
+      let newSessionId = "";
       if (target && (!current || !repoPathsEqual(target, current))) {
         const opened = await handleOpenProject(target);
         if (!opened.ok) return;
         workspaceCreatedSession = !!opened.created_session;
+        newSessionId = (opened.active_session || "").trim();
       } else if (target) {
         setExpandedProjects((prev) => ({ ...prev, [target]: true }));
       }
       if (!workspaceCreatedSession) {
         const created = await api.createSession();
-        // Seed an empty warm-cache entry before Conversation's switch effect runs
-        // so it never paints the previous session's transcript under this id.
-        // seededEmpty marks this as New Session (not an ambiguous zero-row cache).
-        if (created?.id) {
-          writeTranscriptCache(created.id, [], { seededEmpty: true });
-        }
+        newSessionId = (created?.id || "").trim();
+      }
+      // Seed an empty warm-cache entry before Conversation's switch effect runs
+      // so it never paints the previous session's transcript under this id.
+      // seededEmpty marks this as New Session (not an ambiguous zero-row cache).
+      if (newSessionId) {
+        writeTranscriptCache(newSessionId, [], { seededEmpty: true });
       }
       await refreshSessionsRef.current();
     } catch (err) {
@@ -1544,7 +1598,11 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                                   />
                                 ) : (
                                   <RunnerStatusDot
-                                    status={runners[s.id]}
+                                    status={
+                                      runners[s.id] && runners[s.id] !== "missing"
+                                        ? runners[s.id]
+                                        : "idle"
+                                    }
                                     stoppable={shouldOfferBackgroundStop(runners[s.id], !!s.active)}
                                     onStop={() => { void stopBackgroundSession(s.id); }}
                                   />

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -89,6 +89,7 @@ import {
   shouldUseVirtualTranscriptWindow,
 } from "./conversation/transcriptVirtualWindow";
 import {
+  assistantTextForMeasure,
   createTranscriptRowHeightCache,
   rowMeasureSignal,
   shouldAttachDomMeasure,
@@ -789,6 +790,33 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
 
   flush();
   return grouped;
+}
+
+/** Items that groupAgentActivity skips or Bubble would not paint. */
+function msgItemPaints(msg: Msg): boolean {
+  if (msg.role === "user") {
+    return msg.text.trim().length > 0 || Boolean(msg.images?.length);
+  }
+  const text = assistantTextForMeasure(msg.text);
+  return text.trim().length > 0;
+}
+
+function groupedItemPaints(it: GroupedItem): boolean {
+  if (it.kind === "msg") return msgItemPaints(it.msg);
+  if (it.kind === "activity_group") return it.items.length > 0;
+  return true;
+}
+
+/** Count transcript rows that would actually mount — excludes Working... crumbs
+ *  and empty assistant pollution so TranscriptEmptyState matches the feed. */
+export function countPaintableTranscriptItems(items: Item[]): number {
+  const intermediateItems = collectIntermediateAssistantItems(items, false);
+  const grouped = groupAgentActivity(items, intermediateItems);
+  let count = 0;
+  for (const row of grouped) {
+    if (groupedItemPaints(row)) count += 1;
+  }
+  return count;
 }
 
 /** Fingerprint for exact-duplicate failed run_swarm / swarm_result routing chrome.

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -9,6 +9,7 @@ import { panelOpacityClass } from "../../lib/panelTransition";
 import { feedBottomClearancePx, FEED_CHROME_CLEARANCE_VAR } from "./feedScroll";
 import {
   TranscriptList,
+  countPaintableTranscriptItems,
   type Card,
   type CommandApprovalItem,
   type SecretRequestItem,
@@ -105,7 +106,10 @@ export default function ConversationChatColumn({
           ref={feedContentRef}
           className="max-w-3xl mx-auto px-6 py-6 flex flex-col gap-1"
         >
-          <TranscriptEmptyState transcriptStale={transcriptStale} itemCount={items.length} />
+          <TranscriptEmptyState
+            transcriptStale={transcriptStale}
+            itemCount={countPaintableTranscriptItems(items)}
+          />
           {/*
             PERF: The transcript is rendered by TranscriptList, a React.memo
             component whose props are deliberately independent of the composer

--- a/webapp/src/components/leftRailSessions.ts
+++ b/webapp/src/components/leftRailSessions.ts
@@ -88,6 +88,19 @@ export function filterForgottenRecent(recents: string[], path: string): string[]
 }
 
 /**
+ * After removing the active project, land on Home (when pinned) or the first
+ * remaining recent. Never leave a stale cwd selected once the row is gone.
+ */
+export function pickFallbackProjectAfterForget(
+  recents: string[],
+  forgottenPath: string,
+  home?: string,
+): string {
+  const remaining = filterForgottenRecent(recents, forgottenPath);
+  return buildProjectsList("", remaining, home)[0] || "";
+}
+
+/**
  * Settle/Unsettle only work for sessions under the active workspace
  * (POST /api/sessions/settle 403s foreign roots). Hide affordances elsewhere.
  */


### PR DESCRIPTION
## Summary
- Removing the current sidebar project immediately selects Home or a remaining project so the rail stays full contrast (no grey-out).
- New session in any project mounts the same empty-state copy (`Message the pilot…`). Hidden `Working...` crumbs count as empty. No dugout special-case.
- BRANCHES hides stale local-only `release/v0.9.*` that origin already deleted. Keeps `main`, `dev`, the current checkout, origin-backed heads, and live worktrees. Does not delete worktrees.

Pin stays `puppetmaster-ai==1.22.32`. Base is `19358715` (v0.9.347). CoS merges+tags. No 349.

## Test plan
- [ ] Inside a project, remove that project from PROJECTS → remaining rows stay full contrast; Home or another remaining project is selected. Removing a non-current project does not change selection.
- [ ] New session in dugout and Puppetmaster both show the pilot empty-state copy. Never a black pane.
- [ ] BRANCHES does not list leftover local `release/v0.9.286`–`.331`. `.318 WORKTREE` stays only if that worktree directory is live. `main` / `dev` / current checkout stay.
- [ ] CI green on this SHA. Pin still 1.22.32.