### PR TITLE
Release v0.9.367

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.37` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.366, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.367, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.366"
+__version__ = "0.9.367"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.366"
+version = "0.9.367"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/electron/translucency.cjs
+++ b/webapp/electron/translucency.cjs
@@ -61,10 +61,32 @@ function translucencySupportedOn(platform) {
 }
 
 function windowsBuildNumber(release) {
-  const parts = String(release || "").split(".");
+  const text = String(release || "");
+  const parts = text.split(".");
   const raw = parts.length >= 3 ? parts[2] : parts[0];
-  const build = Number.parseInt(raw || "", 10);
+  const dotted = Number.parseInt(raw || "", 10);
+  if (Number.isFinite(dotted) && dotted > 0) return dotted;
+  // "Windows 10.0.26100" / leftover RtlGetVersion blobs without a clean split.
+  const embedded = text.match(/(?:^|\.)(\d{5})(?:\D|$)/);
+  if (!embedded) return 0;
+  const build = Number.parseInt(embedded[1], 10);
   return Number.isFinite(build) ? build : 0;
+}
+
+function isWindowsCompatLieBuild(build) {
+  // GetVersionEx without a Win10+ supportedOS GUID reports these.
+  return build === 9200 || build === 9600;
+}
+
+function windowsRealBuild(value) {
+  const build = windowsBuildNumber(value);
+  return isWindowsCompatLieBuild(build) ? 0 : build;
+}
+
+function windowsEffectiveBuild(release, versionName) {
+  const real = Math.max(windowsRealBuild(release), windowsRealBuild(versionName));
+  if (real > 0) return real;
+  return Math.max(windowsBuildNumber(release), windowsBuildNumber(versionName));
 }
 
 function resolveSystemRelease(explicit) {
@@ -92,10 +114,16 @@ function readOsVersionName(explicit) {
 function glassSupportedOn(platform, release, versionName) {
   if (platform === "darwin") return true;
   if (platform !== "win32") return false;
-  if (windowsBuildNumber(release) >= WINDOWS_GLASS_MIN_BUILD) return true;
-  // Application-manifest compat can make os.release() look like 6.2.9200
-  // on a real Windows 11 box. os.version() still says Windows 11.
-  return /Windows 11/i.test(String(versionName || ""));
+  const real = Math.max(windowsRealBuild(release), windowsRealBuild(versionName));
+  if (real >= WINDOWS_GLASS_MIN_BUILD) return true;
+  if (real > 0) return false;
+  if (/Windows 11/i.test(String(versionName || ""))) return true;
+  // No 10.0.xxxxx from either source — only the GetVersionEx lie.
+  // Electron 33 cannot run on Windows 8, so show the Settings lever.
+  return (
+    isWindowsCompatLieBuild(windowsBuildNumber(release)) ||
+    isWindowsCompatLieBuild(windowsBuildNumber(versionName))
+  );
 }
 
 function normalizeMode(value, glassSupported, legacyIntensity) {
@@ -213,7 +241,7 @@ function capabilities(platform, release, versionName) {
     translucencySupported: translucencySupportedOn(platform),
     glassSupported,
     isWindows: platform === "win32",
-    windowsBuild: platform === "win32" ? windowsBuildNumber(release) : 0,
+    windowsBuild: platform === "win32" ? windowsEffectiveBuild(release, versionName) : 0,
     materials: glassMaterialsFor(platform === "win32" && glassSupported),
   };
 }
@@ -318,7 +346,7 @@ function createTranslucencyController(opts) {
   try {
     log(
       `[translucency] platform=${platform} release=${release} ` +
-        `build=${caps.windowsBuild} glass=${caps.glassSupported}`,
+        `version=${versionName} build=${caps.windowsBuild} glass=${caps.glassSupported}`,
     );
   } catch {
     /* logging must never throw */
@@ -422,6 +450,8 @@ module.exports = {
   readOsVersionName,
   resolveSystemRelease,
   windowsBuildNumber,
+  windowsEffectiveBuild,
+  windowsRealBuild,
   normalizeMaterial,
   normalizeMode,
   normalizeState,

--- a/webapp/electron/translucency.test.cjs
+++ b/webapp/electron/translucency.test.cjs
@@ -64,10 +64,20 @@ describe("platform support", () => {
     assert.equal(glassSupportedOn("win32", "10.0.26100.4652"), true);
     assert.equal(glassSupportedOn("win32", "10.0.19045"), false);
     assert.equal(glassSupportedOn("win32", ""), false);
-    assert.equal(glassSupportedOn("win32", "6.2.9200"), false);
+    // GetVersionEx without a Win10+ supportedOS GUID reports 6.2.9200.
+    // Node os.version() on Windows is RtlGetVersion, e.g. 10.0.26100 — not
+    // the marketing string "Windows 11 Pro" that v0.9.261 tested against.
+    assert.equal(glassSupportedOn("win32", "6.2.9200", "10.0.26100"), true);
+    assert.equal(glassSupportedOn("win32", "6.2.9200", "10.0.26100.4652"), true);
+    assert.equal(glassSupportedOn("win32", "6.2.9200", "10.0.19045"), false);
+    assert.equal(glassSupportedOn("win32", "6.2.9200", "6.2.9200"), true);
+    assert.equal(glassSupportedOn("win32", "6.2.9200", "Windows 10 Pro"), true);
+    assert.equal(glassSupportedOn("win32", "6.2.9200"), true);
     assert.equal(glassSupportedOn("win32", "6.2.9200", "Windows 11 Pro"), true);
     assert.equal(capabilities("win32", "10.0.26100.4652").windowsBuild, 26100);
+    assert.equal(capabilities("win32", "6.2.9200", "10.0.26100").windowsBuild, 26100);
     assert.equal(capabilities("win32", "6.2.9200", "Windows 11 Pro").glassSupported, true);
+    assert.equal(capabilities("win32", "6.2.9200", "10.0.26100").glassSupported, true);
   });
 });
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.366",
+  "version": "0.9.367",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.366",
+      "version": "0.9.367",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.366",
+  "version": "0.9.367",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/RightPane.collapse.test.tsx
+++ b/webapp/src/__tests__/RightPane.collapse.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import RightPane from "../components/RightPane";
 import RightDock from "../components/RightDock";
+import css from "../index.css?raw";
 import { api } from "../lib/api";
 import { dispatchProjectSelected } from "../lib/panelTransition";
 import { usePolling } from "../lib/usePolling";
@@ -89,6 +90,15 @@ describe("RightPane collapse placement", () => {
   it("paints the floating pill with the left-rail panel glass", () => {
     render(<RightDock onOpenTab={vi.fn()} onExpand={vi.fn()} onCollapse={baseProps.onCollapse} />);
     expect(screen.getByTestId("floating-dock-pill")).toHaveClass("shell-inset-glass");
+  });
+
+  it("keeps the Add panel menu on the opaque overlay token, not glass-mixed --shell-panel", () => {
+    const menu = css.match(/\.right-pane-add-menu\s*\{[^}]+\}/)?.[0] ?? "";
+    expect(menu).toContain("background: var(--shell-overlay)");
+    expect(menu).not.toContain("background: var(--shell-panel)");
+    expect(css).toMatch(/--shell-overlay:\s*#181a1d/);
+    const glassBlock = css.match(/:root\[data-marionette-glass\]\s*\{[^}]+\}/)?.[0] ?? "";
+    expect(glassBlock).not.toMatch(/--shell-overlay\s*:/);
   });
 
   it("places collapse in the dock action cluster and invokes onCollapse", () => {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -72,6 +72,9 @@ body {
   --shell-panel: #13161a;
   --shell-panel-border: rgba(255, 255, 255, 0.05);
   --shell-panel-radius: 12px;
+  /* Floating menus over chat. Same fill as Tailwind `panel`. Glass must
+     not mix this token — labels have to stay readable at any tint. */
+  --shell-overlay: #181a1d;
 }
 
 /* Window glass (Settings → General → Transparent background).
@@ -82,7 +85,8 @@ body {
   background-color: transparent !important;
   --shell-chrome: transparent;
   /* Keep every shell surface on one glass curve. Panels retain their borders
-     and slightly lighter base, but no longer become opaque islands. */
+     and slightly lighter base, but no longer become opaque islands.
+     --shell-overlay stays solid: flyouts sit over scrolling chat. */
   --shell-chat: color-mix(in srgb, #0f1113 var(--translucency-glass-keep, 80%), transparent);
   --shell-panel: color-mix(in srgb, #13161a var(--translucency-glass-keep, 80%), transparent);
   --shell-panel-border: rgba(255, 255, 255, 0.08);
@@ -435,7 +439,7 @@ body.is-row-resizing iframe {
   padding: 4px;
   border: 1px solid var(--shell-panel-border);
   border-radius: 7px;
-  background: var(--shell-panel);
+  background: var(--shell-overlay);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
 }
 


### PR DESCRIPTION
## Summary
- Windows 11 glass Settings show the lever when `os.release()` is the GetVersionEx `6.2.9200` lie and `os.version()` is a real `10.0.xxxxx` build (22H2+). Honest Windows 10 `10.0.19045` stays below the floor.
- Add panel flyout uses opaque `--shell-overlay` so chat text cannot bleed through labels at high glass tint. Dock pill stays on glass `--shell-panel`.

## Test plan
- [x] `node --test electron/translucency.test.cjs` 24/24
- [x] Vitest: RightPane overlay contract, WindowGlassSettings, windowGlass (42)
- [x] Local pytest 5234 passed / 78 skipped
- [ ] CI `tests` matrix: 3.9 floor, Windows, frontend-build