### PR TITLE
v0.9.353: mixed swarm chrome, live PTY, one Worked-for

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.33` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.352, deliberately pre-1.0. Rides puppetmaster-ai==1.22.33. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.353, deliberately pre-1.0. Rides puppetmaster-ai==1.22.33. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.352"
+__version__ = "0.9.353"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/command_jobs.py
+++ b/harness/command_jobs.py
@@ -9,7 +9,12 @@ Never infers background from duration, timeout, or command text.
 """
 from __future__ import annotations
 
+import glob
 import hashlib
+import os
+import re
+import shutil
+import subprocess
 import threading
 import uuid
 from typing import Any, Dict, Optional
@@ -38,6 +43,56 @@ COMMAND_TERMINAL_STATES = frozenset({
 # Adapter/role labels that must NOT read as provider-swarm workers.
 COMMAND_JOB_ROLE = "command"
 COMMAND_JOB_ADAPTER = "command"
+
+_TMP_MARIONETTE_RE = re.compile(r"/tmp/marionette[-_./A-Za-z0-9]+")
+
+
+def reap_tmp_marionette_worktrees(command: str) -> list[str]:
+    """Remove /tmp/marionette-* git worktrees named in a backgrounded command.
+
+    A script trap never runs when the job is backgrounded or killed, so
+    detached worktrees leak. Only paths under /tmp/marionette are touched.
+    """
+    removed: list[str] = []
+    candidates: set[str] = set()
+    for raw in _TMP_MARIONETTE_RE.findall(command or ""):
+        raw = raw.rstrip("\\'\"")
+        if "XXXX" in raw:
+            prefix = raw.split("XXXX")[0]
+            candidates.update(glob.glob(prefix + "*"))
+        else:
+            if os.path.isdir(raw):
+                candidates.add(raw)
+            parent = os.path.dirname(raw)
+            base = os.path.basename(raw)
+            if parent == "/tmp" and base:
+                candidates.update(glob.glob(os.path.join("/tmp", base + ".*")))
+                candidates.update(glob.glob(os.path.join("/tmp", base + "*")))
+    for path in sorted(candidates):
+        real = os.path.realpath(path)
+        if not real.startswith("/tmp/marionette"):
+            continue
+        if not os.path.isdir(real):
+            continue
+        gitdir = os.path.join(real, ".git")
+        if not os.path.exists(gitdir):
+            continue
+        try:
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", real],
+                check=False,
+                capture_output=True,
+                timeout=20,
+            )
+        except Exception:
+            pass
+        if os.path.isdir(real):
+            shutil.rmtree(real, ignore_errors=True)
+        if not os.path.isdir(real):
+            removed.append(real)
+    return removed
+
+
 COMMAND_JOB_KIND = "run_command"
 
 # Inline output cap for pending/terminal receipts (matches foreground 50 KiB
@@ -429,6 +484,7 @@ def _run_registered_command_job(
             output_preview=spill_meta.get("output_preview") or "",
             run_status=run_status,
         )
+    reap_tmp_marionette_worktrees(command)
 
 
 def _terminal_summary(status: str, exit_code: int, output: str) -> str:

--- a/harness/internal_uri.py
+++ b/harness/internal_uri.py
@@ -73,6 +73,7 @@ class InternalUriContext:
     state_dir: str
     repo: Optional[str] = None
     session_id: Optional[str] = None
+    live_jobs: Optional[list] = None
 
     def store(self):
         if not self.state_dir:
@@ -113,6 +114,10 @@ def _local_jobs(ctx: InternalUriContext) -> list[dict]:
         row for row in rows
         if isinstance(row, dict) and str(row.get("id") or "").startswith("local-")
     ]
+    for row in (ctx.live_jobs or []):
+        if isinstance(row, dict) and str(row.get("id") or "").startswith("local-"):
+            if not any(str(v.get("id") or "") == str(row.get("id") or "") for v in valid):
+                valid.append(row)
     try:
         from .job_scoping import cwd_under_repo, filter_local_jobs
         visible = filter_local_jobs(
@@ -343,8 +348,10 @@ def search_internal_uris(
             for job in _local_jobs(ctx):
                 jid = str(job.get("id") or "")
                 goal = str(job.get("goal") or "")
-                if needle in goal.lower() or needle in jid.lower():
-                    hits.append(f"job://{jid}\t{goal[:120]}")
+                preview = str(job.get("command_preview") or job.get("command") or "")
+                hay = f"{jid} {goal} {preview}".lower()
+                if needle in hay:
+                    hits.append(f"job://{jid}\t{(preview or goal)[:120]}")
                     if len(hits) >= max_results:
                         break
         elif sch == "artifact":

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -214,10 +214,18 @@ class ToolDispatchMixin:
     """
 
     def _internal_uri_context(self) -> InternalUriContext:
+        live = []
+        fn = getattr(self, "live_local_jobs", None)
+        if callable(fn):
+            try:
+                live = list(fn() or [])
+            except Exception:
+                live = []
         return InternalUriContext(
             state_dir=getattr(self, "state_dir", None) or self.config.state_dir or "",
             repo=self.config.repo or None,
             session_id=getattr(self, "harness_session_id", None) or None,
+            live_jobs=live,
         )
 
     def _do_read_file(self, act: PilotAction) -> tuple[bool, str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.352"
+version = "0.9.353"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.352"
+version = "0.9.353"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.352",
+  "version": "0.9.353",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.352",
+      "version": "0.9.353",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.352",
+  "version": "0.9.353",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
-import SwarmPane, { jobIdentifier, jobSavings, namedSavings, workerSpend, workerOutcome } from "../components/SwarmPane";
+import SwarmPane, { jobDegradedWorkerCount, jobIdentifier, jobSavings, namedSavings, workerSpend, workerOutcome } from "../components/SwarmPane";
 import { api, type Job, type SwarmLive } from "../lib/api";
 import { dispatchProjectSelected } from "../lib/panelTransition";
 import { clearSWRCache, writeSWRCache } from "../lib/useStaleWhileRevalidate";
@@ -3208,5 +3208,114 @@ describe("SwarmPane v0.9.350 collapsed chrome", () => {
     expect(first?.className || "").toMatch(/border-b/);
     expect(first?.className || "").not.toMatch(/rounded-md/);
     expect(second?.className || "").toMatch(/border-b/);
+  });
+});
+
+describe("SwarmPane 353 mixed chrome and routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    clearSWRCache();
+    mockArtifacts.mockResolvedValue([]);
+  });
+
+  it("counts degraded workers so parent chrome is not clean-green", () => {
+    const job = {
+      id: "job-mix",
+      goal: "audit",
+      status: "complete",
+      tasks: [
+        { id: "t1", status: "complete", adapter: "agentic", role: "impl", instruction: "" },
+        { id: "t2", status: "complete", adapter: "agentic", role: "review", instruction: "" },
+        { id: "t3", status: "complete", adapter: "agentic", role: "map", instruction: "" },
+        { id: "t4", status: "complete", adapter: "agentic", role: "conflict", instruction: "" },
+        { id: "t5", status: "complete", adapter: "agentic", role: "ok", instruction: "" },
+      ],
+      artifacts: [
+        { type: "verification", headline: "d", task_id: "t1", result: "degraded" },
+        { type: "verification", headline: "d", task_id: "t2", result: "degraded" },
+        { type: "verification", headline: "d", task_id: "t3", result: "degraded" },
+        { type: "verification", headline: "d", task_id: "t4", result: "degraded" },
+      ],
+    } as Job;
+    expect(jobDegradedWorkerCount(job)).toBe(4);
+  });
+
+  it("paints mixed complete chrome instead of clean-green done", async () => {
+    mockSwarmLive.mockResolvedValue(
+      finishedJob("job-mix", "Audit swarm", {
+        tasks: [
+          { id: "t1", status: "complete", adapter: "agentic", role: "review", instruction: "" },
+          { id: "t2", status: "complete", adapter: "agentic", role: "ok", instruction: "" },
+        ],
+        artifacts: [
+          { type: "verification", headline: "weak", task_id: "t1", result: "degraded" },
+        ],
+        outcome: { quality: "ok", trustworthy: true, reasons: [] },
+      }),
+    );
+    const { container } = render(<SwarmPane />);
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    const row = await screen.findByRole("button", { name: /Audit swarm/ });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Workers")).toHaveTextContent("2/2 · 1 degraded");
+    });
+    // One-line chrome: warn glyph + done (not clean-green check).
+    expect(row.querySelector(".text-warn")).toBeTruthy();
+    expect(row.querySelector(".text-good")).toBeNull();
+    expect(screen.getByText(/^done$/)).toBeInTheDocument();
+    // 349 hold: hairline separators, not card boxes.
+    const card = container.querySelector('[data-job-id="job-mix"]');
+    expect(card?.className || "").toMatch(/border-b/);
+    expect(card?.className || "").not.toMatch(/rounded-md/);
+  });
+
+  it("shows a routed model as soon as ROUTING resolves by role", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        adapter: "agentic",
+        status: "running",
+        tasks: [
+          { id: "w1", status: "running", adapter: "agentic", role: "reviewer", instruction: "" },
+        ],
+        artifacts: [
+          { type: "ROUTING", headline: "routed", role: "reviewer", model: "openai/gpt-5.6" },
+        ],
+      }),
+    );
+    render(<SwarmPane />);
+    await expandVisibleJobs();
+    const worker = await screen.findByRole("button", { name: /reviewer/ });
+    expect(worker).toHaveTextContent("openai/gpt-5.6");
+    expect(worker).not.toHaveTextContent("routing…");
+  });
+
+  it("prefers task.model over an engine-only ROUTING stamp while live", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        adapter: "agentic",
+        status: "running",
+        tasks: [
+          {
+            id: "w1",
+            status: "running",
+            adapter: "agentic",
+            role: "impl",
+            instruction: "",
+            model: "gpt-5.3-codex",
+          },
+        ],
+        artifacts: [
+          { type: "ROUTING", headline: "routed", task_id: "w1", model: "agentic", created_by: "router" },
+        ],
+      }),
+    );
+    render(<SwarmPane />);
+    await expandVisibleJobs();
+    const worker = await screen.findByRole("button", { name: /impl/ });
+    expect(worker).toHaveTextContent("gpt-5.3-codex");
+    expect(worker).not.toHaveTextContent("routing…");
   });
 });

--- a/webapp/src/__tests__/agentLinks.test.ts
+++ b/webapp/src/__tests__/agentLinks.test.ts
@@ -362,6 +362,17 @@ describe("openAgentLink events", () => {
     expect(kinds).not.toContain("harness-focus-tab");
   });
 
+  it("prefers the live session over an unregistered job id", () => {
+    registerAgentCommandSession({ id: "pty-live", command: "pytest -q", output: "....\\n" });
+    const spy = vi.spyOn(window, "dispatchEvent");
+    openAgentCommand("pytest -q", { id: "local-cmd-dead", output: "" });
+    const ev = spy.mock.calls
+      .map((c) => c[0] as CustomEvent)
+      .find((e) => e.type === "harness-open-agent-terminal");
+    expect(ev?.detail?.id).toBe("pty-live");
+    expect(ev?.detail?.id).not.toBe("local-cmd-dead");
+  });
+
   it("opens the registered live session for a later chat command click", () => {
     registerAgentCommandSession({ id: "card-live", command: "git pull", output: "Already up to date.\n" });
     const spy = vi.spyOn(window, "dispatchEvent");

--- a/webapp/src/__tests__/composerStatusStack.test.ts
+++ b/webapp/src/__tests__/composerStatusStack.test.ts
@@ -243,4 +243,20 @@ describe("composerStatusStack", () => {
       output: "still running",
     });
   });
+
+  it("collapses command preview whitespace so the task bar does not stair-step", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const job = {
+      id: "local-cmd-wrap",
+      goal: "git status",
+      source: "harness",
+      status: "running",
+      updated_at: now - 1000,
+      job_kind: "run_command",
+      command_preview: "git status\n  && echo ok",
+    } as any;
+    const row = visibleCommandJob(job, now);
+    expect(row?.label).toBe("git status && echo ok");
+    expect(row?.command).toContain("git status");
+  });
 });

--- a/webapp/src/__tests__/composerTasks.test.ts
+++ b/webapp/src/__tests__/composerTasks.test.ts
@@ -16,6 +16,7 @@ describe("taskState", () => {
     expect(taskState("running")).toBe("in_progress");
     expect(taskState("pending")).toBe("pending");
     expect(taskState("failed")).toBe("failed");
+    expect(taskState("degraded")).toBe("degraded");
   });
 });
 
@@ -57,5 +58,24 @@ describe("buildComposerTasks + progress", () => {
       "reviewer · Audit the Marionette harness Python backend under harness/. React UI under webapp/src/.",
     );
     expect(tasks[0].content.includes("\n")).toBe(false);
+  });
+
+  it("paints degraded workers instead of clean-green complete", () => {
+    const tasks = buildComposerTasks({
+      id: "j",
+      goal: "audit",
+      status: "complete",
+      session_id: "sess-1",
+      tasks: [
+        { id: "ok", role: "impl", instruction: "ship", status: "complete", adapter: "x" },
+        { id: "deg", role: "review", instruction: "review", status: "complete", adapter: "x" },
+      ],
+      artifacts: [
+        { type: "verification", headline: "review", task_id: "deg", result: "degraded", failure: "capability" },
+      ],
+    } as Job);
+    expect(tasks[0].state).toBe("completed");
+    expect(tasks[1].state).toBe("degraded");
+    expect(taskProgress(tasks)).toEqual({ done: 2, total: 2 });
   });
 });

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.352)", () => {
-  it("declares the official motion package and 0.9.352 not 329", () => {
+describe("feed Motion (v0.9.353)", () => {
+  it("declares the official motion package and 0.9.353 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.352");
+    expect(pkg.version).toBe("0.9.353");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/jobClassification.test.ts
+++ b/webapp/src/__tests__/jobClassification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isCommandJob, isSwarmTrackerJob, isTrackerHire, isWaveCoordinator } from "../lib/jobClassification";
+import { countRunningTrackerJobs, isCommandJob, isRunningJobStatus, isSwarmTrackerJob, isTrackerHire, isWaveCoordinator } from "../lib/jobClassification";
 
 describe("isCommandJob", () => {
   it("matches job_kind and local-cmd id prefixes", () => {
@@ -83,5 +83,19 @@ describe("isSwarmTrackerJob allowlist", () => {
     expect(isSwarmTrackerJob({ id: "job-live", goal: "Live audit" } as any)).toBe(true);
     expect(isSwarmTrackerJob({ id: "job_par", goal: "run_parallel wave" })).toBe(true);
     expect(isTrackerHire({ job_kind: "run_swarm" })).toBe(true);
+  });
+});
+
+describe("countRunningTrackerJobs", () => {
+  it("pulses only real swarm hires, not run_command terminals", () => {
+    expect(isRunningJobStatus("running")).toBe(true);
+    expect(isRunningJobStatus("in_progress")).toBe(true);
+    expect(isRunningJobStatus("complete")).toBe(false);
+    expect(countRunningTrackerJobs([
+      { id: "local-cmd-1", job_kind: "run_command", status: "running" },
+      { id: "job_abc", job_kind: "run_swarm", status: "running" },
+      { id: "job_done", job_kind: "run_swarm", status: "complete" },
+      { id: "local-wave-1", job_kind: "parallel_wave", status: "running" },
+    ])).toBe(1);
   });
 });

--- a/webapp/src/__tests__/thinkingStreamUx.test.ts
+++ b/webapp/src/__tests__/thinkingStreamUx.test.ts
@@ -274,6 +274,39 @@ describe("swarm terminal rows stay inside the activity strip", () => {
       "thinking",
     ]);
   });
+
+  it("one Worked-for fold after spoken prose plus a later sealed swarm", () => {
+    const items: Item[] = [
+      { kind: "thinking", id: "th-1", text: "Inspecting the repo." },
+      {
+        kind: "card",
+        card: { id: "ran-1", goal: "git status", running: false, open: false },
+      },
+      { kind: "msg", msg: { role: "assistant", text: "Here is the first look." } },
+      {
+        kind: "swarm_pending",
+        job_ids: ["job-later"],
+        objective: "audit",
+        status: "done",
+      },
+      {
+        kind: "swarm_result",
+        job_id: "job-later",
+        applied: true,
+        files: [],
+        summary: "complete",
+        error: null,
+      },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    expect(grouped.map((row) => row.kind)).toEqual(["activity_group", "msg"]);
+    if (grouped[0].kind !== "activity_group") return;
+    expect(grouped[0].items.map((item) => item.kind)).toEqual([
+      "thinking",
+      "card",
+      "swarm_result",
+    ]);
+  });
 });
 
 describe("feed collapse: telemetry joins the activity strip", () => {
@@ -1846,5 +1879,46 @@ describe("worker_delta / message_delta stream isolation", () => {
     expect(workers[1].msg.worker_id).toBe("local-bb");
     expect(workers[1].msg.text).toBe("beta-1");
     expect(workers[1].msg.streaming).toBe(true);
+  });
+});
+
+describe("353 feed extras", () => {
+  it("folds swarm FAILED spoken text into the activity strip", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "audit" } },
+      { kind: "msg", msg: { role: "assistant", text: "[swarm FAILED for: audit the router] worker failed" } },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    expect(grouped.map((row) => row.kind)).toEqual(["msg", "activity_group"]);
+    if (grouped[1].kind !== "activity_group") return;
+    expect(grouped[1].items.some((item) => item.kind === "msg")).toBe(true);
+  });
+
+  it("hides empty assistant crumbs after a wait", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "go" } },
+      { kind: "msg", msg: { role: "assistant", text: "" } },
+      { kind: "msg", msg: { role: "assistant", text: "***" } },
+      { kind: "msg", msg: { role: "assistant", text: "Done." } },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    const msgs = grouped.filter((row) => row.kind === "msg");
+    expect(msgs).toHaveLength(2);
+    if (msgs[1].kind !== "msg") return;
+    expect(msgs[1].msg.text).toBe("Done.");
+  });
+
+  it("does not paint phantom done swarm_pending before the first user message", () => {
+    const items: Item[] = [
+      {
+        kind: "swarm_pending",
+        job_ids: ["job-phantom"],
+        objective: "stale leftover",
+        status: "done",
+      },
+      { kind: "msg", msg: { role: "user", text: "new turn" } },
+    ];
+    const grouped = groupAgentActivity(items, new Set());
+    expect(grouped.map((row) => row.kind)).toEqual(["msg"]);
   });
 });

--- a/webapp/src/components/RightDock.tsx
+++ b/webapp/src/components/RightDock.tsx
@@ -18,6 +18,7 @@ import {
 import { api } from "../lib/api";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
 import { writeSWRCache } from "../lib/useStaleWhileRevalidate";
+import { countRunningTrackerJobs } from "../lib/jobClassification";
 
 /** Curated destinations for the floating tool windows — Cursor-style icon strip.
  *  Settings is pinned to the foot of the floating pill. */
@@ -135,11 +136,7 @@ export default function RightDock({
           // so expanding into the tracker after a collapsed session is warm too.
           writeSWRCache(`swarm:${swarmRepo || "__default__"}`, data);
           const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
-          const n = jobs.filter((j) => {
-            const s = (j.status || "").toLowerCase();
-            return s.includes("run") || s.includes("progress") || s.includes("active");
-          }).length;
-          setSwarmRunning(n);
+          setSwarmRunning(countRunningTrackerJobs(jobs));
         })
         .catch(() => {
           /* keep last known; dot is best-effort */

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -16,6 +16,7 @@ import { api, type PendingReview } from "../lib/api";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
 import { usePolling } from "../lib/usePolling";
 import { writeSWRCache } from "../lib/useStaleWhileRevalidate";
+import { countRunningTrackerJobs } from "../lib/jobClassification";
 import {
   isSettingsOverlayOpen,
   setSettingsOverlayOpen,
@@ -595,11 +596,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
         // "Loading swarm jobs..." flash — the tab light already polls this payload.
         writeSWRCache(`swarm:${swarmRepo || "__default__"}`, data);
         const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
-        const n = jobs.filter((j) => {
-          const s = (j.status || "").toLowerCase();
-          return s.includes("run") || s.includes("progress") || s.includes("active");
-        }).length;
-        setSwarmRunning(n);
+        setSwarmRunning(countRunningTrackerJobs(jobs));
       })
       .catch(() => {
         /* keep last known; tab light is best-effort */

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -425,6 +425,38 @@ function associateRoutingToTasks(
       }
     }
   }
+  // Role match: ROUTING often stamps role before task_id. Show the resolved
+  // model as soon as routing lands — do not wait for the card to finish.
+  const used = new Set(routingForTask.values());
+  for (const task of tasks) {
+    if (routingForTask.has(task.id)) continue;
+    const role = (task.role || "").trim().toLowerCase();
+    if (!role) continue;
+    const hit = arts.find((a) => {
+      if (used.has(a)) return false;
+      const tid = (a.task_id || "").trim();
+      // Never steal a ROUTING row already scoped to a different worker.
+      if (tid && tid !== task.id) return false;
+      const artRole = (a.role || "").trim().toLowerCase();
+      return artRole === role && !!(a.model || a.adapter_model_name || "").trim();
+    });
+    if (hit) {
+      routingForTask.set(task.id, hit);
+      used.add(hit);
+      if (isUnscopedRouting(hit)) consumedUnscoped.add(hit);
+    }
+  }
+  const unmatchedTasks = tasks.filter((t) => !routingForTask.has(t.id));
+  if (unmatchedTasks.length === 1) {
+    const best = bestUnscopedRouting(arts);
+    if (best && (best.model || "").trim() && !used.has(best)) {
+      routingForTask.set(unmatchedTasks[0].id, best);
+      used.add(best);
+      for (const art of arts) {
+        if (isUnscopedRouting(art)) consumedUnscoped.add(art);
+      }
+    }
+  }
   const ids = new Set(tasks.map((t) => t.id));
   const unmatched = arts.filter((a) => {
     if (consumedUnscoped.has(a)) return false;
@@ -456,6 +488,19 @@ export function workerOutcome(task: Task, failureArt?: Artifact | null): WorkerO
   if (unsuccessful && (life === "done" || life === "idle")) return "degraded";
   if (life === "done") return "ok";
   return "idle";
+}
+
+/** How many workers finished degraded or failed. Parent chrome must not paint these as clean-green. */
+export function jobDegradedWorkerCount(job: Job): number {
+  const tasks = job.tasks || [];
+  const arts = jobArtifactList(job);
+  const failureForTask = failureArtifactsByTaskId(arts);
+  let n = 0;
+  for (const t of tasks) {
+    const o = workerOutcome(t, failureForTask.get(t.id));
+    if (o === "degraded" || o === "failed") n += 1;
+  }
+  return n;
 }
 
 function WorkerOutcomeGlyph({ outcome }: { outcome: WorkerOutcome }) {
@@ -538,23 +583,49 @@ function isInFlightWorker(task: Task): boolean {
 
 function workerModelView(task: Task, routing?: Artifact): WorkerModelView {
   const adapterLabel = (task.adapter || "").trim();
-  // Associated final ROUTING wins over a stale task.model preview from an earlier poll.
-  const rawModel = (routing?.model || task.model || "").trim();
   const policy = routing ? routingPolicy(routing) : "";
-  const display = displayModelId(rawModel, {
-    policy,
-    adapterFallback: isEngineOnlyModelId(adapterLabel) ? "" : adapterLabel,
-  });
+  const adapterFallback = isEngineOnlyModelId(adapterLabel) ? "" : adapterLabel;
+  // Prefer a real routed id over an engine-only ROUTING stamp. PM may leave
+  // task.model empty until the card seals even after ROUTING resolves — paint
+  // the artifact model immediately; do not invent a Puppetmaster pin bump.
+  const candidates = [
+    routing?.model,
+    routing?.adapter_model_name,
+    task.model,
+  ];
+  let rawModel = "";
+  let display = "";
+  for (const candidate of candidates) {
+    const raw = String(candidate || "").trim();
+    if (!raw) continue;
+    const shown = displayModelId(raw, { policy, adapterFallback });
+    if (shown) {
+      rawModel = raw;
+      display = shown;
+      break;
+    }
+    if (!rawModel) rawModel = raw;
+  }
+  if (!display) {
+    // Empty candidates still surface a non-engine adapter chip (openrouter, …).
+    display = displayModelId(rawModel, { policy, adapterFallback });
+  }
   const ts = taskState(task);
   const pinned = policy === "explicit_pin";
   if (display) {
     return { rawModel, display, slot: display, pending: false, residual: false, pinned, policy, routing };
   }
-  if (isInFlightWorker(task)) {
+  // Associated ROUTING with a model stamp means routing finished — never keep
+  // the live "routing…" spinner just because displayModelId stripped engines.
+  const routingResolved = !!routing && !!(
+    String(routing.model || "").trim()
+    || String(routing.adapter_model_name || "").trim()
+  );
+  if (isInFlightWorker(task) && !routingResolved) {
     return { rawModel, display, slot: "routing…", pending: true, residual: false, pinned: false, policy, routing };
   }
   const meaningfulResidual =
-    ts === "fail" || isEngineOnlyModelId(adapterLabel) || isEngineOnlyModelId(rawModel);
+    ts === "fail" || isEngineOnlyModelId(adapterLabel) || isEngineOnlyModelId(rawModel) || routingResolved;
   return {
     rawModel,
     display,
@@ -972,6 +1043,8 @@ function jobPhase(j: Job): { key: string; label: string; index: number; failed: 
     return { key: label, label, index: reached, failed: true };
   }
   if (st === "completed") {
+    // Worker-level degraded paints on the one-line progress chip + warn glyph;
+    // keep phase as outcome quality / "done" (never invent a second row).
     const label = j.outcome?.trustworthy === false ? j.outcome.quality : "done";
     return { key: "done", label, index: 3, failed: false };
   }
@@ -1461,7 +1534,8 @@ export default function SwarmPane() {
   // instead of threading a dozen props.
   const renderJob = (j: Job) => {
     const st = jobStatus(j);
-    const outcomeWarning = st === "completed" && j.outcome?.trustworthy === false;
+    const degradedWorkers = jobDegradedWorkerCount(j);
+    const outcomeWarning = st === "completed" && (j.outcome?.trustworthy === false || degradedWorkers > 0);
     const manualExpanded = expandedJobs[j.id];
     const isExpanded = manualExpanded === true;
     const phase = jobPhase(j);
@@ -1534,7 +1608,7 @@ export default function SwarmPane() {
           role="button"
           tabIndex={0}
           aria-expanded={isExpanded}
-          aria-label={`${j.goal || "Swarm job"}, ${phase.label}`}
+          aria-label={`${j.goal || "Swarm job"}, ${phase.label}${degradedWorkers > 0 ? `, ${degradedWorkers} degraded` : ""}`}
           onClick={toggle}
           onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); } }}
           className={`w-full flex items-center gap-2 py-1 px-1.5 hover:bg-panel2/25 text-left transition-colors select-none cursor-pointer min-h-[1.625rem] ${DISCLOSURE_FOCUS}`}
@@ -1548,7 +1622,7 @@ export default function SwarmPane() {
             ) : st === "failed" ? (
               <XCircle size={12} className="text-risk" />
             ) : outcomeWarning ? (
-              <Circle size={12} className="text-warn" />
+              <AlertTriangle size={12} className="text-warn" />
             ) : st === "completed" ? (
               <CheckCircle2 size={12} className="text-good" />
             ) : st === "cancelled" ? (
@@ -1560,11 +1634,16 @@ export default function SwarmPane() {
           <Tooltip label={j.goal} className="font-semibold text-[11px] text-txt truncate min-w-0 flex-1">
             {j.goal}
           </Tooltip>
-          {showWorkerProgress && (
+          {showWorkerProgress && (() => {
+            const progressText = [
+              `${finishedWorkers}/${workerCount}`,
+              degradedWorkers > 0 ? `${degradedWorkers} degraded` : "",
+            ].filter(Boolean).join(" · ");
+            return (
             <span
               className="inline-flex items-center gap-1 shrink-0"
               aria-label="Workers"
-              title={`${finishedWorkers} of ${workerCount} workers terminal`}
+              title={`${finishedWorkers} of ${workerCount} workers terminal${degradedWorkers > 0 ? `, ${degradedWorkers} degraded` : ""}`}
             >
               <span
                 className="h-0.5 w-8 rounded-full bg-edge/50 overflow-hidden"
@@ -1572,7 +1651,9 @@ export default function SwarmPane() {
               >
                 <span
                   className={`block h-full rounded-full transition-[width] ${
-                    workerProgressFull ? "bg-good/70 w-full" : "bg-accent/70"
+                    workerProgressFull
+                      ? (degradedWorkers > 0 ? "bg-warn/70 w-full" : "bg-good/70 w-full")
+                      : "bg-accent/70"
                   }`}
                   style={{
                     width: workerProgressFull
@@ -1581,11 +1662,14 @@ export default function SwarmPane() {
                   }}
                 />
               </span>
-              <span className="text-[9px] text-muted tabular-nums font-mono">
-                {finishedWorkers}/{workerCount}
+              <span className={`text-[9px] tabular-nums font-mono ${
+                degradedWorkers > 0 ? "text-warn/80" : "text-muted"
+              }`}>
+                {progressText}
               </span>
             </span>
-          )}
+            );
+          })()}
           <span className={`text-[9px] font-medium tabular-nums shrink-0 ${
             phase.key === "cancelled"
               ? "text-muted"

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -697,6 +697,14 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
   const flush = () => {
     const activityItems = [...currentGroup, ...terminalSwarmItems];
     if (activityItems.length > 0) {
+      const prior = bridgeTarget || activityGroupAcrossSpokenProse(grouped);
+      if (prior) {
+        prior.push(...activityItems);
+        currentGroup = [];
+        terminalSwarmItems = [];
+        bridgeTarget = prior;
+        return;
+      }
       grouped.push({ kind: "activity_group", items: activityItems });
       currentGroup = [];
       terminalSwarmItems = [];
@@ -704,7 +712,7 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
     bridgeTarget = null;
   };
 
-  const pushActivity = (item: ActivityItem, live = false) => {
+  const pushActivity = (item: ActivityItem, _live = false) => {
     if (currentGroup.length > 0 || terminalSwarmItems.length > 0) {
       currentGroup.push(item);
       return;
@@ -713,17 +721,19 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
       bridgeTarget.push(item);
       return;
     }
-    if (live) {
-      const prior = activityGroupAcrossSpokenProse(grouped);
-      if (prior) {
-        prior.push(item);
-        bridgeTarget = prior;
-        return;
-      }
+    // One Worked-for / Investigating fold per turn. After spoken prose
+    // flushes the strip, later tools / swarm / thoughts rejoin that fold
+    // even when they are already sealed.
+    const prior = activityGroupAcrossSpokenProse(grouped);
+    if (prior) {
+      prior.push(item);
+      bridgeTarget = prior;
+      return;
     }
     currentGroup.push(item);
   };
 
+  let seenUser = false;
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     if (item.kind === "thinking" && (!item.text || !item.text.trim())) continue;
@@ -731,9 +741,18 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
     if (item.kind === "tool_prep") continue;
 
     if (item.kind === "msg") {
+      if (item.msg.role === "user") seenUser = true;
       // Spoken-prose "Working..." fallback is not a message. Empty session
       // used to paint three of these as stacked Bubbles.
       if (item.msg.role === "assistant" && isWorkingEllipsisFallback(item.msg.text)) {
+        continue;
+      }
+      if (item.msg.role === "assistant" && isTrivialAssistantCrumb(item.msg.text)) {
+        continue;
+      }
+      // [swarm FAILED for: ...] / [swarm result for: ...] stay swarm chrome.
+      if (item.msg.role === "assistant" && /^\[swarm (FAILED|result) for:/i.test(String(item.msg.text || "").trim())) {
+        pushActivity(item);
         continue;
       }
       // Post-tool micro-narration folds into the investigation box. Pre-tool
@@ -760,6 +779,8 @@ export function groupAgentActivity(items: Item[], intermediateItems: Set<Item>):
       grouped.push(item);
     } else if (item.kind === "swarm_pending") {
       const status = item.status || (item.resolved ? "done" : "running");
+      // Phantom done rows that land before the first user message are leftovers.
+      if (!seenUser && status !== "running") continue;
       if (status === "running") {
         // Keep the live swarm pill inside the current Investigating fold with
         // surrounding tool cards / reasoning — including across a top-level

--- a/webapp/src/components/conversation/ComposerStatusStack.tsx
+++ b/webapp/src/components/conversation/ComposerStatusStack.tsx
@@ -4,6 +4,7 @@ import { openAgentCommand, openAgentSwarmJob } from "../../lib/agentLinks";
 import {
   getAgentCommandIndexVersion,
   listAgentCommandSessions,
+  registerAgentCommandSession,
   subscribeAgentCommandIndex,
 } from "../../lib/agentCommandIndex";
 import { buildComposerStatusStackRows, type ComposerStatusStackRow } from "./composerStatusStackData";
@@ -48,6 +49,18 @@ export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly
     () => buildComposerStatusStackRows({ swarmJobs, commandSessions, nowMs: nowTick }),
     [commandSessions, nowTick, swarmJobs],
   );
+
+  useEffect(() => {
+    for (const row of rows) {
+      if (row.kind !== "terminal" || !row.command) continue;
+      registerAgentCommandSession({
+        id: row.id,
+        command: row.command,
+        output: row.output || "",
+        state: row.state,
+      });
+    }
+  }, [rows]);
   const hasTerminalRows = rows.some((row) => row.state !== "running");
 
   useEffect(() => {

--- a/webapp/src/components/conversation/ComposerTasksPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTasksPanel.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { CheckCircle2, ChevronDown, ChevronRight, Circle, Loader2, ListChecks, XCircle } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Circle, Loader2, ListChecks, XCircle } from "lucide-react";
 import type { Job } from "../../lib/api";
 import { buildComposerTasks, pickTaskSourceJob, taskProgress, type ComposerTask } from "../../lib/composerTasks";
 import { COMPOSER_FAMILY_SURFACE } from "./composerFamily";
 
 function TaskIcon({ state }: { state: ComposerTask["state"] }) {
   if (state === "completed") return <CheckCircle2 size={11} className="shrink-0 text-good" />;
+  if (state === "degraded") return <AlertTriangle size={11} className="shrink-0 text-warn" />;
   if (state === "failed") return <XCircle size={11} className="shrink-0 text-risk" />;
   if (state === "in_progress") return <Loader2 size={11} className="shrink-0 animate-spin text-accent" />;
   return <Circle size={11} className="shrink-0 text-faint" />;

--- a/webapp/src/components/conversation/composerStatusStackData.ts
+++ b/webapp/src/components/conversation/composerStatusStackData.ts
@@ -66,6 +66,10 @@ function normalizeState(status: unknown): ComposerStatusStackState {
   return "running";
 }
 
+function oneLinePreview(text: string): string {
+  return String(text || "").replace(/\s+/g, " ").trim();
+}
+
 function jobAccountingOwned(job: Job): boolean {
   if (job.accounting_owned === true) return true;
   if (job.accounting_owned === false) return false;
@@ -113,7 +117,7 @@ export function visibleCommandJob(job: Job, nowMs: number): ComposerStatusStackR
   const id = String(job.id || "").trim();
   if (!id) return null;
   const command = String(job.command_preview || job.goal || "").trim();
-  const label = command || String(job.role || job.id || "").trim() || id;
+  const label = oneLinePreview(command) || String(job.role || job.id || "").trim() || id;
   const receipt = job.terminal_receipt;
   const output = receipt && typeof receipt.summary === "string" ? receipt.summary : undefined;
   return {
@@ -141,10 +145,10 @@ function visibleCommandSession(
   return {
     id,
     kind: "terminal",
-    label: command,
+    label: oneLinePreview(command),
     state,
     updatedAt: session.updatedAt,
-    title: command,
+    title: oneLinePreview(command),
     command,
     output: session.output,
   };

--- a/webapp/src/lib/agentLinks.ts
+++ b/webapp/src/lib/agentLinks.ts
@@ -542,8 +542,10 @@ export type OpenAgentCommandOpts = {
 export function openAgentCommand(command: string, opts?: OpenAgentCommandOpts): void {
   const cmd = (command || "").trim();
   if (!cmd) return;
-  const live = !opts?.id ? lookupAgentCommandSession(cmd) : null;
-  const id = String(opts?.id || live?.id || "").trim();
+  const byId = opts?.id ? lookupAgentCommandSessionById(opts.id) : null;
+  const byCmd = lookupAgentCommandSession(cmd);
+  const live = byId || byCmd;
+  const id = String(live?.id || "").trim();
   const output = String(opts?.output || live?.output || "");
   // Speculative transcript clicks used to mint a blank agent-terminal
   // mirror. Fail closed unless this is an interactive inject or a real
@@ -557,7 +559,8 @@ export function openAgentCommand(command: string, opts?: OpenAgentCommandOpts): 
       );
       return;
     }
-    const revealId = id || stableCommandId(cmd);
+    const revealId = id || (output ? (String(opts?.id || "").trim() || stableCommandId(cmd)) : "");
+    if (!revealId) return;
     registerAgentCommandSession({ id: revealId, command: cmd, output });
     seedAgentTerminalCommand(revealId, cmd);
     if (output) syncAgentTerminalSnapshot(revealId, output);

--- a/webapp/src/lib/composerTasks.ts
+++ b/webapp/src/lib/composerTasks.ts
@@ -1,7 +1,7 @@
 import type { Job, Task } from "./api";
 import { jobInActiveSession } from "./jobScope";
 
-export type ComposerTaskState = "pending" | "in_progress" | "completed" | "failed";
+export type ComposerTaskState = "pending" | "in_progress" | "completed" | "failed" | "degraded";
 
 export type ComposerTask = {
   id: string;
@@ -12,6 +12,7 @@ export type ComposerTask = {
 export function taskState(status: unknown): ComposerTaskState {
   const s = String(status || "").trim().toLowerCase();
   if (s.includes("fail") || s.includes("error") || s.includes("dead")) return "failed";
+  if (s.includes("degrad")) return "degraded";
   if (s.includes("complete") || s.includes("done") || s === "ok" || s.includes("success")) return "completed";
   if (s.includes("run") || s.includes("progress") || s.includes("active")) return "in_progress";
   return "pending";
@@ -44,17 +45,36 @@ function oneLineLabel(task: Task): string {
   return instruction || role || String(task.id || "Task");
 }
 
+function artifactLooksFailed(art: { result?: unknown; type?: unknown; failure?: unknown; task_id?: unknown }): boolean {
+  const result = String(art.result || "").trim().toLowerCase();
+  const kind = String(art.type || "").trim().toLowerCase();
+  return !!art.failure
+    || result === "failed"
+    || result === "blocked"
+    || result === "error"
+    || result === "degraded"
+    || kind === "error";
+}
+
 export function buildComposerTasks(job: Job | null): ComposerTask[] {
-  return (job?.tasks || []).map((task: Task, i) => ({
-    id: String(task.id || `${job?.id || "job"}-${i}`),
-    content: oneLineLabel(task),
-    state: taskState(task.status),
-  }));
+  const arts = Array.isArray(job?.artifacts) ? job.artifacts as { result?: unknown; type?: unknown; failure?: unknown; task_id?: unknown }[] : [];
+  return (job?.tasks || []).map((task: Task, i) => {
+    let state = taskState(task.status);
+    if (state === "completed") {
+      const fail = arts.find((a) => String(a.task_id || "") === String(task.id || "") && artifactLooksFailed(a));
+      if (fail) state = "degraded";
+    }
+    return {
+      id: String(task.id || `${job?.id || "job"}-${i}`),
+      content: oneLineLabel(task),
+      state,
+    };
+  });
 }
 
 export function taskProgress(tasks: readonly ComposerTask[]): { done: number; total: number } {
   return {
-    done: tasks.filter((t) => t.state === "completed").length,
+    done: tasks.filter((t) => t.state === "completed" || t.state === "degraded").length,
     total: tasks.length,
   };
 }

--- a/webapp/src/lib/jobClassification.ts
+++ b/webapp/src/lib/jobClassification.ts
@@ -22,6 +22,7 @@ export type CommandJobSignals = {
   job_kind?: string | null;
   role?: string | null;
   adapter?: string | null;
+  status?: string | null;
 };
 
 function norm(value: unknown): string {
@@ -85,3 +86,12 @@ export function isSwarmTrackerJob(job: CommandJobSignals): boolean {
 
 /** Alias used by SwarmPane / composer stack. */
 export const isTrackerJob = isSwarmTrackerJob;
+
+export function isRunningJobStatus(status: unknown): boolean {
+  const s = String(status || "").toLowerCase();
+  return s.includes("run") || s.includes("progress") || s.includes("active");
+}
+
+export function countRunningTrackerJobs(jobs: readonly CommandJobSignals[]): number {
+  return jobs.filter((j) => isSwarmTrackerJob(j) && isRunningJobStatus(j.status)).length;
+}


### PR DESCRIPTION
## Summary
- Mixed/degraded parent swarm chrome instead of clean-green 5/5 done; Tasks icons match
- Show the routed model as soon as ROUTING resolves; `routing…` only while actually routing
- One Worked-for / Investigating fold per turn (352 `lastBusyElapsedMs` hold)
- Light border box around each Swarm Tracker job; 349 one-line collapsed chrome
- Open terminal / task-bar click prefers the live command PTY (342 run_command stays a terminal)
- Yellow swarm-rail pulse only for real tracker hires, not background `run_command`
- Task-bar command preview is one line (stored command unchanged)
- `search_state` indexes live `local-cmd-*` jobs
- Backgrounded commands reap leaked `/tmp/marionette-*` worktrees
- Hide empty wait crumbs; fold `[swarm FAILED for: …]` as swarm chrome; drop phantom done `swarm_pending` before the first user message

Pin stays `puppetmaster-ai==1.22.33`. One PR. No 354. No Motion. No new adapter.

## Test plan
- [x] jobClassification / composerTasks / agentLinks / composerStatusStack / SwarmPane unit tests
- [ ] CI frontend-build + harness tests on this SHA
- [ ] CoS merges+tags when green