### PR TITLE
Fix stale Investigating after a missed terminal frame

### DIFF
--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -1092,6 +1092,34 @@ describe("mid-turn store-event cursor reattach", () => {
     expect(keep).toBe(true);
   });
 
+  it("settles stale Investigating when the store sees the terminal missed by live SSE", async () => {
+    const applied: string[] = [];
+    const turnSettledRef = { current: false };
+    const deps = reattachDeps({
+      localStreamActiveRef: { current: true },
+      turnSettledRef,
+      applyStreamEventRef: {
+        current: (event: { kind: string }) => {
+          applied.push(event.kind);
+          if (event.kind === "assistant_done") turnSettledRef.current = true;
+        },
+      },
+    });
+    vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      events: [
+        { kind: "runners", data: { state: "idle", runners: { "sess-live": "idle" } } },
+        { kind: "stream", data: { kind: "message_delta", data: { text: "already painted" } } },
+        { kind: "stream", data: { kind: "assistant_done", data: { stop_cause: "natural" } } },
+        { kind: "stream", data: { kind: "done", data: {} } },
+      ],
+    } as any);
+
+    const { pullChatEvents } = createChatEventsReattach(deps as any);
+    await pullChatEvents();
+
+    expect(applied).toEqual(["assistant_done"]);
+  });
+
   it("on getSessionState failure arms store poll without fabricating busy", async () => {
     vi.useFakeTimers();
     const turnOpen = vi.fn();

--- a/webapp/src/components/conversation/chatEventsReattach.ts
+++ b/webapp/src/components/conversation/chatEventsReattach.ts
@@ -382,13 +382,22 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
           continue;
         }
         if (ev.kind === "stream") {
-          if (localStreamActiveRef.current) continue;
           const frame = ev.data || {};
+          const terminal = isTerminalStreamKind(String(frame.kind || ""));
+          // The durable cursor is the recovery path when a live SSE remains open
+          // but misses its terminal frame. Ignore duplicate progress, not an
+          // authoritative terminal the live path has not settled.
+          if (
+            localStreamActiveRef.current
+            && (!terminal || (turnSettledRef?.current ?? false))
+          ) {
+            continue;
+          }
           if (typeof frame.generation === "number" && frame.generation > 0) {
             ringGenerationRef.current = frame.generation;
           }
           applyStreamEventRef.current(storeStreamToStreamEvent(frame));
-          if (isTerminalStreamKind(String(frame.kind || ""))) sawTerminal = true;
+          if (terminal) sawTerminal = true;
         }
       }
 


### PR DESCRIPTION
## Problem

Marionette can finish a turn, persist the final answer, and report the backend runner idle while the header remains stuck on `Investigating`. The durable event cursor has the authoritative `assistant_done`, but currently skips every stored stream frame whenever the local SSE still appears active. If that live SSE missed its terminal frame, no owner settles the renderer.

## Change

- Keep suppressing duplicate stored progress while local SSE is active.
- Replay one stored terminal frame only when the turn is still unsettled.
- Ignore the following `done` frame once `assistant_done` has settled the turn.

Production scope: one existing event-reconciliation file. No new component, state, timer, endpoint, or schema.

## Proof

- RED reproduced the observed sequence: idle runner, duplicate stored progress, missed `assistant_done`, then `done`; before the fix the applied terminal list was empty.
- `npm test -- --run src/__tests__/Conversation.reattach.test.ts` — 29 passed.
- `npx oxlint src/components/conversation/chatEventsReattach.ts src/__tests__/Conversation.reattach.test.ts` — clean.
- `npm run build` — passed.