### PR TITLE
Release v0.9.355

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.28
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.22.35
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.28"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.35"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.28"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.35"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -57,7 +57,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.28"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.35"
 
       - name: Run the offline test suite (shard)
         env:
@@ -103,7 +103,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.22.28"
+          pip install -e ".[dev]" "puppetmaster-ai==1.22.35"
 
       - name: Run offline pmharness/intent/registry units
         run: python -m pytest -q -p no:cacheprovider tests/test_intent.py tests/test_registry.py tests/test_registry_wizard.py tests/test_pilot_driver_templates.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.22.33"
+uv pip install --python .venv -e . "puppetmaster-ai==1.22.35"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.33` (desktop
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.22.35` (desktop
    bootstrap, install/doctor, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.33` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.35` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.354, deliberately pre-1.0. Rides puppetmaster-ai==1.22.33. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.355, deliberately pre-1.0. Rides puppetmaster-ai==1.22.35. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.33` (configurable default reviewer platform, shared `build_cost_report`, safely resumable jobs, honest delivery verdicts, Google Antigravity `agy` adapter, dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
+| **Puppetmaster delegation** | run_swarm (read-only analysis), run_implement (edit-capable worktree worker), run_parallel (concurrent waves). Heavy/multi-file work runs as durable, auditable jobs. Requires `puppetmaster-ai==1.22.35` (configurable default reviewer platform, shared `build_cost_report`, safely resumable jobs, honest delivery verdicts, Google Antigravity `agy` adapter, dashboard per-project isolation, hermetic test-suite credential isolation, swarm timeout propagation, Sonnet 5 catalogs, discovery origin, spawned-worker delegate-first exemption, SWE-bench Bash Only priors, exact registry pins, and Bedrock invoke health). |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Durable memory graph** | Local durable facts/preferences (`MemoryStore`) plus optional relations via `MemoryGraph` (`GET /api/memory/graph`, shape `{nodes,edges}` like the wiki graph; sqlite + append-only jsonl). |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.354"
+__version__ = "0.9.355"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/diag_bundle.py
+++ b/harness/diag_bundle.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 DEFAULT_SESSION_LIMIT = 20
-PIN_FALLBACK = "puppetmaster-ai==1.22.33"
+PIN_FALLBACK = "puppetmaster-ai==1.22.35"
 _PIN_RE = re.compile(r"puppetmaster-ai==[0-9]+(?:\.[0-9]+)*")
 _SECRET_KEY_FRAGMENTS = (
     "api_key",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.354"
+version = "0.9.355"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.33" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.35" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.33"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.22.35"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.33" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.22.35" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.33}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.22.35}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.354"
+version = "0.9.355"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -308,7 +308,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.33";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.22.35";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.33";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.22.35";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 const HARNESS_DIST_NAME = "pm-harness";
 
@@ -95,7 +95,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.22.33" }    -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.22.35" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {
@@ -117,7 +117,7 @@ function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
  * A packaged shell's own require("./update-pm.cjs") is frozen in app.asar; the
  * checkout's copy moves with `git pull`, so it is authoritative (otherwise PM
  * stays stuck on the shell's build-time pin, e.g. 1.21.6 after the tree moved
- * to 1.22.33).
+ * to 1.22.35).
  *
  * @returns {{ pinnedSpec: string, distName: string, planPuppetmasterUpgrade: Function }}
  */

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -135,6 +135,10 @@ test("operational Puppetmaster pins match DEFAULT_PUPPETMASTER_SPEC", () => {
     "scripts/doctor.sh",
     "scripts/doctor.ps1",
     "FINDINGS.md",
+    "harness/diag_bundle.py",
+    ".github/workflows/tests.yml",
+    ".github/workflows/tests-full.yml",
+    ".github/workflows/release.yml",
   ];
   const escaped = spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const specRe = new RegExp(escaped);

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.354",
+  "version": "0.9.355",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.354",
+      "version": "0.9.355",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.354",
+  "version": "0.9.355",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/feedMotion.test.tsx
+++ b/webapp/src/__tests__/feedMotion.test.tsx
@@ -164,15 +164,15 @@ function parseTranslateY(transform: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-describe("feed Motion (v0.9.354)", () => {
-  it("declares the official motion package and 0.9.354 not 329", () => {
+describe("feed Motion", () => {
+  it("declares the official motion package and does not regress to 0.9.329", () => {
     const pkg = JSON.parse(pkgJson) as {
       dependencies?: Record<string, string>;
       version?: string;
     };
     expect(pkg.dependencies?.motion).toBeTruthy();
     expect(pkg.dependencies?.["framer-motion"]).toBeUndefined();
-    expect(pkg.version).toBe("0.9.354");
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
     expect(pkg.version).not.toBe("0.9.329");
   });
 

--- a/webapp/src/__tests__/investigationCollapser.seal.test.tsx
+++ b/webapp/src/__tests__/investigationCollapser.seal.test.tsx
@@ -208,6 +208,8 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
 
     expect(screen.getByText(/Investigating/i)).toBeTruthy();
     expect(screen.queryByText(/Worked for/i)).toBeNull();
+    // Running tool used to swallow the under-fold timer line.
+    expect(screen.getByText(/step /i)).toBeTruthy();
 
     rerender(
       <TranscriptList
@@ -221,6 +223,7 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
 
     expect(screen.getByText(/Investigating/i)).toBeTruthy();
     expect(screen.queryByText(/Worked for/i)).toBeNull();
+    expect(screen.getByText(/step /i)).toBeTruthy();
 
     // Settled tools but pilot still busy — must not seal via hold alone.
     const settledMidTurn: Item[] = [
@@ -238,6 +241,8 @@ describe("holdSwarmAwait transcript latch + awaiting_swarm pause-point", () => {
     );
     expect(screen.getByText(/Investigating/i)).toBeTruthy();
     expect(screen.queryByText(/Worked for/i)).toBeNull();
+    // Finished cards, loop still open: Still working… · step N stays painted.
+    expect(screen.getByText(/Still working/i)).toBeTruthy();
   });
 
   it("awaiting_swarm pause-point does not keep Investigating spinner over settled tools", () => {

--- a/webapp/src/__tests__/turnProgress.test.ts
+++ b/webapp/src/__tests__/turnProgress.test.ts
@@ -345,14 +345,14 @@ describe("turnLooksAnswerComplete / shouldShowBusyFooter (T5)", () => {
     expect(shouldShowBusyFooter(items, "streaming")).toBe(false);
   });
 
-  it("is false while a card is running", () => {
+  it("keeps the footer while a card is running", () => {
     const items: Item[] = [
       msg("user", "go"),
       msg("assistant", "Working on it."),
       card("1", "a.ts", "read_file", true),
     ];
     expect(turnLooksAnswerComplete(items)).toBe(false);
-    expect(shouldShowBusyFooter(items, "executing")).toBe(false);
+    expect(shouldShowBusyFooter(items, "executing")).toBe(true);
   });
 
   it("is false between tool steps after mid-turn narration (no idle blink)", () => {
@@ -371,7 +371,18 @@ describe("turnLooksAnswerComplete / shouldShowBusyFooter (T5)", () => {
     expect(p.pill).not.toBe("idle");
   });
 
-  it("is false while thinking is streaming", () => {
+  it("keeps the footer while thinking streams after tools", () => {
+    const items: Item[] = [
+      msg("user", "go"),
+      card("1", "a.ts", "read_file", false),
+      msg("assistant", "Earlier note."),
+      { kind: "thinking", text: "more", streaming: true },
+    ];
+    expect(turnLooksAnswerComplete(items)).toBe(false);
+    expect(shouldShowBusyFooter(items, "thinking")).toBe(true);
+  });
+
+  it("hides the footer while pre-tool thinking streams (row owns the signal)", () => {
     const items: Item[] = [
       msg("user", "go"),
       msg("assistant", "Earlier note."),
@@ -381,14 +392,23 @@ describe("turnLooksAnswerComplete / shouldShowBusyFooter (T5)", () => {
     expect(shouldShowBusyFooter(items, "thinking")).toBe(false);
   });
 
-  it("is false while tool_prep is active", () => {
+  it("keeps the footer while tool_prep is active", () => {
     const items: Item[] = [
       msg("user", "go"),
       msg("assistant", "Next I will grep."),
       { kind: "tool_prep", name: "grep" },
     ];
     expect(turnLooksAnswerComplete(items)).toBe(false);
-    expect(shouldShowBusyFooter(items, "thinking")).toBe(false);
+    expect(shouldShowBusyFooter(items, "thinking")).toBe(true);
+  });
+
+  it("keeps the footer on idle status flaps while the agent loop is still open", () => {
+    const items: Item[] = [
+      msg("user", "go"),
+      card("1", "a.ts", "read_file", false),
+    ];
+    expect(shouldShowBusyFooter(items, "idle")).toBe(false);
+    expect(shouldShowBusyFooter(items, "idle", true)).toBe(true);
   });
 
   it("is false with no assistant text yet (T3 waiting still shows)", () => {

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -54,7 +54,6 @@ import {
   toolFocusPhrase,
   toolInputFieldKey,
   toolRowLabel,
-  turnHasVisibleBusySurface,
   workFoldLabel,
   ranGoalLine,
 } from "../lib/turnProgress";
@@ -2035,12 +2034,11 @@ export const TranscriptList = memo(function TranscriptList({
   ) : null;
 
   const busyProgress = deriveBusyProgress(items, status, busyElapsedMs);
-  // Hide the under-fold line only while a card / prep / stream already
-  // shows work. A sticky Investigating fold of *finished* tools used to
-  // own chrome and swallow "Still working…" between Kimi-style batches.
-  const hideBusyFooter = turnHasVisibleBusySurface(items);
+  // Latch the step/timer line to the open agent loop. Do not hide it just
+  // because a card or stream is already on screen — that gap is the flicker
+  // between tool calls (and while the current tool is still running).
   const showBusyFooter =
-    (shouldShowBusyFooter(items, status) || pausePoint) && !hideBusyFooter;
+    shouldShowBusyFooter(items, status, agentLoopOpen) || pausePoint;
   const showStall = quietWorkingCueVisible(
     items,
     status,

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -773,17 +773,34 @@ export function turnLooksAnswerComplete(items: TurnItem[]): boolean {
 
 /**
  * Whether the transcript busy footer should render for this status + items.
- * False when the answer already looks complete despite a lagging busy status,
- * or when a stream / running card already owns the live signal — stacking
- * "Still working…" under growing text is the blink in the screenshot.
+ *
+ * Tool loops keep the step/timer line for the whole open agent turn — including
+ * running cards, thinking, and the gap between tool calls. Hiding it whenever
+ * ``turnHasVisibleBusySurface`` was true made "Still working…" vanish while
+ * tools were still running and again in the silent beat before the next call.
+ *
+ * Pure-chat typewriter still owns the live signal (no investigation fold yet),
+ * so a streaming bubble/thinking row there does not also stack a footer.
+ *
+ * ``agentLoopOpen`` covers status flaps to idle while ``turnOpen`` / hold is
+ * still latched, so the footer does not drop between SSE tool events.
  */
-export function shouldShowBusyFooter(items: TurnItem[], status: BusyStatus): boolean {
+export function shouldShowBusyFooter(
+  items: TurnItem[],
+  status: BusyStatus,
+  agentLoopOpen: boolean = false,
+): boolean {
   if (status === "awaiting_swarm") return true;
   const busy =
-    status === "thinking" || status === "executing" || status === "streaming";
+    status === "thinking"
+    || status === "executing"
+    || status === "streaming"
+    || agentLoopOpen;
   if (!busy) return false;
   if (turnLooksAnswerComplete(items)) return false;
-  if (turnHasVisibleBusySurface(items)) return false;
+  if (!turnHasInvestigationActivity(items) && turnHasVisibleBusySurface(items)) {
+    return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Keep the under-fold Still working / step-timer line for the whole open agent turn (running tools and the gap between tool calls). Pure-chat typewriter still owns that signal until tools start.
- Pin desktop and CI to `puppetmaster-ai==1.22.35` (PyPI tip; skip leftover GPT-5 on the hooked stream). Pin-parity test now includes the workflow files so CI cannot lag the desktop spec.

## Test plan
- [x] vitest: turnProgress, investigationCollapser, chatLoopResilience.wave5, swarmAwaitChrome
- [x] electron update + puppetmaster-runtime pin tests
- [x] local pytest 5194 passed, 78 skipped
- [ ] CI tests matrix (3.9, 3.11, Windows, frontend-build)