### PR TITLE
absorb #228: preserve OpenAI Responses assistant phase

### DIFF
--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -84,6 +84,7 @@ from .stream_performance import (
     yield_timed_phase,
 )
 from .text_clean import clean_say
+from pmharness.drivers.base import stamp_assistant_phase
 from .tool_dispatch import _strip_ansi, is_safe_path
 from .send_loop_secrets import (
     iter_extracted_secret_turn,
@@ -1417,17 +1418,17 @@ class SendLoopMixin:
                 else:
                     _history_text = _promoted_say
             # record the pilot's turn in transcript (prose only -- the conversation)
+            assistant_msg: dict[str, Any] = {"role": "assistant"}
             if is_native:
-                assistant_msg: dict[str, Any] = {"role": "assistant"}
-                if _history_text:
-                    assistant_msg["content"] = _history_text
-                else:
-                    assistant_msg["content"] = ""
+                assistant_msg["content"] = _history_text or ""
                 if tool_calls:
                     assistant_msg["tool_calls"] = tool_calls
-                self._history.append(assistant_msg)
             else:
-                self._history.append({"role": "assistant", "content": _history_text or "(acting)"})
+                assistant_msg["content"] = _history_text or "(acting)"
+            stamp_assistant_phase(
+                assistant_msg, getattr(resp, "assistant_phase", None),
+            )
+            self._history.append(assistant_msg)
 
             if (yield from iter_extracted_secret_turn(
                 self, _extracted_secret, turn, user_message=user_message, step=step,

--- a/pmharness/drivers/base.py
+++ b/pmharness/drivers/base.py
@@ -7,7 +7,48 @@ harness's job, identically for every model.
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, Protocol
+from typing import Any, Optional, Protocol
+
+KNOWN_ASSISTANT_PHASES = frozenset(("commentary", "final_answer"))
+
+
+def known_assistant_phase(value: Any) -> Optional[str]:
+    """Return commentary|final_answer when OpenAI supplied that phase.
+
+    Absent, blank, and unknown values stay None so legacy Chat Completions
+    history is never inferred as final_answer.
+    """
+    if not isinstance(value, str):
+        return None
+    phase = value.strip().lower()
+    if phase in KNOWN_ASSISTANT_PHASES:
+        return phase
+    return None
+
+
+def stamp_assistant_phase(msg: dict, value: Any) -> dict:
+    """Copy a known assistant phase onto a history message. No-op otherwise."""
+    phase = known_assistant_phase(value)
+    if phase and isinstance(msg, dict) and msg.get("role") == "assistant":
+        msg["phase"] = phase
+    return msg
+
+
+def chat_completions_messages(messages: list) -> list:
+    """Project history for Chat Completions: drop Responses-only phase.
+
+    Chat Completions cannot represent assistant phase. Copies only rows that
+    carry ``phase`` so live ``_history`` dicts stay intact.
+    """
+    out = []
+    for msg in messages:
+        if isinstance(msg, dict) and "phase" in msg:
+            copy = dict(msg)
+            copy.pop("phase", None)
+            out.append(copy)
+        else:
+            out.append(msg)
+    return out
 
 
 @dataclass
@@ -19,6 +60,7 @@ class DriverResponse:
     model: str = ""
     error: Optional[str] = None
     meta: dict = field(default_factory=dict)
+    assistant_phase: Optional[str] = None
 
 
 SYSTEM_PROMPT = """You are the driver loop for Puppetmaster, an orchestration engine.

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -22,7 +22,7 @@ import urllib.error
 import urllib.request
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from .base import DriverResponse, SYSTEM_PROMPT
+from .base import DriverResponse, SYSTEM_PROMPT, known_assistant_phase
 from .retry import with_retry
 
 
@@ -245,6 +245,18 @@ def _content_parts_to_responses(
     return parts or [{"type": part_type, "text": ""}]
 
 
+def _assistant_message_item(msg: dict, content: List[dict]) -> dict:
+    item = {
+        "type": "message",
+        "role": "assistant",
+        "content": content,
+    }
+    phase = known_assistant_phase(msg.get("phase"))
+    if phase:
+        item["phase"] = phase
+    return item
+
+
 def _messages_to_responses_input(messages: List[dict]) -> List[dict]:
     """Minimal chat → Responses input conversion (text + images + tool stubs)."""
     out: List[dict] = []
@@ -263,11 +275,9 @@ def _messages_to_responses_input(messages: List[dict]) -> List[dict]:
         if role == "assistant" and msg.get("tool_calls"):
             text = content if isinstance(content, str) else ""
             if text:
-                out.append({
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [{"type": "output_text", "text": text}],
-                })
+                out.append(_assistant_message_item(
+                    msg, [{"type": "output_text", "text": text}],
+                ))
             for tc in msg.get("tool_calls") or []:
                 fn = tc.get("function") or {}
                 out.append({
@@ -278,10 +288,14 @@ def _messages_to_responses_input(messages: List[dict]) -> List[dict]:
                 })
             continue
         wire_role = "user" if role == "user" else role
+        content_parts = _content_parts_to_responses(content, role=wire_role)
+        if wire_role == "assistant":
+            out.append(_assistant_message_item(msg, content_parts))
+            continue
         out.append({
             "type": "message",
             "role": wire_role,
-            "content": _content_parts_to_responses(content, role=wire_role),
+            "content": content_parts,
         })
     return out
 
@@ -404,6 +418,39 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
     ):
         text_parts.append(raw["output_text"])
     return "".join(text_parts), tool_calls, finish
+
+
+def _contributing_assistant_phase(raw: dict) -> Optional[str]:
+    """Known phase shared by every answer-channel message item, else None.
+
+    Commentary/analysis are not contributing. A single phase-less (legacy)
+    answer item refuses inference — we must not stamp final_answer.
+    """
+    phases: List[str] = []
+    for item in raw.get("output") or []:
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        if _codex_channel_for_item("message", item.get("phase")) != "answer":
+            continue
+        known = known_assistant_phase(item.get("phase"))
+        if known is None:
+            return None
+        phases.append(known)
+    if not phases:
+        return None
+    first = phases[0]
+    if all(phase == first for phase in phases):
+        return first
+    return None
+
+
+def _saw_answer_message(raw: dict) -> bool:
+    for item in raw.get("output") or []:
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        if _codex_channel_for_item("message", item.get("phase")) == "answer":
+            return True
+    return False
 
 
 def _codex_tool_hint_goal(arguments: Any, name: str) -> str:
@@ -1321,8 +1368,16 @@ class CodexResponsesDriver:
         incomplete_retries: int = 0,
     ) -> DriverResponse:
         text, tool_calls, finish = _extract_text_and_tools(raw)
-        if not text and isinstance(raw.get("output_text"), str):
+        # Extract already falls back to output_text for phase-less bodies.
+        # Do not undo that when an answer-phase item existed (even empty) —
+        # re-applying the mixed blob reintroduces commentary into history.
+        if (
+            not text
+            and not _saw_answer_message(raw)
+            and isinstance(raw.get("output_text"), str)
+        ):
             text = raw["output_text"]
+        assistant_phase = _contributing_assistant_phase(raw)
         if finish == "content_filter":
             meta = {
                 **self._billing_meta(),
@@ -1336,6 +1391,7 @@ class CodexResponsesDriver:
                 error=_CONTENT_FILTER_MSG,
                 latency_ms=(time.time() - t0) * 1000.0,
                 meta=meta,
+                assistant_phase=assistant_phase,
             )
         usage = raw.get("usage") or {}
         tin, tout = _usage_ints(usage)
@@ -1381,6 +1437,7 @@ class CodexResponsesDriver:
             model=self.name,
             error=err_msg,
             meta=meta,
+            assistant_phase=assistant_phase,
         )
 
     def _post_stream(
@@ -1605,6 +1662,7 @@ class CodexResponsesDriver:
                             model=self.name,
                             error=err,
                             meta=meta,
+                            assistant_phase=resp.assistant_phase,
                         )
                     )
                 if kind is None:
@@ -1619,6 +1677,7 @@ class CodexResponsesDriver:
                             latency_ms=resp.latency_ms,
                             model=self.name,
                             meta=_final_meta(resp.meta or {}),
+                            assistant_phase=resp.assistant_phase,
                         )
                     )
 
@@ -1674,11 +1733,15 @@ class CodexResponsesDriver:
                             last_text += str(part.get("text") or "")
                 if last_text.strip() != nudge:
                     if kind == "length" and text.strip():
-                        inp.append({
+                        cont_item = {
                             "type": "message",
                             "role": "assistant",
                             "content": [{"type": "output_text", "text": text}],
-                        })
+                        }
+                        phase = known_assistant_phase(resp.assistant_phase)
+                        if phase:
+                            cont_item["phase"] = phase
+                        inp.append(cont_item)
                     inp.append(_user_input_item(nudge))
                     body["input"] = inp
                     data = json.dumps(body).encode("utf-8")

--- a/pmharness/drivers/openai_compat.py
+++ b/pmharness/drivers/openai_compat.py
@@ -16,7 +16,7 @@ import urllib.parse
 import urllib.request
 from typing import Callable
 
-from .base import DriverResponse, SYSTEM_PROMPT
+from .base import DriverResponse, SYSTEM_PROMPT, chat_completions_messages
 from .prompt_cache import (
     apply_openai_compat_cache_control,
     maybe_attach_openrouter_session_id,
@@ -939,7 +939,7 @@ class OpenAICompatDriver:
         full_messages = []
         if system:
             full_messages.append({"role": "system", "content": system})
-        full_messages.extend(messages)
+        full_messages.extend(chat_completions_messages(messages))
 
         body = {
             "model": self.model,
@@ -1136,7 +1136,7 @@ class OpenAICompatDriver:
         full_messages = []
         if system:
             full_messages.append({"role": "system", "content": system})
-        full_messages.extend(messages)
+        full_messages.extend(chat_completions_messages(messages))
 
         body = {
             "model": self.model,

--- a/tests/test_codex_responses_driver.py
+++ b/tests/test_codex_responses_driver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 import urllib.error
 import urllib.request
 
@@ -130,6 +131,71 @@ def test_extract_empty_final_does_not_fallback_to_commentary():
     assert text == ""
 
 
+def test_response_from_raw_stamps_known_phase_and_skips_legacy():
+    driver = CodexResponsesDriver(name="openai-codex/test", model="gpt-5.6-luna")
+    phased = driver._response_from_raw(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "Checking. "}],
+                },
+                {
+                    "type": "message",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "Done."}],
+                },
+            ],
+        },
+        t0=time.time(),
+    )
+    assert phased.text == "Done."
+    assert phased.assistant_phase == "final_answer"
+
+    legacy = driver._response_from_raw(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "legacy answer"}],
+                },
+            ],
+        },
+        t0=time.time(),
+    )
+    assert legacy.text == "legacy answer"
+    assert legacy.assistant_phase is None
+
+
+def test_response_from_raw_empty_final_does_not_fallback_to_commentary():
+    """Extract already refuses commentary fallback; DriverResponse must too."""
+    driver = CodexResponsesDriver(name="openai-codex/test", model="gpt-5.6-luna")
+    resp = driver._response_from_raw(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "I need to critique…"}],
+                },
+                {
+                    "type": "message",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": ""}],
+                },
+            ],
+            "output_text": "I need to critique…",
+        },
+        t0=time.time(),
+    )
+    assert resp.text == ""
+    assert resp.assistant_phase == "final_answer"
+
+
 def test_commentary_streams_via_delta_but_extract_is_final_only():
     """Commentary arrives on progress/on_delta; extract text is final_answer."""
     progress = []
@@ -168,6 +234,66 @@ def test_messages_to_input_skips_system():
     ])
     assert len(inp) == 1
     assert inp[0]["role"] == "user"
+
+
+def test_messages_to_input_preserves_known_assistant_phase():
+    """Issue #228: replay assistant messages with OpenAI's known phase."""
+    inp = _messages_to_responses_input([
+        {"role": "user", "content": "inspect the sql"},
+        {
+            "role": "assistant",
+            "content": "I'll inspect the SQL first.",
+            "phase": "commentary",
+        },
+        {
+            "role": "assistant",
+            "content": "The employee filter explains it.",
+            "phase": "final_answer",
+        },
+        {
+            "role": "assistant",
+            "content": "calling",
+            "phase": "final_answer",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }],
+        },
+    ])
+    by_text = {
+        part["text"]: item
+        for item in inp
+        if item.get("type") == "message"
+        for part in item.get("content") or []
+        if isinstance(part, dict) and part.get("type") == "output_text"
+    }
+    assert by_text["I'll inspect the SQL first."]["phase"] == "commentary"
+    assert by_text["The employee filter explains it."]["phase"] == "final_answer"
+    assert by_text["calling"]["phase"] == "final_answer"
+    assert inp[-1]["type"] == "function_call"
+
+
+def test_messages_to_input_omits_absent_invalid_and_non_assistant_phase():
+    """Do not infer final_answer; never forward phase on user/tool rows."""
+    inp = _messages_to_responses_input([
+        {"role": "user", "content": "hi", "phase": "final_answer"},
+        {"role": "assistant", "content": "legacy answer"},
+        {"role": "assistant", "content": "nope", "phase": "analysis"},
+        {"role": "assistant", "content": "also-nope", "phase": "FINAL_ANSWER "},
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "ok",
+            "phase": "commentary",
+        },
+    ])
+    assert "phase" not in inp[0]
+    assert inp[1]["role"] == "assistant" and "phase" not in inp[1]
+    assert inp[2]["role"] == "assistant" and "phase" not in inp[2]
+    assert inp[3]["phase"] == "final_answer"
+    assert inp[4]["type"] == "function_call_output"
+    assert "phase" not in inp[4]
 
 
 def test_messages_to_input_emits_input_image_for_multimodal_list():

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from harness.conversation import ConversationalSession
 from harness.config import HarnessConfig
 from harness.sessions import save_transcript, load_transcript
+from pmharness.drivers.base import chat_completions_messages, stamp_assistant_phase
 
 
 def test_export_load_history_roundtrip():
@@ -43,6 +44,64 @@ def test_export_load_history_roundtrip():
     assert session2._history[0]["content"] == "different freshly-built system prompt"
     # and subsequent messages are loaded correctly
     assert session2._history[1:] == turns
+
+
+def test_export_load_history_roundtrip_preserves_assistant_phase():
+    """Issue #228: known Responses phase survives transcript export/reload."""
+    cfg = HarnessConfig()
+    session = ConversationalSession(cfg)
+    turns = [
+        {"role": "user", "content": "inspect the sql"},
+        {
+            "role": "assistant",
+            "content": "I'll inspect the SQL first.",
+            "phase": "commentary",
+        },
+        {
+            "role": "assistant",
+            "content": "The employee filter explains it.",
+            "phase": "final_answer",
+        },
+        {"role": "assistant", "content": "legacy answer"},
+    ]
+    session._history.extend(turns)
+    exported = session.export_history()
+    assert exported[1]["phase"] == "commentary"
+    assert exported[2]["phase"] == "final_answer"
+    assert "phase" not in exported[3]
+
+    session2 = ConversationalSession(cfg)
+    session2.load_history(exported)
+    assert session2._history[2]["phase"] == "commentary"
+    assert session2._history[3]["phase"] == "final_answer"
+    assert "phase" not in session2._history[4]
+
+
+def test_stamp_assistant_phase_only_known_assistant_values():
+    assistant = {"role": "assistant", "content": "hi"}
+    stamp_assistant_phase(assistant, " commentary ")
+    assert assistant["phase"] == "commentary"
+    stamp_assistant_phase(assistant, "analysis")
+    assert assistant["phase"] == "commentary"
+    user = {"role": "user", "content": "hi"}
+    stamp_assistant_phase(user, "final_answer")
+    assert "phase" not in user
+    legacy = {"role": "assistant", "content": "hi"}
+    stamp_assistant_phase(legacy, None)
+    assert "phase" not in legacy
+
+
+def test_chat_completions_messages_drop_phase_without_mutating_history():
+    original = {
+        "role": "assistant",
+        "content": "I'll inspect the SQL first.",
+        "phase": "commentary",
+    }
+    projected = chat_completions_messages([original])
+    assert "phase" not in projected[0]
+    assert projected[0]["content"] == "I'll inspect the SQL first."
+    assert original["phase"] == "commentary"
+    assert projected[0] is not original
 
 
 def test_save_load_transcript_to_disk(tmp_path):


### PR DESCRIPTION
## Summary
- Absorb Benton Ferguson issue #228: keep OpenAI Responses `commentary` / `final_answer` on `ConversationalSession._history` through persist, reload, and the next Responses request.
- Stop `DriverResponse` from re-copying commentary via `output_text` when a final_answer item existed (empty or not).
- Chat Completions drops phase on a copy so a later picker swap cannot send a Responses-only field.

## Test plan
- [x] `pytest -q tests/test_codex_responses_driver.py tests/test_transcripts.py tests/test_codex_incomplete.py tests/test_codex_cache_accounting.py tests/test_openai_compat_prompt_cache.py`
- [ ] CI `tests` workflow on this PR

Fixes #228
