### PR TITLE
Release v0.9.368

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.37` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.367, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.368, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.367"
+__version__ = "0.9.368"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -168,6 +168,14 @@ def _empty_implement_recovery_eligible(
     """
     if cancelled or not expects_diff or not live_dirty_before:
         return False
+    try:
+        err = str(getattr(res, "error", "") or "").strip().lower()
+    except Exception:
+        err = ""
+    # Engine crash / unavailable / route failure is not a seeded-worktree miss.
+    # Stamping worktree_diff_empty on AGENTIC_ERROR must not launch a second run.
+    if err.startswith("agentic_"):
+        return False
     if not _is_empty_diff_implement_failure(res, expects_diff=True):
         return False
     if _worker_stopped_by_guard_or_budget(res):
@@ -875,10 +883,14 @@ class ConversationJobsMixin:
                     if not expects_diff
                     else "Worker failed to produce patch"
                 )
+                failed_files = [
+                    str(path) for path in (getattr(res, "files_changed", None) or [])
+                    if str(path).strip()
+                ]
                 res_dict = {
                     "job_id": job_id,
                     "applied": False,
-                    "files": [],
+                    "files": failed_files,
                     "tokens_in": _nc_t_in,
                     "tokens_out": _nc_t_out,
                     "tokens_cached": _nc_t_cached,

--- a/harness/edit_engines.py
+++ b/harness/edit_engines.py
@@ -23,6 +23,7 @@ model) -- never when agentic ran and simply produced no changes.
 """
 
 import contextlib
+import json
 import os
 import shutil
 import subprocess
@@ -52,6 +53,120 @@ AGENTIC_UNAVAILABLE = "agentic_unavailable"
 AGENTIC_ROUTE_FAILED = "agentic_route_failed"
 AGENTIC_ERROR = "agentic_error"
 _FALLBACK_REASONS = (AGENTIC_UNAVAILABLE, AGENTIC_ROUTE_FAILED, AGENTIC_ERROR)
+
+
+def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
+    """Copy fail-closed facts off the scratch PM store before it is deleted.
+
+    ``Orchestrator.run`` raises ``swarm exited with incomplete tasks`` after the
+    worker/gate already recorded why. The temp sqlite dir is then rmtree'd, so
+    this snapshot is the only durable reason/token/task status the harness keeps.
+    """
+    snap = {
+        "job_id": "",
+        "reason": "",
+        "task_statuses": [],
+        "tokens_in": 0,
+        "tokens_out": 0,
+    }
+    if store is None:
+        return snap
+    resolved = str(job_id or "").strip()
+    if not resolved:
+        try:
+            jobs = list(store.list_jobs() or [])
+        except Exception:
+            jobs = []
+        if jobs:
+            resolved = str(getattr(jobs[-1], "id", "") or "")
+    snap["job_id"] = resolved
+    if not resolved:
+        return snap
+
+    try:
+        tasks = list(store.list_tasks(resolved) or [])
+    except Exception:
+        tasks = []
+    statuses = []
+    for task in tasks:
+        role = str(getattr(task, "role", "") or "").strip()
+        raw_status = getattr(task, "status", "")
+        status = str(getattr(raw_status, "value", raw_status) or "").strip()
+        if role and status:
+            statuses.append(f"{role}={status}")
+        elif status:
+            statuses.append(status)
+    snap["task_statuses"] = statuses
+
+    reason = ""
+    try:
+        records = store.read_events(resolved) if hasattr(store, "read_events") else []
+    except Exception:
+        records = []
+    for rec in records or []:
+        if not isinstance(rec, dict):
+            continue
+        name = str(rec.get("event") or "").strip()
+        payload = rec.get("payload")
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except Exception:
+                payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
+        if name == "worker.gate_failed":
+            text = str(payload.get("reason") or "").strip()
+            if text:
+                reason = text
+        elif name == "worker.failed_task":
+            text = str(payload.get("error") or payload.get("failure") or "").strip()
+            if text:
+                reason = text
+        elif name == "worker.lease_lost":
+            reason = "worker lease lost"
+    snap["reason"] = reason
+
+    try:
+        arts = list(store.list_artifacts(resolved) or [])
+    except Exception:
+        arts = []
+    tokens_in = 0
+    tokens_out = 0
+    art_failure = ""
+    for art in arts:
+        payload = getattr(art, "payload", None)
+        if not isinstance(payload, dict):
+            continue
+        tokens_out += int(payload.get("tokens_out") or 0)
+        tokens_in += int(payload.get("tokens_in") or 0)
+        if not art_failure and payload.get("failure"):
+            art_failure = str(payload.get("failure") or "").strip()
+    snap["tokens_in"] = tokens_in
+    snap["tokens_out"] = tokens_out
+    if not snap["reason"] and art_failure:
+        snap["reason"] = art_failure
+    return snap
+
+
+def _format_agentic_engine_error(
+    exc: BaseException,
+    snapshot: Optional[dict] = None,
+    files_changed: Optional[list] = None,
+) -> str:
+    """Pilot-facing summary for an agentic engine crash after store snapshot."""
+    parts = [f"Agentic engine error: {exc}"]
+    snap = snapshot or {}
+    reason = str(snap.get("reason") or "").strip()
+    if reason and reason not in parts[0]:
+        parts.append(reason)
+    statuses = [str(item) for item in (snap.get("task_statuses") or []) if str(item).strip()]
+    if statuses:
+        parts.append("tasks: " + ", ".join(statuses))
+    files = [str(path) for path in (files_changed or []) if str(path).strip()]
+    if files:
+        parts.append("unapplied worktree files: " + ", ".join(files))
+    return "\n".join(parts)
 
 
 @contextlib.contextmanager
@@ -762,21 +877,56 @@ def run_agentic_edit(
             tmp = tempfile.mkdtemp(prefix="pmh-edit-")
             mark_marionette_host_scratch(tmp)
             mapped_events: list = []
+            result = None
+            orchestrator_exc = None
+            failure_snap: dict = {}
             try:
                 store = create_store("sqlite", tmp)
-                result = Orchestrator(store).run(
-                    goal,
-                    specs=[spec],
-                    worker_mode="inline",
-                    label=job_label_for_session(session_id, dispatch_id=job_id),
-                )
-                pm_job_id = str(getattr(getattr(result, "job", None), "id", "") or "")
-                mapped_events = agentic_events_from_store(store, pm_job_id)
+                try:
+                    result = Orchestrator(store).run(
+                        goal,
+                        specs=[spec],
+                        worker_mode="inline",
+                        label=job_label_for_session(session_id, dispatch_id=job_id),
+                    )
+                    pm_job_id = str(getattr(getattr(result, "job", None), "id", "") or "")
+                    mapped_events = agentic_events_from_store(store, pm_job_id)
+                except Exception as run_exc:
+                    orchestrator_exc = run_exc
+                    failure_snap = _agentic_store_failure_snapshot(store)
+                    mapped_events = agentic_events_from_store(
+                        store, str(failure_snap.get("job_id") or ""),
+                    )
             finally:
                 shutil.rmtree(tmp, ignore_errors=True)
 
-            patch, files_changed = finalize_worktree_patch(wt_path)
-            worktree_diff_empty = not bool(patch.strip())
+            patch = ""
+            files_changed: list = []
+            worktree_diff_empty = None
+            try:
+                patch, files_changed = finalize_worktree_patch(wt_path)
+                worktree_diff_empty = not bool(patch.strip())
+            except Exception as final_exc:
+                _diag("edit_engines.run_agentic_edit.finalize", final_exc)
+
+            if orchestrator_exc is not None:
+                return _stamp_agentic(WorkerResult(
+                    ok=False,
+                    error=AGENTIC_ERROR,
+                    summary=_format_agentic_engine_error(
+                        orchestrator_exc, failure_snap, files_changed,
+                    ),
+                    patch=patch,
+                    files_changed=list(files_changed),
+                    tokens_out=int(failure_snap.get("tokens_out") or 0),
+                    tokens_in=int(failure_snap.get("tokens_in") or 0),
+                    worktree=wt_path,
+                    managed_worktree_path=wt_path,
+                    managed_worktree_mode="managed",
+                    worktree_diff_empty=worktree_diff_empty,
+                    events=list(mapped_events),
+                ), execution_pin=agentic_pin)
+
             tokens_out, tokens_in, failure, final_text = _summarize_agentic_result(result)
             routed_model = _routed_model_id(result)
             if agentic_pin is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.367"
+version = "0.9.368"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_edit_engines.py
+++ b/tests/test_edit_engines.py
@@ -28,6 +28,8 @@ from harness.edit_engines import (
     run_native_edit,
     run_parallel,
     select_edit_engine,
+    _agentic_store_failure_snapshot,
+    _format_agentic_engine_error,
     _summarize_agentic_result,
 )
 from harness.worker import ProviderWorker, WorkerResult
@@ -116,6 +118,49 @@ def _install_agentic_mocks(
     monkeypatch.setattr("puppetmaster.store_factory.create_store", lambda *a, **k: MagicMock())
 
     return storage
+
+
+# --- pure helpers: agentic fail-closed snapshot ---
+
+
+def test_agentic_store_failure_snapshot_prefers_gate_reason():
+    class _Store:
+        def list_jobs(self):
+            return [type("J", (), {"id": "job_1"})()]
+
+        def list_tasks(self, job_id):
+            assert job_id == "job_1"
+            return [type("T", (), {"id": "t1", "role": "implement", "status": "failed"})()]
+
+        def read_events(self, job_id):
+            return [
+                {"event": "worker.failed_task", "payload": {"error": "adapter boom"}},
+                {
+                    "event": "worker.gate_failed",
+                    "payload": {"reason": "require_diff: no PATCH artifact"},
+                },
+            ]
+
+        def list_artifacts(self, job_id):
+            art = type("A", (), {})()
+            art.payload = {"tokens_in": 40, "tokens_out": 12, "failure": "no_model"}
+            return [art]
+
+    snap = _agentic_store_failure_snapshot(_Store())
+    assert snap["job_id"] == "job_1"
+    assert snap["reason"] == "require_diff: no PATCH artifact"
+    assert snap["task_statuses"] == ["implement=failed"]
+    assert snap["tokens_in"] == 40
+    assert snap["tokens_out"] == 12
+    summary = _format_agentic_engine_error(
+        RuntimeError("swarm exited with incomplete tasks"),
+        snap,
+        ["src/lib/scoring/report.ts"],
+    )
+    assert "incomplete tasks" in summary
+    assert "require_diff: no PATCH artifact" in summary
+    assert "tasks: implement=failed" in summary
+    assert "unapplied worktree files: src/lib/scoring/report.ts" in summary
 
 
 # --- pure helpers: _summarize_agentic_result ---
@@ -1005,6 +1050,79 @@ def test_agentic_edit_runtime_exception_returns_agentic_error(monkeypatch):
         assert result.ok is False
         assert result.error == AGENTIC_ERROR
         assert "worktree blew up" in result.summary
+        assert result.managed_worktree_mode == ""
+        assert result.worktree_diff_empty is None
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_incomplete_swarm_stamps_provenance_and_gate_reason(monkeypatch):
+    """Orchestrator fail-closed must not look like 'worktree status unavailable'."""
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        class _BoomOrch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                payload = ((specs[0].payload if specs else {}) or {})
+                cwd = payload.get("cwd") or ""
+                if cwd:
+                    with open(os.path.join(cwd, "test.txt"), "a", encoding="utf-8") as fh:
+                        fh.write("from-worker\n")
+                job, _created = self.store.create_or_get_job(goal or "g", label="boom")
+                self.store.emit(
+                    job.id,
+                    "worker.gate_failed",
+                    {"reason": "require_diff: no PATCH artifact", "task_id": "t1"},
+                )
+                raise RuntimeError("swarm exited with incomplete tasks")
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _BoomOrch)
+        result = run_agentic_edit(cfg, "implement the thing")
+        assert result.ok is False
+        assert result.error == AGENTIC_ERROR
+        assert result.managed_worktree_mode == "managed"
+        assert result.worktree_diff_empty is False
+        assert "test.txt" in (result.files_changed or [])
+        assert (result.patch or "").strip()
+        assert "incomplete tasks" in (result.summary or "")
+        assert "require_diff" in (result.summary or "")
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_incomplete_swarm_empty_worktree_is_explicit(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        class _BoomOrch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                job, _created = self.store.create_or_get_job(goal or "g", label="boom")
+                self.store.emit(
+                    job.id,
+                    "worker.failed_task",
+                    {"error": "adapter boom", "task_id": "t1"},
+                )
+                raise RuntimeError("swarm exited with incomplete tasks")
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _BoomOrch)
+        result = run_agentic_edit(cfg, "implement the thing")
+        assert result.ok is False
+        assert result.error == AGENTIC_ERROR
+        assert result.managed_worktree_mode == "managed"
+        assert result.worktree_diff_empty is True
+        assert result.files_changed == []
+        assert "adapter boom" in (result.summary or "")
+        assert "unavailable" not in (result.summary or "").lower()
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)
 

--- a/tests/test_worker_provenance.py
+++ b/tests/test_worker_provenance.py
@@ -534,6 +534,78 @@ def test_empty_implement_recovery_skips_guard_exhausted_first_attempt(monkeypatc
     ) is False
 
 
+def test_empty_implement_recovery_skips_agentic_engine_error():
+    crashed = WorkerResult(
+        ok=False,
+        error="agentic_error",
+        summary="Agentic engine error: swarm exited with incomplete tasks",
+        worktree_diff_empty=True,
+        patch="",
+        managed_worktree_mode="managed",
+    )
+    assert _empty_implement_recovery_eligible(
+        crashed,
+        expects_diff=True,
+        live_dirty_before=["report.ts"],
+        cancelled=False,
+    ) is False
+
+
+def test_agentic_engine_error_keeps_unapplied_files_without_apply(monkeypatch):
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
+    session = ConversationalSession(cfg)
+    job_id = "job_agentic_crash"
+    session._register_local_job(
+        job_id, goal="harden scoring", role="implement", engine="agentic",
+    )
+    crashed = WorkerResult(
+        ok=False,
+        error="agentic_error",
+        summary=(
+            "Agentic engine error: swarm exited with incomplete tasks\n"
+            "require_diff: no PATCH artifact\n"
+            "unapplied worktree files: src/lib/scoring/report.ts"
+        ),
+        patch="diff --git a/src/lib/scoring/report.ts b/src/lib/scoring/report.ts\n",
+        files_changed=["src/lib/scoring/report.ts"],
+        tokens_in=40,
+        tokens_out=12,
+        engine="agentic",
+        model="agentic/openai-codex/gpt-5.6-luna",
+        managed_worktree_path="/tmp/managed-wt",
+        managed_worktree_mode="managed",
+        worktree_diff_empty=False,
+    )
+    applied = []
+
+    def fake_apply(*_a, **_k):
+        applied.append("ran")
+        return True, ["src/lib/scoring/report.ts"], "ok"
+
+    session._apply_worker_patch = fake_apply
+    monkeypatch.setattr(
+        "harness.worktree_seed._list_git_status_porcelain_paths",
+        lambda _repo: [],
+    )
+    with patch.object(session, "_run_edit_worker_bounded", return_value=crashed):
+        session._run_provider_worker_background(
+            job_id, "harden scoring", expects_diff=True,
+        )
+    item = session._swarm_results.get_nowait()
+    result = item["result"]
+    assert result["error"] == "agentic_error"
+    assert result["applied"] is False
+    assert result["has_patch_art"] is False
+    assert result["files"] == ["src/lib/scoring/report.ts"]
+    assert "require_diff" in (result["summary"] or "")
+    assert "managed" in (result["summary"] or "")
+    assert applied == []
+    finished = session._local_jobs[job_id]
+    assert finished["status"] == "failed"
+    assert finished["worker_provenance"]["managed_worktree_mode"] == "managed"
+    assert finished["worker_provenance"]["worktree_diff_empty"] is False
+
+
 def test_empty_implement_recovery_shares_lifecycle_budget(monkeypatch):
     """Primary + recovery share one ambient lifecycle budget (no double ceiling)."""
     cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.367",
+  "version": "0.9.368",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.367",
+      "version": "0.9.368",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.367",
+  "version": "0.9.368",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Keep agentic implement fail-closed reasons, tokens, and unapplied files instead of labeling `Orchestrator.run` crashes as worktree-unavailable.
- Snapshot the scratch Puppetmaster store and finalize the managed worktree before teardown; do not auto-apply a crashed worker patch.
- Stamp v0.9.368. Pin unchanged: `puppetmaster-ai==1.22.37`.

## Test plan
- [x] Local pytest: 5239 passed, 78 skipped
- [x] `tests/test_version_consistency.py`
- [ ] PR `tests` matrix green (3.9, 3.11, Windows, frontend-build)
- [ ] Merge, `require-green`, tag `v0.9.368`
- [ ] Release assets + one macOS notarization