### PR TITLE
absorb #223: honest Jobs and Economics scope labels

### DIFF
--- a/harness/api/economics.py
+++ b/harness/api/economics.py
@@ -48,20 +48,25 @@ JsonPayload = Union[dict, list]
 
 
 def get_economics(qs: dict, svc: EconomicsServices) -> tuple[int, JsonPayload]:
-    """GET /api/economics?scope=repo|window30|all_projects|conversation."""
+    """GET /api/economics?scope=repo|window30|all_projects|conversation&period=30|all.
+
+    ``scope=window30`` remains a back-compat alias for ownership=repo + 30 days.
+    ``period=30`` is a date cutoff on the chosen ownership, not a third ownership.
+    """
     scope = _qs_scope(qs)
     if scope not in SCOPES:
         return 400, {
             "error": "scope must be repo, window30, all_projects, or conversation",
         }
+    window_days = _qs_window_days(qs, scope)
     try:
-        return 200, _project_economics(scope, svc)
+        return 200, _project_economics(scope, svc, window_days)
     except Exception as exc:
         try:
             svc.diag("server.economics", exc)
         except Exception:
             pass
-        return 200, _unavailable_payload(scope, exc)
+        return 200, _unavailable_payload(scope, exc, window_days)
 
 
 def _qs_scope(qs: Optional[dict]) -> str:
@@ -90,10 +95,34 @@ def _scope_window_days(scope: str) -> Optional[float]:
     return None
 
 
-def _unavailable_payload(scope: str, exc: BaseException) -> dict:
+def _qs_window_days(qs: Optional[dict], scope: str) -> Optional[float]:
+    """30-day cutoff from ``scope=window30`` or ``period=30``; else no window."""
+    if scope == "window30":
+        return 30.0
+    if not qs:
+        return None
+    values = qs.get("period") or [""]
+    raw = (values[0] if values else "") or ""
+    text = str(raw).strip().lower()
+    if text in ("30", "30.0"):
+        return 30.0
+    return None
+
+
+def _ownership_from_scope(scope: str) -> str:
+    if scope == "window30":
+        return "repo"
+    return scope
+
+
+def _unavailable_payload(
+    scope: str,
+    exc: BaseException,
+    window_days: Optional[float] = None,
+) -> dict:
     return {
         "scope": scope,
-        "window_days": _scope_window_days(scope),
+        "window_days": window_days if window_days is not None else _scope_window_days(scope),
         "all_projects": scope == "all_projects",
         "savings_scope": "repo" if scope == "conversation" else scope,
         "available": False,
@@ -245,12 +274,16 @@ def _open_savings_stores(dirs: list) -> list:
     return stores
 
 
-def _build_savings(scope: str, workspace: str) -> Optional[dict]:
+def _build_savings(
+    ownership: str,
+    workspace: str,
+    window_days: Optional[float] = None,
+) -> Optional[dict]:
     from puppetmaster.savings import build_report
 
-    dirs = _savings_state_dirs(scope, workspace)
+    dirs = _savings_state_dirs(ownership, workspace)
     stores = _open_savings_stores(dirs)
-    return build_report(stores, window_days=_scope_window_days(scope))
+    return build_report(stores, window_days=window_days)
 
 
 def _created_at_key(job: dict) -> float:
@@ -537,7 +570,11 @@ def _owned_totals(recent_jobs: list) -> dict:
     }
 
 
-def _recent_job_rows(scope: str, svc: EconomicsServices) -> list:
+def _recent_job_rows(
+    scope: str,
+    svc: EconomicsServices,
+    window_days: Optional[float] = None,
+) -> list:
     repo = str(getattr(svc.cfg, "repo", None) or "").strip()
     jobs, harness_store, cli_store = svc.scoped_jobs_with_stores(
         repo_root=repo or None
@@ -545,8 +582,10 @@ def _recent_job_rows(scope: str, svc: EconomicsServices) -> list:
     jobs = list(jobs or [])
     if scope == "conversation":
         jobs = _conversation_jobs(jobs, svc.active_session_id())
-    elif scope == "window30":
-        jobs = [job for job in jobs if _job_in_window(job, 30.0)]
+    elif scope in ("repo", "window30"):
+        jobs = [job for job in jobs if not job.get("cross_project")]
+    if window_days:
+        jobs = [job for job in jobs if _job_in_window(job, window_days)]
     jobs.sort(key=_created_at_key, reverse=True)
     jobs = jobs[:RECENT_JOB_LIMIT]
     registry: list = []
@@ -589,26 +628,33 @@ def _recent_job_rows(scope: str, svc: EconomicsServices) -> list:
     return rows
 
 
-def _project_economics(scope: str, svc: EconomicsServices) -> dict:
+def _project_economics(
+    scope: str,
+    svc: EconomicsServices,
+    window_days: Optional[float] = None,
+) -> dict:
     workspace = _workspace_root(svc)
+    ownership = _ownership_from_scope(scope)
     # Conversation is jobs-only. Do not open repo-lifetime savings stores.
     if scope == "conversation":
         savings = None
         counterfactual = None
         savings_scope = "repo"
     else:
-        report = _build_savings(scope, workspace)
+        report = _build_savings(ownership, workspace, window_days)
         savings = _serialize_savings(report)
         counterfactual = _with_counterfactual_label(
             (savings or {}).get("counterfactual") if savings else None
         )
         savings_scope = scope
-    recent_jobs = _recent_job_rows(scope, svc)
+    recent_jobs = _recent_job_rows(scope, svc, window_days)
     totals = _owned_totals(recent_jobs)
     return {
         "scope": scope,
+        "ownership": ownership,
+        "period": "30" if window_days else "all",
         "savings_scope": savings_scope,
-        "window_days": _scope_window_days(scope),
+        "window_days": window_days,
         "all_projects": scope == "all_projects",
         "available": True,
         "savings": savings,

--- a/harness/api/jobs.py
+++ b/harness/api/jobs.py
@@ -215,6 +215,7 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
         apply_job_economics_policy,
         annotate_job_accounting,
         filter_local_jobs,
+        job_repo_cwd,
         parse_job_dispatch_id,
         parse_job_session_id,
         resolve_job_model,
@@ -472,9 +473,14 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
             outcome = canonical_job_outcome(raw_arts)
 
             tasks_list = []
+            raw_tasks = []
             try:
                 raw_tasks = (tasks_by_job.get(jid, []) if tasks_by_job is not None
                              else svc.retry_on_locked(lambda: job_store.list_tasks(jid)))
+            except Exception:
+                raw_tasks = []
+            job_cwd = job_repo_cwd(raw_tasks)
+            try:
                 for t in raw_tasks:
                     # Finished cards only need role/status/adapter for the
                     # worker strip; skip long instructions until expand.
@@ -557,8 +563,13 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
                 "session_id": j.get("session_id") or parse_job_session_id(j.get("label"), []),
                 "accounting_scope": j.get("accounting_scope", "visibility_only"),
                 "accounting_owned": bool(j.get("accounting_owned")),
+                "cross_project": bool(j.get("cross_project")),
                 **savings_fields,
             }
+            if j.get("cli_state_dir"):
+                row["cli_state_dir"] = j.get("cli_state_dir")
+            if job_cwd:
+                row["cwd"] = job_cwd
             # Optional validation-reuse provenance (absent on legacy rows).
             for _rk in (
                 "reuse_status",

--- a/harness/cli_job_merge.py
+++ b/harness/cli_job_merge.py
@@ -273,6 +273,7 @@ def merge_running_cli_jobs_all_projects(
                 }
             row["source"] = "cli"
             row["cli_state_dir"] = state_dir
+            row["cross_project"] = True
             out.append(row)
             seen_ids.add(jid)
     return out

--- a/harness/job_scoping.py
+++ b/harness/job_scoping.py
@@ -170,7 +170,10 @@ def job_repo_cwd(tasks: list) -> str:
     """Longest normalized ``cwd`` found on task payloads (deepest wins)."""
     cwds: list[str] = []
     for task in tasks or []:
-        payload = getattr(task, "payload", None) or {}
+        if isinstance(task, dict):
+            payload = task.get("payload") or {}
+        else:
+            payload = getattr(task, "payload", None) or {}
         if not isinstance(payload, dict):
             continue
         cwd = (payload.get("cwd") or "").strip()
@@ -358,6 +361,9 @@ def annotate_job_accounting(
         cli_cost_merge=cli_cost_merge,
     )
     row.update(acct)
+    cwd = job_repo_cwd(tasks or [])
+    if cwd:
+        row["cwd"] = cwd
     return row
 
 

--- a/tests/test_api_economics_peel.py
+++ b/tests/test_api_economics_peel.py
@@ -486,3 +486,87 @@ def test_unpriced_job_cost_is_unknown_not_measured_zero(monkeypatch):
     assert row["measured_cost_usd"] is None
     assert row["cost_basis"] == "unknown"
     assert payload["owned_actual_marginal_usd"] is None
+
+
+def test_get_economics_all_projects_period_30_opens_extra_dirs(tmp_path, monkeypatch):
+    extra = tmp_path / "other-project"
+    extra.mkdir()
+    opened = []
+    reports, opened = _patch_pm(monkeypatch, extra_dirs=[extra], opened=opened)
+    code, payload = get_economics(
+        {"scope": ["all_projects"], "period": ["30"]},
+        _svc(),
+    )
+    assert code == 200
+    assert payload["all_projects"] is True
+    assert payload["window_days"] == 30.0
+    assert reports[0]["window_days"] == 30.0
+    opened_paths = [path for _backend, path in opened]
+    assert "/tmp/pm-primary" in opened_paths
+    assert str(extra) in opened_paths
+    assert len(opened_paths) == 2
+
+
+def test_get_economics_repo_period_30_primary_store_only(tmp_path, monkeypatch):
+    extra = tmp_path / "other-project"
+    extra.mkdir()
+    opened = []
+    reports, opened = _patch_pm(monkeypatch, extra_dirs=[extra], opened=opened)
+    code, payload = get_economics({"scope": ["repo"], "period": ["30"]}, _svc())
+    assert code == 200
+    assert payload["scope"] == "repo"
+    assert payload["all_projects"] is False
+    assert payload["window_days"] == 30.0
+    assert reports[0]["window_days"] == 30.0
+    assert opened == [("sqlite", "/tmp/pm-primary")]
+
+
+def test_conversation_fail_closes_missing_session(monkeypatch):
+    jobs = [
+        {
+            "id": "here",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "session_id": "sess-1",
+            "created_at": "2026-08-20T00:02:00+00:00",
+        },
+    ]
+    _patch_pm(monkeypatch)
+    code, payload = get_economics(
+        {"scope": ["conversation"]},
+        _svc(jobs=jobs, session_id=""),
+    )
+    assert code == 200
+    assert payload["recent_jobs"] == []
+    assert payload["owned_jobs_considered"] == 0
+
+
+def test_repo_economics_drops_cross_project_jobs(monkeypatch):
+    _patch_pm(monkeypatch)
+    jobs = [
+        {
+            "id": "local",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "created_at": "2026-08-20T00:00:00+00:00",
+        },
+        {
+            "id": "foreign",
+            "status": "running",
+            "source": "cli",
+            "cross_project": True,
+            "accounting_owned": False,
+            "created_at": "2026-08-20T00:01:00+00:00",
+        },
+    ]
+    _code, repo_payload = get_economics({"scope": ["repo"]}, _svc(jobs=jobs))
+    repo_ids = [row.get("job_id") for row in repo_payload["recent_jobs"]]
+    assert "local" in repo_ids
+    assert "foreign" not in repo_ids
+
+    _code, all_payload = get_economics({"scope": ["all_projects"]}, _svc(jobs=jobs))
+    all_ids = [row.get("job_id") for row in all_payload["recent_jobs"]]
+    assert "foreign" in all_ids

--- a/tests/test_cli_job_merge.py
+++ b/tests/test_cli_job_merge.py
@@ -121,6 +121,8 @@ def test_merge_dedupes_ids_and_sets_source(tmp_path, monkeypatch):
     by_id = {row["id"]: row for row in merged}
     assert by_id[harness_job.id]["source"] == "harness"
     assert by_id["cli-only"]["source"] == "cli"
+    assert not by_id[harness_job.id].get("cross_project")
+    assert not by_id["cli-only"].get("cross_project")
     assert len(merged) == 2
 
 
@@ -182,6 +184,7 @@ def test_merge_running_cli_jobs_all_projects_surfaces_foreign_live(tmp_path, mon
     assert rows[0]["id"] == job.id
     assert rows[0]["source"] == "cli"
     assert rows[0]["cli_state_dir"]
+    assert rows[0]["cross_project"] is True
     assert job.id in seen
 
 

--- a/tests/test_session_job_scoping.py
+++ b/tests/test_session_job_scoping.py
@@ -379,6 +379,10 @@ def test_cwd_under_repo_longest_prefix():
         SimpleNamespace(payload={"cwd": "/work/a"}),
         SimpleNamespace(payload={"cwd": "/work/a/deep/nested"}),
     ]) == os.path.normcase(os.path.abspath("/work/a/deep/nested"))
+    assert job_repo_cwd([
+        {"payload": {"cwd": "/work/a"}},
+        {"payload": {"cwd": "/work/a/deep/nested"}},
+    ]) == os.path.normcase(os.path.abspath("/work/a/deep/nested"))
 
 
 def _api_server(tmp_state_dir):

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -125,11 +125,34 @@ describe("EconomicsPane", () => {
 
     expect(await screen.findByText("Durable")).toBeInTheDocument();
     expect(screen.getAllByText(/anthropic\/claude-opus-4/).length).toBeGreaterThan(0);
-    expect(screen.getByLabelText("Economics scope")).toBeInTheDocument();
-    expect(screen.getByText("This repo")).toBeInTheDocument();
+    expect(screen.getByLabelText("Economics ownership")).toBeInTheDocument();
+    expect(screen.getByLabelText("Economics period")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "This repo" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Last 30 days" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Last 30 days" }).closest("select")).toHaveAttribute(
+      "aria-label",
+      "Economics period",
+    );
     expect(screen.getByText("Routing saved (measured)")).toBeInTheDocument();
     expect(screen.getByText("CodeGraph (estimated)")).toBeInTheDocument();
     expect(screen.queryByText("Session cost")).not.toBeInTheDocument();
+  });
+
+  it("requests Last 30 days as a period on the selected ownership", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: usageSession,
+      jobs: [],
+    });
+
+    render(<EconomicsPane />);
+    expect(await screen.findByText("Durable")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Economics period"), {
+      target: { value: "30" },
+    });
+    await waitFor(() => {
+      expect(mockGetEconomics).toHaveBeenCalledWith("repo", 30);
+    });
   });
 
   it("labels visibility-only jobs without treating their dollars as owned spend", async () => {
@@ -335,12 +358,15 @@ describe("EconomicsPane", () => {
     render(<EconomicsPane />);
     expect(await screen.findByText("Routing saved (measured)")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("Economics scope"), {
+    fireEvent.change(screen.getByLabelText("Economics ownership"), {
       target: { value: "conversation" },
     });
     await waitFor(() => {
       expect(screen.queryByText("Routing saved (measured)")).not.toBeInTheDocument();
     });
+    expect(
+      mockGetEconomics.mock.calls.some((call) => call[0] === "conversation"),
+    ).toBe(true);
   });
 
   it("does not present repo savings as conversation spend", async () => {
@@ -357,7 +383,7 @@ describe("EconomicsPane", () => {
     render(<EconomicsPane />);
     expect(await screen.findByText("Durable")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("Economics scope"), {
+    fireEvent.change(screen.getByLabelText("Economics ownership"), {
       target: { value: "conversation" },
     });
     expect(

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -75,6 +75,7 @@ describe("SwarmPane sort and filter controls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -164,6 +165,7 @@ describe("SwarmPane SWR cache first-open", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -200,6 +202,7 @@ describe("SwarmPane model badge", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockSwarmLive.mockResolvedValue(liveJob());
@@ -441,6 +444,7 @@ describe("SwarmPane worker details", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -595,6 +599,7 @@ describe("SwarmPane pin attribution", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -756,6 +761,7 @@ describe("SwarmPane routing dedupe", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -867,6 +873,7 @@ describe("SwarmPane mid-run job-row meters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -1145,6 +1152,7 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -1293,6 +1301,7 @@ describe("SwarmPane cancel Kill contract", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -1390,6 +1399,7 @@ describe("SwarmPane canonical outcome", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -1424,6 +1434,7 @@ describe("SwarmPane findings section collapse", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -1503,6 +1514,7 @@ describe("SwarmPane worker-owned routing surface", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -1763,6 +1775,7 @@ describe("SwarmPane worker tokens and cost", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -1825,6 +1838,7 @@ describe("SwarmPane worker progress", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -1860,6 +1874,7 @@ describe("SwarmPane worker outcome hierarchy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -2082,6 +2097,7 @@ describe("SwarmPane tracker header", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -2119,6 +2135,7 @@ describe("SwarmPane external (CLI) source badge", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -2177,6 +2194,44 @@ describe("SwarmPane external (CLI) source badge", () => {
       ),
     ).toBeNull();
   });
+
+  it("discloses cwd for cross-project CLI jobs instead of only external", async () => {
+    localStorage.setItem("marionette.jobScope.v1", "all");
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-foreign",
+        goal: "Foreign swarm",
+        status: "running",
+        adapter: "cursor",
+        source: "cli",
+        cross_project: true,
+        cwd: "/Users/x/other-repo",
+        cli_state_dir: "/tmp/pm-other",
+        tasks: [
+          {
+            id: "t1",
+            role: "cursor",
+            instruction: "do the thing",
+            status: "running",
+            adapter: "cursor",
+          },
+        ],
+      }),
+    );
+
+    render(<SwarmPane />);
+    fireEvent.click(screen.getByRole("button", { name: "All projects" }));
+    await expandJob(/Foreign swarm/);
+
+    await waitFor(() => {
+      expect(screen.getByTitle("/Users/x/other-repo")).toHaveTextContent("/Users/x/other-repo");
+    });
+    expect(
+      screen.queryByTitle(
+        "Started outside Marionette (Cursor MCP or terminal Puppetmaster) for this workspace",
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("SwarmPane repo-scoped dismiss", () => {
@@ -2186,6 +2241,7 @@ describe("SwarmPane repo-scoped dismiss", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -2371,6 +2427,7 @@ describe("SwarmPane harness-open-swarm-job deep-link", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     const { clearPendingSwarmOpenJob } = await import("../lib/pendingSwarmOpenJob");
@@ -2509,6 +2566,7 @@ describe("SwarmPane final-review blockers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -2810,6 +2868,7 @@ describe("SwarmPane job-card expansion persistence", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -2947,6 +3006,7 @@ describe("swarm tracker usage pills (0.9.300)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -3026,6 +3086,7 @@ describe("SwarmPane command vs swarm split", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -3148,6 +3209,7 @@ describe("SwarmPane v0.9.350 collapsed chrome", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);
@@ -3215,6 +3277,7 @@ describe("SwarmPane 353 mixed chrome and routing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "repo");
     sessionStorage.clear();
     clearSWRCache();
     mockArtifacts.mockResolvedValue([]);

--- a/webapp/src/__tests__/jobScope.test.ts
+++ b/webapp/src/__tests__/jobScope.test.ts
@@ -5,6 +5,7 @@ const jobs = [
   { id: "a", session_id: "sess-1" },
   { id: "b", session_id: "sess-2" },
   { id: "c" },
+  { id: "foreign", session_id: "sess-9", cross_project: true },
 ];
 
 describe("jobInActiveSession", () => {
@@ -20,11 +21,36 @@ describe("filterJobsByScope", () => {
     expect(filterJobsByScope(jobs, "session", "sess-1").map((j) => j.id)).toEqual(["a"]);
   });
 
-  it("repo keeps the full already-visible list", () => {
+  it("session without an active id fail-closes", () => {
+    expect(filterJobsByScope(jobs, "session", "").map((j) => j.id)).toEqual([]);
+  });
+
+  it("session does not match jobs missing session_id", () => {
+    expect(filterJobsByScope(jobs, "session", "sess-1").map((j) => j.id)).not.toContain("c");
+  });
+
+  it("repo drops cross_project rows", () => {
     expect(filterJobsByScope(jobs, "repo", "sess-1").map((j) => j.id)).toEqual(["a", "b", "c"]);
   });
 
-  it("session without an active id keeps the list", () => {
-    expect(filterJobsByScope(jobs, "session", "").map((j) => j.id)).toEqual(["a", "b", "c"]);
+  it("all keeps cross_project rows", () => {
+    expect(filterJobsByScope(jobs, "all", "sess-1").map((j) => j.id)).toEqual([
+      "a",
+      "b",
+      "c",
+      "foreign",
+    ]);
+  });
+
+  it("includeJobIds resurrects a foreign id under session", () => {
+    expect(
+      filterJobsByScope(jobs, "session", "sess-1", { includeJobIds: ["foreign"] }).map((j) => j.id),
+    ).toEqual(["a", "foreign"]);
+  });
+
+  it("includeJobIds resurrects a foreign id under repo", () => {
+    expect(
+      filterJobsByScope(jobs, "repo", "sess-1", { includeJobIds: ["foreign"] }).map((j) => j.id),
+    ).toEqual(["a", "b", "c", "foreign"]);
   });
 });

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -1,11 +1,15 @@
 import type { EconomicsData, EconomicsJobRow, EconomicsScope } from "../lib/api";
 import { openAgentSwarmJob } from "../lib/agentLinks";
 
-const SCOPES: Array<{ value: EconomicsScope; label: string }> = [
-  { value: "repo", label: "This repo" },
-  { value: "window30", label: "Last 30 days" },
-  { value: "all_projects", label: "All projects" },
+const OWNERSHIP: Array<{ value: EconomicsScope; label: string }> = [
   { value: "conversation", label: "This conversation" },
+  { value: "repo", label: "This repo" },
+  { value: "all_projects", label: "All projects" },
+];
+
+const PERIODS: Array<{ value: "all" | "30"; label: string }> = [
+  { value: "all", label: "All time" },
+  { value: "30", label: "Last 30 days" },
 ];
 
 function isFiniteNumber(value: unknown): value is number {
@@ -37,10 +41,14 @@ export default function EconomicsDurable({
   data,
   scope,
   onScopeChange,
+  periodDays,
+  onPeriodChange,
 }: {
   data: EconomicsData | null;
   scope: EconomicsScope;
   onScopeChange: (scope: EconomicsScope) => void;
+  periodDays: 30 | null;
+  onPeriodChange: (periodDays: 30 | null) => void;
 }) {
   const referenceId = data?.counterfactual?.reference_model_id
     || data?.savings?.counterfactual?.reference_model_id
@@ -56,19 +64,35 @@ export default function EconomicsDurable({
       <div className="text-[10px] uppercase tracking-wide text-faint">Durable</div>
       <p className="text-[10px] text-muted mb-2 leading-snug">
         {scope === "conversation"
-          ? "Owned jobs for this conversation. Puppetmaster savings stay on This repo / Last 30 days / All projects."
-          : "Puppetmaster savings for the selected scope. Recent jobs are this workspace tracker; Last 30 days keeps jobs created in that window. App-run spend stays above. Vs reference is a list-price counterfactual, not Swarm Tracker receipt savings."}
+          ? "Owned jobs for this conversation. Puppetmaster savings stay on This repo / All projects."
+          : "Puppetmaster savings for the selected ownership. Last 30 days is a date cutoff on the selected ownership, not a different project set. App-run spend stays above. Vs reference is a list-price counterfactual, not Swarm Tracker receipt savings. $0 route estimates stay forecasts, not cash."}
       </p>
 
       <label className="flex items-center justify-between mb-2 text-faint">
-        <span className="text-[10px] uppercase tracking-wide">Scope</span>
+        <span className="text-[10px] uppercase tracking-wide">Ownership</span>
         <select
           className="bg-transparent text-[11px] text-txt"
-          value={scope}
+          value={scope === "window30" ? "repo" : scope}
           onChange={(event) => onScopeChange(event.target.value as EconomicsScope)}
-          aria-label="Economics scope"
+          aria-label="Economics ownership"
         >
-          {SCOPES.map((option) => (
+          {OWNERSHIP.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex items-center justify-between mb-2 text-faint">
+        <span className="text-[10px] uppercase tracking-wide">Period</span>
+        <select
+          className="bg-transparent text-[11px] text-txt"
+          value={periodDays === 30 ? "30" : "all"}
+          onChange={(event) => onPeriodChange(event.target.value === "30" ? 30 : null)}
+          aria-label="Economics period"
+        >
+          {PERIODS.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
             </option>

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -17,8 +17,9 @@ export default function EconomicsPane() {
   );
   const [error, setError] = useState<string | null>(null);
   const [scope, setScope] = useState<EconomicsScope>("repo");
+  const [periodDays, setPeriodDays] = useState<30 | null>(null);
   const [economics, setEconomics] = useState<EconomicsData | null>(
-    () => readSWRCache<EconomicsData>("economics:repo") ?? null,
+    () => readSWRCache<EconomicsData>("economics:repo:all") ?? null,
   );
 
   const loadUsage = () =>
@@ -36,10 +37,10 @@ export default function EconomicsPane() {
       });
 
   const loadEconomics = () =>
-    Promise.resolve(api.getEconomics(scope))
+    Promise.resolve(api.getEconomics(scope, periodDays ?? "all"))
       .then((data) => {
         if (isEconomicsPayload(data) && (!data.scope || data.scope === scope)) {
-          writeSWRCache(`economics:${scope}`, data);
+          writeSWRCache(`economics:${scope}:${periodDays || "all"}`, data);
           setEconomics(data);
           return;
         }
@@ -67,11 +68,11 @@ export default function EconomicsPane() {
       window.removeEventListener("harness-usage-refresh", onRefresh);
       window.removeEventListener("harness-session-changed", onRefresh);
     };
-  }, [scope]);
+  }, [scope, periodDays]);
 
   useEffect(() => {
     void loadEconomics();
-  }, [scope]);
+  }, [scope, periodDays]);
 
 
   if (!session && error) {
@@ -92,7 +93,13 @@ export default function EconomicsPane() {
         </div>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <EconomicsDurable data={economics} scope={scope} onScopeChange={setScope} />
+        <EconomicsDurable
+          data={economics}
+          scope={scope}
+          onScopeChange={setScope}
+          periodDays={periodDays}
+          onPeriodChange={setPeriodDays}
+        />
       </div>
     </div>
   );

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -110,6 +110,11 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
   );
   const [hiddenJobIds, setHiddenJobIds] = useState<Set<string>>(loadHiddenSessionJobs);
   const [jobScope, setJobScope] = useState<JobScope>(() => loadJobScope());
+  useEffect(() => {
+    const onScope = () => setJobScope(loadJobScope());
+    window.addEventListener("harness-job-scope-changed", onScope);
+    return () => window.removeEventListener("harness-job-scope-changed", onScope);
+  }, []);
   const [confirmClearJobs, setConfirmClearJobs] = useState(false);
   const [showAllJobs, setShowAllJobs] = useState(false);
   const [expandedJobs, setExpandedJobs] = useState<Record<string, boolean>>({});
@@ -1932,16 +1937,16 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
           </button>
           {!sessionJobsCollapsed && (
             <div className="flex h-5 overflow-hidden rounded border border-edge/70 shrink-0">
-              {(["session", "repo"] as const).map((scope) => (
+              {(["session", "repo", "all"] as const).map((scope) => (
                 <button
                   key={scope}
                   type="button"
                   aria-pressed={jobScope === scope}
-                  aria-label={scope === "session" ? "This session" : "This repo, ever"}
+                  aria-label={scope === "session" ? "This session" : scope === "repo" ? "This repo" : "All projects"}
                   onClick={(e) => { e.stopPropagation(); setJobScope(scope); saveJobScope(scope); }}
                   className={`px-1.5 text-[9px] uppercase tracking-wider ${jobScope === scope ? "bg-accent/15 text-txt" : "text-muted hover:text-txt"}`}
                 >
-                  {scope === "session" ? "Session" : "Repo"}
+                  {scope === "session" ? "Session" : scope === "repo" ? "Repo" : "All"}
                 </button>
               ))}
             </div>

--- a/webapp/src/components/RightDock.tsx
+++ b/webapp/src/components/RightDock.tsx
@@ -19,6 +19,7 @@ import { api } from "../lib/api";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
 import { writeSWRCache } from "../lib/useStaleWhileRevalidate";
 import { countRunningTrackerJobs } from "../lib/jobClassification";
+import { filterJobsByScope, JOB_SCOPE_CHANGED_EVENT, loadJobScope } from "../lib/jobScope";
 
 /** Curated destinations for the floating tool windows — Cursor-style icon strip.
  *  Settings is pinned to the foot of the floating pill. */
@@ -98,6 +99,22 @@ export default function RightDock({
   const [addMenuOpen, setAddMenuOpen] = useState(false);
   const [menuVersion, setMenuVersion] = useState(0);
   const addMenuRef = useRef<HTMLDivElement | null>(null);
+  const [activitySessionId, setActivitySessionId] = useState("");
+  const [scopeEpoch, setScopeEpoch] = useState(0);
+
+  useEffect(() => {
+    const onSession = (e: Event) => {
+      const id = String((e as CustomEvent<{ sessionId?: string | null }>).detail?.sessionId || "");
+      setActivitySessionId(id);
+    };
+    const onScope = () => setScopeEpoch((n) => n + 1);
+    window.addEventListener("harness-session-changed", onSession);
+    window.addEventListener(JOB_SCOPE_CHANGED_EVENT, onScope);
+    return () => {
+      window.removeEventListener("harness-session-changed", onSession);
+      window.removeEventListener(JOB_SCOPE_CHANGED_EVENT, onScope);
+    };
+  }, []);
 
   useEffect(() => {
     if (!addMenuOpen) return;
@@ -136,7 +153,11 @@ export default function RightDock({
           // so expanding into the tracker after a collapsed session is warm too.
           writeSWRCache(`swarm:${swarmRepo || "__default__"}`, data);
           const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
-          setSwarmRunning(countRunningTrackerJobs(jobs));
+          setSwarmRunning(
+            countRunningTrackerJobs(
+              filterJobsByScope(jobs, loadJobScope(), activitySessionId),
+            ),
+          );
         })
         .catch(() => {
           /* keep last known; dot is best-effort */
@@ -149,7 +170,7 @@ export default function RightDock({
       clearInterval(t);
       window.removeEventListener("harness-reviews-refresh", load);
     };
-  }, [swarmRepo]);
+  }, [swarmRepo, activitySessionId, scopeEpoch]);
 
   return (
     <aside

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -17,6 +17,7 @@ import { lastSelectedProjectRoot } from "../lib/panelTransition";
 import { usePolling } from "../lib/usePolling";
 import { writeSWRCache } from "../lib/useStaleWhileRevalidate";
 import { countRunningTrackerJobs } from "../lib/jobClassification";
+import { filterJobsByScope, JOB_SCOPE_CHANGED_EVENT, loadJobScope } from "../lib/jobScope";
 import {
   isSettingsOverlayOpen,
   setSettingsOverlayOpen,
@@ -563,14 +564,27 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
   const [swarmRepo, setSwarmRepo] = useState<string | undefined>(
     () => lastSelectedProjectRoot() || undefined,
   );
+  const [activitySessionId, setActivitySessionId] = useState("");
+  const [scopeEpoch, setScopeEpoch] = useState(0);
 
   useEffect(() => {
     const onProject = (e: Event) => {
       const path = (e as CustomEvent<string>).detail;
       if (typeof path === "string") setSwarmRepo(path || undefined);
     };
+    const onSession = (e: Event) => {
+      const id = String((e as CustomEvent<{ sessionId?: string | null }>).detail?.sessionId || "");
+      setActivitySessionId(id);
+    };
+    const onScope = () => setScopeEpoch((n) => n + 1);
     window.addEventListener("harness-project-selected", onProject);
-    return () => window.removeEventListener("harness-project-selected", onProject);
+    window.addEventListener("harness-session-changed", onSession);
+    window.addEventListener(JOB_SCOPE_CHANGED_EVENT, onScope);
+    return () => {
+      window.removeEventListener("harness-project-selected", onProject);
+      window.removeEventListener("harness-session-changed", onSession);
+      window.removeEventListener(JOB_SCOPE_CHANGED_EVENT, onScope);
+    };
   }, []);
 
   const fetchReviews = () => {
@@ -596,7 +610,11 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
         // "Loading swarm jobs..." flash — the tab light already polls this payload.
         writeSWRCache(`swarm:${swarmRepo || "__default__"}`, data);
         const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
-        setSwarmRunning(countRunningTrackerJobs(jobs));
+        setSwarmRunning(
+          countRunningTrackerJobs(
+            filterJobsByScope(jobs, loadJobScope(), activitySessionId),
+          ),
+        );
       })
       .catch(() => {
         /* keep last known; tab light is best-effort */
@@ -605,6 +623,10 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
 
   usePolling(fetchReviews, 4000);
   usePolling(fetchSwarmActivity, 4000);
+
+  useEffect(() => {
+    void fetchSwarmActivity();
+  }, [activitySessionId, scopeEpoch, swarmRepo]);
 
   // Immediate refresh when a swarm parks a DiffReview (pending_review stream/poll).
   useEffect(() => {

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -920,6 +920,22 @@ function creditDelegationSavings(
   return 0;
 }
 
+function cliOriginCaption(job: Job): { text: string; title: string } {
+  if (job.cross_project) {
+    const cwd = String(job.cwd || "").trim();
+    const stateDir = String(job.cli_state_dir || "").trim();
+    const shown = cwd || (stateDir.replace(/[\\/]+$/, "").split(/[/\\]/).pop() || stateDir);
+    return {
+      text: shown || "other project",
+      title: cwd || stateDir || "Started in another project",
+    };
+  }
+  return {
+    text: "external",
+    title: "Started outside Marionette (Cursor MCP or terminal Puppetmaster) for this workspace",
+  };
+}
+
 /** Missing ownership is owned for harness/local rows; CLI/external fail closed. */
 export function jobAccountingOwned(j: Job): boolean {
   if (j.accounting_owned === true) return true;
@@ -1135,6 +1151,11 @@ export default function SwarmPane() {
   const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
   const [jobScope, setJobScope] = useState<JobScope>(() => loadJobScope());
   const [activeSessionId, setActiveSessionId] = useState("");
+  useEffect(() => {
+    const onScope = () => setJobScope(loadJobScope());
+    window.addEventListener("harness-job-scope-changed", onScope);
+    return () => window.removeEventListener("harness-job-scope-changed", onScope);
+  }, []);
   // Job ids we have asked the backend to cancel. Held in local view state so the
   // row can show a subtle 'cancelling...' affordance immediately, before the next
   // poll reflects the terminal 'cancelled' status from /api/swarm/live.
@@ -1445,7 +1466,10 @@ export default function SwarmPane() {
     };
   }, [scopedRepo, applyLive]);
 
-  const allJobs = filterJobsByScope(data?.jobs || [], jobScope, activeSessionId).filter(
+  const pendingOpenId = peekPendingSwarmOpenJob();
+  const allJobs = filterJobsByScope(data?.jobs || [], jobScope, activeSessionId, {
+    includeJobIds: pendingOpenId ? [pendingOpenId] : undefined,
+  }).filter(
     (job) => isTrackerJob(job),
   );
   // Clear/dismiss is archive chrome for finished runs only. Live (and pending)
@@ -1830,9 +1854,9 @@ export default function SwarmPane() {
                   {j.source === "cli" && (
                     <span
                       className="text-muted uppercase tracking-[0.1em]"
-                      title="Started outside Marionette (Cursor MCP or terminal Puppetmaster) for this workspace"
+                      title={cliOriginCaption(j).title}
                     >
-                      external
+                      {cliOriginCaption(j).text}
                     </span>
                   )}
                   {j.reuse_status && ["reused", "partial", "invalidated", "fresh"].includes(
@@ -2284,16 +2308,16 @@ export default function SwarmPane() {
           <option value="oldest">Oldest first</option>
         </select>
         <div className="col-span-2 flex h-6 overflow-hidden rounded border border-edge">
-          {(["session", "repo"] as const).map((scope) => (
+          {(["session", "repo", "all"] as const).map((scope) => (
             <button
               key={scope}
               type="button"
               aria-pressed={jobScope === scope}
-              aria-label={scope === "session" ? "This session" : "This repo, ever"}
+              aria-label={scope === "session" ? "This session" : scope === "repo" ? "This repo" : "All projects"}
               onClick={() => { setJobScope(scope); saveJobScope(scope); }}
               className={`flex-1 text-[10px] ${jobScope === scope ? "bg-accent/15 text-txt" : "bg-panel2/40 text-muted hover:text-txt"}`}
             >
-              {scope === "session" ? "This session" : "This repo"}
+              {scope === "session" ? "Session" : scope === "repo" ? "Repo" : "All"}
             </button>
           ))}
         </div>

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -212,6 +212,12 @@ export type Job = {
   adapter?: string;
   /** "harness" (Marionette-dispatched) or "cli" (Cursor MCP / terminal PM). */
   source?: "harness" | "cli" | string;
+  /** True when this live row was merged from a foreign Puppetmaster store. */
+  cross_project?: boolean;
+  /** Puppetmaster project store that owns a CLI-merged row. */
+  cli_state_dir?: string;
+  /** Deepest task-payload cwd (workspace the job actually ran in). */
+  cwd?: string;
   /** marionette | visibility_only — whether Marionette owns economic totals. */
   accounting_scope?: "marionette" | "visibility_only" | string;
   /** False for external/CLI jobs that are visible but must not bill Marionette meters. */
@@ -1135,8 +1141,15 @@ export const api = {
     diagnostic?: Record<string, unknown> | null;
   }>("/api/diagnostics"),
   getUsage: () => getJSON<UsageData>("/api/usage"),
-  getEconomics: (scope: EconomicsScope | string = "repo") =>
-    getJSONSoft<EconomicsData>(`/api/economics?scope=${encodeURIComponent(scope)}`),
+  getEconomics: (
+    scope: EconomicsScope | string = "repo",
+    period?: 30 | "30" | "all",
+  ) => {
+    const params = new URLSearchParams();
+    params.set("scope", String(scope));
+    if (period === 30 || period === "30") params.set("period", "30");
+    return getJSONSoft<EconomicsData>(`/api/economics?${params.toString()}`);
+  },
   settings: () => getJSON<Settings>("/api/settings"),
   updateSettings: (partial: Partial<Settings> & { api_key?: string; clear_api_key?: boolean }) => postJSON<Settings>("/api/settings", partial),
   jobs: (repoRoot?: string) => {

--- a/webapp/src/lib/jobScope.ts
+++ b/webapp/src/lib/jobScope.ts
@@ -1,10 +1,15 @@
-/** Session vs repo-ever views over already-visible jobs. */
+/** Ownership views over already-visible jobs: session, this repo, or all projects. */
 
-export type JobScope = "session" | "repo";
+export type JobScope = "session" | "repo" | "all";
 
 export type ScopedJob = {
+  id?: string;
   session_id?: string | null;
+  cross_project?: boolean;
 };
+
+export const JOB_SCOPE_KEY = "marionette.jobScope.v1";
+export const JOB_SCOPE_CHANGED_EVENT = "harness-job-scope-changed";
 
 export function jobSessionId(job: ScopedJob): string {
   return String(job.session_id || "").trim();
@@ -20,18 +25,37 @@ export function filterJobsByScope<T extends ScopedJob>(
   jobs: readonly T[],
   scope: JobScope,
   activeSessionId: string,
+  opts?: { includeJobIds?: Iterable<string> },
 ): T[] {
-  if (scope !== "session") return [...jobs];
-  // No active chat yet: keep the repo list rather than going blank.
-  if (!(activeSessionId || "").trim()) return [...jobs];
-  return jobs.filter((job) => jobInActiveSession(job, activeSessionId));
+  const includeIds = new Set(
+    [...(opts?.includeJobIds || [])].map((id) => String(id || "").trim()).filter(Boolean),
+  );
+  let filtered: T[];
+  if (scope === "all") {
+    filtered = [...jobs];
+  } else if (scope === "session") {
+    if (!(activeSessionId || "").trim()) {
+      filtered = [];
+    } else {
+      filtered = jobs.filter((job) => jobInActiveSession(job, activeSessionId));
+    }
+  } else {
+    filtered = jobs.filter((job) => !job.cross_project);
+  }
+  if (includeIds.size === 0) return filtered;
+  const kept = new Set(filtered.map((job) => String(job.id || "").trim()).filter(Boolean));
+  const extras = jobs.filter((job) => {
+    const id = String(job.id || "").trim();
+    return Boolean(id && includeIds.has(id) && !kept.has(id));
+  });
+  return extras.length ? [...filtered, ...extras] : filtered;
 }
-
-export const JOB_SCOPE_KEY = "marionette.jobScope.v1";
 
 export function loadJobScope(): JobScope {
   try {
-    return localStorage.getItem(JOB_SCOPE_KEY) === "repo" ? "repo" : "session";
+    const raw = localStorage.getItem(JOB_SCOPE_KEY);
+    if (raw === "repo" || raw === "all" || raw === "session") return raw;
+    return "session";
   } catch {
     return "session";
   }
@@ -40,6 +64,7 @@ export function loadJobScope(): JobScope {
 export function saveJobScope(scope: JobScope): void {
   try {
     localStorage.setItem(JOB_SCOPE_KEY, scope);
+    window.dispatchEvent(new CustomEvent(JOB_SCOPE_CHANGED_EVENT, { detail: { scope } }));
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Summary
- Absorb issue #223 from Benton Ferguson (@kbentonferguson): Jobs and Economics labels now match ownership vs period.
- This session fail-closes without an active session id. This repo excludes foreign running CLI merges (cross_project). Those stay under All projects. Last 30 days is a date cutoff on the selected Economics ownership (period=30; window30 remains an alias).
- Foreign running rows disclose cwd (not only external). Swarm Tracker activity lights use the same ownership chips as the opened pane. Deep links can still resurrect a hidden job.

Fixes #223
