### PR TITLE
Marionette v0.9.352 — haul leftover 350 chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.33` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.351, deliberately pre-1.0. Rides puppetmaster-ai==1.22.33. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.352, deliberately pre-1.0. Rides puppetmaster-ai==1.22.33. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.351"
+__version__ = "0.9.352"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/workspaces.py
+++ b/harness/workspaces.py
@@ -150,34 +150,20 @@ def _origin_branch_names(repo: str) -> set[str]:
     return names
 
 
-def _is_live_worktree_path(path: str | None) -> bool:
-    if not path:
-        return False
-    try:
-        return os.path.isdir(path)
-    except Exception:
-        return False
-
-
 def _is_stale_local_release(row: dict, remote: set[str]) -> bool:
     """True when BRANCHES should hide a leftover local release/v0.9.* head.
 
     Origin already deleted these. Keep main/dev (not this prefix), the current
-    checkout, and any still-on-origin release. Dead leftover worktrees
-    (release/v0.9.318) are hidden, not deleted.
-
-    When origin exists but only has non-release heads (typical main+dev), local
-    release leftovers without a live worktree are stale. An empty remote picture
-    (no origin / unread) still hides inactive local-only release rows that lack
-    a live worktree — leftover release/v0.9.* are never useful on the rail.
+    checkout, and any still-on-origin release. Leftover release worktrees
+    (e.g. release/v0.9.318) are hidden from the rail — the directory is not
+    deleted.
     """
     name = str(row.get("name") or "")
     if not name.startswith("release/v0.9."):
         return False
     if row.get("active"):
         return False
-    # Leftover release/v0.9.* worktrees (e.g. 318) stay on disk but are not
-    # listed. Do not delete the directory; only hide the BRANCHES row.
+    # Leftover release/v0.9.* worktrees stay on disk but are not listed.
     if name in remote:
         return False
     # Remote picture empty OR origin has no copy of this release → hide.

--- a/harness/workspaces.py
+++ b/harness/workspaces.py
@@ -163,8 +163,8 @@ def _is_stale_local_release(row: dict, remote: set[str]) -> bool:
     """True when BRANCHES should hide a leftover local release/v0.9.* head.
 
     Origin already deleted these. Keep main/dev (not this prefix), the current
-    checkout, any still-on-origin release, and a *live* worktree checkout.
-    Do not delete the worktree — only hide the row.
+    checkout, and any still-on-origin release. Dead leftover worktrees
+    (release/v0.9.318) are hidden, not deleted.
 
     When origin exists but only has non-release heads (typical main+dev), local
     release leftovers without a live worktree are stale. An empty remote picture
@@ -176,8 +176,8 @@ def _is_stale_local_release(row: dict, remote: set[str]) -> bool:
         return False
     if row.get("active"):
         return False
-    if _is_live_worktree_path(row.get("worktree_path")):
-        return False
+    # Leftover release/v0.9.* worktrees (e.g. 318) stay on disk but are not
+    # listed. Do not delete the directory; only hide the BRANCHES row.
     if name in remote:
         return False
     # Remote picture empty OR origin has no copy of this release → hide.

--- a/harness/worktrees.py
+++ b/harness/worktrees.py
@@ -712,11 +712,10 @@ def delete_branch(repo: str, branch: str) -> None:
 def prune_orphan_edit_branches(repo: str) -> dict:
     """Delete unused local edit/worker and leftover release/v0.9.* branches.
 
-    Skips the current checkout, protected main/dev, and any branch still
-    attached to a *live* worktree directory. Stale local-only release heads
-    (origin already dropped them) are removed so Prune actually clears the
-    BRANCHES rail leftovers that ``git fetch --prune`` cannot.
-    Returns ``{"deleted": [...], "count": N}``.
+    Skips the current checkout, protected main/dev, and live pmedit-/pmworker-
+    worktrees. Leftover local release/v0.9.* heads are pruned even when a
+    leftover worktree directory still exists (``git worktree remove`` then
+    delete the branch). Returns ``{"deleted": [...], "count": N}``.
     """
     if not repo or not _is_repo(repo):
         return {"deleted": [], "count": 0}
@@ -769,8 +768,25 @@ def prune_orphan_edit_branches(repo: str) -> dict:
     for branch in candidates:
         if branch in _PROTECTED_BRANCHES:
             continue
-        if branch == current or branch in attached_live:
+        if branch == current:
             continue
+        if branch in attached_live:
+            if not _is_stale_release_branch_name(branch):
+                continue
+            wt_path = attached_paths.get(branch) or ""
+            if wt_path:
+                try:
+                    remove_worktree(repo, wt_path, force=True)
+                except Exception:
+                    subprocess.run(
+                        ["git", "-C", repo, "worktree", "remove", "--force", wt_path],
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                        timeout=15,
+                    )
+                    _git(repo, "worktree", "prune")
         before = _branch_exists(repo, branch)
         if not before:
             continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.351"
+version = "0.9.352"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_workspaces_unit.py
+++ b/tests/test_workspaces_unit.py
@@ -201,8 +201,8 @@ def test_switch_workspace_soft_refuses_branch_locked_in_worktree(tmp_path):
 def test_list_workspaces_hides_stale_local_release_keeps_live(tmp_path):
     """BRANCHES hides leftover local release/v0.9.* once origin deleted them.
 
-    Keep main, dev, the current checkout, origin-backed release heads, and a
-    live worktree. Do not delete the worktree.
+    Keep main, dev, the current checkout, and origin-backed release heads.
+    Hide leftover release worktrees (318); do not delete the directory.
     """
     repo = _init_repo(tmp_path, branch="main")
     _git(repo, "branch", "dev")
@@ -229,12 +229,9 @@ def test_list_workspaces_hides_stale_local_release_keeps_live(tmp_path):
     assert "dev" in names
     assert "feature" in names
     assert "release/v0.9.348" in names  # still on origin
-    assert "release/v0.9.318" in names  # live worktree
+    assert "release/v0.9.318" not in names  # leftover worktree hidden, dir stays
     assert "release/v0.9.286" not in names  # stale local-only leftover
-
-    listed = {r["name"]: r for r in list_workspaces(str(repo))}
-    assert listed["release/v0.9.318"].get("worktree_path")
-    assert Path(listed["release/v0.9.318"]["worktree_path"]).is_dir()
+    assert Path(wt).is_dir()  # do not delete the worktree directory
 
 
 def test_list_workspaces_keeps_current_release_checkout_even_if_local_only(tmp_path):

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -323,7 +323,7 @@ def test_prune_orphan_edit_branches_skips_active_and_attached_worktree():
 
 
 def test_prune_orphan_edit_branches_deletes_stale_local_release():
-    """Prune must delete leftover local-only release/v0.9.* (not live worktrees)."""
+    """Prune deletes leftover local-only release/v0.9.* including leftover worktrees."""
     repo = create_temp_git_repo()
     parent = os.path.dirname(repo)
     managed_dir = os.path.abspath(os.path.join(parent, ".pmharness-worktrees"))
@@ -357,7 +357,7 @@ def test_prune_orphan_edit_branches_deletes_stale_local_release():
         result = _wt.prune_orphan_edit_branches(repo)
         deleted = set(result["deleted"])
         assert "release/v0.9.308" in deleted
-        assert "release/v0.9.318" not in deleted  # live worktree
+        assert "release/v0.9.318" in deleted  # leftover worktree removed
         assert "release/v0.9.348" not in deleted  # still on origin
         assert "feature-keep" not in deleted
         assert "main" not in deleted
@@ -365,9 +365,10 @@ def test_prune_orphan_edit_branches_deletes_stale_local_release():
 
         branches = _branch_list(repo)
         assert "release/v0.9.308" not in branches
-        assert "release/v0.9.318" in branches
+        assert "release/v0.9.318" not in branches
         assert "release/v0.9.348" in branches
         assert "feature-keep" in branches
+        assert not os.path.isdir(wt)
     finally:
         subprocess.run(
             ["git", "-C", repo, "worktree", "remove", "--force", wt],

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.351"
+version = "0.9.352"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -114,7 +114,7 @@ function statusPath(line) {
 }
 
 function isTrackedSelfEditLine(line) {
-  if (!line.trim() || line.startsWith("??")) return false;
+  if (!line.trim() || line.startsWith("??") || line.startsWith("!!")) return false;
   const file = statusPath(line);
   return !(
     file.startsWith("results/") ||
@@ -270,7 +270,7 @@ async function recoverInterruptedMerge(repoRoot) {
 // a dirty tree can be stashed + reapplied, but an ahead/diverged tree needs the
 // user to rebase or reset -- we never rewrite their commits silently.
 async function inspectTree(repoRoot, branch) {
-  const status = await gitCapture(repoRoot, ["status", "--porcelain"]);
+  const status = await gitCapture(repoRoot, ["status", "--porcelain", "-uno"]);
   // Only TRACKED modifications count as dirty. Untracked files ("?? ") cannot
   // block a fast-forward merge, and the pilot routinely drops scratch files
   // (analysis scripts, result dumps) into the checkout -- counting those made

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.351",
+  "version": "0.9.352",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.351",
+      "version": "0.9.352",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.351",
+  "version": "0.9.352",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   clearToolPrepPlaceholders,
   coalesceThinkingChunk,
+  sanitizeThinkingStatusGlue,
   finalizeStreamingThinking,
   hoistCardsBeforeTrailingFinals,
   newThinkingId,
@@ -647,6 +648,8 @@ describe("thinkingToolPrep module", () => {
     expect(coalesceThinkingChunk("Planning…", "Validating…")).toBe("Validating…");
     expect(coalesceThinkingChunk("redesign", "****")).toBe("redesign");
     expect(coalesceThinkingChunk("redesign", "****Finalizing...")).toBe("redesign Finalizing...");
+    expect(coalesceThinkingChunk("Diagnosing…", "****Inspecting…")).toBe("Inspecting…");
+    expect(sanitizeThinkingStatusGlue("Diagnosing…****Inspecting…")).toBe("Inspecting…");
   });
 
   it("upsertStreamingThinking coalesceSnapshots uses coalesce; default strict-appends", () => {

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -650,6 +650,7 @@ describe("thinkingToolPrep module", () => {
     expect(coalesceThinkingChunk("redesign", "****Finalizing...")).toBe("redesign Finalizing...");
     expect(coalesceThinkingChunk("Diagnosing…", "****Inspecting…")).toBe("Inspecting…");
     expect(sanitizeThinkingStatusGlue("Diagnosing…****Inspecting…")).toBe("Inspecting…");
+    expect(sanitizeThinkingStatusGlue("hello****Inspecting…")).toBe("Inspecting…");
   });
 
   it("upsertStreamingThinking coalesceSnapshots uses coalesce; default strict-appends", () => {

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -647,7 +647,7 @@ describe("thinkingToolPrep module", () => {
     ).toBe("Searching CodeGraph for branch logic");
     expect(coalesceThinkingChunk("Planning…", "Validating…")).toBe("Validating…");
     expect(coalesceThinkingChunk("redesign", "****")).toBe("redesign");
-    expect(coalesceThinkingChunk("redesign", "****Finalizing...")).toBe("redesign Finalizing...");
+    expect(coalesceThinkingChunk("redesign", "****Finalizing...")).toBe("Finalizing...");
     expect(coalesceThinkingChunk("Diagnosing…", "****Inspecting…")).toBe("Inspecting…");
     expect(sanitizeThinkingStatusGlue("Diagnosing…****Inspecting…")).toBe("Inspecting…");
     expect(sanitizeThinkingStatusGlue("hello****Inspecting…")).toBe("Inspecting…");

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.351)", () => {
-  it("declares the official motion package and 0.9.351 not 329", () => {
+describe("feed Motion (v0.9.352)", () => {
+  it("declares the official motion package and 0.9.352 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.351");
+    expect(pkg.version).toBe("0.9.352");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/leftRailBranches.test.ts
+++ b/webapp/src/__tests__/leftRailBranches.test.ts
@@ -29,8 +29,9 @@ describe("leftRailBranches stale release filter", () => {
     ];
     const origin = new Set(["main", "dev", "release/v0.9.348"]);
     const names = filterBranchWorkspaces(rows, origin).map((r) => r.name);
-    expect(names).toEqual(["main", "dev", "release/v0.9.318", "release/v0.9.348", "feature"]);
+    expect(names).toEqual(["main", "dev", "release/v0.9.348", "feature"]);
     expect(names).not.toContain("release/v0.9.308");
+    expect(names).not.toContain("release/v0.9.318");
   });
 
   it("keeps the active release checkout even when local-only", () => {
@@ -46,11 +47,11 @@ describe("leftRailBranches stale release filter", () => {
     expect(isStaleLocalReleaseBranch(row("dev"))).toBe(false);
   });
 
-  it("keeps a release that still has a worktree_path even without origin", () => {
+  it("hides a leftover release worktree the user no longer wants", () => {
     expect(
       isStaleLocalReleaseBranch(
         row("release/v0.9.318", { worktree_path: "C:\\wt\\318" }),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
+++ b/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
@@ -64,9 +64,11 @@ describe("stacked fold labels", () => {
   it("formats Worked for / Thought / Ran chrome", () => {
     expect(workedForLabel(23_000)).toBe("Worked for 23s");
     expect(workedForLabel(6 * 60_000)).toBe("Worked for 6m");
-    expect(workedForLabel(0)).toBe("Worked for");
-    expect(workedForLabel(500)).toBe("Worked for");
+    expect(workedForLabel(0)).toBe("");
+    expect(workedForLabel(null)).toBe("");
+    expect(workedForLabel(500)).toBe("Worked for 1s");
     expect(workedForLabel(0)).not.toMatch(/0s/);
+    expect(workedForLabel(500)).not.toMatch(/0s/);
     expect(thoughtFoldLabel({ live: true })).toBe("Thinking…");
     expect(thoughtFoldLabel({ durationMs: 8_000 })).toBe("Thought 8s");
     expect(ranCommandsLabel(1)).toBe("Ran 1 command");

--- a/webapp/src/__tests__/turnProgress.test.ts
+++ b/webapp/src/__tests__/turnProgress.test.ts
@@ -406,6 +406,8 @@ describe("turnLooksAnswerComplete / shouldShowBusyFooter (T5)", () => {
 describe("looksLikeFinalAnswer / late Cursor tool insert", () => {
   it("treats short preambles as non-final and long/table answers as final", () => {
     expect(looksLikeFinalAnswer("I'll validate the schedule fixes.")).toBe(false);
+    expect(looksLikeFinalAnswer("Inspecting…")).toBe(false);
+    expect(looksLikeFinalAnswer("Investigating…")).toBe(false);
     expect(looksLikeFinalAnswer("x".repeat(240))).toBe(true);
     expect(
       looksLikeFinalAnswer(

--- a/webapp/src/__tests__/turnTerminal.wave3.test.ts
+++ b/webapp/src/__tests__/turnTerminal.wave3.test.ts
@@ -421,6 +421,10 @@ describe("Wave 3: truthful cause copy", () => {
 
   it("maps assistant_done causes onto the lifecycle", () => {
     expect(settleFromAssistantDone({ stopCause: "natural" }).lifecycle).toBe("settled_complete");
+    expect(settleFromAssistantDone({
+      stopCause: "natural",
+      incompleteReason: "length",
+    }).lifecycle).toBe("settled_incomplete");
     expect(settleFromAssistantDone({ stopCause: "turn_budget" }).lifecycle).toBe("settled_incomplete");
     expect(settleFromTransportEof({
       turnSettled: false,

--- a/webapp/src/__tests__/turnTerminal.wave3.test.ts
+++ b/webapp/src/__tests__/turnTerminal.wave3.test.ts
@@ -425,12 +425,47 @@ describe("Wave 3: truthful cause copy", () => {
       stopCause: "natural",
       incompleteReason: "length",
     }).lifecycle).toBe("settled_incomplete");
+    expect(settleFromAssistantDone({
+      stopCause: "natural",
+      incompleteReason: "length",
+    }).cause).toBe("length");
+    expect(settleFromAssistantDone({
+      stopCause: "natural",
+      incompleteReason: "max_output_tokens",
+    }).cause).toBe("length");
     expect(settleFromAssistantDone({ stopCause: "turn_budget" }).lifecycle).toBe("settled_incomplete");
     expect(settleFromTransportEof({
       turnSettled: false,
       userStopped: false,
       hasPartialAnswer: false,
     })).toMatchObject({ lifecycle: "aborted" });
+  });
+
+  it("incomplete_reason mid-finale seals Investigating chrome (turnOpen false, done)", () => {
+    const { state, apply } = makeApplyDeps();
+    apply({
+      kind: "thinking",
+      data: { text: "Investigating…", delta: true, stream_id: "rs_finale" },
+    });
+    apply({ kind: "message_delta", data: { text: "The fix should " } });
+    expect(state.turnOpen).toBe(true);
+    apply({
+      kind: "assistant_done",
+      data: {
+        stop_cause: "natural",
+        finish_reason: "incomplete",
+        incomplete_reason: "max_output_tokens",
+      },
+    });
+    expect(state.settle?.lifecycle).toBe("settled_incomplete");
+    expect(state.settle?.cause).toBe("length");
+    expect(state.turnOpen).toBe(false);
+    expect(state.status).toBe("done");
+    expect(state.turnSettledRef.current).toBe(true);
+    const thinking = state.items.find((it) => it.kind === "thinking") as
+      | Extract<Item, { kind: "thinking" }>
+      | undefined;
+    expect(thinking?.streaming).toBeFalsy();
   });
 });
 

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -468,6 +468,12 @@ export default function Conversation({
     return () => window.clearInterval(id);
   }, [busyStartedAt]);
   const busyElapsedMs = busyStartedAt != null ? Math.max(0, busyNow - busyStartedAt) : null;
+  // status idle/done/error clears busyStartedAt; keep the last tick so a
+  // just-sealed Worked for row still has a real duration.
+  const [lastBusyElapsedMs, setLastBusyElapsedMs] = useState<number | null>(null);
+  useEffect(() => {
+    if (busyElapsedMs != null && busyElapsedMs > 0) setLastBusyElapsedMs(busyElapsedMs);
+  }, [busyElapsedMs]);
   // Sticky until assistant_done / error / Stop — never infer end-of-turn from
   // transcript shape (mid-turn narration after tools looks like a final answer).
   // awaiting_swarm: model turn closed after background dispatch, but workers
@@ -3605,7 +3611,7 @@ export default function Conversation({
           editingIndex={editingIndex}
           auto={auto}
           plan={plan}
-          busyElapsedMs={busyElapsedMs}
+          busyElapsedMs={busyElapsedMs ?? lastBusyElapsedMs}
           turnOpen={turnOpen}
           holdSwarmAwait={holdSwarmAwait}
           feedSettled={feedSettled}

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -60,6 +60,11 @@ import {
 } from "../lib/turnProgress";
 import { isAgentLoopOpen } from "./conversation/runnersBusy";
 import {
+  isTrivialAssistantCrumb,
+  looksLikeStatusHeadline,
+  sanitizeThinkingStatusGlue,
+} from "./conversation/thinkingToolPrep";
+import {
   autoHaltPresentation,
   autoStatusPresentation,
   commandApprovalStatusCopy,
@@ -2110,6 +2115,15 @@ function cleanAssistantText(text: string): string {
   // never paint that string (it leaked as three stacked Bubbles on a fresh
   // idle session when crumbs already held the fallback).
   if (!result || isWorkingEllipsisFallback(result)) return "";
+  // Status headlines / ****-glued title frames belong in fold chrome — never as
+  // a spoken Bubble. Keep intentional markdown (**emphasis**) in real prose.
+  if (isTrivialAssistantCrumb(result) || looksLikeStatusHeadline(result)) return "";
+  if (/\*{2,}|_{2,}/.test(result)) {
+    const glued = sanitizeThinkingStatusGlue(result);
+    if (!glued || isTrivialAssistantCrumb(glued) || looksLikeStatusHeadline(glued)) {
+      return "";
+    }
+  }
   return result;
 }
 
@@ -2513,8 +2527,9 @@ function ActivityGroup({
   const sealedWorkMs = (() => {
     const fromItems = activityWorkDurationMs(items);
     if (fromItems != null && fromItems > 0) return fromItems;
-    // Sealed or live: a real wall-clock timer seeds Worked for (clamped to 1s).
-    if (busyElapsedMs != null && busyElapsedMs > 0) return busyElapsedMs;
+    // Live fold only: wall-clock busy timer seeds Worked for (label clamps to 1s).
+    // Prior folds must not inherit the current turn's busyElapsedMs.
+    if (isLiveFold && busyElapsedMs != null && busyElapsedMs > 0) return busyElapsedMs;
     // Tools/thinking ran but no duration was recorded — chrome is visible, so
     // show at least 1s instead of a bare "Worked for" label.
     if (actionCount > 0 || thinkingItems.length > 0) return 1000;

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -2512,8 +2512,12 @@ function ActivityGroup({
 
   const sealedWorkMs = (() => {
     const fromItems = activityWorkDurationMs(items);
-    if (fromItems != null) return fromItems;
-    if (isLiveFold && busyElapsedMs != null && busyElapsedMs >= 1000) return busyElapsedMs;
+    if (fromItems != null && fromItems > 0) return fromItems;
+    // Sealed or live: a real wall-clock timer seeds Worked for (clamped to 1s).
+    if (busyElapsedMs != null && busyElapsedMs > 0) return busyElapsedMs;
+    // Tools/thinking ran but no duration was recorded — chrome is visible, so
+    // show at least 1s instead of a bare "Worked for" label.
+    if (actionCount > 0 || thinkingItems.length > 0) return 1000;
     return null;
   })();
 
@@ -2573,6 +2577,11 @@ function ActivityGroup({
   ]
     .filter(Boolean)
     .join(" · ");
+
+  // No timer and no other sealed title → hide the Worked for row entirely.
+  if (!investigating && !String(quietSummary || "").trim()) {
+    return null;
+  }
 
   return (
     <div className="my-1 w-full" ref={foldRootRef} data-testid="activity-fold" data-worked-for={!investigating ? "1" : undefined}>

--- a/webapp/src/components/conversation/streamBubbles.ts
+++ b/webapp/src/components/conversation/streamBubbles.ts
@@ -203,7 +203,7 @@ export function appendStreamingTextToItems(
       kind: "msg",
       msg: {
         role: "assistant",
-        text: chunk,
+        text: sanitizeThinkingStatusGlue(chunk),
         streaming: true,
         isPlan: opts?.isPlan,
         ...(workerStream ? { workerStream: true } : {}),

--- a/webapp/src/components/conversation/thinkingToolPrep.ts
+++ b/webapp/src/components/conversation/thinkingToolPrep.ts
@@ -78,7 +78,7 @@ export function looksLikeStatusHeadline(text: string): boolean {
 export function sanitizeThinkingStatusGlue(text: string): string {
   const raw = String(text || "");
   if (!raw.includes("*") && !raw.includes("_")) return raw;
-  // Split on emphasis glue runs; if every non-empty part is a status headline,
+  // Split on emphasis glue runs; if ANY non-empty part is a status headline,
   // keep only the latest (Codex bold-title frames).
   const parts = raw
     .split(/\*{2,}|_{2,}/)
@@ -311,6 +311,8 @@ export type ToolPrepOpts = {
 export function looksLikeFinalAnswer(text: string): boolean {
   const t = (text || "").trim();
   if (!t) return false;
+  // Status headlines are fold chrome, not a 343 spoken finale.
+  if (looksLikeStatusHeadline(t)) return false;
   if (t.length >= 240) return true;
   if ((t.match(/\n/g) || []).length >= 3) return true;
   // Markdown table (audit validation summaries).

--- a/webapp/src/components/conversation/thinkingToolPrep.ts
+++ b/webapp/src/components/conversation/thinkingToolPrep.ts
@@ -49,7 +49,7 @@ export function isTrivialAssistantCrumb(text: string): boolean {
  * Discrete frames must replace each other — never glue with `****` or spaces.
  */
 const STATUS_HEADLINE_RE =
-  /^(Investigating|Explored|Diagnosing|Planning|Assessing|Searching|Looking|Thinking|Thought|Validating|Finalizing|Still working|Working)\b/i;
+  /^(Investigating|Explored|Diagnosing|Inspecting|Planning|Assessing|Searching|Looking|Thinking|Thought|Validating|Finalizing|Still working|Working)\b/i;
 
 /** Strip surrounding emphasis markers so `**Planning…**` compares as a title. */
 export function stripThinkingEmphasisChrome(text: string): string {

--- a/webapp/src/components/conversation/thinkingToolPrep.ts
+++ b/webapp/src/components/conversation/thinkingToolPrep.ts
@@ -84,8 +84,9 @@ export function sanitizeThinkingStatusGlue(text: string): string {
     .split(/\*{2,}|_{2,}/)
     .map((p) => p.trim())
     .filter(Boolean);
-  if (parts.length >= 2 && parts.every(looksLikeStatusHeadline)) {
-    return stripThinkingEmphasisChrome(parts[parts.length - 1]);
+  if (parts.length >= 2 && parts.some(looksLikeStatusHeadline)) {
+    const headlines = parts.filter(looksLikeStatusHeadline);
+    return stripThinkingEmphasisChrome(headlines[headlines.length - 1] || parts[parts.length - 1]);
   }
   // Marker-only crumbs already handled upstream; strip residual glue runs so
   // `redesign****Finalizing...` never paints literal asterisks.

--- a/webapp/src/components/conversation/transcriptRowHeight.ts
+++ b/webapp/src/components/conversation/transcriptRowHeight.ts
@@ -10,6 +10,11 @@
 import { layout, prepare, type PreparedText } from "@chenglou/pretext";
 import type { GroupedItem, Msg } from "../TranscriptList";
 import { isWorkingEllipsisFallback } from "../../lib/turnProgress";
+import {
+  isTrivialAssistantCrumb,
+  looksLikeStatusHeadline,
+  sanitizeThinkingStatusGlue,
+} from "./thinkingToolPrep";
 
 /** Canvas font strings synced with TranscriptList bubble typography. */
 export const TRANSCRIPT_USER_FONT =
@@ -131,6 +136,13 @@ export function assistantTextForMeasure(raw: string): string {
   // Match Bubble cleanAssistantText — empty after strip, or the Working...
   // placeholder itself, stays empty (never leak into fold chrome / heights).
   if (!result || isWorkingEllipsisFallback(result)) return "";
+  if (isTrivialAssistantCrumb(result) || looksLikeStatusHeadline(result)) return "";
+  if (/\*{2,}|_{2,}/.test(result)) {
+    const glued = sanitizeThinkingStatusGlue(result);
+    if (!glued || isTrivialAssistantCrumb(glued) || looksLikeStatusHeadline(glued)) {
+      return "";
+    }
+  }
   return result;
 }
 

--- a/webapp/src/components/leftRailBranches.ts
+++ b/webapp/src/components/leftRailBranches.ts
@@ -4,7 +4,7 @@ import type { Workspace } from "../lib/api";
  * Client-side mirror of harness.workspaces._is_stale_local_release.
  * Hides leftover local-only release/v0.9.* even when a stale SWR cache or
  * older API payload still lists them. Keep main/dev, the active checkout,
- * origin-backed names (when known), and a live worktree path.
+ * origin-backed names (when known). Leftover release worktrees are hidden.
  */
 export function isStaleLocalReleaseBranch(
   row: Pick<Workspace, "name" | "active" | "worktree_path">,
@@ -13,9 +13,8 @@ export function isStaleLocalReleaseBranch(
   const name = String(row.name || "");
   if (!name.startsWith("release/v0.9.")) return false;
   if (row.active) return false;
-  const wt = String(row.worktree_path || "").trim();
-  // Live worktree path present → keep (dir check is best-effort in the UI).
-  if (wt) return false;
+  // Leftover release worktrees stay on disk; hide them on the rail unless
+  // they are the active checkout or still on origin.
   if (originBranches) {
     const remote = originBranches instanceof Set
       ? originBranches

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -571,10 +571,6 @@ body.is-row-resizing iframe {
   user-select: text;
   font-weight: 400;
 }
-.transcript-msg-body strong,
-.transcript-msg-body b {
-  font-weight: 400;
-}
 .transcript-fold-chrome {
   font-weight: 400;
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -571,6 +571,10 @@ body.is-row-resizing iframe {
   user-select: text;
   font-weight: 400;
 }
+.transcript-msg-body strong,
+.transcript-msg-body b {
+  font-weight: 400;
+}
 .transcript-fold-chrome {
   font-weight: 400;
 }

--- a/webapp/src/lib/sessionTitleLock.ts
+++ b/webapp/src/lib/sessionTitleLock.ts
@@ -12,7 +12,7 @@ export function isActivityHeadlineText(text: string): boolean {
   if (/^Stopped\.?$/i.test(raw)) return true;
 
   const lineRe =
-    /^(Investigating|Explored|Diagnosing|Planning|Assessing|Still working|Looking|Thinking|Thought|Worked for|Ran\s+\d+\s+commands?|Working\.\.\.?)\b/i;
+    /^(Investigating|Explored|Diagnosing|Inspecting|Planning|Assessing|Still working|Looking|Thinking|Thought|Worked for|Ran\s+\d+\s+commands?|Working\.\.\.?)\b/i;
 
   const lines = raw
     .split(/\r?\n/)

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -452,15 +452,14 @@ export function formatFoldDuration(ms: number): string {
 
 /** Sealed outer activity fold — replaces Explored once the turn seals. */
 export function workedForLabel(durationMs?: number | null): string {
-  if (durationMs == null || !Number.isFinite(durationMs) || durationMs < 0) {
-    return "Worked for";
+  // No timer → hide the whole Worked for row (not a bare label).
+  if (durationMs == null || !Number.isFinite(durationMs) || durationMs <= 0) {
+    return "";
   }
-  // Empty / sub-second crumbs stay duration-less (never "Worked for 0s").
-  if (durationMs < 1000) {
-    return "Worked for";
-  }
-  const label = formatFoldDuration(durationMs);
-  return label ? `Worked for ${label}` : "Worked for";
+  // Visible chrome with a real elapsed always shows at least 1s (never 0s).
+  const shown = Math.max(durationMs, 1000);
+  const label = formatFoldDuration(shown);
+  return label ? `Worked for ${label}` : "";
 }
 
 /**

--- a/webapp/src/lib/turnTerminal.ts
+++ b/webapp/src/lib/turnTerminal.ts
@@ -206,6 +206,25 @@ export function isNaturalStopCause(cause: TerminalCause): boolean {
   return cause === CAUSE_NATURAL;
 }
 
+/**
+ * Map provider ``incomplete_reason`` onto a terminal cause.
+ * Empty → null (no incomplete signal). Unknown non-empty → incomplete.
+ */
+export function causeFromIncompleteReason(raw: unknown): TerminalCause | null {
+  const text = String(raw || "").trim();
+  if (!text) return null;
+  const lower = text.toLowerCase();
+  if (lower === "max_output_tokens" || lower === "length" || lower === "max_tokens") {
+    return CAUSE_LENGTH;
+  }
+  if (lower === "content_filter" || lower === "content_filtered") {
+    return CAUSE_CONTENT_FILTER;
+  }
+  const mapped = canonicalizeTerminalCause(text);
+  if (mapped !== CAUSE_UNSPECIFIED && mapped !== CAUSE_NATURAL) return mapped;
+  return CAUSE_INCOMPLETE;
+}
+
 export function isAuthoritativeComplete(opts: {
   stopCause?: unknown;
   userStopped?: boolean;
@@ -277,7 +296,7 @@ export function settleFromAssistantDone(opts: {
   liveJobs?: boolean;
 }): TurnSettle {
   const cause = canonicalizeTerminalCause(opts.stopCause);
-  const incomplete = String(opts.incompleteReason || "").trim();
+  const incompleteCause = causeFromIncompleteReason(opts.incompleteReason);
   if (opts.liveJobs) {
     return {
       kind: "settle",
@@ -292,17 +311,20 @@ export function settleFromAssistantDone(opts: {
   }
   // Model died mid-finale: backend may still send stop_cause=natural plus
   // incomplete_reason. Use existing incomplete chrome; do not hang Investigating.
-  if (incomplete) {
+  if (incompleteCause) {
+    const settledCause = isNaturalStopCause(cause) || cause === CAUSE_UNSPECIFIED
+      ? incompleteCause
+      : cause;
     return {
       kind: "settle",
       lifecycle: TURN_SETTLED_INCOMPLETE,
-      cause: isNaturalStopCause(cause) ? CAUSE_INCOMPLETE : cause,
+      cause: settledCause,
       status: "done",
       turnOpen: false,
       explanation: dirtyFinishExplanation({
-        cause: isNaturalStopCause(cause) ? CAUSE_INCOMPLETE : cause,
+        cause: settledCause,
         finishReason: opts.finishReason,
-      }) || terminalCauseCopy(CAUSE_INCOMPLETE),
+      }) || terminalCauseCopy(settledCause),
     };
   }
   if (isNaturalStopCause(cause)) {

--- a/webapp/src/lib/turnTerminal.ts
+++ b/webapp/src/lib/turnTerminal.ts
@@ -277,6 +277,7 @@ export function settleFromAssistantDone(opts: {
   liveJobs?: boolean;
 }): TurnSettle {
   const cause = canonicalizeTerminalCause(opts.stopCause);
+  const incomplete = String(opts.incompleteReason || "").trim();
   if (opts.liveJobs) {
     return {
       kind: "settle",
@@ -287,6 +288,21 @@ export function settleFromAssistantDone(opts: {
       explanation: isNaturalStopCause(cause)
         ? null
         : dirtyFinishExplanation({ cause, finishReason: opts.finishReason }),
+    };
+  }
+  // Model died mid-finale: backend may still send stop_cause=natural plus
+  // incomplete_reason. Use existing incomplete chrome; do not hang Investigating.
+  if (incomplete) {
+    return {
+      kind: "settle",
+      lifecycle: TURN_SETTLED_INCOMPLETE,
+      cause: isNaturalStopCause(cause) ? CAUSE_INCOMPLETE : cause,
+      status: "done",
+      turnOpen: false,
+      explanation: dirtyFinishExplanation({
+        cause: isNaturalStopCause(cause) ? CAUSE_INCOMPLETE : cause,
+        finishReason: opts.finishReason,
+      }) || terminalCauseCopy(CAUSE_INCOMPLETE),
     };
   }
   if (isNaturalStopCause(cause)) {


### PR DESCRIPTION
Haul of the four live 350 gaps on top of v0.9.351 (`ed611a95`). Pin stays `puppetmaster-ai==1.22.33`.

- Worked for: hide the row when there is no timer; show at least 1s when chrome is visible
- Bold + ****: add Inspecting to status headlines so Diagnosing…****Inspecting… cannot leak; spoken-body strong/b stay regular weight
- BRANCHES: hide leftover local release/v0.9.* including dead worktree leftovers (318); do not delete the directory; keep current/main/dev
- Dead ending: `incomplete_reason` on assistant_done settles TURN_SETTLED_INCOMPLETE even if stop_cause looks natural

No feed Motion. No new adapter. No merge, no tag in this PR.