### PR TITLE
Release v0.9.364

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.37` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.363, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.364, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.363"
+__version__ = "0.9.364"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -1373,6 +1373,9 @@ class SendLoopMixin:
 
             cleaned_say_text, _extracted_secret = peel_secret_request_message(
                 clean_say(turn.say) if turn.say else "")
+            commentary_history_text = ""
+            if getattr(resp, "assistant_phase", None) == "commentary":
+                commentary_history_text, cleaned_say_text = cleaned_say_text, ""
             _resp_meta = getattr(resp, "meta", None) or {}
             if not isinstance(_resp_meta, dict):
                 _resp_meta = {}
@@ -1386,6 +1389,8 @@ class SendLoopMixin:
                     _resp_meta.get("reasoning") or turn.thinking or ""
                 ),
             )
+            if commentary_history_text:
+                _promoted_say = ""
             if _promoted_say:
                 _promoted_say = clean_say(_promoted_say) or _promoted_say
             if cleaned_say_text:
@@ -1411,7 +1416,7 @@ class SendLoopMixin:
                     "role": "assistant",
                     "text": _promoted_say,
                 })
-            _history_text = cleaned_say_text or ""
+            _history_text = commentary_history_text or cleaned_say_text or ""
             if _promoted_say:
                 if _history_text and _promoted_say.strip() != _history_text.strip():
                     _history_text = f"{_history_text}\n\n{_promoted_say}"

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -84,7 +84,7 @@ from .stream_performance import (
     yield_timed_phase,
 )
 from .text_clean import clean_say
-from pmharness.drivers.base import stamp_assistant_phase
+from pmharness.drivers.base import known_assistant_phase, stamp_assistant_phase
 from .tool_dispatch import _strip_ansi, is_safe_path
 from .send_loop_secrets import (
     iter_extracted_secret_turn,
@@ -1374,7 +1374,10 @@ class SendLoopMixin:
             cleaned_say_text, _extracted_secret = peel_secret_request_message(
                 clean_say(turn.say) if turn.say else "")
             commentary_history_text = ""
-            if getattr(resp, "assistant_phase", None) == "commentary":
+            _resp_phase = known_assistant_phase(
+                getattr(resp, "assistant_phase", None),
+            )
+            if _resp_phase == "commentary":
                 commentary_history_text, cleaned_say_text = cleaned_say_text, ""
             _resp_meta = getattr(resp, "meta", None) or {}
             if not isinstance(_resp_meta, dict):
@@ -1389,7 +1392,7 @@ class SendLoopMixin:
                     _resp_meta.get("reasoning") or turn.thinking or ""
                 ),
             )
-            if commentary_history_text:
+            if _resp_phase == "commentary":
                 _promoted_say = ""
             if _promoted_say:
                 _promoted_say = clean_say(_promoted_say) or _promoted_say

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -63,8 +63,8 @@ from .send_loop_phases import (
     emit_stagnation_halt,
     finalize_assistant_turn,
     native_tools_blocked,
-    promote_trailing_reasoning_to_say,
     record_provider_dispatch_error_receipt,
+    resolve_emit_say_texts,
     run_auto_verify,
     yield_session_interrupted,
 )
@@ -84,7 +84,7 @@ from .stream_performance import (
     yield_timed_phase,
 )
 from .text_clean import clean_say
-from pmharness.drivers.base import known_assistant_phase, stamp_assistant_phase
+from pmharness.drivers.base import stamp_assistant_phase
 from .tool_dispatch import _strip_ansi, is_safe_path
 from .send_loop_secrets import (
     iter_extracted_secret_turn,
@@ -1373,29 +1373,13 @@ class SendLoopMixin:
 
             cleaned_say_text, _extracted_secret = peel_secret_request_message(
                 clean_say(turn.say) if turn.say else "")
-            commentary_history_text = ""
-            _resp_phase = known_assistant_phase(
-                getattr(resp, "assistant_phase", None),
+            cleaned_say_text, commentary_history_text, _promoted_say = (
+                resolve_emit_say_texts(
+                    cleaned_say_text=cleaned_say_text,
+                    resp=resp,
+                    turn_thinking=turn.thinking or "",
+                )
             )
-            if _resp_phase == "commentary":
-                commentary_history_text, cleaned_say_text = cleaned_say_text, ""
-            _resp_meta = getattr(resp, "meta", None) or {}
-            if not isinstance(_resp_meta, dict):
-                _resp_meta = {}
-            _promoted_say = promote_trailing_reasoning_to_say(
-                say_text=cleaned_say_text,
-                streamed_reasoning=str(_resp_meta.get("streamed_reasoning") or ""),
-                stream_ended_on_reasoning=bool(
-                    _resp_meta.get("stream_ended_on_reasoning")
-                ),
-                meta_reasoning=str(
-                    _resp_meta.get("reasoning") or turn.thinking or ""
-                ),
-            )
-            if _resp_phase == "commentary":
-                _promoted_say = ""
-            if _promoted_say:
-                _promoted_say = clean_say(_promoted_say) or _promoted_say
             if cleaned_say_text:
                 step_emitted_user_prose = True
                 # If this prose was already streamed token-by-token, flag it so the

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -25,6 +25,7 @@ from functools import partial
 from typing import Any, Dict, Iterator, Optional
 
 from pmharness.bridge import execute_intent
+from pmharness.drivers.base import known_assistant_phase
 
 from .log_reconstruction import check_outbound_reconstruction
 from .pilot import PilotAction, StreamingSayExtractor
@@ -59,6 +60,7 @@ from .terminal_cause import (
     loop_exit_message,
     provider_tools_are_executable,
 )
+from .text_clean import clean_say
 from .tool_timeout import invoke_do, run_with_tool_deadline
 from .workspace_rules_refresh import maybe_refresh_workspace_rules
 from .url_safety import sanitize_url_for_display
@@ -1215,6 +1217,47 @@ def promote_trailing_reasoning_to_say(
     if reasoning in say:
         return ""
     return reasoning
+
+
+def resolve_emit_say_texts(
+    *,
+    cleaned_say_text: str,
+    resp: Any,
+    turn_thinking: str = "",
+) -> tuple[str, str, str]:
+    """Apply commentary fail-close and optional reasoning promotion.
+
+    Returns ``(cleaned_say_text, commentary_history_text, promoted_say)``.
+
+    When ``assistant_phase`` is commentary, keep text on history only (not
+    rendered as a completed assistant message) and never promote trailing
+    reasoning into a say bubble. Empty final_answer still wins upstream;
+    analysis is never promoted by ``promote_trailing_reasoning_to_say``.
+    """
+    commentary_history_text = ""
+    resp_phase = known_assistant_phase(
+        getattr(resp, "assistant_phase", None),
+    )
+    if resp_phase == "commentary":
+        commentary_history_text, cleaned_say_text = cleaned_say_text, ""
+    resp_meta = getattr(resp, "meta", None) or {}
+    if not isinstance(resp_meta, dict):
+        resp_meta = {}
+    promoted_say = promote_trailing_reasoning_to_say(
+        say_text=cleaned_say_text,
+        streamed_reasoning=str(resp_meta.get("streamed_reasoning") or ""),
+        stream_ended_on_reasoning=bool(
+            resp_meta.get("stream_ended_on_reasoning")
+        ),
+        meta_reasoning=str(
+            resp_meta.get("reasoning") or turn_thinking or ""
+        ),
+    )
+    if resp_phase == "commentary":
+        promoted_say = ""
+    if promoted_say:
+        promoted_say = clean_say(promoted_say) or promoted_say
+    return cleaned_say_text, commentary_history_text, promoted_say
 
 
 def _emit_batched_delta(

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -376,6 +376,7 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
     commentary_parts: List[str] = []
     tool_calls: List[dict] = []
     saw_answer_item = False
+    saw_non_answer_item = False
     status = str(raw.get("status") or "")
     reason = _incomplete_reason(raw)
     if status == "incomplete" and reason == "content_filter":
@@ -393,6 +394,7 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
             # reasoning, final_answer / phase-less -> answer.
             channel = _codex_channel_for_item("message", item.get("phase"))
             if channel == "progress":
+                saw_non_answer_item = True
                 commentary_parts.extend(
                     str(part.get("text") or "")
                     for part in item.get("content") or []
@@ -401,6 +403,7 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
                 )
                 continue
             if channel != "answer":
+                saw_non_answer_item = True
                 continue
             saw_answer_item = True
             for part in item.get("content") or []:
@@ -424,8 +427,11 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
     # — that would re-introduce commentary contamination via a mixed blob.
     if not text_parts and not saw_answer_item and tool_calls and commentary_parts:
         text_parts.extend(commentary_parts)
-    elif not text_parts and not saw_answer_item and isinstance(
-        raw.get("output_text"), str
+    elif (
+        not text_parts
+        and not saw_answer_item
+        and not saw_non_answer_item
+        and isinstance(raw.get("output_text"), str)
     ):
         text_parts.append(raw["output_text"])
     return "".join(text_parts), tool_calls, finish
@@ -463,15 +469,6 @@ def _contributing_assistant_phase(raw: dict) -> Optional[str]:
             ):
                 return "commentary"
     return None
-
-
-def _saw_answer_message(raw: dict) -> bool:
-    for item in raw.get("output") or []:
-        if not isinstance(item, dict) or item.get("type") != "message":
-            continue
-        if _codex_channel_for_item("message", item.get("phase")) == "answer":
-            return True
-    return False
 
 
 def _codex_tool_hint_goal(arguments: Any, name: str) -> str:
@@ -1389,15 +1386,6 @@ class CodexResponsesDriver:
         incomplete_retries: int = 0,
     ) -> DriverResponse:
         text, tool_calls, finish = _extract_text_and_tools(raw)
-        # Extract already falls back to output_text for phase-less bodies.
-        # Do not undo that when an answer-phase item existed (even empty) —
-        # re-applying the mixed blob reintroduces commentary into history.
-        if (
-            not text
-            and not _saw_answer_message(raw)
-            and isinstance(raw.get("output_text"), str)
-        ):
-            text = raw["output_text"]
         assistant_phase = _contributing_assistant_phase(raw)
         if finish == "content_filter":
             meta = {

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -368,11 +368,12 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
     burning continuation retries.
 
     Message text for ``DriverResponse.text`` prefers ``final_answer`` and
-    phase-less (legacy) items. Commentary and analysis are excluded — they
-    stream via progress/reasoning callbacks and must not contaminate the
-    final answer even when final text is empty.
+    phase-less (legacy) items. Commentary is retained only when it precedes a
+    tool call and no answer exists, so history can replay the preamble with its
+    phase. Analysis is always excluded.
     """
     text_parts: List[str] = []
+    commentary_parts: List[str] = []
     tool_calls: List[dict] = []
     saw_answer_item = False
     status = str(raw.get("status") or "")
@@ -391,6 +392,14 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
             # Reuse channel policy: commentary -> progress, analysis ->
             # reasoning, final_answer / phase-less -> answer.
             channel = _codex_channel_for_item("message", item.get("phase"))
+            if channel == "progress":
+                commentary_parts.extend(
+                    str(part.get("text") or "")
+                    for part in item.get("content") or []
+                    if isinstance(part, dict)
+                    and part.get("type") in ("output_text", "text")
+                )
+                continue
             if channel != "answer":
                 continue
             saw_answer_item = True
@@ -413,7 +422,9 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
     # Legacy / SSE-assembled bodies may only populate output_text. Never fall
     # back to it when answer-phase items existed (even if their text is empty)
     # — that would re-introduce commentary contamination via a mixed blob.
-    if not text_parts and not saw_answer_item and isinstance(
+    if not text_parts and not saw_answer_item and tool_calls and commentary_parts:
+        text_parts.extend(commentary_parts)
+    elif not text_parts and not saw_answer_item and isinstance(
         raw.get("output_text"), str
     ):
         text_parts.append(raw["output_text"])
@@ -421,10 +432,9 @@ def _extract_text_and_tools(raw: dict) -> Tuple[str, list, str]:
 
 
 def _contributing_assistant_phase(raw: dict) -> Optional[str]:
-    """Known phase shared by every answer-channel message item, else None.
+    """Phase of final text, or commentary before a tool call, else None.
 
-    Commentary/analysis are not contributing. A single phase-less (legacy)
-    answer item refuses inference — we must not stamp final_answer.
+    A phase-less legacy answer refuses inference. Analysis never contributes.
     """
     phases: List[str] = []
     for item in raw.get("output") or []:
@@ -436,11 +446,22 @@ def _contributing_assistant_phase(raw: dict) -> Optional[str]:
         if known is None:
             return None
         phases.append(known)
-    if not phases:
+    if phases:
+        first = phases[0]
+        if all(phase == first for phase in phases):
+            return first
         return None
-    first = phases[0]
-    if all(phase == first for phase in phases):
-        return first
+    if any(
+        isinstance(item, dict) and item.get("type") == "function_call"
+        for item in raw.get("output") or []
+    ):
+        for item in raw.get("output") or []:
+            if (
+                isinstance(item, dict)
+                and item.get("type") == "message"
+                and known_assistant_phase(item.get("phase")) == "commentary"
+            ):
+                return "commentary"
     return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.363"
+version = "0.9.364"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_codex_responses_driver.py
+++ b/tests/test_codex_responses_driver.py
@@ -170,6 +170,33 @@ def test_response_from_raw_stamps_known_phase_and_skips_legacy():
     assert legacy.assistant_phase is None
 
 
+def test_response_from_raw_preserves_commentary_before_tool_call():
+    """OpenAI Agents JS #1513 follow-up: replay commentary before the tool."""
+    driver = CodexResponsesDriver(name="openai-codex/test", model="gpt-5.6-luna")
+    resp = driver._response_from_raw(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "Checking. "}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": "{}",
+                },
+            ],
+        },
+        t0=time.time(),
+    )
+
+    assert resp.text == "Checking. "
+    assert resp.assistant_phase == "commentary"
+
+
 def test_response_from_raw_empty_final_does_not_fallback_to_commentary():
     """Extract already refuses commentary fallback; DriverResponse must too."""
     driver = CodexResponsesDriver(name="openai-codex/test", model="gpt-5.6-luna")

--- a/tests/test_codex_responses_driver.py
+++ b/tests/test_codex_responses_driver.py
@@ -246,6 +246,49 @@ def test_response_from_raw_commentary_without_tool_stays_empty():
     assert resp.assistant_phase is None
 
 
+def test_extract_non_answer_items_do_not_use_mixed_output_text():
+    """Structured commentary/analysis must not lose to a mixed output_text blob."""
+    commentary_only = {
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "phase": "commentary",
+                "content": [{"type": "output_text", "text": "Checking. "}],
+            },
+        ],
+        "output_text": "Checking. ",
+    }
+    text, _, _ = _extract_text_and_tools(commentary_only)
+    assert text == ""
+
+    analysis_and_tool = {
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "phase": "analysis",
+                "content": [{"type": "output_text", "text": "thinking aloud "}],
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "read_file",
+                "arguments": "{}",
+            },
+        ],
+        "output_text": "thinking aloud ",
+    }
+    text, tools, _ = _extract_text_and_tools(analysis_and_tool)
+    assert text == ""
+    assert tools[0]["id"] == "call_1"
+
+    driver = CodexResponsesDriver(name="openai-codex/test", model="gpt-5.6-luna")
+    resp = driver._response_from_raw(analysis_and_tool, t0=time.time())
+    assert resp.text == ""
+    assert resp.assistant_phase is None
+
+
 def test_messages_to_input_replays_commentary_on_tool_row():
     """Same assistant row carries commentary then function_call then the tool result."""
     inp = _messages_to_responses_input([

--- a/tests/test_codex_responses_driver.py
+++ b/tests/test_codex_responses_driver.py
@@ -197,6 +197,81 @@ def test_response_from_raw_preserves_commentary_before_tool_call():
     assert resp.assistant_phase == "commentary"
 
 
+def test_response_from_raw_analysis_before_tool_is_not_promoted():
+    """Analysis stays off DriverResponse.text even when a tool call follows."""
+    driver = CodexResponsesDriver(name="openai-codex/test", model="gpt-5.6-luna")
+    resp = driver._response_from_raw(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "phase": "analysis",
+                    "content": [{"type": "output_text", "text": "thinking aloud "}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": "{}",
+                },
+            ],
+        },
+        t0=time.time(),
+    )
+
+    assert resp.text == ""
+    assert resp.assistant_phase is None
+    assert resp.meta["tool_calls"][0]["id"] == "call_1"
+
+
+def test_response_from_raw_commentary_without_tool_stays_empty():
+    """Commentary-only still streams via progress; do not stamp a ledger row."""
+    driver = CodexResponsesDriver(name="openai-codex/test", model="gpt-5.6-luna")
+    resp = driver._response_from_raw(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "Checking. "}],
+                },
+            ],
+        },
+        t0=time.time(),
+    )
+
+    assert resp.text == ""
+    assert resp.assistant_phase is None
+
+
+def test_messages_to_input_replays_commentary_on_tool_row():
+    """Same assistant row carries commentary then function_call then the tool result."""
+    inp = _messages_to_responses_input([
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": "Checking. ",
+            "phase": "commentary",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+    ])
+    assert inp[0]["role"] == "user"
+    assert inp[1]["type"] == "message"
+    assert inp[1]["phase"] == "commentary"
+    assert inp[1]["content"][0]["text"] == "Checking. "
+    assert inp[2]["type"] == "function_call"
+    assert inp[2]["call_id"] == "call_1"
+    assert inp[3]["type"] == "function_call_output"
+    assert inp[3]["call_id"] == "call_1"
+
+
 def test_response_from_raw_empty_final_does_not_fallback_to_commentary():
     """Extract already refuses commentary fallback; DriverResponse must too."""
     driver = CodexResponsesDriver(name="openai-codex/test", model="gpt-5.6-luna")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -18,10 +18,12 @@ class FakeStreamingDriver:
         self.chat_called = False
         self.chat_stream_called = False
         self.calls = 0
+        self.messages = []
 
     def chat(self, messages, *, tools=None, system=None):
         self.chat_called = True
         self.calls += 1
+        self.messages.append(messages)
         if self.calls == 1:
             if self.use_native_tool_calls:
                 meta = {
@@ -39,7 +41,10 @@ class FakeStreamingDriver:
                     "finish_reason": "tool_calls",
                     "stream_terminal": "tool_calls",
                 }
-                return DriverResponse(text="Reading...", meta=meta)
+                return DriverResponse(
+                    text="Reading...", meta=meta,
+                    assistant_phase="commentary",
+                )
             else:
                 text = '{"say":"Reading...","actions":[{"kind":"read_file","path":"test.txt"}]}'
                 return DriverResponse(text=text, meta={"finish_reason": "stop"})
@@ -47,17 +52,20 @@ class FakeStreamingDriver:
             return DriverResponse(
                 text="Done.",
                 meta={"tool_calls": [], "reasoning": "", "finish_reason": "stop"},
+                assistant_phase="final_answer",
             )
 
     def chat_stream(self, messages, *, tools=None, system=None, on_delta,
                     on_reasoning_delta=None, on_tool_hint=None):
         self.chat_stream_called = True
         self.calls += 1
+        self.messages.append(messages)
 
-        # Fire off some deltas
-        on_delta("Read")
-        on_delta("ing")
-        on_delta("...")
+        # Fire off progress before the tool, answer prose after its result.
+        channel = "progress" if self.calls == 1 else "answer"
+        on_delta({"text": "Read", "channel": channel})
+        on_delta({"text": "ing", "channel": channel})
+        on_delta({"text": "...", "channel": channel})
 
         if self.calls == 1:
             if self.use_native_tool_calls:
@@ -77,7 +85,10 @@ class FakeStreamingDriver:
                     "stream_terminal": "tool_calls",
                     "stream_started": True,
                 }
-                return DriverResponse(text="Reading...", meta=meta)
+                return DriverResponse(
+                    text="Reading...", meta=meta,
+                    assistant_phase="commentary",
+                )
             else:
                 text = '{"say":"Reading...","actions":[{"kind":"read_file","path":"test.txt"}]}'
                 return DriverResponse(
@@ -94,6 +105,7 @@ class FakeStreamingDriver:
                     "stream_started": True,
                     "stream_terminal": "stop",
                 },
+                assistant_phase="final_answer",
             )
 
 
@@ -353,11 +365,28 @@ def test_conversational_loop_streaming():
     assert delta_events[4].data["text"] == "ing"
     assert delta_events[5].data["text"] == "..."
 
-    # final 'message' event still arrives with the cleaned text
+    # Commentary was already streamed as progress; only the final answer closes
+    # as a durable assistant message.
     msg_events = [e for e in events if e.kind == "message"]
-    assert len(msg_events) == 2
-    assert msg_events[0].data["text"] == "Reading..."
-    assert msg_events[1].data["text"] == "Done."
+    assert [event.data["text"] for event in msg_events] == ["Done."]
+
+    assistant_history = [
+        item for item in s._history if item.get("role") == "assistant"
+    ]
+    assert assistant_history[0]["content"] == "Reading..."
+    assert assistant_history[0]["phase"] == "commentary"
+    assert assistant_history[-1]["content"] == "Done."
+    assert assistant_history[-1]["phase"] == "final_answer"
+    replayed = s.pilot.messages[1]
+    commentary_index = next(
+        index for index, item in enumerate(replayed)
+        if item.get("role") == "assistant"
+        and item.get("phase") == "commentary"
+        and item.get("content") == "Reading..."
+    )
+    assert replayed[commentary_index]["tool_calls"][0]["id"] == "call_1"
+    assert replayed[commentary_index + 1]["role"] == "tool"
+    assert replayed[commentary_index + 1]["tool_call_id"] == "call_1"
 
     # tool_calls assembled from the stream still execute
     assert "action_start" in kinds

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.363",
+  "version": "0.9.364",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.363",
+      "version": "0.9.364",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.363",
+  "version": "0.9.364",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Release v0.9.364: absorb Benton Ferguson PR #231 (dest #232) so OpenAI Responses commentary that precedes a tool call is kept on the history ledger and replayed before the function call, without rendering as a completed answer.
- Pin stays puppetmaster-ai==1.22.37. Not a Puppetmaster product bump.

## Test plan
- [x] dest absorb focused suite 90 passed
- [ ] dest-into-main `tests` matrix (3.9 floor, Windows, frontend-build)
