### PR TITLE
Release v0.9.369

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.37` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.368, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.369, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.368"
+__version__ = "0.9.369"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -28,6 +28,18 @@ from ._exec import _puppetmaster_cmd
 
 _WORKER_PROVENANCE_PATH_CAP = 12
 
+_PROVENANCE_STAGE_CODES = frozenset({
+    "agentic_unavailable",
+    "agentic_route_failed",
+    "agentic_error",
+    "worktree_create_failed",
+    "agentic_orchestrator_failed",
+    "patch_capture_failed",
+    "worker_cleanup_failed",
+    "agentic_provider_rate_limited",
+    "agentic_timeout",
+})
+
 # Soft-refuse cue for pilots/guards: empty managed implement already recovered once.
 EMPTY_MANAGED_IMPLEMENT_EXHAUSTED = "empty_managed_implement_exhausted"
 
@@ -176,6 +188,12 @@ def _empty_implement_recovery_eligible(
     # Stamping worktree_diff_empty on AGENTIC_ERROR must not launch a second run.
     if err.startswith("agentic_"):
         return False
+    if err in (
+        "worktree_create_failed",
+        "patch_capture_failed",
+        "worker_cleanup_failed",
+    ):
+        return False
     if not _is_empty_diff_implement_failure(res, expects_diff=True):
         return False
     if _worker_stopped_by_guard_or_budget(res):
@@ -214,6 +232,14 @@ def _annotate_empty_managed_implement_exhausted(
         pass
 
 
+def _should_meter_worker_usage(res) -> bool:
+    """False when usage artifacts were missing — do not treat zeros as measured."""
+    try:
+        return getattr(res, "usage_known", None) is not False
+    except Exception:
+        return True
+
+
 def _worker_provenance_text(provenance: dict, *, expects_diff: bool = True) -> str:
     """Render measured worker/live-tree facts for pilot-facing text.
 
@@ -224,9 +250,17 @@ def _worker_provenance_text(provenance: dict, *, expects_diff: bool = True) -> s
         return ""
     before = list(provenance.get("live_dirty_paths_before") or [])
     after = list(provenance.get("live_dirty_paths_after") or [])
-    mode = str(provenance.get("managed_worktree_mode") or "unknown")
+    requested_mode = str(provenance.get("requested_mode") or "")
+    if not requested_mode:
+        requested_mode = "implement" if expects_diff else "analysis"
     path = str(provenance.get("managed_worktree_path") or "")
+    mode = str(provenance.get("managed_worktree_mode") or "")
+    if requested_mode == "implement" and mode in ("", "unknown"):
+        mode = "managed" if path else "none"
+    elif not mode:
+        mode = "unknown"
     diff_empty = provenance.get("worktree_diff_empty")
+    error = str(provenance.get("error") or "").strip()
     if diff_empty is True:
         if not expects_diff:
             worker_line = (
@@ -238,7 +272,9 @@ def _worker_provenance_text(provenance: dict, *, expects_diff: bool = True) -> s
     elif diff_empty is False:
         worker_line = "Worker produced changes in disposable managed worktree"
     else:
-        worker_line = "Worker worktree diff status unavailable"
+        worker_line = "worktree diff could not be determined"
+    if error and error in _PROVENANCE_STAGE_CODES and error not in worker_line:
+        worker_line = f"{error}: {worker_line}"
     def path_list(paths: list) -> str:
         shown = [str(item) for item in paths[:_WORKER_PROVENANCE_PATH_CAP]]
         suffix = f", +{len(paths) - len(shown)} more" if len(paths) > len(shown) else ""
@@ -802,18 +838,31 @@ class ConversationJobsMixin:
                 except Exception:
                     return default
 
+            requested_mode = str(
+                _worker_attribute("requested_mode")
+                or ("implement" if expects_diff else "analysis")
+            )
+            wt_path = str(
+                _worker_attribute("managed_worktree_path")
+                or _worker_attribute("worktree")
+                or ""
+            )
+            raw_mode = str(_worker_attribute("managed_worktree_mode") or "")
+            if requested_mode == "implement" and raw_mode in ("", "unknown"):
+                mode = "managed" if wt_path else "none"
+            else:
+                mode = raw_mode or ("managed" if wt_path else "unknown")
             provenance = {
                 "live_dirty_paths_before": list(live_dirty_before),
                 "live_dirty_paths_after": list(live_dirty_after),
-                "managed_worktree_path": str(
-                    _worker_attribute("managed_worktree_path")
-                    or _worker_attribute("worktree")
-                    or ""
+                "managed_worktree_path": wt_path,
+                "managed_worktree_mode": mode,
+                "requested_mode": requested_mode,
+                "error": str(_worker_attribute("error") or ""),
+                "patch_capture_status": str(
+                    _worker_attribute("patch_capture_status") or ""
                 ),
-                "managed_worktree_mode": str(
-                    _worker_attribute("managed_worktree_mode")
-                    or ("managed" if _worker_attribute("worktree") else "unknown")
-                ),
+                "usage_known": _worker_attribute("usage_known", None),
                 "worktree_diff_empty": _worker_attribute("worktree_diff_empty", None),
                 "empty_implement_recovery": bool(should_recover),
                 "empty_managed_implement_exhausted": bool(
@@ -836,8 +885,11 @@ class ConversationJobsMixin:
                     tokens=(
                         int(_worker_attribute("tokens_in", 0) or 0)
                         + int(_worker_attribute("tokens_out", 0) or 0)
+                    ) if _should_meter_worker_usage(res) else 0,
+                    est_cost_usd=(
+                        float(_worker_attribute("est_cost_usd", 0.0) or 0.0)
+                        if _should_meter_worker_usage(res) else 0.0
                     ),
-                    est_cost_usd=float(_worker_attribute("est_cost_usd", 0.0) or 0.0),
                 )
                 return
             raw_worker_summary = res.summary or ""
@@ -863,7 +915,9 @@ class ConversationJobsMixin:
                 _nc_t_in = int(getattr(res, "tokens_in", 0) or 0)
                 _nc_t_out = int(getattr(res, "tokens_out", 0) or 0)
                 _nc_t_cached = int(getattr(res, "tokens_cached", 0) or 0)
-                if _nc_t_in or _nc_t_out or _nc_t_cached:
+                if _should_meter_worker_usage(res) and (
+                    _nc_t_in or _nc_t_out or _nc_t_cached
+                ):
                     with self._apply_lock:
                         self._tokens_used += _nc_t_out + _nc_t_in
                         self._tokens_in += _nc_t_in
@@ -919,15 +973,16 @@ class ConversationJobsMixin:
                 tokens_in = int(getattr(res, "tokens_in", 0) or 0)
                 tokens_out = int(getattr(res, "tokens_out", 0) or 0)
                 tokens_cached = int(getattr(res, "tokens_cached", 0) or 0)
-                with self._apply_lock:
-                    self._tokens_used += tokens_out + tokens_in
-                    self._tokens_in += tokens_in
-                    self._tokens_out += tokens_out
-                    self._tokens_cached += tokens_cached
-                    self._attribute_worker_cost(
-                        tokens_in, tokens_out,
-                        real_cost_usd=float(getattr(res, "est_cost_usd", 0.0) or 0.0),
-                        tokens_cached=tokens_cached)
+                if _should_meter_worker_usage(res):
+                    with self._apply_lock:
+                        self._tokens_used += tokens_out + tokens_in
+                        self._tokens_in += tokens_in
+                        self._tokens_out += tokens_out
+                        self._tokens_cached += tokens_cached
+                        self._attribute_worker_cost(
+                            tokens_in, tokens_out,
+                            real_cost_usd=float(getattr(res, "est_cost_usd", 0.0) or 0.0),
+                            tokens_cached=tokens_cached)
                 summary = res.summary or "Successfully completed analysis task"
                 substantive = True
                 if not expects_diff:
@@ -1031,26 +1086,27 @@ class ConversationJobsMixin:
                 tokens_in = res.tokens_in
                 tokens_out = res.tokens_out
                 tokens_cached = int(getattr(res, "tokens_cached", 0) or 0)
-                with self._apply_lock:
-                    # Attribute the worker's FULL spend (prompt + completion) to
-                    # the parent session's cost meter. Track _tokens_out too, not
-                    # just _tokens_in: the cost accounting prices output at the
-                    # (higher) completion rate, so dropping _tokens_out here made
-                    # implement-worker output get billed at the cheaper input
-                    # rate -- undercounting every implement worker's real cost.
-                    self._tokens_used += tokens_out + tokens_in
-                    self._tokens_in += tokens_in
-                    self._tokens_out += tokens_out
-                    # Cached prompt tokens are already inside tokens_in above;
-                    # feed the parent's cache-savings meter without inflating
-                    # _tokens_used (avoids double-counting).
-                    self._tokens_cached += tokens_cached
-                    # Worker dollars at the worker's own model rate (prefer the
-                    # result's real cost when present, else derive from rate).
-                    self._attribute_worker_cost(
-                        tokens_in, tokens_out,
-                        real_cost_usd=float(getattr(res, "est_cost_usd", 0.0) or 0.0),
-                        tokens_cached=tokens_cached)
+                if _should_meter_worker_usage(res):
+                    with self._apply_lock:
+                        # Attribute the worker's FULL spend (prompt + completion) to
+                        # the parent session's cost meter. Track _tokens_out too, not
+                        # just _tokens_in: the cost accounting prices output at the
+                        # (higher) completion rate, so dropping _tokens_out here made
+                        # implement-worker output get billed at the cheaper input
+                        # rate -- undercounting every implement worker's real cost.
+                        self._tokens_used += tokens_out + tokens_in
+                        self._tokens_in += tokens_in
+                        self._tokens_out += tokens_out
+                        # Cached prompt tokens are already inside tokens_in above;
+                        # feed the parent's cache-savings meter without inflating
+                        # _tokens_used (avoids double-counting).
+                        self._tokens_cached += tokens_cached
+                        # Worker dollars at the worker's own model rate (prefer the
+                        # result's real cost when present, else derive from rate).
+                        self._attribute_worker_cost(
+                            tokens_in, tokens_out,
+                            real_cost_usd=float(getattr(res, "est_cost_usd", 0.0) or 0.0),
+                            tokens_cached=tokens_cached)
 
                 patch_summary = ""
                 if res.files_changed:
@@ -1200,8 +1256,14 @@ class ConversationJobsMixin:
                 ok=not res_dict.get("error"),
                 summary=res_dict.get("summary", ""),
                 files=res_dict.get("files") or [],
-                tokens=res_dict.get("tokens_out", 0) + res_dict.get("tokens_in", 0),
-                est_cost_usd=float(getattr(res, "est_cost_usd", 0.0) or 0.0),
+                tokens=(
+                    (res_dict.get("tokens_out", 0) + res_dict.get("tokens_in", 0))
+                    if _should_meter_worker_usage(res) else 0
+                ),
+                est_cost_usd=(
+                    float(getattr(res, "est_cost_usd", 0.0) or 0.0)
+                    if _should_meter_worker_usage(res) else 0.0
+                ),
                 engine=wr_engine,
                 model=wr_model,
                 findings=_signal_rows,
@@ -1237,7 +1299,8 @@ class ConversationJobsMixin:
                 "live_dirty_paths_before": list(live_dirty_before),
                 "live_dirty_paths_after": list(live_dirty_after),
                 "managed_worktree_path": "",
-                "managed_worktree_mode": "unknown",
+                "managed_worktree_mode": "none" if expects_diff else "unknown",
+                "requested_mode": "implement" if expects_diff else "analysis",
                 "worktree_diff_empty": None,
             }
             if self._local_job_cancelled(job_id):

--- a/harness/edit_engines.py
+++ b/harness/edit_engines.py
@@ -48,11 +48,38 @@ _ARTIFACT_PATHSPECS = [
 ]
 
 # Machine-readable reasons that mean "the agentic engine could not run at all"
-# (as opposed to "ran fine, made no changes"). Only these trigger native fallback.
+# (as opposed to "ran fine, made no changes"). Only never-started reasons
+# trigger native fallback — post-start stage codes must not.
 AGENTIC_UNAVAILABLE = "agentic_unavailable"
 AGENTIC_ROUTE_FAILED = "agentic_route_failed"
 AGENTIC_ERROR = "agentic_error"
-_FALLBACK_REASONS = (AGENTIC_UNAVAILABLE, AGENTIC_ROUTE_FAILED, AGENTIC_ERROR)
+WORKTREE_CREATE_FAILED = "worktree_create_failed"
+AGENTIC_ORCHESTRATOR_FAILED = "agentic_orchestrator_failed"
+PATCH_CAPTURE_FAILED = "patch_capture_failed"
+WORKER_CLEANUP_FAILED = "worker_cleanup_failed"
+AGENTIC_PROVIDER_RATE_LIMITED = "agentic_provider_rate_limited"
+AGENTIC_TIMEOUT = "agentic_timeout"
+_FALLBACK_REASONS = (
+    AGENTIC_UNAVAILABLE,
+    AGENTIC_ROUTE_FAILED,
+    WORKTREE_CREATE_FAILED,
+)
+_RATE_LIMIT_MARKERS = (
+    "429",
+    "retry-after",
+    "rate limit",
+    "rate_limit",
+    "ratelimit",
+    "too many requests",
+    "quota",
+    "resource exhausted",
+)
+_TIMEOUT_MARKERS = (
+    "timeout",
+    "timed out",
+    "time out",
+    "deadline exceeded",
+)
 
 
 def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
@@ -66,8 +93,10 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
         "job_id": "",
         "reason": "",
         "task_statuses": [],
+        "task_ids": [],
         "tokens_in": 0,
         "tokens_out": 0,
+        "usage_known": False,
     }
     if store is None:
         return snap
@@ -88,7 +117,11 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
     except Exception:
         tasks = []
     statuses = []
+    task_ids = []
     for task in tasks:
+        tid = str(getattr(task, "id", "") or "").strip()
+        if tid:
+            task_ids.append(tid)
         role = str(getattr(task, "role", "") or "").strip()
         raw_status = getattr(task, "status", "")
         status = str(getattr(raw_status, "value", raw_status) or "").strip()
@@ -97,6 +130,7 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
         elif status:
             statuses.append(status)
     snap["task_statuses"] = statuses
+    snap["task_ids"] = task_ids
 
     reason = ""
     try:
@@ -133,17 +167,21 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
         arts = []
     tokens_in = 0
     tokens_out = 0
+    usage_known = False
     art_failure = ""
     for art in arts:
         payload = getattr(art, "payload", None)
         if not isinstance(payload, dict):
             continue
-        tokens_out += int(payload.get("tokens_out") or 0)
-        tokens_in += int(payload.get("tokens_in") or 0)
+        if "tokens_in" in payload or "tokens_out" in payload:
+            usage_known = True
+            tokens_out += int(payload.get("tokens_out") or 0)
+            tokens_in += int(payload.get("tokens_in") or 0)
         if not art_failure and payload.get("failure"):
             art_failure = str(payload.get("failure") or "").strip()
     snap["tokens_in"] = tokens_in
     snap["tokens_out"] = tokens_out
+    snap["usage_known"] = usage_known
     if not snap["reason"] and art_failure:
         snap["reason"] = art_failure
     return snap
@@ -155,9 +193,11 @@ def _format_agentic_engine_error(
     files_changed: Optional[list] = None,
 ) -> str:
     """Pilot-facing summary for an agentic engine crash after store snapshot."""
-    parts = [f"Agentic engine error: {exc}"]
+    from harness.api.redaction import redact_secret_text
+
+    parts = [f"Agentic engine error: {redact_secret_text(str(exc))}"]
     snap = snapshot or {}
-    reason = str(snap.get("reason") or "").strip()
+    reason = redact_secret_text(str(snap.get("reason") or "").strip())
     if reason and reason not in parts[0]:
         parts.append(reason)
     statuses = [str(item) for item in (snap.get("task_statuses") or []) if str(item).strip()]
@@ -167,6 +207,164 @@ def _format_agentic_engine_error(
     if files:
         parts.append("unapplied worktree files: " + ", ".join(files))
     return "\n".join(parts)
+
+
+def _redact_text(text: str) -> str:
+    from harness.api.redaction import redact_secret_text
+
+    return redact_secret_text(text or "")
+
+
+def _git_failed_message(wt_path: str, args: tuple, rc: int, stderr: str, stdout: str) -> str:
+    detail = _redact_text((stderr or stdout or "").strip())
+    cmd = " ".join(("git", "-C", str(wt_path)) + tuple(str(a) for a in args))
+    return f"{cmd} failed (exit {rc}): {detail}"
+
+
+def _raise_git_failed(wt_path: str, args: tuple, rc: int, stderr: str, stdout: str) -> None:
+    raise RuntimeError(_git_failed_message(wt_path, args, rc, stderr, stdout))
+
+
+def classify_agentic_exception(
+    exc: BaseException,
+    snapshot: Optional[dict] = None,
+) -> str:
+    """Map orchestrator/snapshot exceptions onto a stage error code."""
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        status = getattr(exc, "status", None)
+    if status is None:
+        status = getattr(exc, "http_status", None)
+    try:
+        status_i = int(status) if status is not None else None
+    except (TypeError, ValueError):
+        status_i = None
+    if status_i == 429:
+        return AGENTIC_PROVIDER_RATE_LIMITED
+    if isinstance(exc, TimeoutError):
+        return AGENTIC_TIMEOUT
+    parts = [_redact_text(str(exc))]
+    if snapshot:
+        parts.append(str(snapshot.get("reason") or ""))
+    text = " ".join(parts).lower()
+    if any(marker in text for marker in _RATE_LIMIT_MARKERS):
+        return AGENTIC_PROVIDER_RATE_LIMITED
+    if any(marker in text for marker in _TIMEOUT_MARKERS):
+        return AGENTIC_TIMEOUT
+    return AGENTIC_ORCHESTRATOR_FAILED
+
+
+def _failure_http_hints(exc: BaseException) -> tuple:
+    http_status = None
+    retry_after = ""
+    request_id = ""
+    for obj in (exc, getattr(exc, "__cause__", None), getattr(exc, "__context__", None)):
+        if obj is None:
+            continue
+        for attr in ("status_code", "status", "http_status"):
+            raw = getattr(obj, attr, None)
+            if raw is None:
+                continue
+            try:
+                http_status = int(raw)
+                break
+            except (TypeError, ValueError):
+                continue
+        headers = getattr(obj, "headers", None)
+        if isinstance(headers, dict):
+            if not retry_after:
+                retry_after = str(
+                    headers.get("Retry-After") or headers.get("retry-after") or ""
+                )
+            if not request_id:
+                request_id = str(
+                    headers.get("x-request-id")
+                    or headers.get("X-Request-Id")
+                    or headers.get("request-id")
+                    or ""
+                )
+        if not retry_after:
+            retry_after = str(getattr(obj, "retry_after", "") or "")
+        if not request_id:
+            request_id = str(
+                getattr(obj, "request_id", "")
+                or getattr(obj, "provider_request_id", "")
+                or ""
+            )
+    text = _redact_text(str(exc))
+    if http_status is None and "429" in text:
+        http_status = 429
+    if not retry_after:
+        lowered = text.lower()
+        key = "retry-after"
+        idx = lowered.find(key)
+        if idx >= 0:
+            rest = text[idx + len(key):].lstrip(":= \t")
+            token = rest.split()[0] if rest.split() else ""
+            retry_after = token.rstrip(".,;")
+    return http_status, retry_after, request_id
+
+
+def _failure_fields_from_exc(exc: BaseException) -> dict:
+    text = str(exc)
+    failure_command = ""
+    failure_exit_code = None
+    failure_stderr = text
+    marker = " failed (exit "
+    if text.startswith("git ") and marker in text:
+        idx = text.find(marker)
+        failure_command = text[:idx]
+        rest = text[idx + len(marker):]
+        code_s, sep, err = rest.partition("): ")
+        if sep:
+            try:
+                failure_exit_code = int(code_s)
+            except ValueError:
+                failure_exit_code = None
+            failure_stderr = err
+    return {
+        "failure_command": failure_command,
+        "failure_exit_code": failure_exit_code,
+        "failure_stderr": _redact_text(failure_stderr),
+    }
+
+
+def _usage_from_snapshot(snap: Optional[dict]) -> dict:
+    data = snap or {}
+    known = data.get("usage_known")
+    if known is True:
+        return {
+            "tokens_in": int(data.get("tokens_in") or 0),
+            "tokens_out": int(data.get("tokens_out") or 0),
+            "usage_known": True,
+            "cost_known": False,
+        }
+    return {
+        "tokens_in": 0,
+        "tokens_out": 0,
+        "usage_known": False if known is False else None,
+        "cost_known": False if known is False else None,
+    }
+
+
+def _artifacts_usage_known(result) -> bool:
+    for art in getattr(result, "artifacts", []) or []:
+        payload = getattr(art, "payload", {}) or {}
+        if isinstance(payload, dict) and (
+            "tokens_in" in payload or "tokens_out" in payload
+        ):
+            return True
+    return False
+
+
+def _should_native_fallback(result: "WorkerResult") -> bool:
+    if result is None:
+        return False
+    if (getattr(result, "patch", None) or "").strip():
+        return False
+    if getattr(result, "files_changed", None):
+        return False
+    return getattr(result, "error", "") in _FALLBACK_REASONS
 
 
 @contextlib.contextmanager
@@ -229,28 +427,47 @@ def finalize_worktree_patch(wt_path: str) -> tuple[str, list[str]]:
     Returns the ``git diff --cached`` unified diff and the list of changed paths.
     Raises RuntimeError when a git step fails so the caller can report honestly.
     """
-    rc_add, out_add, err_add = _git(wt_path, "add", "-A")
+    from harness.worktrees import _is_repo
+
+    if not wt_path or not os.path.exists(wt_path):
+        raise RuntimeError(f"worktree path does not exist: {wt_path!r}")
+    if not _is_repo(wt_path):
+        raise RuntimeError(f"worktree path is not a git repository: {wt_path!r}")
+
+    add_args = ("add", "-A")
+    rc_add, out_add, err_add = _git(wt_path, *add_args)
     if rc_add != 0:
-        raise RuntimeError(f"git add failed: {err_add or out_add}")
+        _raise_git_failed(wt_path, add_args, rc_add, err_add, out_add)
 
     reset_specs: list[str] = []
     for spec in _ARTIFACT_PATHSPECS:
         reset_specs.append(f":(glob){spec}")
         reset_specs.append(f":(glob)**/{spec}")
-    _git(wt_path, "reset", "-q", "--", *reset_specs)
+    reset_args = ("reset", "-q", "--") + tuple(reset_specs)
+    rc_reset, out_reset, err_reset = _git(wt_path, *reset_args)
+    if rc_reset != 0:
+        _raise_git_failed(wt_path, reset_args, rc_reset, err_reset, out_reset)
 
+    diff_args = ("diff", "--cached", "--no-color")
     p_diff = subprocess.run(
-        ["git", "-C", wt_path, "diff", "--cached", "--no-color"],
+        ["git", "-C", wt_path, *diff_args],
         capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30,
     )
     if p_diff.returncode != 0:
-        raise RuntimeError(f"git diff failed: {p_diff.stderr or p_diff.stdout}")
+        _raise_git_failed(
+            wt_path, diff_args, p_diff.returncode, p_diff.stderr, p_diff.stdout,
+        )
     patch = p_diff.stdout
 
+    name_args = ("diff", "--cached", "--name-only")
     p_files = subprocess.run(
-        ["git", "-C", wt_path, "diff", "--cached", "--name-only"],
+        ["git", "-C", wt_path, *name_args],
         capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15,
     )
+    if p_files.returncode != 0:
+        _raise_git_failed(
+            wt_path, name_args, p_files.returncode, p_files.stderr, p_files.stdout,
+        )
     files_changed = [ln.strip() for ln in p_files.stdout.splitlines() if ln.strip()]
     return patch, files_changed
 
@@ -492,7 +709,7 @@ def run_edit_worker(
             config, goal, session_id=session_id, cwd=target_cwd,
             expects_diff=expects_diff, job_id=job_id,
         )
-        if result.error in _FALLBACK_REASONS:
+        if _should_native_fallback(result):
             _diag("edit_engines.run_edit_worker",
                   msg=f"cursor engine unavailable ({result.error}); falling back to native")
             return run_native_edit(
@@ -508,7 +725,7 @@ def run_edit_worker(
         )
         if strict_agentic:
             return result
-        if result.error in _FALLBACK_REASONS:
+        if _should_native_fallback(result):
             if cursor_platform_available():
                 _diag("edit_engines.run_edit_worker",
                       msg=f"agentic unavailable ({result.error}); trying cursor")
@@ -516,7 +733,7 @@ def run_edit_worker(
                     config, goal, session_id=session_id, cwd=target_cwd,
                     expects_diff=expects_diff, job_id=job_id,
                 )
-                if cursor_result.error not in _FALLBACK_REASONS:
+                if not _should_native_fallback(cursor_result):
                     return cursor_result
             _diag("edit_engines.run_edit_worker",
                   msg=f"agentic engine unavailable ({result.error}); falling back to native")
@@ -755,11 +972,36 @@ def run_agentic_edit(
     from harness.cli_job_merge import mark_marionette_host_scratch
     from harness.job_scoping import job_label_for_session, stamp_task_payload
 
+    requested_mode = "implement" if expects_diff else "analysis"
+
+    def finish(
+        wr: "WorkerResult",
+        pm_result=None,
+        *,
+        worktree_existed: bool = False,
+        snap: Optional[dict] = None,
+        job_id_hint: str = "",
+    ) -> "WorkerResult":
+        wr.requested_mode = requested_mode
+        if requested_mode == "implement" and (wr.managed_worktree_mode or "") in (
+            "", "unknown",
+        ):
+            wr.managed_worktree_mode = "managed" if worktree_existed else "none"
+        if job_id_hint and not wr.pm_job_id:
+            wr.pm_job_id = job_id_hint
+        if snap:
+            if not wr.pm_job_id:
+                wr.pm_job_id = str(snap.get("job_id") or "")
+            if not wr.task_ids and snap.get("task_ids"):
+                wr.task_ids = list(snap.get("task_ids") or [])
+        return _stamp_agentic(wr, pm_result, execution_pin=agentic_pin)
+
     if not agentic_available():
-        return _stamp_agentic(WorkerResult(
+        return finish(WorkerResult(
             ok=False, error=AGENTIC_UNAVAILABLE,
             summary="No provider key visible for the agentic engine.",
-        ), execution_pin=agentic_pin)
+            patch_capture_status="skipped",
+        ), worktree_existed=False)
 
     try:
         from puppetmaster.orchestrator import Orchestrator
@@ -767,10 +1009,11 @@ def run_agentic_edit(
         from puppetmaster.workers import WorkerSpec
     except Exception as exc:
         _diag("edit_engines.run_agentic_edit.import", exc)
-        return _stamp_agentic(WorkerResult(
+        return finish(WorkerResult(
             ok=False, error=AGENTIC_UNAVAILABLE,
-            summary=f"Puppetmaster unavailable: {exc}",
-        ), execution_pin=agentic_pin)
+            summary=f"Puppetmaster unavailable: {_redact_text(str(exc))}",
+            patch_capture_status="skipped",
+        ), worktree_existed=False)
 
     provider = (
         agentic_pin.provider
@@ -783,9 +1026,11 @@ def run_agentic_edit(
         else (os.environ.get("HARNESS_IMPLEMENT_MODEL", "") or "").strip()
     )
 
+    worktree_entered = False
     try:
         repo_root = cwd or config.repo
         with managed_worktree_for_goal(repo_root, goal) as wt_path:
+            worktree_entered = True
             from pmharness.bridge import (
                 _analysis_capability_payload,
                 _analysis_instruction,
@@ -880,6 +1125,8 @@ def run_agentic_edit(
             result = None
             orchestrator_exc = None
             failure_snap: dict = {}
+            store_cleanup_exc = None
+            pm_job_id = ""
             try:
                 store = create_store("sqlite", tmp)
                 try:
@@ -891,43 +1138,128 @@ def run_agentic_edit(
                     )
                     pm_job_id = str(getattr(getattr(result, "job", None), "id", "") or "")
                     mapped_events = agentic_events_from_store(store, pm_job_id)
+                    try:
+                        failure_snap = _agentic_store_failure_snapshot(store, pm_job_id)
+                    except Exception as snap_exc:
+                        _diag("edit_engines.run_agentic_edit.snapshot", snap_exc)
                 except Exception as run_exc:
                     orchestrator_exc = run_exc
-                    failure_snap = _agentic_store_failure_snapshot(store)
-                    mapped_events = agentic_events_from_store(
-                        store, str(failure_snap.get("job_id") or ""),
-                    )
+                    try:
+                        failure_snap = _agentic_store_failure_snapshot(store)
+                        mapped_events = agentic_events_from_store(
+                            store, str(failure_snap.get("job_id") or ""),
+                        )
+                    except Exception as snap_exc:
+                        _diag("edit_engines.run_agentic_edit.snapshot", snap_exc)
             finally:
-                shutil.rmtree(tmp, ignore_errors=True)
+                try:
+                    shutil.rmtree(tmp, ignore_errors=True)
+                except Exception as rmtree_exc:
+                    store_cleanup_exc = rmtree_exc
 
             patch = ""
             files_changed: list = []
             worktree_diff_empty = None
+            patch_capture_status = "skipped"
+            finalize_exc = None
             try:
                 patch, files_changed = finalize_worktree_patch(wt_path)
                 worktree_diff_empty = not bool(patch.strip())
+                patch_capture_status = "ok"
             except Exception as final_exc:
+                finalize_exc = final_exc
+                patch_capture_status = "failed"
+                worktree_diff_empty = None
                 _diag("edit_engines.run_agentic_edit.finalize", final_exc)
 
+            primary_error = ""
             if orchestrator_exc is not None:
-                return _stamp_agentic(WorkerResult(
+                primary_error = classify_agentic_exception(
+                    orchestrator_exc, failure_snap,
+                )
+            elif finalize_exc is not None:
+                primary_error = PATCH_CAPTURE_FAILED
+            elif store_cleanup_exc is not None and result is None:
+                primary_error = WORKER_CLEANUP_FAILED
+
+            if orchestrator_exc is not None:
+                usage = _usage_from_snapshot(failure_snap)
+                http_status, retry_after, request_id = _failure_http_hints(
+                    orchestrator_exc,
+                )
+                git_fail = (
+                    _failure_fields_from_exc(finalize_exc)
+                    if finalize_exc is not None else {}
+                )
+                return finish(WorkerResult(
                     ok=False,
-                    error=AGENTIC_ERROR,
+                    error=primary_error,
                     summary=_format_agentic_engine_error(
                         orchestrator_exc, failure_snap, files_changed,
                     ),
                     patch=patch,
                     files_changed=list(files_changed),
-                    tokens_out=int(failure_snap.get("tokens_out") or 0),
-                    tokens_in=int(failure_snap.get("tokens_in") or 0),
+                    tokens_out=int(usage["tokens_out"]),
+                    tokens_in=int(usage["tokens_in"]),
+                    usage_known=usage["usage_known"],
+                    cost_known=usage["cost_known"],
                     worktree=wt_path,
                     managed_worktree_path=wt_path,
                     managed_worktree_mode="managed",
                     worktree_diff_empty=worktree_diff_empty,
                     events=list(mapped_events),
-                ), execution_pin=agentic_pin)
+                    patch_capture_status=patch_capture_status,
+                    http_status=http_status,
+                    retry_after=retry_after,
+                    provider_request_id=request_id,
+                    finish_reason=str((failure_snap or {}).get("reason") or ""),
+                    failure_command=str(git_fail.get("failure_command") or ""),
+                    failure_exit_code=git_fail.get("failure_exit_code"),
+                    failure_stderr=str(git_fail.get("failure_stderr") or ""),
+                ), worktree_existed=True, snap=failure_snap)
+
+            if finalize_exc is not None:
+                git_fail = _failure_fields_from_exc(finalize_exc)
+                return finish(WorkerResult(
+                    ok=False,
+                    error=PATCH_CAPTURE_FAILED,
+                    summary=_redact_text(
+                        f"Patch capture failed: {finalize_exc}"
+                    ),
+                    worktree=wt_path,
+                    managed_worktree_path=wt_path,
+                    managed_worktree_mode="managed",
+                    worktree_diff_empty=None,
+                    events=list(mapped_events),
+                    patch_capture_status="failed",
+                    usage_known=_artifacts_usage_known(result) if result is not None else False,
+                    cost_known=False,
+                    failure_command=str(git_fail.get("failure_command") or ""),
+                    failure_exit_code=git_fail.get("failure_exit_code"),
+                    failure_stderr=str(git_fail.get("failure_stderr") or ""),
+                ), result, worktree_existed=True, snap=failure_snap,
+                    job_id_hint=pm_job_id)
+
+            if store_cleanup_exc is not None and result is None:
+                return finish(WorkerResult(
+                    ok=False,
+                    error=WORKER_CLEANUP_FAILED,
+                    summary=_redact_text(
+                        f"Worker cleanup failed: {store_cleanup_exc}"
+                    ),
+                    worktree=wt_path,
+                    managed_worktree_path=wt_path,
+                    managed_worktree_mode="managed",
+                    worktree_diff_empty=worktree_diff_empty,
+                    events=list(mapped_events),
+                    patch_capture_status=patch_capture_status,
+                    usage_known=False,
+                    cost_known=False,
+                ), worktree_existed=True, snap=failure_snap)
 
             tokens_out, tokens_in, failure, final_text = _summarize_agentic_result(result)
+            usage_known = _artifacts_usage_known(result)
+            cost_known = False if usage_known else None
             routed_model = _routed_model_id(result)
             if agentic_pin is not None:
                 from harness.swarm_model_pin import agentic_pin_matches_routed_model
@@ -936,7 +1268,7 @@ def run_agentic_edit(
                     agentic_pin,
                     routed_model,
                 ):
-                    return _stamp_agentic(WorkerResult(
+                    return finish(WorkerResult(
                         ok=False,
                         error=AGENTIC_ROUTE_FAILED,
                         summary=(
@@ -950,7 +1282,11 @@ def run_agentic_edit(
                         managed_worktree_mode="managed",
                         worktree_diff_empty=worktree_diff_empty,
                         events=list(mapped_events),
-                    ), result, execution_pin=agentic_pin)
+                        patch_capture_status=patch_capture_status,
+                        usage_known=usage_known,
+                        cost_known=cost_known,
+                    ), result, worktree_existed=True, snap=failure_snap,
+                        job_id_hint=pm_job_id)
 
             # Analysis/review: never report seed leftovers as applied edits.
             if not expects_diff:
@@ -961,7 +1297,7 @@ def run_agentic_edit(
                 # Distinguish "engine could not run" (route/provider failure) from
                 # "ran fine but changed nothing" so fallback only fires for the former.
                 if failure in ("no_model", "unknown_provider", "route_failed"):
-                    return _stamp_agentic(WorkerResult(
+                    return finish(WorkerResult(
                         ok=False, error=AGENTIC_ROUTE_FAILED,
                         summary=final_text or "Agentic engine could not select a model/provider.",
                         model=routed_model,
@@ -970,7 +1306,11 @@ def run_agentic_edit(
                         managed_worktree_mode="managed",
                         worktree_diff_empty=worktree_diff_empty,
                         events=list(mapped_events),
-                    ), result, execution_pin=agentic_pin)
+                        patch_capture_status=patch_capture_status,
+                        usage_known=usage_known,
+                        cost_known=cost_known,
+                    ), result, worktree_existed=True, snap=failure_snap,
+                        job_id_hint=pm_job_id)
                 if not expects_diff:
                     # Gate on structured findings — never green unlabeled prose.
                     # Same rescue order as swarm/bridge: promote verification-
@@ -1012,7 +1352,7 @@ def run_agentic_edit(
                         signal_rows = parse_analysis_signal_rows(analysis_text)
                         if not signal_rows and has_structured:
                             signal_rows = _signal_rows_from_compact(compact)
-                        return _stamp_agentic(WorkerResult(
+                        return finish(WorkerResult(
                             ok=True, tokens_out=tokens_out, tokens_in=tokens_in,
                             summary=summary,
                             model=routed_model,
@@ -1022,14 +1362,18 @@ def run_agentic_edit(
                             worktree_diff_empty=worktree_diff_empty,
                             events=list(mapped_events),
                             findings=signal_rows,
-                        ), result, execution_pin=agentic_pin)
+                            patch_capture_status=patch_capture_status,
+                            usage_known=usage_known,
+                            cost_known=cost_known,
+                        ), result, worktree_existed=True, snap=failure_snap,
+                            job_id_hint=pm_job_id)
                     label = degrade_reason or "no structured findings"
                     summary_parts = [label]
                     if final_text:
                         summary_parts.append(
                             f"Last assistant message: {final_text}"
                         )
-                    return _stamp_agentic(WorkerResult(
+                    return finish(WorkerResult(
                         ok=False, error=label,
                         tokens_out=tokens_out, tokens_in=tokens_in,
                         summary="\n".join(summary_parts),
@@ -1039,8 +1383,12 @@ def run_agentic_edit(
                         managed_worktree_mode="managed",
                         worktree_diff_empty=worktree_diff_empty,
                         events=list(mapped_events),
-                    ), result, execution_pin=agentic_pin)
-                return _stamp_agentic(WorkerResult(
+                        patch_capture_status=patch_capture_status,
+                        usage_known=usage_known,
+                        cost_known=cost_known,
+                    ), result, worktree_existed=True, snap=failure_snap,
+                        job_id_hint=pm_job_id)
+                return finish(WorkerResult(
                     ok=False, tokens_out=tokens_out, tokens_in=tokens_in,
                     summary=final_text or "no changes produced",
                     model=routed_model,
@@ -1049,9 +1397,13 @@ def run_agentic_edit(
                     managed_worktree_mode="managed",
                     worktree_diff_empty=worktree_diff_empty,
                     events=list(mapped_events),
-                ), result, execution_pin=agentic_pin)
+                    patch_capture_status=patch_capture_status,
+                    usage_known=usage_known,
+                    cost_known=cost_known,
+                ), result, worktree_existed=True, snap=failure_snap,
+                    job_id_hint=pm_job_id)
 
-            return _stamp_agentic(WorkerResult(
+            return finish(WorkerResult(
                 ok=True, patch=patch, files_changed=files_changed,
                 tokens_out=tokens_out, tokens_in=tokens_in,
                 summary=final_text or (f"Files changed: {', '.join(files_changed)}" if files_changed else "Patch generated"),
@@ -1061,12 +1413,34 @@ def run_agentic_edit(
                 managed_worktree_mode="managed",
                 worktree_diff_empty=worktree_diff_empty,
                 events=list(mapped_events),
-            ), result, execution_pin=agentic_pin)
+                patch_capture_status=patch_capture_status,
+                usage_known=usage_known,
+                cost_known=cost_known,
+            ), result, worktree_existed=True, snap=failure_snap,
+                job_id_hint=pm_job_id)
     except Exception as exc:
         _diag("edit_engines.run_agentic_edit", exc)
-        return _stamp_agentic(WorkerResult(
-            ok=False, error=AGENTIC_ERROR, summary=f"Agentic engine error: {exc}",
-        ), execution_pin=agentic_pin)
+        if not worktree_entered:
+            git_fail = _failure_fields_from_exc(exc)
+            return finish(WorkerResult(
+                ok=False,
+                error=WORKTREE_CREATE_FAILED,
+                summary=f"Worktree create failed: {_redact_text(str(exc))}",
+                managed_worktree_mode="none",
+                worktree_diff_empty=None,
+                patch_capture_status="skipped",
+                failure_command=git_fail.get("failure_command") or "git worktree add",
+                failure_exit_code=git_fail.get("failure_exit_code"),
+                failure_stderr=_redact_text(str(exc)),
+            ), worktree_existed=False)
+        return finish(WorkerResult(
+            ok=False,
+            error=AGENTIC_ERROR,
+            summary=f"Agentic engine error: {_redact_text(str(exc))}",
+            managed_worktree_mode="managed",
+            worktree_diff_empty=None,
+            patch_capture_status="skipped",
+        ), worktree_existed=True)
 
 
 # Store event names that already mean a tool/action boundary (not lifecycle).
@@ -1264,6 +1638,7 @@ def _stamp_agentic(
 ) -> "WorkerResult":
     """Label a WorkerResult as the agentic engine + routed model (best-effort)."""
     result.engine = "agentic"
+    result.adapter = "agentic"
     if not (result.model or "").strip() and pm_result is not None:
         routed = _routed_model_id(pm_result)
         if routed:

--- a/harness/worker.py
+++ b/harness/worker.py
@@ -119,6 +119,22 @@ class WorkerResult:
     # True when the inner turn stopped because the tool-call / AutoBudget ceiling
     # tripped (empty-diff recovery must not burn a second full attempt).
     stopped_by_guard_or_budget: bool = False
+    # Stage-specific agentic provenance. Empty/None defaults keep positional
+    # construction back-compatible; WorkerResult.error remains the stage code.
+    requested_mode: str = ""
+    adapter: str = ""
+    pm_job_id: str = ""
+    task_ids: list[str] = field(default_factory=list)
+    patch_capture_status: str = ""
+    failure_command: str = ""
+    failure_exit_code: Optional[int] = None
+    failure_stderr: str = ""
+    usage_known: Optional[bool] = None
+    cost_known: Optional[bool] = None
+    http_status: Optional[int] = None
+    retry_after: str = ""
+    provider_request_id: str = ""
+    finish_reason: str = ""
 
 
 def scope_goal_paths_to_worktree(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.368"
+version = "0.9.369"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_edit_engines.py
+++ b/tests/test_edit_engines.py
@@ -15,8 +15,13 @@ import pytest
 from harness.config import HarnessConfig
 from harness.edit_engines import (
     AGENTIC_ERROR,
+    AGENTIC_ORCHESTRATOR_FAILED,
+    AGENTIC_PROVIDER_RATE_LIMITED,
     AGENTIC_ROUTE_FAILED,
+    AGENTIC_TIMEOUT,
     AGENTIC_UNAVAILABLE,
+    PATCH_CAPTURE_FAILED,
+    WORKTREE_CREATE_FAILED,
     agentic_available,
     agentic_events_from_store,
     finalize_worktree_patch,
@@ -152,6 +157,8 @@ def test_agentic_store_failure_snapshot_prefers_gate_reason():
     assert snap["task_statuses"] == ["implement=failed"]
     assert snap["tokens_in"] == 40
     assert snap["tokens_out"] == 12
+    assert snap["usage_known"] is True
+    assert snap["task_ids"] == ["t1"]
     summary = _format_agentic_engine_error(
         RuntimeError("swarm exited with incomplete tasks"),
         snap,
@@ -161,6 +168,29 @@ def test_agentic_store_failure_snapshot_prefers_gate_reason():
     assert "require_diff: no PATCH artifact" in summary
     assert "tasks: implement=failed" in summary
     assert "unapplied worktree files: src/lib/scoring/report.ts" in summary
+
+
+def test_agentic_store_failure_snapshot_unknown_usage_is_not_measured_zero():
+    class _Store:
+        def list_jobs(self):
+            return [type("J", (), {"id": "job_1"})()]
+
+        def list_tasks(self, job_id):
+            return [type("T", (), {"id": "t9", "role": "implement", "status": "failed"})()]
+
+        def read_events(self, job_id):
+            return []
+
+        def list_artifacts(self, job_id):
+            art = type("A", (), {})()
+            art.payload = {"failure": "boom"}
+            return [art]
+
+    snap = _agentic_store_failure_snapshot(_Store())
+    assert snap["usage_known"] is False
+    assert snap["tokens_in"] == 0
+    assert snap["tokens_out"] == 0
+    assert snap["task_ids"] == ["t9"]
 
 
 # --- pure helpers: _summarize_agentic_result ---
@@ -460,6 +490,43 @@ def test_finalize_worktree_patch_empty_when_no_changes():
             patch, files = finalize_worktree_patch(wt_path)
             assert patch.strip() == ""
             assert files == []
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_finalize_worktree_patch_rejects_missing_path():
+    with pytest.raises(RuntimeError, match="does not exist"):
+        finalize_worktree_patch("/no/such/worktree-path")
+
+
+def test_finalize_worktree_patch_rejects_non_repo(tmp_path):
+    with pytest.raises(RuntimeError, match="not a git repository"):
+        finalize_worktree_patch(str(tmp_path))
+
+
+def test_finalize_worktree_patch_name_only_failure_does_not_return_empty(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        with managed_worktree(repo_dir) as wt_path:
+            with open(os.path.join(wt_path, "x.txt"), "w", encoding="utf-8") as fh:
+                fh.write("x\n")
+            real_run = subprocess.run
+
+            def fake_run(cmd, *a, **k):
+                if isinstance(cmd, (list, tuple)) and "--name-only" in cmd:
+                    return type(
+                        "P", (),
+                        {"returncode": 1, "stdout": "", "stderr": "name-only boom"},
+                    )()
+                return real_run(cmd, *a, **k)
+
+            monkeypatch.setattr(subprocess, "run", fake_run)
+            with pytest.raises(RuntimeError) as caught:
+                finalize_worktree_patch(wt_path)
+            text = str(caught.value)
+            assert "failed (exit 1)" in text
+            assert "--name-only" in text
+            assert "name-only boom" in text
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)
 
@@ -1034,24 +1101,59 @@ def test_agentic_edit_empty_diff_route_failure(monkeypatch):
         shutil.rmtree(repo_dir, ignore_errors=True)
 
 
-def test_agentic_edit_runtime_exception_returns_agentic_error(monkeypatch):
+def test_agentic_edit_worktree_create_failed(monkeypatch):
     repo_dir = create_temp_git_repo()
     try:
         cfg = _cfg(repo_dir)
         monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
 
         @contextlib.contextmanager
-        def _boom_worktree(repo, base="HEAD"):
-            raise RuntimeError("worktree blew up")
+        def _boom_worktree(repo, goal, base="HEAD"):
+            raise RuntimeError(
+                "fatal: could not create worktree api_key=sk-abcdefghijklmnopqrstuvwxyz"
+            )
             yield ""  # pragma: no cover
 
-        monkeypatch.setattr("harness.edit_engines.managed_worktree", _boom_worktree)
+        monkeypatch.setattr(
+            "harness.edit_engines.managed_worktree_for_goal", _boom_worktree,
+        )
+        result = run_agentic_edit(cfg, "goal")
+        assert result.ok is False
+        assert result.error == WORKTREE_CREATE_FAILED
+        assert result.requested_mode == "implement"
+        assert result.managed_worktree_mode == "none"
+        assert result.patch_capture_status == "skipped"
+        assert "fatal" in result.summary
+        assert "sk-abcdefghijklmnopqrstuvwxyz" not in result.summary
+        assert "sk-abcdefghijklmnopqrstuvwxyz" not in result.failure_stderr
+        assert result.failure_command
+        assert result.engine == "agentic"
+        assert result.adapter == "agentic"
+        assert result.worktree_diff_empty is None
+        assert "unavailable" not in (result.summary or "").lower()
+        assert "mode=unknown" not in (result.summary or "")
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_unclassified_crash_stamps_requested_mode(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        def boom_store(*_a, **_k):
+            raise RuntimeError("store exploded")
+
+        monkeypatch.setattr("puppetmaster.store_factory.create_store", boom_store)
         result = run_agentic_edit(cfg, "goal")
         assert result.ok is False
         assert result.error == AGENTIC_ERROR
-        assert "worktree blew up" in result.summary
-        assert result.managed_worktree_mode == ""
-        assert result.worktree_diff_empty is None
+        assert result.requested_mode == "implement"
+        assert result.engine == "agentic"
+        assert result.adapter == "agentic"
+        assert result.managed_worktree_mode == "managed"
+        assert "store exploded" in result.summary
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)
 
@@ -1084,13 +1186,20 @@ def test_agentic_edit_incomplete_swarm_stamps_provenance_and_gate_reason(monkeyp
         monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _BoomOrch)
         result = run_agentic_edit(cfg, "implement the thing")
         assert result.ok is False
-        assert result.error == AGENTIC_ERROR
+        assert result.error == AGENTIC_ORCHESTRATOR_FAILED
+        assert result.requested_mode == "implement"
+        assert result.engine == "agentic"
+        assert result.adapter == "agentic"
         assert result.managed_worktree_mode == "managed"
         assert result.worktree_diff_empty is False
+        assert result.patch_capture_status == "ok"
         assert "test.txt" in (result.files_changed or [])
         assert (result.patch or "").strip()
         assert "incomplete tasks" in (result.summary or "")
         assert "require_diff" in (result.summary or "")
+        assert result.pm_job_id
+        assert "unavailable" not in (result.summary or "").lower()
+        assert "mode=unknown" not in (result.summary or "")
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)
 
@@ -1117,12 +1226,14 @@ def test_agentic_edit_incomplete_swarm_empty_worktree_is_explicit(monkeypatch):
         monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _BoomOrch)
         result = run_agentic_edit(cfg, "implement the thing")
         assert result.ok is False
-        assert result.error == AGENTIC_ERROR
+        assert result.error == AGENTIC_ORCHESTRATOR_FAILED
+        assert result.requested_mode == "implement"
         assert result.managed_worktree_mode == "managed"
         assert result.worktree_diff_empty is True
         assert result.files_changed == []
         assert "adapter boom" in (result.summary or "")
         assert "unavailable" not in (result.summary or "").lower()
+        assert "mode=unknown" not in (result.summary or "")
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)
 
@@ -1236,6 +1347,11 @@ def test_agentic_edit_success_with_patch(monkeypatch):
         assert result.files_changed == ["x.py"]
         assert result.tokens_out == 200
         assert result.tokens_in == 80
+        assert result.requested_mode == "implement"
+        assert result.engine == "agentic"
+        assert result.adapter == "agentic"
+        assert result.patch_capture_status == "ok"
+        assert result.usage_known is True
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)
 
@@ -1537,12 +1653,298 @@ def test_run_edit_worker_falls_back_on_route_and_runtime_errors(monkeypatch):
         monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
         native_sentinel = WorkerResult(ok=True, summary="native")
 
-        for err in (AGENTIC_ROUTE_FAILED, AGENTIC_ERROR):
+        for err in (AGENTIC_ROUTE_FAILED, WORKTREE_CREATE_FAILED):
             monkeypatch.setattr(
                 "harness.edit_engines.run_agentic_edit",
                 lambda *a, err=err, **k: WorkerResult(ok=False, error=err),
             )
             monkeypatch.setattr("harness.edit_engines.run_native_edit", lambda *a, **k: native_sentinel)
             assert run_edit_worker(cfg, "goal") is native_sentinel
+
+        native_called = []
+        monkeypatch.setattr(
+            "harness.edit_engines.run_native_edit",
+            lambda *a, **k: native_called.append(True) or WorkerResult(ok=False),
+        )
+        for err in (AGENTIC_ORCHESTRATOR_FAILED, PATCH_CAPTURE_FAILED, AGENTIC_ERROR):
+            monkeypatch.setattr(
+                "harness.edit_engines.run_agentic_edit",
+                lambda *a, err=err, **k: WorkerResult(ok=False, error=err, patch=""),
+            )
+            result = run_edit_worker(cfg, "goal")
+            assert result.error == err
+            assert native_called == []
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_run_edit_worker_no_fallback_on_partial_implement(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.select_edit_engine", lambda *a, **k: "agentic")
+        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
+        native_called = []
+        monkeypatch.setattr(
+            "harness.edit_engines.run_native_edit",
+            lambda *a, **k: native_called.append(True) or WorkerResult(ok=False),
+        )
+        partial = WorkerResult(
+            ok=False,
+            error=WORKTREE_CREATE_FAILED,
+            patch="diff --git a/x b/x\n+line",
+            files_changed=["x.py"],
+        )
+        monkeypatch.setattr(
+            "harness.edit_engines.run_agentic_edit",
+            lambda *a, **k: partial,
+        )
+        result = run_edit_worker(cfg, "goal")
+        assert result is partial
+        assert native_called == []
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_ignores_parent_dirty_file(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        parent_file = os.path.join(repo_dir, "test.txt")
+        with open(parent_file, "a", encoding="utf-8") as fh:
+            fh.write("parent-dirty\n")
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        class _Orch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                payload = ((specs[0].payload if specs else {}) or {})
+                cwd = payload.get("cwd") or ""
+                with open(os.path.join(cwd, "new_from_worker.txt"), "w", encoding="utf-8") as out:
+                    out.write("only-in-wt\n")
+                return _fake_pm_result([
+                    _fake_artifact(tokens_out=1, tokens_in=1, stdout="ok"),
+                ])
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _Orch)
+        result = run_agentic_edit(cfg, "add worker_only.txt")
+        assert result.ok is True
+        assert "new_from_worker.txt" in (result.files_changed or [])
+        assert "test.txt" not in (result.files_changed or [])
+        with open(parent_file, encoding="utf-8") as fh:
+            assert "parent-dirty" in fh.read()
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_patch_capture_failed(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        _install_agentic_mocks(monkeypatch, orchestrator_result=_fake_pm_result([
+            _fake_artifact(tokens_out=2, tokens_in=1, stdout="ok"),
+        ]))
+
+        def boom_finalize(_wt):
+            raise RuntimeError(
+                "git -C /tmp/wt diff --cached --name-only failed (exit 1): boom"
+            )
+
+        monkeypatch.setattr("harness.edit_engines.finalize_worktree_patch", boom_finalize)
+        result = run_agentic_edit(cfg, "goal")
+        assert result.ok is False
+        assert result.error == PATCH_CAPTURE_FAILED
+        assert result.worktree_diff_empty is None
+        assert result.patch_capture_status == "failed"
+        assert result.requested_mode == "implement"
+        assert result.managed_worktree_mode == "managed"
+        assert result.worktree_diff_empty is not True
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_finalize_fail_keeps_orchestrator_error(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        class _BoomOrch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                raise RuntimeError("swarm exited with incomplete tasks")
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _BoomOrch)
+        monkeypatch.setattr(
+            "harness.edit_engines.finalize_worktree_patch",
+            lambda _wt: (_ for _ in ()).throw(RuntimeError("git add failed")),
+        )
+        result = run_agentic_edit(cfg, "implement the thing")
+        assert result.error == AGENTIC_ORCHESTRATOR_FAILED
+        assert result.patch_capture_status == "failed"
+        assert result.worktree_diff_empty is None
+        assert result.managed_worktree_mode == "managed"
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_cleanup_failure_keeps_orchestrator_error(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        class _BoomOrch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                raise RuntimeError("swarm exited with incomplete tasks")
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _BoomOrch)
+        real_rmtree = shutil.rmtree
+
+        def boom_rmtree(path, *a, **k):
+            if os.path.basename(str(path)).startswith("pmh-edit-"):
+                raise OSError("rmtree denied")
+            return real_rmtree(path, *a, **k)
+
+        monkeypatch.setattr("harness.edit_engines.shutil.rmtree", boom_rmtree)
+        result = run_agentic_edit(cfg, "implement the thing")
+        assert result.error == AGENTIC_ORCHESTRATOR_FAILED
+        assert "incomplete tasks" in (result.summary or "")
+        assert result.managed_worktree_mode == "managed"
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_no_leaked_pmh_edit_dirs(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    created = []
+    real_mkdtemp = tempfile.mkdtemp
+
+    def spy_mkdtemp(*a, **k):
+        path = real_mkdtemp(*a, **k)
+        if str(k.get("prefix") or "").startswith("pmh-edit"):
+            created.append(path)
+        return path
+
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("tempfile.mkdtemp", spy_mkdtemp)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+        _install_agentic_mocks(monkeypatch, orchestrator_result=_fake_pm_result([
+            _fake_artifact(tokens_out=1, tokens_in=1, stdout="ok"),
+        ]))
+        monkeypatch.setattr(
+            "harness.edit_engines.finalize_worktree_patch",
+            lambda _wt: ("diff --git a/x b/x\n+line", ["x.py"]),
+        )
+        ok_result = run_agentic_edit(cfg, "goal")
+        assert ok_result.ok is True
+
+        class _BoomOrch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                raise RuntimeError("swarm exited with incomplete tasks")
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _BoomOrch)
+        fail_result = run_agentic_edit(cfg, "goal")
+        assert fail_result.ok is False
+        assert created
+        for path in created:
+            assert not os.path.exists(path)
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_managed_worktree_for_goal_paths_are_distinct():
+    from harness.edit_engines import managed_worktree_for_goal
+
+    repo_dir = create_temp_git_repo()
+    try:
+        with managed_worktree_for_goal(repo_dir, "goal a") as wt1:
+            with open(os.path.join(wt1, "only_in_first.txt"), "w", encoding="utf-8") as fh:
+                fh.write("secret-patch-a\n")
+            patch1, files1 = finalize_worktree_patch(wt1)
+            with managed_worktree_for_goal(repo_dir, "goal b") as wt2:
+                assert wt1 != wt2
+                patch2, files2 = finalize_worktree_patch(wt2)
+                assert "only_in_first.txt" not in files2
+                assert "secret-patch-a" not in patch2
+            assert "only_in_first.txt" in files1
+        assert not os.path.exists(wt1)
+        assert not os.path.exists(wt2)
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_classifies_rate_limit(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        class _BoomOrch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                raise RuntimeError("HTTP 429 Too Many Requests Retry-After: 12 quota exceeded")
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _BoomOrch)
+        result = run_agentic_edit(cfg, "implement the thing")
+        assert result.error == AGENTIC_PROVIDER_RATE_LIMITED
+        assert result.http_status == 429
+        assert result.retry_after == "12"
+        assert result.managed_worktree_mode == "managed"
+        assert result.requested_mode == "implement"
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_classifies_timeout(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        class _BoomOrch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                raise TimeoutError("request timed out waiting for provider")
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _BoomOrch)
+        result = run_agentic_edit(cfg, "implement the thing")
+        assert result.error == AGENTIC_TIMEOUT
+        assert result.managed_worktree_mode == "managed"
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_connection_error_is_orchestrator_failed(monkeypatch):
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        class _BoomOrch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                raise RuntimeError("connection refused")
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _BoomOrch)
+        result = run_agentic_edit(cfg, "implement the thing")
+        assert result.error == AGENTIC_ORCHESTRATOR_FAILED
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)

--- a/tests/test_worker_provenance.py
+++ b/tests/test_worker_provenance.py
@@ -250,7 +250,7 @@ def test_cancelled_worker_provenance_collection_failure_is_best_effort(
     saved = json.loads((tmp_path / "jobs.json").read_text(encoding="utf-8"))
     job = saved["jobs"][0]
     assert job["status"] == "cancelled"
-    assert job["worker_provenance"]["managed_worktree_mode"] == "unknown"
+    assert job["worker_provenance"]["managed_worktree_mode"] == "none"
 
 
 def test_empty_diff_implement_failure_detector():
@@ -795,3 +795,114 @@ def test_lifecycle_halted_skips_recovery_but_marks_exhausted(monkeypatch):
     finished = session._local_jobs[job_id]
     assert finished["worker_provenance"]["empty_implement_recovery"] is False
     assert finished["worker_provenance"]["empty_managed_implement_exhausted"] is True
+
+
+def test_implement_provenance_never_renders_mode_unknown():
+    text = _worker_provenance_text({
+        "requested_mode": "implement",
+        "worktree_diff_empty": None,
+        "error": "patch_capture_failed",
+        "live_dirty_paths_before": [],
+        "live_dirty_paths_after": [],
+    })
+    assert "mode=unknown" not in text
+    assert "unavailable" not in text.lower()
+    assert "patch_capture_failed" in text
+    assert "could not be determined" in text
+
+
+def test_undetermined_diff_not_empty_recovery_or_unavailable_unknown():
+    res = WorkerResult(
+        ok=False,
+        error="patch_capture_failed",
+        worktree_diff_empty=None,
+        patch="",
+        requested_mode="implement",
+        managed_worktree_mode="managed",
+    )
+    assert _is_empty_diff_implement_failure(res, expects_diff=True) is False
+    assert _empty_implement_recovery_eligible(
+        res,
+        expects_diff=True,
+        live_dirty_before=["report.ts"],
+        cancelled=False,
+    ) is False
+    text = _worker_provenance_text({
+        "requested_mode": "implement",
+        "managed_worktree_mode": "managed",
+        "worktree_diff_empty": None,
+        "error": "patch_capture_failed",
+        "live_dirty_paths_before": [],
+        "live_dirty_paths_after": [],
+    })
+    assert "unavailable" not in text.lower()
+    assert "mode=unknown" not in text
+
+
+def test_usage_known_false_does_not_claim_measured_zero():
+    text = _worker_provenance_text({
+        "requested_mode": "implement",
+        "managed_worktree_mode": "managed",
+        "worktree_diff_empty": None,
+        "error": "agentic_orchestrator_failed",
+        "usage_known": False,
+        "live_dirty_paths_before": [],
+        "live_dirty_paths_after": [],
+    })
+    assert "$0" not in text
+    assert "0.00" not in text
+    assert "measured $0" not in text.lower()
+
+
+def test_agentic_orchestrator_failed_skips_empty_implement_recovery():
+    crashed = WorkerResult(
+        ok=False,
+        error="agentic_orchestrator_failed",
+        summary="Agentic engine error: swarm exited with incomplete tasks",
+        worktree_diff_empty=True,
+        patch="",
+        managed_worktree_mode="managed",
+    )
+    assert _empty_implement_recovery_eligible(
+        crashed,
+        expects_diff=True,
+        live_dirty_before=["report.ts"],
+        cancelled=False,
+    ) is False
+
+
+def test_stage_codes_skip_empty_implement_recovery():
+    for err in (
+        "worktree_create_failed",
+        "patch_capture_failed",
+        "worker_cleanup_failed",
+    ):
+        res = WorkerResult(
+            ok=False,
+            error=err,
+            worktree_diff_empty=True,
+            patch="",
+            managed_worktree_mode="none" if err == "worktree_create_failed" else "managed",
+        )
+        assert _empty_implement_recovery_eligible(
+            res,
+            expects_diff=True,
+            live_dirty_before=["report.ts"],
+            cancelled=False,
+        ) is False
+
+
+def test_failure_stamp_fields_survive_in_provenance_text():
+    text = _worker_provenance_text({
+        "requested_mode": "implement",
+        "managed_worktree_mode": "managed",
+        "worktree_diff_empty": True,
+        "error": "agentic_orchestrator_failed",
+        "engine": "agentic",
+        "adapter": "agentic",
+        "model": "agentic/openrouter/foo",
+        "live_dirty_paths_before": [],
+        "live_dirty_paths_after": [],
+    })
+    assert text.startswith("[provenance] agentic_orchestrator_failed:")
+    assert "mode=managed" in text

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.368",
+  "version": "0.9.369",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.368",
+      "version": "0.9.369",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.368",
+  "version": "0.9.369",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Stage-specific agentic worker failure codes (`worktree_create_failed`, `agentic_orchestrator_failed`, `patch_capture_failed`, `worker_cleanup_failed`, plus rate-limit/timeout) instead of collapsing to `Worker worktree diff status unavailable; mode=unknown`.
- Harden `finalize_worktree_patch` (git `-C`, repo existence, exit codes, stderr); keep partial patches; no native fallback after a started implement or partial patch.
- Explicit provenance: requested mode, adapter, job/task ids, `worktree_diff_empty` tri-state, unknown usage/cost not snapped to 0. Keep v0.9.368 store snapshot and AGENTIC fail-closed recovery skip.

## Test plan
- [x] `tests/test_edit_engines.py` + `tests/test_worker_provenance.py` (102 with version consistency)
- [ ] dest-into-main `tests` matrix (3.9, 3.11, Windows, frontend-build)
- [ ] After merge: `python scripts/ci_release_gate.py require-green` then tag `v0.9.369` if `merge^{tree}` matches
