### PR TITLE
v0.9.354: foreground command jobs, cancel reap, session-fence pending, Stop assistant_done

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.33` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.353, deliberately pre-1.0. Rides puppetmaster-ai==1.22.33. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.354, deliberately pre-1.0. Rides puppetmaster-ai==1.22.33. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.353"
+__version__ = "0.9.354"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/busy_control.py
+++ b/harness/busy_control.py
@@ -187,6 +187,35 @@ class BusyControlMixin:
                 release(reason="interrupt")
         except Exception:
             pass
+        try:
+            self._emit_stop_assistant_done()
+        except Exception:
+            pass
+
+    def _emit_stop_assistant_done(self) -> None:
+        """Stop must settle the receipt and SSE ring even if the generator is blocked.
+
+        Does not start a new ring generation. Best-effort; never raises.
+        """
+        try:
+            from harness.send_loop_phases import mark_latest_receipt_assistant_done
+            mark_latest_receipt_assistant_done(self, stop_cause="cancelled")
+        except Exception:
+            pass
+        try:
+            from harness.api.sse import _sse_ring_lookup
+            sid = str(getattr(self, "harness_session_id", "") or "").strip()
+            if not sid:
+                return
+            ring = _sse_ring_lookup(sid)
+            if ring is None:
+                return
+            ring.append(
+                "assistant_done",
+                {"stop_cause": "cancelled", "reason": "user_stop"},
+            )
+        except Exception:
+            return
 
     def _interrupt_owner_tokens(self) -> list:
         """Cancel Events that own in-flight run_cancellable trees for this session."""

--- a/harness/command_jobs.py
+++ b/harness/command_jobs.py
@@ -1,9 +1,10 @@
-"""Opt-in durable background ``run_command`` jobs on the local-job seam.
+"""Durable ``run_command`` jobs on the local-job seam.
 
 Wave 2 of chat-loop resilience: an explicit ``PilotAction.background`` flag
 registers a Marionette-owned local command job *before* process launch and
 returns a pending receipt without holding the pilot turn open. Foreground
-``run_command`` stays on the synchronous ``_do_run_command`` path.
+``run_command`` stays on the synchronous ``_do_run_command`` path but also
+gets a ``local-cmd-*`` tracker row so Stop / search_state can find it.
 
 Never infers background from duration, timeout, or command text.
 """
@@ -337,6 +338,73 @@ def start_background_run_command(
     return receipt
 
 
+def register_foreground_command_job(session: Any, act: Any, action_id: str) -> str:
+    """Allocate a ``local-cmd-*`` row for a synchronous foreground command.
+
+    Best-effort: missing register helpers return ``\"\"`` so dispatch still
+    runs the command. Never persists the raw command string.
+    """
+    register = getattr(session, "_register_command_job", None)
+    if not callable(register):
+        return ""
+    command = str(getattr(act, "command", "") or "")
+    repo = str(getattr(getattr(session, "config", None), "repo", "") or "")
+    job_id = "local-cmd-" + uuid.uuid4().hex[:8]
+    register(
+        job_id,
+        command=command,
+        action_id=action_id,
+        command_fingerprint=command_fingerprint(command),
+        command_preview=secret_free_command_preview(command),
+        cwd=repo,
+    )
+    mark = getattr(session, "_mark_command_job_running", None)
+    if callable(mark):
+        mark(job_id)
+    return job_id
+
+
+def finish_foreground_command_job(
+    session: Any,
+    job_id: str,
+    ok: bool,
+    status: str,
+    val: Any,
+) -> None:
+    """Map a foreground ``_do_run_command`` outcome onto one terminal receipt."""
+    if not job_id:
+        return
+    finish = getattr(session, "_finish_command_job", None)
+    if not callable(finish):
+        return
+    run_status = str(status or "")
+    output = ""
+    exit_code = -1
+    if isinstance(val, dict):
+        run_status = str(val.get("status") or status or "")
+        output = str(val.get("output") or "")
+        try:
+            exit_code = int(val.get("exit_code"))
+        except (TypeError, ValueError):
+            exit_code = -1
+    if ok:
+        terminal = "truncated" if run_status == "truncated" else "completed"
+    elif status == "cancelled" or run_status == "cancelled":
+        terminal = "cancelled"
+    elif status == "timeout" or run_status == "timeout":
+        terminal = "timeout"
+    else:
+        terminal = "failed"
+    finish(
+        job_id,
+        status=terminal,
+        summary=_terminal_summary(terminal, exit_code, output),
+        exit_code=exit_code,
+        output=output[:_INLINE_OUTPUT_CAP] if output else "",
+        run_status=run_status or str(status or ""),
+    )
+
+
 def _run_registered_command_job(
     session: Any,
     job_id: str,
@@ -430,61 +498,69 @@ def _run_registered_command_job(
 
     from harness.command_policy import effective_command_timeout, run_cancellable
 
+    output = ""
+    exit_code = -1
+    run_status = "error"
     try:
-        output, exit_code, run_status = run_cancellable(
-            command,
-            cwd=cwd,
-            timeout=effective_command_timeout(),
-            cancel_event=cancel_event,
+        try:
+            output, exit_code, run_status = run_cancellable(
+                command,
+                cwd=cwd,
+                timeout=effective_command_timeout(),
+                cancel_event=cancel_event,
+            )
+        except Exception as exc:
+            finish = getattr(session, "_finish_command_job", None)
+            if callable(finish):
+                finish(
+                    job_id,
+                    status="failed",
+                    summary=f"Command execution error: {exc}",
+                    exit_code=-1,
+                    output="",
+                )
+            return
+
+        if run_status in ("success", None, ""):
+            run_status = "ok"
+        # Map run_cancellable status onto durable job states.
+        if run_status == "ok":
+            terminal = "completed"
+        elif run_status in COMMAND_TERMINAL_STATES:
+            terminal = run_status
+        elif run_status == "error":
+            terminal = "failed"
+        else:
+            terminal = "failed"
+
+        # Cooperative cancel may have already terminalized the row.
+        if getattr(session, "_local_job_cancelled", lambda _jid: False)(job_id):
+            terminal = "cancelled"
+
+        bounded_output, spill_meta = _bound_or_spill_output(
+            session,
+            job_id,
+            output if isinstance(output, str) else str(output or ""),
         )
-    except Exception as exc:
         finish = getattr(session, "_finish_command_job", None)
         if callable(finish):
             finish(
                 job_id,
-                status="failed",
-                summary=f"Command execution error: {exc}",
-                exit_code=-1,
-                output="",
+                status=terminal,
+                summary=_terminal_summary(terminal, exit_code, bounded_output),
+                exit_code=int(exit_code) if exit_code is not None else -1,
+                output=bounded_output,
+                spill_uri=spill_meta.get("spill_uri") or "",
+                spill_path=spill_meta.get("spill_path") or "",
+                output_chars=int(spill_meta.get("output_chars") or len(bounded_output)),
+                output_preview=spill_meta.get("output_preview") or "",
+                run_status=run_status,
             )
-        return
-
-    if run_status in ("success", None, ""):
-        run_status = "ok"
-    # Map run_cancellable status onto durable job states.
-    if run_status == "ok":
-        terminal = "completed"
-    elif run_status in COMMAND_TERMINAL_STATES:
-        terminal = run_status
-    elif run_status == "error":
-        terminal = "failed"
-    else:
-        terminal = "failed"
-
-    # Cooperative cancel may have already terminalized the row.
-    if getattr(session, "_local_job_cancelled", lambda _jid: False)(job_id):
-        terminal = "cancelled"
-
-    bounded_output, spill_meta = _bound_or_spill_output(
-        session,
-        job_id,
-        output if isinstance(output, str) else str(output or ""),
-    )
-    finish = getattr(session, "_finish_command_job", None)
-    if callable(finish):
-        finish(
-            job_id,
-            status=terminal,
-            summary=_terminal_summary(terminal, exit_code, bounded_output),
-            exit_code=int(exit_code) if exit_code is not None else -1,
-            output=bounded_output,
-            spill_uri=spill_meta.get("spill_uri") or "",
-            spill_path=spill_meta.get("spill_path") or "",
-            output_chars=int(spill_meta.get("output_chars") or len(bounded_output)),
-            output_preview=spill_meta.get("output_preview") or "",
-            run_status=run_status,
-        )
-    reap_tmp_marionette_worktrees(command)
+    finally:
+        try:
+            reap_tmp_marionette_worktrees(command)
+        except Exception:
+            pass
 
 
 def _terminal_summary(status: str, exit_code: int, output: str) -> str:

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -1681,6 +1681,33 @@ class ConversationalSession(
             return []
         return [dict(m) for m in self._history[1:]]
 
+    def _display_swarm_pending_allowed(self, row: Any) -> bool:
+        """True when a persisted swarm_pending row belongs to this session."""
+        if not isinstance(row, dict) or row.get("type") != "swarm_pending":
+            return True
+        mine = str(getattr(self, "harness_session_id", "") or "")
+        theirs = str(row.get("session_id") or "")
+        if theirs:
+            return theirs == mine
+        if not mine:
+            return True
+        jobs = getattr(self, "_local_jobs", None) or {}
+        wave_id = str(row.get("wave_id") or "")
+        if wave_id:
+            parent = jobs.get(wave_id)
+            if isinstance(parent, dict):
+                return str(parent.get("session_id") or "") == mine
+        job_ids = [str(x) for x in (row.get("job_ids") or []) if str(x)]
+        if not job_ids:
+            return False
+        for jid in job_ids:
+            job = jobs.get(jid)
+            if not isinstance(job, dict):
+                return False
+            if str(job.get("session_id") or "") != mine:
+                return False
+        return True
+
     def export_display_transcript(self) -> list:
         """Return the display transcript, restoring any still-pending approvals.
 
@@ -1693,6 +1720,8 @@ class ConversationalSession(
         """
         display: list = []
         for row in self._display_transcript:
+            if not self._display_swarm_pending_allowed(row):
+                continue
             if (
                 isinstance(row, dict)
                 and (row.get("type") or "message") == "message"
@@ -1747,6 +1776,11 @@ class ConversationalSession(
             history_list = messages.get("history", [])
             self._display_transcript = messages.get("display", [])
             self._session_job_ids = messages.get("job_ids", [])
+            if isinstance(self._display_transcript, list):
+                self._display_transcript = [
+                    row for row in self._display_transcript
+                    if self._display_swarm_pending_allowed(row)
+                ]
         else:
             history_list = messages
             self._display_transcript = []

--- a/harness/local_jobs.py
+++ b/harness/local_jobs.py
@@ -604,6 +604,10 @@ class LocalJobsMixin:
         display = getattr(self, "_display_transcript", None)
         if not isinstance(display, list):
             return
+        mine = str(getattr(self, "harness_session_id", "") or "")
+        theirs = str((parent or {}).get("session_id") or "")
+        if theirs != mine:
+            return
         child_ids = [str(x) for x in (parent.get("child_job_ids") or []) if str(x)]
         terminals = [str(x) for x in (parent.get("terminal_job_ids") or []) if str(x)]
         wave_id = str(parent.get("id") or "")
@@ -615,6 +619,7 @@ class LocalJobsMixin:
             "objective": str(parent.get("goal") or ""),
             "terminal_job_ids": list(terminals),
             "status": "done" if settled else "running",
+            "session_id": mine,
         }
         for i, existing in enumerate(display):
             if not isinstance(existing, dict) or existing.get("type") != "swarm_pending":
@@ -1634,7 +1639,10 @@ class LocalJobsMixin:
             for job in list(self._local_jobs.values()):
                 if isinstance(job, dict) and job.get("job_kind") == "parallel_wave":
                     self._sync_parallel_wave_locked(job)
-                    self._upsert_display_parallel_wave_locked(job)
+                    mine = str(getattr(self, "harness_session_id", "") or "")
+                    theirs = str(job.get("session_id") or "")
+                    if theirs == mine:
+                        self._upsert_display_parallel_wave_locked(job)
             # Rewrite so the healed statuses are the new on-disk baseline.
             self._persist_local_jobs_locked()
 

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -66,6 +66,7 @@ from .send_loop_phases import (
     promote_trailing_reasoning_to_say,
     record_provider_dispatch_error_receipt,
     run_auto_verify,
+    yield_session_interrupted,
 )
 from .terminal_cause import (
     TERMINAL_DRIVER_SWAP,
@@ -1106,7 +1107,7 @@ class SendLoopMixin:
             self._sanitize_tool_pairs()
             if self._cancel.is_set():
                 yield from self._yield_stop_boundary_notices()
-                yield ConvEvent("interrupted", {"reason": "session interrupted"})
+                yield from yield_session_interrupted(self)
                 return
 
             # Consume any pending steer at the start of the step: it's now in

--- a/harness/send_loop_actions.py
+++ b/harness/send_loop_actions.py
@@ -48,6 +48,7 @@ from .send_loop_phases import (
     dispatch_local_action,
     dispatch_readonly_action,
     run_parallel_prefetch,
+    yield_session_interrupted,
 )
 
 
@@ -177,7 +178,7 @@ def execute_turn_actions(
                     flush_steer = getattr(session, "_flush_steer_drop_notice", None)
                     if callable(flush_steer):
                         yield from flush_steer()
-                yield ConvEvent("interrupted", {"reason": "session interrupted"})
+                yield from yield_session_interrupted(session)
                 counters["action_seq"] = action_seq
                 counters["swarms"] = swarms
                 counters["demo_swarms"] = demo_swarms
@@ -202,7 +203,7 @@ def execute_turn_actions(
                 flush_steer = getattr(session, "_flush_steer_drop_notice", None)
                 if callable(flush_steer):
                     yield from flush_steer()
-            yield ConvEvent("interrupted", {"reason": "session interrupted"})
+            yield from yield_session_interrupted(session)
             counters["action_seq"] = action_seq
             counters["swarms"] = swarms
             counters["demo_swarms"] = demo_swarms

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -1759,6 +1759,18 @@ def mark_latest_receipt_assistant_done(
         return
 
 
+def yield_session_interrupted(session: Any) -> Iterator[Any]:
+    """Stop unwind: keep ``interrupted`` for old tests, also emit assistant_done."""
+    from .conversation import ConvEvent
+
+    yield ConvEvent("interrupted", {"reason": "session interrupted"})
+    try:
+        mark_latest_receipt_assistant_done(session, stop_cause="cancelled")
+    except Exception:
+        pass
+    yield ConvEvent("assistant_done", {"stop_cause": "cancelled"})
+
+
 def _receipt_identity_kwargs(resp: Any, driver: str) -> Dict[str, Any]:
     """Pull requested/served identity + token totals off a driver response."""
     meta = getattr(resp, "meta", None) if resp is not None else None
@@ -3169,7 +3181,9 @@ def dispatch_local_action(
         # Wave 2: explicit background mode returns a durable pending receipt
         # and never holds the turn on run_cancellable. Opt-in only.
         from harness.command_jobs import (
+            finish_foreground_command_job,
             is_background_run_command,
+            register_foreground_command_job,
             secret_free_command_preview,
             start_background_run_command,
         )
@@ -3231,7 +3245,18 @@ def dispatch_local_action(
             return
         # FULL-AUTO safety + cancellable execution live in
         # ToolDispatchMixin._do_run_command; yield/append stay here.
+        # Foreground still holds the turn, but a local-cmd-* row makes Stop
+        # and search_state able to find the in-flight/cancelled command.
+        job_id = ""
+        try:
+            job_id = register_foreground_command_job(session, act, aid)
+        except Exception:
+            job_id = ""
         ok, status, val = session._do_run_command(act)
+        try:
+            finish_foreground_command_job(session, job_id, ok, status, val)
+        except Exception:
+            pass
         if not ok:
             if status == "blocked":
                 block = val if isinstance(val, dict) else {"message": str(val)}
@@ -3279,6 +3304,7 @@ def dispatch_local_action(
                     "retry_handle": block.get("retry_handle") or command_hash,
                     "command_preview": block.get("command_preview") or "",
                     "recovery": block.get("recovery") or "",
+                    **({"job_id": job_id} if job_id else {}),
                 })
                 session._append_action_result(act, aid, f"(run_command {aid} {block_msg})", is_native)
                 return
@@ -3309,6 +3335,8 @@ def dispatch_local_action(
                     "mode": "tool",
                     "artifacts": [{"type": "command", "headline": headline}],
                 }
+                if job_id:
+                    result["job_id"] = job_id
                 for key in ("hint", "spill_uri", "output_spilled", "output_chars"):
                     if val.get(key) not in (None, ""):
                         result[key] = val[key]
@@ -3331,6 +3359,7 @@ def dispatch_local_action(
                 return
             yield ConvEvent("action_result", {
                 "id": aid, "error": val, "kind": "run_command", "command": command,
+                **({"job_id": job_id} if job_id else {}),
             })
             session._append_action_result(act, aid, f"(run_command {aid} failed: {val})", is_native)
             return
@@ -3358,6 +3387,8 @@ def dispatch_local_action(
             "mode": "tool",
             "artifacts": [{"type": "command", "headline": headline}],
         }
+        if job_id:
+            result["job_id"] = job_id
         for key in ("hint", "spill_uri", "output_spilled", "output_chars"):
             if val.get(key) not in (None, ""):
                 result[key] = val[key]

--- a/harness/terminal_cause.py
+++ b/harness/terminal_cause.py
@@ -57,6 +57,8 @@ _CAUSE_ALIASES = {
     "eof": TERMINAL_PROVIDER_EOF,
     "error": TERMINAL_TRANSPORT_ERROR,
     "transport": TERMINAL_TRANSPORT_ERROR,
+    "user_stop": TERMINAL_CANCELLED,
+    "user-stop": TERMINAL_CANCELLED,
 }
 
 # Provider dialects that mean an affirmative natural stop (no tools).

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -1409,12 +1409,22 @@ class ToolDispatchMixin:
         effective_cwd = preflight.get("cwd") or self.config.repo
 
         cmd_timeout = effective_command_timeout()
-        output, exit_code, run_status = run_cancellable(
-            effective_command,
-            cwd=effective_cwd,
-            timeout=cmd_timeout,
-            cancel_event=getattr(self, "_cancel", None),
-        )
+        from .command_jobs import reap_tmp_marionette_worktrees
+        try:
+            output, exit_code, run_status = run_cancellable(
+                effective_command,
+                cwd=effective_cwd,
+                timeout=cmd_timeout,
+                cancel_event=getattr(self, "_cancel", None),
+            )
+        finally:
+            try:
+                reap_tmp_marionette_worktrees(effective_command)
+                original = act.command or ""
+                if original and original != effective_command:
+                    reap_tmp_marionette_worktrees(original)
+            except Exception:
+                pass
         # Normalize legacy aliases used by older mocks / callers.
         if run_status in ("success", None, ""):
             run_status = "ok"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.353"
+version = "0.9.354"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_command_jobs.py
+++ b/tests/test_command_jobs.py
@@ -2,8 +2,8 @@
 
 Covers registration-before-start, terminal persistence, output caps/spill
 metadata, restart-safe lookup, accounting ownership, and secret-free command
-metadata. Foreground ``run_command`` must remain synchronous and must not
-create a local job unless ``background=True`` is explicit.
+metadata. Foreground ``run_command`` stays synchronous and also registers a
+``local-cmd-*`` tracker row so Stop / search_state can find it.
 """
 from __future__ import annotations
 
@@ -280,26 +280,28 @@ def test_projection_is_command_not_provider_swarm(session):
     assert "command" not in fields
 
 
-def test_foreground_dispatch_does_not_create_command_job(session):
+def test_foreground_dispatch_creates_command_job(session):
     sess, state_dir, repo = session
     act = PilotAction(kind="run_command", command="echo fg", background=False)
-    host = SimpleNamespace(
-        config=SimpleNamespace(repo=repo),
-        _do_run_command=MagicMock(
-            return_value=(
-                True,
-                "success",
-                {"output": "fg\n", "exit_code": 0, "status": "ok"},
-            ),
+    sess._do_run_command = MagicMock(
+        return_value=(
+            True,
+            "success",
+            {"output": "fg\n", "exit_code": 0, "status": "ok"},
         ),
-        _append_action_result=MagicMock(),
-        _register_command_job=MagicMock(),
     )
-    events = list(dispatch_local_action(host, act, "a-fg", True, []))
+    events = list(dispatch_local_action(sess, act, "a-fg", True, []))
     assert events[0].data["status"] == "ok"
-    assert "job_id" not in events[0].data
-    host._register_command_job.assert_not_called()
-    host._do_run_command.assert_called_once()
+    assert events[0].data["adapter"] == "local"
+    assert events[0].data["mode"] == "tool"
+    job_id = events[0].data["job_id"]
+    assert str(job_id).startswith("local-cmd-")
+    sess._do_run_command.assert_called_once()
+    job = sess.get_local_job(job_id)
+    assert job is not None
+    assert job["status"] == "completed"
+    assert job.get("job_kind") == COMMAND_JOB_KIND
+    assert "command" not in job
 
 
 def test_background_dispatch_returns_pending_receipt(session):
@@ -551,3 +553,89 @@ def test_auto_guard_classify_error_blocks_job(session):
     assert "BLOCKED: auto guard error:" in receipt.get("summary", "")
     assert "simulated classify failure" in receipt.get("summary", "")
     assert job.get("exit_code") == -1
+
+
+def test_cancelled_foreground_dispatch_reaps_tmp_marionette_worktree(session):
+    sess, state_dir, repo = session
+    script = (
+        "git worktree add /tmp/marionette-origin-main-audit.XXXXXX "
+        "origin/main"
+    )
+    act = PilotAction(kind="run_command", command=script, background=False)
+    sess._do_run_command = MagicMock(
+        return_value=(
+            False,
+            "cancelled",
+            {
+                "output": "",
+                "exit_code": 130,
+                "status": "cancelled",
+            },
+        ),
+    )
+    events = list(dispatch_local_action(sess, act, "a-cancel", True, []))
+    data = events[0].data
+    assert data["status"] == "cancelled"
+    assert data["adapter"] == "local"
+    assert data["mode"] == "tool"
+    job_id = data["job_id"]
+    assert str(job_id).startswith("local-cmd-")
+    job = sess.get_local_job(job_id)
+    assert job["status"] == "cancelled"
+
+
+def test_background_run_reaps_after_cancellable_returns(session):
+    from harness.command_jobs import _run_registered_command_job
+
+    sess, state_dir, repo = session
+    cmd = "echo /tmp/marionette-origin-main-audit.HbTUUR"
+    sess._register_command_job("local-cmd-reap", command=cmd, action_id="a-reap", cwd=repo)
+    with patch(
+        "harness.command_policy.run_cancellable",
+        return_value=("ok\n", 0, "ok"),
+    ), patch(
+        "harness.command_jobs.reap_tmp_marionette_worktrees",
+        return_value=[],
+    ) as reap:
+        _run_registered_command_job(sess, "local-cmd-reap", cmd, repo)
+    reap.assert_called()
+    assert "marionette-origin-main-audit" in str(reap.call_args[0][0])
+
+
+def test_load_local_jobs_does_not_upsert_foreign_parallel_wave(tmp_path):
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cfg_a = HarnessConfig(driver="stub-oracle-v2", state_dir=str(tmp_path))
+    cfg_a.repo = str(repo)
+    sess_a = ConversationalSession(cfg_a)
+    sess_a.harness_session_id = "sess-a"
+    sess_a._register_parallel_wave(
+        "wave-foreign",
+        child_job_ids=["job_dugout"],
+        objective="Dugout swarm",
+        action_id="a-foreign",
+    )
+    pending_a = [
+        row for row in sess_a._display_transcript
+        if isinstance(row, dict) and row.get("type") == "swarm_pending"
+    ]
+    assert len(pending_a) == 1
+    assert pending_a[0].get("session_id") == "sess-a"
+
+    cfg_b = HarnessConfig(driver="stub-oracle-v2", state_dir=str(tmp_path))
+    cfg_b.repo = str(repo)
+    sess_b = ConversationalSession(cfg_b)
+    sess_b.harness_session_id = "sess-b"
+    pending_b = [
+        row for row in sess_b._display_transcript
+        if isinstance(row, dict) and row.get("type") == "swarm_pending"
+    ]
+    assert pending_b == []
+    exported = sess_b.export_display_transcript()
+    assert not any(
+        isinstance(row, dict) and row.get("type") == "swarm_pending"
+        for row in exported
+    )

--- a/tests/test_interrupt.py
+++ b/tests/test_interrupt.py
@@ -159,3 +159,48 @@ def test_send_loop_with_cancel_preset_halts_quickly():
     # The action must not have executed (the action result event should not exist)
     action_result_events = [ev for ev in events if ev.kind == "action_result"]
     assert len(action_result_events) == 0
+    assert any(ev.kind == "assistant_done" for ev in events)
+
+
+def test_interrupt_appends_assistant_done_to_live_sse_ring(tmp_path):
+    from pmharness.drivers.base import DriverResponse
+
+    from harness.api.sse import (
+        _sse_ring_begin,
+        _sse_ring_clear_for_tests,
+        _sse_ring_lookup,
+    )
+    from harness.config import HarnessConfig
+    from harness.send_loop_phases import record_provider_stream_receipt
+    from harness.stream_performance_store import StreamPerformanceReceiptStore
+
+    _sse_ring_clear_for_tests()
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=str(tmp_path))
+    cfg.repo = str(tmp_path)
+    session = ConversationalSession(cfg)
+    sid = "sess-stop-354"
+    session.harness_session_id = sid
+    resp = DriverResponse(
+        text="ok",
+        tokens_in=4,
+        tokens_out=2,
+        latency_ms=1.0,
+        meta={"finish_reason": "stop", "stream_terminal": "stop", "stream_started": True},
+    )
+    record_provider_stream_receipt(session, resp, provider_step=1, provider_attempt=1)
+    before = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts(sid)
+    assert before
+    assert before[-1].get("assistant_done_emitted") is False
+
+    ring = _sse_ring_begin(sid)
+    gen = ring.generation
+    session.interrupt()
+
+    live = _sse_ring_lookup(sid)
+    assert live is ring
+    assert live.generation == gen
+    kinds = [ev["kind"] for ev in ring.since(0)["events"]]
+    assert "assistant_done" in kinds
+    after = StreamPerformanceReceiptStore(str(tmp_path)).list_receipts(sid)
+    assert after[-1].get("assistant_done_emitted") is True
+    assert after[-1].get("terminal_cause") == "cancelled"

--- a/tests/test_tool_dispatch_mixin.py
+++ b/tests/test_tool_dispatch_mixin.py
@@ -118,6 +118,27 @@ def test_do_run_command_cancelled_is_not_success():
     assert "interrupted by user" in val["output"]
 
 
+def test_do_run_command_reaps_tmp_marionette_worktrees_on_cancel():
+    session = _dispatch_session()
+    act = PilotAction(
+        kind="run_command",
+        command="git worktree add /tmp/marionette-origin-main-audit.XXXXXX x",
+    )
+    with patch(
+        "harness.command_policy.run_cancellable",
+        return_value=("", 130, "cancelled"),
+    ), patch(
+        "harness.command_jobs.reap_tmp_marionette_worktrees",
+        return_value=[],
+    ) as reap:
+        ok, status, val = ToolDispatchMixin._do_run_command(session, act)
+    assert ok is False
+    assert status == "cancelled"
+    reap.assert_called()
+    texts = [str(call.args[0]) for call in reap.call_args_list]
+    assert any("marionette-origin-main-audit" in text for text in texts)
+
+
 def test_do_run_command_timeout_is_not_success():
     session = _dispatch_session()
     act = PilotAction(kind="run_command", command="sleep 30")

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.353"
+version = "0.9.354"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.353",
+  "version": "0.9.354",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.353",
+      "version": "0.9.354",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.353",
+  "version": "0.9.354",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/Conversation.transcriptDedupe.test.ts
+++ b/webapp/src/__tests__/Conversation.transcriptDedupe.test.ts
@@ -421,6 +421,26 @@ describe("transcriptFingerprint", () => {
 });
 
 describe("transcriptResponseToItems", () => {
+  it("hydrates swarm_pending display rows instead of falling through to msg", () => {
+    const items = transcriptResponseToItems({
+      display: [{
+        type: "swarm_pending",
+        job_ids: ["job_dugout"],
+        objective: "Dugout swarm",
+        status: "done",
+        session_id: "other-session",
+      }],
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: "swarm_pending",
+      job_ids: ["job_dugout"],
+      objective: "Dugout swarm",
+      status: "done",
+      resolved: true,
+    });
+  });
+
   it("hydrates invalidated_paths onto swarm_result rows", () => {
     const items = transcriptResponseToItems({
       display: [{

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.353)", () => {
-  it("declares the official motion package and 0.9.353 not 329", () => {
+describe("feed Motion (v0.9.354)", () => {
+  it("declares the official motion package and 0.9.354 not 329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.353");
+    expect(pkg.version).toBe("0.9.354");
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/components/conversation/transcriptItems.ts
+++ b/webapp/src/components/conversation/transcriptItems.ts
@@ -461,6 +461,31 @@ export function transcriptResponseToItems(res: {
           status,
           ...(typeof m.error === "string" && m.error ? { error: m.error } : {}),
         }];
+      } else if (m.type === "swarm_pending") {
+        const jobIds = normalizeSwarmJobIds(
+          Array.isArray(m.job_ids) ? m.job_ids.map((id: unknown) => String(id || "")) : [],
+        );
+        if (jobIds.length === 0) return [];
+        const rawStatus = String(m.status || "").trim();
+        const status = (
+          rawStatus === "done"
+          || rawStatus === "failed"
+          || rawStatus === "ended"
+          || rawStatus === "running"
+        ) ? rawStatus as "done" | "failed" | "ended" | "running"
+          : (m.resolved ? "done" : "running");
+        return [{
+          kind: "swarm_pending" as const,
+          job_ids: jobIds,
+          objective: String(m.objective || ""),
+          status,
+          resolved: status !== "running",
+          terminal_job_ids: normalizeSwarmJobIds(
+            Array.isArray(m.terminal_job_ids)
+              ? m.terminal_job_ids.map((id: unknown) => String(id || ""))
+              : [],
+          ),
+        }];
       } else if (m.type === "turn_terminal") {
         const text = String(m.text || "").trim();
         if (!text) return [];


### PR DESCRIPTION
## Summary
- Foreground `run_command` now registers a `local-cmd-*` tracker row (chat card stays `adapter: local` / `mode: tool`) so Stop and `search_state` can find it.
- Cancel/Stop reaps `/tmp/marionette-*` worktrees from the command text even when the script trap never runs (exit 130). Live leftover dirs on disk are not deleted by this patch.
- `swarm_pending` is session-fenced: other sessions' waves are not upserted, persisted, or hydrated into this transcript.
- Stop emits `assistant_done` onto the live SSE ring (same generation) and marks the latest receipt so store poll can settle.

Pin stays `puppetmaster-ai==1.22.33`. Feed Motion stays declared but off. No new adapter.

## Test plan
- [ ] `pytest tests/test_command_jobs.py tests/test_tool_dispatch_mixin.py tests/test_interrupt.py tests/test_version_consistency.py tests/test_send_loop_terminals.py tests/test_terminal_evidence_pr2.py`
- [ ] Full `pytest -q` (5194 passed locally)
- [ ] CI: pytest-linux, pytest-windows 1-4, frontend-build, pmharness-units, mac/win/linux builds
- [ ] After green: `gh pr merge N --merge` only, then lightweight tag `v0.9.354` on merge SHA, then delete `origin/release/v0.9.354` (and leftover `origin/release/v0.9.353` if still present)