### PR TITLE
feat: add Hermes-style composer spelling menu

### DIFF
--- a/webapp/electron/link-menu.test.cjs
+++ b/webapp/electron/link-menu.test.cjs
@@ -10,8 +10,18 @@ describe("v0.9.344 link menu and Cmd+W intercept", () => {
     assert.match(main, /Open in system browser/);
     assert.match(main, /Open in-app browser/);
     assert.match(main, /Copy link/);
-    assert.match(main, /wireLinkContextMenu/);
+    assert.match(main, /wireContextMenu/);
     assert.match(main, /browser:openInApp/);
+  });
+
+  it("main.cjs wires spelling and link items through one context menu", () => {
+    const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+    const preload = fs.readFileSync(path.join(__dirname, "preload.cjs"), "utf8");
+    assert.match(main, /wireContextMenu/);
+    assert.match(main, /context-menu:open/);
+    assert.match(main, /addWordToSpellCheckerDictionary/);
+    assert.match(preload, /onContextMenuOpen/);
+    assert.match(preload, /contextMenuEdit/);
   });
 
   it("main.cjs intercepts Cmd\/Ctrl+W so Close Window is not first", () => {

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -1529,16 +1529,27 @@ function linkContextMenuTemplate(url) {
   ];
 }
 
-function wireLinkContextMenu(contents) {
+function wireContextMenu(contents) {
   if (!contents || contents.isDestroyed()) return;
   contents.on("context-menu", (_e, params) => {
+    if (params && params.isEditable) {
+      contents.send("context-menu:open", {
+        x: params.x,
+        y: params.y,
+        misspelledWord: params.misspelledWord || "",
+        suggestions: Array.isArray(params.dictionarySuggestions)
+          ? params.dictionarySuggestions
+          : [],
+      });
+      return;
+    }
     const url = params && params.linkURL;
     if (!url || !isAllowedBrowserUrl(url)) return;
     const owner = (win && !win.isDestroyed()) ? win : BrowserWindow.fromWebContents(contents);
     try {
       Menu.buildFromTemplate(linkContextMenuTemplate(url)).popup({ window: owner || undefined });
     } catch (err) {
-      logMain(`link context-menu failed: ${err && err.message ? err.message : err}`);
+      logMain(`context-menu failed: ${err && err.message ? err.message : err}`);
     }
   });
 }
@@ -1608,7 +1619,7 @@ function createWindow() {
   }
   trackWindowState(win);
   loadRenderer();
-  wireLinkContextMenu(win.webContents);
+  wireContextMenu(win.webContents);
   wireCloseTabShortcut(win.webContents);
 
   // Drop the reference when the window is closed so a reopen builds a clean one
@@ -1960,7 +1971,7 @@ app.on("web-contents-created", (_e, contents) => {
   if (type === "webview") {
     applyChromeFingerprint(contents);
     wireWikiConnectNavigation(contents);
-    wireLinkContextMenu(contents);
+    wireContextMenu(contents);
     wireCloseTabShortcut(contents);
     logMain(`[browser] webview contents created; UA applied`);
     contents.setWindowOpenHandler(() => {
@@ -2092,6 +2103,19 @@ ipcMain.handle("browser:openExternal", async (_e, url) => {
     logMain(`browser:openExternal failed: ${e && e.message ? e.message : e}`);
     return { ok: false, error: String(e && e.message ? e.message : e) };
   }
+});
+
+ipcMain.handle("context-menu:edit", (event, command) => {
+  if (command === "copy") event.sender.copy();
+  else if (command === "cut") event.sender.cut();
+  else if (command === "paste") event.sender.paste();
+});
+
+ipcMain.handle("context-menu:spellcheck", (event, action) => {
+  const word = typeof action?.word === "string" ? action.word : "";
+  if (!word) return;
+  if (action.kind === "replace") event.sender.replaceMisspelling(word);
+  else if (action.kind === "add") event.sender.session.addWordToSpellCheckerDictionary(word);
 });
 
 ipcMain.handle("window:close", () => {

--- a/webapp/electron/preload.cjs
+++ b/webapp/electron/preload.cjs
@@ -23,6 +23,13 @@ contextBridge.exposeInMainWorld("harnessIPC", {
     ipcRenderer.on("browser:openInApp", handler);
     return () => ipcRenderer.removeListener("browser:openInApp", handler);
   },
+  onContextMenuOpen: (cb) => {
+    const handler = (_e, payload) => { try { cb(payload); } catch (_) {} };
+    ipcRenderer.on("context-menu:open", handler);
+    return () => ipcRenderer.removeListener("context-menu:open", handler);
+  },
+  contextMenuEdit: (command) => ipcRenderer.invoke("context-menu:edit", command),
+  contextMenuSpellcheck: (action) => ipcRenderer.invoke("context-menu:spellcheck", action),
   uploadFile: (payload) => ipcRenderer.invoke("harness:uploadFile", payload),
   // Electron no longer sets File.path; this is the supported drop-path API.
   pathForFile: (file) => {

--- a/webapp/src/__tests__/ComposerContextMenu.test.tsx
+++ b/webapp/src/__tests__/ComposerContextMenu.test.tsx
@@ -1,0 +1,80 @@
+import { act, createRef } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ComposerContextMenu from "../components/conversation/ComposerContextMenu";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  delete (window as any).harnessIPC;
+  document.body.innerHTML = "";
+});
+
+describe("ComposerContextMenu", () => {
+  it("renders Hermes-style edit actions for the composer gesture only", async () => {
+    let openMenu: ((payload: {
+      x: number;
+      y: number;
+      misspelledWord: string;
+      suggestions: string[];
+    }) => void) | undefined;
+    const contextMenuEdit = vi.fn().mockResolvedValue(undefined);
+    const contextMenuSpellcheck = vi.fn().mockResolvedValue(undefined);
+    (window as any).harnessIPC = {
+      onContextMenuOpen: (callback: typeof openMenu) => {
+        openMenu = callback;
+        return () => { openMenu = undefined; };
+      },
+      contextMenuEdit,
+      contextMenuSpellcheck,
+    };
+    const textarea = document.createElement("textarea");
+    textarea.value = "ostencibly";
+    textarea.setSelectionRange(0, 10);
+    document.body.appendChild(textarea);
+    const textareaRef = createRef<HTMLTextAreaElement>();
+    (textareaRef as any).current = textarea;
+
+    vi.stubGlobal("innerHeight", 600);
+    render(<ComposerContextMenu textareaRef={textareaRef} />);
+    await waitFor(() => expect(openMenu).toBeTypeOf("function"));
+    act(() => openMenu?.({ x: 20, y: 20, misspelledWord: "elsewhere", suggestions: ["elsewhere"] }));
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(textarea, { clientX: 120, clientY: 350 });
+    act(() => openMenu?.({
+      x: 121,
+      y: 351,
+      misspelledWord: "ostencibly",
+      suggestions: ["ostensibly"],
+    }));
+
+    const menu = await screen.findByRole("menu");
+    expect(menu.className).toContain("backdrop-blur");
+    expect(menu.style.top).toBe("351px");
+    expect(screen.getByText("Cut")).toBeTruthy();
+    expect(screen.getByText("Copy")).toBeTruthy();
+    expect(screen.getByText("Paste")).toBeTruthy();
+    expect(screen.getByText("Select all")).toBeTruthy();
+
+    fireEvent.click(await screen.findByText("ostensibly"));
+
+    await waitFor(() => expect(contextMenuSpellcheck).toHaveBeenCalledWith({
+      kind: "replace",
+      word: "ostensibly",
+    }));
+
+    fireEvent.contextMenu(textarea, { clientX: 120, clientY: 180 });
+    act(() => openMenu?.({ x: 120, y: 180, misspelledWord: "ostencibly", suggestions: ["ostensibly"] }));
+    fireEvent.click(await screen.findByText("Add to dictionary"));
+    await waitFor(() => expect(contextMenuSpellcheck).toHaveBeenCalledWith({
+      kind: "add",
+      word: "ostencibly",
+    }));
+
+    fireEvent.contextMenu(textarea, { clientX: 120, clientY: 180 });
+    act(() => openMenu?.({ x: 120, y: 180, misspelledWord: "", suggestions: [] }));
+    fireEvent.click(await screen.findByText("Copy"));
+    await waitFor(() => expect(contextMenuEdit).toHaveBeenCalledWith("copy"));
+  });
+});

--- a/webapp/src/components/conversation/ComposerContextMenu.tsx
+++ b/webapp/src/components/conversation/ComposerContextMenu.tsx
@@ -1,0 +1,130 @@
+import type { RefObject } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { BookPlus, Clipboard, ClipboardPaste, Pencil, Scissors, TextSelect } from "lucide-react";
+import { isMacNavigator } from "../../lib/terminalSelection";
+
+type Spellcheck = { misspelledWord: string; suggestions: string[] };
+type MenuState = { x: number; y: number; spellcheck: Spellcheck | null };
+type EditCommand = "copy" | "cut" | "paste";
+
+const itemClass = "flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-[12px] text-txt transition-colors hover:bg-accent/15 disabled:pointer-events-none disabled:opacity-40";
+
+export default function ComposerContextMenu({
+  textareaRef,
+}: {
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+}) {
+  const [menu, setMenu] = useState<MenuState | null>(null);
+  const [position, setPosition] = useState({ left: 0, top: 0 });
+  const menuRef = useRef<HTMLDivElement>(null);
+  const composerGesture = useRef(false);
+
+  useEffect(() => {
+    const markGesture = (event: MouseEvent) => {
+      composerGesture.current = event.target === textareaRef.current;
+    };
+    window.addEventListener("contextmenu", markGesture, true);
+    return () => window.removeEventListener("contextmenu", markGesture, true);
+  }, [textareaRef]);
+
+  useEffect(() => {
+    const ipc = (window as any).harnessIPC;
+    return ipc?.onContextMenuOpen?.((payload: Spellcheck & { x: number; y: number }) => {
+      const belongsToComposer = composerGesture.current;
+      composerGesture.current = false;
+      if (!belongsToComposer) return;
+      setMenu({
+        x: payload.x,
+        y: payload.y,
+        spellcheck: payload.misspelledWord ? payload : null,
+      });
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!menu || !menuRef.current) return;
+    const bounds = menuRef.current.getBoundingClientRect();
+    setPosition({
+      left: Math.max(8, Math.min(menu.x, window.innerWidth - bounds.width - 8)),
+      top: Math.max(8, Math.min(menu.y, window.innerHeight - bounds.height - 8)),
+    });
+  }, [menu]);
+
+  useEffect(() => {
+    if (!menu) return;
+    const close = () => setMenu(null);
+    const escape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+    document.addEventListener("mousedown", close);
+    document.addEventListener("keydown", escape);
+    return () => {
+      document.removeEventListener("mousedown", close);
+      document.removeEventListener("keydown", escape);
+    };
+  }, [menu]);
+
+  if (!menu) return null;
+
+  const textarea = textareaRef.current;
+  const hasSelection = Boolean(textarea && textarea.selectionStart !== textarea.selectionEnd);
+  const hasText = Boolean(textarea?.value);
+  const modifier = isMacNavigator() ? "⌘" : "Ctrl+";
+  const run = (action: () => void) => {
+    setMenu(null);
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+      action();
+    });
+  };
+  const edit = (command: EditCommand) => run(() => {
+    void (window as any).harnessIPC?.contextMenuEdit?.(command);
+  });
+  const spell = (kind: "add" | "replace", word: string) => run(() => {
+    void (window as any).harnessIPC?.contextMenuSpellcheck?.({ kind, word });
+  });
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="Composer menu"
+      className="fixed z-[100] min-w-[220px] overflow-hidden rounded-xl border border-edge bg-panel/95 p-1.5 text-txt shadow-2xl shadow-black/40 backdrop-blur-xl"
+      style={position}
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      {menu.spellcheck && (
+        <>
+          {menu.spellcheck.suggestions.slice(0, 5).map((suggestion) => (
+            <button key={suggestion} role="menuitem" className={itemClass} onClick={() => spell("replace", suggestion)}>
+              <Pencil size={13} className="text-accent" />
+              <span>{suggestion}</span>
+            </button>
+          ))}
+          <button role="menuitem" className={itemClass} onClick={() => spell("add", menu.spellcheck!.misspelledWord)}>
+            <BookPlus size={13} className="text-muted" />
+            <span>Add to dictionary</span>
+          </button>
+          <div className="mx-1 my-1 h-px bg-edge/70" />
+        </>
+      )}
+      <button role="menuitem" className={itemClass} disabled={!hasSelection} onClick={() => edit("cut")}>
+        <Scissors size={13} className="text-muted" />
+        <span>Cut</span><span className="ml-auto font-mono text-[10px] text-faint">{modifier}X</span>
+      </button>
+      <button role="menuitem" className={itemClass} disabled={!hasSelection} onClick={() => edit("copy")}>
+        <Clipboard size={13} className="text-muted" />
+        <span>Copy</span><span className="ml-auto font-mono text-[10px] text-faint">{modifier}C</span>
+      </button>
+      <button role="menuitem" className={itemClass} onClick={() => edit("paste")}>
+        <ClipboardPaste size={13} className="text-muted" />
+        <span>Paste</span><span className="ml-auto font-mono text-[10px] text-faint">{modifier}V</span>
+      </button>
+      <div className="mx-1 my-1 h-px bg-edge/70" />
+      <button role="menuitem" className={itemClass} disabled={!hasText} onClick={() => run(() => textareaRef.current?.select())}>
+        <TextSelect size={13} className="text-muted" />
+        <span>Select all</span><span className="ml-auto font-mono text-[10px] text-faint">{modifier}A</span>
+      </button>
+    </div>
+  );
+}

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -28,6 +28,7 @@ import {
 import { api, type Config, type ContextUsageResponse, type Job } from "../../lib/api";
 import PilotPicker from "../PilotPicker";
 import WorkspaceChip from "./WorkspaceChip";
+import ComposerContextMenu from "./ComposerContextMenu";
 import ComposerStatusStack from "./ComposerStatusStack";
 import ComposerTasksPanel from "./ComposerTasksPanel";
 import { formatMentionListingCapMessage, type MentionListingCap } from "./slashCommands";
@@ -972,6 +973,7 @@ export default function ComposerDock({
             onPaste={handlePaste}
             rows={1} placeholder={auto ? "Give the pilot an objective..." : "Message the pilot..."}
             className="w-full bg-transparent px-3 pt-2.5 pb-1 text-[0.8125rem] resize-none focus:outline-none overflow-hidden placeholder:text-faint" />
+          <ComposerContextMenu textareaRef={taRef} />
           <div className="composer-toolbar px-3 pb-2">
             <div className="composer-toolbar-actions">
             <button type="button" onClick={() => {


### PR DESCRIPTION
## Summary

- Replace the composer's missing/unstyled Electron edit menu with a Hermes-inspired renderer menu.
- Use Chromium's authoritative `misspelledWord` and `dictionarySuggestions` for corrections and dictionary updates.
- Add Cut, Copy, Paste, and Select all with native Electron edit actions and platform-correct shortcut labels.
- Measure the rendered menu before viewport clamping so it opens at the click unless the real menu would overflow.

## Ownership

Electron owns the original editable right-click facts and edit/spellcheck operations. The renderer owns menu presentation. A composer gesture marker ensures the global Electron event cannot open this menu for another editable field.

This borrows the behavior and visual model from Hermes Desktop without porting its global context-menu store, guest-browser handling, terminal menus, IPC surface, or localization system.

## User-visible proof

Mounted in the source-run dev instance on macOS:

- spelling suggestions appeared after the final Electron-owned event correction;
- replacement worked;
- Add to dictionary, Cut, Copy, Paste, and Select all rendered;
- menu placement and visual treatment were accepted;
- the suggestion icon was corrected from clipboard to pencil after review.
<img width="260" height="304" alt="Screenshot 2026-08-27 at 3 12 50 PM" src="https://github.com/user-attachments/assets/eeadf9f7-83e4-46b8-afe8-28d088245f9a" />


## Test plan

- [x] RED: no spelling-menu owner or Electron bridge existed.
- [x] RED: fixed-height placement moved the menu above the click.
- [x] RED: opening the renderer menu before Electron inspection produced `editable=false`, no misspelled word, and zero suggestions.
- [x] RED: accepting the global Electron payload without a composer gesture could open the composer menu for another editable.
- [x] `NODE_ENV=test npx vitest run src/__tests__/ComposerContextMenu.test.tsx src/__tests__/ComposerDock.slashEmpty.test.tsx` — 4 passed
- [x] `node --test electron/link-menu.test.cjs` — 4 passed
- [x] `node --check electron/main.cjs && node --check electron/preload.cjs`
- [x] `env -u NODE_ENV npm run build`
- [x] `git diff --check`
