### PR TITLE
Release v0.9.366

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.37` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.365, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.366, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.365"
+__version__ = "0.9.366"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.365"
+version = "0.9.366"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.365",
+  "version": "0.9.366",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.365",
+      "version": "0.9.366",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.365",
+  "version": "0.9.366",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/RegistryWizard.test.tsx
+++ b/webapp/src/__tests__/RegistryWizard.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import RegistryWizard from "../components/RegistryWizard";
+import wizardSrc from "../components/RegistryWizard.tsx?raw";
+import settingsSrc from "../components/SettingsShell.tsx?raw";
+import SettingsShell from "../components/SettingsShell";
 import { api } from "../lib/api";
 
 vi.mock("../lib/api", () => ({
@@ -8,6 +11,14 @@ vi.mock("../lib/api", () => ({
     providers: vi.fn(),
     setProviderKey: vi.fn(),
   },
+}));
+
+vi.mock("../components/ModelsSettingsPage", () => ({
+  default: () => <div data-testid="models-page" />,
+}));
+
+vi.mock("../components/SettingsPane", () => ({
+  default: () => <div data-testid="settings-section" />,
 }));
 
 const providers = [
@@ -42,6 +53,12 @@ const providers = [
 
 describe("RegistryWizard first-run connect", () => {
   beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "offsetParent", {
+      configurable: true,
+      get() {
+        return this.parentElement;
+      },
+    });
     vi.clearAllMocks();
     vi.mocked(api.providers).mockResolvedValue(providers);
     vi.mocked(api.setProviderKey).mockResolvedValue({
@@ -91,5 +108,35 @@ describe("RegistryWizard first-run connect", () => {
     fireEvent.click(screen.getByRole("button", { name: /choose a provider later/i }));
     expect(api.setProviderKey).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("portals above the Settings shell so Connect a provider is not buried", async () => {
+    expect(wizardSrc).toContain("OverlayPortal");
+    expect(wizardSrc).toContain("z-[90]");
+    expect(settingsSrc).toContain("z-[80]");
+
+    const onSettingsClose = vi.fn();
+    const onWizardClose = vi.fn();
+    const host = document.createElement("div");
+    document.body.append(host);
+    render(
+      <>
+        <SettingsShell onClose={onSettingsClose} onOpenWizard={vi.fn()} />
+        <RegistryWizard onClose={onWizardClose} />
+      </>,
+      { container: host },
+    );
+
+    const wizard = await screen.findByTestId("provider-onboarding");
+    const settings = screen.getByTestId("settings-shell");
+    expect(document.body.contains(wizard)).toBe(true);
+    expect(host.contains(wizard)).toBe(false);
+    expect(wizard.className).toMatch(/z-\[90\]/);
+    expect(settings.className).toContain("z-[80]");
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onWizardClose).toHaveBeenCalledTimes(1);
+    expect(onSettingsClose).not.toHaveBeenCalled();
+    host.remove();
   });
 });

--- a/webapp/src/__tests__/SettingsShell.providersFocus.test.tsx
+++ b/webapp/src/__tests__/SettingsShell.providersFocus.test.tsx
@@ -50,4 +50,12 @@ describe("SettingsShell Accounts & Keys focus", () => {
     fireEvent.click(screen.getByRole("button", { name: /Accounts & Keys/i }));
     expect(screen.getByTestId("settings-section-providers")).toBeTruthy();
   });
+
+  it("Escape still closes Settings when no provider modal is stacked", () => {
+    const onClose = vi.fn();
+    render(<SettingsShell onClose={onClose} onOpenWizard={vi.fn()} />);
+    expect(screen.getByTestId("settings-shell")).toBeTruthy();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/webapp/src/__tests__/feedScroll.test.ts
+++ b/webapp/src/__tests__/feedScroll.test.ts
@@ -75,6 +75,26 @@ describe("feedScroll hysteresis", () => {
     expect(shouldShowJumpToBottom({ pinned: false, settling: true })).toBe(false);
     expect(shouldShowJumpToBottom({ pinned: false, settling: false })).toBe(true);
   });
+
+  it("hides jump-to-latest when the viewport is already at the tail", () => {
+    expect(
+      shouldShowJumpToBottom({ pinned: false, settling: false, atTail: true }),
+    ).toBe(false);
+    expect(
+      shouldShowJumpToBottom({
+        pinned: false,
+        settling: false,
+        distanceFromEndPx: 10,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowJumpToBottom({
+        pinned: false,
+        settling: false,
+        distanceFromEndPx: 80,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("scrollTopAfterFeedHeightChange", () => {

--- a/webapp/src/__tests__/overlayFocus.test.tsx
+++ b/webapp/src/__tests__/overlayFocus.test.tsx
@@ -73,4 +73,23 @@ describe("useOverlayFocus", () => {
 
     trigger.remove();
   });
+
+  it("only the topmost overlay handles Escape when two traps are open", async () => {
+    const onBottom = vi.fn();
+    const onTop = vi.fn();
+    render(
+      <>
+        <OverlayTrapFixture open onClose={onBottom} />
+        <div>
+          <OverlayTrapFixture open onClose={onTop} />
+        </div>
+      </>,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByRole("dialog", { name: "trap" })).toHaveLength(2);
+    });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onTop).toHaveBeenCalledTimes(1);
+    expect(onBottom).not.toHaveBeenCalled();
+  });
 });

--- a/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
+++ b/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
@@ -104,6 +104,36 @@ describe("stacked fold labels", () => {
     expect(rows[1].items).toHaveLength(3);
     expect(rows[1].items.filter((it) => it.kind === "thinking")).toHaveLength(1);
   });
+
+  it("coalesces consecutive Thought siblings into one fold", () => {
+    const items = [
+      { kind: "thinking" as const },
+      { kind: "thinking" as const },
+      { kind: "thinking" as const },
+      { kind: "card", cardKind: "run_command" },
+      { kind: "other" as const },
+      { kind: "thinking" as const },
+      { kind: "thinking" as const },
+    ];
+    const rows = partitionStackedActivity(items, (row) => ({
+      cardKind: row.kind === "card" ? row.cardKind : null,
+      isThinking: row.kind === "thinking",
+    }));
+    expect(rows.map((r) => r.kind)).toEqual([
+      "thought",
+      "commands",
+      "item",
+      "thought",
+    ]);
+    expect(rows[0]?.kind).toBe("thought");
+    if (rows[0]?.kind === "thought") {
+      expect(rows[0].items).toHaveLength(3);
+    }
+    expect(rows[3]?.kind).toBe("thought");
+    if (rows[3]?.kind === "thought") {
+      expect(rows[3].items).toHaveLength(2);
+    }
+  });
 });
 
 describe("live stacked folds (Investigating + Thinking + Ran)", () => {

--- a/webapp/src/__tests__/thinkingStreamUx.test.ts
+++ b/webapp/src/__tests__/thinkingStreamUx.test.ts
@@ -712,6 +712,56 @@ describe("createApplyStreamEvent Sol reasoning coalescing", () => {
     expect(afterTool[0].id).toBe(thinking[0].id);
   });
 
+  it("keeps one thinking fold across Codex/Luna Responses item-id rotation", () => {
+    const state = {
+      items: [{ kind: "msg", msg: { role: "user", text: "go" } }] as Item[],
+      itemsRef: { current: [] as Item[] },
+      typeBufRef: { current: "" },
+    };
+    state.itemsRef.current = state.items;
+    const apply = createApplyStreamEvent(makeApplyDeps(state));
+    apply({
+      kind: "thinking",
+      data: { text: "Planning the audit. ", delta: true, stream_id: "rs_a" },
+    });
+    apply({ kind: "stream_item_done", data: { stream_id: "rs_a" } });
+    apply({
+      kind: "thinking",
+      data: { text: "Prioritizing P0 fixes. ", delta: true, stream_id: "rs_b" },
+    });
+    apply({ kind: "stream_item_done", data: { stream_id: "rs_b" } });
+    apply({
+      kind: "thinking",
+      data: { text: "Designing tests.", delta: true, stream_id: "rs_c" },
+    });
+    const beforeTool = thinkingRows(state.items);
+    expect(beforeTool).toHaveLength(1);
+    expect(beforeTool[0].text).toBe(
+      "Planning the audit. Prioritizing P0 fixes. Designing tests.",
+    );
+
+    apply({
+      kind: "tool_prep",
+      data: { name: "run_swarm", id: "call-1", goal: "audit" },
+    });
+    apply({
+      kind: "thinking",
+      data: { text: "Synthesizing evidence. ", delta: true, stream_id: "rs_d" },
+    });
+    apply({ kind: "stream_item_done", data: { stream_id: "rs_d" } });
+    apply({
+      kind: "thinking",
+      data: { text: "Planning the rollout.", delta: true, stream_id: "rs_e" },
+    });
+    const afterTool = thinkingRows(state.items);
+    expect(afterTool).toHaveLength(2);
+    expect(afterTool[0].text).toBe(
+      "Planning the audit. Prioritizing P0 fixes. Designing tests.",
+    );
+    expect(afterTool[1].text).toBe("Synthesizing evidence. Planning the rollout.");
+    expect(afterTool[1].id).not.toBe(afterTool[0].id);
+  });
+
   it("stream_item_done without stream_id seals all open stream surfaces", () => {
     // Regression: missing/empty stream_id used to no-op and leave streaming:true.
     const state = {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -1126,9 +1126,22 @@ export default function Conversation({
   const scrollFeedToEndRef = useRef<(() => void) | null>(null);
   const publishJumpVisibilityRef = useRef(() => {});
   publishJumpVisibilityRef.current = () => {
+    const el = feedRef.current;
+    const atTail = el
+      ? isAtFeedTail(el.scrollHeight, el.scrollTop, el.clientHeight)
+      : false;
+    const distanceFromEndPx = el
+      ? el.scrollHeight - el.scrollTop - el.clientHeight
+      : undefined;
+    if (atTail) {
+      pinnedToBottomRef.current = true;
+      scrollReleasedByGestureRef.current = false;
+    }
     const next = shouldShowJumpToBottom({
       pinned: pinnedToBottomRef.current,
       settling: scrollSettlingRef.current,
+      atTail,
+      distanceFromEndPx,
     });
     setShowJumpToBottom((prev) => (prev === next ? prev : next));
   };

--- a/webapp/src/components/RegistryWizard.tsx
+++ b/webapp/src/components/RegistryWizard.tsx
@@ -7,6 +7,7 @@ import {
   onboardingCopy,
   openOnboardingKeyUrl,
 } from "../lib/onboardingProviders";
+import { OverlayPortal } from "../lib/overlayPortal";
 import { usePanelNotice } from "../lib/useOperationalDiagnostic";
 import { setConfigured, skipFirstRun } from "../state/onboardingStore";
 
@@ -35,17 +36,6 @@ export default function RegistryWizard({ onClose }: RegistryWizardProps) {
   const copy = onboardingCopy(selected);
   const selectedProvider = tiles.find((p) => p.name === selected);
   const canConnect = Boolean(keyValue.trim()) && !saving && Boolean(selected);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        dismissWizard();
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
 
   useEffect(() => {
     let cancelled = false;
@@ -97,9 +87,11 @@ export default function RegistryWizard({ onClose }: RegistryWizardProps) {
   };
 
   return (
-    <div
-      data-testid="provider-onboarding"
-      className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6"
+    <OverlayPortal
+      open
+      onClose={skip}
+      testId="provider-onboarding"
+      className="fixed inset-0 z-[90] flex items-center justify-center px-4 py-6"
       style={{
         background:
           "radial-gradient(ellipse at 50% 38%, rgba(224,164,90,0.08) 0%, transparent 52%), #0f1113",
@@ -220,6 +212,6 @@ export default function RegistryWizard({ onClose }: RegistryWizardProps) {
           </button>
         </div>
       </div>
-    </div>
+    </OverlayPortal>
   );
 }

--- a/webapp/src/components/SettingsShell.tsx
+++ b/webapp/src/components/SettingsShell.tsx
@@ -59,17 +59,6 @@ export default function SettingsShell({
     onClose,
   });
 
-  // Escape always closes settings -- a keyboard escape hatch so a missed click
-  // on the X (e.g. a busy main thread during a swarm) can never trap the user
-  // behind this full-window overlay. Capture phase so it wins over inner inputs.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { e.stopPropagation(); onClose(); }
-    };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [onClose]);
-
   // Add key / hotkeys can request Accounts & Keys while Settings is already open.
   useEffect(() => {
     const onPage = (e: Event) => {

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -43,6 +43,7 @@ import {
   deriveBusyProgress,
   explorationShelfAnchorId,
   investigatingHeadline,
+  joinThoughtFoldText,
   partitionStackedActivity,
   ranCommandsLabel,
   resolveCardCliInput,
@@ -2650,7 +2651,26 @@ function ActivityGroup({
             isThinking: row.kind === "thinking",
           })).map((row) => {
             if (row.kind === "thought") {
-              return renderInner(row.item, row.index);
+              const thoughts = row.items.filter(
+                (it): it is Extract<ActivityItem, { kind: "thinking" }> =>
+                  it.kind === "thinking",
+              );
+              const first = thoughts[0];
+              if (!first) return null;
+              const durationMs = thoughts.reduce((sum, t) => {
+                return typeof t.duration_ms === "number" && Number.isFinite(t.duration_ms)
+                  ? sum + Math.max(0, t.duration_ms)
+                  : sum;
+              }, 0);
+              return (
+                <ThinkingBlock
+                  key={first.id || `${groupId}-think-${row.indexes[0]}`}
+                  blockId={first.id || `${groupId}-think-${row.indexes[0]}`}
+                  text={joinThoughtFoldText(thoughts.map((t) => t.text))}
+                  live={thoughts.some((t) => t.streaming)}
+                  durationMs={durationMs > 0 ? durationMs : null}
+                />
+              );
             }
             if (row.kind === "commands") {
               const cmdCards = row.items.filter(

--- a/webapp/src/components/conversation/feedScroll.ts
+++ b/webapp/src/components/conversation/feedScroll.ts
@@ -178,8 +178,17 @@ export function nextFeedPinState(opts: {
 export function shouldShowJumpToBottom(opts: {
   pinned: boolean;
   settling: boolean;
+  atTail?: boolean;
+  distanceFromEndPx?: number;
 }): boolean {
-  return !opts.pinned && !opts.settling;
+  if (opts.pinned || opts.settling || opts.atTail) return false;
+  if (
+    opts.distanceFromEndPx != null
+    && opts.distanceFromEndPx < FEED_REPIN_THRESHOLD_PX
+  ) {
+    return false;
+  }
+  return true;
 }
 
 /** Upward wheel unpins even during session-switch settle glue. */

--- a/webapp/src/components/conversation/thinkingToolPrep.ts
+++ b/webapp/src/components/conversation/thinkingToolPrep.ts
@@ -206,6 +206,7 @@ export function upsertStreamingThinking(
   const turnStart = turnStartIndex(items);
 
   if (streamId) {
+    let latestThinkingIdx = -1;
     for (let i = items.length - 1; i >= turnStart; i--) {
       const it = items[i];
       // Never resume a reasoning row that sits above a tool boundary.
@@ -215,6 +216,26 @@ export function upsertStreamingThinking(
       if (it.kind === "thinking" && it.stream_id === streamId) {
         const copy = items.slice();
         copy[i] = {
+          kind: "thinking",
+          text: mergeThinkingText(it.text, chunk, coalesceSnapshots),
+          streaming: true,
+          id: it.id || newThinkingId(),
+          stream_id: streamId,
+          started_at_ms: thinkingStartedAt(it),
+        };
+        return copy;
+      }
+      if (it.kind === "thinking" && latestThinkingIdx < 0) {
+        latestThinkingIdx = i;
+      }
+    }
+    // Codex/Luna Responses rotates output-item ids per reasoning snapshot.
+    // Same phase (no tool fence) continues the latest Thought fold.
+    if (latestThinkingIdx >= 0) {
+      const it = items[latestThinkingIdx];
+      if (it.kind === "thinking") {
+        const copy = items.slice();
+        copy[latestThinkingIdx] = {
           kind: "thinking",
           text: mergeThinkingText(it.text, chunk, coalesceSnapshots),
           streaming: true,

--- a/webapp/src/lib/overlayFocus.ts
+++ b/webapp/src/lib/overlayFocus.ts
@@ -3,6 +3,9 @@ import { useEffect, useRef } from "react";
 const FOCUSABLE =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
+const overlayStack: number[] = [];
+let overlaySeq = 0;
+
 function focusableElements(root: HTMLElement): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
     (el) => !el.hasAttribute("disabled") && el.tabIndex !== -1 && el.offsetParent !== null,
@@ -23,6 +26,10 @@ export function useOverlayFocus(
 
   useEffect(() => {
     if (!open) return;
+    const id = ++overlaySeq;
+    overlayStack.push(id);
+    const isTop = () => overlayStack[overlayStack.length - 1] === id;
+
     triggerRef.current = document.activeElement instanceof HTMLElement
       ? document.activeElement
       : null;
@@ -30,6 +37,7 @@ export function useOverlayFocus(
     const root = rootRef.current;
     const initial = opts?.initialFocusRef?.current;
     const t = window.setTimeout(() => {
+      if (!isTop()) return;
       if (initial) {
         initial.focus();
       } else if (root) {
@@ -39,6 +47,7 @@ export function useOverlayFocus(
     }, 0);
 
     const onKeyDown = (e: KeyboardEvent) => {
+      if (!isTop()) return;
       if (e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
@@ -64,6 +73,8 @@ export function useOverlayFocus(
 
     window.addEventListener("keydown", onKeyDown, true);
     return () => {
+      const idx = overlayStack.lastIndexOf(id);
+      if (idx >= 0) overlayStack.splice(idx, 1);
       window.clearTimeout(t);
       window.removeEventListener("keydown", onKeyDown, true);
       if (opts?.restoreFocus !== false && triggerRef.current) {

--- a/webapp/src/lib/overlayPortal.tsx
+++ b/webapp/src/lib/overlayPortal.tsx
@@ -2,6 +2,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type CSSProperties,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -22,6 +23,7 @@ export type OverlayPortalProps = {
   restoreFocus?: boolean;
   onBackdropClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
   onBackdropMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  style?: CSSProperties;
 };
 
 /**
@@ -41,6 +43,7 @@ export function OverlayPortal({
   restoreFocus = true,
   onBackdropClick,
   onBackdropMouseDown,
+  style,
 }: OverlayPortalProps) {
   const backdropRef = useRef<HTMLDivElement>(null);
   const rootRef = focusRootRef ?? backdropRef;
@@ -76,6 +79,7 @@ export function OverlayPortal({
       data-testid={testId}
       data-starting-style={phase === "enter" ? "" : undefined}
       data-instant={phase === "leave" ? "" : undefined}
+      style={style}
       onClick={onBackdropClick}
       onMouseDown={onBackdropMouseDown}
     >

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -559,10 +559,16 @@ export function activityWorkDurationMs(
 }
 
 export type StackedActivityRow<T> =
-  | { kind: "thought"; item: T; index: number }
+  | { kind: "thought"; items: T[]; indexes: number[] }
   | { kind: "commands"; items: T[]; indexes: number[] }
   | { kind: "shelf"; items: T[]; indexes: number[] }
   | { kind: "item"; item: T; index: number };
+
+/** Join consecutive sealed reasoning snapshots into one Thought body. */
+export function joinThoughtFoldText(texts: string[]): string {
+  const parts = texts.map((t) => String(t || "").trim()).filter(Boolean);
+  return parts.join("\n\n");
+}
 
 /**
  * Partition an open activity fold into Cursor-style stacked rows:
@@ -581,8 +587,14 @@ export function partitionStackedActivity<T>(
     const cur = meta(items[i]);
 
     if (cur.isThinking && !seenCommand) {
-      out.push({ kind: "thought", item: items[i], index: i });
-      i += 1;
+      const group: T[] = [];
+      const indexes: number[] = [];
+      while (i < items.length && meta(items[i]).isThinking) {
+        group.push(items[i]);
+        indexes.push(i);
+        i += 1;
+      }
+      out.push({ kind: "thought", items: group, indexes });
       continue;
     }
 
@@ -612,8 +624,14 @@ export function partitionStackedActivity<T>(
     }
 
     if (cur.isThinking) {
-      out.push({ kind: "thought", item: items[i], index: i });
-      i += 1;
+      const group: T[] = [];
+      const indexes: number[] = [];
+      while (i < items.length && meta(items[i]).isThinking) {
+        group.push(items[i]);
+        indexes.push(i);
+        i += 1;
+      }
+      out.push({ kind: "thought", items: group, indexes });
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Settings Connect a provider now opens the wizard over the Settings overlay (z-90 portal + overlay focus stack).
- Jump-to-latest hides when the feed is already at the tail; pin repairs instead of showing a no-op chevron.
- Codex/Luna Responses reasoning item-id rotation stays one Thought fold; consecutive Thought siblings render as one.

## Test plan
- [x] Vitest: feedScroll at-tail hide, stacked thought coalesce, Luna stream_id rotation, Settings/wizard stack + Escape
- [x] Local pytest 5234 passed / 78 skipped
- [ ] CI `tests` matrix: 3.9 floor, 3.11, Windows, frontend-build