### PR TITLE
absorb #215: settle stale Investigating from stored terminal

### DIFF
--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -1120,6 +1120,30 @@ describe("mid-turn store-event cursor reattach", () => {
     expect(applied).toEqual(["assistant_done"]);
   });
 
+  it("does not re-apply a stored terminal after live SSE already settled the turn", async () => {
+    const applied: string[] = [];
+    const deps = reattachDeps({
+      localStreamActiveRef: { current: true },
+      turnSettledRef: { current: true },
+      applyStreamEventRef: {
+        current: (event: { kind: string }) => {
+          applied.push(event.kind);
+        },
+      },
+    });
+    vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      events: [
+        { kind: "stream", data: { kind: "assistant_done", data: { stop_cause: "natural" } } },
+        { kind: "stream", data: { kind: "done", data: {} } },
+      ],
+    } as any);
+
+    const { pullChatEvents } = createChatEventsReattach(deps as any);
+    await pullChatEvents();
+
+    expect(applied).toEqual([]);
+  });
+
   it("on getSessionState failure arms store poll without fabricating busy", async () => {
     vi.useFakeTimers();
     const turnOpen = vi.fn();

--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -1092,6 +1092,34 @@ describe("mid-turn store-event cursor reattach", () => {
     expect(keep).toBe(true);
   });
 
+  it("settles stale Investigating when the store sees the terminal missed by live SSE", async () => {
+    const applied: string[] = [];
+    const turnSettledRef = { current: false };
+    const deps = reattachDeps({
+      localStreamActiveRef: { current: true },
+      turnSettledRef,
+      applyStreamEventRef: {
+        current: (event: { kind: string }) => {
+          applied.push(event.kind);
+          if (event.kind === "assistant_done") turnSettledRef.current = true;
+        },
+      },
+    });
+    vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      events: [
+        { kind: "runners", data: { state: "idle", runners: { "sess-live": "idle" } } },
+        { kind: "stream", data: { kind: "message_delta", data: { text: "already painted" } } },
+        { kind: "stream", data: { kind: "assistant_done", data: { stop_cause: "natural" } } },
+        { kind: "stream", data: { kind: "done", data: {} } },
+      ],
+    } as any);
+
+    const { pullChatEvents } = createChatEventsReattach(deps as any);
+    await pullChatEvents();
+
+    expect(applied).toEqual(["assistant_done"]);
+  });
+
   it("on getSessionState failure arms store poll without fabricating busy", async () => {
     vi.useFakeTimers();
     const turnOpen = vi.fn();

--- a/webapp/src/components/conversation/chatEventsReattach.ts
+++ b/webapp/src/components/conversation/chatEventsReattach.ts
@@ -382,13 +382,22 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
           continue;
         }
         if (ev.kind === "stream") {
-          if (localStreamActiveRef.current) continue;
           const frame = ev.data || {};
+          const terminal = isTerminalStreamKind(String(frame.kind || ""));
+          // The durable cursor is the recovery path when a live SSE remains open
+          // but misses its terminal frame. Ignore duplicate progress, not an
+          // authoritative terminal the live path has not settled.
+          if (
+            localStreamActiveRef.current
+            && (!terminal || (turnSettledRef?.current ?? false))
+          ) {
+            continue;
+          }
           if (typeof frame.generation === "number" && frame.generation > 0) {
             ringGenerationRef.current = frame.generation;
           }
           applyStreamEventRef.current(storeStreamToStreamEvent(frame));
-          if (isTerminalStreamKind(String(frame.kind || ""))) sawTerminal = true;
+          if (terminal) sawTerminal = true;
         }
       }
 


### PR DESCRIPTION
## Summary
- Absorb [@kbentonferguson](https://github.com/kbentonferguson) [#215](https://github.com/professorpalmer/marionette/pull/215): when live SSE stays open but misses `assistant_done`, replay one stored terminal so Investigating can settle.
- Keep suppressing duplicate stored progress while local SSE is active; skip stored terminals once `turnSettledRef` is already true (live path already painted the settle).
- Proof: RED on the new reattach test without the skip-exception (`applied === []`); GREEN with the fix (`applied === ["assistant_done"]`). Extra regression: already-settled stored `assistant_done`/`done` apply nothing. `Conversation.reattach.test.ts` 30 passed; oxlint clean.

## Test plan
- [x] `cd webapp && npm test -- --run src/__tests__/Conversation.reattach.test.ts`
- [x] `npx oxlint src/components/conversation/chatEventsReattach.ts src/__tests__/Conversation.reattach.test.ts`

Credit: cherry-pick Author `bferguson_jepp <bferguson@foreflight.com>`; follow-up `Co-authored-by: Benton <kbentonferguson@users.noreply.github.com>`.

Does not ship a version bump. Lands on `dev` for the next cut.