### PR TITLE
Release v0.9.356

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.35` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.355, deliberately pre-1.0. Rides puppetmaster-ai==1.22.35. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.356, deliberately pre-1.0. Rides puppetmaster-ai==1.22.35. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.355"
+__version__ = "0.9.356"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/economics.py
+++ b/harness/api/economics.py
@@ -315,7 +315,11 @@ def _serialize_job_counterfactual(cf: Any) -> Optional[dict]:
 
 
 def _models_from_job_cost(job_cost: Any) -> list:
-    by_model = getattr(job_cost, "by_model", None) or {}
+    by_model = (
+        job_cost.get("by_model")
+        if isinstance(job_cost, dict)
+        else getattr(job_cost, "by_model", None)
+    ) or {}
     rows = []
     for model_id, bucket in by_model.items():
         info = bucket if isinstance(bucket, dict) else {}
@@ -438,7 +442,12 @@ def _project_job_row(
                 job_cost = None
                 cf = None
 
-    models = _models_from_job_cost(job_cost) if job_cost is not None else []
+    if pm_receipt is not None:
+        models = _models_from_job_cost(
+            ((pm_receipt.get("pm_report") or {}).get("actual_cost") or {})
+        )
+    else:
+        models = _models_from_job_cost(job_cost) if job_cost is not None else []
     arts = receipt.get("artifacts") if isinstance(receipt, dict) else None
     efficiency = receipt.get("efficiency") if isinstance(receipt, dict) else None
     tasks = receipt.get("tasks") if isinstance(receipt, dict) else None

--- a/harness/pilot.py
+++ b/harness/pilot.py
@@ -815,8 +815,9 @@ def _run_swarm_model_pin_description() -> str:
     """Tool-schema text for run_swarm.model, including live agentic catalog."""
     base = (
         "Optional worker model pin (agentic registry id or adapter model name). "
-        "Use only when the user names a specific swarm worker model; omit for "
-        "auto-route. Prompt text alone does not pin a model. "
+        "Pass it when the user names a swarm worker model. Omitting auto-routes "
+        "only among Models-enabled workers, not the full agentic catalog. "
+        "Prompt text alone does not pin a model. "
     )
     try:
         from .swarm_model_pin import swarm_model_pin_hint
@@ -824,7 +825,7 @@ def _run_swarm_model_pin_description() -> str:
         return base + swarm_model_pin_hint()
     except Exception:
         return base + (
-            "Omit model for auto-route among keyed agentic providers. Session "
+            "Omit model to auto-route among Models-enabled workers. Session "
             "pilot ids remap when a matching worker row exists."
         )
 

--- a/harness/swarm_model_pin.py
+++ b/harness/swarm_model_pin.py
@@ -186,16 +186,16 @@ def swarm_model_pin_hint(*, limit: int = 16) -> str:
     available = list_available_worker_models(limit=limit, adapters=allow or None)
     if not available:
         return (
-            "Omit model for auto-route among currently keyed worker adapters "
+            "Omit model to auto-route among Models-enabled workers "
             "(OpenCode Go, OpenRouter, ChatGPT Codex OAuth, Cursor API, …). "
-            "Session pilot ids are remapped when a matching worker row exists; "
-            "otherwise the harness auto-routes."
+            "Session pilot ids are remapped when a matching worker row exists."
         )
     shown = ", ".join(available)
     return (
-        "Omit model for auto-route (preferred). Live worker catalog: "
+        "Omit model to auto-route among Models-enabled workers. Live catalog: "
         f"{shown}. Session pilot ids (openai-codex:…, cursor/…, codex/…) remap "
-        "to a matching row when present; unknown pins demote to auto-route."
+        "to a matching row when present; unknown pins demote to auto-route "
+        "inside the enabled set."
     )
 
 

--- a/harness/swarm_worker_allowlist.py
+++ b/harness/swarm_worker_allowlist.py
@@ -156,11 +156,36 @@ def adapters_from_visibility(specs: Optional[list[str]] = None) -> set[str]:
     return out
 
 
+def allowed_model_ids_from_specs(
+    specs: Optional[list[str]] = None,
+) -> list[str]:
+    """Map Models-enabled specs to Puppetmaster ``allowed_model_ids``.
+
+    Uses the same alias expansion as ``run_swarm`` pins so
+    ``openai-codex:gpt-5.6-luna`` matches ``agentic/openai-codex/gpt-5.6-luna``.
+    An empty result must be omitted from the worker payload (empty array
+    fails closed in Puppetmaster).
+    """
+    from .swarm_model_pin import pin_candidates
+
+    rows = list(specs) if specs is not None else _enabled_or_visible_specs()
+    out = []
+    seen = set()
+    for spec in rows:
+        for cand in pin_candidates(spec):
+            key = cand.strip().lower()
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            out.append(cand.strip())
+    return out
+
+
 def resolve_swarm_worker_allowlist(
     *,
     specs: Optional[list[str]] = None,
 ) -> dict[str, Any]:
-    """Compute payload ``allowed_adapters`` + ``prefer_plan_billed`` for swarms.
+    """Compute payload ``allowed_adapters`` + model-id allowlist for swarms.
 
     Returns:
       {
@@ -169,6 +194,7 @@ def resolve_swarm_worker_allowlist(
         "primary_adapter": str,         # WorkerSpec.adapter default
         "visibility_adapters": list[str],
         "platform_lock": list[str] | None,
+        "allowed_model_ids": list[str], # empty => do not constrain catalog
       }
     """
     visibility = adapters_from_visibility(specs)
@@ -238,6 +264,11 @@ def resolve_swarm_worker_allowlist(
         "primary_adapter": primary,
         "visibility_adapters": sorted(visibility),
         "platform_lock": sorted(lock) if lock is not None else None,
+        # Empty means "do not constrain the live catalog" (two-tier among
+        # keyed rows). Non-empty is fail-closed to Models toggles so a
+        # disabled gpt-5-3-codex cannot win auto-route while Luna is the
+        # only enabled picker row.
+        "allowed_model_ids": allowed_model_ids_from_specs(specs),
     }
 
 

--- a/pmharness/bridge.py
+++ b/pmharness/bridge.py
@@ -1565,6 +1565,11 @@ def execute_intent(
             primary_adapter = str(
                 _allow.get("primary_adapter") or "agentic"
             ).strip().lower() or "agentic"
+            allowed_model_ids = [
+                str(item).strip()
+                for item in (_allow.get("allowed_model_ids") or [])
+                if str(item).strip()
+            ]
             roles = intent.roles or infer_roles(intent.goal)
             _browser = _browser_swarm_enabled(intent.goal)
             pinned_model = (getattr(intent, "model", None) or "").strip()
@@ -1628,6 +1633,10 @@ def execute_intent(
                     "routing_policy": "balanced",
                     **_analysis_capability_payload(),
                 }
+                if allowed_model_ids and not pin_fields:
+                    # Fail-closed to Settings Models toggles. A global
+                    # intent.model pin still wins via pin_fields below.
+                    base_payload["allowed_model_ids"] = list(allowed_model_ids)
                 if pin_fields:
                     base_payload.update(pin_fields)
                 base_payload = _payload_with_acceptance_criteria(

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -94,10 +94,37 @@ _POST_ANSWER_SLICE_SECONDS = 0.25
 _POST_ANSWER_IDLE_SECONDS = 0.5
 _POST_ANSWER_MAX_SECONDS = 2.0
 _POST_ANSWER_KEEPALIVE_LIMIT = 3
+_INCOMPLETE_ANSWER_SUFFIXES = (":", ",", ";", "—", "–", "-", "/", "(", "[", "{")
 _CONTENT_FILTER_MSG = (
     "Model declined to respond (content filter). Try rephrasing the request "
     "or narrowing the context."
 )
+
+
+def answer_looks_incomplete(text: str) -> bool:
+    """True when idle-drain would cut a clause still being written."""
+    t = (text or "").rstrip()
+    if not t:
+        return False
+    if t.endswith(_INCOMPLETE_ANSWER_SUFFIXES):
+        return True
+    if t.count("```") % 2 == 1:
+        return True
+    return False
+
+
+def responses_input_has_tool_results(body: Optional[dict]) -> bool:
+    """True when this POST is a tool-result follow-up, not a first-shot chat."""
+    items = (body or {}).get("input") if isinstance(body, dict) else None
+    if not isinstance(items, list):
+        return False
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        kind = str(item.get("type") or "")
+        if kind in ("function_call_output", "function_call"):
+            return True
+    return False
 
 
 def _codex_cloudflare_headers(access_token: str, *, streaming: bool = True) -> Dict[str, str]:
@@ -558,6 +585,7 @@ def _consume_codex_sse(
     on_stream_item_done: Optional[Callable[..., None]] = None,
     chatgpt_backend: bool = True,
     stream_label: Optional[str] = None,
+    allow_post_answer_idle: bool = True,
 ) -> dict:
     """Consume Codex Responses SSE; return a synthetic Responses-shaped dict.
 
@@ -569,9 +597,10 @@ def _consume_codex_sse(
     stay on the reasoning stream; final_answer is the answer stream.
 
     The post-answer idle drain (forge ``completed`` after 0.5s idle / 2.0s
-    total) is ChatGPT-only. Non-ChatGPT Responses hosts wait for
-    ``response.completed`` / ``incomplete`` / ``failed``; EOF or ``[DONE]``
-    without that terminal is incomplete/error and keeps partial text.
+    total) is ChatGPT-only and only for a tool-free first-shot answer that
+    already looks finished. Tool-result follow-ups and hanging clauses
+    (``Cloudflare's:``) wait for ``response.completed`` / ``incomplete`` /
+    ``failed``. Non-ChatGPT Responses hosts never idle-drain.
     """
     label = stream_label or responses_stream_label(
         chatgpt_backend=chatgpt_backend,
@@ -669,6 +698,15 @@ def _consume_codex_sse(
         terminal_status = "completed"
         _seal_open_channels(("progress", "reasoning", "answer"), "")
 
+    def _idle_drain_allowed():
+        if not chatgpt_backend or not allow_post_answer_idle:
+            return False
+        if has_tool_calls:
+            return False
+        if answer_looks_incomplete("".join(text_deltas)):
+            return False
+        return True
+
     def _note_answer_text():
         """Only answer tokens extend the idle clock. Trailing summary must not."""
         nonlocal last_meaningful, keepalive_streak
@@ -676,7 +714,7 @@ def _consume_codex_sse(
         keepalive_streak = 0
 
     def _should_finish_drain():
-        if not chatgpt_backend or not post_answer_drain or has_tool_calls:
+        if not _idle_drain_allowed() or not post_answer_drain:
             return False
         now = time.monotonic()
         if now - last_meaningful >= _POST_ANSWER_IDLE_SECONDS:
@@ -697,7 +735,7 @@ def _consume_codex_sse(
         nonlocal keepalive_streak
         if not chatgpt_backend:
             return True
-        if has_tool_calls:
+        if not _idle_drain_allowed():
             return True
         if post_answer_drain:
             return True
@@ -720,8 +758,7 @@ def _consume_codex_sse(
             break
         except (TimeoutError, socket.timeout):
             if (
-                chatgpt_backend
-                and not has_tool_calls
+                _idle_drain_allowed()
                 and (answer_item_done or text_deltas or collected_items)
             ):
                 _finish_tool_free_answer()
@@ -740,7 +777,7 @@ def _consume_codex_sse(
 
         line = raw_line.decode("utf-8", "replace").strip() if isinstance(raw_line, bytes) else str(raw_line).strip()
         if not line or not line.startswith("data:"):
-            if post_answer_drain and not has_tool_calls:
+            if post_answer_drain and _idle_drain_allowed():
                 keepalive_streak += 1
                 if keepalive_streak >= _POST_ANSWER_KEEPALIVE_LIMIT or _should_finish_drain():
                     _finish_tool_free_answer()
@@ -750,7 +787,7 @@ def _consume_codex_sse(
         if not data_str or data_str == "[DONE]":
             if data_str == "[DONE]":
                 break
-            if post_answer_drain and not has_tool_calls:
+            if post_answer_drain and _idle_drain_allowed():
                 keepalive_streak += 1
                 if keepalive_streak >= _POST_ANSWER_KEEPALIVE_LIMIT or _should_finish_drain():
                     _finish_tool_free_answer()
@@ -982,6 +1019,13 @@ def _consume_codex_sse(
             err_msg = responses_stream_error(
                 label, "ended", last_provider_event,
             )
+    elif not saw_terminal and chatgpt_backend:
+        assembled_preview = "".join(text_deltas)
+        if (
+            not allow_post_answer_idle
+            or answer_looks_incomplete(assembled_preview)
+        ) and (assembled_preview or output):
+            terminal_status = "incomplete"
 
     out = {
         "status": terminal_status,
@@ -1209,6 +1253,7 @@ class CodexResponsesDriver:
                             chatgpt_backend=self.chatgpt_backend,
                             base_url=self.base_url,
                         ),
+                        allow_post_answer_idle=not responses_input_has_tool_results(body),
                     )
                 return raw, None, data
             except urllib.error.HTTPError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.355"
+version = "0.9.356"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_economics_peel.py
+++ b/tests/test_api_economics_peel.py
@@ -183,6 +183,49 @@ def test_get_economics_all_projects_opens_extra_dirs(tmp_path, monkeypatch):
     assert len(opened_paths) == 2
 
 
+def test_recent_job_keeps_model_from_pm_financial_report(monkeypatch):
+    _patch_pm(monkeypatch)
+    monkeypatch.setattr(
+        "harness.financial_receipt.load_pm_cost_report",
+        lambda store, job_id, registry=None: {
+            "job_id": job_id,
+            "actual_cost": {
+                "total_marginal_cost_usd": 1.25,
+                "measured_cost_usd": 1.25,
+                "estimated_cost_usd": 0.0,
+                "measured_runs": 1,
+                "estimated_runs": 0,
+                "priced_tasks": 1,
+                "unpriced_tasks": 0,
+                "by_model": {
+                    "composer-2": {
+                        "billing": "metered", "calls": 1,
+                        "tokens_in": 100, "tokens_out": 50,
+                    }
+                },
+            },
+            "counterfactual": None,
+        },
+    )
+    job = {
+        "id": "job_model_receipt",
+        "status": "complete",
+        "source": "harness",
+        "accounting_owned": True,
+        "accounting_scope": "marionette",
+        "created_at": "2026-08-20T00:00:00+00:00",
+    }
+
+    code, payload = get_economics({}, _svc(jobs=[job]))
+
+    assert code == 200
+    assert isinstance(payload, dict)
+    assert payload["recent_jobs"][0]["models"] == [{
+        "model_id": "composer-2", "billing": "metered", "calls": 1,
+        "tokens_in": 100, "tokens_out": 50,
+    }]
+
+
 def test_visibility_only_job_listed_but_omitted_from_owned_totals(monkeypatch):
     jobs = [
         {

--- a/tests/test_bridge_agentic_swarm_routing.py
+++ b/tests/test_bridge_agentic_swarm_routing.py
@@ -14,6 +14,9 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 import pmharness.bridge as bridge
+from harness.swarm_worker_allowlist import (
+    resolve_swarm_worker_allowlist as _real_resolve_swarm_worker_allowlist,
+)
 from pmharness.intent import DriverIntent
 
 
@@ -621,5 +624,46 @@ def test_run_swarm_global_pin_applies_to_every_role(monkeypatch, tmp_path):
     for spec in _CapturingWorkerSpec._last_captured:
         assert spec.payload.get("auto_route") is False
         assert spec.payload.get("pinned_model") == "agentic/openai-codex/gpt-5.6-luna"
+    selected = {model_id for _role, model_id, _payload in _RoutingOrchestrator.last_decisions}
+    assert selected == {"agentic/openai-codex/gpt-5.6-luna"}
+
+
+def test_run_swarm_settings_singleton_blocks_disabled_catalog_peer(monkeypatch, tmp_path):
+    """Only Luna on in Settings: conflict-auditor must not leap to Sol / gpt-5-3."""
+    import harness.swarm_worker_allowlist as swa
+
+    _install_two_tier_product_path(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        swa,
+        "_enabled_or_visible_specs",
+        lambda: ["openai-codex:gpt-5.6-luna"],
+    )
+    monkeypatch.setattr(swa, "_agentic_eligible", lambda: True)
+    monkeypatch.setattr(swa, "_cursor_platform_ready", lambda: False)
+    monkeypatch.setattr(
+        swa,
+        "_platform_locked_adapters",
+        lambda: frozenset({"agentic", "cursor"}),
+    )
+    # _install_two_tier stubs resolve_swarm_worker_allowlist (empty model ids
+    # so two-tier can pick Sol). Restore the real resolver captured at import.
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist.resolve_swarm_worker_allowlist",
+        _real_resolve_swarm_worker_allowlist,
+    )
+    intent = DriverIntent(
+        action="run_swarm",
+        goal="Map the auth middleware",
+        roles=["explore", "conflict-auditor"],
+    )
+    result = bridge.execute_intent(intent, state_dir=str(tmp_path / "state"))
+    assert result is not None
+    captured = {spec.role: spec.payload for spec in _CapturingWorkerSpec._last_captured}
+    for payload in captured.values():
+        ids = [str(item).lower() for item in (payload.get("allowed_model_ids") or [])]
+        blob = " ".join(ids)
+        assert "gpt-5.6-luna" in blob
+        assert "gpt-5.6-sol" not in blob
+        assert "gpt-5-3" not in blob
     selected = {model_id for _role, model_id, _payload in _RoutingOrchestrator.last_decisions}
     assert selected == {"agentic/openai-codex/gpt-5.6-luna"}

--- a/tests/test_codex_responses_driver.py
+++ b/tests/test_codex_responses_driver.py
@@ -15,6 +15,8 @@ from pmharness.drivers.codex_responses import (
     _consume_codex_sse,
     _extract_text_and_tools,
     _messages_to_responses_input,
+    answer_looks_incomplete,
+    responses_input_has_tool_results,
     responses_stream_error,
     responses_stream_label,
 )
@@ -272,6 +274,45 @@ def test_consume_sse_answer_done_timeout_completes():
     assert raw["status"] == "completed"
     assert raw["output_text"] == "Test received."
     assert not raw.get("error")
+
+
+def test_consume_sse_hanging_colon_timeout_stays_incomplete():
+    """A mid-clause stop like 'Cloudflare's:' must not forge completed."""
+
+    def lines():
+        yield b'data: {"type":"response.output_item.added","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"Cloudflare\'s:"}\n'
+        yield b'data: {"type":"response.output_item.done","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        raise TimeoutError("timed out")
+
+    raw = _consume_codex_sse(lines())
+    assert raw["status"] == "incomplete"
+    assert raw["output_text"].endswith(":")
+
+
+def test_consume_sse_tool_followup_timeout_does_not_forge_completed():
+    """Post-swarm synthesis is a tool-result follow-up; idle-drain must not seal it."""
+
+    def lines():
+        yield b'data: {"type":"response.output_item.added","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        yield b'data: {"type":"response.output_text.delta","item_id":"msg_f","delta":"Workers launched Chrome."}\n'
+        yield b'data: {"type":"response.output_item.done","item":{"type":"message","phase":"final_answer","id":"msg_f"}}\n'
+        raise TimeoutError("timed out")
+
+    raw = _consume_codex_sse(lines(), allow_post_answer_idle=False)
+    assert raw["status"] == "incomplete"
+    assert "Chrome" in raw["output_text"]
+
+
+def test_answer_looks_incomplete_and_tool_result_input():
+    assert answer_looks_incomplete("Cloudflare's:") is True
+    assert answer_looks_incomplete("Test received.") is False
+    assert responses_input_has_tool_results({
+        "input": [{"type": "function_call_output", "call_id": "c1", "output": "ok"}],
+    }) is True
+    assert responses_input_has_tool_results({
+        "input": [{"type": "message", "role": "user", "content": []}],
+    }) is False
 
 
 def test_consume_sse_keepalives_after_answer_complete():

--- a/tests/test_swarm_worker_allowlist.py
+++ b/tests/test_swarm_worker_allowlist.py
@@ -135,6 +135,16 @@ def test_enabled_specs_keep_cursor_cli_intent_when_pilots_drop_it(monkeypatch):
     assert out["prefer_plan_billed"] is False
 
 
+def test_singleton_enabled_spec_maps_luna_not_gpt53():
+    from harness.swarm_worker_allowlist import allowed_model_ids_from_specs
+
+    ids = allowed_model_ids_from_specs(["openai-codex:gpt-5.6-luna"])
+    blob = " ".join(ids).lower()
+    assert "gpt-5.6-luna" in blob
+    assert "gpt-5-3" not in blob
+    assert "gpt-5.3" not in blob
+
+
 def test_prefer_plan_billed_true_only_when_cursor_only(monkeypatch):
     monkeypatch.setattr(
         "harness.swarm_worker_allowlist._enabled_or_visible_specs",

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.355"
+version = "0.9.356"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.355",
+  "version": "0.9.356",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.355",
+      "version": "0.9.356",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.355",
+  "version": "0.9.356",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -73,11 +73,16 @@ describe("EconomicsPane", () => {
     expect(await screen.findByText("This app run")).toBeInTheDocument();
     expect(screen.getByText("Economics")).toBeInTheDocument();
     expect(container.firstElementChild).toHaveClass("flex", "flex-col", "h-full", "overflow-hidden");
-    expect(screen.getByText("This app run").parentElement?.parentElement).toHaveClass(
+    const appRun = screen.getByText("This app run");
+    const econ = screen.getByText("Economics");
+    expect(appRun.compareDocumentPosition(econ) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(econ.closest(".shrink-0")).toBeTruthy();
+    expect(screen.getByText("Durable").closest(".overflow-y-auto")).toHaveClass(
       "flex-1",
       "min-h-0",
       "overflow-y-auto",
     );
+    expect(screen.getByText(/not Swarm Tracker receipt savings/)).toBeInTheDocument();
   });
 
   it("keeps the last Economics data visible across card remounts", async () => {
@@ -175,7 +180,7 @@ describe("EconomicsPane", () => {
     const ownedScope = within(ownedRow as HTMLElement);
     expect(ownedScope.getByText("Measured Cost")).toBeInTheDocument();
     expect(ownedScope.getByText("Estimated Cost")).toBeInTheDocument();
-    expect(ownedScope.getByText("Estimated Savings").parentElement).toHaveTextContent("Estimated Savings$2.00");
+    expect(ownedScope.getByText("Vs reference").parentElement).toHaveTextContent("Vs reference$2.00");
     expect(ownedScope.getAllByText("$1.25").length).toBeGreaterThanOrEqual(1);
     expect(ownedScope.getAllByText("—").length).toBeGreaterThanOrEqual(1);
   });
@@ -234,8 +239,8 @@ describe("EconomicsPane", () => {
     expect(screen.getByText("Estimated Cost")).toBeInTheDocument();
     expect(screen.getAllByText("$1.25").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("$0.25")).toBeInTheDocument();
-    expect(screen.getByText("Estimated Savings").parentElement).toHaveTextContent("Estimated Savings$3.00");
     const mixedRow = within(screen.getByText("mixed-1").closest(".mb-2") as HTMLElement);
+    expect(mixedRow.getByText("Vs reference").parentElement).toHaveTextContent("Vs reference$3.00");
     expect(mixedRow.getByText("$1.25")).toHaveClass("text-warn/90");
     expect(mixedRow.getByText("$0.25")).toHaveClass("text-warn/90");
     expect(mixedRow.getByText("$3.00")).toHaveClass("text-good/90");

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -2,6 +2,8 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import EconomicsPane from "../components/EconomicsPane";
 import { api } from "../lib/api";
+import { openAgentSwarmJob } from "../lib/agentLinks";
+import { clearSWRCache } from "../lib/useStaleWhileRevalidate";
 
 vi.mock("../lib/api", () => ({
   api: {
@@ -17,8 +19,13 @@ vi.mock("../lib/usePolling", () => ({
   },
 }));
 
+vi.mock("../lib/agentLinks", () => ({
+  openAgentSwarmJob: vi.fn(),
+}));
+
 const mockGetUsage = vi.mocked(api.getUsage);
 const mockGetEconomics = vi.mocked(api.getEconomics);
+const mockOpenAgentSwarmJob = vi.mocked(openAgentSwarmJob);
 
 const usageSession = {
   tokens_used: 8000,
@@ -51,7 +58,40 @@ const durablePayload = {
 describe("EconomicsPane", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearSWRCache();
     mockGetEconomics.mockResolvedValue(durablePayload);
+  });
+
+  it("owns a persistent header and height-constrained scroll viewport", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: usageSession,
+      jobs: [],
+    });
+
+    const { container } = render(<EconomicsPane />);
+
+    expect(await screen.findByText("This app run")).toBeInTheDocument();
+    expect(screen.getByText("Economics")).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveClass("flex", "flex-col", "h-full", "overflow-hidden");
+    expect(screen.getByText("This app run").parentElement?.parentElement).toHaveClass(
+      "flex-1",
+      "min-h-0",
+      "overflow-y-auto",
+    );
+  });
+
+  it("keeps the last Economics data visible across card remounts", async () => {
+    mockGetUsage.mockResolvedValue({ session: usageSession, jobs: [] });
+
+    const first = render(<EconomicsPane />);
+    expect(await screen.findByText("This app run")).toBeInTheDocument();
+    first.unmount();
+    mockGetUsage.mockImplementation(() => new Promise(() => {}));
+
+    render(<EconomicsPane />);
+
+    expect(screen.getByText("This app run")).toBeInTheDocument();
+    expect(screen.queryByText("Loading this app run…")).not.toBeInTheDocument();
   });
 
   it("shows spend and list-price value from getUsage", async () => {
@@ -126,18 +166,46 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("Job vis-1")).toBeInTheDocument();
+    expect(await screen.findByText("vis-1")).toBeInTheDocument();
     expect(screen.getByText(/visible only/)).toBeInTheDocument();
     expect(screen.queryByText("$9.99")).not.toBeInTheDocument();
     expect(screen.queryByText("~$9.99")).not.toBeInTheDocument();
-    expect(screen.getByText("$1.25 vs $2.00 · measured")).toBeInTheDocument();
-    const ownedRow = screen.getByText("Job owned-1").closest(".mb-2");
+    const ownedRow = screen.getByText("owned-1").closest(".mb-2");
     expect(ownedRow).toBeTruthy();
     const ownedScope = within(ownedRow as HTMLElement);
-    expect(ownedScope.getByText("Measured")).toBeInTheDocument();
-    expect(ownedScope.getByText("Estimated")).toBeInTheDocument();
+    expect(ownedScope.getByText("Measured Cost")).toBeInTheDocument();
+    expect(ownedScope.getByText("Estimated Cost")).toBeInTheDocument();
+    expect(ownedScope.getByText("Estimated Savings").parentElement).toHaveTextContent("Estimated Savings$2.00");
     expect(ownedScope.getAllByText("$1.25").length).toBeGreaterThanOrEqual(1);
     expect(ownedScope.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("opens a recent PM job in the Swarm Tracker", async () => {
+    mockGetUsage.mockResolvedValue({ session: usageSession, jobs: [] });
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      recent_jobs: [
+        {
+          job_id: "job_abcdef012345",
+          accounting_owned: true,
+          models: [{ model_id: "agentic/gpt-5.6-luna" }],
+          tokens: 800,
+          typed_artifacts: 4,
+          tokens_per_typed_artifact: 200,
+          degraded_rate: 0,
+          actual_marginal_usd: 1.25,
+          counterfactual: { avoided_usd: 2.0 },
+        },
+      ],
+    });
+
+    render(<EconomicsPane />);
+    fireEvent.click(await screen.findByRole("button", { name: "job_abcdef012345" }));
+
+    expect(mockOpenAgentSwarmJob).toHaveBeenCalledWith("job_abcdef012345");
+    expect(screen.getByText("agentic/gpt-5.6-luna")).toBeInTheDocument();
+    expect(screen.queryByText(/typed/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/degraded/)).not.toBeInTheDocument();
   });
 
   it("shows headline sum and measured/estimated lines for mixed job cost", async () => {
@@ -161,11 +229,16 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("$1.50 vs $3.00 · mixed basis")).toBeInTheDocument();
-    expect(screen.getByText("Measured")).toBeInTheDocument();
-    expect(screen.getByText("Estimated")).toBeInTheDocument();
+    expect(await screen.findByText("mixed-1")).toBeInTheDocument();
+    expect(screen.getByText("Measured Cost")).toBeInTheDocument();
+    expect(screen.getByText("Estimated Cost")).toBeInTheDocument();
     expect(screen.getAllByText("$1.25").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("$0.25")).toBeInTheDocument();
+    expect(screen.getByText("Estimated Savings").parentElement).toHaveTextContent("Estimated Savings$3.00");
+    const mixedRow = within(screen.getByText("mixed-1").closest(".mb-2") as HTMLElement);
+    expect(mixedRow.getByText("$1.25")).toHaveClass("text-warn/90");
+    expect(mixedRow.getByText("$0.25")).toHaveClass("text-warn/90");
+    expect(mixedRow.getByText("$3.00")).toHaveClass("text-good/90");
   });
 
   it("shows measured-only headline without faking a zero estimated line", async () => {
@@ -187,10 +260,10 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("$2.00 vs — · measured")).toBeInTheDocument();
-    const row = within(screen.getByText("Job meas-1").closest(".mb-2") as HTMLElement);
-    expect(row.getByText("Measured").parentElement).toHaveTextContent("Measured$2.00");
-    expect(row.getByText("Estimated").parentElement).toHaveTextContent("Estimated—");
+    expect(await screen.findByText("meas-1")).toBeInTheDocument();
+    const row = within(screen.getByText("meas-1").closest(".mb-2") as HTMLElement);
+    expect(row.getByText("Measured Cost").parentElement).toHaveTextContent("Measured Cost$2.00");
+    expect(row.getByText("Estimated Cost").parentElement).toHaveTextContent("Estimated Cost—");
     expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
   });
 
@@ -213,10 +286,10 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("$0.75 vs — · estimated")).toBeInTheDocument();
-    const row = within(screen.getByText("Job est-1").closest(".mb-2") as HTMLElement);
-    expect(row.getByText("Measured").parentElement).toHaveTextContent("Measured—");
-    expect(row.getByText("Estimated").parentElement).toHaveTextContent("Estimated$0.75");
+    expect(await screen.findByText("est-1")).toBeInTheDocument();
+    const row = within(screen.getByText("est-1").closest(".mb-2") as HTMLElement);
+    expect(row.getByText("Measured Cost").parentElement).toHaveTextContent("Measured Cost—");
+    expect(row.getByText("Estimated Cost").parentElement).toHaveTextContent("Estimated Cost$0.75");
     expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
   });
 
@@ -238,7 +311,7 @@ describe("EconomicsPane", () => {
 
     render(<EconomicsPane />);
 
-    expect(await screen.findByText("$1.10 vs — · measured")).toBeInTheDocument();
+    expect(await screen.findByText("legacy-1")).toBeInTheDocument();
     expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
   });
 

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -600,7 +600,7 @@ describe("SwarmPane pin attribution", () => {
     mockArtifacts.mockResolvedValue([]);
   });
 
-  it("keeps explicit_pin full registry id and a pin marker on the worker", async () => {
+  it("keeps a scannable model id and pin policy in worker details", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
         status: "running",
@@ -635,8 +635,8 @@ describe("SwarmPane pin attribution", () => {
     await expandVisibleJobs();
 
     const worker = await screen.findByRole("button", { name: /Worker/ });
-    expect(worker).toHaveTextContent("agentic/meta/muse-spark-1.1");
-    expect(screen.getByTitle("explicit_pin · not auto-routed")).toHaveTextContent("pin");
+    expect(worker).toHaveTextContent("meta/muse-spark-1.1");
+    expect(screen.queryByTitle("explicit_pin · not auto-routed")).not.toBeInTheDocument();
     expect(screen.queryByText("Router pick")).not.toBeInTheDocument();
     expect(screen.queryByText("Explicit pin · not auto-routed")).not.toBeInTheDocument();
 
@@ -1541,7 +1541,7 @@ describe("SwarmPane worker-owned routing surface", () => {
     const worker = await screen.findByRole("button", { name: /test-coverage-reviewer/ });
     expect(worker).toHaveTextContent("test-coverage-reviewer");
     expect(worker.textContent || "").not.toMatch(/test-coverage-reviewer \(/);
-    const modelSlot = screen.getByLabelText("Model: agentic/meta/muse-spark-1.1");
+    const modelSlot = screen.getByLabelText("Model: meta/muse-spark-1.1");
     expect(modelSlot).toBeInTheDocument();
     expect(modelSlot.className).toMatch(/truncate/);
     expect(modelSlot.className).toMatch(/min-w-0/);
@@ -2751,7 +2751,7 @@ describe("SwarmPane final-review blockers", () => {
     const worker = await screen.findByRole("button", { name: /test-coverage-reviewer/ });
     expect(worker).toHaveTextContent("test-coverage-reviewer");
     expect(worker.textContent || "").not.toMatch(/test-coverage-reviewer \(/);
-    const modelSlot = screen.getByLabelText("Model: agentic/meta/muse-spark-1.1");
+    const modelSlot = screen.getByLabelText("Model: meta/muse-spark-1.1");
     expect(modelSlot).toBeInTheDocument();
     expect(modelSlot.className).toMatch(/truncate/);
     expect(modelSlot.className).toMatch(/min-w-0/);
@@ -2792,7 +2792,7 @@ describe("SwarmPane final-review blockers", () => {
 
     const worker = await screen.findByRole("button", { name: /test-coverage-reviewer/ });
     expect(worker).toHaveTextContent("test-coverage-reviewer");
-    const modelSlot = screen.getByLabelText("Model: agentic/meta/muse-spark-1.1");
+    const modelSlot = screen.getByLabelText("Model: meta/muse-spark-1.1");
     expect(modelSlot).toBeInTheDocument();
     expect(modelSlot.className).toMatch(/truncate/);
     expect(modelSlot.className).toMatch(/min-w-0/);

--- a/webapp/src/__tests__/modelIdentity.test.ts
+++ b/webapp/src/__tests__/modelIdentity.test.ts
@@ -17,10 +17,15 @@ describe("modelIdentity display helpers", () => {
     );
   });
 
-  it("keeps full registry id for explicit pins", () => {
+  it("strips engine prefixes for pinned and auto-routed badges alike", () => {
     expect(
       displayModelId("agentic/meta/muse-spark-1.1", { policy: "explicit_pin" }),
-    ).toBe("agentic/meta/muse-spark-1.1");
+    ).toBe("meta/muse-spark-1.1");
+    expect(
+      displayModelId("agentic/openai-codex/gpt-5.6-luna", { policy: "explicit_pin" }),
+    ).toBe(
+      displayModelId("agentic/openai-codex/gpt-5.6-luna", { policy: "balanced" }),
+    );
   });
 
   it("strips engine prefixes for auto-routed badges including doubles", () => {

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -752,7 +752,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       {est > 0 ? (
         <div className="flex items-center justify-between mb-1">
           <span className="text-muted">{spendLabel}</span>
-          <span className="text-good font-medium tabular-nums">{spendPrefix}{fmtCost(est)}</span>
+          <span className="text-warn font-medium tabular-nums">{spendPrefix}{fmtCost(est)}</span>
         </div>
       ) : null}
 
@@ -817,7 +817,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
           <span className="text-muted">
             Prompt-cache value{swarmCachePartial ? " (partial)" : ""}
           </span>
-          <span className="text-accent font-medium tabular-nums">~{fmtCost(promptCacheSaved)}</span>
+          <span className="text-good font-medium tabular-nums">~{fmtCost(promptCacheSaved)}</span>
         </div>
       ) : null}
 
@@ -835,7 +835,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
           <span className="text-muted">
             Model selection value{routingEstimated && delegationSaved <= 0 ? " (est.)" : ""}
           </span>
-          <span className="text-accent font-medium tabular-nums">~{fmtCost(modelSelectionSaved)}</span>
+          <span className="text-good font-medium tabular-nums">~{fmtCost(modelSelectionSaved)}</span>
         </div>
       ) : null}
 
@@ -852,7 +852,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       {compactSavings > 0 ? (
         <div className="flex items-center justify-between mb-1">
           <span className="text-muted">Compact tool outputs saved</span>
-          <span className="text-accent font-medium tabular-nums">~{fmtCost(compactSavings)}</span>
+          <span className="text-good font-medium tabular-nums">~{fmtCost(compactSavings)}</span>
         </div>
       ) : null}
 

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -742,7 +742,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
   };
 
   return (
-    <div className="w-full min-h-0 overflow-auto px-3 py-3 text-[11px] text-txt">
+    <div className="w-full min-h-0 px-3 py-3 text-[11px] text-txt">
       <div className="text-[10px] uppercase tracking-wide text-faint">This app run</div>
       <p className="text-[10px] text-muted mb-2 leading-snug">
         Process spend since launch. Resets on full quit — not Swarm pane repo-session spend, not conversation lifetime.
@@ -908,7 +908,10 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
 
       {showContextHealth ? (
       <div className="mt-3 pt-2 border-t border-edge/60">
-        <div className="text-[10px] uppercase tracking-wide text-faint mb-2">Context health</div>
+        <div className="text-[10px] uppercase tracking-wide text-faint mb-1">Context health</div>
+        <p className="text-[10px] text-muted mb-2 leading-snug">
+          Process memory and spills for this app run — not job cash.
+        </p>
       {historyCompactions > 0 ? (
         <div
           className="flex items-center justify-between mb-1 text-faint"

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -57,7 +57,7 @@ export default function EconomicsDurable({
       <p className="text-[10px] text-muted mb-2 leading-snug">
         {scope === "conversation"
           ? "Owned jobs for this conversation. Puppetmaster savings stay on This repo / Last 30 days / All projects."
-          : "Puppetmaster savings for the selected scope. Recent jobs are this workspace tracker; Last 30 days keeps jobs created in that window. App-run spend stays above."}
+          : "Puppetmaster savings for the selected scope. Recent jobs are this workspace tracker; Last 30 days keeps jobs created in that window. App-run spend stays above. Vs reference is a list-price counterfactual, not Swarm Tracker receipt savings."}
       </p>
 
       <label className="flex items-center justify-between mb-2 text-faint">
@@ -118,10 +118,10 @@ export default function EconomicsDurable({
 
       {isFiniteNumber(avoided) ? (
         <div className="flex items-center justify-between mb-1 text-faint">
-          <span>
+          <span title="List-price counterfactual vs the named reference model, not Swarm Tracker receipt savings.">
             {referenceId
-              ? `Estimated savings vs ${referenceId}`
-              : "Estimated savings"}
+              ? `Vs reference (${referenceId})`
+              : "Vs reference"}
           </span>
           <span className="tabular-nums text-good/90">{fmtUnknownMoney(avoided)}</span>
         </div>
@@ -180,7 +180,7 @@ export default function EconomicsDurable({
                       <span className="tabular-nums shrink-0 text-warn/90">{fmtUnknownMoney(job.estimated_cost_usd)}</span>
                     </div>
                     <div className="flex items-center justify-between text-faint pl-2">
-                      <span>Estimated Savings</span>
+                      <span title="List-price counterfactual vs the pane reference, not Swarm Tracker receipt savings.">Vs reference</span>
                       <span className="tabular-nums shrink-0 text-good/90">{fmtUnknownMoney(jobAvoided)}</span>
                     </div>
                   </>

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -1,4 +1,5 @@
 import type { EconomicsData, EconomicsJobRow, EconomicsScope } from "../lib/api";
+import { openAgentSwarmJob } from "../lib/agentLinks";
 
 const SCOPES: Array<{ value: EconomicsScope; label: string }> = [
   { value: "repo", label: "This repo" },
@@ -19,40 +20,6 @@ function fmtUnknownMoney(value: number | null | undefined): string {
   return `$${value.toFixed(2)}`;
 }
 
-function fmtTokens(value: number | null | undefined): string {
-  if (!isFiniteNumber(value)) return "—";
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
-  if (value >= 1000) return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}k`;
-  return String(value);
-}
-
-function fmtRate(value: number | null | undefined): string {
-  if (!isFiniteNumber(value)) return "—";
-  return `${Math.round(value * 100)}%`;
-}
-
-function shortModel(model: string | undefined): string {
-  const text = (model || "").trim();
-  if (!text) return "unknown";
-  const afterColon = text.includes(":") ? text.slice(text.lastIndexOf(":") + 1) : text;
-  const slash = afterColon.lastIndexOf("/");
-  return slash >= 0 ? afterColon.slice(slash + 1) : afterColon;
-}
-
-function jobModel(row: EconomicsJobRow): string {
-  const id = row.models?.[0]?.model_id;
-  return shortModel(id);
-}
-
-function costBasisLabel(basis: string | null | undefined): string {
-  const value = (basis || "").trim().toLowerCase();
-  if (value === "plan") return " · plan $0-marginal";
-  if (value === "estimated") return " · estimated";
-  if (value === "mixed") return " · mixed basis";
-  if (value === "unknown") return " · unknown basis";
-  if (value.includes("measured")) return " · measured";
-  return "";
-}
 
 /** Headline total: measured + estimated when either is known; else legacy actual_marginal. */
 export function jobHeadlineTotal(job: Pick<EconomicsJobRow, "measured_cost_usd" | "estimated_cost_usd" | "actual_marginal_usd">): number | null {
@@ -133,7 +100,7 @@ export default function EconomicsDurable({
       {isFiniteNumber(routingSaved) && routingSaved > 0 ? (
         <div className="flex items-center justify-between mb-1 text-faint">
           <span>Routing saved (measured)</span>
-          <span className="tabular-nums">{fmtUnknownMoney(routingSaved)}</span>
+          <span className="tabular-nums text-good/90">{fmtUnknownMoney(routingSaved)}</span>
         </div>
       ) : data?.available !== false && data?.savings && !isFiniteNumber(routingSaved) ? (
         <div className="flex items-center justify-between mb-1 text-faint">
@@ -145,7 +112,7 @@ export default function EconomicsDurable({
       {isFiniteNumber(codegraphEst) ? (
         <div className="flex items-center justify-between mb-1 text-faint">
           <span>CodeGraph (estimated)</span>
-          <span className="tabular-nums">{fmtUnknownMoney(codegraphEst)}</span>
+          <span className="tabular-nums text-good/90">{fmtUnknownMoney(codegraphEst)}</span>
         </div>
       ) : null}
 
@@ -156,7 +123,7 @@ export default function EconomicsDurable({
               ? `Estimated savings vs ${referenceId}`
               : "Estimated savings"}
           </span>
-          <span className="tabular-nums">{fmtUnknownMoney(avoided)}</span>
+          <span className="tabular-nums text-good/90">{fmtUnknownMoney(avoided)}</span>
         </div>
       ) : null}
 
@@ -174,41 +141,51 @@ export default function EconomicsDurable({
           <div className="text-[10px] uppercase tracking-wide text-faint mb-2">Recent jobs</div>
           {jobs.map((job) => {
             const owned = Boolean(job.accounting_owned);
-            const headlineTotal = owned ? jobHeadlineTotal(job) : null;
+            const modelIds = (job.models || []).map((model) => model.model_id || "").filter(Boolean);
+            const measuredCost = isFiniteNumber(job.measured_cost_usd)
+              ? job.measured_cost_usd
+              : (!isFiniteNumber(job.estimated_cost_usd) && isFiniteNumber(job.actual_marginal_usd)
+                ? job.actual_marginal_usd
+                : null);
             const jobAvoided = owned ? job.counterfactual?.avoided_usd : null;
             return (
               <div key={job.job_id || `${job.source}-${job.status}`} className="mb-2">
                 <div className="flex items-center justify-between text-faint">
-                  <span className="truncate pr-2">{job.job_id ? `Job ${job.job_id}` : "Job"}</span>
-                  <span className="tabular-nums shrink-0">
-                    {owned
-                      ? `${fmtUnknownMoney(headlineTotal)} vs ${fmtUnknownMoney(jobAvoided)}${costBasisLabel(job.cost_basis)}`
-                      : "—"}
-                  </span>
+                  {job.job_id ? (
+                    <button
+                      type="button"
+                      className="truncate pr-2 font-mono text-accent/85 hover:underline underline-offset-2 cursor-pointer bg-transparent border-0 p-0 text-left"
+                      onClick={() => openAgentSwarmJob(job.job_id || "")}
+                    >
+                      {job.job_id}
+                    </button>
+                  ) : (
+                    <span className="truncate pr-2">Job</span>
+                  )}
                 </div>
+                {modelIds.length > 0 ? (
+                  <div className="flex items-start justify-between gap-2 text-faint pl-2">
+                    <span>{modelIds.length === 1 ? "Model" : "Models"}</span>
+                    <span className="font-mono text-right break-words min-w-0">{modelIds.join(", ")}</span>
+                  </div>
+                ) : null}
                 {owned ? (
                   <>
                     <div className="flex items-center justify-between text-faint pl-2">
-                      <span>Measured</span>
-                      <span className="tabular-nums shrink-0">{fmtUnknownMoney(job.measured_cost_usd)}</span>
+                      <span>Measured Cost</span>
+                      <span className="tabular-nums shrink-0 text-warn/90">{fmtUnknownMoney(measuredCost)}</span>
                     </div>
                     <div className="flex items-center justify-between text-faint pl-2">
-                      <span>Estimated</span>
-                      <span className="tabular-nums shrink-0">{fmtUnknownMoney(job.estimated_cost_usd)}</span>
+                      <span>Estimated Cost</span>
+                      <span className="tabular-nums shrink-0 text-warn/90">{fmtUnknownMoney(job.estimated_cost_usd)}</span>
+                    </div>
+                    <div className="flex items-center justify-between text-faint pl-2">
+                      <span>Estimated Savings</span>
+                      <span className="tabular-nums shrink-0 text-good/90">{fmtUnknownMoney(jobAvoided)}</span>
                     </div>
                   </>
                 ) : null}
-                <div className="flex items-center justify-between text-faint">
-                  <span className="truncate pr-2">
-                    {jobModel(job)}
-                    {!owned ? " · visible only" : ""}
-                  </span>
-                  <span className="tabular-nums shrink-0">
-                    {fmtTokens(job.tokens)} · {isFiniteNumber(job.typed_artifacts) ? job.typed_artifacts : "—"} typed
-                    {isFiniteNumber(job.tokens_per_typed_artifact) ? ` · ${fmtTokens(job.tokens_per_typed_artifact)}/typed` : ""}
-                    {` · ${fmtRate(job.degraded_rate)} degraded`}
-                  </span>
-                </div>
+                {!owned ? <div className="text-faint pl-2">visible only</div> : null}
               </div>
             );
           })}

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
+import { CircleDollarSign } from "lucide-react";
 import { api, type EconomicsData, type EconomicsScope, type UsageData } from "../lib/api";
 import { usePolling } from "../lib/usePolling";
+import { readSWRCache, writeSWRCache } from "../lib/useStaleWhileRevalidate";
 import CostBreakdown, { usageToCostBreakdownData } from "./CostBreakdown";
 import EconomicsDurable from "./EconomicsDurable";
 
@@ -10,15 +12,20 @@ function isEconomicsPayload(data: unknown): data is EconomicsData {
 
 /** Right-pane Economics card: live process spend plus durable PM projection. */
 export default function EconomicsPane() {
-  const [session, setSession] = useState<UsageData["session"] | null>(null);
+  const [session, setSession] = useState<UsageData["session"] | null>(
+    () => readSWRCache<UsageData>("economics:usage")?.session ?? null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [scope, setScope] = useState<EconomicsScope>("repo");
-  const [economics, setEconomics] = useState<EconomicsData | null>(null);
+  const [economics, setEconomics] = useState<EconomicsData | null>(
+    () => readSWRCache<EconomicsData>("economics:repo") ?? null,
+  );
 
   const loadUsage = () =>
     api.getUsage()
       .then((data) => {
         if (data?.session) {
+          writeSWRCache("economics:usage", data);
           setSession(data.session);
           setError(null);
         }
@@ -32,6 +39,7 @@ export default function EconomicsPane() {
     Promise.resolve(api.getEconomics(scope))
       .then((data) => {
         if (isEconomicsPayload(data) && (!data.scope || data.scope === scope)) {
+          writeSWRCache(`economics:${scope}`, data);
           setEconomics(data);
           return;
         }
@@ -65,6 +73,7 @@ export default function EconomicsPane() {
     void loadEconomics();
   }, [scope]);
 
+
   if (!session && error) {
     return <p className="px-3 py-3 text-[11px] text-muted">{error}</p>;
   }
@@ -72,9 +81,17 @@ export default function EconomicsPane() {
     return <p className="px-3 py-3 text-[11px] text-muted">Loading this app run…</p>;
   }
   return (
-    <div className="w-full min-h-0 overflow-auto">
-      <CostBreakdown data={usageToCostBreakdownData(session)} />
-      <EconomicsDurable data={economics} scope={scope} onScopeChange={setScope} />
+    <div className="flex flex-col h-full overflow-hidden bg-transparent">
+      <div className="shrink-0 flex items-center px-3 py-2 border-b border-[var(--shell-panel-border)] select-none">
+        <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-faint font-semibold">
+          <CircleDollarSign size={11} className="text-faint/70" />
+          <span>Economics</span>
+        </div>
+      </div>
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <CostBreakdown data={usageToCostBreakdownData(session)} />
+        <EconomicsDurable data={economics} scope={scope} onScopeChange={setScope} />
+      </div>
     </div>
   );
 }

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -82,14 +82,16 @@ export default function EconomicsPane() {
   }
   return (
     <div className="flex flex-col h-full overflow-hidden bg-transparent">
-      <div className="shrink-0 flex items-center px-3 py-2 border-b border-[var(--shell-panel-border)] select-none">
+      <div className="shrink-0 max-h-[45%] overflow-y-auto">
+        <CostBreakdown data={usageToCostBreakdownData(session)} />
+      </div>
+      <div className="shrink-0 flex items-center px-3 py-2 border-y border-[var(--shell-panel-border)] select-none">
         <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-faint font-semibold">
           <CircleDollarSign size={11} className="text-faint/70" />
           <span>Economics</span>
         </div>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <CostBreakdown data={usageToCostBreakdownData(session)} />
         <EconomicsDurable data={economics} scope={scope} onScopeChange={setScope} />
       </div>
     </div>

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -1082,14 +1082,6 @@ function WorkerModelSlot({
           {view.slot}
         </span>
       </Tooltip>
-      {view.pinned && (
-        <span
-          className="text-[7.5px] text-faint uppercase tracking-[0.12em] shrink-0"
-          title="explicit_pin · not auto-routed"
-        >
-          pinned
-        </span>
-      )}
     </span>
   );
 }

--- a/webapp/src/lib/modelIdentity.ts
+++ b/webapp/src/lib/modelIdentity.ts
@@ -1,8 +1,8 @@
 /** Display-side model identity helpers for SwarmPane badges.
 
 Mirrors the *display* half of `harness/model_identity.py` without re-implementing
-envelope stamping: collapse repeated `agentic/` / `native/` prefixes, and strip
-one engine segment for auto-routed badges. Explicit pins keep the full registry id.
+envelope stamping: collapse repeated `agentic/` / `native/` prefixes, then always
+strip engine segments so pin and auto-route badges show the same worker model.
 */
 
 const ENGINE_LABELS = new Set(["agentic", "native"]);
@@ -47,9 +47,9 @@ export function isEngineOnlyModelId(modelId: string): boolean {
 
 /**
  * Badge text for a routed/job model id.
- * - explicit_pin: keep full collapsed registry id (`agentic/meta/...`)
- * - otherwise: strip engine prefixes for scannability next to the adapter chip
- * - never surfaces bare agentic/native (adapter chip stays separate)
+ * Always strip engine prefixes so the same worker model looks the same
+ * whether ROUTING stamped explicit_pin or balanced. Adapter chip stays
+ * separate; never surface bare agentic/native.
  */
 export function displayModelId(
   modelId: string,
@@ -59,11 +59,7 @@ export function displayModelId(
   const adapter = (opts?.adapterFallback || "").trim();
   const safeAdapter = isEngineOnlyModelId(adapter) ? "" : adapter;
   if (!raw || isEngineOnlyModelId(raw)) return safeAdapter;
-  const collapsed = collapseEnginePrefixes(raw);
-  if ((opts?.policy || "").trim() === "explicit_pin") {
-    return collapsed || safeAdapter;
-  }
-  return stripEnginePrefixes(collapsed).trim() || safeAdapter;
+  return stripEnginePrefixes(collapseEnginePrefixes(raw)).trim() || safeAdapter;
 }
 
 /** Identity equality after stripping engine prefixes (case-insensitive). */


### PR DESCRIPTION
## Summary
- Constrain `run_swarm` auto-route to Models-enabled ids (`allowed_model_ids`). A Luna-only picker can no longer send workers to `gpt-5-3-codex`.
- Stop ChatGPT Codex idle-drain from forging `completed` on post-tool synthesis or hanging clauses (`Cloudflare's:`), so length-continue can finish the answer.
- Unify Swarm Tracker worker badges: always strip `agentic/` prefixes; drop the per-row PINNED chip (policy stays in the disclosure).
- Absorb Benton PR #212 (Economics header, scroll, SWR, job-id links). This app run / Context Health sits above the money header; job savings are labeled Vs reference (list-price counterfactual, not Tracker receipt savings).

## Test plan
- [x] pytest: swarm allowlist, bridge two-tier + singleton Luna, Codex idle-drain hanging colon / tool follow-up
- [x] vitest: EconomicsPane, SwarmPane, modelIdentity (123 passed)
- [x] local pytest 5200 passed, 78 skipped
- [ ] CI tests matrix (3.9, 3.11, Windows, frontend-build)