### PR TITLE
absorb #218: canonicalize workspace case aliases

### DIFF
--- a/harness/api/workspace.py
+++ b/harness/api/workspace.py
@@ -244,22 +244,25 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
     is_git = False
     branch = ""
     try:
-        proc = subprocess.run(
-            ["git", "-C", target_repo, "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if proc.returncode == 0:
-            canonical_repo = proc.stdout.strip()
-            if canonical_repo and os.path.isdir(canonical_repo):
+        from ..paths import git_toplevel
+        canonical_repo = git_toplevel(target_repo)
+        if canonical_repo:
+            is_git = True
+            if os.path.isdir(canonical_repo):
                 try:
+                    # Case aliases (macOS/Windows) share an inode with Git's
+                    # toplevel; nested dirs such as webapp do not.
                     if os.path.samefile(target_repo, canonical_repo):
                         target_repo = canonical_repo
                 except OSError:
                     pass
-            is_git = True
             proc_branch = subprocess.run(
                 ["git", "-C", target_repo, "rev-parse", "--abbrev-ref", "HEAD"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
             )
             if proc_branch.returncode == 0:
                 branch = proc_branch.stdout.strip()

--- a/harness/api/workspace.py
+++ b/harness/api/workspace.py
@@ -241,6 +241,31 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
     if not target_repo or not os.path.isdir(target_repo):
         return 400, {"error": "Path is not an existing directory"}
 
+    is_git = False
+    branch = ""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", target_repo, "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if proc.returncode == 0:
+            canonical_repo = proc.stdout.strip()
+            if canonical_repo and os.path.isdir(canonical_repo):
+                try:
+                    if os.path.samefile(target_repo, canonical_repo):
+                        target_repo = canonical_repo
+                except OSError:
+                    pass
+            is_git = True
+            proc_branch = subprocess.run(
+                ["git", "-C", target_repo, "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if proc_branch.returncode == 0:
+                branch = proc_branch.stdout.strip()
+    except Exception:
+        pass
+
     # Save outgoing conversation transcript for the current active runner
     if svc.save_active_transcript is not None:
         svc.save_active_transcript()
@@ -290,24 +315,6 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
             svc.record_recent_workspace(target_repo)
     except Exception as e:
         svc.diag("server.record_recent_workspace", e)
-
-    is_git = False
-    branch = ""
-    try:
-        proc = subprocess.run(
-            ["git", "-C", target_repo, "rev-parse", "--is-inside-work-tree"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if proc.returncode == 0:
-            is_git = True
-            proc_branch = subprocess.run(
-                ["git", "-C", target_repo, "rev-parse", "--abbrev-ref", "HEAD"],
-                capture_output=True, text=True, timeout=5,
-            )
-            if proc_branch.returncode == 0:
-                branch = proc_branch.stdout.strip()
-    except Exception:
-        pass
 
     # Select/create the target project's session, then attach via registry
     # (do not rebuild in a way that orphans busy runners).

--- a/tests/test_api_workspace_peel.py
+++ b/tests/test_api_workspace_peel.py
@@ -173,10 +173,19 @@ def test_workspace_open_requires_dir(tmp_path):
     assert post_workspace_open({"path": str(tmp_path / "missing")}, svc)[0] == 400
 
 
-def test_workspace_open_switches(tmp_path):
-    repo = tmp_path / "proj"
+def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
+    repo = tmp_path / "RepoAlias"
+    canonical = tmp_path / "repo"
     repo.mkdir()
+    canonical.mkdir()
     cfg = SimpleNamespace(repo="", driver="m1")
+
+    def git_run(args, **kwargs):
+        stdout = "main\n" if "--abbrev-ref" in args else f"{canonical}\n"
+        return SimpleNamespace(returncode=0, stdout=stdout)
+
+    monkeypatch.setattr("harness.api.workspace.subprocess.run", git_run)
+    monkeypatch.setattr("harness.api.workspace.os.path.samefile", lambda a, b: True)
 
     class _Sessions:
         active = None
@@ -216,10 +225,10 @@ def test_workspace_open_switches(tmp_path):
     svc.get_codegraph_status = lambda r: cg_status["v"]
 
     code, payload = post_workspace_open({"path": str(repo)}, svc)
-    assert code == 200 and payload["ok"] is True
-    assert payload["repo"] == str(repo)
+    assert code == 200 and isinstance(payload, dict) and payload["ok"] is True
+    assert payload["repo"] == str(canonical)
     assert payload["created_session"] is True
-    assert cfg.repo == str(repo)
+    assert cfg.repo == str(canonical)
     assert sessions.active == "s1"
     assert attached["n"] == 1
 

--- a/tests/test_api_workspace_peel.py
+++ b/tests/test_api_workspace_peel.py
@@ -2,7 +2,11 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from types import SimpleNamespace
+
+import pytest
 
 from harness.api.workspace import (
     WorkspaceServices,
@@ -80,8 +84,6 @@ def test_workspace_forget_clears_active(tmp_path):
 
 
 def test_get_workspace_reports_unborn_head(tmp_path):
-    import subprocess
-
     repo = tmp_path / "unborn"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True, capture_output=True)
@@ -173,20 +175,7 @@ def test_workspace_open_requires_dir(tmp_path):
     assert post_workspace_open({"path": str(tmp_path / "missing")}, svc)[0] == 400
 
 
-def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
-    repo = tmp_path / "RepoAlias"
-    canonical = tmp_path / "repo"
-    repo.mkdir()
-    canonical.mkdir()
-    cfg = SimpleNamespace(repo="", driver="m1")
-
-    def git_run(args, **kwargs):
-        stdout = "main\n" if "--abbrev-ref" in args else f"{canonical}\n"
-        return SimpleNamespace(returncode=0, stdout=stdout)
-
-    monkeypatch.setattr("harness.api.workspace.subprocess.run", git_run)
-    monkeypatch.setattr("harness.api.workspace.os.path.samefile", lambda a, b: True)
-
+def _fresh_sessions():
     class _Sessions:
         active = None
 
@@ -200,11 +189,12 @@ def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
         def switch(self, sid):
             self.active = sid
 
-    sessions = _Sessions()
+    return _Sessions()
+
+
+def _bind_workspace_open(svc, sessions, tmp_path):
     attached = {"n": 0}
     cg_status = {"v": "none"}
-
-    svc, _, _, _ = _svc(cfg, tmp_path)
     svc.sessions = sessions
     svc.save_active_transcript = lambda: None
     svc.note_boot_repo = lambda r: None
@@ -223,6 +213,44 @@ def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
     svc.index_codegraph_bg = lambda r: None
     svc.maybe_refresh_codegraph = lambda r: None
     svc.get_codegraph_status = lambda r: cg_status["v"]
+    return attached, cg_status
+
+
+def test_workspace_open_switches(tmp_path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    cfg = SimpleNamespace(repo="", driver="m1")
+    sessions = _fresh_sessions()
+    svc, _, _, _ = _svc(cfg, tmp_path)
+    attached, _ = _bind_workspace_open(svc, sessions, tmp_path)
+
+    code, payload = post_workspace_open({"path": str(repo)}, svc)
+    assert code == 200 and payload["ok"] is True
+    assert payload["repo"] == str(repo)
+    assert payload["created_session"] is True
+    assert cfg.repo == str(repo)
+    assert sessions.active == "s1"
+    assert attached["n"] == 1
+
+
+def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
+    repo = tmp_path / "RepoAlias"
+    canonical = tmp_path / "repo"
+    repo.mkdir()
+    canonical.mkdir()
+    cfg = SimpleNamespace(repo="", driver="m1")
+    monkeypatch.setattr(
+        "harness.paths.git_toplevel",
+        lambda path: str(canonical),
+    )
+    monkeypatch.setattr("harness.api.workspace.os.path.samefile", lambda a, b: True)
+    monkeypatch.setattr(
+        "harness.api.workspace.subprocess.run",
+        lambda args, **kwargs: SimpleNamespace(returncode=0, stdout="main\n"),
+    )
+    sessions = _fresh_sessions()
+    svc, _, _, _ = _svc(cfg, tmp_path)
+    attached, _ = _bind_workspace_open(svc, sessions, tmp_path)
 
     code, payload = post_workspace_open({"path": str(repo)}, svc)
     assert code == 200 and isinstance(payload, dict) and payload["ok"] is True
@@ -231,6 +259,68 @@ def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
     assert cfg.repo == str(canonical)
     assert sessions.active == "s1"
     assert attached["n"] == 1
+
+
+def test_workspace_open_keeps_nested_dir_when_not_samefile(monkeypatch, tmp_path):
+    root = tmp_path / "marionette"
+    nested = root / "webapp"
+    nested.mkdir(parents=True)
+    cfg = SimpleNamespace(repo="", driver="m1")
+    monkeypatch.setattr("harness.paths.git_toplevel", lambda path: str(root))
+    monkeypatch.setattr(
+        "harness.api.workspace.subprocess.run",
+        lambda args, **kwargs: SimpleNamespace(returncode=0, stdout="dev\n"),
+    )
+    sessions = _fresh_sessions()
+    svc, _, _, _ = _svc(cfg, tmp_path)
+    _bind_workspace_open(svc, sessions, tmp_path)
+
+    code, payload = post_workspace_open({"path": str(nested)}, svc)
+    assert code == 200 and isinstance(payload, dict)
+    assert payload["repo"] == str(nested)
+    assert payload["is_git"] is True
+    assert cfg.repo == str(nested)
+
+
+def test_workspace_open_case_alias_adopts_real_git_toplevel(tmp_path):
+    repo = tmp_path / "marionette"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "-q"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    alias = tmp_path / "Marionette"
+    if not os.path.isdir(alias):
+        pytest.skip("filesystem is case-sensitive")
+    try:
+        if not os.path.samefile(repo, alias):
+            pytest.skip("entered spelling is not a case alias of the git root")
+    except OSError:
+        pytest.skip("samefile failed for case alias")
+    top = subprocess.run(
+        ["git", "-C", str(alias), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    ).stdout.strip()
+    cfg = SimpleNamespace(repo="", driver="m1")
+    sessions = _fresh_sessions()
+    svc, _, _, _ = _svc(cfg, tmp_path)
+    _bind_workspace_open(svc, sessions, tmp_path)
+
+    code, payload = post_workspace_open({"path": str(alias)}, svc)
+    assert code == 200 and isinstance(payload, dict)
+    assert payload["is_git"] is True
+    assert os.path.samefile(payload["repo"], top)
+    assert os.path.samefile(cfg.repo, alias)
+    if os.path.normcase(str(alias)) != os.path.normcase(top):
+        assert payload["repo"] != str(alias)
 
 
 def test_workspace_open_existing_sessions_does_not_create(tmp_path):


### PR DESCRIPTION
## Summary
- Absorb [@kbentonferguson](https://github.com/kbentonferguson) [#218](https://github.com/professorpalmer/marionette/pull/218): `workspace/open` adopts Git's `--show-toplevel` spelling when `os.path.samefile` proves the entered path is the same directory (macOS/Windows case aliases).
- Stack edit: reuse `harness.paths.git_toplevel` (UTF-8, cached) instead of a second Git probe. Nested paths such as `webapp` stay nested because they are not the same directory.
- No Project entry, session, or job is deleted or migrated. Uppercase recents can remain; the active workspace identity is Git's root.

## Test plan
- [x] RED without canonicalize: `payload['repo']` stayed `RepoAlias`
- [x] GREEN: `tests/test_api_workspace_peel.py` 14 passed
- [x] Live macOS case alias `Marionette` to Git toplevel; nested `webapp` kept
- [x] `py_compile harness/api/workspace.py`

Credit: cherry-pick Author `bferguson_jepp <bferguson@foreflight.com>`; follow-up `Co-authored-by: Benton <kbentonferguson@users.noreply.github.com>`.

Does not ship a version bump. Lands on dest for the next cut.