### PR TITLE
Release v0.9.358

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.36` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.357, deliberately pre-1.0. Rides puppetmaster-ai==1.22.36. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.358, deliberately pre-1.0. Rides puppetmaster-ai==1.22.36. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.357"
+__version__ = "0.9.358"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.357"
+version = "0.9.358"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.357"
+version = "0.9.358"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.357",
+  "version": "0.9.358",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.357",
+      "version": "0.9.358",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.357",
+  "version": "0.9.358",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -1120,6 +1120,30 @@ describe("mid-turn store-event cursor reattach", () => {
     expect(applied).toEqual(["assistant_done"]);
   });
 
+  it("does not re-apply a stored terminal after live SSE already settled the turn", async () => {
+    const applied: string[] = [];
+    const deps = reattachDeps({
+      localStreamActiveRef: { current: true },
+      turnSettledRef: { current: true },
+      applyStreamEventRef: {
+        current: (event: { kind: string }) => {
+          applied.push(event.kind);
+        },
+      },
+    });
+    vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      events: [
+        { kind: "stream", data: { kind: "assistant_done", data: { stop_cause: "natural" } } },
+        { kind: "stream", data: { kind: "done", data: {} } },
+      ],
+    } as any);
+
+    const { pullChatEvents } = createChatEventsReattach(deps as any);
+    await pullChatEvents();
+
+    expect(applied).toEqual([]);
+  });
+
   it("on getSessionState failure arms store poll without fabricating busy", async () => {
     vi.useFakeTimers();
     const turnOpen = vi.fn();

--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -1092,6 +1092,34 @@ describe("mid-turn store-event cursor reattach", () => {
     expect(keep).toBe(true);
   });
 
+  it("settles stale Investigating when the store sees the terminal missed by live SSE", async () => {
+    const applied: string[] = [];
+    const turnSettledRef = { current: false };
+    const deps = reattachDeps({
+      localStreamActiveRef: { current: true },
+      turnSettledRef,
+      applyStreamEventRef: {
+        current: (event: { kind: string }) => {
+          applied.push(event.kind);
+          if (event.kind === "assistant_done") turnSettledRef.current = true;
+        },
+      },
+    });
+    vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      events: [
+        { kind: "runners", data: { state: "idle", runners: { "sess-live": "idle" } } },
+        { kind: "stream", data: { kind: "message_delta", data: { text: "already painted" } } },
+        { kind: "stream", data: { kind: "assistant_done", data: { stop_cause: "natural" } } },
+        { kind: "stream", data: { kind: "done", data: {} } },
+      ],
+    } as any);
+
+    const { pullChatEvents } = createChatEventsReattach(deps as any);
+    await pullChatEvents();
+
+    expect(applied).toEqual(["assistant_done"]);
+  });
+
   it("on getSessionState failure arms store poll without fabricating busy", async () => {
     vi.useFakeTimers();
     const turnOpen = vi.fn();

--- a/webapp/src/components/conversation/chatEventsReattach.ts
+++ b/webapp/src/components/conversation/chatEventsReattach.ts
@@ -382,13 +382,22 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
           continue;
         }
         if (ev.kind === "stream") {
-          if (localStreamActiveRef.current) continue;
           const frame = ev.data || {};
+          const terminal = isTerminalStreamKind(String(frame.kind || ""));
+          // The durable cursor is the recovery path when a live SSE remains open
+          // but misses its terminal frame. Ignore duplicate progress, not an
+          // authoritative terminal the live path has not settled.
+          if (
+            localStreamActiveRef.current
+            && (!terminal || (turnSettledRef?.current ?? false))
+          ) {
+            continue;
+          }
           if (typeof frame.generation === "number" && frame.generation > 0) {
             ringGenerationRef.current = frame.generation;
           }
           applyStreamEventRef.current(storeStreamToStreamEvent(frame));
-          if (isTerminalStreamKind(String(frame.kind || ""))) sawTerminal = true;
+          if (terminal) sawTerminal = true;
         }
       }
 


### PR DESCRIPTION
## Summary
- Absorb [@kbentonferguson](https://github.com/kbentonferguson) [#215](https://github.com/professorpalmer/marionette/pull/215): when live SSE stays open but misses `assistant_done`, replay one stored terminal so Investigating can settle.
- Duplicate stored progress stays suppressed while local SSE is active; stored terminals are skipped once `turnSettledRef` is already true.
- Pin stays `puppetmaster-ai==1.22.36`.

## Test plan
- [x] `python -m pytest tests/test_version_consistency.py tests/test_ci_release_gate.py -q` (16 passed)
- [x] `cd webapp && npm test -- --run src/__tests__/Conversation.reattach.test.ts` (30 passed)
- [ ] `tests` workflow green on this `dev` to `main` PR (3.9, 3.11, Windows, frontend-build)