### PR TITLE
v0.9.350: Luna **** fold glue and leftover BRANCHES prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.32` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.349, deliberately pre-1.0. Rides puppetmaster-ai==1.22.32. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.350, deliberately pre-1.0. Rides puppetmaster-ai==1.22.32. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.349"
+__version__ = "0.9.350"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/workspaces.py
+++ b/harness/workspaces.py
@@ -40,9 +40,48 @@ def _is_repo(repo: str) -> bool:
     return rc == 0 and out == "true"
 
 
+def _dirty_tracked_paths(repo: str) -> list[str]:
+    """Paths with real tracked dirt (M/A/D/R/C/U) — not untracked or ignored.
+
+    ``git status --porcelain`` treats ``??`` untracked (and ignored noise when
+    shown) as dirty; those must not block branch switch / stash prompts.
+
+    Do not go through ``_git``: that helper ``.strip()``s stdout and eats the
+    leading porcelain space (`` M README.md`` becomes ``M README.md``).
+    """
+    p = subprocess.run(
+        ["git", "-C", repo, "status", "--porcelain", "-uno"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+    )
+    if p.returncode != 0 or not (p.stdout or "").strip():
+        return []
+    paths: list[str] = []
+    for raw in p.stdout.splitlines():
+        line = raw.rstrip('\n\r')
+        if len(line) < 4:
+            continue
+        code = line[:2]
+        # Untracked / ignored are never a stash block.
+        if code in ("??", "!!"):
+            continue
+        # Skip blank xy (should not appear with -uno, but be safe).
+        if code.strip() == "":
+            continue
+        path = line[3:].strip()
+        # Rename lines: "R  old -> new" — report the new path.
+        if " -> " in path:
+            path = path.split(" -> ", 1)[-1].strip()
+        if path:
+            paths.append(path)
+    return paths
+
+
 def _dirty(repo: str) -> bool:
-    rc, out, _ = _git(repo, "status", "--porcelain")
-    return rc == 0 and bool(out.strip())
+    return bool(_dirty_tracked_paths(repo))
 
 
 def list_workspaces(repo: str) -> list[dict]:
@@ -126,6 +165,11 @@ def _is_stale_local_release(row: dict, remote: set[str]) -> bool:
     Origin already deleted these. Keep main/dev (not this prefix), the current
     checkout, any still-on-origin release, and a *live* worktree checkout.
     Do not delete the worktree — only hide the row.
+
+    When origin exists but only has non-release heads (typical main+dev), local
+    release leftovers without a live worktree are stale. An empty remote picture
+    (no origin / unread) still hides inactive local-only release rows that lack
+    a live worktree — leftover release/v0.9.* are never useful on the rail.
     """
     name = str(row.get("name") or "")
     if not name.startswith("release/v0.9."):
@@ -136,10 +180,22 @@ def _is_stale_local_release(row: dict, remote: set[str]) -> bool:
         return False
     if name in remote:
         return False
-    # No origin picture: do not hide (offline / no-remote test repos).
-    if not remote:
-        return False
+    # Remote picture empty OR origin has no copy of this release → hide.
     return True
+
+
+def is_stale_local_release_branch(
+    name: str,
+    *,
+    active: bool = False,
+    worktree_path: str | None = None,
+    remote: set[str] | None = None,
+) -> bool:
+    """Public predicate shared with prune — same rules as list filter."""
+    return _is_stale_local_release(
+        {"name": name, "active": active, "worktree_path": worktree_path},
+        remote if remote is not None else set(),
+    )
 
 
 def _worktree_holding_branch(repo: str, branch: str) -> Optional[str]:
@@ -192,13 +248,27 @@ def _friendly_worktree_busy_error(branch: str, wt_path: str) -> dict:
 
 
 def switch_workspace(repo: str, name: str, *, allow_dirty: bool = False) -> dict:
-    """Check out the workspace's branch. Refuses over uncommitted changes unless
-    allow_dirty (git itself also refuses if the checkout would clobber)."""
+    """Check out the workspace's branch. Refuses over tracked dirty paths unless
+    allow_dirty (git itself also refuses if the checkout would clobber).
+
+    Untracked / gitignored noise is not a stash block. When refusing, returns
+    ``dirty_paths`` so the UI can show what actually needs stash/commit.
+    """
     if not _is_repo(repo):
         return {"ok": False, "error": "no git repo configured"}
-    if _dirty(repo) and not allow_dirty:
-        return {"ok": False, "error": f"uncommitted changes in {repo}; commit/stash first "
-                f"or allow_dirty", "dirty": True}
+    dirty_paths = _dirty_tracked_paths(repo)
+    if dirty_paths and not allow_dirty:
+        shown = ", ".join(dirty_paths[:8])
+        extra = f" (+{len(dirty_paths) - 8} more)" if len(dirty_paths) > 8 else ""
+        return {
+            "ok": False,
+            "error": (
+                f"uncommitted changes in {repo}: {shown}{extra}; "
+                f"commit/stash first or allow_dirty"
+            ),
+            "dirty": True,
+            "dirty_paths": dirty_paths,
+        }
     if name.startswith("-"):
         return {"ok": False, "error": "invalid workspace name (cannot start with '-')"}
     held = _worktree_holding_branch(repo, name)

--- a/harness/worktrees.py
+++ b/harness/worktrees.py
@@ -661,11 +661,15 @@ def reap_stale_managed_worktrees(repo: str, max_age_seconds: float = 0) -> dict:
 
 
 _MANAGED_BRANCH_PREFIXES = ("pmedit-", "pmworker-")
-_PROTECTED_BRANCHES = frozenset({"main", "master"})
+_PROTECTED_BRANCHES = frozenset({"main", "master", "dev"})
 
 
 def _is_managed_branch_name(branch: str) -> bool:
     return bool(branch) and branch.startswith(_MANAGED_BRANCH_PREFIXES)
+
+
+def _is_stale_release_branch_name(branch: str) -> bool:
+    return bool(branch) and branch.startswith("release/v0.9.")
 
 
 def _current_branch(repo: str) -> str:
@@ -677,13 +681,17 @@ def _current_branch(repo: str) -> str:
 
 
 def delete_branch(repo: str, branch: str) -> None:
-    """Force-delete a managed edit/worker branch.
+    """Force-delete a managed edit/worker branch or a stale local release head.
 
-    Only ``pmedit-*`` and ``pmworker-*`` names are eligible. Current checkout,
-    ``main``, and ``master`` are never deleted; unrelated names are refused
-    (no-op) so callers cannot scrub arbitrary local branches.
+    ``pmedit-*`` / ``pmworker-*`` and leftover ``release/v0.9.*`` are eligible.
+    Current checkout, ``main`` / ``master`` / ``dev`` are never deleted;
+    unrelated names are refused (no-op).
     """
-    if not branch or not _is_managed_branch_name(branch):
+    if not branch:
+        return
+    managed = _is_managed_branch_name(branch)
+    stale_release = _is_stale_release_branch_name(branch)
+    if not managed and not stale_release:
         return
     if branch in _PROTECTED_BRANCHES:
         return
@@ -702,9 +710,12 @@ def delete_branch(repo: str, branch: str) -> None:
 
 
 def prune_orphan_edit_branches(repo: str) -> dict:
-    """Delete local ``pmedit-*`` / ``pmworker-*`` branches that are not in use.
+    """Delete unused local edit/worker and leftover release/v0.9.* branches.
 
-    Skips the current checkout and any branch still attached to a worktree.
+    Skips the current checkout, protected main/dev, and any branch still
+    attached to a *live* worktree directory. Stale local-only release heads
+    (origin already dropped them) are removed so Prune actually clears the
+    BRANCHES rail leftovers that ``git fetch --prune`` cannot.
     Returns ``{"deleted": [...], "count": N}``.
     """
     if not repo or not _is_repo(repo):
@@ -714,26 +725,51 @@ def prune_orphan_edit_branches(repo: str) -> dict:
     if rc != 0:
         return {"deleted": [], "count": 0}
 
-    candidates = [
-        line.strip()
-        for line in (out or "").splitlines()
-        if _is_managed_branch_name(line.strip())
-    ]
+    current = _current_branch(repo)
+    attached_live: set[str] = set()
+    attached_paths: dict[str, str] = {}
+    for wt in list_worktrees(repo):
+        wt_branch = (wt.get("branch") or "").strip()
+        wt_path = (wt.get("path") or "").strip()
+        if not wt_branch:
+            continue
+        if wt_path and os.path.isdir(wt_path):
+            attached_live.add(wt_branch)
+            attached_paths[wt_branch] = wt_path
+
+    try:
+        from .workspaces import _origin_branch_names, is_stale_local_release_branch
+    except Exception:
+        _origin_branch_names = lambda _r: set()  # type: ignore[assignment]
+        is_stale_local_release_branch = None  # type: ignore[assignment]
+
+    remote = _origin_branch_names(repo) if callable(_origin_branch_names) else set()
+
+    candidates: list[str] = []
+    for line in (out or "").splitlines():
+        name = line.strip()
+        if not name:
+            continue
+        if _is_managed_branch_name(name):
+            candidates.append(name)
+            continue
+        if _is_stale_release_branch_name(name) and is_stale_local_release_branch:
+            if is_stale_local_release_branch(
+                name,
+                active=(name == current),
+                worktree_path=attached_paths.get(name),
+                remote=remote,
+            ):
+                candidates.append(name)
+
     if not candidates:
         return {"deleted": [], "count": 0}
-
-    current = _current_branch(repo)
-    attached = {
-        (wt.get("branch") or "").strip()
-        for wt in list_worktrees(repo)
-        if (wt.get("branch") or "").strip()
-    }
 
     deleted: list[str] = []
     for branch in candidates:
         if branch in _PROTECTED_BRANCHES:
             continue
-        if branch == current or branch in attached:
+        if branch == current or branch in attached_live:
             continue
         before = _branch_exists(repo, branch)
         if not before:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.349"
+version = "0.9.350"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_workspaces_unit.py
+++ b/tests/test_workspaces_unit.py
@@ -250,3 +250,44 @@ def test_list_workspaces_keeps_current_release_checkout_even_if_local_only(tmp_p
     assert "release/v0.9.331" in names
     active = [r for r in list_workspaces(str(repo)) if r["active"]]
     assert active and active[0]["name"] == "release/v0.9.331"
+
+
+def test_switch_workspace_ignores_untracked_noise(tmp_path):
+    """Untracked / ignored files must not trip the dirty stash block."""
+    repo = _init_repo(tmp_path)
+    _git(repo, "branch", "feature")
+    (repo / "scratch.local").write_text("noise\n", encoding="utf-8")
+    (repo / ".gitignore").write_text("scratch.local\nignored.tmp\n", encoding="utf-8")
+    _git(repo, "add", ".gitignore")
+    _git(repo, "commit", "-qm", "ignore scratch")
+    (repo / "ignored.tmp").write_text("also noise\n", encoding="utf-8")
+    (repo / "untracked.txt").write_text("untracked\n", encoding="utf-8")
+
+    result = switch_workspace(str(repo), "feature")
+    assert result == {"ok": True, "active": "feature"}
+
+
+def test_switch_workspace_reports_tracked_dirty_paths(tmp_path):
+    repo = _init_repo(tmp_path)
+    _git(repo, "branch", "feature")
+    (repo / "README.md").write_text("tracked dirty\n", encoding="utf-8")
+
+    result = switch_workspace(str(repo), "feature")
+    assert result["ok"] is False
+    assert result.get("dirty") is True
+    assert "README.md" in (result.get("dirty_paths") or [])
+    assert "README.md" in result["error"]
+
+
+def test_list_workspaces_hides_stale_release_even_without_origin_picture(tmp_path):
+    """Empty remote picture must not resurrect leftover release/v0.9.* on BRANCHES."""
+    repo = _init_repo(tmp_path, branch="main")
+    _git(repo, "branch", "dev")
+    _git(repo, "branch", "release/v0.9.308")
+    _git(repo, "branch", "feature")
+
+    names = {r["name"] for r in list_workspaces(str(repo))}
+    assert "main" in names
+    assert "dev" in names
+    assert "feature" in names
+    assert "release/v0.9.308" not in names

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -322,6 +322,63 @@ def test_prune_orphan_edit_branches_skips_active_and_attached_worktree():
         shutil.rmtree(managed_dir, ignore_errors=True)
 
 
+def test_prune_orphan_edit_branches_deletes_stale_local_release():
+    """Prune must delete leftover local-only release/v0.9.* (not live worktrees)."""
+    repo = create_temp_git_repo()
+    parent = os.path.dirname(repo)
+    managed_dir = os.path.abspath(os.path.join(parent, ".pmharness-worktrees"))
+    remote = os.path.join(parent, "origin-prune.git")
+    wt = os.path.join(parent, "wt-318")
+    try:
+        _create_branch(repo, "dev")
+        _create_branch(repo, "release/v0.9.308")
+        _create_branch(repo, "release/v0.9.318")
+        _create_branch(repo, "release/v0.9.348")
+        _create_branch(repo, "feature-keep")
+
+        subprocess.run(["git", "init", "-q", "--bare", remote], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", repo, "remote", "add", "origin", remote],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", repo, "push", "-q", "origin", "main", "dev", "release/v0.9.348"],
+            check=True,
+            capture_output=True,
+        )
+
+        subprocess.run(
+            ["git", "-C", repo, "worktree", "add", wt, "release/v0.9.318"],
+            check=True,
+            capture_output=True,
+        )
+
+        result = _wt.prune_orphan_edit_branches(repo)
+        deleted = set(result["deleted"])
+        assert "release/v0.9.308" in deleted
+        assert "release/v0.9.318" not in deleted  # live worktree
+        assert "release/v0.9.348" not in deleted  # still on origin
+        assert "feature-keep" not in deleted
+        assert "main" not in deleted
+        assert "dev" not in deleted
+
+        branches = _branch_list(repo)
+        assert "release/v0.9.308" not in branches
+        assert "release/v0.9.318" in branches
+        assert "release/v0.9.348" in branches
+        assert "feature-keep" in branches
+    finally:
+        subprocess.run(
+            ["git", "-C", repo, "worktree", "remove", "--force", wt],
+            capture_output=True,
+        )
+        shutil.rmtree(wt, ignore_errors=True)
+        shutil.rmtree(repo, ignore_errors=True)
+        shutil.rmtree(managed_dir, ignore_errors=True)
+        shutil.rmtree(remote, ignore_errors=True)
+
+
 def test_prune_edit_branches_endpoint():
     repo = create_temp_git_repo()
     httpd, port, srv = _server(repo)

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.349"
+version = "0.9.350"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.349",
+  "version": "0.9.350",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.349",
+      "version": "0.9.350",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.349",
+  "version": "0.9.350",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -3144,7 +3144,7 @@ describe("SwarmPane command vs swarm split", () => {
   });
 });
 
-describe("SwarmPane v0.9.349 collapsed chrome", () => {
+describe("SwarmPane v0.9.350 collapsed chrome", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();

--- a/webapp/src/__tests__/chromeSelect.test.tsx
+++ b/webapp/src/__tests__/chromeSelect.test.tsx
@@ -28,6 +28,7 @@ describe("feed selection chrome", () => {
   it("CSS keeps message body selectable and fold/virtual chrome unselectable", () => {
     expect(css).toMatch(/\.transcript-msg-body\s*\{[^}]*user-select:\s*text/);
     expect(css).toMatch(/\.transcript-msg-body\s*\{[^}]*font-weight:\s*400/);
+    expect(css).toMatch(/\.transcript-fold-chrome\s*\{[^}]*font-weight:\s*400/);
     expect(css).toMatch(/\[data-testid="transcript-virtual-row"\][^{]*\{[^}]*user-select:\s*none/);
     expect(css).toMatch(/\.transcript-fold-chrome[^{]*\{[^}]*user-select:\s*none/);
     expect(column).toMatch(/data-testid="composer-chrome"/);
@@ -82,5 +83,33 @@ describe("feed selection chrome", () => {
     const strong = spoken!.querySelector("strong");
     expect(strong).toBeTruthy();
     expect(strong!.className).toMatch(/font-semibold/);
+  });
+
+  it("fold chrome stays regular weight (no bold Investigating / Worked for)", () => {
+    render(
+      <TranscriptList
+        {...listProps([
+          { kind: "msg", msg: { role: "user", text: "ask" } },
+          {
+            kind: "card",
+            card: {
+              id: "c1",
+              goal: "a.ts",
+              cwd: null,
+              kind: "read_file",
+              running: false,
+              open: false,
+              result: { status: "ok", duration_ms: 2000 },
+            },
+          },
+        ])}
+      />,
+    );
+    const fold = document.querySelector(".transcript-fold-chrome");
+    expect(fold).toBeTruthy();
+    expect(fold!.className).toMatch(/font-normal/);
+    expect(fold!.className).not.toMatch(/font-semibold/);
+    expect(fold!.className).not.toMatch(/font-bold/);
+    expect(fold!.className).not.toMatch(/font-medium/);
   });
 });

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -637,6 +637,18 @@ describe("thinkingToolPrep module", () => {
     expect(coalesceThinkingChunk("alpha", "beta")).toBe("alphabeta");
   });
 
+  it("coalesceThinkingChunk never glues status headlines with ****", () => {
+    expect(
+      coalesceThinkingChunk(
+        "Investigating branch list UI issue",
+        "****Searching CodeGraph for branch logic",
+      ),
+    ).toBe("Searching CodeGraph for branch logic");
+    expect(coalesceThinkingChunk("Planning…", "Validating…")).toBe("Validating…");
+    expect(coalesceThinkingChunk("redesign", "****")).toBe("redesign");
+    expect(coalesceThinkingChunk("redesign", "****Finalizing...")).toBe("redesign Finalizing...");
+  });
+
   it("upsertStreamingThinking coalesceSnapshots uses coalesce; default strict-appends", () => {
     let snap: Item[] = [{ kind: "msg", msg: { role: "user", text: "go" } }];
     snap = upsertStreamingThinking(snap, "hello world", { coalesceSnapshots: true });

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.349)", () => {
-  it("declares the official motion package and 0.9.349 not 329", () => {
+describe("feed Motion (v0.9.350)", () => {
+  it("declares the official motion package and 0.9.350 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.349");
+    expect(pkg.version).toBe("0.9.350");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/leftRailBranches.test.ts
+++ b/webapp/src/__tests__/leftRailBranches.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterBranchWorkspaces,
+  isStaleLocalReleaseBranch,
+} from "../components/leftRailBranches";
+import type { Workspace } from "../lib/api";
+
+function row(
+  name: string,
+  opts?: Partial<Workspace>,
+): Workspace {
+  return {
+    name,
+    branch: name,
+    active: false,
+    ...opts,
+  };
+}
+
+describe("leftRailBranches stale release filter", () => {
+  it("hides leftover local-only release/v0.9.* without a live worktree", () => {
+    const rows = [
+      row("main", { active: true }),
+      row("dev"),
+      row("release/v0.9.308"),
+      row("release/v0.9.318", { worktree_path: "/tmp/live-wt" }),
+      row("release/v0.9.348"),
+      row("feature"),
+    ];
+    const origin = new Set(["main", "dev", "release/v0.9.348"]);
+    const names = filterBranchWorkspaces(rows, origin).map((r) => r.name);
+    expect(names).toEqual(["main", "dev", "release/v0.9.318", "release/v0.9.348", "feature"]);
+    expect(names).not.toContain("release/v0.9.308");
+  });
+
+  it("keeps the active release checkout even when local-only", () => {
+    expect(
+      isStaleLocalReleaseBranch(row("release/v0.9.331", { active: true }), new Set(["main"])),
+    ).toBe(false);
+  });
+
+  it("hides inactive release leftovers when origin picture is empty (cache miss safety)", () => {
+    expect(isStaleLocalReleaseBranch(row("release/v0.9.310"))).toBe(true);
+    expect(isStaleLocalReleaseBranch(row("release/v0.9.310"), new Set())).toBe(true);
+    expect(isStaleLocalReleaseBranch(row("main"))).toBe(false);
+    expect(isStaleLocalReleaseBranch(row("dev"))).toBe(false);
+  });
+
+  it("keeps a release that still has a worktree_path even without origin", () => {
+    expect(
+      isStaleLocalReleaseBranch(
+        row("release/v0.9.318", { worktree_path: "C:\\wt\\318" }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
+++ b/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
@@ -64,6 +64,9 @@ describe("stacked fold labels", () => {
   it("formats Worked for / Thought / Ran chrome", () => {
     expect(workedForLabel(23_000)).toBe("Worked for 23s");
     expect(workedForLabel(6 * 60_000)).toBe("Worked for 6m");
+    expect(workedForLabel(0)).toBe("Worked for");
+    expect(workedForLabel(500)).toBe("Worked for");
+    expect(workedForLabel(0)).not.toMatch(/0s/);
     expect(thoughtFoldLabel({ live: true })).toBe("Thinking…");
     expect(thoughtFoldLabel({ durationMs: 8_000 })).toBe("Thought 8s");
     expect(ranCommandsLabel(1)).toBe("Ran 1 command");

--- a/webapp/src/__tests__/thinkingStreamUx.test.ts
+++ b/webapp/src/__tests__/thinkingStreamUx.test.ts
@@ -454,7 +454,7 @@ describe("createApplyStreamEvent Sol reasoning coalescing", () => {
     expect(thinking[0].streaming).toBe(true);
   });
 
-  it("coalesces markdown markers split across thinking deltas", () => {
+  it("drops markdown **** glue between thinking deltas (never redesign****Finalizing)", () => {
     const state = {
       items: [{ kind: "msg", msg: { role: "user", text: "go" } }] as Item[],
       itemsRef: { current: [] as Item[] },
@@ -467,7 +467,46 @@ describe("createApplyStreamEvent Sol reasoning coalescing", () => {
     apply({ kind: "thinking", data: { text: "Finalizing...", delta: true } });
     const thinking = thinkingRows(state.items);
     expect(thinking).toHaveLength(1);
-    expect(thinking[0].text).toBe("redesign****Finalizing...");
+    expect(thinking[0].text).toBe("redesign Finalizing...");
+    expect(thinking[0].text).not.toContain("****");
+    expect(thinking[0].text).not.toMatch(/\*{2,}/);
+  });
+
+  it("replaces Codex status headlines instead of gluing with ****", () => {
+    const state = {
+      items: [{ kind: "msg", msg: { role: "user", text: "go" } }] as Item[],
+      itemsRef: { current: [] as Item[] },
+      typeBufRef: { current: "" },
+    };
+    state.itemsRef.current = state.items;
+    const apply = createApplyStreamEvent(makeApplyDeps(state));
+    apply({
+      kind: "thinking",
+      data: { text: "Investigating branch list UI issue", delta: true, stream_id: "rs_1" },
+    });
+    apply({
+      kind: "thinking",
+      data: { text: "****", delta: true, stream_id: "rs_1" },
+    });
+    apply({
+      kind: "thinking",
+      data: { text: "Searching CodeGraph for branch logic", delta: true, stream_id: "rs_1" },
+    });
+    const thinking = thinkingRows(state.items);
+    expect(thinking).toHaveLength(1);
+    expect(thinking[0].text).toBe("Searching CodeGraph for branch logic");
+    expect(thinking[0].text).not.toContain("****");
+    expect(thinking[0].text).not.toContain("Investigating");
+  });
+
+  it("coalesceSnapshots replaces Planning… with Validating… (no **** joiner)", () => {
+    let items: Item[] = [{ kind: "msg", msg: { role: "user", text: "go" } }];
+    items = upsertStreamingThinking(items, "Planning…", { coalesceSnapshots: true });
+    items = upsertStreamingThinking(items, "****Validating…", { coalesceSnapshots: true });
+    const thinking = items.find((i) => i.kind === "thinking") as Extract<Item, { kind: "thinking" }>;
+    expect(thinking.text).toBe("Validating…");
+    expect(thinking.text).not.toContain("****");
+    expect(thinking.text).not.toContain("Planning");
   });
 
   it("ignores interleaved trivial message_delta crumbs between word deltas", () => {

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -19,6 +19,7 @@ import { writeTranscriptCache } from "./Conversation";
 import { sharedReadinessNotice } from "../lib/operationalDiagnostic";
 import { useOperationalDiagnostic } from "../lib/useOperationalDiagnostic";
 import { filterJobsByScope, loadJobScope, saveJobScope, type JobScope } from "../lib/jobScope";
+import { filterBranchWorkspaces } from "./leftRailBranches";
 
 export {
   SESSION_LEASE_EXHAUSTED_MESSAGE,
@@ -673,8 +674,14 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     try {
       let res = await api.switchWorkspace(name);
       if (!res.ok && res.dirty) {
+        const paths = Array.isArray((res as { dirty_paths?: string[] }).dirty_paths)
+          ? (res as { dirty_paths?: string[] }).dirty_paths!
+          : [];
+        const pathHint = paths.length
+          ? `\n\nTracked changes:\n${paths.slice(0, 8).join("\n")}${paths.length > 8 ? `\n(+${paths.length - 8} more)` : ""}`
+          : "";
         const proceed = window.confirm(
-          "Uncommitted changes in this repo. Switch branch anyway? (may fail if checkout would overwrite files)",
+          `Uncommitted tracked changes in this repo. Switch branch anyway? (may fail if checkout would overwrite files)${pathHint}`,
         );
         if (!proceed) return;
         res = await api.switchWorkspace(name, { allow_dirty: true });
@@ -715,7 +722,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
   const pruneEditBranches = async () => {
     if (pruningBranches) return;
     const proceed = window.confirm(
-      "Delete unused local edit/worker branches (pmedit-*, pmworker-*)? Active checkout and worktree-attached branches are kept.",
+      "Delete unused local edit/worker branches (pmedit-*, pmworker-*) and leftover release/v0.9.* branches that origin already dropped? Active checkout and live worktree-attached branches are kept.",
     );
     if (!proceed) return;
     setPruningBranches(true);
@@ -724,8 +731,8 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       await revalidateWorkspaces();
       const count = typeof res.count === "number" ? res.count : (res.deleted?.length ?? 0);
       toast(count > 0
-        ? `Pruned ${count} unused edit branch${count === 1 ? "" : "es"}`
-        : "No unused edit branches to prune");
+        ? `Pruned ${count} unused branch${count === 1 ? "" : "es"}`
+        : "No unused edit or leftover release branches to prune");
     } catch (err: any) {
       toast(err?.error || err?.message || "Could not prune edit branches");
     } finally {
@@ -1819,7 +1826,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
             <div className="flex items-center gap-0.5">
               <IconBtn
                 onClick={() => { void pruneEditBranches(); }}
-                title="Prune unused edit/worker branches"
+                title="Prune unused edit/worker and leftover release branches"
                 disabled={pruningBranches}
               >
                 {pruningBranches ? <Loader2 size={13} className="animate-spin" /> : <Brush size={13} />}
@@ -1828,11 +1835,11 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
             </div>
           }
         >
-          {workspaces.length === 0 && (
+          {filterBranchWorkspaces(workspaces).length === 0 && (
             <Empty>{workspaceInfo?.head_unborn ? "No commits yet" : "No branches"}</Empty>
           )}
           <div className="space-y-0.5 overflow-y-auto" style={{ height: branchesHeight }}>
-            {workspaces.map((w) => {
+            {filterBranchWorkspaces(workspaces).map((w) => {
               const linked = !!w.worktree_path;
               const linkKind = w.name.startsWith("pmworker-")
                 ? "worker"

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -2731,7 +2731,8 @@ function CommandFold({
 export function normalizeReasoningPreview(text: string, maxLen = 160): string {
   const first = String(text || "").trim().split("\n", 1)[0] || "";
   // Strip Markdown chrome for collapsed previews — keep ordinary * math/globs
-  // (2*3*4, a*b*c) and snake_case identifiers intact.
+  // (2*3*4, a*b*c) and snake_case identifiers intact. Also collapse Codex
+  // `title****title` bold-glue so two headlines never leak literal asterisks.
   const cleaned = first
     .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")

--- a/webapp/src/components/conversation/StatusPill.tsx
+++ b/webapp/src/components/conversation/StatusPill.tsx
@@ -84,7 +84,7 @@ export default function StatusPill({
   const hoverText = statusPillHoverText(status, detail);
   const clickable = statusPillClickable(status, detail, onDetailClick);
   const className =
-    `text-[10.5px] flex items-center gap-1.5 min-w-0 max-w-[42ch] ${statusPillTextClass(status)}`
+    `text-[10.5px] font-normal flex items-center gap-1.5 min-w-0 max-w-[42ch] ${statusPillTextClass(status)}`
     + (clickable ? " cursor-pointer hover:underline underline-offset-2" : "");
   if (clickable) {
     return (

--- a/webapp/src/components/conversation/reexports.ts
+++ b/webapp/src/components/conversation/reexports.ts
@@ -28,6 +28,9 @@ export {
   looksLikeFinalAnswer,
   hoistCardsBeforeTrailingFinals,
   isTrivialAssistantCrumb,
+  looksLikeStatusHeadline,
+  sanitizeThinkingStatusGlue,
+  stripThinkingEmphasisChrome,
   sealStreamById,
 } from "./thinkingToolPrep";
 export {

--- a/webapp/src/components/conversation/streamBubbles.ts
+++ b/webapp/src/components/conversation/streamBubbles.ts
@@ -1,5 +1,5 @@
 import type { Item, Msg } from "../TranscriptList";
-import { isTrivialAssistantCrumb } from "./thinkingToolPrep";
+import { isTrivialAssistantCrumb, sanitizeThinkingStatusGlue } from "./thinkingToolPrep";
 
 /**
  * Short shared prefixes ("I will") must never suppress a distinct post-tool
@@ -178,11 +178,14 @@ export function appendStreamingTextToItems(
     const updated = [...items];
     const stampWorkerId =
       workerStream && workerId && !(bubble.msg.worker_id || "").trim();
+    const nextText = isTrivialAssistantCrumb(chunk)
+      ? bubble.msg.text
+      : sanitizeThinkingStatusGlue(bubble.msg.text + chunk);
     updated[idx] = {
       kind: "msg",
       msg: {
         ...bubble.msg,
-        text: bubble.msg.text + chunk,
+        text: nextText,
         ...(stampWorkerId ? { worker_id: workerId } : {}),
       },
     };

--- a/webapp/src/components/conversation/thinkingToolPrep.ts
+++ b/webapp/src/components/conversation/thinkingToolPrep.ts
@@ -45,27 +45,94 @@ export function isTrivialAssistantCrumb(text: string): boolean {
 }
 
 /**
+ * Codex / Luna Max status headlines (Investigating / Planning / Searching…).
+ * Discrete frames must replace each other — never glue with `****` or spaces.
+ */
+const STATUS_HEADLINE_RE =
+  /^(Investigating|Explored|Diagnosing|Planning|Assessing|Searching|Looking|Thinking|Thought|Validating|Finalizing|Still working|Working)\b/i;
+
+/** Strip surrounding emphasis markers so `**Planning…**` compares as a title. */
+export function stripThinkingEmphasisChrome(text: string): string {
+  let t = String(text || "").trim();
+  // Peel paired wrappers and leftover glue runs (`****` between titles).
+  for (let i = 0; i < 4; i++) {
+    const next = t
+      .replace(/^\*{1,}|_{1,}|`{1,}|~{1,}/g, "")
+      .replace(/\*{1,}$|_{1,}$|`{1,}$|~{1,}$/g, "")
+      .trim();
+    if (next === t) break;
+    t = next;
+  }
+  return t;
+}
+
+export function looksLikeStatusHeadline(text: string): boolean {
+  const core = stripThinkingEmphasisChrome(text);
+  return Boolean(core) && STATUS_HEADLINE_RE.test(core);
+}
+
+/**
+ * Drop `****` / `**` glue between status headlines. Keeps the latest title when
+ * two headlines were concatenated; otherwise strips marker runs only.
+ */
+export function sanitizeThinkingStatusGlue(text: string): string {
+  const raw = String(text || "");
+  if (!raw.includes("*") && !raw.includes("_")) return raw;
+  // Split on emphasis glue runs; if every non-empty part is a status headline,
+  // keep only the latest (Codex bold-title frames).
+  const parts = raw
+    .split(/\*{2,}|_{2,}/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (parts.length >= 2 && parts.every(looksLikeStatusHeadline)) {
+    return stripThinkingEmphasisChrome(parts[parts.length - 1]);
+  }
+  // Marker-only crumbs already handled upstream; strip residual glue runs so
+  // `redesign****Finalizing...` never paints literal asterisks.
+  if (/\*{2,}|_{2,}/.test(raw)) {
+    return raw
+      .split(/\*{2,}|_{2,}/)
+      .map((p) => p.trim())
+      .filter(Boolean)
+      .join(" ")
+      .trim();
+  }
+  return raw;
+}
+
+/**
  * Merge a cumulative snapshot frame into an existing thinking row.
  * Identical / stale-prefix / strict-extension snapshots replace once;
- * non-overlapping fragments still append. Used only by non-delta
- * (`appendNonStreamingThinking`) paths — never for provider `delta:true`
- * chunks, which must keep strict append semantics.
+ * status headlines replace (never concatenate); other non-overlapping
+ * fragments still append. Used by non-delta (`appendNonStreamingThinking`)
+ * paths and shared with delta merge so `****` glue cannot leak.
  */
 export function coalesceThinkingChunk(existing: string, chunk: string): string {
   if (!chunk) return existing;
-  if (!existing) return chunk;
+  if (isTrivialAssistantCrumb(chunk)) return existing;
+  if (!existing || isTrivialAssistantCrumb(existing)) {
+    return sanitizeThinkingStatusGlue(chunk);
+  }
   if (chunk === existing) return existing;
-  if (existing.startsWith(chunk)) return existing;
-  if (chunk.startsWith(existing)) return chunk;
+  if (existing.startsWith(chunk)) return sanitizeThinkingStatusGlue(existing);
+  if (chunk.startsWith(existing)) return sanitizeThinkingStatusGlue(chunk);
+
+  const existingCore = stripThinkingEmphasisChrome(existing);
+  const chunkCore = stripThinkingEmphasisChrome(chunk);
+  // Two investigating / planning / searching titles → keep the latest only.
+  if (looksLikeStatusHeadline(existingCore) && looksLikeStatusHeadline(chunkCore)) {
+    return chunkCore;
+  }
+
   // Partial overlap: longest suffix of existing that is a prefix of chunk
   // (avoids "world"+"world foo" style duplication on snapshot frames).
   const maxOverlap = Math.min(existing.length, chunk.length);
   for (let n = maxOverlap; n > 0; n--) {
     if (chunk.startsWith(existing.slice(-n))) {
-      return existing + chunk.slice(n);
+      return sanitizeThinkingStatusGlue(existing + chunk.slice(n));
     }
   }
-  return existing + chunk;
+  return sanitizeThinkingStatusGlue(existing + chunk);
 }
 
 export type UpsertStreamingThinkingOpts = {
@@ -84,10 +151,25 @@ function mergeThinkingText(
   chunk: string,
   coalesceSnapshots: boolean,
 ): string {
+  // Shared sanitize for both snapshot coalesce and live deltas so Codex/Luna
+  // bold-title frames (`****` between Investigating / Searching) never paint.
   if (coalesceSnapshots) return coalesceThinkingChunk(existing, chunk);
   if (!chunk) return existing;
-  if (!existing) return chunk;
-  return existing + chunk;
+  if (isTrivialAssistantCrumb(chunk)) return existing;
+  if (!existing || isTrivialAssistantCrumb(existing)) {
+    return sanitizeThinkingStatusGlue(chunk);
+  }
+  const existingCore = stripThinkingEmphasisChrome(existing);
+  const chunkCore = stripThinkingEmphasisChrome(chunk);
+  if (looksLikeStatusHeadline(existingCore) && looksLikeStatusHeadline(chunkCore)) {
+    return chunkCore;
+  }
+  if (looksLikeStatusHeadline(chunkCore) && !looksLikeStatusHeadline(existingCore)) {
+    // Dropped `****` crumbs would otherwise smash "redesign"+"Finalizing...".
+    const sep = /\s$/.test(existing) ? "" : " ";
+    return sanitizeThinkingStatusGlue(existing + sep + chunkCore);
+  }
+  return sanitizeThinkingStatusGlue(existing + chunk);
 }
 
 function turnStartIndex(items: Item[]): number {
@@ -146,7 +228,7 @@ export function upsertStreamingThinking(
       ...items,
       {
         kind: "thinking",
-        text: chunk,
+        text: sanitizeThinkingStatusGlue(chunk),
         streaming: true,
         id: newThinkingId(),
         stream_id: streamId,
@@ -177,7 +259,7 @@ export function upsertStreamingThinking(
         ...sealed,
         {
           kind: "thinking",
-          text: chunk,
+          text: sanitizeThinkingStatusGlue(chunk),
           streaming: true,
           id: newThinkingId(),
           started_at_ms: Date.now(),
@@ -201,7 +283,7 @@ export function upsertStreamingThinking(
     ...items,
     {
       kind: "thinking",
-      text: chunk,
+      text: sanitizeThinkingStatusGlue(chunk),
       streaming: true,
       id: newThinkingId(),
       started_at_ms: Date.now(),

--- a/webapp/src/components/leftRailBranches.ts
+++ b/webapp/src/components/leftRailBranches.ts
@@ -1,0 +1,35 @@
+import type { Workspace } from "../lib/api";
+
+/**
+ * Client-side mirror of harness.workspaces._is_stale_local_release.
+ * Hides leftover local-only release/v0.9.* even when a stale SWR cache or
+ * older API payload still lists them. Keep main/dev, the active checkout,
+ * origin-backed names (when known), and a live worktree path.
+ */
+export function isStaleLocalReleaseBranch(
+  row: Pick<Workspace, "name" | "active" | "worktree_path">,
+  originBranches?: Iterable<string> | null,
+): boolean {
+  const name = String(row.name || "");
+  if (!name.startsWith("release/v0.9.")) return false;
+  if (row.active) return false;
+  const wt = String(row.worktree_path || "").trim();
+  // Live worktree path present → keep (dir check is best-effort in the UI).
+  if (wt) return false;
+  if (originBranches) {
+    const remote = originBranches instanceof Set
+      ? originBranches
+      : new Set(Array.from(originBranches));
+    if (remote.has(name)) return false;
+  }
+  // No origin picture or origin already dropped this release → hide.
+  return true;
+}
+
+/** Filter BRANCHES rows so phantom release leftovers cannot paint. */
+export function filterBranchWorkspaces(
+  rows: Workspace[],
+  originBranches?: Iterable<string> | null,
+): Workspace[] {
+  return (rows || []).filter((row) => !isStaleLocalReleaseBranch(row, originBranches));
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -565,9 +565,13 @@ body.is-row-resizing iframe {
 
 
 /* Feed selection: highlight a clean text range, not fold chrome.
-   Spoken body stays regular weight (400); fold chrome / labels / strong keep their own. */
+   Spoken body stays regular weight (400); fold chrome / labels stay regular
+   too (345 hold) — never inherit semibold from rail/header ancestors. */
 .transcript-msg-body {
   user-select: text;
+  font-weight: 400;
+}
+.transcript-fold-chrome {
   font-weight: 400;
 }
 [data-testid="transcript-virtual-row"],

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1162,6 +1162,7 @@ export const api = {
       active?: string;
       error?: string;
       dirty?: boolean;
+      dirty_paths?: string[];
       worktree_busy?: boolean;
       worktree_path?: string;
     }>(

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -455,6 +455,10 @@ export function workedForLabel(durationMs?: number | null): string {
   if (durationMs == null || !Number.isFinite(durationMs) || durationMs < 0) {
     return "Worked for";
   }
+  // Empty / sub-second crumbs stay duration-less (never "Worked for 0s").
+  if (durationMs < 1000) {
+    return "Worked for";
+  }
   const label = formatFoldDuration(durationMs);
   return label ? `Worked for ${label}` : "Worked for";
 }


### PR DESCRIPTION
## Summary
- Codex/Luna no longer concatenates investigating/thinking headlines with literal `****`. Fold/status chrome stays regular weight (345 hold). Empty / 0s Worked-for crumbs stay hidden (347 hold).
- BRANCHES hides stale local-only `release/v0.9.*` that origin already deleted (API + LeftRail). Keeps main, dev, current checkout, origin-backed heads, and live worktrees.
- Prune deletes those leftover local release refs (not live worktrees, not current, not main/dev).
- Branch switch ignores untracked/gitignored noise. Real tracked dirt reports the paths.

Pin stays `puppetmaster-ai==1.22.32`. Base is `cb7ada33` (v0.9.349). CoS merges+tags. No 351.

## Test plan
- [ ] Luna/Codex session: no `Investigating …****Searching …` glue; fold labels not bold.
- [ ] BRANCHES does not list leftover local `release/v0.9.308`–`.331`. `.318 WORKTREE` only if that dir is live.
- [ ] Prune removes leftover local release refs and keeps a live worktree.
- [ ] Switch branch with only untracked noise succeeds. Tracked dirty files are named.
- [ ] CI green. Pin still 1.22.32.