### PR TITLE
fix: preserve Responses commentary before tool calls

### DIFF
--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -1373,6 +1373,9 @@ class SendLoopMixin:
 
             cleaned_say_text, _extracted_secret = peel_secret_request_message(
                 clean_say(turn.say) if turn.say else "")
+            commentary_history_text = ""
+            if getattr(resp, "assistant_phase", None) == "commentary":
+                commentary_history_text, cleaned_say_text = cleaned_say_text, ""
             _resp_meta = getattr(resp, "meta", None) or {}
             if not isinstance(_resp_meta, dict):
                 _resp_meta = {}
@@ -1386,6 +1389,8 @@ class SendLoopMixin:
                     _resp_meta.get("reasoning") or turn.thinking or ""
                 ),
             )
+            if commentary_history_text:
+                _promoted_say = ""
             if _promoted_say:
                 _promoted_say = clean_say(_promoted_say) or _promoted_say
             if cleaned_say_text:
@@ -1411,7 +1416,7 @@ class SendLoopMixin:
                     "role": "assistant",
                     "text": _promoted_say,
                 })
-            _history_text = cleaned_say_text or ""
+            _history_text = commentary_history_text or cleaned_say_text or ""
             if _promoted_say:
                 if _history_text and _promoted_say.strip() != _history_text.strip():
                     _history_text = f"{_history_text}\n\n{_promoted_say}"

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -368,11 +368,12 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
     burning continuation retries.
 
     Message text for ``DriverResponse.text`` prefers ``final_answer`` and
-    phase-less (legacy) items. Commentary and analysis are excluded — they
-    stream via progress/reasoning callbacks and must not contaminate the
-    final answer even when final text is empty.
+    phase-less (legacy) items. Commentary is retained only when it precedes a
+    tool call and no answer exists, so history can replay the preamble with its
+    phase. Analysis is always excluded.
     """
     text_parts: List[str] = []
+    commentary_parts: List[str] = []
     tool_calls: List[dict] = []
     saw_answer_item = False
     status = str(raw.get("status") or "")
@@ -391,6 +392,14 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
             # Reuse channel policy: commentary -> progress, analysis ->
             # reasoning, final_answer / phase-less -> answer.
             channel = _codex_channel_for_item("message", item.get("phase"))
+            if channel == "progress":
+                commentary_parts.extend(
+                    str(part.get("text") or "")
+                    for part in item.get("content") or []
+                    if isinstance(part, dict)
+                    and part.get("type") in ("output_text", "text")
+                )
+                continue
             if channel != "answer":
                 continue
             saw_answer_item = True
@@ -413,7 +422,9 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
     # Legacy / SSE-assembled bodies may only populate output_text. Never fall
     # back to it when answer-phase items existed (even if their text is empty)
     # — that would re-introduce commentary contamination via a mixed blob.
-    if not text_parts and not saw_answer_item and isinstance(
+    if not text_parts and not saw_answer_item and tool_calls and commentary_parts:
+        text_parts.extend(commentary_parts)
+    elif not text_parts and not saw_answer_item and isinstance(
         raw.get("output_text"), str
     ):
         text_parts.append(raw["output_text"])
@@ -421,10 +432,9 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
 
 
 def _contributing_assistant_phase(raw: dict) -> Optional[str]:
-    """Known phase shared by every answer-channel message item, else None.
+    """Phase of final text, or commentary before a tool call, else None.
 
-    Commentary/analysis are not contributing. A single phase-less (legacy)
-    answer item refuses inference — we must not stamp final_answer.
+    A phase-less legacy answer refuses inference. Analysis never contributes.
     """
     phases: List[str] = []
     for item in raw.get("output") or []:
@@ -436,11 +446,22 @@ def _contributing_assistant_phase(raw: dict) -> Optional[str]:
         if known is None:
             return None
         phases.append(known)
-    if not phases:
+    if phases:
+        first = phases[0]
+        if all(phase == first for phase in phases):
+            return first
         return None
-    first = phases[0]
-    if all(phase == first for phase in phases):
-        return first
+    if any(
+        isinstance(item, dict) and item.get("type") == "function_call"
+        for item in raw.get("output") or []
+    ):
+        for item in raw.get("output") or []:
+            if (
+                isinstance(item, dict)
+                and item.get("type") == "message"
+                and known_assistant_phase(item.get("phase")) == "commentary"
+            ):
+                return "commentary"
     return None
 
 

--- a/tests/test_codex_responses_driver.py
+++ b/tests/test_codex_responses_driver.py
@@ -170,6 +170,33 @@ def test_response_from_raw_stamps_known_phase_and_skips_legacy():
     assert legacy.assistant_phase is None
 
 
+def test_response_from_raw_preserves_commentary_before_tool_call():
+    """OpenAI Agents JS #1513 follow-up: replay commentary before the tool."""
+    driver = CodexResponsesDriver(name="openai-codex/test", model="gpt-5.6-luna")
+    resp = driver._response_from_raw(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "Checking. "}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": "{}",
+                },
+            ],
+        },
+        t0=time.time(),
+    )
+
+    assert resp.text == "Checking. "
+    assert resp.assistant_phase == "commentary"
+
+
 def test_response_from_raw_empty_final_does_not_fallback_to_commentary():
     """Extract already refuses commentary fallback; DriverResponse must too."""
     driver = CodexResponsesDriver(name="openai-codex/test", model="gpt-5.6-luna")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -18,10 +18,12 @@ class FakeStreamingDriver:
         self.chat_called = False
         self.chat_stream_called = False
         self.calls = 0
+        self.messages = []
 
     def chat(self, messages, *, tools=None, system=None):
         self.chat_called = True
         self.calls += 1
+        self.messages.append(messages)
         if self.calls == 1:
             if self.use_native_tool_calls:
                 meta = {
@@ -39,7 +41,10 @@ class FakeStreamingDriver:
                     "finish_reason": "tool_calls",
                     "stream_terminal": "tool_calls",
                 }
-                return DriverResponse(text="Reading...", meta=meta)
+                return DriverResponse(
+                    text="Reading...", meta=meta,
+                    assistant_phase="commentary",
+                )
             else:
                 text = '{"say":"Reading...","actions":[{"kind":"read_file","path":"test.txt"}]}'
                 return DriverResponse(text=text, meta={"finish_reason": "stop"})
@@ -47,17 +52,20 @@ class FakeStreamingDriver:
             return DriverResponse(
                 text="Done.",
                 meta={"tool_calls": [], "reasoning": "", "finish_reason": "stop"},
+                assistant_phase="final_answer",
             )
 
     def chat_stream(self, messages, *, tools=None, system=None, on_delta,
                     on_reasoning_delta=None, on_tool_hint=None):
         self.chat_stream_called = True
         self.calls += 1
+        self.messages.append(messages)
 
-        # Fire off some deltas
-        on_delta("Read")
-        on_delta("ing")
-        on_delta("...")
+        # Fire off progress before the tool, answer prose after its result.
+        channel = "progress" if self.calls == 1 else "answer"
+        on_delta({"text": "Read", "channel": channel})
+        on_delta({"text": "ing", "channel": channel})
+        on_delta({"text": "...", "channel": channel})
 
         if self.calls == 1:
             if self.use_native_tool_calls:
@@ -77,7 +85,10 @@ class FakeStreamingDriver:
                     "stream_terminal": "tool_calls",
                     "stream_started": True,
                 }
-                return DriverResponse(text="Reading...", meta=meta)
+                return DriverResponse(
+                    text="Reading...", meta=meta,
+                    assistant_phase="commentary",
+                )
             else:
                 text = '{"say":"Reading...","actions":[{"kind":"read_file","path":"test.txt"}]}'
                 return DriverResponse(
@@ -94,6 +105,7 @@ class FakeStreamingDriver:
                     "stream_started": True,
                     "stream_terminal": "stop",
                 },
+                assistant_phase="final_answer",
             )
 
 
@@ -353,11 +365,28 @@ def test_conversational_loop_streaming():
     assert delta_events[4].data["text"] == "ing"
     assert delta_events[5].data["text"] == "..."
 
-    # final 'message' event still arrives with the cleaned text
+    # Commentary was already streamed as progress; only the final answer closes
+    # as a durable assistant message.
     msg_events = [e for e in events if e.kind == "message"]
-    assert len(msg_events) == 2
-    assert msg_events[0].data["text"] == "Reading..."
-    assert msg_events[1].data["text"] == "Done."
+    assert [event.data["text"] for event in msg_events] == ["Done."]
+
+    assistant_history = [
+        item for item in s._history if item.get("role") == "assistant"
+    ]
+    assert assistant_history[0]["content"] == "Reading..."
+    assert assistant_history[0]["phase"] == "commentary"
+    assert assistant_history[-1]["content"] == "Done."
+    assert assistant_history[-1]["phase"] == "final_answer"
+    replayed = s.pilot.messages[1]
+    commentary_index = next(
+        index for index, item in enumerate(replayed)
+        if item.get("role") == "assistant"
+        and item.get("phase") == "commentary"
+        and item.get("content") == "Reading..."
+    )
+    assert replayed[commentary_index]["tool_calls"][0]["id"] == "call_1"
+    assert replayed[commentary_index + 1]["role"] == "tool"
+    assert replayed[commentary_index + 1]["tool_call_id"] == "call_1"
 
     # tool_calls assembled from the stream still execute
     assert "action_start" in kinds


### PR DESCRIPTION
## Summary

- Follow up merged PR #229 using its canonical `DriverResponse.text` + `assistant_phase` owner.
- Preserve a Responses `commentary` message when it immediately precedes a function call and no final answer exists.
- Replay that commentary before the function call and tool result without rendering it again as a completed answer or promoting trailing reasoning in its place.

This completes the normal tool-bearing case from #228 without adding a parallel response-message representation.

## Upstream precedent

OpenAI Agents JS preserves assistant phases across Responses history and replay in openai/openai-agents-js#1513:

https://github.com/openai/openai-agents-js/pull/1513

This follow-up stays inside Marionette's one-message-per-provider-step contract established by #229.

## Behavioral contract

```text
commentary → function_call → function_call_output → final_answer
```

- `final_answer` still wins when present.
- An empty final answer never falls back to commentary.
- Analysis and phase-less legacy behavior are unchanged.
- No UI, Puppetmaster, reasoning-effort, or output-token policy changes.

## Test plan

- [x] RED: commentary plus function call previously returned empty `DriverResponse.text` with no assistant phase.
- [x] RED: commentary was emitted again as a completed assistant message.
- [x] Exact replay-order assertion binds commentary/tool call to the following matching tool result.
- [x] `.venv/bin/python -m pytest -q tests/test_codex_responses_driver.py tests/test_streaming.py tests/test_transcripts.py tests/test_codex_incomplete.py tests/test_codex_cache_accounting.py tests/test_openai_compat_prompt_cache.py -o 'addopts='` — `86 passed`
- [x] `git diff --check`
