### PR TITLE
fix: make swarm await chrome truthful

### DIFF
--- a/webapp/src/__tests__/agentLinks.test.ts
+++ b/webapp/src/__tests__/agentLinks.test.ts
@@ -18,6 +18,7 @@ import {
   openAgentCommand,
   openAgentImage,
   openAgentWorkspace,
+  openAgentBusyDetail,
   openAgentSwarmJob,
   openAgentSpill,
 } from "../lib/agentLinks";
@@ -472,6 +473,21 @@ describe("openAgentLink events", () => {
     expect(kinds).toEqual(["harness-focus-tab", "harness-open-swarm-job"]);
     expect(events[0]?.detail).toBe("swarm");
     expect(events[1]?.detail).toEqual({ jobId: "job_abcdef012345" });
+  });
+
+  it("awaiting-swarm busy chrome opens its exact job instead of Terminal", () => {
+    const spy = vi.spyOn(window, "dispatchEvent");
+
+    openAgentBusyDetail("awaiting_swarm", ["job_abcdef012345"]);
+
+    const events = spy.mock.calls.map((c) => c[0] as CustomEvent);
+    expect(events.map((event) => event.type)).toEqual([
+      "harness-focus-tab",
+      "harness-open-swarm-job",
+    ]);
+    expect(events[0]?.detail).toBe("swarm");
+    expect(events[1]?.detail).toEqual({ jobId: "job_abcdef012345" });
+    expect(events.some((event) => event.detail === "terminal")).toBe(false);
   });
 
   it("openAgentSwarmJob queues the job id before dispatch for late SwarmPane mount", async () => {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -161,7 +161,7 @@ import {
   uploadErrorMessage,
   type DirectoryEntryLike,
 } from "./conversation/composerInput";
-import { openAgentWorkspace } from "../lib/agentLinks";
+import { openAgentBusyDetail, openAgentWorkspace } from "../lib/agentLinks";
 import { AUTH_FAILURE, sharedReadinessNotice, fromBackendDiagnostic } from "../lib/operationalDiagnostic";
 import { getActiveDiagnostic, publishDiagnostic } from "../lib/operationalDiagnosticBus";
 import {
@@ -1616,19 +1616,19 @@ export default function Conversation({
       api.getSessionState({ sessionId: requestSid })
         .then((res) => {
           if (!stillCurrent() || !res) return;
-          setBackendPendingSwarms(!!res.pending_swarms);
-          // Restore Still working… when switching into a pause-point session
-          // (pending_swarms / state===awaiting_swarm). Stop suppresses restore.
-          if (
-            sessionStateShowsAwaitingSwarm({
-              state: res.state,
-              pendingSwarms: !!res.pending_swarms,
-              userStopped: userStoppedRef.current,
-            })
-          ) {
+          const awaitingSwarm = sessionStateShowsAwaitingSwarm({
+            state: res.state,
+            pendingSwarms: !!res.pending_swarms,
+            userStopped: userStoppedRef.current,
+          });
+          setBackendPendingSwarms(awaitingSwarm);
+          if (awaitingSwarm) {
             setTurnOpen(false);
             setStatus("awaiting_swarm");
             setWaitHint(SWARM_AWAIT_HINT);
+          } else {
+            setStatus((prev) => (prev === "awaiting_swarm" ? "idle" : prev));
+            setWaitHint((prev) => clearSwarmAwaitWaitHint(prev));
           }
           // resume_pending is an EXPLICIT one-shot latch from the self-edit
           // restart path (backend /api/session/persist or /api/restart) -- NOT
@@ -3572,14 +3572,7 @@ export default function Conversation({
         }
         recoveryAction={recoveryAction}
         onBusyDetailClick={() => {
-          // Worker / shell busy chrome → terminal, never the file editor.
-          try {
-            window.dispatchEvent(
-              new CustomEvent("harness-focus-tab", { detail: "terminal" }),
-            );
-          } catch {
-            /* ignore */
-          }
+          openAgentBusyDetail(pillStatus, pendingJobIdsRef.current);
         }}
       />
 

--- a/webapp/src/components/conversation/StatusPill.tsx
+++ b/webapp/src/components/conversation/StatusPill.tsx
@@ -30,7 +30,7 @@ const BUSY_PILL_STATUSES = new Set([
   "awaiting_swarm",
 ]);
 
-/** True when the pill may focus the live terminal via onDetailClick. */
+/** True when the pill may focus its source-backed live surface. */
 export function statusPillClickable(
   status: string,
   detail: string | undefined,
@@ -77,7 +77,7 @@ export default function StatusPill({
 }: {
   status: string;
   detail?: string;
-  /** When set, the busy detail (e.g. "Investigating…") focuses the live surface. */
+  /** When set, the busy detail focuses its source-backed live surface. */
   onDetailClick?: () => void;
 }) {
   const label = statusPillLabel(status, detail);
@@ -92,7 +92,7 @@ export default function StatusPill({
         type="button"
         onClick={onDetailClick}
         className={className}
-        title="Open terminal for live worker output"
+        title="Open live activity"
       >
         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusPillDotClass(status)}`} />
         <span className="truncate">{label}</span>

--- a/webapp/src/lib/agentLinks.ts
+++ b/webapp/src/lib/agentLinks.ts
@@ -510,6 +510,24 @@ export function openAgentSwarmJob(jobId: string, artifactId?: string): void {
   }
 }
 
+/** Awaiting swarms own tracker navigation; other live work owns Terminal. */
+export function openAgentBusyDetail(status: string, jobIds: readonly string[]): void {
+  if (status === "awaiting_swarm") {
+    const jobId = jobIds.find((id) => looksLikeJobId(String(id || "").trim()));
+    if (jobId) {
+      openAgentSwarmJob(jobId);
+      return;
+    }
+  }
+  try {
+    window.dispatchEvent(new CustomEvent("harness-focus-tab", {
+      detail: status === "awaiting_swarm" ? "swarm" : "terminal",
+    }));
+  } catch {
+    /* ignore */
+  }
+}
+
 /**
  * Open a spilled tool-output URI in the operator peek surface.
  * Conversation fetches ``/api/spill/read`` and paints a read-only modal.


### PR DESCRIPTION
## Problem

A completed background swarm can leave `Still working` painted after the backend reports idle. While a swarm really is pending, clicking that status opens Terminal even though Puppetmaster output belongs to the Swarm Tracker, producing an empty terminal.
<img width="973" height="945" alt="Screenshot 2026-08-26 at 9 59 51 AM" src="https://github.com/user-attachments/assets/4095b7b6-5a81-41ab-9c76-195c6a976e52" />


## Change

- Revoke stale `awaiting_swarm` status and wait text when authoritative session state reports no pending swarm.
- Open the exact pending swarm from `Still working`; fall back to the Swarm Tracker when no job ID is available.
- Keep non-swarm busy activity routed to Terminal.
- Replace the terminal-specific tooltip with `Open live activity`.

## Proof

- RED: awaiting-swarm busy chrome originally had no source-aware navigation and the focused regression failed.
- `NODE_ENV=test npm test -- --run src/__tests__/agentLinks.test.ts src/__tests__/swarmAwaitChrome.test.ts src/__tests__/conversation.helpers.test.ts` — 206 passed.
- `npm run build` — passed.
- `npm run lint` — passed with pre-existing warnings only.

## Non-goals

This does not change Jobs-pane Session/Repo/global visibility semantics; that remains a separate product question.