### PR TITLE
Release v0.9.373

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.37` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.372, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.373, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.372"
+__version__ = "0.9.373"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -40,6 +40,8 @@ _PROVENANCE_STAGE_CODES = frozenset({
     "agentic_timeout",
 })
 
+_GENERIC_INCOMPLETE_TASKS = "swarm exited with incomplete tasks"
+
 # Soft-refuse cue for pilots/guards: empty managed implement already recovered once.
 EMPTY_MANAGED_IMPLEMENT_EXHAUSTED = "empty_managed_implement_exhausted"
 
@@ -49,6 +51,74 @@ _EMPTY_WORKTREE_MARKERS = (
     "no changes produced",
     "worker produced no changes",
 )
+
+
+def _non_generic_failure_reason(*candidates) -> str:
+    """Prefer a specific reason over the generic incomplete-tasks string."""
+    generic = _GENERIC_INCOMPLETE_TASKS
+    for raw in candidates:
+        text = str(raw or "").strip()
+        if not text:
+            continue
+        lowered = text.lower()
+        if lowered in _PROVENANCE_STAGE_CODES:
+            continue
+        if lowered == generic or lowered.endswith(generic):
+            continue
+        return text
+    return ""
+
+
+def _enrich_worker_provenance(
+    provenance: dict,
+    res,
+    *,
+    applied: bool = False,
+    held_for_review: bool = False,
+    retry_count: int = 0,
+) -> dict:
+    """Stamp structured failure fields onto worker_provenance (and finish copies)."""
+    from harness.edit_engines import failure_is_retryable
+
+    if not isinstance(provenance, dict):
+        provenance = {}
+    ok = bool(getattr(res, "ok", False))
+    stage = str(getattr(res, "error", "") or provenance.get("error") or "")
+    http_status = getattr(res, "http_status", None)
+    finish_reason = str(getattr(res, "finish_reason", "") or "")
+    summary = str(getattr(res, "summary", "") or "") if not ok else ""
+    failure_reason = _non_generic_failure_reason(
+        finish_reason,
+        summary,
+        provenance.get("failure_reason"),
+        provenance.get("error"),
+    )
+    files = [
+        str(path) for path in (getattr(res, "files_changed", None) or [])
+        if str(path).strip()
+    ]
+    try:
+        status_i = int(http_status) if http_status is not None else None
+    except (TypeError, ValueError):
+        status_i = None
+    provenance.update({
+        "failure_stage": stage,
+        "failure_reason": failure_reason,
+        "http_status": status_i,
+        "retry_after": str(getattr(res, "retry_after", "") or ""),
+        "provider_request_id": str(getattr(res, "provider_request_id", "") or ""),
+        "pm_job_id": str(getattr(res, "pm_job_id", "") or ""),
+        "task_ids": list(getattr(res, "task_ids", None) or []),
+        "provider": str(getattr(res, "provider", "") or provenance.get("provider") or ""),
+        "model": str(getattr(res, "model", "") or provenance.get("model") or ""),
+        "retryable": failure_is_retryable(stage, status_i),
+        "retry_count": int(retry_count or 0),
+        "partial_patch": bool(files) and not ok,
+        "applied": bool(applied),
+        "held_for_review": bool(held_for_review),
+        "files": files,
+    })
+    return provenance
 
 
 def _is_empty_diff_implement_failure(res, *, expects_diff: bool) -> bool:
@@ -668,6 +738,12 @@ class ConversationJobsMixin:
         target_repo: str = "", expects_diff: bool = True,
         agentic_pin=None, strict_adapter: bool = False,
     ) -> None:
+        try:
+            mark = getattr(self, "_mark_local_job_started", None)
+            if callable(mark):
+                mark(job_id)
+        except Exception:
+            pass
         from .conversation import append_failed_declarative_checks_summary
 
         live_repo = target_repo or self.config.repo or ""
@@ -1219,6 +1295,21 @@ class ConversationJobsMixin:
                     "pending_review": pending_review_info
                 }
 
+            retry_count = 0
+            try:
+                prior = (getattr(self, "_local_jobs", {}) or {}).get(job_id) or {}
+                retry_count = int(prior.get("retry_count") or 0)
+                if not retry_count and isinstance(prior.get("worker_provenance"), dict):
+                    retry_count = int(prior["worker_provenance"].get("retry_count") or 0)
+            except Exception:
+                retry_count = 0
+            _enrich_worker_provenance(
+                provenance,
+                res,
+                applied=bool(res_dict.get("applied")),
+                held_for_review=bool(res_dict.get("held_for_review")),
+                retry_count=retry_count,
+            )
             res_dict["worker_provenance"] = provenance
             for routing_key, routing_value in (
                 ("adapter", getattr(res, "engine", "")),
@@ -1316,6 +1407,13 @@ class ConversationJobsMixin:
                 "managed_worktree_mode": "none" if expects_diff else "unknown",
                 "requested_mode": "implement" if expects_diff else "analysis",
                 "worktree_diff_empty": None,
+                "failure_stage": "agentic_error",
+                "failure_reason": str(e),
+                "retryable": False,
+                "retry_count": 0,
+                "applied": False,
+                "held_for_review": False,
+                "partial_patch": False,
             }
             if self._local_job_cancelled(job_id):
                 # A failure while collecting late facts must not turn a
@@ -1539,12 +1637,27 @@ class ConversationJobsMixin:
                             res_job["artifacts"] = delivered
                             res_job["artifact_delivery"] = delivery
                         try:
+                            from harness.local_jobs import _TERMINAL_LOCAL_JOB_STATUSES
                             with self._local_jobs_lock:
                                 local = (getattr(self, "_local_jobs", {}) or {}).get(job_id)
                                 if isinstance(local, dict):
                                     local["artifact_delivery"] = delivery
                                     if delivered and not local.get("artifacts"):
                                         local["artifacts"] = list(delivered)
+                                    if display_error and not local.get("error"):
+                                        local["error"] = display_error
+                                    if applied_files and not local.get("files"):
+                                        local["files"] = list(applied_files)
+                                    if "applied" not in local:
+                                        local["applied"] = bool(applied)
+                                    if held_for_review:
+                                        local["held_for_review"] = True
+                                    if (
+                                        failed
+                                        and str(local.get("status") or "")
+                                        not in _TERMINAL_LOCAL_JOB_STATUSES
+                                    ):
+                                        local["status"] = "failed"
                         except Exception:
                             pass
                         manifest = _render_swarm_delivery_manifest(

--- a/harness/edit_engines.py
+++ b/harness/edit_engines.py
@@ -82,6 +82,20 @@ _TIMEOUT_MARKERS = (
 )
 
 
+def failure_is_retryable(stage: str = "", http_status: Any = None) -> bool:
+    """True only for timeout, provider rate-limit, or HTTP 429."""
+    if str(stage or "").strip() in (AGENTIC_TIMEOUT, AGENTIC_PROVIDER_RATE_LIMITED):
+        return True
+    try:
+        return int(http_status) == 429
+    except (TypeError, ValueError):
+        return False
+
+
+def _status_text(raw: Any) -> str:
+    return str(getattr(raw, "value", raw) or "").strip()
+
+
 def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
     """Copy fail-closed facts off the scratch PM store before it is deleted.
 
@@ -97,10 +111,14 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
         "tokens_in": 0,
         "tokens_out": 0,
         "usage_known": False,
+        "event_names": [],
+        "job_status": "",
+        "artifact_types": [],
     }
     if store is None:
         return snap
     resolved = str(job_id or "").strip()
+    jobs: list = []
     if not resolved:
         try:
             jobs = list(store.list_jobs() or [])
@@ -118,21 +136,29 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
         tasks = []
     statuses = []
     task_ids = []
+    task_fail_text = ""
     for task in tasks:
         tid = str(getattr(task, "id", "") or "").strip()
         if tid:
             task_ids.append(tid)
         role = str(getattr(task, "role", "") or "").strip()
-        raw_status = getattr(task, "status", "")
-        status = str(getattr(raw_status, "value", raw_status) or "").strip()
+        status = _status_text(getattr(task, "status", ""))
         if role and status:
             statuses.append(f"{role}={status}")
         elif status:
             statuses.append(status)
+        if not task_fail_text:
+            for attr in ("error", "failure", "failure_reason", "reason"):
+                text = str(getattr(task, attr, "") or "").strip()
+                if text:
+                    task_fail_text = text
+                    break
     snap["task_statuses"] = statuses
     snap["task_ids"] = task_ids
 
     reason = ""
+    event_names: list = []
+    last_payload_reason = ""
     try:
         records = store.read_events(resolved) if hasattr(store, "read_events") else []
     except Exception:
@@ -141,6 +167,8 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
         if not isinstance(rec, dict):
             continue
         name = str(rec.get("event") or "").strip()
+        if name:
+            event_names.append(name)
         payload = rec.get("payload")
         if isinstance(payload, str):
             try:
@@ -149,6 +177,10 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
                 payload = {}
         if not isinstance(payload, dict):
             payload = {}
+        for key in ("error", "failure", "reason"):
+            text = str(payload.get(key) or "").strip()
+            if text:
+                last_payload_reason = text
         if name == "worker.gate_failed":
             text = str(payload.get("reason") or "").strip()
             if text:
@@ -159,7 +191,29 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
                 reason = text
         elif name == "worker.lease_lost":
             reason = "worker lease lost"
+    snap["event_names"] = event_names[-20:]
     snap["reason"] = reason
+
+    job_status = ""
+    try:
+        if hasattr(store, "get_job"):
+            job_obj = store.get_job(resolved)
+            if job_obj is not None:
+                job_status = _status_text(getattr(job_obj, "status", ""))
+    except Exception:
+        job_status = ""
+    if not job_status:
+        if not jobs:
+            try:
+                jobs = list(store.list_jobs() or [])
+            except Exception:
+                jobs = []
+        for job in jobs:
+            if str(getattr(job, "id", "") or "") != resolved:
+                continue
+            job_status = _status_text(getattr(job, "status", ""))
+            break
+    snap["job_status"] = job_status
 
     try:
         arts = list(store.list_artifacts(resolved) or [])
@@ -169,7 +223,11 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
     tokens_out = 0
     usage_known = False
     art_failure = ""
+    artifact_types: list = []
     for art in arts:
+        atype = str(getattr(art, "type", "") or getattr(art, "kind", "") or "").strip()
+        if atype:
+            artifact_types.append(atype)
         payload = getattr(art, "payload", None)
         if not isinstance(payload, dict):
             continue
@@ -182,6 +240,11 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
     snap["tokens_in"] = tokens_in
     snap["tokens_out"] = tokens_out
     snap["usage_known"] = usage_known
+    snap["artifact_types"] = artifact_types
+    if not snap["reason"] and last_payload_reason:
+        snap["reason"] = last_payload_reason
+    if not snap["reason"] and task_fail_text:
+        snap["reason"] = task_fail_text
     if not snap["reason"] and art_failure:
         snap["reason"] = art_failure
     return snap
@@ -200,6 +263,13 @@ def _format_agentic_engine_error(
     reason = redact_secret_text(str(snap.get("reason") or "").strip())
     if reason and reason not in parts[0]:
         parts.append(reason)
+    if not reason:
+        names = [str(item) for item in (snap.get("event_names") or []) if str(item).strip()]
+        if names:
+            parts.append("events: " + ", ".join(names[-20:]))
+        job_status = str(snap.get("job_status") or "").strip()
+        if job_status:
+            parts.append("job_status: " + job_status)
     statuses = [str(item) for item in (snap.get("task_statuses") or []) if str(item).strip()]
     if statuses:
         parts.append("tasks: " + ", ".join(statuses))

--- a/harness/local_jobs.py
+++ b/harness/local_jobs.py
@@ -44,10 +44,133 @@ from .model_identity import (
 from .provenance_sanitize import sanitize_clean_tree_claims
 
 # Job statuses that must never accept a fresh status=running nested row.
-# Includes command-job terminals (timeout/truncated) from Wave 2 durability.
+# Includes command-job terminals (timeout/truncated) from Wave 2 durability
+# and parallel_wave aggregate terminals (partial / timed_out).
 _TERMINAL_LOCAL_JOB_STATUSES = frozenset({
     "completed", "failed", "cancelled", "timeout", "truncated",
+    "partial", "timed_out",
 })
+
+_SUCCESS_CHILD_STATUSES = frozenset({"completed", "done"})
+_TIMEOUT_CHILD_STATUSES = frozenset({"timeout", "timed_out"})
+_CANCEL_CHILD_STATUSES = frozenset({"cancelled", "canceled"})
+_HARD_FAIL_CHILD_STATUSES = frozenset({"failed", "truncated", "error"})
+_ANALYSIS_ROLES = frozenset({"analysis", "review"})
+_WAVE_RETRY_PARENT_STATUSES = frozenset({"partial", "failed", "timed_out"})
+_WAVE_FAILURE_COPY_KEYS = (
+    "failure_stage",
+    "failure_reason",
+    "http_status",
+    "retry_after",
+    "provider_request_id",
+    "pm_job_id",
+    "task_ids",
+    "provider",
+    "retryable",
+    "retry_count",
+    "partial_patch",
+    "applied",
+    "held_for_review",
+    "files",
+    "error",
+)
+
+
+def _normalize_job_role(role: Any) -> str:
+    return str(role or "").split("(")[0].strip().lower()
+
+
+def _child_outcome_kind(status: str) -> str:
+    st = str(status or "").strip().lower()
+    if st in _SUCCESS_CHILD_STATUSES:
+        return "success"
+    if st in _TIMEOUT_CHILD_STATUSES:
+        return "timeout"
+    if st in _HARD_FAIL_CHILD_STATUSES:
+        return "failed"
+    if st in _CANCEL_CHILD_STATUSES:
+        return "cancelled"
+    return "other"
+
+
+def aggregate_parallel_wave_status(statuses: list) -> str:
+    """Parent lifecycle from child terminal statuses. No artifact merge."""
+    kinds = [_child_outcome_kind(s) for s in statuses]
+    n_ok = sum(1 for k in kinds if k == "success")
+    n_fail = sum(1 for k in kinds if k == "failed")
+    n_timeout = sum(1 for k in kinds if k == "timeout")
+    n_cancel = sum(1 for k in kinds if k == "cancelled")
+    any_hard = n_fail > 0
+    any_bad = any_hard or n_timeout > 0
+    if n_ok and any_bad:
+        return "partial"
+    if n_ok and n_cancel and not any_bad:
+        return "cancelled"
+    if n_ok and not any_bad and not n_cancel:
+        return "completed"
+    if n_timeout and not any_hard:
+        return "timed_out"
+    if any_hard:
+        return "failed"
+    if n_cancel:
+        return "cancelled"
+    return "failed"
+
+
+def _wave_is_analysis_or_review(parent: dict, children: list) -> bool:
+    parent_role = _normalize_job_role((parent or {}).get("role"))
+    if parent_role in _ANALYSIS_ROLES:
+        return True
+    roles = []
+    for child in children or []:
+        if not isinstance(child, dict):
+            continue
+        role = _normalize_job_role(child.get("role"))
+        if role in _ANALYSIS_ROLES:
+            roles.append(role)
+        elif role and role != "parallel_wave":
+            roles.append(role)
+    if not roles:
+        return False
+    return all(r in _ANALYSIS_ROLES for r in roles)
+
+
+def _job_file_set(job: dict) -> set:
+    paths = set()
+    if not isinstance(job, dict):
+        return paths
+    for raw in list(job.get("files") or []):
+        text = str(raw or "").strip()
+        if text:
+            paths.add(text)
+    prov = job.get("worker_provenance")
+    if isinstance(prov, dict):
+        for raw in list(prov.get("files") or []):
+            text = str(raw or "").strip()
+            if text:
+                paths.add(text)
+    return paths
+
+
+def _child_retry_count(child: dict) -> int:
+    if not isinstance(child, dict):
+        return 0
+    try:
+        n = child.get("retry_count")
+        if n is None and isinstance(child.get("worker_provenance"), dict):
+            n = child["worker_provenance"].get("retry_count")
+        return int(n or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _child_is_retryable(child: dict) -> bool:
+    if not isinstance(child, dict):
+        return False
+    if child.get("retryable") is True:
+        return True
+    prov = child.get("worker_provenance")
+    return isinstance(prov, dict) and prov.get("retryable") is True
 
 
 def _reconcile_routing_artifact(art: dict, selected_model: str) -> dict:
@@ -449,13 +572,7 @@ class LocalJobsMixin:
                 "tokens": 0,
                 "est_cost_usd": 0.0,
                 "artifacts": [],
-                "tasks": [{
-                    "id": f"{wave_id}-w0",
-                    "role": "parallel_wave",
-                    "instruction": objective or f"Parallel wave ({len(ids)} jobs)",
-                    "status": "running",
-                    "adapter": "parallel_wave",
-                }],
+                "tasks": [],
                 "actions": [],
                 "source": "harness",
                 "accounting_owned": True,
@@ -465,12 +582,14 @@ class LocalJobsMixin:
                 "terminal_job_ids": [],
                 "child_count": len(ids),
                 "mixed_terminal": False,
+                "review_required": False,
             }
             self._local_jobs[wave_id] = row
             for cid in ids:
                 child = self._local_jobs.get(cid)
                 if isinstance(child, dict):
                     child["parent_wave_id"] = wave_id
+            self._sync_parallel_wave_locked(row)
             self._upsert_display_parallel_wave_locked(row)
             self._persist_local_jobs_locked()
             return copy.deepcopy(row)
@@ -499,6 +618,7 @@ class LocalJobsMixin:
         if not wave_id:
             return
         cid = str(child_id or "").strip()
+        retry_ids: list = []
         with self._local_jobs_lock:
             parent = self._local_jobs.get(wave_id)
             if not isinstance(parent, dict) or parent.get("job_kind") != "parallel_wave":
@@ -508,8 +628,11 @@ class LocalJobsMixin:
                 terminals.append(cid)
             parent["terminal_job_ids"] = terminals
             self._sync_parallel_wave_locked(parent)
+            retry_ids = self._collect_parallel_wave_retries_locked(parent)
             self._upsert_display_parallel_wave_locked(parent)
             self._persist_local_jobs_locked()
+        if retry_ids:
+            self._launch_parallel_wave_retries(wave_id, retry_ids)
 
     def _sync_parallel_wave_from_children(self, wave_id: str) -> None:
         wid = str(wave_id or "").strip()
@@ -523,15 +646,89 @@ class LocalJobsMixin:
             self._upsert_display_parallel_wave_locked(parent)
             self._persist_local_jobs_locked()
 
+    def _project_parallel_wave_tasks_locked(self, parent: dict) -> None:
+        """One parent.tasks row per child — membership display, not artifacts."""
+        child_ids = [str(x) for x in (parent.get("child_job_ids") or []) if str(x)]
+        tasks = []
+        for cid in child_ids:
+            child = self._local_jobs.get(cid) or {}
+            if not isinstance(child, dict):
+                child = {}
+            role = str(child.get("role") or "implement").strip() or "implement"
+            prov = child.get("worker_provenance")
+            if not isinstance(prov, dict):
+                prov = {}
+            tasks.append({
+                "id": cid,
+                "role": role,
+                "instruction": str(child.get("goal") or ""),
+                "status": str(child.get("status") or "queued"),
+                "adapter": str(child.get("adapter") or ""),
+                "model": str(child.get("model") or ""),
+                "error": str(child.get("error") or prov.get("error") or ""),
+                "failure_stage": str(
+                    child.get("failure_stage") or prov.get("failure_stage") or ""
+                ),
+                "failure_reason": str(
+                    child.get("failure_reason") or prov.get("failure_reason") or ""
+                ),
+                "applied": bool(
+                    child.get("applied")
+                    if child.get("applied") is not None
+                    else prov.get("applied")
+                ),
+                "retryable": bool(child.get("retryable") or prov.get("retryable")),
+            })
+        parent["tasks"] = tasks
+        parent["task_count"] = len(child_ids)
+        parent["child_count"] = len(child_ids)
+
+    def _parallel_child_receipt_row_locked(self, cid: str) -> dict:
+        child = self._local_jobs.get(cid) or {}
+        if not isinstance(child, dict):
+            child = {}
+        prov = child.get("worker_provenance")
+        if not isinstance(prov, dict):
+            prov = {}
+        files = list(child.get("files") or prov.get("files") or [])
+        applied = child.get("applied")
+        if applied is None:
+            applied = prov.get("applied")
+        return {
+            "id": cid,
+            "goal": str(child.get("goal") or ""),
+            "status": str(child.get("status") or ""),
+            "error": str(child.get("error") or prov.get("error") or ""),
+            "failure_stage": str(
+                child.get("failure_stage") or prov.get("failure_stage") or ""
+            ),
+            "failure_reason": str(
+                child.get("failure_reason") or prov.get("failure_reason") or ""
+            ),
+            "model": str(child.get("model") or prov.get("model") or ""),
+            "provider": str(child.get("provider") or prov.get("provider") or ""),
+            "applied": bool(applied),
+            "held_for_review": bool(
+                child.get("held_for_review") or prov.get("held_for_review")
+            ),
+            "retryable": bool(child.get("retryable") or prov.get("retryable")),
+            "retry_count": _child_retry_count(child),
+            "files": [str(p) for p in files if str(p).strip()],
+        }
+
     def _sync_parallel_wave_locked(self, parent: dict) -> None:
         """Refresh aggregate lifecycle from accepted children. No artifact merge."""
         import time
 
         child_ids = [str(x) for x in (parent.get("child_job_ids") or []) if str(x)]
         terminals = [str(x) for x in (parent.get("terminal_job_ids") or []) if str(x)]
-        statuses: list[str] = []
+        statuses: list = []
+        child_rows: list = []
         for cid in child_ids:
             child = self._local_jobs.get(cid) or {}
+            if not isinstance(child, dict):
+                child = {}
+            child_rows.append(child)
             st = str(child.get("status") or "")
             if st in _TERMINAL_LOCAL_JOB_STATUSES and cid not in terminals:
                 terminals.append(cid)
@@ -553,38 +750,28 @@ class LocalJobsMixin:
                 statuses.append(st or "running")
         parent["terminal_job_ids"] = terminals
         parent["updated_at"] = time.time()
-        parent["child_count"] = len(child_ids)
-        parent["task_count"] = len(child_ids)
         # Parent never owns child evidence.
         parent["artifacts"] = []
+        self._project_parallel_wave_tasks_locked(parent)
 
         all_settled = bool(child_ids) and all(cid in terminals for cid in child_ids)
         if not all_settled:
             parent["status"] = "running"
             parent["terminal_receipt"] = None
             parent["mixed_terminal"] = False
-            if parent.get("tasks"):
-                try:
-                    parent["tasks"][0]["status"] = "running"
-                except Exception:
-                    pass
+            parent["review_required"] = False
             return
 
         mixed = len(set(statuses)) > 1
-        if any(s in ("failed", "timeout", "truncated") for s in statuses):
-            aggregate = "failed"
-        elif any(s == "cancelled" for s in statuses):
-            aggregate = "cancelled"
-        else:
-            aggregate = "completed"
+        aggregate = aggregate_parallel_wave_status(statuses)
+        review_required = (
+            aggregate == "partial"
+            and not _wave_is_analysis_or_review(parent, child_rows)
+        )
         parent["status"] = aggregate
         parent["mixed_terminal"] = mixed
-        if parent.get("tasks"):
-            try:
-                parent["tasks"][0]["status"] = aggregate
-            except Exception:
-                pass
-        counts: dict[str, int] = {}
+        parent["review_required"] = review_required
+        counts: dict = {}
         for s in statuses:
             counts[s] = counts.get(s, 0) + 1
         parent["terminal_receipt"] = {
@@ -596,9 +783,148 @@ class LocalJobsMixin:
             "finished_at": parent["updated_at"],
             "child_statuses": dict(counts),
             "mixed_terminal": mixed,
+            "review_required": review_required,
             "child_job_ids": list(child_ids),
             "terminal_job_ids": list(terminals),
+            "children": [
+                self._parallel_child_receipt_row_locked(cid) for cid in child_ids
+            ],
         }
+
+    def _collect_parallel_wave_retries_locked(self, parent: dict) -> list:
+        """Reopen retryable children once after the parent first settles."""
+        if parent.get("wave_auto_retry_attempted"):
+            return []
+        if str(parent.get("status") or "") not in _WAVE_RETRY_PARENT_STATUSES:
+            return []
+        parent["wave_auto_retry_attempted"] = True
+        child_ids = [str(x) for x in (parent.get("child_job_ids") or []) if str(x)]
+        success_files = set()
+        for cid in child_ids:
+            child = self._local_jobs.get(cid) or {}
+            if _child_outcome_kind(str(child.get("status") or "")) != "success":
+                continue
+            if child.get("applied") is False:
+                continue
+            success_files.update(_job_file_set(child))
+        retry_ids = []
+        terminals = [str(x) for x in (parent.get("terminal_job_ids") or []) if str(x)]
+        for cid in child_ids:
+            child = self._local_jobs.get(cid)
+            if not isinstance(child, dict):
+                continue
+            if not _child_is_retryable(child):
+                continue
+            if _child_retry_count(child) >= 1:
+                continue
+            child_files = _job_file_set(child)
+            if child_files and success_files and child_files & success_files:
+                continue
+            child["retry_count"] = 1
+            child["retryable"] = True
+            prov = child.get("worker_provenance")
+            if isinstance(prov, dict):
+                prov["retry_count"] = 1
+            child["status"] = "queued"
+            if child.get("tasks"):
+                try:
+                    child["tasks"][0]["status"] = "queued"
+                except Exception:
+                    pass
+            if cid in terminals:
+                terminals = [x for x in terminals if x != cid]
+            if cid not in self._local_job_cancels:
+                self._local_job_cancels[cid] = threading.Event()
+            retry_ids.append(cid)
+        parent["terminal_job_ids"] = terminals
+        if retry_ids:
+            self._sync_parallel_wave_locked(parent)
+        return retry_ids
+
+    def _fail_wave_retry_child(self, wave_id: str, cid: str, reason: str) -> None:
+        with self._local_jobs_lock:
+            child = self._local_jobs.get(cid)
+            if isinstance(child, dict):
+                child["status"] = "failed"
+                child["error"] = reason
+                child["failure_stage"] = "retry_launch"
+                child["failure_reason"] = reason
+                child["retryable"] = False
+                if child.get("tasks"):
+                    try:
+                        child["tasks"][0]["status"] = "failed"
+                    except Exception:
+                        pass
+            parent = self._local_jobs.get(wave_id)
+            if not isinstance(parent, dict) or parent.get("job_kind") != "parallel_wave":
+                return
+            terminals = [str(x) for x in (parent.get("terminal_job_ids") or []) if str(x)]
+            if cid not in terminals:
+                terminals.append(cid)
+            parent["terminal_job_ids"] = terminals
+            self._sync_parallel_wave_locked(parent)
+            self._upsert_display_parallel_wave_locked(parent)
+            self._persist_local_jobs_locked()
+
+    def _launch_parallel_wave_retries(self, wave_id: str, retry_ids: list) -> None:
+        submit = getattr(self, "_submit_swarm", None)
+        run_fn = getattr(self, "_run_provider_worker_background", None)
+        if not callable(submit) or not callable(run_fn):
+            for cid in retry_ids:
+                self._fail_wave_retry_child(wave_id, cid, "retry launcher unavailable")
+            return
+        for cid in retry_ids:
+            child = {}
+            with self._local_jobs_lock:
+                raw = self._local_jobs.get(cid)
+                if isinstance(raw, dict):
+                    child = copy.deepcopy(raw)
+            goal = str(child.get("goal") or "")
+            if not goal:
+                self._fail_wave_retry_child(wave_id, cid, "retry child has no goal")
+                continue
+            role = _normalize_job_role(child.get("role"))
+            expects_diff = role not in _ANALYSIS_ROLES
+            adapter = str(child.get("adapter") or "")
+            requested_adapter = adapter if adapter in ("agentic", "native") else ""
+            target_repo = str(child.get("cwd") or getattr(self.config, "repo", "") or "")
+            pin = None
+            requested = str(child.get("requested_model") or "").strip()
+            provider = str(child.get("provider") or "").strip()
+            if requested and provider:
+                try:
+                    from harness.swarm_model_pin import AgenticModelPin
+                    model = str(child.get("model") or "")
+                    pin = AgenticModelPin(
+                        requested=requested,
+                        provider=provider,
+                        model=model.split("/")[-1] if model else requested,
+                        router_model_id=model or requested,
+                        policy=str(child.get("routing_policy") or "explicit_pin"),
+                    )
+                except Exception:
+                    pin = None
+            claim = getattr(self, "_claim_objective", None)
+            if callable(claim):
+                try:
+                    claim(goal)
+                except Exception:
+                    pass
+            try:
+                submit(
+                    run_fn,
+                    cid,
+                    goal,
+                    requested_adapter,
+                    target_repo,
+                    expects_diff,
+                    pin,
+                    False,
+                )
+            except Exception as exc:
+                self._fail_wave_retry_child(
+                    wave_id, cid, f"retry launch failed: {exc}",
+                )
 
     def _upsert_display_parallel_wave_locked(self, parent: dict) -> None:
         display = getattr(self, "_display_transcript", None)
@@ -612,13 +938,24 @@ class LocalJobsMixin:
         terminals = [str(x) for x in (parent.get("terminal_job_ids") or []) if str(x)]
         wave_id = str(parent.get("id") or "")
         settled = bool(child_ids) and all(cid in terminals for cid in child_ids)
+        parent_status = str(parent.get("status") or "")
+        if not settled:
+            display_status = "running"
+        elif parent_status == "completed":
+            display_status = "done"
+        elif parent_status == "partial":
+            display_status = "partial"
+        elif parent_status == "cancelled":
+            display_status = "ended"
+        else:
+            display_status = "failed"
         row = {
             "type": "swarm_pending",
             "wave_id": wave_id,
             "job_ids": list(child_ids),
             "objective": str(parent.get("goal") or ""),
             "terminal_job_ids": list(terminals),
-            "status": "done" if settled else "running",
+            "status": display_status,
             "session_id": mine,
         }
         for i, existing in enumerate(display):
@@ -823,7 +1160,8 @@ class LocalJobsMixin:
 
     def _register_local_job(self, job_id: str, goal: str, role: str = "implement",
                             cwd: str = "", engine: str = "", model: str = "",
-                            *, skip_routing_preview: bool = False) -> None:
+                            *, skip_routing_preview: bool = False,
+                            initial_status: str = "") -> None:
         """Record a dispatched in-process edit worker so it appears in the swarm
         panel while it runs (the panel otherwise only sees Puppetmaster store
         jobs). Shaped like a store job: a single synthesized worker task carries
@@ -888,12 +1226,15 @@ class LocalJobsMixin:
         else:
             display_model = ""
             model_id = ""
+        start_status = (initial_status or "running").strip() or "running"
+        if start_status not in ("queued", "running", "registered"):
+            start_status = "running"
         task_role = f"{role} ({engine_label})" if role else f"implement ({engine_label})"
         task_row = {
             "id": f"{job_id}-w0",
             "role": task_role,
             "instruction": goal,
-            "status": "running",
+            "status": start_status,
             "adapter": engine_label,
         }
         if display_model:
@@ -904,7 +1245,7 @@ class LocalJobsMixin:
             row = {
                 "id": job_id,
                 "goal": goal,
-                "status": "running",
+                "status": start_status,
                 "role": role,
                 "adapter": engine_label,
                 "model": display_model,
@@ -949,6 +1290,36 @@ class LocalJobsMixin:
                     )
                 except Exception:
                     pass
+
+    def _mark_local_job_started(self, job_id: str) -> None:
+        """Flip queued/registered children to running when the worker thread starts."""
+        import time
+
+        jid = str(job_id or "").strip()
+        if not jid:
+            return
+        with self._local_jobs_lock:
+            job = self._local_jobs.get(jid)
+            if not isinstance(job, dict):
+                return
+            if job.get("status") in _TERMINAL_LOCAL_JOB_STATUSES:
+                return
+            now = time.time()
+            job["status"] = "running"
+            job["started_at"] = job.get("started_at") or now
+            job["updated_at"] = now
+            if job.get("tasks"):
+                try:
+                    job["tasks"][0]["status"] = "running"
+                except Exception:
+                    pass
+            self._persist_local_jobs_locked()
+        try:
+            wave_id = self._parallel_wave_id_for_child(jid)
+            if wave_id:
+                self._sync_parallel_wave_from_children(wave_id)
+        except Exception:
+            pass
 
     def _refresh_local_job_routed_model(
         self, job_id: str, model: str, engine: str = "",
@@ -1033,8 +1404,17 @@ class LocalJobsMixin:
             # A user-cancelled job settles into a distinct 'cancelled' state so the
             # UI can render it differently from a natural completion/failure.
             cancelled = bool(job.get("status") == "cancelled" or status == "cancelled")
+            stage = ""
+            if isinstance(worker_provenance, dict):
+                stage = str(worker_provenance.get("failure_stage") or "")
             if cancelled:
                 terminal = "cancelled"
+            elif not ok and (
+                status in ("timeout", "timed_out") or stage == "agentic_timeout"
+            ):
+                terminal = "timeout"
+            elif not ok and status == "truncated":
+                terminal = "truncated"
             else:
                 terminal = "completed" if ok else "failed"
             job["status"] = terminal
@@ -1148,7 +1528,33 @@ class LocalJobsMixin:
             except Exception:
                 pass
             if isinstance(worker_provenance, dict):
-                job["worker_provenance"] = copy.deepcopy(worker_provenance)
+                prov = copy.deepcopy(worker_provenance)
+                if files and not prov.get("files"):
+                    prov["files"] = list(files)
+                if "retryable" not in prov and not ok:
+                    try:
+                        from harness.edit_engines import failure_is_retryable
+                        prov["retryable"] = failure_is_retryable(
+                            str(prov.get("failure_stage") or stage),
+                            prov.get("http_status"),
+                        )
+                    except Exception:
+                        prov["retryable"] = False
+                job["worker_provenance"] = prov
+                for key in _WAVE_FAILURE_COPY_KEYS:
+                    if key in prov:
+                        job[key] = copy.deepcopy(prov[key])
+            if files:
+                job["files"] = list(files)
+            if not ok and not cancelled and not job.get("error"):
+                err = ""
+                if isinstance(worker_provenance, dict):
+                    err = str(
+                        worker_provenance.get("error")
+                        or worker_provenance.get("failure_reason")
+                        or ""
+                    )
+                job["error"] = err or (summary or "Worker failed")
             summary_text = summary or ""
             if isinstance(worker_provenance, dict):
                 summary_text = sanitize_clean_tree_claims(
@@ -1567,7 +1973,7 @@ class LocalJobsMixin:
                         except Exception:
                             pass
                     # Fall through to action settle; do not heal-overwrite.
-                elif job.get("status") in ("running", "registered"):
+                elif job.get("status") in ("running", "registered", "queued"):
                     # running *and* registered-but-not-started rows are stale
                     # after process death — heal to cancelled so the panel
                     # never spins. Launch-checkpoint distinguishes "never

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -1920,6 +1920,7 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                                         else ''
                                     )
                                 ),
+                                initial_status="queued",
                                 **(
                                     {"skip_routing_preview": True}
                                     if agentic_pin is not None
@@ -2019,6 +2020,7 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                                         else ''
                                     )
                                 ),
+                                initial_status="queued",
                                 **(
                                     {"skip_routing_preview": True}
                                     if agentic_pin is not None
@@ -2103,6 +2105,7 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                                 else ''
                             )
                         ),
+                        initial_status="queued",
                         **(
                             {"skip_routing_preview": True}
                             if agentic_pin is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.372"
+version = "0.9.373"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_edit_engines.py
+++ b/tests/test_edit_engines.py
@@ -37,6 +37,7 @@ from harness.edit_engines import (
     _agentic_store_failure_snapshot,
     _format_agentic_engine_error,
     _summarize_agentic_result,
+    failure_is_retryable,
 )
 from harness.worker import ProviderWorker, WorkerResult
 from pmharness.bridge import _router_supports_max_capability
@@ -195,6 +196,74 @@ def test_agentic_store_failure_snapshot_unknown_usage_is_not_measured_zero():
     assert snap["tokens_in"] == 0
     assert snap["tokens_out"] == 0
     assert snap["task_ids"] == ["t9"]
+
+
+def test_agentic_store_failure_snapshot_captures_events_when_reason_empty():
+    class _Store:
+        def list_jobs(self):
+            return [type("J", (), {"id": "job_1", "status": "failed"})()]
+
+        def list_tasks(self, job_id):
+            return [type("T", (), {
+                "id": "t1",
+                "role": "implement",
+                "status": "failed",
+                "error": "",
+                "failure": "task attr boom",
+            })()]
+
+        def read_events(self, job_id):
+            return [
+                {"event": "worker.started", "payload": {}},
+                {"event": "worker.progress", "payload": {}},
+                {"event": "worker.tool_error", "payload": {"error": "adapter 500"}},
+            ]
+
+        def list_artifacts(self, job_id):
+            art = type("A", (), {})()
+            art.payload = {"tokens_in": 3}
+            art.type = "PATCH"
+            return [art]
+
+    snap = _agentic_store_failure_snapshot(_Store())
+    assert snap["reason"] == "adapter 500"
+    assert snap["event_names"][-1] == "worker.tool_error"
+    assert "worker.started" in snap["event_names"]
+    assert snap["job_status"] == "failed"
+    assert "PATCH" in snap["artifact_types"]
+    assert snap["task_ids"] == ["t1"]
+    summary = _format_agentic_engine_error(
+        RuntimeError("swarm exited with incomplete tasks"),
+        snap,
+    )
+    assert "incomplete tasks" in summary
+    assert "adapter 500" in summary
+    assert summary.strip() != "Agentic engine error: swarm exited with incomplete tasks"
+
+
+def test_format_agentic_engine_error_includes_events_when_reason_empty():
+    snap = {
+        "reason": "",
+        "event_names": ["worker.started", "worker.lease_check"],
+        "task_statuses": ["implement=running"],
+        "job_status": "running",
+    }
+    summary = _format_agentic_engine_error(
+        RuntimeError("swarm exited with incomplete tasks"),
+        snap,
+    )
+    assert "incomplete tasks" in summary
+    assert "events: worker.started, worker.lease_check" in summary
+    assert "tasks: implement=running" in summary
+    assert summary.strip() != "Agentic engine error: swarm exited with incomplete tasks"
+
+
+def test_failure_is_retryable_only_timeout_or_429():
+    assert failure_is_retryable("agentic_timeout") is True
+    assert failure_is_retryable("agentic_provider_rate_limited") is True
+    assert failure_is_retryable("agentic_error", 429) is True
+    assert failure_is_retryable("agentic_error") is False
+    assert failure_is_retryable("agentic_orchestrator_failed", 500) is False
 
 
 # --- pure helpers: _summarize_agentic_result ---

--- a/tests/test_parallel_wave_status.py
+++ b/tests/test_parallel_wave_status.py
@@ -1,0 +1,347 @@
+"""Parallel-wave aggregate status, child task projection, and retryable stamps."""
+from __future__ import annotations
+
+import tempfile
+
+from harness.config import HarnessConfig
+from harness.conversation import ConversationalSession
+from harness.local_jobs import aggregate_parallel_wave_status
+
+
+def _session(tmp_path):
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
+    cfg.repo = str(tmp_path)
+    sess = ConversationalSession(cfg)
+    sess.harness_session_id = "sess-wave"
+    return sess
+
+
+def _put_child(session, job_id, *, status, role="implement", goal="", **extra):
+    row = {
+        "id": job_id,
+        "goal": goal or job_id,
+        "status": status,
+        "role": role,
+        "adapter": extra.pop("adapter", "agentic"),
+        "model": extra.pop("model", "agentic/test"),
+        "artifacts": [],
+        "tasks": [{
+            "id": f"{job_id}-w0",
+            "role": role,
+            "instruction": goal or job_id,
+            "status": status,
+            "adapter": "agentic",
+        }],
+    }
+    row.update(extra)
+    session._local_jobs[job_id] = row
+    return row
+
+
+def _pending(session):
+    return next(
+        row for row in session.export_display_transcript()
+        if row.get("type") == "swarm_pending"
+    )
+
+
+def test_aggregate_status_helpers():
+    assert aggregate_parallel_wave_status(["completed", "completed"]) == "completed"
+    assert aggregate_parallel_wave_status(["completed", "failed"]) == "partial"
+    assert aggregate_parallel_wave_status(["failed", "failed"]) == "failed"
+    assert aggregate_parallel_wave_status(["timeout", "timeout"]) == "timed_out"
+    assert aggregate_parallel_wave_status(["timeout", "failed"]) == "failed"
+    assert aggregate_parallel_wave_status(["completed", "timeout"]) == "partial"
+    assert aggregate_parallel_wave_status(["cancelled", "cancelled"]) == "cancelled"
+    assert aggregate_parallel_wave_status(["completed", "cancelled"]) == "cancelled"
+
+
+def test_all_success_wave_completed_pending_done(tmp_path):
+    session = _session(tmp_path)
+    _put_child(session, "c1", status="completed", goal="one")
+    _put_child(session, "c2", status="completed", goal="two")
+    wave = session._register_parallel_wave(
+        "local-wave-ok",
+        child_job_ids=["c1", "c2"],
+        objective="all ok",
+    )
+    session._sync_parallel_wave_from_children("local-wave-ok")
+    parent = session._local_jobs["local-wave-ok"]
+    assert parent["status"] == "completed"
+    assert parent["review_required"] is False
+    assert parent["mixed_terminal"] is False
+    assert list(parent.get("artifacts") or []) == []
+    assert wave["child_job_ids"] == ["c1", "c2"]
+    assert _pending(session).get("status") == "done"
+
+
+def test_partial_success_wave_projects_child_tasks(tmp_path):
+    session = _session(tmp_path)
+    ids = [f"c{i}" for i in range(8)]
+    for i, cid in enumerate(ids):
+        status = "completed" if i < 4 else "failed"
+        _put_child(
+            session, cid, status=status, goal=f"goal {i}",
+            error="" if status == "completed" else "agentic_error",
+            failure_stage="" if status == "completed" else "agentic_error",
+            failure_reason="" if status == "completed" else "adapter boom",
+        )
+    session._register_parallel_wave(
+        "local-wave-mix",
+        child_job_ids=ids,
+        objective="mixed implement",
+    )
+    session._sync_parallel_wave_from_children("local-wave-mix")
+    parent = session._local_jobs["local-wave-mix"]
+    assert parent["status"] == "partial"
+    assert parent["review_required"] is True
+    assert parent["mixed_terminal"] is True
+    assert len(parent["tasks"]) == 8
+    assert parent["task_count"] == 8
+    assert [t["id"] for t in parent["tasks"]] == ids
+    assert parent["tasks"][0]["role"] == "implement"
+    assert parent["tasks"][0]["instruction"] == "goal 0"
+    receipt = parent["terminal_receipt"]
+    assert receipt["status"] == "partial"
+    assert "wave partial:" in receipt["summary"]
+    assert receipt["child_statuses"]["completed"] == 4
+    assert receipt["child_statuses"]["failed"] == 4
+    assert receipt["review_required"] is True
+    assert len(receipt["children"]) == 8
+    assert receipt["children"][4]["failure_stage"] == "agentic_error"
+    assert receipt["children"][4]["failure_reason"] == "adapter boom"
+    assert parent["tasks"][4]["failure_stage"] == "agentic_error"
+    assert parent["tasks"][4]["failure_reason"] == "adapter boom"
+    assert list(parent.get("artifacts") or []) == []
+    assert _pending(session).get("status") == "partial"
+
+
+def test_two_child_partial_task_len(tmp_path):
+    session = _session(tmp_path)
+    _put_child(session, "ok", status="completed")
+    _put_child(session, "bad", status="failed", error="boom")
+    session._register_parallel_wave(
+        "local-wave-2",
+        child_job_ids=["ok", "bad"],
+        objective="pair",
+    )
+    session._sync_parallel_wave_from_children("local-wave-2")
+    parent = session._local_jobs["local-wave-2"]
+    assert parent["status"] == "partial"
+    assert len(parent["tasks"]) == 2
+
+
+def test_all_fail_wave(tmp_path):
+    session = _session(tmp_path)
+    _put_child(session, "a", status="failed")
+    _put_child(session, "b", status="failed")
+    session._register_parallel_wave(
+        "local-wave-fail",
+        child_job_ids=["a", "b"],
+        objective="all fail",
+    )
+    session._sync_parallel_wave_from_children("local-wave-fail")
+    parent = session._local_jobs["local-wave-fail"]
+    assert parent["status"] == "failed"
+    assert parent["review_required"] is False
+    assert _pending(session).get("status") == "failed"
+
+
+def test_timeout_only_none_succeeded(tmp_path):
+    session = _session(tmp_path)
+    _put_child(session, "t1", status="timeout")
+    _put_child(session, "t2", status="timeout")
+    session._register_parallel_wave(
+        "local-wave-to",
+        child_job_ids=["t1", "t2"],
+        objective="timeouts",
+    )
+    session._sync_parallel_wave_from_children("local-wave-to")
+    parent = session._local_jobs["local-wave-to"]
+    assert parent["status"] == "timed_out"
+    assert _pending(session).get("status") == "failed"
+
+
+def test_analysis_partial_not_review_required(tmp_path):
+    session = _session(tmp_path)
+    _put_child(session, "a1", status="completed", role="analysis")
+    _put_child(session, "a2", status="failed", role="analysis")
+    session._register_parallel_wave(
+        "local-wave-an",
+        child_job_ids=["a1", "a2"],
+        objective="analysis wave",
+    )
+    session._sync_parallel_wave_from_children("local-wave-an")
+    parent = session._local_jobs["local-wave-an"]
+    assert parent["status"] == "partial"
+    assert parent["review_required"] is False
+
+
+def test_rate_limit_child_stamps_retryable(tmp_path):
+    session = _session(tmp_path)
+    session._register_local_job("local-rl", "rate limit goal", role="implement")
+    session._finish_local_job(
+        "local-rl",
+        ok=False,
+        summary="provider rate limited",
+        worker_provenance={
+            "failure_stage": "agentic_provider_rate_limited",
+            "failure_reason": "too many requests",
+            "http_status": 429,
+            "retry_after": "2",
+            "error": "agentic_provider_rate_limited",
+        },
+    )
+    job = session._local_jobs["local-rl"]
+    assert job["retryable"] is True
+    assert job["failure_stage"] == "agentic_provider_rate_limited"
+    assert job["worker_provenance"]["retryable"] is True
+    assert job["http_status"] == 429
+
+
+def test_generic_agentic_error_is_not_retryable(tmp_path):
+    session = _session(tmp_path)
+    session._register_local_job("local-ge", "incomplete", role="implement")
+    session._finish_local_job(
+        "local-ge",
+        ok=False,
+        summary="Agentic engine error: swarm exited with incomplete tasks",
+        worker_provenance={
+            "failure_stage": "agentic_error",
+            "failure_reason": "",
+            "error": "agentic_error",
+            "http_status": None,
+        },
+    )
+    job = session._local_jobs["local-ge"]
+    assert job["retryable"] is False
+
+
+def test_timeout_finish_maps_child_status(tmp_path):
+    session = _session(tmp_path)
+    session._register_local_job("local-to", "slow", role="implement")
+    session._finish_local_job(
+        "local-to",
+        ok=False,
+        summary="deadline",
+        worker_provenance={
+            "failure_stage": "agentic_timeout",
+            "failure_reason": "worker exceeded deadline",
+            "error": "agentic_timeout",
+        },
+    )
+    job = session._local_jobs["local-to"]
+    assert job["status"] == "timeout"
+    assert job["retryable"] is True
+
+
+def test_coordinator_with_no_children_stays_non_complete(tmp_path):
+    session = _session(tmp_path)
+    wave = session._register_parallel_wave(
+        "local-wave-empty",
+        child_job_ids=[],
+        objective="empty coordinator",
+    )
+    session._sync_parallel_wave_from_children("local-wave-empty")
+    parent = session._local_jobs["local-wave-empty"]
+    assert parent["status"] != "completed"
+    assert parent["status"] == "running"
+    assert parent.get("terminal_receipt") is None
+    assert wave["child_count"] == 0
+
+
+def test_retryable_timeout_wave_relaunches_once(tmp_path, monkeypatch):
+    session = _session(tmp_path)
+    _put_child(
+        session, "retry-me", status="timeout", goal="retry goal",
+        retryable=True, retry_count=0, cwd=str(tmp_path),
+    )
+    launched = []
+
+    def _fake_submit(fn, *args, **kwargs):
+        launched.append((fn, args))
+        return True
+
+    monkeypatch.setattr(session, "_submit_swarm", _fake_submit)
+    session._register_parallel_wave(
+        "local-wave-retry",
+        child_job_ids=["retry-me"],
+        objective="retry",
+    )
+    session._note_parallel_child_receipt("retry-me")
+    child = session._local_jobs["retry-me"]
+    assert child["retry_count"] == 1
+    assert child["status"] == "queued"
+    parent = session._local_jobs["local-wave-retry"]
+    assert parent["status"] == "running"
+    assert parent.get("wave_auto_retry_attempted") is True
+    assert launched
+    assert launched[0][1][0] == "retry-me"
+
+
+def test_file_overlap_skips_retry(tmp_path, monkeypatch):
+    session = _session(tmp_path)
+    _put_child(
+        session, "ok", status="completed", goal="ok",
+        applied=True, files=["src/a.py"],
+    )
+    _put_child(
+        session, "bad", status="timeout", goal="bad",
+        retryable=True, retry_count=0, files=["src/a.py"],
+    )
+    launched = []
+    monkeypatch.setattr(session, "_submit_swarm", lambda *a, **k: launched.append(a) or True)
+    session._register_parallel_wave(
+        "local-wave-overlap",
+        child_job_ids=["ok", "bad"],
+        objective="overlap",
+    )
+    session._note_parallel_child_receipt("bad")
+    assert launched == []
+    assert session._local_jobs["bad"]["status"] == "timeout"
+    assert session._local_jobs["local-wave-overlap"]["status"] == "partial"
+
+
+def test_retry_launch_failure_settles_child(tmp_path, monkeypatch):
+    session = _session(tmp_path)
+    _put_child(
+        session, "retry-me", status="timeout", goal="retry goal",
+        retryable=True, retry_count=0, cwd=str(tmp_path),
+    )
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("pool full")
+
+    monkeypatch.setattr(session, "_submit_swarm", _boom)
+    session._register_parallel_wave(
+        "local-wave-retry-fail",
+        child_job_ids=["retry-me"],
+        objective="retry",
+    )
+    session._note_parallel_child_receipt("retry-me")
+    child = session._local_jobs["retry-me"]
+    assert child["status"] == "failed"
+    assert child["failure_stage"] == "retry_launch"
+    assert "pool full" in child["failure_reason"]
+    parent = session._local_jobs["local-wave-retry-fail"]
+    assert parent["status"] == "failed"
+
+
+def test_enrich_uses_summary_when_finish_reason_empty():
+    from harness.conversation_jobs import _enrich_worker_provenance
+    from harness.worker import WorkerResult
+
+    res = WorkerResult(
+        ok=False,
+        error="agentic_error",
+        summary=(
+            "Agentic engine error: swarm exited with incomplete tasks\n"
+            "events: worker.tool_error\n"
+            "tasks: implement=failed"
+        ),
+        finish_reason="",
+    )
+    prov = _enrich_worker_provenance({"error": "agentic_error"}, res)
+    assert prov["failure_stage"] == "agentic_error"
+    assert "events: worker.tool_error" in prov["failure_reason"]
+    assert prov["retryable"] is False

--- a/tests/test_send_loop_dispatch.py
+++ b/tests/test_send_loop_dispatch.py
@@ -471,7 +471,7 @@ def test_dispatch_parallel_uses_resolved_git_child_cwd(tmp_path, monkeypatch):
     )
     registered: list = []
 
-    def _register(job_id, goal, role="implement", cwd="", engine="", model=""):
+    def _register(job_id, goal, role="implement", cwd="", engine="", model="", **_kw):
         registered.append({"job_id": job_id, "cwd": cwd, "goal": goal})
 
     session = SimpleNamespace(

--- a/tests/test_terminal_evidence_pr2.py
+++ b/tests/test_terminal_evidence_pr2.py
@@ -151,9 +151,10 @@ def test_parallel_children_keep_exact_independent_receipts(tmp_path):
 
     parent = reloaded._local_jobs["local-wave-pr2"]
     assert set(parent["terminal_job_ids"]) == {ok_id, bad_id}
-    assert parent["status"] in {"failed", "completed"}
+    assert parent["status"] == "partial"
     receipt = parent["terminal_receipt"]
     assert receipt is not None
+    assert receipt["status"] == "partial"
     assert set(receipt["child_job_ids"]) == {ok_id, bad_id}
     assert "artifacts" not in receipt
     assert list(parent.get("artifacts") or []) == []
@@ -163,7 +164,7 @@ def test_parallel_children_keep_exact_independent_receipts(tmp_path):
         if row.get("type") == "swarm_pending"
     )
     assert set(pending["terminal_job_ids"]) == {ok_id, bad_id}
-    assert pending.get("status") == "done"
+    assert pending.get("status") == "partial"
 
 
 def test_identical_artifact_ids_do_not_leak_through_shared_store(tmp_path):

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.372",
+  "version": "0.9.373",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.372",
+      "version": "0.9.373",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.372",
+  "version": "0.9.373",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/composerFamilyChrome.test.tsx
+++ b/webapp/src/__tests__/composerFamilyChrome.test.tsx
@@ -161,4 +161,33 @@ describe("composer-family chrome", () => {
       expect(el?.className).not.toMatch(/text-muted-foreground|rose-500|uppercase tracking-\[0\.16em\]/);
     }
   });
+
+  it("renders parallel wave partial header from child counts", () => {
+    const waveTasks = Array.from({ length: 8 }, (_, i) => ({
+      id: `c${i}`,
+      role: "implement",
+      instruction: `goal ${i}`,
+      status: i < 4 ? "completed" : "failed",
+      adapter: "x",
+      applied: i < 4,
+    }));
+    const wave = {
+      id: "local-wave-mix",
+      goal: "mixed implement",
+      status: "partial",
+      session_id: "sess-1",
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+      child_count: 8,
+      review_required: true,
+      tasks: waveTasks,
+    } as Job;
+    const { getByText } = render(
+      <ComposerTasksPanel jobs={[wave]} sessionId="sess-1" />,
+    );
+    expect(
+      getByText("Parallel wave — partial 4/8 completed · 4 failed · 4 patches applied · review required"),
+    ).toBeInTheDocument();
+  });
 });

--- a/webapp/src/__tests__/composerTasks.test.ts
+++ b/webapp/src/__tests__/composerTasks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildComposerTasks, pickTaskSourceJob, taskProgress, taskState } from "../lib/composerTasks";
+import { buildComposerTasks, pickTaskSourceJob, taskProgress, taskState, waveHeaderText, waveProgress } from "../lib/composerTasks";
 import type { Job } from "../lib/api";
 
 const job = (id: string, status: string, session_id: string, tasks: Job["tasks"]): Job => ({
@@ -17,6 +17,8 @@ describe("taskState", () => {
     expect(taskState("pending")).toBe("pending");
     expect(taskState("failed")).toBe("failed");
     expect(taskState("degraded")).toBe("degraded");
+    expect(taskState("partial")).toBe("degraded");
+    expect(taskState("timeout")).toBe("failed");
   });
 });
 
@@ -28,6 +30,26 @@ describe("pickTaskSourceJob", () => {
       job("other", "running", "sess-2", [{ id: "t2", role: "impl", instruction: "other", status: "running", adapter: "x" }]),
     ], "sess-1");
     expect(picked?.id).toBe("live");
+  });
+
+  it("prefers the wave coordinator in the active session", () => {
+    const wave: Job = {
+      ...job("local-wave-abc", "partial", "sess-1", [
+        { id: "c1", role: "implement", instruction: "one", status: "completed", adapter: "x" },
+        { id: "c2", role: "implement", instruction: "two", status: "failed", adapter: "x" },
+      ]),
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+      child_count: 8,
+    };
+    const picked = pickTaskSourceJob([
+      job("local-child-1", "failed", "sess-1", [
+        { id: "c1", role: "implement", instruction: "child", status: "failed", adapter: "x" },
+      ]),
+      wave,
+    ], "sess-1");
+    expect(picked?.id).toBe("local-wave-abc");
   });
 });
 
@@ -77,5 +99,33 @@ describe("buildComposerTasks + progress", () => {
     expect(tasks[0].state).toBe("completed");
     expect(tasks[1].state).toBe("degraded");
     expect(taskProgress(tasks)).toEqual({ done: 2, total: 2 });
+  });
+
+  it("wave coordinator header and progress use child counts 4/8", () => {
+    const tasks = Array.from({ length: 8 }, (_, i) => ({
+      id: `c${i}`,
+      role: "implement",
+      instruction: `goal ${i}`,
+      status: i < 4 ? "completed" : "failed",
+      adapter: "x",
+      applied: i < 4,
+      failure_stage: i < 4 ? "" : "agentic_error",
+      failure_reason: i < 4 ? "" : "adapter boom",
+    }));
+    const wave = {
+      ...job("local-wave-mix", "partial", "sess-1", tasks),
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      child_count: 8,
+      review_required: true,
+    } as Job;
+    const built = buildComposerTasks(wave);
+    expect(built.filter((t) => t.state === "failed")).toHaveLength(4);
+    expect(built.filter((t) => t.state === "completed")).toHaveLength(4);
+    expect(built[4].detail).toBe("agentic_error: adapter boom");
+    expect(waveProgress(wave)).toEqual({ completed: 4, failed: 4, applied: 4, total: 8 });
+    expect(waveHeaderText(wave)).toBe(
+      "Parallel wave — partial 4/8 completed · 4 failed · 4 patches applied · review required",
+    );
   });
 });

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -1362,7 +1362,7 @@ describe("streamApply module", () => {
     }
   });
 
-  it("run_parallel pill waits for all jobs and fails if any failed", () => {
+  it("run_parallel pill waits for all jobs and marks mixed waves partial", () => {
     let items: Item[] = [
       {
         kind: "swarm_pending",
@@ -1394,7 +1394,7 @@ describe("streamApply module", () => {
     });
     expect(items[0]).toMatchObject({
       kind: "swarm_pending",
-      status: "failed",
+      status: "partial",
       resolved: true,
     });
   });

--- a/webapp/src/__tests__/swarmPendingIdentity.test.ts
+++ b/webapp/src/__tests__/swarmPendingIdentity.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSwarmPendingTerminalStatus,
+  swarmPendingStatusRank,
+} from "../components/conversation/swarmPendingIdentity";
+
+describe("swarmPendingStatusRank", () => {
+  it("ranks failed above partial above done", () => {
+    expect(swarmPendingStatusRank("failed")).toBeGreaterThan(swarmPendingStatusRank("partial"));
+    expect(swarmPendingStatusRank("partial")).toBeGreaterThan(swarmPendingStatusRank("done"));
+    expect(swarmPendingStatusRank("done")).toBeGreaterThan(swarmPendingStatusRank("ended"));
+    expect(swarmPendingStatusRank("ended")).toBeGreaterThan(swarmPendingStatusRank("running"));
+  });
+
+  it("treats partial as terminal", () => {
+    expect(isSwarmPendingTerminalStatus("partial")).toBe(true);
+    expect(isSwarmPendingTerminalStatus("failed")).toBe(true);
+    expect(isSwarmPendingTerminalStatus("done")).toBe(true);
+    expect(isSwarmPendingTerminalStatus("ended")).toBe(true);
+    expect(isSwarmPendingTerminalStatus("running")).toBe(false);
+  });
+});

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -171,7 +171,7 @@ export type Card = {
              output_preview?: string };
 };
 /** Inline swarm status pill lifecycle (running spinner vs terminal chips). */
-export type SwarmPendingStatus = "running" | "done" | "failed" | "ended";
+export type SwarmPendingStatus = "running" | "done" | "failed" | "ended" | "partial";
 
 export type SwarmPendingItem = {
   kind: "swarm_pending";
@@ -3991,25 +3991,31 @@ function SwarmPendingPill({
   const truncatedObj = objective.length > 60 ? objective.slice(0, 60) + "..." : objective;
   const label = status === "failed"
     ? "swarm failed"
-    : status === "ended"
-      ? "swarm ended"
-      : status === "done"
-        ? "swarm done"
-        : "swarm running";
+    : status === "partial"
+      ? "swarm partial"
+      : status === "ended"
+        ? "swarm ended"
+        : status === "done"
+          ? "swarm done"
+          : "swarm running";
   const shell =
     status === "failed"
       ? "bg-risk/10 border-risk/30 text-risk/80"
-      : status === "ended"
-        ? "bg-panel2/15 border-edge/20 text-faint"
-        : status === "done"
-          ? "bg-panel2/20 border-edge/30 text-faint"
-          : "bg-panel2/60 border-edge/60 text-muted";
+      : status === "partial"
+        ? "bg-warn/10 border-warn/30 text-warn"
+        : status === "ended"
+          ? "bg-panel2/15 border-edge/20 text-faint"
+          : status === "done"
+            ? "bg-panel2/20 border-edge/30 text-faint"
+            : "bg-panel2/60 border-edge/60 text-muted";
   const dot =
     status === "failed"
       ? "bg-risk/50"
-      : status === "done"
-        ? "bg-good/40"
-        : "bg-faint/40";
+      : status === "partial"
+        ? "bg-warn/50"
+        : status === "done"
+          ? "bg-good/40"
+          : "bg-faint/40";
   return (
     <div className={`flex items-center gap-1.5 py-1 px-3 rounded-full border text-[11px] w-fit my-1 select-none ${shell}`}>
       {status === "running"

--- a/webapp/src/components/conversation/ComposerTasksPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTasksPanel.tsx
@@ -1,8 +1,17 @@
 import { useState } from "react";
 import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Circle, Loader2, ListChecks, XCircle } from "lucide-react";
 import type { Job } from "../../lib/api";
-import { buildComposerTasks, pickTaskSourceJob, taskProgress, type ComposerTask } from "../../lib/composerTasks";
+import { isWaveCoordinator } from "../../lib/jobClassification";
+import { buildComposerTasks, pickTaskSourceJob, taskProgress, waveHeaderText, type ComposerTask } from "../../lib/composerTasks";
 import { COMPOSER_FAMILY_SURFACE } from "./composerFamily";
+
+function waveHeaderTone(status: string): string {
+  const s = status.toLowerCase();
+  if (s.includes("fail") || s.includes("timed")) return "text-risk";
+  if (s === "partial") return "text-warn";
+  if (s.includes("complete")) return "text-good";
+  return "text-txt";
+}
 
 function TaskIcon({ state }: { state: ComposerTask["state"] }) {
   if (state === "completed") return <CheckCircle2 size={11} className="shrink-0 text-good" />;
@@ -25,6 +34,9 @@ export default function ComposerTasksPanel({
   const tasks = buildComposerTasks(job);
   const { done, total } = taskProgress(tasks);
   if (!total) return null;
+  const wave = Boolean(job && isWaveCoordinator(job));
+  const header = wave && job ? waveHeaderText(job) : `Tasks ${done}/${total}`;
+  const headerTone = wave ? waveHeaderTone(String(job?.status || "")) : "text-txt";
 
   return (
     <div
@@ -39,7 +51,7 @@ export default function ComposerTasksPanel({
       >
         {open ? <ChevronDown size={11} className="text-faint" /> : <ChevronRight size={11} className="text-faint" />}
         <ListChecks size={11} className="text-faint" />
-        <span className="font-medium">Tasks {done}/{total}</span>
+        <span className={`font-medium ${headerTone}`}>{header}</span>
       </button>
       {open && (
         <div className="border-t border-edge/50 px-2 py-1 space-y-0.5">
@@ -56,6 +68,9 @@ export default function ComposerTasksPanel({
                 <TaskIcon state={task.state} />
                 <span className={`${task.state === "pending" ? "text-faint" : "text-txt"} ${expanded ? "whitespace-pre-wrap break-words" : "min-w-0 truncate"}`}>
                   {task.content}
+                  {expanded && task.detail ? (
+                    <span className="mt-0.5 block text-faint">{task.detail}</span>
+                  ) : null}
                 </span>
               </button>
             );

--- a/webapp/src/components/conversation/streamApply.ts
+++ b/webapp/src/components/conversation/streamApply.ts
@@ -25,6 +25,7 @@ import {
   mergeSwarmPendingReplay,
   normalizeSwarmJobIds,
   swarmPendingStatusOf,
+  swarmPendingStatusRank,
 } from "./swarmPendingIdentity";
 import {
   boundActionField,
@@ -124,7 +125,7 @@ function swarmResultLooksFailed(resObj: {
 
 function withPendingTerminal(
   item: SwarmPendingItem,
-  status: "done" | "failed" | "ended",
+  status: SwarmPendingStatus,
   terminalJobIds: string[],
 ): SwarmPendingItem {
   return {
@@ -1477,14 +1478,19 @@ function pendingStatusFromCoveredResults(
   if (!allTerminal) {
     return { status: "running", resolved: false, terminal_job_ids: terminals };
   }
-  const anyFailed = items.some(
-    (it) =>
-      it.kind === "swarm_result"
-      && ids.includes(it.job_id)
-      && swarmResultLooksFailed(it),
+  const members = items.filter(
+    (it): it is Extract<Item, { kind: "swarm_result" }> =>
+      it.kind === "swarm_result" && ids.includes(it.job_id),
   );
+  const anyFailed = members.some((it) => swarmResultLooksFailed(it));
+  const anyOk = members.some((it) => !swarmResultLooksFailed(it));
+  const status: SwarmPendingStatus = anyFailed && anyOk
+    ? "partial"
+    : anyFailed
+      ? "failed"
+      : "done";
   return {
-    status: anyFailed ? "failed" : "done",
+    status,
     resolved: true,
     terminal_job_ids: terminals,
   };
@@ -1536,7 +1542,7 @@ export function appendSwarmPending(
       ],
     );
     if (!isSwarmPendingTerminal(merged) && covered.resolved) {
-      merged = withPendingTerminal(merged, covered.status as "done" | "failed", covered.terminal_job_ids);
+      merged = withPendingTerminal(merged, covered.status, covered.terminal_job_ids);
     } else {
       merged = { ...merged, terminal_job_ids: covered.terminal_job_ids };
     }
@@ -1846,13 +1852,7 @@ function findSwarmPendingForResult(
   for (let i = 0; i < items.length; i++) {
     const it = items[i];
     if (it.kind !== "swarm_pending" || !it.job_ids.includes(jobId)) continue;
-    const rank = isSwarmPendingTerminal(it)
-      ? swarmPendingStatus(it) === "failed"
-        ? 3
-        : swarmPendingStatus(it) === "done"
-          ? 2
-          : 1
-      : 0;
+    const rank = swarmPendingStatusRank(swarmPendingStatus(it));
     if (bestIdx < 0 || rank > bestRank) {
       bestIdx = i;
       bestRank = rank;
@@ -1880,13 +1880,7 @@ function findSwarmPendingForResult(
     ) {
       continue;
     }
-    const rank = isSwarmPendingTerminal(it)
-      ? swarmPendingStatus(it) === "failed"
-        ? 3
-        : swarmPendingStatus(it) === "done"
-          ? 2
-          : 1
-      : 0;
+    const rank = swarmPendingStatusRank(swarmPendingStatus(it));
     // Prefer still-running so a spinner clears; otherwise keep most advanced.
     const prefer = !isSwarmPendingTerminal(it) ? 10 : rank;
     if (aliasIdx < 0 || prefer > aliasRank) {
@@ -2085,16 +2079,25 @@ export function applySwarmResultToItems(
       };
     }
 
-    // Any prior credited failure on this pill, or this result, flips to failed.
-    const priorFailed = swarmPendingStatus(item) === "failed";
     const siblingFailed = items.some(
       (it) =>
         it.kind === "swarm_result"
         && item.job_ids.includes(it.job_id)
         && swarmResultLooksFailed(it),
     );
-    const status: "done" | "failed" =
-      priorFailed || siblingFailed || resultFailed ? "failed" : "done";
+    const siblingOk = items.some(
+      (it) =>
+        it.kind === "swarm_result"
+        && item.job_ids.includes(it.job_id)
+        && !swarmResultLooksFailed(it),
+    );
+    const anyFailed = siblingFailed || resultFailed || swarmPendingStatus(item) === "failed";
+    const anyOk = siblingOk || !resultFailed;
+    const status: SwarmPendingStatus = anyFailed && anyOk
+      ? "partial"
+      : anyFailed
+        ? "failed"
+        : "done";
     return withPendingTerminal(item, status, terminalJobIds);
   });
 
@@ -2183,12 +2186,21 @@ export function finalizeOrphanSwarmPills(
     const allTerminal =
       item.job_ids.every((id) => terminalFromResults.has(id)) || objectiveCovered;
     if (allTerminal) {
-      const anyFailed =
-        objectiveFailed
-        || [...terminalFromResults].some((id) => resultByJob.get(id)?.failed);
+      const failedIds = [...terminalFromResults].filter((id) => resultByJob.get(id)?.failed);
+      const okIds = [...terminalFromResults].filter((id) => {
+        const row = resultByJob.get(id);
+        return row != null && !row.failed;
+      });
+      const anyFailed = objectiveFailed || failedIds.length > 0;
+      const anyOk = okIds.length > 0 && !objectiveFailed;
+      const status: SwarmPendingStatus = anyFailed && anyOk
+        ? "partial"
+        : anyFailed
+          ? "failed"
+          : "done";
       return withPendingTerminal(
         item,
-        anyFailed ? "failed" : "done",
+        status,
         [...terminalFromResults],
       );
     }

--- a/webapp/src/components/conversation/swarmPendingIdentity.ts
+++ b/webapp/src/components/conversation/swarmPendingIdentity.ts
@@ -33,7 +33,7 @@ export function swarmPendingStatusOf(
 export function isSwarmPendingTerminalStatus(
   status: SwarmPendingStatus,
 ): boolean {
-  return status === "done" || status === "failed" || status === "ended";
+  return status === "done" || status === "failed" || status === "ended" || status === "partial";
 }
 
 export function isSwarmPendingTerminal(item: SwarmPendingItem): boolean {
@@ -44,13 +44,19 @@ export function isSwarmPendingTerminal(item: SwarmPendingItem): boolean {
 export function swarmPendingStatusRank(status: SwarmPendingStatus): number {
   switch (status) {
     case "failed":
+      return 4;
+    case "partial":
       return 3;
     case "done":
       return 2;
     case "ended":
       return 1;
-    default:
+    case "running":
       return 0;
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
   }
 }
 

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -202,10 +202,16 @@ export type Task = {
   estimated?: boolean;
   /** Pre-run routing forecast — never spend. */
   route_forecast_usd?: number;
+  error?: string;
+  failure_stage?: string;
+  failure_reason?: string;
+  applied?: boolean;
+  retryable?: boolean;
 };
 export type Job = {
   id: string;
   goal: string;
+  /** running | completed | partial | failed | cancelled | timed_out | … */
   status: string;
   /** Harness chat that dispatched this job, when stamped. */
   session_id?: string;
@@ -330,7 +336,32 @@ export type Job = {
   child_count?: number;
   max_concurrency?: number;
   mixed_terminal?: boolean;
-  /** Durable terminal receipt once the command settles. */
+  /** Implement parallel_wave: mixed success+failure needs review. */
+  review_required?: boolean;
+  worker_provenance?: {
+    failure_stage?: string;
+    failure_reason?: string;
+    http_status?: number | null;
+    retry_after?: string;
+    provider_request_id?: string;
+    pm_job_id?: string;
+    task_ids?: string[];
+    provider?: string;
+    model?: string;
+    retryable?: boolean;
+    retry_count?: number;
+    partial_patch?: boolean;
+    applied?: boolean;
+    held_for_review?: boolean;
+    event_names?: string[];
+    files?: string[];
+    error?: string;
+  };
+  failure_stage?: string;
+  failure_reason?: string;
+  retryable?: boolean;
+  retry_count?: number;
+  /** Durable terminal receipt once the command or wave settles. */
   terminal_receipt?: {
     status?: string;
     run_status?: string;
@@ -342,9 +373,26 @@ export type Job = {
     output_spilled?: boolean;
     child_statuses?: Record<string, number>;
     mixed_terminal?: boolean;
+    review_required?: boolean;
     child_job_ids?: string[];
+    terminal_job_ids?: string[];
     recovery?: string;
     had_launch_checkpoint?: boolean;
+    children?: Array<{
+      id?: string;
+      goal?: string;
+      status?: string;
+      error?: string;
+      failure_stage?: string;
+      failure_reason?: string;
+      model?: string;
+      provider?: string;
+      applied?: boolean;
+      held_for_review?: boolean;
+      retryable?: boolean;
+      retry_count?: number;
+      files?: string[];
+    }>;
   } | null;
   /**
    * Wave 4 launch fact persisted before the child process can start.

--- a/webapp/src/lib/composerTasks.ts
+++ b/webapp/src/lib/composerTasks.ts
@@ -1,4 +1,5 @@
 import type { Job, Task } from "./api";
+import { isWaveCoordinator } from "./jobClassification";
 import { jobInActiveSession } from "./jobScope";
 
 export type ComposerTaskState = "pending" | "in_progress" | "completed" | "failed" | "degraded";
@@ -7,12 +8,16 @@ export type ComposerTask = {
   id: string;
   content: string;
   state: ComposerTaskState;
+  detail?: string;
 };
 
 export function taskState(status: unknown): ComposerTaskState {
   const s = String(status || "").trim().toLowerCase();
   if (s.includes("fail") || s.includes("error") || s.includes("dead")) return "failed";
-  if (s.includes("degrad")) return "degraded";
+  if (s.includes("timeout") || s.includes("timed_out") || s.includes("cancel") || s.includes("truncat")) {
+    return "failed";
+  }
+  if (s.includes("partial") || s.includes("degrad")) return "degraded";
   if (s.includes("complete") || s.includes("done") || s === "ok" || s.includes("success")) return "completed";
   if (s.includes("run") || s.includes("progress") || s.includes("active")) return "in_progress";
   return "pending";
@@ -29,7 +34,9 @@ function jobRank(job: Job): number {
 export function pickTaskSourceJob(jobs: readonly Job[], activeSessionId: string): Job | null {
   const scoped = jobs.filter((job) => jobInActiveSession(job, activeSessionId) && (job.tasks || []).length);
   if (!scoped.length) return null;
-  return [...scoped].sort((a, b) => {
+  const wave = scoped.filter((job) => isWaveCoordinator(job));
+  const pool = wave.length ? wave : scoped;
+  return [...pool].sort((a, b) => {
     const rank = jobRank(a) - jobRank(b);
     if (rank !== 0) return rank;
     return String(b.updated_at || b.created_at || "").localeCompare(String(a.updated_at || a.created_at || ""));
@@ -64,10 +71,12 @@ export function buildComposerTasks(job: Job | null): ComposerTask[] {
       const fail = arts.find((a) => String(a.task_id || "") === String(task.id || "") && artifactLooksFailed(a));
       if (fail) state = "degraded";
     }
+    const detail = waveChildDetail(task);
     return {
       id: String(task.id || `${job?.id || "job"}-${i}`),
       content: oneLineLabel(task),
       state,
+      ...(detail ? { detail } : {}),
     };
   });
 }
@@ -77,4 +86,43 @@ export function taskProgress(tasks: readonly ComposerTask[]): { done: number; to
     done: tasks.filter((t) => t.state === "completed" || t.state === "degraded").length,
     total: tasks.length,
   };
+}
+
+export function waveProgress(job: Job | null): { completed: number; failed: number; applied: number; total: number } {
+  const receiptChildren = job?.terminal_receipt?.children;
+  const rows = Array.isArray(receiptChildren) && receiptChildren.length
+    ? receiptChildren
+    : (job?.tasks || []);
+  const total = Number(job?.child_count) || Number(job?.task_count) || rows.length;
+  let completed = 0;
+  let failed = 0;
+  let applied = 0;
+  for (const row of rows) {
+    const st = taskState(row.status);
+    if (st === "completed") completed += 1;
+    else if (st === "failed") failed += 1;
+    if (row.applied) applied += 1;
+  }
+  return { completed, failed, applied, total };
+}
+
+function waveChildDetail(task: Task): string {
+  const stage = String(task.failure_stage || "").trim();
+  const reason = String(task.failure_reason || task.error || "").trim();
+  if (stage && reason && reason.toLowerCase() !== stage.toLowerCase()) {
+    return `${stage}: ${reason}`;
+  }
+  return reason || stage;
+}
+
+export function waveHeaderText(job: Job): string {
+  const { completed, failed, applied, total } = waveProgress(job);
+  const status = String(job.status || "running").trim().toLowerCase().replace(/_/g, " ");
+  let text = `Parallel wave — ${status} ${completed}/${total} completed`;
+  if (failed > 0) text += ` · ${failed} failed`;
+  if (applied > 0) text += ` · ${applied} patch${applied === 1 ? "" : "es"} applied`;
+  if (job.review_required || job.terminal_receipt?.review_required) {
+    text += " · review required";
+  }
+  return text;
 }


### PR DESCRIPTION
## Why

A mixed `run_parallel` wave was rendering as one opaque failed task (`Tasks 0/1`). Child workers only showed `Agentic engine error: swarm exited with incomplete tasks`, so you could not tell partial success from total failure.

## Scope

- Parent `parallel_wave` status is now `completed` / `partial` / `failed` / `cancelled` / `timed_out`. Mixed implement waves stay `partial` with `review_required`; they are never `done`.
- Parent `tasks[]` is one row per child. `terminal_receipt.children[]` keeps failure stage, reason, model, provider, applied/held, retryable.
- Composer Tasks header: `Parallel wave — partial 4/8 completed · 4 failed · N patches applied · review required`. Tracker still hides `local-wave-*`.
- Snapshot the agentic scratch store before cleanup. Retry once, failed children only, and only for timeout / 429 / rate-limit. Skip file overlap with successful siblings.
- Concurrency stays `max_workers=4` (already configurable).

## Tradeoffs

Sketch A: parent owns membership and aggregate lifecycle only. Child artifacts stay on children (PR2). No second WaveResultCard.

## Blast radius

Local-job terminal set now includes `partial` and `timed_out`. Swarm pending pills gain `partial`. Command jobs unchanged.

## Verification

- Focused pytest: `tests/test_parallel_wave_status.py` plus terminal-evidence, edit-engines, send-loop-dispatch, worker-provenance.
- Full local pytest after the register-kwarg / success-path retryable fixes: 5306 passed, 78 skipped, then the two previously failing tests green.
- Vitest: composerTasks, swarmPendingIdentity, conversation.helpers, composerFamilyChrome, jobClassification (165 passed in that slice).
- Composer header proven by `composerFamilyChrome` render test. Live Electron GUI was not running this session.
- Cursor review `job_e5cf04fe2d01` completed degraded (verification-only, no FINDINGs).

## Test plan

- [x] Local pytest + focused vitest
- [ ] Dest-into-main `tests` matrix (3.9, 3.11, Windows, frontend-build)
- [ ] After merge: `scripts/ci_release_gate.py require-green`, tag `v0.9.373` when `merge^{tree}` matches this PR tree
- [ ] No wiki this session
