### PR TITLE
fix: make Economics pane navigable and truthful

### DIFF
--- a/harness/api/economics.py
+++ b/harness/api/economics.py
@@ -315,7 +315,11 @@ def _serialize_job_counterfactual(cf: Any) -> Optional[dict]:
 
 
 def _models_from_job_cost(job_cost: Any) -> list:
-    by_model = getattr(job_cost, "by_model", None) or {}
+    by_model = (
+        job_cost.get("by_model")
+        if isinstance(job_cost, dict)
+        else getattr(job_cost, "by_model", None)
+    ) or {}
     rows = []
     for model_id, bucket in by_model.items():
         info = bucket if isinstance(bucket, dict) else {}
@@ -438,7 +442,12 @@ def _project_job_row(
                 job_cost = None
                 cf = None
 
-    models = _models_from_job_cost(job_cost) if job_cost is not None else []
+    if pm_receipt is not None:
+        models = _models_from_job_cost(
+            ((pm_receipt.get("pm_report") or {}).get("actual_cost") or {})
+        )
+    else:
+        models = _models_from_job_cost(job_cost) if job_cost is not None else []
     arts = receipt.get("artifacts") if isinstance(receipt, dict) else None
     efficiency = receipt.get("efficiency") if isinstance(receipt, dict) else None
     tasks = receipt.get("tasks") if isinstance(receipt, dict) else None

--- a/tests/test_api_economics_peel.py
+++ b/tests/test_api_economics_peel.py
@@ -183,6 +183,49 @@ def test_get_economics_all_projects_opens_extra_dirs(tmp_path, monkeypatch):
     assert len(opened_paths) == 2
 
 
+def test_recent_job_keeps_model_from_pm_financial_report(monkeypatch):
+    _patch_pm(monkeypatch)
+    monkeypatch.setattr(
+        "harness.financial_receipt.load_pm_cost_report",
+        lambda store, job_id, registry=None: {
+            "job_id": job_id,
+            "actual_cost": {
+                "total_marginal_cost_usd": 1.25,
+                "measured_cost_usd": 1.25,
+                "estimated_cost_usd": 0.0,
+                "measured_runs": 1,
+                "estimated_runs": 0,
+                "priced_tasks": 1,
+                "unpriced_tasks": 0,
+                "by_model": {
+                    "composer-2": {
+                        "billing": "metered", "calls": 1,
+                        "tokens_in": 100, "tokens_out": 50,
+                    }
+                },
+            },
+            "counterfactual": None,
+        },
+    )
+    job = {
+        "id": "job_model_receipt",
+        "status": "complete",
+        "source": "harness",
+        "accounting_owned": True,
+        "accounting_scope": "marionette",
+        "created_at": "2026-08-20T00:00:00+00:00",
+    }
+
+    code, payload = get_economics({}, _svc(jobs=[job]))
+
+    assert code == 200
+    assert isinstance(payload, dict)
+    assert payload["recent_jobs"][0]["models"] == [{
+        "model_id": "composer-2", "billing": "metered", "calls": 1,
+        "tokens_in": 100, "tokens_out": 50,
+    }]
+
+
 def test_visibility_only_job_listed_but_omitted_from_owned_totals(monkeypatch):
     jobs = [
         {

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -2,6 +2,8 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import EconomicsPane from "../components/EconomicsPane";
 import { api } from "../lib/api";
+import { openAgentSwarmJob } from "../lib/agentLinks";
+import { clearSWRCache } from "../lib/useStaleWhileRevalidate";
 
 vi.mock("../lib/api", () => ({
   api: {
@@ -17,8 +19,13 @@ vi.mock("../lib/usePolling", () => ({
   },
 }));
 
+vi.mock("../lib/agentLinks", () => ({
+  openAgentSwarmJob: vi.fn(),
+}));
+
 const mockGetUsage = vi.mocked(api.getUsage);
 const mockGetEconomics = vi.mocked(api.getEconomics);
+const mockOpenAgentSwarmJob = vi.mocked(openAgentSwarmJob);
 
 const usageSession = {
   tokens_used: 8000,
@@ -51,7 +58,40 @@ const durablePayload = {
 describe("EconomicsPane", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearSWRCache();
     mockGetEconomics.mockResolvedValue(durablePayload);
+  });
+
+  it("owns a persistent header and height-constrained scroll viewport", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: usageSession,
+      jobs: [],
+    });
+
+    const { container } = render(<EconomicsPane />);
+
+    expect(await screen.findByText("This app run")).toBeInTheDocument();
+    expect(screen.getByText("Economics")).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveClass("flex", "flex-col", "h-full", "overflow-hidden");
+    expect(screen.getByText("This app run").parentElement?.parentElement).toHaveClass(
+      "flex-1",
+      "min-h-0",
+      "overflow-y-auto",
+    );
+  });
+
+  it("keeps the last Economics data visible across card remounts", async () => {
+    mockGetUsage.mockResolvedValue({ session: usageSession, jobs: [] });
+
+    const first = render(<EconomicsPane />);
+    expect(await screen.findByText("This app run")).toBeInTheDocument();
+    first.unmount();
+    mockGetUsage.mockImplementation(() => new Promise(() => {}));
+
+    render(<EconomicsPane />);
+
+    expect(screen.getByText("This app run")).toBeInTheDocument();
+    expect(screen.queryByText("Loading this app run…")).not.toBeInTheDocument();
   });
 
   it("shows spend and list-price value from getUsage", async () => {
@@ -126,18 +166,46 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("Job vis-1")).toBeInTheDocument();
+    expect(await screen.findByText("vis-1")).toBeInTheDocument();
     expect(screen.getByText(/visible only/)).toBeInTheDocument();
     expect(screen.queryByText("$9.99")).not.toBeInTheDocument();
     expect(screen.queryByText("~$9.99")).not.toBeInTheDocument();
-    expect(screen.getByText("$1.25 vs $2.00 · measured")).toBeInTheDocument();
-    const ownedRow = screen.getByText("Job owned-1").closest(".mb-2");
+    const ownedRow = screen.getByText("owned-1").closest(".mb-2");
     expect(ownedRow).toBeTruthy();
     const ownedScope = within(ownedRow as HTMLElement);
-    expect(ownedScope.getByText("Measured")).toBeInTheDocument();
-    expect(ownedScope.getByText("Estimated")).toBeInTheDocument();
+    expect(ownedScope.getByText("Measured Cost")).toBeInTheDocument();
+    expect(ownedScope.getByText("Estimated Cost")).toBeInTheDocument();
+    expect(ownedScope.getByText("Estimated Savings").parentElement).toHaveTextContent("Estimated Savings$2.00");
     expect(ownedScope.getAllByText("$1.25").length).toBeGreaterThanOrEqual(1);
     expect(ownedScope.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("opens a recent PM job in the Swarm Tracker", async () => {
+    mockGetUsage.mockResolvedValue({ session: usageSession, jobs: [] });
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      recent_jobs: [
+        {
+          job_id: "job_abcdef012345",
+          accounting_owned: true,
+          models: [{ model_id: "agentic/gpt-5.6-luna" }],
+          tokens: 800,
+          typed_artifacts: 4,
+          tokens_per_typed_artifact: 200,
+          degraded_rate: 0,
+          actual_marginal_usd: 1.25,
+          counterfactual: { avoided_usd: 2.0 },
+        },
+      ],
+    });
+
+    render(<EconomicsPane />);
+    fireEvent.click(await screen.findByRole("button", { name: "job_abcdef012345" }));
+
+    expect(mockOpenAgentSwarmJob).toHaveBeenCalledWith("job_abcdef012345");
+    expect(screen.getByText("agentic/gpt-5.6-luna")).toBeInTheDocument();
+    expect(screen.queryByText(/typed/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/degraded/)).not.toBeInTheDocument();
   });
 
   it("shows headline sum and measured/estimated lines for mixed job cost", async () => {
@@ -161,11 +229,16 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("$1.50 vs $3.00 · mixed basis")).toBeInTheDocument();
-    expect(screen.getByText("Measured")).toBeInTheDocument();
-    expect(screen.getByText("Estimated")).toBeInTheDocument();
+    expect(await screen.findByText("mixed-1")).toBeInTheDocument();
+    expect(screen.getByText("Measured Cost")).toBeInTheDocument();
+    expect(screen.getByText("Estimated Cost")).toBeInTheDocument();
     expect(screen.getAllByText("$1.25").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("$0.25")).toBeInTheDocument();
+    expect(screen.getByText("Estimated Savings").parentElement).toHaveTextContent("Estimated Savings$3.00");
+    const mixedRow = within(screen.getByText("mixed-1").closest(".mb-2") as HTMLElement);
+    expect(mixedRow.getByText("$1.25")).toHaveClass("text-warn/90");
+    expect(mixedRow.getByText("$0.25")).toHaveClass("text-warn/90");
+    expect(mixedRow.getByText("$3.00")).toHaveClass("text-good/90");
   });
 
   it("shows measured-only headline without faking a zero estimated line", async () => {
@@ -187,10 +260,10 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("$2.00 vs — · measured")).toBeInTheDocument();
-    const row = within(screen.getByText("Job meas-1").closest(".mb-2") as HTMLElement);
-    expect(row.getByText("Measured").parentElement).toHaveTextContent("Measured$2.00");
-    expect(row.getByText("Estimated").parentElement).toHaveTextContent("Estimated—");
+    expect(await screen.findByText("meas-1")).toBeInTheDocument();
+    const row = within(screen.getByText("meas-1").closest(".mb-2") as HTMLElement);
+    expect(row.getByText("Measured Cost").parentElement).toHaveTextContent("Measured Cost$2.00");
+    expect(row.getByText("Estimated Cost").parentElement).toHaveTextContent("Estimated Cost—");
     expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
   });
 
@@ -213,10 +286,10 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("$0.75 vs — · estimated")).toBeInTheDocument();
-    const row = within(screen.getByText("Job est-1").closest(".mb-2") as HTMLElement);
-    expect(row.getByText("Measured").parentElement).toHaveTextContent("Measured—");
-    expect(row.getByText("Estimated").parentElement).toHaveTextContent("Estimated$0.75");
+    expect(await screen.findByText("est-1")).toBeInTheDocument();
+    const row = within(screen.getByText("est-1").closest(".mb-2") as HTMLElement);
+    expect(row.getByText("Measured Cost").parentElement).toHaveTextContent("Measured Cost—");
+    expect(row.getByText("Estimated Cost").parentElement).toHaveTextContent("Estimated Cost$0.75");
     expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
   });
 
@@ -238,7 +311,7 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("$1.10 vs — · measured")).toBeInTheDocument();
+    expect(await screen.findByText("legacy-1")).toBeInTheDocument();
     expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
   });
 

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -752,7 +752,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       {est > 0 ? (
         <div className="flex items-center justify-between mb-1">
           <span className="text-muted">{spendLabel}</span>
-          <span className="text-good font-medium tabular-nums">{spendPrefix}{fmtCost(est)}</span>
+          <span className="text-warn font-medium tabular-nums">{spendPrefix}{fmtCost(est)}</span>
         </div>
       ) : null}
 
@@ -817,7 +817,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
           <span className="text-muted">
             Prompt-cache value{swarmCachePartial ? " (partial)" : ""}
           </span>
-          <span className="text-accent font-medium tabular-nums">~{fmtCost(promptCacheSaved)}</span>
+          <span className="text-good font-medium tabular-nums">~{fmtCost(promptCacheSaved)}</span>
         </div>
       ) : null}
 
@@ -835,7 +835,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
           <span className="text-muted">
             Model selection value{routingEstimated && delegationSaved <= 0 ? " (est.)" : ""}
           </span>
-          <span className="text-accent font-medium tabular-nums">~{fmtCost(modelSelectionSaved)}</span>
+          <span className="text-good font-medium tabular-nums">~{fmtCost(modelSelectionSaved)}</span>
         </div>
       ) : null}
 
@@ -852,7 +852,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       {compactSavings > 0 ? (
         <div className="flex items-center justify-between mb-1">
           <span className="text-muted">Compact tool outputs saved</span>
-          <span className="text-accent font-medium tabular-nums">~{fmtCost(compactSavings)}</span>
+          <span className="text-good font-medium tabular-nums">~{fmtCost(compactSavings)}</span>
         </div>
       ) : null}
 

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -1,4 +1,5 @@
 import type { EconomicsData, EconomicsJobRow, EconomicsScope } from "../lib/api";
+import { openAgentSwarmJob } from "../lib/agentLinks";
 
 const SCOPES: Array<{ value: EconomicsScope; label: string }> = [
   { value: "repo", label: "This repo" },
@@ -19,40 +20,6 @@ function fmtUnknownMoney(value: number | null | undefined): string {
   return `$${value.toFixed(2)}`;
 }
 
-function fmtTokens(value: number | null | undefined): string {
-  if (!isFiniteNumber(value)) return "—";
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
-  if (value >= 1000) return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}k`;
-  return String(value);
-}
-
-function fmtRate(value: number | null | undefined): string {
-  if (!isFiniteNumber(value)) return "—";
-  return `${Math.round(value * 100)}%`;
-}
-
-function shortModel(model: string | undefined): string {
-  const text = (model || "").trim();
-  if (!text) return "unknown";
-  const afterColon = text.includes(":") ? text.slice(text.lastIndexOf(":") + 1) : text;
-  const slash = afterColon.lastIndexOf("/");
-  return slash >= 0 ? afterColon.slice(slash + 1) : afterColon;
-}
-
-function jobModel(row: EconomicsJobRow): string {
-  const id = row.models?.[0]?.model_id;
-  return shortModel(id);
-}
-
-function costBasisLabel(basis: string | null | undefined): string {
-  const value = (basis || "").trim().toLowerCase();
-  if (value === "plan") return " · plan $0-marginal";
-  if (value === "estimated") return " · estimated";
-  if (value === "mixed") return " · mixed basis";
-  if (value === "unknown") return " · unknown basis";
-  if (value.includes("measured")) return " · measured";
-  return "";
-}
 
 /** Headline total: measured + estimated when either is known; else legacy actual_marginal. */
 export function jobHeadlineTotal(job: Pick<EconomicsJobRow, "measured_cost_usd" | "estimated_cost_usd" | "actual_marginal_usd">): number | null {
@@ -133,7 +100,7 @@ export default function EconomicsDurable({
       {isFiniteNumber(routingSaved) && routingSaved > 0 ? (
         <div className="flex items-center justify-between mb-1 text-faint">
           <span>Routing saved (measured)</span>
-          <span className="tabular-nums">{fmtUnknownMoney(routingSaved)}</span>
+          <span className="tabular-nums text-good/90">{fmtUnknownMoney(routingSaved)}</span>
         </div>
       ) : data?.available !== false && data?.savings && !isFiniteNumber(routingSaved) ? (
         <div className="flex items-center justify-between mb-1 text-faint">
@@ -145,7 +112,7 @@ export default function EconomicsDurable({
       {isFiniteNumber(codegraphEst) ? (
         <div className="flex items-center justify-between mb-1 text-faint">
           <span>CodeGraph (estimated)</span>
-          <span className="tabular-nums">{fmtUnknownMoney(codegraphEst)}</span>
+          <span className="tabular-nums text-good/90">{fmtUnknownMoney(codegraphEst)}</span>
         </div>
       ) : null}
 
@@ -156,7 +123,7 @@ export default function EconomicsDurable({
               ? `Estimated savings vs ${referenceId}`
               : "Estimated savings"}
           </span>
-          <span className="tabular-nums">{fmtUnknownMoney(avoided)}</span>
+          <span className="tabular-nums text-good/90">{fmtUnknownMoney(avoided)}</span>
         </div>
       ) : null}
 
@@ -174,41 +141,51 @@ export default function EconomicsDurable({
           <div className="text-[10px] uppercase tracking-wide text-faint mb-2">Recent jobs</div>
           {jobs.map((job) => {
             const owned = Boolean(job.accounting_owned);
-            const headlineTotal = owned ? jobHeadlineTotal(job) : null;
+            const modelIds = (job.models || []).map((model) => model.model_id || "").filter(Boolean);
+            const measuredCost = isFiniteNumber(job.measured_cost_usd)
+              ? job.measured_cost_usd
+              : (!isFiniteNumber(job.estimated_cost_usd) && isFiniteNumber(job.actual_marginal_usd)
+                ? job.actual_marginal_usd
+                : null);
             const jobAvoided = owned ? job.counterfactual?.avoided_usd : null;
             return (
               <div key={job.job_id || `${job.source}-${job.status}`} className="mb-2">
                 <div className="flex items-center justify-between text-faint">
-                  <span className="truncate pr-2">{job.job_id ? `Job ${job.job_id}` : "Job"}</span>
-                  <span className="tabular-nums shrink-0">
-                    {owned
-                      ? `${fmtUnknownMoney(headlineTotal)} vs ${fmtUnknownMoney(jobAvoided)}${costBasisLabel(job.cost_basis)}`
-                      : "—"}
-                  </span>
+                  {job.job_id ? (
+                    <button
+                      type="button"
+                      className="truncate pr-2 font-mono text-accent/85 hover:underline underline-offset-2 cursor-pointer bg-transparent border-0 p-0 text-left"
+                      onClick={() => openAgentSwarmJob(job.job_id || "")}
+                    >
+                      {job.job_id}
+                    </button>
+                  ) : (
+                    <span className="truncate pr-2">Job</span>
+                  )}
                 </div>
+                {modelIds.length > 0 ? (
+                  <div className="flex items-start justify-between gap-2 text-faint pl-2">
+                    <span>{modelIds.length === 1 ? "Model" : "Models"}</span>
+                    <span className="font-mono text-right break-words min-w-0">{modelIds.join(", ")}</span>
+                  </div>
+                ) : null}
                 {owned ? (
                   <>
                     <div className="flex items-center justify-between text-faint pl-2">
-                      <span>Measured</span>
-                      <span className="tabular-nums shrink-0">{fmtUnknownMoney(job.measured_cost_usd)}</span>
+                      <span>Measured Cost</span>
+                      <span className="tabular-nums shrink-0 text-warn/90">{fmtUnknownMoney(measuredCost)}</span>
                     </div>
                     <div className="flex items-center justify-between text-faint pl-2">
-                      <span>Estimated</span>
-                      <span className="tabular-nums shrink-0">{fmtUnknownMoney(job.estimated_cost_usd)}</span>
+                      <span>Estimated Cost</span>
+                      <span className="tabular-nums shrink-0 text-warn/90">{fmtUnknownMoney(job.estimated_cost_usd)}</span>
+                    </div>
+                    <div className="flex items-center justify-between text-faint pl-2">
+                      <span>Estimated Savings</span>
+                      <span className="tabular-nums shrink-0 text-good/90">{fmtUnknownMoney(jobAvoided)}</span>
                     </div>
                   </>
                 ) : null}
-                <div className="flex items-center justify-between text-faint">
-                  <span className="truncate pr-2">
-                    {jobModel(job)}
-                    {!owned ? " · visible only" : ""}
-                  </span>
-                  <span className="tabular-nums shrink-0">
-                    {fmtTokens(job.tokens)} · {isFiniteNumber(job.typed_artifacts) ? job.typed_artifacts : "—"} typed
-                    {isFiniteNumber(job.tokens_per_typed_artifact) ? ` · ${fmtTokens(job.tokens_per_typed_artifact)}/typed` : ""}
-                    {` · ${fmtRate(job.degraded_rate)} degraded`}
-                  </span>
-                </div>
+                {!owned ? <div className="text-faint pl-2">visible only</div> : null}
               </div>
             );
           })}

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
+import { CircleDollarSign } from "lucide-react";
 import { api, type EconomicsData, type EconomicsScope, type UsageData } from "../lib/api";
 import { usePolling } from "../lib/usePolling";
+import { readSWRCache, writeSWRCache } from "../lib/useStaleWhileRevalidate";
 import CostBreakdown, { usageToCostBreakdownData } from "./CostBreakdown";
 import EconomicsDurable from "./EconomicsDurable";
 
@@ -10,15 +12,20 @@ function isEconomicsPayload(data: unknown): data is EconomicsData {
 
 /** Right-pane Economics card: live process spend plus durable PM projection. */
 export default function EconomicsPane() {
-  const [session, setSession] = useState<UsageData["session"] | null>(null);
+  const [session, setSession] = useState<UsageData["session"] | null>(
+    () => readSWRCache<UsageData>("economics:usage")?.session ?? null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [scope, setScope] = useState<EconomicsScope>("repo");
-  const [economics, setEconomics] = useState<EconomicsData | null>(null);
+  const [economics, setEconomics] = useState<EconomicsData | null>(
+    () => readSWRCache<EconomicsData>("economics:repo") ?? null,
+  );
 
   const loadUsage = () =>
     api.getUsage()
       .then((data) => {
         if (data?.session) {
+          writeSWRCache("economics:usage", data);
           setSession(data.session);
           setError(null);
         }
@@ -32,6 +39,7 @@ export default function EconomicsPane() {
     Promise.resolve(api.getEconomics(scope))
       .then((data) => {
         if (isEconomicsPayload(data) && (!data.scope || data.scope === scope)) {
+          writeSWRCache(`economics:${scope}`, data);
           setEconomics(data);
           return;
         }
@@ -65,6 +73,7 @@ export default function EconomicsPane() {
     void loadEconomics();
   }, [scope]);
 
+
   if (!session && error) {
     return <p className="px-3 py-3 text-[11px] text-muted">{error}</p>;
   }
@@ -72,9 +81,17 @@ export default function EconomicsPane() {
     return <p className="px-3 py-3 text-[11px] text-muted">Loading this app run…</p>;
   }
   return (
-    <div className="w-full min-h-0 overflow-auto">
-      <CostBreakdown data={usageToCostBreakdownData(session)} />
-      <EconomicsDurable data={economics} scope={scope} onScopeChange={setScope} />
+    <div className="flex flex-col h-full overflow-hidden bg-transparent">
+      <div className="shrink-0 flex items-center px-3 py-2 border-b border-[var(--shell-panel-border)] select-none">
+        <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-faint font-semibold">
+          <CircleDollarSign size={11} className="text-faint/70" />
+          <span>Economics</span>
+        </div>
+      </div>
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <CostBreakdown data={usageToCostBreakdownData(session)} />
+        <EconomicsDurable data={economics} scope={scope} onScopeChange={setScope} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Give Economics a persistent header and independently scrollable body.
<img width="330" height="138" alt="Screenshot 2026-08-25 at 3 03 43 PM" src="https://github.com/user-attachments/assets/d054f29f-e91c-42e6-8d3f-fc97c4f3af7d" />

- Keep last-known Economics data visible while card remounts revalidate in the background.
- Link exact PM job IDs to their existing Swarm Tracker cards.
- Show exact model identity with explicit measured cost, estimated cost, and estimated savings
<img width="321" height="331" alt="Screenshot 2026-08-25 at 3 03 30 PM" src="https://github.com/user-attachments/assets/633f51b1-904a-45f6-aa2f-c393079a9429" />

- Keep tokens, typed-artifact ratios, and degradation details in Swarm Tracker.
- Use amber for costs and green for savings.

## Test plan

- [x] SwarmPane, EconomicsPane, and CostBreakdown tests: 145 passed
- [x] Economics API and HTTP route tests: 21 passed
- [x] TypeScript/Vite production build
- [x] `git diff --check`
- [x] Mounted source-run verification

## Intentional Deferrement 
Does Context Health belong in Economics?
<img width="316" height="102" alt="Screenshot 2026-08-25 at 3 11 15 PM" src="https://github.com/user-attachments/assets/17bac08e-28a4-4825-9df4-5d4f39ccf6c9" />

What is the difference in "savings" between the Econimics pane and Swarm Tracker pane?
<img width="311" height="360" alt="Screenshot 2026-08-25 at 3 08 48 PM" src="https://github.com/user-attachments/assets/f39c3cbd-91c5-48b7-8c37-94afcd893802" />
