### PR TITLE
Release v0.9.370

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.37` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.369, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.370, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.369"
+__version__ = "0.9.370"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/compaction_advisor.py
+++ b/harness/compaction_advisor.py
@@ -96,6 +96,8 @@ def _none_advice() -> dict[str, Any]:
         "reasons": [],
         "needs_intervention": False,
         "warning_reason": "",
+        "budget_kind": "",
+        "budget_tokens": 0,
     }
 
 
@@ -195,6 +197,8 @@ def apply_manual_compaction_ack(
         cleared["needs_intervention"] = False
         cleared["warning_reason"] = ""
         cleared["reasons"] = []
+        cleared["budget_kind"] = ""
+        cleared["budget_tokens"] = 0
         cleared["acked_manual_compact"] = True
         out = dict(advice)
         out["compaction_advice"] = cleared
@@ -271,25 +275,34 @@ def assess_layer_pressure(snapshot: dict, max_context_tokens: int) -> dict[str, 
 
     reasons: list[str] = []
     level = "none"
+    budget_kind = ""
+    budget_tokens = 0
 
     now_threshold, soon_threshold, binding_now, binding_soon = _effective_thresholds(budget)
 
     if hot_ratio >= now_threshold:
         level = "now"
         if binding_now:
+            budget_kind = "absolute"
+            budget_tokens = binding_now
             reasons.append(f"hot context above {binding_now} tokens on a large window")
         else:
+            budget_kind = "percent"
             pct = int(round(hot_ratio * 100))
             reasons.append(f"hot context at {pct} percent of budget")
     elif hot_ratio >= soon_threshold:
         level = "soon"
         if binding_soon:
+            budget_kind = "absolute"
+            budget_tokens = binding_soon
             reasons.append(f"hot context above {binding_soon} tokens on a large window")
         else:
+            budget_kind = "percent"
             pct = int(round(hot_ratio * 100))
             reasons.append(f"hot context at {pct} percent of budget")
     elif hot_ratio >= _HOT_L1_COMBO_RATIO and l1_bytes > _L1_PRESSURE_BYTES:
         level = "soon"
+        budget_kind = "l1"
         pct = int(round(hot_ratio * 100))
         reasons.append(
             f"session state exceeds 5 MB with warm context at {pct} percent of budget"
@@ -301,6 +314,8 @@ def assess_layer_pressure(snapshot: dict, max_context_tokens: int) -> dict[str, 
         "l1_bytes": l1_bytes,
         "l3_reclaimed_bytes": l3_reclaimed,
         "reasons": reasons,
+        "budget_kind": budget_kind,
+        "budget_tokens": budget_tokens,
     }
     advice.update(_intervention_fields(level, reasons, l3_reclaimed))
     return advice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.369"
+version = "0.9.370"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_compaction_advisor.py
+++ b/tests/test_compaction_advisor.py
@@ -75,6 +75,8 @@ def test_hot_now_boundary_at():
     assert advice["reasons"]
     assert advice["needs_intervention"] is True
     assert advice["warning_reason"] == advice["reasons"][0]
+    assert advice["budget_kind"] == "percent"
+    assert advice["budget_tokens"] == 0
 
 
 def test_hot_soon_boundary_below():
@@ -94,6 +96,8 @@ def test_hot_soon_boundary_at():
     assert "hot context" in advice["reasons"][0]
     assert advice["needs_intervention"] is True
     assert "hot context" in advice["warning_reason"]
+    assert advice["budget_kind"] == "percent"
+    assert advice["budget_tokens"] == 0
 
 
 def test_needs_intervention_false_when_calm():
@@ -101,6 +105,8 @@ def test_needs_intervention_false_when_calm():
     assert advice["level"] == "none"
     assert advice["needs_intervention"] is False
     assert advice["warning_reason"] == ""
+    assert advice["budget_kind"] == ""
+    assert advice["budget_tokens"] == 0
 
 
 def test_needs_intervention_with_reclaim_under_pressure():
@@ -202,6 +208,8 @@ def test_manual_ack_clears_intervention_until_history_grows():
     assert body["level"] == "none"
     assert body["acked_manual_compact"] is True
     assert body["warning_reason"] == ""
+    assert body["budget_kind"] == ""
+    assert body["budget_tokens"] == 0
 
     pilot._history = list(pilot._history) + [{"role": "user", "content": "more"}]
     pilot._estimate_context_tokens = lambda: 140
@@ -403,6 +411,8 @@ def test_small_window_ratio_behavior_unchanged():
     advice = assess_layer_pressure(_snapshot(l0_at), budget)
     assert advice["level"] == "soon"
     assert "percent of budget" in advice["reasons"][0]
+    assert advice["budget_kind"] == "percent"
+    assert advice["budget_tokens"] == 0
 
 
 def test_large_window_absolute_soon_fires_before_ratio():
@@ -412,6 +422,18 @@ def test_large_window_absolute_soon_fires_before_ratio():
     advice = assess_layer_pressure(_snapshot(l0_bytes), budget)
     assert advice["level"] == "soon"
     assert "150000 tokens on a large window" in advice["reasons"][0]
+    assert advice["budget_kind"] == "absolute"
+    assert advice["budget_tokens"] == 150_000
+
+
+def test_large_window_absolute_now_fires_at_270k():
+    budget = 1_000_000
+    l0_bytes = 280_000 * 4
+    advice = assess_layer_pressure(_snapshot(l0_bytes), budget)
+    assert advice["level"] == "now"
+    assert "270000 tokens on a large window" in advice["reasons"][0]
+    assert advice["budget_kind"] == "absolute"
+    assert advice["budget_tokens"] == 270_000
 
 
 def test_absolute_threshold_env_zero_restores_ratio_only(monkeypatch):
@@ -430,3 +452,5 @@ def test_absolute_threshold_invalid_env_ignored(monkeypatch):
     advice = assess_layer_pressure(_snapshot(l0_bytes), budget)
     assert advice["level"] == "soon"
     assert "150000 tokens on a large window" in advice["reasons"][0]
+    assert advice["budget_kind"] == "absolute"
+    assert advice["budget_tokens"] == 150_000

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.369",
+  "version": "0.9.370",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.369",
+      "version": "0.9.370",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.369",
+  "version": "0.9.370",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CostBreakdown.test.tsx
+++ b/webapp/src/__tests__/CostBreakdown.test.tsx
@@ -42,24 +42,48 @@ const baseData: CostBreakdownData = {
     reasons: ["hot context above 150000 tokens on a large window"],
     needs_intervention: true,
     warning_reason: "hot context above 150000 tokens on a large window",
+    budget_kind: "absolute",
+    budget_tokens: 150000,
   },
   price_in: 3,
   price_out: 15,
 };
 
 describe("compactionAdvicePresentation", () => {
-  it("maps soon to calm Long session copy", () => {
-    const copy = compactionAdvicePresentation("soon");
+  it("maps soon absolute to working-context budget copy", () => {
+    const copy = compactionAdvicePresentation("soon", {
+      budget_kind: "absolute",
+      budget_tokens: 150000,
+    });
     expect(copy.label).toBe("Long session");
-    expect(copy.message).toMatch(/getting long/i);
+    expect(copy.message).toMatch(/~150k working-context budget/);
+    expect(copy.message).toMatch(/advertised window is larger/i);
     expect(copy.message).not.toMatch(/150000/);
+    expect(copy.message).not.toMatch(/tidied/i);
   });
 
-  it("maps now to Needs attention with actionable copy", () => {
-    const copy = compactionAdvicePresentation("now");
+  it("maps soon percent to threshold copy without a token number", () => {
+    const copy = compactionAdvicePresentation("soon", { budget_kind: "percent" });
+    expect(copy.label).toBe("Long session");
+    expect(copy.message).toMatch(/working-context threshold/);
+    expect(copy.message).not.toMatch(/~150k/);
+  });
+
+  it("maps now absolute to Needs attention with the binding budget", () => {
+    const copy = compactionAdvicePresentation("now", {
+      budget_kind: "absolute",
+      budget_tokens: 270000,
+    });
     expect(copy.label).toBe("Needs attention");
-    expect(copy.message).toMatch(/very long/i);
-    expect(copy.message).toMatch(/Compact it now/i);
+    expect(copy.message).toMatch(/~270k working-context budget/);
+    expect(copy.message).toMatch(/Compact now or start a fresh session/i);
+  });
+
+  it("maps now percent to Needs attention without a token number", () => {
+    const copy = compactionAdvicePresentation("now", { budget_kind: "percent" });
+    expect(copy.label).toBe("Needs attention");
+    expect(copy.message).toMatch(/working-context threshold/);
+    expect(copy.message).toMatch(/Compact now or start a fresh session/i);
   });
 });
 
@@ -145,7 +169,7 @@ describe("CostBreakdown", () => {
     expect(screen.getByText("Memory layers")).toBeInTheDocument();
     expect(screen.getByText("Long session")).toBeInTheDocument();
     expect(
-      screen.getByText(/This conversation is getting long/),
+      screen.getByText(/~150k working-context budget/),
     ).toBeInTheDocument();
     expect(screen.queryByText(/150000 tokens/)).not.toBeInTheDocument();
     const badge = screen.getByRole("status");
@@ -266,6 +290,8 @@ describe("CostBreakdown", () => {
             needs_intervention: true,
             warning_reason: "hot context above 150000 tokens on a large window",
             reasons: ["hot context above 150000 tokens on a large window"],
+            budget_kind: "absolute",
+            budget_tokens: 150000,
           },
         }}
       />,
@@ -274,8 +300,9 @@ describe("CostBreakdown", () => {
     expect(screen.getByText("Long session")).toBeInTheDocument();
     expect(screen.queryByText("Needs attention")).not.toBeInTheDocument();
     expect(
-      screen.getByText(/Older history can be tidied/),
+      screen.getByText(/~150k working-context budget/),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/tidied/)).not.toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveAttribute(
       "title",
       "hot context above 150000 tokens on a large window",
@@ -300,7 +327,7 @@ describe("CostBreakdown", () => {
 
     expect(screen.getByText("Needs attention")).toBeInTheDocument();
     expect(
-      screen.getByText(/Compact it now or start a fresh session/),
+      screen.getByText(/Compact now or start a fresh session/),
     ).toBeInTheDocument();
     expect(screen.queryByText(/80 percent of budget/)).not.toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveAttribute(

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -65,6 +65,10 @@ export type CostBreakdownData = {
     reasons?: string[];
     needs_intervention?: boolean;
     warning_reason?: string;
+    /** absolute | percent | l1 — which advisor rule bound. */
+    budget_kind?: "absolute" | "percent" | "l1" | "";
+    /** Absolute working-context budget when budget_kind is absolute. */
+    budget_tokens?: number;
   };
   history_compaction_ran?: boolean;
   /** estimated — standing floor / TTL (HARNESS_STANDING_ECONOMICS; flag-off omits). */
@@ -455,22 +459,46 @@ function fmtDurationMs(ms: number): string {
   return rem ? `${h}h ${rem}m` : `${h}h`;
 }
 
+function formatWorkingContextBudget(tokens: number): string {
+  if (!Number.isFinite(tokens) || tokens <= 0) return "";
+  if (tokens >= 1000) {
+    const k = tokens / 1000;
+    const label = Number.isInteger(k) ? String(k) : k.toFixed(1).replace(/\.0$/, "");
+    return `~${label}k`;
+  }
+  return String(Math.round(tokens));
+}
+
+export type CompactionAdviceCopyInput = {
+  budget_kind?: "absolute" | "percent" | "l1" | "";
+  budget_tokens?: number;
+};
+
 /** Calm user-facing copy for compaction advice. Machine reasons stay in title. */
 export function compactionAdvicePresentation(
   level: string | undefined,
+  advice?: CompactionAdviceCopyInput,
 ): { label: string; message: string; showCompactAction: boolean } {
+  const absolute =
+    advice?.budget_kind === "absolute"
+    && typeof advice.budget_tokens === "number"
+    && advice.budget_tokens > 0
+      ? formatWorkingContextBudget(advice.budget_tokens)
+      : "";
   if (level === "soon") {
     return {
       label: "Long session",
-      message:
-        "This conversation is getting long. Older history can be tidied to keep responses fast and costs down.",
+      message: absolute
+        ? `Past the ${absolute} working-context budget. The advertised window is larger; quality drops well before it fills. Compact older history. Auto-compact waits until a higher budget.`
+        : "This session is past the working-context threshold for this model. Compact older history.",
       showCompactAction: true,
     };
   }
   return {
     label: "Needs attention",
-    message:
-      "This conversation is very long. Compact it now or start a fresh session for best results.",
+    message: absolute
+      ? `Well past the ${absolute} working-context budget. Compact now or start a fresh session.`
+      : "This session is well past the working-context threshold. Compact now or start a fresh session.",
     showCompactAction: true,
   };
 }
@@ -686,7 +714,10 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
             : "") ||
           (data.history_compaction_ran ? "history compaction ran under context pressure" : ""))
       : "";
-  const adviceCopy = compactionAdvicePresentation(compactionAdviceLevel);
+  const adviceCopy = compactionAdvicePresentation(
+    compactionAdviceLevel,
+    data.compaction_advice,
+  );
   const showContextHealth =
     historyCompactions > 0
     || standingFloorCost > 0

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -782,6 +782,8 @@ export type UsageData = {
       reasons?: string[];
       needs_intervention?: boolean;
       warning_reason?: string;
+      budget_kind?: "absolute" | "percent" | "l1" | "";
+      budget_tokens?: number;
     };
     history_compaction_ran?: boolean;
     /** estimated — AGNT standing floor / TTL fields (HARNESS_STANDING_ECONOMICS). */


### PR DESCRIPTION
## Why

The yellow Long session card on a 1M-class window looked like a false 16% alarm. Compaction already fires on a working-context budget (150k soon / 270k now, dual with 55%/70% of the model window). Residual mode does not change those ranges. The product gap was copy.

## Scope

- Advisor emits `budget_kind` (`absolute` | `percent` | `l1`) and `budget_tokens`.
- CostBreakdown names the ~150k / ~270k working-context budget versus the advertised window.
- Thresholds, auto-compact, catalog/hybrid/summary, and the Puppetmaster pin are unchanged.

## Tradeoffs

No per-model compact table and no Strict/Standard/Relaxed Settings. Those are false precision or unused knobs. Copy is the honest signal.

## Blast radius

Economics pane compaction advice only. Composer `% Full` still shows percent of the advertised window (a different meter).

## Verification

- `.venv/bin/python -m pytest tests/test_compaction_advisor.py -q` (including 1M-window 150k/270k)
- `webapp`: `npm test -- src/__tests__/CostBreakdown.test.tsx` (40 passed)
- `.venv/bin/python -m pytest -q` — 5261 passed, 78 skipped
- Did not click the live Electron Economics pane; RTL covers the card text.
