### PR TITLE
Release v0.9.372

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.37` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.371, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.372, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 
@@ -260,6 +260,7 @@ The driver and keys are set in the app (Settings pane) or via env. Key vars:
 | `HARNESS_COMPACTION_RESIDUAL` | Compact residual. Default `catalog` (also the empty/invalid fallback). Settings cycle: catalog, hybrid, summary. `off` is env-only. |
 | `HARNESS_COMPACTION_VAULT` | SQLite FTS retrieve of compacted history (default on). Set `0` to disable inject. |
 | `HARNESS_AUTO_COMMAND_GUARD` | Full-auto danger guard; default on, off to disable. |
+| `HARNESS_BROWSER_REAL_PROFILE` | Consent-gated copy of last-used Chrome/Chromium login data into `~/.pmharness/browser-profile-real`. Default off. Settings > Safety: Use my Chrome login. |
 | `HARNESS_WIKI_ORCHESTRATE` | Local wiki structuring: unset (off), 1/approve (prepare-and-approve), auto (silent ingest). |
 | `HARNESS_AUTO_MAX_SWARMS` / `_TOKENS` / `_SECONDS` / `_MAX_IDLE` | Full-auto budget governor ceilings. |
 | `HARNESS_APPEND_ONLY_CONTEXT` | Force append-only KV-cache context mode (auto-detected for local/cache-discounting endpoints when unset). |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.371"
+__version__ = "0.9.372"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/settings.py
+++ b/harness/api/settings.py
@@ -210,6 +210,16 @@ def post_settings(body: dict, svc: SettingsServices) -> tuple[int, JsonPayload]:
         g_val = svc.parse_bool(body["autoCommandGuard"])
         pilot._auto_command_guard = g_val
         _set_env_setting("HARNESS_AUTO_COMMAND_GUARD", "true" if g_val else "off")
+    if "browserRealProfile" in body:
+        rp_val = svc.parse_bool(body["browserRealProfile"])
+        _set_env_setting("HARNESS_BROWSER_REAL_PROFILE", "1" if rp_val else "0")
+        if not rp_val:
+            from ..browser_real_profile import cleanup_real_profile_snapshots
+            cleanup_real_profile_snapshots()
+        else:
+            # Drop a process-lifetime isolated-profile bind so the next
+            # browser launch re-resolves through snapshot_real_profile.
+            os.environ.pop("PM_BROWSER_USER_DATA_DIR", None)
     if "autoVerify" in body:
         av_val = svc.parse_bool(body["autoVerify"])
         cfg.auto_verify = av_val

--- a/harness/browser.py
+++ b/harness/browser.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import sys
 import time
+from pathlib import Path
 from typing import Optional
 
 try:
@@ -214,7 +215,13 @@ def browser_get_text() -> str:
 
 
 def browser_screenshot(out_dir: Optional[str] = None) -> str:
-    return _call("screenshot", "screenshot", out_dir)
+    if out_dir is None or not str(out_dir).strip():
+        dest = Path.home() / ".pmharness" / "browser-shots"
+        dest.mkdir(parents=True, exist_ok=True)
+        resolved = str(dest)
+    else:
+        resolved = out_dir
+    return _call("screenshot", "screenshot", resolved)
 
 
 def browser_relay_enabled() -> bool:

--- a/harness/browser_auth.py
+++ b/harness/browser_auth.py
@@ -18,6 +18,8 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from .browser_real_profile import real_profile_enabled, snapshot_real_profile
+
 AUTH_ENV = "HARNESS_BROWSER_AUTH"
 HEADED_ENV = "HARNESS_BROWSER_HEADED"
 DEFAULT_CDP_PORT = "9333"
@@ -72,9 +74,14 @@ def ensure_shared_browser_env(*, headed: Optional[bool] = None) -> dict:
         elif headed_enabled() and "PM_BROWSER_HEADED" not in os.environ:
             os.environ["PM_BROWSER_HEADED"] = "1"
         if not (os.environ.get("PM_BROWSER_USER_DATA_DIR") or "").strip():
-            path = default_profile_dir()
-            Path(path).mkdir(parents=True, exist_ok=True)
-            os.environ["PM_BROWSER_USER_DATA_DIR"] = path
+            if real_profile_enabled():
+                copy_dir, _err = snapshot_real_profile()
+                if copy_dir:
+                    os.environ["PM_BROWSER_USER_DATA_DIR"] = copy_dir
+            if not (os.environ.get("PM_BROWSER_USER_DATA_DIR") or "").strip():
+                path = default_profile_dir()
+                Path(path).mkdir(parents=True, exist_ok=True)
+                os.environ["PM_BROWSER_USER_DATA_DIR"] = path
         if not (os.environ.get("PM_BROWSER_CDP_PORT") or "").strip():
             os.environ["PM_BROWSER_CDP_PORT"] = DEFAULT_CDP_PORT
         applied = {

--- a/harness/browser_real_profile.py
+++ b/harness/browser_real_profile.py
@@ -1,0 +1,322 @@
+"""Consent-gated snapshot of the user's real Chromium profile auth files.
+
+When ``HARNESS_BROWSER_REAL_PROFILE`` is on, copy last-used Chrome / Chromium
+/ Edge / Brave auth files into a Marionette-owned directory and launch against
+that copy — never the live user-data-dir (SingletonLock / Chrome >= 136).
+Default off, including on desktop, until the user consents. Under pytest/CI
+the flag stays off unless the env is explicitly truthy.
+
+Never logs or returns cookies or passwords. Never kills the user's browser.
+A locked cookie DB (Windows PermissionError) fails closed so we do not launch
+a silently signed-out copy.
+"""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import sqlite3
+from pathlib import Path
+from typing import Optional, Tuple
+from urllib.request import pathname2url
+
+REAL_PROFILE_ENV = "HARNESS_BROWSER_REAL_PROFILE"
+_TRUTHY = ("1", "true", "yes", "on")
+_SNAPSHOT_DONE_MARKER = ".marionette-snapshot-complete"
+_COPY_ROOT_NAME = "browser-profile-real"
+
+# Profile-dir names skipped on the first copytree. Auth SQLite files are
+# excluded here and copied via online-backup so a live Chrome lock cannot
+# abort the tree copy or leave a torn DB.
+_COPYTREE_IGNORES = (
+    "Cache",
+    "Code Cache",
+    "GPUCache",
+    "Service Worker",
+    "Crashpad",
+    "Cookies",
+    "Login Data",
+    "Login Data For Account",
+    "Web Data",
+    "*-journal",
+    "*-wal",
+    "*-shm",
+    "SingletonLock",
+    "SingletonSocket",
+    "SingletonCookie",
+)
+
+_AUTH_DB_RELS = (
+    "Cookies",
+    "Network/Cookies",
+    "Login Data",
+    "Login Data For Account",
+    "Web Data",
+)
+_AUTH_PLAIN_RELS = ("Preferences",)
+
+_BROWSER_PATHS = {
+    "chrome": (
+        ("Google", "Chrome"),
+        ("Google", "Chrome", "User Data"),
+        "google-chrome",
+    ),
+    "edge": (
+        ("Microsoft Edge",),
+        ("Microsoft", "Edge", "User Data"),
+        "microsoft-edge",
+    ),
+    "brave": (
+        ("BraveSoftware", "Brave-Browser"),
+        ("BraveSoftware", "Brave-Browser", "User Data"),
+        "BraveSoftware/Brave-Browser",
+    ),
+    "chromium": (
+        ("Chromium",),
+        ("Chromium", "User Data"),
+        "chromium",
+    ),
+}
+
+_LINUX_SNAP_PARTS = {
+    "chrome": ("snap", "google-chrome", "current", ".config", "google-chrome"),
+    "chromium": ("snap", "chromium", "common", "chromium"),
+    "brave": ("snap", "brave", "current", ".config", "BraveSoftware", "Brave-Browser"),
+}
+
+_LINUX_FLATPAK_IDS = {
+    "chrome": "com.google.Chrome",
+    "chromium": "org.chromium.Chromium",
+    "brave": "com.brave.Browser",
+    "edge": "com.microsoft.Edge",
+}
+
+
+def real_profile_enabled() -> bool:
+    """Return whether the user consented to a real-profile snapshot.
+
+    Off unless ``HARNESS_BROWSER_REAL_PROFILE`` is 1/true/yes/on. Unlike
+    browser auth, desktop does not default this on — consent is required.
+    """
+    raw = (os.environ.get(REAL_PROFILE_ENV) or "").strip().lower()
+    return raw in _TRUTHY
+
+
+def real_profile_data_dir(browser: str = "chrome", system: Optional[str] = None) -> Path:
+    """Return the OS default user-data-dir for ``browser``."""
+    key = browser if browser in _BROWSER_PATHS else "chrome"
+    mac_parts, win_parts, linux_name = _BROWSER_PATHS[key]
+    host = system or platform.system()
+    home = Path.home()
+    if host == "Darwin":
+        return home / "Library" / "Application Support" / Path(*mac_parts)
+    if host == "Windows":
+        local = os.environ.get("LOCALAPPDATA") or str(home / "AppData" / "Local")
+        return Path(local).joinpath(*win_parts)
+    config = os.environ.get("XDG_CONFIG_HOME") or str(home / ".config")
+    candidates = [Path(config).joinpath(*linux_name.split("/"))]
+    snap = _LINUX_SNAP_PARTS.get(key)
+    if snap:
+        candidates.append(home.joinpath(*snap))
+    flatpak_id = _LINUX_FLATPAK_IDS.get(key)
+    if flatpak_id:
+        candidates.append(
+            home / ".var" / "app" / flatpak_id / "config" / Path(*linux_name.split("/"))
+        )
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    return candidates[0]
+
+
+def real_profile_copy_dir(browser: str = "chrome") -> Path:
+    """Return the Marionette-owned snapshot dir for ``browser``."""
+    return Path.home() / ".pmharness" / _COPY_ROOT_NAME / browser
+
+
+def _last_used_profile(src: Path) -> str:
+    """Return ``Local State`` ``profile.last_used``, or Default."""
+    try:
+        with open(src / "Local State", encoding="utf-8", errors="replace") as fh:
+            state = json.load(fh)
+        last = ((state.get("profile") or {}).get("last_used")) or "Default"
+    except (OSError, ValueError, TypeError, AttributeError):
+        last = "Default"
+    if not isinstance(last, str) or not (src / last).is_dir():
+        return "Default"
+    return last
+
+
+def _copy_auth_db(src_file: Path, dst_file: Path) -> bool:
+    """Copy one SQLite auth DB via URI readonly + ``Connection.backup``."""
+    if not src_file.is_file():
+        return False
+    dst_file.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        if dst_file.exists():
+            dst_file.unlink()
+    except OSError:
+        pass
+    uri = "file:%s?mode=ro" % pathname2url(os.path.abspath(str(src_file)))
+    try:
+        source = sqlite3.connect(uri, uri=True, timeout=5)
+        try:
+            dest = sqlite3.connect(str(dst_file))
+            try:
+                source.backup(dest)
+            finally:
+                dest.close()
+        finally:
+            source.close()
+        return True
+    except Exception:
+        return False
+
+
+def _cookie_db_path(src: Path, source_profile: str) -> Optional[Path]:
+    for rel in ("Network/Cookies", "Cookies"):
+        cand = src / source_profile / rel
+        if cand.is_file():
+            return cand
+    return None
+
+
+def _lock_error(src: Path, source_profile: str) -> Optional[str]:
+    db = _cookie_db_path(src, source_profile)
+    if db is None:
+        return None
+    try:
+        with open(db, "rb"):
+            return None
+    except PermissionError:
+        return (
+            "profile locked: cookie database is in use. Fully quit Chrome "
+            "(including any background/tray instance) and retry. Closing "
+            "Chrome may be required on Windows if the copy fails."
+        )
+    except OSError:
+        return None
+
+
+def _chmod_owner_only(path: Path) -> None:
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        pass
+
+
+def snapshot_real_profile(
+    browser: str = "chrome",
+    src: Optional[Path] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Copy last-used profile auth into the Marionette-owned copy dir.
+
+    Returns ``(copy_dir, None)`` on success or ``(None, error)`` on failure.
+    The error for a locked cookie DB always starts with ``profile locked:``.
+    """
+    if src is None:
+        src_path = real_profile_data_dir(browser)
+    else:
+        src_path = Path(src)
+    if not src_path.is_dir():
+        return None, (
+            "profile directory for %r was not found (%s). Launch that browser "
+            "at least once, or turn off Use my Chrome login."
+            % (browser, src_path)
+        )
+    last_used = _last_used_profile(src_path)
+    locked = _lock_error(src_path, last_used)
+    if locked:
+        return None, locked
+
+    copy_dir = real_profile_copy_dir(browser)
+    try:
+        copy_dir.mkdir(parents=True, exist_ok=True)
+        parent = copy_dir.parent
+        _chmod_owner_only(parent)
+        _chmod_owner_only(copy_dir)
+
+        local_state = src_path / "Local State"
+        if local_state.is_file():
+            shutil.copy2(str(local_state), str(copy_dir / "Local State"))
+
+        marker = copy_dir / _SNAPSHOT_DONE_MARKER
+        if not marker.is_file():
+            src_profile = src_path / last_used
+            dst_default = copy_dir / "Default"
+            if not src_profile.is_dir():
+                return None, (
+                    "profile directory for %r was not found (%s). Launch that "
+                    "browser at least once, or turn off Use my Chrome login."
+                    % (browser, src_profile)
+                )
+            shutil.rmtree(str(dst_default), ignore_errors=True)
+            try:
+                shutil.copytree(
+                    str(src_profile),
+                    str(dst_default),
+                    symlinks=False,
+                    ignore=shutil.ignore_patterns(*_COPYTREE_IGNORES),
+                    ignore_dangling_symlinks=True,
+                    dirs_exist_ok=True,
+                )
+            except shutil.Error:
+                pass
+
+        dst_default = copy_dir / "Default"
+        for rel in _AUTH_DB_RELS:
+            src_file = src_path / last_used / rel
+            if not src_file.is_file():
+                continue
+            if not _copy_auth_db(src_file, dst_default / rel):
+                return None, (
+                    "could not copy login data from the %r profile. Fully quit "
+                    "the browser and retry, or turn off Use my Chrome login."
+                    % browser
+                )
+        for rel in _AUTH_PLAIN_RELS:
+            src_file = src_path / last_used / rel
+            if not src_file.is_file():
+                continue
+            dest = dst_default / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                shutil.copy2(str(src_file), str(dest))
+            except OSError:
+                return None, (
+                    "could not copy login data from the %r profile. Fully quit "
+                    "the browser and retry, or turn off Use my Chrome login."
+                    % browser
+                )
+
+        for leftover in ("SingletonLock", "SingletonSocket", "SingletonCookie"):
+            try:
+                (copy_dir / leftover).unlink()
+            except OSError:
+                pass
+
+        marker.write_text(last_used, encoding="utf-8")
+    except OSError as e:
+        return None, "could not snapshot the %r profile into %s: %s" % (
+            browser,
+            copy_dir,
+            e,
+        )
+    return str(copy_dir), None
+
+
+def cleanup_real_profile_snapshots() -> None:
+    """Delete the real-profile copy tree. Idempotent; ignore_errors."""
+    root = Path.home() / ".pmharness" / _COPY_ROOT_NAME
+    shutil.rmtree(str(root), ignore_errors=True)
+    current = (os.environ.get("PM_BROWSER_USER_DATA_DIR") or "").strip()
+    if not current:
+        return
+    try:
+        cur = Path(current).resolve()
+        root_resolved = root.resolve()
+        if root_resolved == cur or root_resolved in cur.parents:
+            os.environ.pop("PM_BROWSER_USER_DATA_DIR", None)
+    except (OSError, ValueError):
+        pass

--- a/harness/compaction_mixin.py
+++ b/harness/compaction_mixin.py
@@ -22,6 +22,8 @@ import threading
 import time
 from typing import Iterator, Optional
 
+from .context_budget import age_history_images
+
 # grok-build-style quality floors (see xai-grok-compaction summary.rs /
 # intra_compaction/config.rs). Floor / reduction guards fail closed: an
 # exception in those paths refuses compaction rather than applying a bad rewrite.
@@ -841,6 +843,16 @@ class CompactionContextMixin:
             RESIDUAL_OFF,
             compaction_residual_mode,
         )
+        # 413 recovery is a byte problem: drop stale data-URL images before
+        # any residual/trigger gate so emergency compact actually frees payload.
+        if emergency:
+            try:
+                aged = age_history_images(self._history, keep_last_user=True)
+                if aged:
+                    self._history[:] = aged
+                    self._invalidate_ctx_cache()
+            except Exception:
+                pass
 
         residual_mode = compaction_residual_mode()
         # Explicit off only — empty/invalid env values stay on catalog.
@@ -941,6 +953,15 @@ class CompactionContextMixin:
 
         middle_block = self._history[1:split_idx]
         recent_block = self._history[split_idx:]
+        # Non-emergency: strip images from the summarized/dropped middle only.
+        # Live tail (including the latest user image) stays intact.
+        if not emergency:
+            try:
+                middle_block = age_history_images(
+                    middle_block, keep_last_user=False,
+                )
+            except Exception:
+                pass
         if not middle_block:
             self._set_compaction_attempt(
                 REASON_NO_COMPACTABLE,

--- a/harness/context_budget.py
+++ b/harness/context_budget.py
@@ -1,4 +1,6 @@
 import os
+import copy
+import json
 import math
 import hashlib
 import logging
@@ -41,6 +43,74 @@ def truncate_bytes(content: str, max_bytes: int) -> str:
         return content
     # Decode the leading max_bytes, dropping any partial trailing character.
     return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def serialized_history_bytes(messages: Any) -> int:
+    """UTF-8 byte length of json-serialized history. Never raises.
+
+    HTTP 413 is a byte-size error. Inline data-URL image payloads dominate
+    that budget and must be counted exactly — token heuristics price images
+    cheap and will report "no progress" after a compact that freed megabytes.
+    """
+    try:
+        if not isinstance(messages, (list, tuple)):
+            return 0
+        payload = json.dumps(messages, default=str, ensure_ascii=False)
+        return len(payload.encode("utf-8"))
+    except Exception:
+        return 0
+
+
+_IMAGE_REMOVED_DURING_COMPACTION = "[image removed during compaction]"
+
+
+def _is_image_url_part(part: Any) -> bool:
+    return isinstance(part, dict) and part.get("type") == "image_url"
+
+
+def age_history_images(messages: Any, keep_last_user: bool = True) -> list:
+    """Replace stale ``image_url`` parts with a text marker. Copies only.
+
+    Walks each message; list-of-parts content has ``image_url`` parts swapped
+    for ``{"type": "text", "text": "[image removed during compaction]"}``.
+    When ``keep_last_user`` is True, image parts on the most recent user
+    message are kept (the live tail the model still needs to see).
+    """
+    if not isinstance(messages, list):
+        return []
+    try:
+        last_user_idx = -1
+        if keep_last_user:
+            for i in range(len(messages) - 1, -1, -1):
+                msg = messages[i]
+                if isinstance(msg, dict) and msg.get("role") == "user":
+                    last_user_idx = i
+                    break
+        aged: list = []
+        for i, msg in enumerate(messages):
+            if not isinstance(msg, dict):
+                aged.append(copy.deepcopy(msg))
+                continue
+            cloned = copy.deepcopy(msg)
+            if keep_last_user and i == last_user_idx:
+                aged.append(cloned)
+                continue
+            content = cloned.get("content")
+            if isinstance(content, list):
+                cloned["content"] = [
+                    (
+                        {"type": "text", "text": _IMAGE_REMOVED_DURING_COMPACTION}
+                        if _is_image_url_part(part)
+                        else part
+                    )
+                    for part in content
+                ]
+            aged.append(cloned)
+        return aged
+    except Exception:
+        # Never hand the caller an empty list for a non-empty history
+        # (emergency compact assigns this onto `_history`).
+        return list(messages) if isinstance(messages, list) else []
 
 
 def content_hash(content: str, length: int = 12) -> str:

--- a/harness/pilot.py
+++ b/harness/pilot.py
@@ -1289,7 +1289,7 @@ def build_tools_schema(
         "type": "function",
         "function": {
             "name": "view_image",
-            "description": "View/describe an image file (screenshot, diagram, photo, mockup). Use this to SEE an image referenced in the task or repo -- it is transcribed to a precise text description you can reason over. Requires path (path to a .png/.jpg/.jpeg/.webp image, relative to the repo or absolute).",
+            "description": "View an image file. Path required. Native-vision pilots see the image; text-only pilots get a sidecar transcription.",
             "parameters": {
                 "type": "object",
                 "properties": {

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -172,6 +172,9 @@ def profile_skips_auto_inject(session: Any) -> tuple[bool, bool]:
 # After emergency compact, a remaining "overflow" on a tiny history is almost
 # always a misclassified provider 400 (completion max_tokens), not a window blow.
 OVERFLOW_RETRY_SMALL_CONTEXT_TOKENS = 16_000
+# HTTP 413 is a byte-size error. Retry while serialized history shrinks, not
+# forever and not on a flat token heuristic (images are priced cheap).
+OVERFLOW_RETRY_MAX_ATTEMPTS = 3
 
 
 def format_overflow_persist_error(
@@ -202,6 +205,50 @@ def format_overflow_persist_error(
             "after compaction. Start a fresh session or pick a "
             "longer-context model."
         )
+
+
+def iter_overflow_byte_recovery(session, resp, attempt, timing):
+    """Emergency-compact after CONTEXT_OVERFLOW; retry only if bytes drop.
+
+    Yields compaction (and possibly persist-error) events. Return value is
+    True when the caller should ``continue`` the provider loop.
+    """
+    from .conversation import ConvEvent
+    from .context_budget import serialized_history_bytes
+
+    def _persist():
+        try:
+            est = int(session._estimate_context_tokens() or 0)
+        except Exception:
+            est = 0
+        return ConvEvent("error", {
+            "error": format_overflow_persist_error(
+                (getattr(resp, "error", None) or ""),
+                est,
+                session._humanize_pilot_error,
+            ),
+        })
+
+    if attempt >= OVERFLOW_RETRY_MAX_ATTEMPTS - 1:
+        yield _persist()
+        return False
+    try:
+        bytes_before = serialized_history_bytes(session._history)
+    except Exception:
+        bytes_before = 0
+    reset_provider_step_timing(timing)
+    yield from yield_timed_phase(
+        timing, "advisory_compaction",
+        session._maybe_compact_history(force=True, emergency=True),
+    )
+    try:
+        bytes_after = serialized_history_bytes(session._history)
+    except Exception:
+        bytes_after = bytes_before
+    if bytes_after >= bytes_before:
+        yield _persist()
+        return False
+    return True
 
 
 class SendLoopMixin:
@@ -1197,7 +1244,7 @@ class SendLoopMixin:
 
             resp = None
             self._streamed_prose = ""  # reset per step; set if this step streams
-            for attempt in range(2):
+            for attempt in range(OVERFLOW_RETRY_MAX_ATTEMPTS):
                 # Sanitize BEFORE rendering/dispatch so both chat() and
                 # complete() see healed tool_use/tool_result pairs. (A prior
                 # interrupted spree — cancel/steer/worker-ceiling/exception —
@@ -1275,30 +1322,12 @@ class SendLoopMixin:
                     from pmharness.drivers import error_classifier
                     err_cls = error_classifier.classify(None, resp.error)
                     if err_cls == error_classifier.ErrorClass.CONTEXT_OVERFLOW:
-                        if attempt == 0:
-                            # Reset this attempt's provider marks only —
-                            # keep closed turn-once pre-request durations.
-                            reset_provider_step_timing(timing)
-                            yield from yield_timed_phase(
-                                timing, "advisory_compaction",
-                                self._maybe_compact_history(
-                                    force=True, emergency=True,
-                                ),
-                            )
+                        retry = yield from iter_overflow_byte_recovery(
+                            self, resp, attempt, timing,
+                        )
+                        if retry:
                             continue
-                        else:
-                            try:
-                                est = int(self._estimate_context_tokens() or 0)
-                            except Exception:
-                                est = 0
-                            yield ConvEvent("error", {
-                                "error": format_overflow_persist_error(
-                                    resp.error or "",
-                                    est,
-                                    self._humanize_pilot_error,
-                                ),
-                            })
-                            return
+                        return
 
                 # If there's no error or it is not context overflow, we're done
                 break

--- a/harness/server.py
+++ b/harness/server.py
@@ -2962,6 +2962,7 @@ def _settings_compaction_residual():
 
 
 def _get_settings_dict():
+    from harness.browser_real_profile import real_profile_enabled
     from harness.hash_edit import hash_edit_enabled
     from harness.reasoning_effort import current_reasoning_effort
     from harness.session_trace import session_trace_export_enabled
@@ -2989,6 +2990,7 @@ def _get_settings_dict():
         "autoVerify": getattr(_cfg, "auto_verify", True),
         "verifyCommand": getattr(_cfg, "verify_command", ""),
         "autoCommandGuard": getattr(_pilot, "_auto_command_guard", True),
+        "browserRealProfile": real_profile_enabled(),
         "hash_edit_enabled": hash_edit_enabled(),
         "session_trace_export": session_trace_export_enabled(),
         "commandTimeout": (os.environ.get("HARNESS_COMMAND_TIMEOUT", "").strip() or "120"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.371"
+version = "0.9.372"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,6 +336,7 @@ def _isolate_pilot_env(monkeypatch):
         "HARNESS_AUTO_VERIFY",
         "HARNESS_HASH_EDIT",
         "HARNESS_COMPACTION_RESIDUAL",
+        "HARNESS_BROWSER_REAL_PROFILE",
         "HARNESS_VERIFY_COMMAND",
         "HARNESS_COMMAND_TIMEOUT",
         "HARNESS_SWARM_ADAPTER",

--- a/tests/test_413_image_payload_recovery.py
+++ b/tests/test_413_image_payload_recovery.py
@@ -1,0 +1,108 @@
+"""HTTP 413 is a byte-size error. Token heuristics undercount data-URL images."""
+
+from harness.compaction_mixin import CompactionContextMixin
+from harness.context_budget import age_history_images, serialized_history_bytes
+
+
+def _huge_data_url(n_bytes=80_000):
+    return "data:image/png;base64," + ("A" * n_bytes)
+
+
+def _image_part(url):
+    return {"type": "image_url", "image_url": {"url": url}}
+
+
+def _history_with_stale_image(payload_bytes=80_000):
+    return [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "see this older shot"},
+                _image_part(_huge_data_url(payload_bytes)),
+            ],
+        },
+        {"role": "assistant", "content": "noted"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "and this live one"},
+                _image_part("data:image/png;base64,LIVE"),
+            ],
+        },
+    ]
+
+
+def _flat_per_image_token_estimate(messages):
+    """Same cheap clock compaction uses: list content is priced as len(parts)."""
+    mixin = CompactionContextMixin.__new__(CompactionContextMixin)
+    return mixin._estimate_context_tokens_for_list(messages)
+
+
+def test_serialized_history_bytes_never_raises_on_bad_input():
+    assert serialized_history_bytes(None) == 0
+    assert serialized_history_bytes("not-a-list") == 0
+    assert serialized_history_bytes(object()) == 0
+    assert serialized_history_bytes([]) == 2  # "[]"
+
+
+def test_huge_data_url_bytes_dwarf_token_heuristic():
+    history = _history_with_stale_image()
+    nbytes = serialized_history_bytes(history)
+    tokens = _flat_per_image_token_estimate(history)
+    assert nbytes > 80_000
+    assert nbytes > tokens * 20
+
+
+def test_age_history_images_drops_bytes_token_estimate_barely_moves():
+    history = _history_with_stale_image()
+    original_url = history[1]["content"][1]["image_url"]["url"]
+    before_bytes = serialized_history_bytes(history)
+    before_tokens = _flat_per_image_token_estimate(history)
+
+    aged = age_history_images(history, keep_last_user=True)
+
+    after_bytes = serialized_history_bytes(aged)
+    after_tokens = _flat_per_image_token_estimate(aged)
+
+    assert after_bytes < before_bytes
+    assert before_bytes - after_bytes > 70_000
+    # Replacing image_url with a short text part barely moves chars//4.
+    assert abs(after_tokens - before_tokens) <= 20
+    # Overflow recovery treats a byte drop as progress (not token equality).
+    assert after_bytes < before_bytes
+
+    # Copies only — shared fixtures keep their payloads.
+    assert history[1]["content"][1]["type"] == "image_url"
+    assert history[1]["content"][1]["image_url"]["url"] == original_url
+    assert aged[1]["content"][1]["type"] == "text"
+    assert aged[1]["content"][1]["text"] == "[image removed during compaction]"
+    assert any(
+        isinstance(p, dict) and p.get("type") == "image_url"
+        for p in aged[-1]["content"]
+    )
+
+
+def test_age_history_images_exception_does_not_wipe(monkeypatch):
+    history = _history_with_stale_image(payload_bytes=1000)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("copy fail")
+
+    monkeypatch.setattr("harness.context_budget.copy.deepcopy", _boom)
+    aged = age_history_images(history, keep_last_user=True)
+    assert len(aged) == len(history)
+    assert aged[1]["content"][1]["type"] == "image_url"
+
+
+def test_age_history_images_can_strip_last_user_when_asked():
+    history = _history_with_stale_image(payload_bytes=1000)
+    aged = age_history_images(history, keep_last_user=False)
+    for msg in aged:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        assert all(
+            not (isinstance(p, dict) and p.get("type") == "image_url")
+            for p in content
+        )

--- a/tests/test_api_settings_peel.py
+++ b/tests/test_api_settings_peel.py
@@ -200,6 +200,28 @@ def test_post_settings_compaction_residual_rejects_off():
     assert payload["error"] == "Invalid compactionResidual"
 
 
+def test_post_settings_browser_real_profile_roundtrip(monkeypatch):
+    import os
+
+    cleaned = []
+    monkeypatch.setattr(
+        "harness.browser_real_profile.cleanup_real_profile_snapshots",
+        lambda: cleaned.append(True),
+    )
+    monkeypatch.setenv("PM_BROWSER_USER_DATA_DIR", "/tmp/isolated-profile")
+    svc, _, _, calls = _svc()
+    code, _ = post_settings({"browserRealProfile": True}, svc)
+    assert code == 200
+    assert dict(calls["persist"])["HARNESS_BROWSER_REAL_PROFILE"] == "1"
+    assert cleaned == []
+    assert "PM_BROWSER_USER_DATA_DIR" not in os.environ
+
+    code, _ = post_settings({"browserRealProfile": False}, svc)
+    assert code == 200
+    assert dict(calls["persist"])["HARNESS_BROWSER_REAL_PROFILE"] == "0"
+    assert cleaned == [True]
+
+
 def test_post_settings_bad_budget():
     svc, _, _, _ = _svc()
     assert post_settings({"budget": "x"}, svc)[0] == 400

--- a/tests/test_browser_real_profile.py
+++ b/tests/test_browser_real_profile.py
@@ -1,0 +1,184 @@
+"""Consent-gated real Chromium profile snapshot: copy, lock, wipe, env wire."""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import harness.browser_auth as auth
+import harness.browser_real_profile as rp
+
+
+def _write_cookie_db(path: Path, marker: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE cookies (host TEXT, name TEXT, value TEXT)")
+        conn.execute(
+            "INSERT INTO cookies VALUES ('example.com', 'sid', ?)", (marker,)
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _cookie_marker(path: Path) -> str:
+    conn = sqlite3.connect(str(path))
+    try:
+        row = conn.execute("SELECT value FROM cookies WHERE name = 'sid'").fetchone()
+        return row[0] if row else ""
+    finally:
+        conn.close()
+
+
+def _make_src(root: Path, last_used: str = "Default", marker: str = "v1") -> Path:
+    profile = root / last_used
+    (profile / "Network").mkdir(parents=True)
+    (profile / "Cache" / "Cache_Data").mkdir(parents=True)
+    (profile / "Cache" / "Cache_Data" / "big").write_text("x" * 100)
+    (profile / "Preferences").write_text("{}", encoding="utf-8")
+    _write_cookie_db(profile / "Cookies", marker)
+    _write_cookie_db(profile / "Network" / "Cookies", marker + "-net")
+    (root / "Local State").write_text(
+        json.dumps({"profile": {"last_used": last_used}}),
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_real_profile_default_off_under_pytest(monkeypatch):
+    monkeypatch.delenv("HARNESS_BROWSER_REAL_PROFILE", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "tests/test_browser_real_profile.py")
+    assert rp.real_profile_enabled() is False
+
+
+def test_real_profile_enabled_only_when_env_truthy(monkeypatch):
+    monkeypatch.setenv("HARNESS_BROWSER_REAL_PROFILE", "1")
+    assert rp.real_profile_enabled() is True
+    monkeypatch.setenv("HARNESS_BROWSER_REAL_PROFILE", "0")
+    assert rp.real_profile_enabled() is False
+
+
+def test_snapshot_copies_auth_skips_cache_and_last_used(tmp_path, monkeypatch):
+    monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    src = _make_src(tmp_path / "real", last_used="Profile 1", marker="from-p1")
+    (src / "Default").mkdir()
+    _write_cookie_db(src / "Default" / "Cookies", "from-default")
+
+    copy_dir, err = rp.snapshot_real_profile("chrome", src=src)
+    assert err is None
+    assert copy_dir == str(tmp_path / "home" / ".pmharness" / "browser-profile-real" / "chrome")
+    dest = Path(copy_dir)
+    assert dest.joinpath("Local State").is_file()
+    assert dest.joinpath(".marionette-snapshot-complete").read_text(encoding="utf-8") == "Profile 1"
+    assert _cookie_marker(dest / "Default" / "Cookies") == "from-p1"
+    assert (dest / "Default" / "Preferences").is_file()
+    assert not (dest / "Default" / "Cache").exists()
+    assert not (dest / "SingletonLock").exists()
+
+
+def test_snapshot_missing_src_names_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    missing = tmp_path / "nope"
+    copy_dir, err = rp.snapshot_real_profile("chrome", src=missing)
+    assert copy_dir is None
+    assert err is not None
+    assert str(missing) in err
+
+
+def test_snapshot_lock_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    src = _make_src(tmp_path / "real")
+    real_open = open
+
+    def locked_open(path, mode="r", *args, **kwargs):
+        text = str(path)
+        if "Cookies" in text and "rb" in str(mode):
+            raise PermissionError("locked")
+        return real_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", locked_open)
+    copy_dir, err = rp.snapshot_real_profile("chrome", src=src)
+    assert copy_dir is None
+    assert err is not None
+    assert err.startswith("profile locked:")
+
+
+def test_cleanup_wipes_copy_and_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    src = _make_src(tmp_path / "real")
+    copy_dir, err = rp.snapshot_real_profile("chrome", src=src)
+    assert err is None and Path(copy_dir).is_dir()
+    monkeypatch.setenv("PM_BROWSER_USER_DATA_DIR", copy_dir)
+    rp.cleanup_real_profile_snapshots()
+    assert not Path(copy_dir).exists()
+    assert (os.environ.get("PM_BROWSER_USER_DATA_DIR") or "") == ""
+    rp.cleanup_real_profile_snapshots()
+
+
+def test_ensure_shared_browser_env_points_at_copy_when_enabled(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(auth.Path, "home", classmethod(lambda cls: home))
+    src = _make_src(tmp_path / "real")
+    monkeypatch.setattr(rp, "real_profile_data_dir", lambda browser="chrome", system=None: src)
+    monkeypatch.setenv("HARNESS_BROWSER_AUTH", "1")
+    monkeypatch.setenv("HARNESS_BROWSER_REAL_PROFILE", "1")
+    monkeypatch.delenv("PM_BROWSER_USER_DATA_DIR", raising=False)
+    monkeypatch.delenv("PM_BROWSER_CDP_PORT", raising=False)
+    monkeypatch.delenv("PM_BROWSER_HEADED", raising=False)
+    applied = auth.ensure_shared_browser_env()
+    expected = str(home / ".pmharness" / "browser-profile-real" / "chrome")
+    assert applied["user_data_dir"] == expected
+    assert Path(expected, "Default", "Cookies").is_file()
+
+
+def test_ensure_shared_browser_env_keeps_preset_user_data_dir(tmp_path, monkeypatch):
+    preset = tmp_path / "preset-profile"
+    preset.mkdir()
+    monkeypatch.setenv("HARNESS_BROWSER_AUTH", "1")
+    monkeypatch.setenv("HARNESS_BROWSER_REAL_PROFILE", "1")
+    monkeypatch.setenv("PM_BROWSER_USER_DATA_DIR", str(preset))
+    monkeypatch.delenv("PM_BROWSER_CDP_PORT", raising=False)
+    applied = auth.ensure_shared_browser_env()
+    assert applied["user_data_dir"] == str(preset)
+
+
+def test_ensure_shared_browser_env_falls_back_when_snapshot_fails(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(auth.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(
+        rp,
+        "real_profile_data_dir",
+        lambda browser="chrome", system=None: tmp_path / "missing-chrome",
+    )
+    monkeypatch.setenv("HARNESS_BROWSER_AUTH", "1")
+    monkeypatch.setenv("HARNESS_BROWSER_REAL_PROFILE", "1")
+    monkeypatch.delenv("PM_BROWSER_USER_DATA_DIR", raising=False)
+    monkeypatch.delenv("PM_BROWSER_CDP_PORT", raising=False)
+    applied = auth.ensure_shared_browser_env()
+    assert applied["user_data_dir"] == str(home / ".pmharness" / "browser-profile")
+
+
+def test_real_profile_data_dir_darwin(monkeypatch):
+    monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: Path("/Users/t")))
+    got = rp.real_profile_data_dir("chrome", system="Darwin")
+    assert got == Path("/Users/t/Library/Application Support/Google/Chrome")
+
+
+def test_real_profile_data_dir_windows(monkeypatch):
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\T\AppData\Local")
+    got = rp.real_profile_data_dir("chrome", system="Windows")
+    assert got == Path(r"C:\Users\T\AppData\Local") / "Google" / "Chrome" / "User Data"
+
+
+def test_real_profile_data_dir_linux_first_existing(tmp_path, monkeypatch):
+    monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    snap = tmp_path / "snap" / "google-chrome" / "current" / ".config" / "google-chrome"
+    snap.mkdir(parents=True)
+    got = rp.real_profile_data_dir("chrome", system="Linux")
+    assert got == snap

--- a/tests/test_browser_screenshot_dir.py
+++ b/tests/test_browser_screenshot_dir.py
@@ -1,0 +1,39 @@
+"""browser_screenshot defaults off /tmp into ~/.pmharness/browser-shots."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import harness.browser as browser
+
+
+def test_browser_screenshot_defaults_under_pmharness(monkeypatch):
+    captured = []
+
+    def _capture(op_name, method_name, *args, **kwargs):
+        captured.append((op_name, method_name, args, kwargs))
+        return "ok"
+
+    monkeypatch.setattr(browser, "_call", _capture)
+    assert browser.browser_screenshot() == "ok"
+    assert len(captured) == 1
+    op_name, method_name, args, kwargs = captured[0]
+    assert op_name == "screenshot"
+    assert method_name == "screenshot"
+    out_dir = args[0] if args else kwargs.get("out_dir")
+    resolved = Path(out_dir)
+    assert ".pmharness" in resolved.parts
+    assert "browser-shots" in resolved.parts
+    assert resolved == Path.home() / ".pmharness" / "browser-shots"
+
+
+def test_browser_screenshot_explicit_out_dir_unchanged(monkeypatch, tmp_path):
+    captured = []
+
+    def _capture(op_name, method_name, *args, **kwargs):
+        captured.append(args[0] if args else kwargs.get("out_dir"))
+        return "ok"
+
+    monkeypatch.setattr(browser, "_call", _capture)
+    explicit = str(tmp_path / "custom-shots")
+    assert browser.browser_screenshot(explicit) == "ok"
+    assert captured == [explicit]

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -486,28 +486,33 @@ def test_advisory_compact_once_per_user_turn_not_per_tool_step(monkeypatch, tmp_
     import inspect
     import json
 
+    from harness.send_loop import iter_overflow_byte_recovery
     from pmharness.drivers.openai_compat import DriverResponse
 
     # Call-site contract: advisory compact is before the step loop; emergency
-    # overflow path stays inside the loop. Timing may wrap the advisory call
-    # in yield_timed_phase — do not require the obsolete bare yield-from.
+    # overflow path stays inside the loop (via iter_overflow_byte_recovery).
+    # Timing may wrap the advisory call in yield_timed_phase — do not require
+    # the obsolete bare yield-from.
     src = inspect.getsource(ConversationalSession._send_locked_inner)
     advisory_idx = src.find("self._maybe_compact_history()")
-    force_idx = src.find("emergency=True")
+    force_idx = src.find("iter_overflow_byte_recovery")
     step_loop_idx = src.find("for step in _step_iter:")
     assert advisory_idx != -1, "advisory _maybe_compact_history() must remain"
-    assert force_idx != -1, "CONTEXT_OVERFLOW force=True compact must remain"
+    assert force_idx != -1, "CONTEXT_OVERFLOW recovery must remain in the send loop"
     assert step_loop_idx != -1
     assert advisory_idx < step_loop_idx, (
         "advisory compact must run once before the tool-loop step iterator"
     )
     assert force_idx > step_loop_idx, (
-        "emergency=True overflow compact must stay inside the step loop"
+        "overflow byte recovery must stay inside the step loop"
     )
     # No per-step no-arg advisory call after the loop starts (only emergency).
     after_loop = src[step_loop_idx:]
     assert "self._maybe_compact_history()" not in after_loop
-    assert "emergency=True" in after_loop
+    assert "iter_overflow_byte_recovery" in after_loop
+    helper = inspect.getsource(iter_overflow_byte_recovery)
+    assert "emergency=True" in helper
+    assert "force=True" in helper
 
     class _TwoStepPilot:
         name = "two-step-compact-spy"
@@ -932,6 +937,42 @@ def test_second_compact_does_not_rewrap_previous_historical(monkeypatch):
     summarizer_input = s.pilot.chat_calls[0][0][0]["content"]
     assert "PREVIOUS HISTORICAL CONVERSATION SUMMARY:" not in summarizer_input
     assert "PREVIOUS HISTORICAL CONVERSATION SUMMARY:" not in s._history[1]["content"]
+
+
+def test_emergency_compact_strips_older_image_url():
+    """emergency=True ages stale image_url parts; live last-user images stay."""
+    cfg = HarnessConfig(max_context_tokens=100000)
+    s = ConversationalSession(cfg)
+    s.pilot = MockPilot()  # type: ignore
+    older = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "old shot"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64," + ("B" * 500)},
+            },
+        ],
+    }
+    live = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "live shot"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,LIVE"}},
+        ],
+    }
+    s._history.append(older)
+    s._history.append({"role": "assistant", "content": "ok"})
+    s._history.append(live)
+
+    list(s._maybe_compact_history(emergency=True))
+
+    assert older["content"][1]["type"] == "image_url"
+    aged_older = s._history[1]["content"]
+    assert aged_older[1]["type"] == "text"
+    assert aged_older[1]["text"] == "[image removed during compaction]"
+    assert s._history[-1]["content"][1]["type"] == "image_url"
+    assert s._history[-1]["content"][1]["image_url"]["url"].endswith("LIVE")
 
 
 def test_live_goal_tail_does_not_expand_to_fill_acks(monkeypatch):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -37,6 +37,7 @@ def test_settings_get_returns_expected_shape(monkeypatch):
     # Live developer shells often pin HARNESS_CODEX_REASONING_EFFORT=max;
     # this shape test asserts the factory default, not the host preference.
     monkeypatch.delenv("HARNESS_CODEX_REASONING_EFFORT", raising=False)
+    monkeypatch.delenv("HARNESS_BROWSER_REAL_PROFILE", raising=False)
     httpd, port, srv = _server()
     try:
         resp = _get(port, "/api/settings")
@@ -55,6 +56,8 @@ def test_settings_get_returns_expected_shape(monkeypatch):
         assert data["reasoning_effort"] == "low"
         assert "compactionResidual" in data
         assert data["compactionResidual"] == "catalog"
+        assert "browserRealProfile" in data
+        assert data["browserRealProfile"] is False
         assert "state_dir" in data
         assert "repo" in data
     finally:
@@ -218,5 +221,66 @@ def test_settings_post_persists_compaction_residual(tmp_path, monkeypatch):
         )
         assert restore_resp.status == 200
         assert json.loads(restore_resp.read().decode())["compactionResidual"] == "summary"
+    finally:
+        httpd.shutdown()
+
+
+def test_settings_post_persists_browser_real_profile(tmp_path, monkeypatch):
+    import os
+
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("HARNESS_BROWSER_REAL_PROFILE", raising=False)
+    monkeypatch.setattr(
+        "harness.browser_real_profile.Path.home",
+        classmethod(lambda cls: tmp_path / "home"),
+    )
+    cleaned = []
+    real_cleanup = __import__(
+        "harness.browser_real_profile", fromlist=["cleanup_real_profile_snapshots"]
+    ).cleanup_real_profile_snapshots
+
+    def _cleanup():
+        cleaned.append(True)
+        real_cleanup()
+
+    monkeypatch.setattr(
+        "harness.browser_real_profile.cleanup_real_profile_snapshots",
+        _cleanup,
+    )
+    httpd, port, srv = _server()
+    try:
+        assert json.loads(_get(port, "/api/settings").read().decode())[
+            "browserRealProfile"
+        ] is False
+
+        post_resp = _post(
+            port,
+            "/api/settings",
+            {"browserRealProfile": True},
+            {"Content-Type": "application/json", "X-Harness-Token": srv._TOKEN},
+        )
+        assert post_resp.status == 200
+        post_data = json.loads(post_resp.read().decode())
+        assert post_data["browserRealProfile"] is True
+        assert os.environ.get("HARNESS_BROWSER_REAL_PROFILE") == "1"
+
+        env_path = os.path.join(str(tmp_path), "env_settings.json")
+        with open(env_path, encoding="utf-8") as f:
+            persisted = json.load(f)
+        assert persisted["HARNESS_BROWSER_REAL_PROFILE"] == "1"
+
+        off_resp = _post(
+            port,
+            "/api/settings",
+            {"browserRealProfile": False},
+            {"Content-Type": "application/json", "X-Harness-Token": srv._TOKEN},
+        )
+        assert off_resp.status == 200
+        assert json.loads(off_resp.read().decode())["browserRealProfile"] is False
+        assert os.environ.get("HARNESS_BROWSER_REAL_PROFILE") == "0"
+        assert cleaned == [True]
+        with open(env_path, encoding="utf-8") as f:
+            persisted = json.load(f)
+        assert persisted["HARNESS_BROWSER_REAL_PROFILE"] == "0"
     finally:
         httpd.shutdown()

--- a/tests/test_stream_performance.py
+++ b/tests/test_stream_performance.py
@@ -1345,6 +1345,7 @@ def test_step0_overflow_retry_keeps_turn_once_phases(monkeypatch, tmp_path):
     )
 
     compact_calls = []
+    _pad = {"role": "user", "content": "X" * 1000}
 
     cfg = HarnessConfig(
         driver="stub-oracle-v2",
@@ -1354,9 +1355,13 @@ def test_step0_overflow_retry_keeps_turn_once_phases(monkeypatch, tmp_path):
     session = ConversationalSession(cfg)
     monkeypatch.setattr(session, "_resolve_append_only", lambda: False)
     session._get_codegraph_context = lambda msg: ""
+    session._history.append(_pad)
 
     def _spy_compact(force=False, emergency=False):
         compact_calls.append({"force": force, "emergency": emergency})
+        # One-shot byte drop so overflow retry scores progress (413 is bytes).
+        if emergency and _pad in session._history:
+            session._history.remove(_pad)
         if False:
             yield None
 

--- a/tests/test_stream_performance_store.py
+++ b/tests/test_stream_performance_store.py
@@ -452,13 +452,17 @@ def test_overflow_failed_and_retry_are_separate_attempts(monkeypatch, tmp_path):
             return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
 
     compact_calls = []
+    _pad = {"role": "user", "content": "X" * 1000}
 
     def _spy_compact(force=False, emergency=False):
         compact_calls.append({"force": force, "emergency": emergency})
+        if emergency and _pad in session._history:
+            session._history.remove(_pad)
         if False:
             yield None
 
     session = _send_session(tmp_path, monkeypatch, OverflowThenOk(), sid="sess-ovf")
+    session._history.append(_pad)
     monkeypatch.setattr(session, "_maybe_compact_history", _spy_compact)
     events = list(session.send("audit overflow receipts"))
     assert not any(getattr(e, "kind", None) == "error" for e in events)
@@ -797,13 +801,17 @@ def test_persistent_overflow_records_both_attempts(monkeypatch, tmp_path):
             return DriverResponse(text="summary", tokens_out=1, latency_ms=1.0)
 
     compact_calls = []
+    _pad = {"role": "user", "content": "X" * 1000}
 
     def _spy_compact(force=False, emergency=False):
         compact_calls.append({"force": force, "emergency": emergency})
+        if emergency and _pad in session._history:
+            session._history.remove(_pad)
         if False:
             yield None
 
     session = _send_session(tmp_path, monkeypatch, DoubleOverflow(), sid="sess-ovf-persist")
+    session._history.append(_pad)
     monkeypatch.setattr(session, "_maybe_compact_history", _spy_compact)
     events = list(session.send("overflow twice"))
     assert any(getattr(e, "kind", None) == "error" for e in events)

--- a/tests/test_view_image.py
+++ b/tests/test_view_image.py
@@ -27,7 +27,14 @@ def test_view_image_schema():
     schemas_normal = build_tools_schema(no_delegation=False)
     normal_names = [s["function"]["name"] for s in schemas_normal]
     assert "view_image" in normal_names
-    
+    view_fn = next(s["function"] for s in schemas_normal if s["function"]["name"] == "view_image")
+    desc = view_fn["description"]
+    desc_l = desc.lower()
+    assert "precise text description" not in desc_l
+    mentions_pixels_or_see = "pixel" in desc_l or "see" in desc_l
+    mentions_native_vs_sidecar = "native" in desc_l or "sidecar" in desc_l
+    assert mentions_pixels_or_see or mentions_native_vs_sidecar
+
     schemas_worker = build_tools_schema(no_delegation=True)
     worker_names = [s["function"]["name"] for s in schemas_worker]
     assert "view_image" in worker_names

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.371",
+  "version": "0.9.372",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.371",
+      "version": "0.9.372",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.371",
+  "version": "0.9.372",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SettingsPane.cache.test.tsx
+++ b/webapp/src/__tests__/SettingsPane.cache.test.tsx
@@ -148,4 +148,13 @@ describe("toSafeSettingsSnapshot", () => {
     const stored = JSON.parse(localStorage.getItem(SETTINGS_SNAPSHOT_KEY)!);
     expect(stored.settings.pilotToolBudget).toBe("25");
   });
+
+  it("includes browserRealProfile in safe snapshot fields", () => {
+    const raw = { ...sampleSettings, browserRealProfile: true };
+    const safe = toSafeSettingsSnapshot(raw);
+    expect(safe.browserRealProfile).toBe(true);
+    writeSettingsSnapshot(raw);
+    const stored = JSON.parse(localStorage.getItem(SETTINGS_SNAPSHOT_KEY)!);
+    expect(stored.settings.browserRealProfile).toBe(true);
+  });
 });

--- a/webapp/src/__tests__/SettingsPane.optIns.test.tsx
+++ b/webapp/src/__tests__/SettingsPane.optIns.test.tsx
@@ -35,6 +35,7 @@ const sampleSettings: Settings = {
   reviewEditsBeforeApply: false,
   hash_edit_enabled: false,
   autoVerify: true,
+  browserRealProfile: false,
   compactionResidual: "catalog",
   state_dir: "/tmp/state",
   repo: "/tmp/repo",
@@ -62,6 +63,25 @@ describe("SettingsPane Opt-ins section", () => {
     fireEvent.click(screen.getByTestId("settings-opt-in-reviewEditsBeforeApply"));
     await waitFor(() => {
       expect(mockUpdate).toHaveBeenCalledWith({ reviewEditsBeforeApply: true });
+    });
+  });
+});
+
+describe("SettingsPane Safety Chrome login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeSettingsSnapshot(sampleSettings);
+    mockSettings.mockResolvedValue(sampleSettings);
+    mockUpdate.mockImplementation(async (partial) => ({ ...sampleSettings, ...partial }));
+  });
+
+  it("toggles browserRealProfile from Safety", async () => {
+    render(<SettingsPane onOpenWizard={vi.fn()} section="safety" />);
+
+    expect(await screen.findByText("Use my Chrome login")).toBeTruthy();
+    fireEvent.click(screen.getByText("Use my Chrome login"));
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith({ browserRealProfile: true });
     });
   });
 });

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -1128,6 +1128,29 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
         </div>
 
         </>)}
+        {gate("safety", "browser chrome cookies real profile login") && settings && (
+        <div className="space-y-1.5">
+          <button
+            onClick={() => update({ browserRealProfile: !(settings.browserRealProfile ?? false) })}
+            disabled={saving}
+            className={`w-full flex items-center justify-between px-3 py-2 rounded border transition text-left ${
+              (settings.browserRealProfile ?? false)
+                ? "bg-accent/10 border-accent/30 text-accent"
+                : "bg-panel2 border-edge text-muted"
+            } disabled:opacity-50`}
+          >
+            <span className="font-medium text-[11px]">Use my Chrome login</span>
+            <span className="text-[10px] uppercase font-bold tracking-wider">
+              {(settings.browserRealProfile ?? false) ? "on" : "off"}
+            </span>
+          </button>
+          <p className="text-[10px] text-muted">
+            Copies cookies into a Marionette-owned profile so the agent browser is already
+            signed in. Off by default. Closing Chrome may be required on Windows if copy
+            fails.
+          </p>
+        </div>
+        )}
         {gate("safety", "full-auto safety command guard timeout max investigation steps per-turn tool-call cap iteration budget guard") && settings && (<>
         {/* Full-Auto Safety: command guard + timeout */}
         <div className="space-y-1.5">

--- a/webapp/src/components/settingsSnapshot.ts
+++ b/webapp/src/components/settingsSnapshot.ts
@@ -14,6 +14,7 @@ export function toSafeSettingsSnapshot(s: Settings): Settings {
     reviewEditsBeforeApply: s.reviewEditsBeforeApply,
     autoVerify: s.autoVerify,
     autoCommandGuard: s.autoCommandGuard,
+    browserRealProfile: s.browserRealProfile,
     hash_edit_enabled: s.hash_edit_enabled,
     commandTimeout: s.commandTimeout,
     maxPilotSteps: s.maxPilotSteps,

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -64,6 +64,7 @@ export type Settings = {
   reviewEditsBeforeApply?: boolean;
   autoVerify?: boolean;
   autoCommandGuard?: boolean;
+  browserRealProfile?: boolean;
   hash_edit_enabled?: boolean;
   commandTimeout?: string;
   maxPilotSteps?: string;


### PR DESCRIPTION
## Summary
- Consent-gated **Use my Chrome login** copies last-used Chromium auth (Cookies / Login Data) into `~/.pmharness/browser-profile-real` via sqlite backup. Never attach `--user-data-dir` to the live OS profile. Off wipes the copy; on clears a process-lifetime isolated-profile bind so the next launch re-snapshots.
- HTTP 413 recovery scores serialized history **bytes**, not the cheap token heuristic. Emergency compact ages stale `image_url` parts; overflow retries only while bytes drop (max 3 attempts).
- `view_image` schema tells native-vision vs sidecar truth. Browser screenshots default to `~/.pmharness/browser-shots`.

Pin stays `puppetmaster-ai==1.22.37`.

## Test plan
- [x] Focused pytest: 150 passed after send-loop peel (413, compaction, real-profile, settings, stream performance, version stamps, residual fence at 674/700)
- [x] Settings vitest: 1495 passed (138 files), including Safety Chrome-login toggle
- [ ] Dest-into-main `tests` matrix (3.9, 3.11, Windows, frontend-build)
- [ ] After merge: `scripts/ci_release_gate.py require-green`, tag `v0.9.372` when `merge^{tree}` matches this PR tree