### PR TITLE
Canonicalize workspace case aliases

### DIFF
--- a/harness/api/workspace.py
+++ b/harness/api/workspace.py
@@ -241,6 +241,31 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
     if not target_repo or not os.path.isdir(target_repo):
         return 400, {"error": "Path is not an existing directory"}
 
+    is_git = False
+    branch = ""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", target_repo, "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if proc.returncode == 0:
+            canonical_repo = proc.stdout.strip()
+            if canonical_repo and os.path.isdir(canonical_repo):
+                try:
+                    if os.path.samefile(target_repo, canonical_repo):
+                        target_repo = canonical_repo
+                except OSError:
+                    pass
+            is_git = True
+            proc_branch = subprocess.run(
+                ["git", "-C", target_repo, "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if proc_branch.returncode == 0:
+                branch = proc_branch.stdout.strip()
+    except Exception:
+        pass
+
     # Save outgoing conversation transcript for the current active runner
     if svc.save_active_transcript is not None:
         svc.save_active_transcript()
@@ -290,24 +315,6 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
             svc.record_recent_workspace(target_repo)
     except Exception as e:
         svc.diag("server.record_recent_workspace", e)
-
-    is_git = False
-    branch = ""
-    try:
-        proc = subprocess.run(
-            ["git", "-C", target_repo, "rev-parse", "--is-inside-work-tree"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if proc.returncode == 0:
-            is_git = True
-            proc_branch = subprocess.run(
-                ["git", "-C", target_repo, "rev-parse", "--abbrev-ref", "HEAD"],
-                capture_output=True, text=True, timeout=5,
-            )
-            if proc_branch.returncode == 0:
-                branch = proc_branch.stdout.strip()
-    except Exception:
-        pass
 
     # Select/create the target project's session, then attach via registry
     # (do not rebuild in a way that orphans busy runners).

--- a/tests/test_api_workspace_peel.py
+++ b/tests/test_api_workspace_peel.py
@@ -173,10 +173,19 @@ def test_workspace_open_requires_dir(tmp_path):
     assert post_workspace_open({"path": str(tmp_path / "missing")}, svc)[0] == 400
 
 
-def test_workspace_open_switches(tmp_path):
-    repo = tmp_path / "proj"
+def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
+    repo = tmp_path / "RepoAlias"
+    canonical = tmp_path / "repo"
     repo.mkdir()
+    canonical.mkdir()
     cfg = SimpleNamespace(repo="", driver="m1")
+
+    def git_run(args, **kwargs):
+        stdout = "main\n" if "--abbrev-ref" in args else f"{canonical}\n"
+        return SimpleNamespace(returncode=0, stdout=stdout)
+
+    monkeypatch.setattr("harness.api.workspace.subprocess.run", git_run)
+    monkeypatch.setattr("harness.api.workspace.os.path.samefile", lambda a, b: True)
 
     class _Sessions:
         active = None
@@ -216,10 +225,10 @@ def test_workspace_open_switches(tmp_path):
     svc.get_codegraph_status = lambda r: cg_status["v"]
 
     code, payload = post_workspace_open({"path": str(repo)}, svc)
-    assert code == 200 and payload["ok"] is True
-    assert payload["repo"] == str(repo)
+    assert code == 200 and isinstance(payload, dict) and payload["ok"] is True
+    assert payload["repo"] == str(canonical)
     assert payload["created_session"] is True
-    assert cfg.repo == str(repo)
+    assert cfg.repo == str(canonical)
     assert sessions.active == "s1"
     assert attached["n"] == 1
 


### PR DESCRIPTION
## Question

On a case-insensitive filesystem, should opening `.../Marionette` and `.../marionette` create separate workspace identities when Git resolves both to the same checkout?

## Observed behavior

On macOS, both paths had the same inode and Git resolved both to lowercase `.../marionette`. Mari retained the entered spelling:

- lowercase workspace: 7 Economics jobs
- uppercase workspace: 0 Economics jobs

The uppercase Project entry itself is valid and remains in recents.

## Change

`workspace/open` now uses the existing Git probe to read `--show-toplevel` before writing workspace state. It adopts Git’s path only when `os.path.samefile()` proves the entered path and Git root are the same directory.

Nested workspace behavior is unchanged: opening `.../marionette/webapp` remains scoped to `webapp`. No Project entry, session, or job is deleted or migrated.

## Proof

- RED: a case alias remained the active workspace instead of Git’s canonical root.
- GREEN: the alias opens as lowercase `.../marionette` while the uppercase recent entry remains present.
- Isolated backend: uppercase alias canonicalized; nested `webapp` remained nested.
- Focused workspace/session/job suite: 69 passed.
- `py_compile` and `git diff --check`: passed.