### PR TITLE
Release v0.9.360

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.36` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.359, deliberately pre-1.0. Rides puppetmaster-ai==1.22.36. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.360, deliberately pre-1.0. Rides puppetmaster-ai==1.22.36. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.359"
+__version__ = "0.9.360"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.359"
+version = "0.9.360"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.359"
+version = "0.9.360"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.359",
+  "version": "0.9.360",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.359",
+      "version": "0.9.360",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.359",
+  "version": "0.9.360",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/agentLinks.test.ts
+++ b/webapp/src/__tests__/agentLinks.test.ts
@@ -490,6 +490,43 @@ describe("openAgentLink events", () => {
     expect(events.some((event) => event.detail === "terminal")).toBe(false);
   });
 
+  it("awaiting-swarm busy chrome skips invalid ids then opens the real job", () => {
+    const spy = vi.spyOn(window, "dispatchEvent");
+
+    openAgentBusyDetail("awaiting_swarm", ["not-a-job", "job_abcdef012345"]);
+
+    const events = spy.mock.calls.map((c) => c[0] as CustomEvent);
+    expect(events.map((event) => event.type)).toEqual([
+      "harness-focus-tab",
+      "harness-open-swarm-job",
+    ]);
+    expect(events[1]?.detail).toEqual({ jobId: "job_abcdef012345" });
+    expect(events.some((event) => event.detail === "terminal")).toBe(false);
+  });
+
+  it("awaiting-swarm busy chrome without a job id opens Swarm Tracker, not Terminal", () => {
+    const spy = vi.spyOn(window, "dispatchEvent");
+
+    openAgentBusyDetail("awaiting_swarm", ["nope"]);
+
+    const events = spy.mock.calls.map((c) => c[0] as CustomEvent);
+    expect(events.map((event) => event.type)).toEqual(["harness-focus-tab"]);
+    expect(events[0]?.detail).toBe("swarm");
+    expect(events.some((event) => event.detail === "terminal")).toBe(false);
+    expect(events.some((event) => event.type === "harness-open-swarm-job")).toBe(false);
+  });
+
+  it("non-swarm busy chrome still opens Terminal", () => {
+    const spy = vi.spyOn(window, "dispatchEvent");
+
+    openAgentBusyDetail("thinking", ["job_abcdef012345"]);
+
+    const events = spy.mock.calls.map((c) => c[0] as CustomEvent);
+    expect(events.map((event) => event.type)).toEqual(["harness-focus-tab"]);
+    expect(events[0]?.detail).toBe("terminal");
+    expect(events.some((event) => event.type === "harness-open-swarm-job")).toBe(false);
+  });
+
   it("openAgentSwarmJob queues the job id before dispatch for late SwarmPane mount", async () => {
     const { peekPendingSwarmOpenJob, clearPendingSwarmOpenJob } = await import(
       "../lib/pendingSwarmOpenJob"

--- a/webapp/src/__tests__/agentLinks.test.ts
+++ b/webapp/src/__tests__/agentLinks.test.ts
@@ -18,6 +18,7 @@ import {
   openAgentCommand,
   openAgentImage,
   openAgentWorkspace,
+  openAgentBusyDetail,
   openAgentSwarmJob,
   openAgentSpill,
 } from "../lib/agentLinks";
@@ -472,6 +473,21 @@ describe("openAgentLink events", () => {
     expect(kinds).toEqual(["harness-focus-tab", "harness-open-swarm-job"]);
     expect(events[0]?.detail).toBe("swarm");
     expect(events[1]?.detail).toEqual({ jobId: "job_abcdef012345" });
+  });
+
+  it("awaiting-swarm busy chrome opens its exact job instead of Terminal", () => {
+    const spy = vi.spyOn(window, "dispatchEvent");
+
+    openAgentBusyDetail("awaiting_swarm", ["job_abcdef012345"]);
+
+    const events = spy.mock.calls.map((c) => c[0] as CustomEvent);
+    expect(events.map((event) => event.type)).toEqual([
+      "harness-focus-tab",
+      "harness-open-swarm-job",
+    ]);
+    expect(events[0]?.detail).toBe("swarm");
+    expect(events[1]?.detail).toEqual({ jobId: "job_abcdef012345" });
+    expect(events.some((event) => event.detail === "terminal")).toBe(false);
   });
 
   it("openAgentSwarmJob queues the job id before dispatch for late SwarmPane mount", async () => {

--- a/webapp/src/__tests__/swarmAwaitChrome.test.ts
+++ b/webapp/src/__tests__/swarmAwaitChrome.test.ts
@@ -193,6 +193,78 @@ describe("swarm await chrome", () => {
     ).toBe(false);
   });
 
+  it("session peek idle revokes stale awaiting_swarm chrome without clobbering other status", () => {
+    // Mirror Conversation getSessionState peek: authoritative idle must drop
+    // Still working… / Looking…, but leave thinking/error alone.
+    const applyPeek = (opts: {
+      prevStatus: string;
+      prevWaitHint: string | null;
+      state: string;
+      pendingSwarms: boolean;
+      userStopped: boolean;
+    }) => {
+      const awaiting = sessionStateShowsAwaitingSwarm({
+        state: opts.state,
+        pendingSwarms: opts.pendingSwarms,
+        userStopped: opts.userStopped,
+      });
+      const backendPendingSwarms = awaiting;
+      let status = opts.prevStatus;
+      let waitHint = opts.prevWaitHint;
+      if (awaiting) {
+        status = "awaiting_swarm";
+        waitHint = SWARM_AWAIT_HINT;
+      } else {
+        status = status === "awaiting_swarm" ? "idle" : status;
+        waitHint = clearSwarmAwaitWaitHint(waitHint);
+      }
+      return { awaiting, backendPendingSwarms, status, waitHint };
+    };
+
+    expect(
+      applyPeek({
+        prevStatus: "awaiting_swarm",
+        prevWaitHint: SWARM_AWAIT_HINT,
+        state: "idle",
+        pendingSwarms: false,
+        userStopped: false,
+      }),
+    ).toEqual({
+      awaiting: false,
+      backendPendingSwarms: false,
+      status: "idle",
+      waitHint: null,
+    });
+    expect(
+      applyPeek({
+        prevStatus: "thinking",
+        prevWaitHint: "Compacting…",
+        state: "idle",
+        pendingSwarms: false,
+        userStopped: false,
+      }),
+    ).toEqual({
+      awaiting: false,
+      backendPendingSwarms: false,
+      status: "thinking",
+      waitHint: "Compacting…",
+    });
+    expect(
+      applyPeek({
+        prevStatus: "awaiting_swarm",
+        prevWaitHint: PILOT_LOOKING_HINT,
+        state: "awaiting_swarm",
+        pendingSwarms: true,
+        userStopped: true,
+      }),
+    ).toEqual({
+      awaiting: false,
+      backendPendingSwarms: false,
+      status: "idle",
+      waitHint: null,
+    });
+  });
+
   it("seeds pendingJobIds from unresolved swarm_pending cards only", () => {
     const items: Item[] = [
       {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -161,7 +161,7 @@ import {
   uploadErrorMessage,
   type DirectoryEntryLike,
 } from "./conversation/composerInput";
-import { openAgentWorkspace } from "../lib/agentLinks";
+import { openAgentBusyDetail, openAgentWorkspace } from "../lib/agentLinks";
 import { AUTH_FAILURE, sharedReadinessNotice, fromBackendDiagnostic } from "../lib/operationalDiagnostic";
 import { getActiveDiagnostic, publishDiagnostic } from "../lib/operationalDiagnosticBus";
 import {
@@ -1616,19 +1616,19 @@ export default function Conversation({
       api.getSessionState({ sessionId: requestSid })
         .then((res) => {
           if (!stillCurrent() || !res) return;
-          setBackendPendingSwarms(!!res.pending_swarms);
-          // Restore Still working… when switching into a pause-point session
-          // (pending_swarms / state===awaiting_swarm). Stop suppresses restore.
-          if (
-            sessionStateShowsAwaitingSwarm({
-              state: res.state,
-              pendingSwarms: !!res.pending_swarms,
-              userStopped: userStoppedRef.current,
-            })
-          ) {
+          const awaitingSwarm = sessionStateShowsAwaitingSwarm({
+            state: res.state,
+            pendingSwarms: !!res.pending_swarms,
+            userStopped: userStoppedRef.current,
+          });
+          setBackendPendingSwarms(awaitingSwarm);
+          if (awaitingSwarm) {
             setTurnOpen(false);
             setStatus("awaiting_swarm");
             setWaitHint(SWARM_AWAIT_HINT);
+          } else {
+            setStatus((prev) => (prev === "awaiting_swarm" ? "idle" : prev));
+            setWaitHint((prev) => clearSwarmAwaitWaitHint(prev));
           }
           // resume_pending is an EXPLICIT one-shot latch from the self-edit
           // restart path (backend /api/session/persist or /api/restart) -- NOT
@@ -3572,14 +3572,7 @@ export default function Conversation({
         }
         recoveryAction={recoveryAction}
         onBusyDetailClick={() => {
-          // Worker / shell busy chrome → terminal, never the file editor.
-          try {
-            window.dispatchEvent(
-              new CustomEvent("harness-focus-tab", { detail: "terminal" }),
-            );
-          } catch {
-            /* ignore */
-          }
+          openAgentBusyDetail(pillStatus, pendingJobIdsRef.current);
         }}
       />
 

--- a/webapp/src/components/conversation/StatusPill.tsx
+++ b/webapp/src/components/conversation/StatusPill.tsx
@@ -30,7 +30,7 @@ const BUSY_PILL_STATUSES = new Set([
   "awaiting_swarm",
 ]);
 
-/** True when the pill may focus the live terminal via onDetailClick. */
+/** True when the pill may focus its source-backed live surface. */
 export function statusPillClickable(
   status: string,
   detail: string | undefined,
@@ -77,7 +77,7 @@ export default function StatusPill({
 }: {
   status: string;
   detail?: string;
-  /** When set, the busy detail (e.g. "Investigating…") focuses the live surface. */
+  /** When set, the busy detail focuses its source-backed live surface. */
   onDetailClick?: () => void;
 }) {
   const label = statusPillLabel(status, detail);
@@ -92,7 +92,7 @@ export default function StatusPill({
         type="button"
         onClick={onDetailClick}
         className={className}
-        title="Open terminal for live worker output"
+        title="Open live activity"
       >
         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusPillDotClass(status)}`} />
         <span className="truncate">{label}</span>

--- a/webapp/src/lib/agentLinks.ts
+++ b/webapp/src/lib/agentLinks.ts
@@ -510,6 +510,24 @@ export function openAgentSwarmJob(jobId: string, artifactId?: string): void {
   }
 }
 
+/** Awaiting swarms own tracker navigation; other live work owns Terminal. */
+export function openAgentBusyDetail(status: string, jobIds: readonly string[]): void {
+  if (status === "awaiting_swarm") {
+    const jobId = jobIds.find((id) => looksLikeJobId(String(id || "").trim()));
+    if (jobId) {
+      openAgentSwarmJob(jobId);
+      return;
+    }
+  }
+  try {
+    window.dispatchEvent(new CustomEvent("harness-focus-tab", {
+      detail: status === "awaiting_swarm" ? "swarm" : "terminal",
+    }));
+  } catch {
+    /* ignore */
+  }
+}
+
 /**
  * Open a spilled tool-output URI in the operator peek surface.
  * Conversation fetches ``/api/spill/read`` and paints a read-only modal.


### PR DESCRIPTION
## Summary
- Absorb Benton Ferguson PR #221 (landed dest #222): stale Still working chrome revokes when session state is idle.
- Busy-pill clicks open the pending swarm job or Swarm Tracker instead of an empty Terminal.
- Non-swarm busy still routes to Terminal.

## Test plan
- [x] NODE_ENV=test npx vitest --run src/__tests__/agentLinks.test.ts src/__tests__/swarmAwaitChrome.test.ts src/__tests__/conversation.helpers.test.ts src/__tests__/Conversation.warmCache.test.ts — 245 passed
- [x] npm run build
- [x] tests/test_version_consistency.py tests/test_ci_release_gate.py — 16 passed
- [ ] CI tests matrix on this dest-into-main PR (3.9, 3.11, Windows, frontend-build)
