### PR TITLE
Release v0.9.359

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.36` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.358, deliberately pre-1.0. Rides puppetmaster-ai==1.22.36. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.359, deliberately pre-1.0. Rides puppetmaster-ai==1.22.36. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.358"
+__version__ = "0.9.359"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/workspace.py
+++ b/harness/api/workspace.py
@@ -244,22 +244,25 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
     is_git = False
     branch = ""
     try:
-        proc = subprocess.run(
-            ["git", "-C", target_repo, "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if proc.returncode == 0:
-            canonical_repo = proc.stdout.strip()
-            if canonical_repo and os.path.isdir(canonical_repo):
+        from ..paths import git_toplevel
+        canonical_repo = git_toplevel(target_repo)
+        if canonical_repo:
+            is_git = True
+            if os.path.isdir(canonical_repo):
                 try:
+                    # Case aliases (macOS/Windows) share an inode with Git's
+                    # toplevel; nested dirs such as webapp do not.
                     if os.path.samefile(target_repo, canonical_repo):
                         target_repo = canonical_repo
                 except OSError:
                     pass
-            is_git = True
             proc_branch = subprocess.run(
                 ["git", "-C", target_repo, "rev-parse", "--abbrev-ref", "HEAD"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
             )
             if proc_branch.returncode == 0:
                 branch = proc_branch.stdout.strip()

--- a/harness/api/workspace.py
+++ b/harness/api/workspace.py
@@ -241,6 +241,31 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
     if not target_repo or not os.path.isdir(target_repo):
         return 400, {"error": "Path is not an existing directory"}
 
+    is_git = False
+    branch = ""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", target_repo, "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if proc.returncode == 0:
+            canonical_repo = proc.stdout.strip()
+            if canonical_repo and os.path.isdir(canonical_repo):
+                try:
+                    if os.path.samefile(target_repo, canonical_repo):
+                        target_repo = canonical_repo
+                except OSError:
+                    pass
+            is_git = True
+            proc_branch = subprocess.run(
+                ["git", "-C", target_repo, "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if proc_branch.returncode == 0:
+                branch = proc_branch.stdout.strip()
+    except Exception:
+        pass
+
     # Save outgoing conversation transcript for the current active runner
     if svc.save_active_transcript is not None:
         svc.save_active_transcript()
@@ -290,24 +315,6 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
             svc.record_recent_workspace(target_repo)
     except Exception as e:
         svc.diag("server.record_recent_workspace", e)
-
-    is_git = False
-    branch = ""
-    try:
-        proc = subprocess.run(
-            ["git", "-C", target_repo, "rev-parse", "--is-inside-work-tree"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if proc.returncode == 0:
-            is_git = True
-            proc_branch = subprocess.run(
-                ["git", "-C", target_repo, "rev-parse", "--abbrev-ref", "HEAD"],
-                capture_output=True, text=True, timeout=5,
-            )
-            if proc_branch.returncode == 0:
-                branch = proc_branch.stdout.strip()
-    except Exception:
-        pass
 
     # Select/create the target project's session, then attach via registry
     # (do not rebuild in a way that orphans busy runners).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.358"
+version = "0.9.359"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_workspace_peel.py
+++ b/tests/test_api_workspace_peel.py
@@ -173,10 +173,19 @@ def test_workspace_open_requires_dir(tmp_path):
     assert post_workspace_open({"path": str(tmp_path / "missing")}, svc)[0] == 400
 
 
-def test_workspace_open_switches(tmp_path):
-    repo = tmp_path / "proj"
+def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
+    repo = tmp_path / "RepoAlias"
+    canonical = tmp_path / "repo"
     repo.mkdir()
+    canonical.mkdir()
     cfg = SimpleNamespace(repo="", driver="m1")
+
+    def git_run(args, **kwargs):
+        stdout = "main\n" if "--abbrev-ref" in args else f"{canonical}\n"
+        return SimpleNamespace(returncode=0, stdout=stdout)
+
+    monkeypatch.setattr("harness.api.workspace.subprocess.run", git_run)
+    monkeypatch.setattr("harness.api.workspace.os.path.samefile", lambda a, b: True)
 
     class _Sessions:
         active = None
@@ -216,10 +225,10 @@ def test_workspace_open_switches(tmp_path):
     svc.get_codegraph_status = lambda r: cg_status["v"]
 
     code, payload = post_workspace_open({"path": str(repo)}, svc)
-    assert code == 200 and payload["ok"] is True
-    assert payload["repo"] == str(repo)
+    assert code == 200 and isinstance(payload, dict) and payload["ok"] is True
+    assert payload["repo"] == str(canonical)
     assert payload["created_session"] is True
-    assert cfg.repo == str(repo)
+    assert cfg.repo == str(canonical)
     assert sessions.active == "s1"
     assert attached["n"] == 1
 

--- a/tests/test_api_workspace_peel.py
+++ b/tests/test_api_workspace_peel.py
@@ -2,7 +2,11 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from types import SimpleNamespace
+
+import pytest
 
 from harness.api.workspace import (
     WorkspaceServices,
@@ -80,8 +84,6 @@ def test_workspace_forget_clears_active(tmp_path):
 
 
 def test_get_workspace_reports_unborn_head(tmp_path):
-    import subprocess
-
     repo = tmp_path / "unborn"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True, capture_output=True)
@@ -173,20 +175,7 @@ def test_workspace_open_requires_dir(tmp_path):
     assert post_workspace_open({"path": str(tmp_path / "missing")}, svc)[0] == 400
 
 
-def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
-    repo = tmp_path / "RepoAlias"
-    canonical = tmp_path / "repo"
-    repo.mkdir()
-    canonical.mkdir()
-    cfg = SimpleNamespace(repo="", driver="m1")
-
-    def git_run(args, **kwargs):
-        stdout = "main\n" if "--abbrev-ref" in args else f"{canonical}\n"
-        return SimpleNamespace(returncode=0, stdout=stdout)
-
-    monkeypatch.setattr("harness.api.workspace.subprocess.run", git_run)
-    monkeypatch.setattr("harness.api.workspace.os.path.samefile", lambda a, b: True)
-
+def _fresh_sessions():
     class _Sessions:
         active = None
 
@@ -200,11 +189,12 @@ def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
         def switch(self, sid):
             self.active = sid
 
-    sessions = _Sessions()
+    return _Sessions()
+
+
+def _bind_workspace_open(svc, sessions, tmp_path):
     attached = {"n": 0}
     cg_status = {"v": "none"}
-
-    svc, _, _, _ = _svc(cfg, tmp_path)
     svc.sessions = sessions
     svc.save_active_transcript = lambda: None
     svc.note_boot_repo = lambda r: None
@@ -223,6 +213,44 @@ def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
     svc.index_codegraph_bg = lambda r: None
     svc.maybe_refresh_codegraph = lambda r: None
     svc.get_codegraph_status = lambda r: cg_status["v"]
+    return attached, cg_status
+
+
+def test_workspace_open_switches(tmp_path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    cfg = SimpleNamespace(repo="", driver="m1")
+    sessions = _fresh_sessions()
+    svc, _, _, _ = _svc(cfg, tmp_path)
+    attached, _ = _bind_workspace_open(svc, sessions, tmp_path)
+
+    code, payload = post_workspace_open({"path": str(repo)}, svc)
+    assert code == 200 and payload["ok"] is True
+    assert payload["repo"] == str(repo)
+    assert payload["created_session"] is True
+    assert cfg.repo == str(repo)
+    assert sessions.active == "s1"
+    assert attached["n"] == 1
+
+
+def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
+    repo = tmp_path / "RepoAlias"
+    canonical = tmp_path / "repo"
+    repo.mkdir()
+    canonical.mkdir()
+    cfg = SimpleNamespace(repo="", driver="m1")
+    monkeypatch.setattr(
+        "harness.paths.git_toplevel",
+        lambda path: str(canonical),
+    )
+    monkeypatch.setattr("harness.api.workspace.os.path.samefile", lambda a, b: True)
+    monkeypatch.setattr(
+        "harness.api.workspace.subprocess.run",
+        lambda args, **kwargs: SimpleNamespace(returncode=0, stdout="main\n"),
+    )
+    sessions = _fresh_sessions()
+    svc, _, _, _ = _svc(cfg, tmp_path)
+    attached, _ = _bind_workspace_open(svc, sessions, tmp_path)
 
     code, payload = post_workspace_open({"path": str(repo)}, svc)
     assert code == 200 and isinstance(payload, dict) and payload["ok"] is True
@@ -231,6 +259,68 @@ def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
     assert cfg.repo == str(canonical)
     assert sessions.active == "s1"
     assert attached["n"] == 1
+
+
+def test_workspace_open_keeps_nested_dir_when_not_samefile(monkeypatch, tmp_path):
+    root = tmp_path / "marionette"
+    nested = root / "webapp"
+    nested.mkdir(parents=True)
+    cfg = SimpleNamespace(repo="", driver="m1")
+    monkeypatch.setattr("harness.paths.git_toplevel", lambda path: str(root))
+    monkeypatch.setattr(
+        "harness.api.workspace.subprocess.run",
+        lambda args, **kwargs: SimpleNamespace(returncode=0, stdout="dev\n"),
+    )
+    sessions = _fresh_sessions()
+    svc, _, _, _ = _svc(cfg, tmp_path)
+    _bind_workspace_open(svc, sessions, tmp_path)
+
+    code, payload = post_workspace_open({"path": str(nested)}, svc)
+    assert code == 200 and isinstance(payload, dict)
+    assert payload["repo"] == str(nested)
+    assert payload["is_git"] is True
+    assert cfg.repo == str(nested)
+
+
+def test_workspace_open_case_alias_adopts_real_git_toplevel(tmp_path):
+    repo = tmp_path / "marionette"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "-q"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    alias = tmp_path / "Marionette"
+    if not os.path.isdir(alias):
+        pytest.skip("filesystem is case-sensitive")
+    try:
+        if not os.path.samefile(repo, alias):
+            pytest.skip("entered spelling is not a case alias of the git root")
+    except OSError:
+        pytest.skip("samefile failed for case alias")
+    top = subprocess.run(
+        ["git", "-C", str(alias), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    ).stdout.strip()
+    cfg = SimpleNamespace(repo="", driver="m1")
+    sessions = _fresh_sessions()
+    svc, _, _, _ = _svc(cfg, tmp_path)
+    _bind_workspace_open(svc, sessions, tmp_path)
+
+    code, payload = post_workspace_open({"path": str(alias)}, svc)
+    assert code == 200 and isinstance(payload, dict)
+    assert payload["is_git"] is True
+    assert os.path.samefile(payload["repo"], top)
+    assert os.path.samefile(cfg.repo, alias)
+    if os.path.normcase(str(alias)) != os.path.normcase(top):
+        assert payload["repo"] != str(alias)
 
 
 def test_workspace_open_existing_sessions_does_not_create(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.358"
+version = "0.9.359"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.358",
+  "version": "0.9.359",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.358",
+      "version": "0.9.359",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.358",
+  "version": "0.9.359",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Absorb [@kbentonferguson](https://github.com/kbentonferguson) [#218](https://github.com/professorpalmer/marionette/pull/218): `workspace/open` adopts Git's toplevel spelling when `samefile` proves the entered path is the same directory, so macOS/Windows case aliases share one workspace identity.
- Nested paths such as `webapp` stay nested. Recents/sessions/jobs are not deleted. Reuses `harness.paths.git_toplevel`.
- Pin stays `puppetmaster-ai==1.22.36`.

## Test plan
- [x] `python -m pytest tests/test_version_consistency.py tests/test_ci_release_gate.py tests/test_api_workspace_peel.py -q` (30 passed)
- [x] Live macOS case alias `Marionette` to Git toplevel; nested `webapp` kept
- [ ] `tests` workflow green on this dest to `main` PR (3.9, Windows, frontend-build)