### PR TITLE
Release v0.9.371

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.37` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.370, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.371, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.370"
+__version__ = "0.9.371"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -279,12 +279,23 @@ def _worker_provenance_text(provenance: dict, *, expects_diff: bool = True) -> s
         shown = [str(item) for item in paths[:_WORKER_PROVENANCE_PATH_CAP]]
         suffix = f", +{len(paths) - len(shown)} more" if len(paths) > len(shown) else ""
         return ", ".join(shown) + suffix if shown else "none"
-    return (
+    text = (
         f"[provenance] {worker_line}; mode={mode}"
         f"{f', path={path}' if path else ''}. "
         f"User checkout had {len(before)} pre-existing dirty paths before"
         f" ({path_list(before)}) and {len(after)} after ({path_list(after)})."
     )
+    if str(provenance.get("cleanup_status") or "") == "failed":
+        stage = str(provenance.get("cleanup_stage") or "").strip()
+        detail = str(provenance.get("cleanup_error") or "").strip()
+        extra = " Cleanup failed"
+        if stage:
+            extra += f" ({stage})"
+        extra += "."
+        if detail:
+            extra += f" {detail}"
+        text += extra
+    return text
 
 
 def _analysis_signal_rows_for_job(res, summary_text: str) -> list:
@@ -862,6 +873,9 @@ class ConversationJobsMixin:
                 "patch_capture_status": str(
                     _worker_attribute("patch_capture_status") or ""
                 ),
+                "cleanup_status": str(_worker_attribute("cleanup_status") or ""),
+                "cleanup_stage": str(_worker_attribute("cleanup_stage") or ""),
+                "cleanup_error": str(_worker_attribute("cleanup_error") or ""),
                 "usage_known": _worker_attribute("usage_known", None),
                 "worktree_diff_empty": _worker_attribute("worktree_diff_empty", None),
                 "empty_implement_recovery": bool(should_recover),

--- a/harness/edit_engines.py
+++ b/harness/edit_engines.py
@@ -367,13 +367,83 @@ def _should_native_fallback(result: "WorkerResult") -> bool:
     return getattr(result, "error", "") in _FALLBACK_REASONS
 
 
+def _record_cleanup_error(bag: Optional[list], stage: str, exc: BaseException) -> None:
+    if bag is None:
+        return
+    bag.append({"stage": stage, "exc": exc})
+
+
+def _cleanup_store_dir(tmp: str, cleanup_errors: Optional[list]) -> None:
+    try:
+        shutil.rmtree(tmp)
+    except Exception as exc:
+        _record_cleanup_error(cleanup_errors, "store", exc)
+        try:
+            shutil.rmtree(tmp, ignore_errors=True)
+        except Exception:
+            pass
+
+
+def _apply_cleanup_provenance(
+    wr: "WorkerResult", cleanup_errors: Optional[list],
+) -> "WorkerResult":
+    """Attach worktree/store cleanup failures without replacing a primary error."""
+    errors = list(cleanup_errors or [])
+    if wr.cleanup_status == "failed":
+        return wr
+    if not errors:
+        if not wr.cleanup_status:
+            wr.cleanup_status = "ok"
+        return wr
+    wr.cleanup_status = "failed"
+    stages = []
+    parts = []
+    for item in errors:
+        stage = str(item.get("stage") or "cleanup")
+        stages.append(stage)
+        parts.append("%s: %s" % (stage, _redact_text(str(item.get("exc") or ""))))
+    wr.cleanup_stage = ",".join(stages)
+    wr.cleanup_error = "; ".join(parts)
+    extra = "Cleanup also failed: " + wr.cleanup_error
+    if not wr.error:
+        wr.error = WORKER_CLEANUP_FAILED
+        wr.ok = False
+        extra = "Worker cleanup failed: " + wr.cleanup_error
+    if wr.summary:
+        wr.summary = (wr.summary + "\n" + extra).strip()
+    else:
+        wr.summary = extra
+    return wr
+
+
 @contextlib.contextmanager
-def managed_worktree(repo: str, base: str = "HEAD") -> Iterator[str]:
+def _managed_worktree_collecting(
+    repo: str,
+    goal: str,
+    cleanup_errors: list,
+    pending: dict,
+) -> Iterator[str]:
+    try:
+        with managed_worktree_for_goal(
+            repo, goal, cleanup_errors=cleanup_errors,
+        ) as wt_path:
+            yield wt_path
+    finally:
+        wr = pending.get("wr")
+        if wr is not None:
+            _apply_cleanup_provenance(wr, cleanup_errors)
+
+
+@contextlib.contextmanager
+def managed_worktree(
+    repo: str, base: str = "HEAD", cleanup_errors: Optional[list] = None,
+) -> Iterator[str]:
     """Create a confined git worktree for `repo`, yield its path, always clean up.
 
     Both engines edit inside the worktree so the live repo is untouched until the
     review/apply gate runs. The worktree and its throwaway branch are removed on
-    exit even when the body raises.
+    exit even when the body raises. Removal failures are appended to
+    ``cleanup_errors`` when provided; they are never swallowed silently.
     """
     from harness.worktrees import (
         _get_managed_dir,
@@ -386,6 +456,7 @@ def managed_worktree(repo: str, base: str = "HEAD") -> Iterator[str]:
 
     branch_name = _safe_branch_name(f"pmedit-{uuid.uuid4().hex[:8]}")
     wt_path = ""
+    bag = cleanup_errors if cleanup_errors is not None else []
     try:
         wt_info = add_worktree(repo, branch=branch_name, base=base)
         wt_path = wt_info["path"]
@@ -396,15 +467,23 @@ def managed_worktree(repo: str, base: str = "HEAD") -> Iterator[str]:
         yield wt_path
     finally:
         if wt_path:
-            with contextlib.suppress(Exception):
+            try:
                 remove_worktree(repo, wt_path, force=True)
-        with contextlib.suppress(Exception):
-            delete_branch(repo, branch_name)
+            except Exception as exc:
+                _record_cleanup_error(bag, "worktree_remove", exc)
+                if cleanup_errors is None:
+                    _diag("edit_engines.managed_worktree.remove", exc)
+        try:
+            delete_branch(repo, branch_name, raise_on_error=True)
+        except Exception as exc:
+            _record_cleanup_error(bag, "branch_delete", exc)
+            if cleanup_errors is None:
+                _diag("edit_engines.managed_worktree.branch", exc)
 
 
 @contextlib.contextmanager
 def managed_worktree_for_goal(
-    repo: str, goal: str, base: str = "HEAD",
+    repo: str, goal: str, base: str = "HEAD", cleanup_errors: Optional[list] = None,
 ) -> Iterator[str]:
     """Like :func:`managed_worktree`, then seed live goal paths into the worktree.
 
@@ -414,7 +493,7 @@ def managed_worktree_for_goal(
     """
     from harness.worktree_seed import commit_seed_baseline, seed_worktree_from_goal
 
-    with managed_worktree(repo, base=base) as wt_path:
+    with managed_worktree(repo, base=base, cleanup_errors=cleanup_errors) as wt_path:
         with contextlib.suppress(Exception):
             seed_result = seed_worktree_from_goal(repo, wt_path, goal)
             commit_seed_baseline(wt_path, seed_result.paths)
@@ -853,9 +932,19 @@ def run_cursor_edit(
             summary=f"Puppetmaster unavailable: {exc}",
         ))
 
+    pending = {"wr": None}
+    cleanup_errors: list = []
+
+    def cursor_finish(wr: "WorkerResult", pm_result=None) -> "WorkerResult":
+        wr = _stamp_agentic(wr, pm_result)
+        pending["wr"] = wr
+        return wr
+
     try:
         repo_root = cwd or config.repo
-        with managed_worktree_for_goal(repo_root, goal) as wt_path:
+        with _managed_worktree_collecting(
+            repo_root, goal, cleanup_errors, pending,
+        ) as wt_path:
             from pmharness.bridge import (
                 _analysis_instruction,
                 _analyze_max_turns,
@@ -911,7 +1000,7 @@ def run_cursor_edit(
                     label=job_label_for_session(session_id, dispatch_id=job_id),
                 )
             finally:
-                shutil.rmtree(tmp, ignore_errors=True)
+                _cleanup_store_dir(tmp, cleanup_errors)
 
             patch, files_changed = finalize_worktree_patch(wt_path)
             if not expects_diff:
@@ -920,7 +1009,7 @@ def run_cursor_edit(
             tokens_out, tokens_in, failure, final_text = _summarize_agentic_result(result)
             routed_model = _routed_model_id(result)
             if failure in ("no_model", "unknown_provider", "route_failed"):
-                return _stamp_agentic(WorkerResult(
+                return cursor_finish(WorkerResult(
                     ok=False, error=AGENTIC_ROUTE_FAILED,
                     summary=final_text or "Cursor engine could not select a model.",
                     model=routed_model,
@@ -928,7 +1017,7 @@ def run_cursor_edit(
                     managed_worktree_path=wt_path,
                     managed_worktree_mode="managed",
                 ), result)
-            return _stamp_agentic(WorkerResult(
+            return cursor_finish(WorkerResult(
                 ok=True,
                 patch=patch,
                 files_changed=files_changed,
@@ -943,10 +1032,10 @@ def run_cursor_edit(
             ), result)
     except Exception as exc:
         _diag("edit_engines.run_cursor_edit", exc)
-        return _stamp_agentic(WorkerResult(
+        return _apply_cleanup_provenance(cursor_finish(WorkerResult(
             ok=False, error=AGENTIC_ERROR,
             summary=str(exc),
-        ))
+        )), cleanup_errors)
 
 
 def run_agentic_edit(
@@ -973,6 +1062,8 @@ def run_agentic_edit(
     from harness.job_scoping import job_label_for_session, stamp_task_payload
 
     requested_mode = "implement" if expects_diff else "analysis"
+    pending = {"wr": None}
+    cleanup_errors: list = []
 
     def finish(
         wr: "WorkerResult",
@@ -994,7 +1085,9 @@ def run_agentic_edit(
                 wr.pm_job_id = str(snap.get("job_id") or "")
             if not wr.task_ids and snap.get("task_ids"):
                 wr.task_ids = list(snap.get("task_ids") or [])
-        return _stamp_agentic(wr, pm_result, execution_pin=agentic_pin)
+        wr = _stamp_agentic(wr, pm_result, execution_pin=agentic_pin)
+        pending["wr"] = wr
+        return wr
 
     if not agentic_available():
         return finish(WorkerResult(
@@ -1029,7 +1122,9 @@ def run_agentic_edit(
     worktree_entered = False
     try:
         repo_root = cwd or config.repo
-        with managed_worktree_for_goal(repo_root, goal) as wt_path:
+        with _managed_worktree_collecting(
+            repo_root, goal, cleanup_errors, pending,
+        ) as wt_path:
             worktree_entered = True
             from pmharness.bridge import (
                 _analysis_capability_payload,
@@ -1125,7 +1220,6 @@ def run_agentic_edit(
             result = None
             orchestrator_exc = None
             failure_snap: dict = {}
-            store_cleanup_exc = None
             pm_job_id = ""
             try:
                 store = create_store("sqlite", tmp)
@@ -1152,10 +1246,7 @@ def run_agentic_edit(
                     except Exception as snap_exc:
                         _diag("edit_engines.run_agentic_edit.snapshot", snap_exc)
             finally:
-                try:
-                    shutil.rmtree(tmp, ignore_errors=True)
-                except Exception as rmtree_exc:
-                    store_cleanup_exc = rmtree_exc
+                _cleanup_store_dir(tmp, cleanup_errors)
 
             patch = ""
             files_changed: list = []
@@ -1179,8 +1270,6 @@ def run_agentic_edit(
                 )
             elif finalize_exc is not None:
                 primary_error = PATCH_CAPTURE_FAILED
-            elif store_cleanup_exc is not None and result is None:
-                primary_error = WORKER_CLEANUP_FAILED
 
             if orchestrator_exc is not None:
                 usage = _usage_from_snapshot(failure_snap)
@@ -1239,23 +1328,6 @@ def run_agentic_edit(
                     failure_stderr=str(git_fail.get("failure_stderr") or ""),
                 ), result, worktree_existed=True, snap=failure_snap,
                     job_id_hint=pm_job_id)
-
-            if store_cleanup_exc is not None and result is None:
-                return finish(WorkerResult(
-                    ok=False,
-                    error=WORKER_CLEANUP_FAILED,
-                    summary=_redact_text(
-                        f"Worker cleanup failed: {store_cleanup_exc}"
-                    ),
-                    worktree=wt_path,
-                    managed_worktree_path=wt_path,
-                    managed_worktree_mode="managed",
-                    worktree_diff_empty=worktree_diff_empty,
-                    events=list(mapped_events),
-                    patch_capture_status=patch_capture_status,
-                    usage_known=False,
-                    cost_known=False,
-                ), worktree_existed=True, snap=failure_snap)
 
             tokens_out, tokens_in, failure, final_text = _summarize_agentic_result(result)
             usage_known = _artifacts_usage_known(result)
@@ -1422,7 +1494,7 @@ def run_agentic_edit(
         _diag("edit_engines.run_agentic_edit", exc)
         if not worktree_entered:
             git_fail = _failure_fields_from_exc(exc)
-            return finish(WorkerResult(
+            return _apply_cleanup_provenance(finish(WorkerResult(
                 ok=False,
                 error=WORKTREE_CREATE_FAILED,
                 summary=f"Worktree create failed: {_redact_text(str(exc))}",
@@ -1432,15 +1504,15 @@ def run_agentic_edit(
                 failure_command=git_fail.get("failure_command") or "git worktree add",
                 failure_exit_code=git_fail.get("failure_exit_code"),
                 failure_stderr=_redact_text(str(exc)),
-            ), worktree_existed=False)
-        return finish(WorkerResult(
+            ), worktree_existed=False), cleanup_errors)
+        return _apply_cleanup_provenance(finish(WorkerResult(
             ok=False,
             error=AGENTIC_ERROR,
             summary=f"Agentic engine error: {_redact_text(str(exc))}",
             managed_worktree_mode="managed",
             worktree_diff_empty=None,
             patch_capture_status="skipped",
-        ), worktree_existed=True)
+        ), worktree_existed=True), cleanup_errors)
 
 
 # Store event names that already mean a tool/action boundary (not lifecycle).

--- a/harness/worker.py
+++ b/harness/worker.py
@@ -129,6 +129,9 @@ class WorkerResult:
     failure_command: str = ""
     failure_exit_code: Optional[int] = None
     failure_stderr: str = ""
+    cleanup_status: str = ""
+    cleanup_stage: str = ""
+    cleanup_error: str = ""
     usage_known: Optional[bool] = None
     cost_known: Optional[bool] = None
     http_status: Optional[int] = None

--- a/harness/worktrees.py
+++ b/harness/worktrees.py
@@ -680,12 +680,13 @@ def _current_branch(repo: str) -> str:
     return "" if name == "HEAD" else name
 
 
-def delete_branch(repo: str, branch: str) -> None:
+def delete_branch(repo: str, branch: str, raise_on_error: bool = False) -> None:
     """Force-delete a managed edit/worker branch or a stale local release head.
 
     ``pmedit-*`` / ``pmworker-*`` and leftover ``release/v0.9.*`` are eligible.
     Current checkout, ``main`` / ``master`` / ``dev`` are never deleted;
-    unrelated names are refused (no-op).
+    unrelated names are refused (no-op). Missing branches are success.
+    When ``raise_on_error`` is true, a real ``git branch -D`` failure raises.
     """
     if not branch:
         return
@@ -699,7 +700,7 @@ def delete_branch(repo: str, branch: str) -> None:
         return
     if branch == _current_branch(repo):
         return
-    subprocess.run(
+    proc = subprocess.run(
         ["git", "-C", repo, "branch", "-D", branch],
         capture_output=True,
         text=True,
@@ -707,6 +708,14 @@ def delete_branch(repo: str, branch: str) -> None:
         errors="replace",
         timeout=15,
     )
+    if proc.returncode == 0:
+        return
+    err = ((proc.stderr or "") + "\n" + (proc.stdout or "")).strip()
+    lowered = err.lower()
+    if "not found" in lowered or "does not exist" in lowered or "doesn't exist" in lowered:
+        return
+    if raise_on_error:
+        raise RuntimeError(err or "git branch -D failed")
 
 
 def prune_orphan_edit_branches(repo: str) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.370"
+version = "0.9.371"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_edit_engines.py
+++ b/tests/test_edit_engines.py
@@ -46,7 +46,10 @@ EXPECTED_CAP_KEY = "max_capability" if ROUTER_HAS_CEILING else "min_capability"
 
 
 def create_temp_git_repo():
-    repo_dir = tempfile.mkdtemp()
+    # Unique parent so xdist workers do not share /tmp/.pmharness-worktrees.
+    root = tempfile.mkdtemp()
+    repo_dir = os.path.join(root, "repo")
+    os.mkdir(repo_dir)
     subprocess.run(["git", "init", "-b", "main"], cwd=repo_dir, capture_output=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_dir, capture_output=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_dir, capture_output=True)

--- a/tests/test_edit_engines.py
+++ b/tests/test_edit_engines.py
@@ -21,6 +21,7 @@ from harness.edit_engines import (
     AGENTIC_TIMEOUT,
     AGENTIC_UNAVAILABLE,
     PATCH_CAPTURE_FAILED,
+    WORKER_CLEANUP_FAILED,
     WORKTREE_CREATE_FAILED,
     agentic_available,
     agentic_events_from_store,
@@ -75,7 +76,7 @@ def _fake_pm_result(artifacts=None):
 
 
 @contextlib.contextmanager
-def _fake_managed_worktree(repo: str, base: str = "HEAD"):
+def _fake_managed_worktree(*_args, **_kwargs):
     wt = tempfile.mkdtemp()
     try:
         yield wt
@@ -1108,7 +1109,7 @@ def test_agentic_edit_worktree_create_failed(monkeypatch):
         monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
 
         @contextlib.contextmanager
-        def _boom_worktree(repo, goal, base="HEAD"):
+        def _boom_worktree(*_args, **_kwargs):
             raise RuntimeError(
                 "fatal: could not create worktree api_key=sk-abcdefghijklmnopqrstuvwxyz"
             )
@@ -1666,7 +1667,10 @@ def test_run_edit_worker_falls_back_on_route_and_runtime_errors(monkeypatch):
             "harness.edit_engines.run_native_edit",
             lambda *a, **k: native_called.append(True) or WorkerResult(ok=False),
         )
-        for err in (AGENTIC_ORCHESTRATOR_FAILED, PATCH_CAPTURE_FAILED, AGENTIC_ERROR):
+        for err in (
+            AGENTIC_ORCHESTRATOR_FAILED, PATCH_CAPTURE_FAILED, AGENTIC_ERROR,
+            WORKER_CLEANUP_FAILED,
+        ):
             monkeypatch.setattr(
                 "harness.edit_engines.run_agentic_edit",
                 lambda *a, err=err, **k: WorkerResult(ok=False, error=err, patch=""),
@@ -1756,6 +1760,7 @@ def test_agentic_edit_patch_capture_failed(monkeypatch):
         result = run_agentic_edit(cfg, "goal")
         assert result.ok is False
         assert result.error == PATCH_CAPTURE_FAILED
+        assert result.patch == ""
         assert result.worktree_diff_empty is None
         assert result.patch_capture_status == "failed"
         assert result.requested_mode == "implement"
@@ -1810,6 +1815,8 @@ def test_agentic_edit_cleanup_failure_keeps_orchestrator_error(monkeypatch):
 
         def boom_rmtree(path, *a, **k):
             if os.path.basename(str(path)).startswith("pmh-edit-"):
+                if k.get("ignore_errors"):
+                    return real_rmtree(path, *a, **k)
                 raise OSError("rmtree denied")
             return real_rmtree(path, *a, **k)
 
@@ -1817,8 +1824,155 @@ def test_agentic_edit_cleanup_failure_keeps_orchestrator_error(monkeypatch):
         result = run_agentic_edit(cfg, "implement the thing")
         assert result.error == AGENTIC_ORCHESTRATOR_FAILED
         assert "incomplete tasks" in (result.summary or "")
+        assert "Cleanup also failed" in (result.summary or "")
         assert result.managed_worktree_mode == "managed"
+        assert result.cleanup_status == "failed"
+        assert "store" in (result.cleanup_stage or "")
     finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_apply_cleanup_provenance_keeps_primary_and_patch():
+    from harness.edit_engines import _apply_cleanup_provenance
+
+    wr = WorkerResult(
+        ok=False,
+        error=AGENTIC_ORCHESTRATOR_FAILED,
+        summary="orch boom",
+        patch="diff --git a/x b/x\n+line",
+    )
+    _apply_cleanup_provenance(wr, [{"stage": "store", "exc": OSError("rmtree denied")}])
+    assert wr.error == AGENTIC_ORCHESTRATOR_FAILED
+    assert wr.ok is False
+    assert wr.patch.startswith("diff --git")
+    assert wr.cleanup_status == "failed"
+    assert wr.cleanup_stage == "store"
+    assert "Cleanup also failed" in wr.summary
+
+    clean = WorkerResult(ok=True, patch="diff --git a/y b/y\n+ok")
+    _apply_cleanup_provenance(clean, [
+        {"stage": "worktree_remove", "exc": RuntimeError("worktree remove denied")},
+    ])
+    assert clean.error == WORKER_CLEANUP_FAILED
+    assert clean.ok is False
+    assert clean.patch.startswith("diff --git")
+    assert clean.cleanup_stage == "worktree_remove"
+    assert "Worker cleanup failed" in clean.summary
+
+
+def test_managed_worktree_records_remove_failure(monkeypatch):
+    from harness.worktrees import list_worktrees
+    from harness.worktrees import remove_worktree as real_remove
+
+    repo_dir = create_temp_git_repo()
+    bag = []
+
+    def boom_remove(*_a, **_k):
+        raise RuntimeError("worktree remove denied")
+
+    monkeypatch.setattr("harness.worktrees.remove_worktree", boom_remove)
+    try:
+        with managed_worktree(repo_dir, cleanup_errors=bag) as wt_path:
+            assert os.path.isdir(wt_path)
+        assert bag
+        assert bag[0]["stage"] == "worktree_remove"
+    finally:
+        for wt in list_worktrees(repo_dir):
+            path = (wt.get("path") or "").strip()
+            if path and os.path.realpath(path) != os.path.realpath(repo_dir):
+                with contextlib.suppress(Exception):
+                    real_remove(repo_dir, path, force=True)
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_worktree_remove_failure_keeps_patch(monkeypatch):
+    from harness.worktrees import list_worktrees
+    from harness.worktrees import remove_worktree as real_remove
+
+    repo_dir = create_temp_git_repo()
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        class _OkOrch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                return _fake_pm_result([
+                    _fake_artifact(tokens_out=1, tokens_in=1, stdout="ok"),
+                ])
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _OkOrch)
+        monkeypatch.setattr(
+            "harness.edit_engines.finalize_worktree_patch",
+            lambda _wt: ("diff --git a/x b/x\n+line", ["x.py"]),
+        )
+
+        def boom_remove(*_a, **_k):
+            raise RuntimeError("worktree remove denied")
+
+        monkeypatch.setattr("harness.worktrees.remove_worktree", boom_remove)
+        result = run_agentic_edit(cfg, "goal")
+        assert result.ok is False
+        assert result.error == WORKER_CLEANUP_FAILED
+        assert result.patch.startswith("diff --git")
+        assert result.cleanup_status == "failed"
+        assert "worktree_remove" in (result.cleanup_stage or "").split(",")
+        assert "Worker cleanup failed" in (result.summary or "")
+    finally:
+        for wt in list_worktrees(repo_dir):
+            path = (wt.get("path") or "").strip()
+            if path and os.path.realpath(path) != os.path.realpath(repo_dir):
+                with contextlib.suppress(Exception):
+                    real_remove(repo_dir, path, force=True)
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_agentic_edit_branch_delete_failure_keeps_patch(monkeypatch):
+    from harness.worktrees import delete_branch as real_delete
+    from harness.worktrees import list_worktrees
+    from harness.worktrees import remove_worktree as real_remove
+
+    repo_dir = create_temp_git_repo()
+
+    def boom_delete(repo, branch, raise_on_error=False):
+        if raise_on_error:
+            raise RuntimeError("branch delete denied")
+        return real_delete(repo, branch, raise_on_error=raise_on_error)
+
+    try:
+        cfg = _cfg(repo_dir)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+
+        class _OkOrch:
+            def __init__(self, store):
+                self.store = store
+
+            def run(self, goal, specs=None, **kwargs):
+                return _fake_pm_result([
+                    _fake_artifact(tokens_out=1, tokens_in=1, stdout="ok"),
+                ])
+
+        monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _OkOrch)
+        monkeypatch.setattr(
+            "harness.edit_engines.finalize_worktree_patch",
+            lambda _wt: ("diff --git a/x b/x\n+line", ["x.py"]),
+        )
+        monkeypatch.setattr("harness.worktrees.delete_branch", boom_delete)
+        result = run_agentic_edit(cfg, "goal")
+        assert result.ok is False
+        assert result.error == WORKER_CLEANUP_FAILED
+        assert result.patch.startswith("diff --git")
+        assert result.cleanup_status == "failed"
+        assert result.cleanup_stage == "branch_delete"
+    finally:
+        monkeypatch.setattr("harness.worktrees.delete_branch", real_delete)
+        for wt in list_worktrees(repo_dir):
+            path = (wt.get("path") or "").strip()
+            if path and os.path.realpath(path) != os.path.realpath(repo_dir):
+                with contextlib.suppress(Exception):
+                    real_remove(repo_dir, path, force=True)
         shutil.rmtree(repo_dir, ignore_errors=True)
 
 
@@ -1846,6 +2000,7 @@ def test_agentic_edit_no_leaked_pmh_edit_dirs(monkeypatch):
         )
         ok_result = run_agentic_edit(cfg, "goal")
         assert ok_result.ok is True
+        assert ok_result.cleanup_status == "ok"
 
         class _BoomOrch:
             def __init__(self, store):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,7 +11,10 @@ from harness.worktrees import _is_repo
 
 
 def create_temp_git_repo():
-    repo_dir = tempfile.mkdtemp()
+    # Unique parent so xdist workers do not share /tmp/.pmharness-worktrees.
+    root = tempfile.mkdtemp()
+    repo_dir = os.path.join(root, "repo")
+    os.mkdir(repo_dir)
     subprocess.run(["git", "init", "-b", "main"], cwd=repo_dir, capture_output=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_dir, capture_output=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_dir, capture_output=True)
@@ -473,7 +476,7 @@ def test_provider_worker_leak_and_failure_cleanup(monkeypatch):
             keep_worktree_on_failure=False  # default is False now
         )
         res = worker.run()
-        assert res.ok is True
+        assert res.ok is True, (res.error, res.summary)
 
         # Assert worktree dir is gone
         assert not os.path.exists(res.worktree)

--- a/tests/test_worker_provenance.py
+++ b/tests/test_worker_provenance.py
@@ -811,6 +811,23 @@ def test_implement_provenance_never_renders_mode_unknown():
     assert "could not be determined" in text
 
 
+def test_cleanup_failed_provenance_is_secondary():
+    text = _worker_provenance_text({
+        "requested_mode": "implement",
+        "managed_worktree_mode": "managed",
+        "worktree_diff_empty": False,
+        "error": "agentic_orchestrator_failed",
+        "cleanup_status": "failed",
+        "cleanup_stage": "store",
+        "cleanup_error": "store: rmtree denied",
+        "live_dirty_paths_before": [],
+        "live_dirty_paths_after": [],
+    })
+    assert text.startswith("[provenance] agentic_orchestrator_failed:")
+    assert "Cleanup failed (store)" in text
+    assert "rmtree denied" in text
+
+
 def test_undetermined_diff_not_empty_recovery_or_unavailable_unknown():
     res = WorkerResult(
         ok=False,

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -13,8 +13,10 @@ from harness import worktrees as _wt
 
 
 def create_temp_git_repo():
-    repo_dir = tempfile.mkdtemp()
-    # Use config that doesn't rely on global user
+    # Unique parent so xdist workers do not share /tmp/.pmharness-worktrees.
+    root = tempfile.mkdtemp()
+    repo_dir = os.path.join(root, "repo")
+    os.mkdir(repo_dir)
     subprocess.run(["git", "init", "-b", "main"], cwd=repo_dir, capture_output=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_dir, capture_output=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_dir, capture_output=True)

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -213,6 +213,34 @@ def test_delete_branch_refuses_current_checkout():
         shutil.rmtree(repo, ignore_errors=True)
 
 
+def test_delete_branch_missing_is_success_with_raise_on_error():
+    repo = create_temp_git_repo()
+    try:
+        _wt.delete_branch(repo, "pmedit-missing1", raise_on_error=True)
+    finally:
+        shutil.rmtree(repo, ignore_errors=True)
+
+
+def test_delete_branch_raise_on_error_when_checked_out_in_worktree():
+    repo = create_temp_git_repo()
+    info = None
+    try:
+        info = _wt.add_worktree(repo, "pmedit-locked01")
+        with pytest.raises(RuntimeError):
+            _wt.delete_branch(repo, "pmedit-locked01", raise_on_error=True)
+        _wt.delete_branch(repo, "pmedit-locked01")
+        assert "pmedit-locked01" in _branch_list(repo)
+    finally:
+        if info and info.get("path"):
+            subprocess.run(
+                ["git", "-C", repo, "worktree", "remove", "--force", info["path"]],
+                capture_output=True,
+            )
+        shutil.rmtree(repo, ignore_errors=True)
+        managed_dir = os.path.abspath(os.path.join(repo, "..", ".pmharness-worktrees"))
+        shutil.rmtree(managed_dir, ignore_errors=True)
+
+
 def test_reap_stale_managed_worktrees_removes_leftover_pmedit():
     repo = create_temp_git_repo()
     managed_dir = os.path.abspath(os.path.join(repo, "..", ".pmharness-worktrees"))

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.370",
+  "version": "0.9.371",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.370",
+      "version": "0.9.371",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.370",
+  "version": "0.9.371",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Propagate managed-worktree cleanup failures (worktree remove, branch delete, store rmtree) instead of swallowing them with `contextlib.suppress` / `ignore_errors`.
- Keep orchestrator and patch-capture errors as primary; attach cleanup as secondary `WorkerResult` provenance (`cleanup_status` / `cleanup_stage` / `cleanup_error`).
- Return `worker_cleanup_failed` only when cleanup is the sole failure, and keep a captured patch on that result. `worker_cleanup_failed` stays out of native fallback.

## Test plan
- [x] Local `.venv` pytest: 5268 passed, 78 skipped
- [ ] Dest-into-main `tests` matrix (3.9, 3.11, Windows, frontend-build)
- [ ] After merge: `scripts/ci_release_gate.py require-green`, tag `v0.9.371` when `merge^{tree}` matches this PR tree
- [ ] Post-install: tiny pinned Luna `run_implement` probe (user)