### PR TITLE
Release v0.9.374

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.37` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.373, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.374, deliberately pre-1.0. Rides puppetmaster-ai==1.22.37. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.373"
+__version__ = "0.9.374"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.373"
+version = "0.9.374"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.373",
+  "version": "0.9.374",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.373",
+      "version": "0.9.374",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.373",
+  "version": "0.9.374",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/ComposerStatusStack.test.tsx
+++ b/webapp/src/__tests__/ComposerStatusStack.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ComposerStatusStack from "../components/conversation/ComposerStatusStack";
+import { api } from "../lib/api";
+import { openAgentCommand } from "../lib/agentLinks";
+import type { Job } from "../lib/api";
+
+vi.mock("../lib/api", () => ({
+  api: { swarmCancel: vi.fn().mockResolvedValue({ ok: true }) },
+}));
+vi.mock("../lib/agentLinks", () => ({
+  openAgentCommand: vi.fn(),
+  openAgentSwarmJob: vi.fn(),
+}));
+vi.mock("../lib/agentCommandIndex", () => ({
+  subscribeAgentCommandIndex: (cb: () => void) => {
+    void cb;
+    return () => {};
+  },
+  getAgentCommandIndexVersion: () => 1,
+  listAgentCommandSessions: () => [],
+  registerAgentCommandSession: () => null,
+}));
+
+function commandJob(partial: Partial<Job> & Pick<Job, "id" | "status">): Job {
+  return {
+    goal: "find ~/.pmharness",
+    source: "harness",
+    updated_at: Date.now(),
+    job_kind: "run_command",
+    role: "command",
+    adapter: "command",
+    command_preview: "find ~/.pmharness",
+    ...partial,
+  } as Job;
+}
+
+describe("ComposerStatusStack", () => {
+  beforeEach(() => {
+    vi.mocked(api.swarmCancel).mockClear();
+    vi.mocked(openAgentCommand).mockClear();
+  });
+  it("collapses settled terminal rows behind a header like the wave bar", () => {
+    render(
+      <ComposerStatusStack
+        swarmJobs={[commandJob({ id: "local-cmd-trunc", status: "truncated" })]}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Terminal" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Open terminal")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
+    expect(screen.getByRole("button", { name: "Terminal" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Open terminal")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Stop command" })).not.toBeInTheDocument();
+  });
+
+  it("expands running commands and stops them without opening the terminal", () => {
+    render(
+      <ComposerStatusStack
+        swarmJobs={[commandJob({ id: "local-cmd-live", status: "running" })]}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Terminal" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Open terminal")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Stop command" }));
+    expect(api.swarmCancel).toHaveBeenCalledWith("local-cmd-live");
+    expect(openAgentCommand).not.toHaveBeenCalled();
+  });
+
+  it("stops every running command from the group header X while collapsed", () => {
+    render(
+      <ComposerStatusStack
+        swarmJobs={[
+          commandJob({ id: "local-cmd-a", status: "running", command_preview: "find a" }),
+          commandJob({ id: "local-cmd-b", status: "running", command_preview: "find b" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
+    expect(screen.getByRole("button", { name: "Terminal" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Open terminal")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Stop all commands" }));
+    expect(api.swarmCancel).toHaveBeenCalledWith("local-cmd-a");
+    expect(api.swarmCancel).toHaveBeenCalledWith("local-cmd-b");
+    expect(openAgentCommand).not.toHaveBeenCalled();
+  });
+});

--- a/webapp/src/__tests__/composerFamilyChrome.test.tsx
+++ b/webapp/src/__tests__/composerFamilyChrome.test.tsx
@@ -8,7 +8,7 @@ import { COMPOSER_FAMILY_CLASS } from "../components/conversation/composerFamily
 import type { Job } from "../lib/api";
 
 vi.mock("../lib/api", () => ({
-  api: {},
+  api: { swarmCancel: vi.fn() },
 }));
 vi.mock("../components/PilotPicker", () => ({
   default: () => <div data-testid="pilot-picker" />,
@@ -23,6 +23,7 @@ vi.mock("../lib/agentCommandIndex", () => ({
   },
   getAgentCommandIndexVersion: () => 1,
   listAgentCommandSessions: () => [],
+  registerAgentCommandSession: () => null,
 }));
 
 const noop = () => {};

--- a/webapp/src/__tests__/composerStatusStack.test.ts
+++ b/webapp/src/__tests__/composerStatusStack.test.ts
@@ -244,6 +244,58 @@ describe("composerStatusStack", () => {
     });
   });
 
+  it("treats truncated command jobs as failed, not running", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const job = {
+      id: "local-cmd-trunc",
+      goal: "find ~/.pmharness",
+      source: "harness",
+      status: "truncated",
+      updated_at: now - 1000,
+      job_kind: "run_command",
+      role: "command",
+      adapter: "command",
+      command_preview: "find ~/.pmharness",
+    } as any;
+    expect(visibleCommandJob(job, now)).toMatchObject({
+      id: "local-cmd-trunc",
+      kind: "terminal",
+      state: "failed",
+    });
+  });
+
+  it("lets a truncated live job overlay a still-running command session", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [{
+        id: "local-cmd-e35cf193",
+        goal: "find ~/.pmharness",
+        source: "harness",
+        status: "truncated",
+        updated_at: now - 1000,
+        job_kind: "run_command",
+        role: "command",
+        adapter: "command",
+        command_preview: "find ~/.pmharness",
+      } as any],
+      commandSessions: [{
+        id: "local-cmd-e35cf193",
+        command: "find ~/.pmharness",
+        output: "truncated (exit -1)",
+        state: "running",
+        updatedAt: now - 200,
+      }],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "local-cmd-e35cf193",
+      kind: "terminal",
+      state: "failed",
+      output: "truncated (exit -1)",
+    });
+  });
+
   it("collapses command preview whitespace so the task bar does not stair-step", () => {
     const now = Date.parse("2026-08-23T12:00:00Z");
     const job = {

--- a/webapp/src/components/conversation/ComposerStatusStack.tsx
+++ b/webapp/src/components/conversation/ComposerStatusStack.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
-import { ChevronRight, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { ChevronDown, ChevronRight, CheckCircle2, Loader2, X, XCircle } from "lucide-react";
+import { api, type Job } from "../../lib/api";
 import { openAgentCommand, openAgentSwarmJob } from "../../lib/agentLinks";
 import {
   getAgentCommandIndexVersion,
@@ -9,7 +10,11 @@ import {
 } from "../../lib/agentCommandIndex";
 import { buildComposerStatusStackRows, type ComposerStatusStackRow } from "./composerStatusStackData";
 import { COMPOSER_FAMILY_LABEL, COMPOSER_FAMILY_SURFACE } from "./composerFamily";
-import type { Job } from "../../lib/api";
+
+const ROW_FOCUS =
+  "focus-visible:border-accent/60 focus-visible:outline-none";
+const ICON_FOCUS =
+  "focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-accent";
 
 function statusIcon(row: ComposerStatusStackRow) {
   if (row.state === "running") {
@@ -34,8 +39,123 @@ function groupLabel(kind: ComposerStatusStackRow["kind"]): string {
   return kind === "swarm" ? "Puppetmaster" : "Terminal";
 }
 
+function stopAllLabel(kind: ComposerStatusStackRow["kind"]): string {
+  return kind === "swarm" ? "Stop all Puppetmaster jobs" : "Stop all commands";
+}
+
+function stopRowLabel(kind: ComposerStatusStackRow["kind"]): string {
+  return kind === "swarm" ? "Stop job" : "Stop command";
+}
+
+function StatusStackGroup({
+  kind,
+  rows,
+  cancelling,
+  onCancel,
+}: {
+  kind: ComposerStatusStackRow["kind"];
+  rows: ComposerStatusStackRow[];
+  cancelling: ReadonlySet<string>;
+  onCancel: (ids: string[]) => void;
+}) {
+  const runningIds = rows.filter((row) => row.state === "running").map((row) => row.id);
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
+  const open = userOpen ?? runningIds.length > 0;
+
+  return (
+    <div>
+      <div className="flex items-center">
+        <button
+          type="button"
+          aria-label={groupLabel(kind)}
+          aria-expanded={open}
+          onClick={() => setUserOpen(!open)}
+          className={`flex min-w-0 flex-1 items-center gap-1.5 px-2 py-1 text-left text-[10.5px] leading-4 text-txt hover:bg-panel/35 ${ICON_FOCUS}`}
+        >
+          {open
+            ? <ChevronDown size={11} className="shrink-0 text-faint" aria-hidden />
+            : <ChevronRight size={11} className="shrink-0 text-faint" aria-hidden />}
+          <span className={`${COMPOSER_FAMILY_LABEL} font-medium`}>{groupLabel(kind)}</span>
+          <span className="ml-auto font-mono text-[10.5px] text-muted tabular-nums">
+            {rows.length}
+          </span>
+        </button>
+        {runningIds.length > 0 && (
+          runningIds.every((id) => cancelling.has(id)) ? (
+            <span className="shrink-0 px-1.5 text-[9px] italic text-risk/70">cancelling...</span>
+          ) : (
+            <button
+              type="button"
+              title={stopAllLabel(kind)}
+              aria-label={stopAllLabel(kind)}
+              onClick={() => onCancel(runningIds)}
+              className={`mr-1.5 shrink-0 text-faint/50 hover:text-risk ${ICON_FOCUS}`}
+            >
+              <X size={11} />
+            </button>
+          )
+        )}
+      </div>
+      {open && (
+        <div className="space-y-0.5 border-t border-edge/50 px-2 py-1">
+          {rows.map((row) => {
+            const stopping = cancelling.has(row.id);
+            const onOpen = () => {
+              if (row.kind === "swarm") {
+                openAgentSwarmJob(row.id);
+                return;
+              }
+              openAgentCommand(row.command || row.label, {
+                id: row.id,
+                output: row.output || "",
+              });
+            };
+
+            return (
+              <div key={`${row.kind}:${row.id}`} className="flex items-center gap-0.5">
+                <button
+                  type="button"
+                  onClick={onOpen}
+                  title={row.title}
+                  className={`flex min-w-0 flex-1 items-center gap-1.5 rounded-md border border-edge/50 bg-panel/60 px-1.5 py-1 text-left text-[10.5px] leading-4 text-txt transition-colors hover:border-edge2 hover:bg-panel2/70 ${ROW_FOCUS}`}
+                >
+                  <span className="flex h-[20px] shrink-0 items-center rounded-md border border-edge/30 bg-panel2/40 px-1 text-[10.5px] font-medium text-faint">
+                    {rowKindLabel(row.kind)}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{row.label}</span>
+                  <span className="flex shrink-0 items-center gap-1 text-[10.5px] text-muted">
+                    {statusIcon(row)}
+                    <span>{rowActionLabel(row)}</span>
+                  </span>
+                  <ChevronRight size={11} className="shrink-0 text-faint" aria-hidden />
+                </button>
+                {row.state === "running" && (
+                  stopping ? (
+                    <span className="shrink-0 px-1 text-[9px] italic text-risk/70">cancelling...</span>
+                  ) : (
+                    <button
+                      type="button"
+                      title={stopRowLabel(row.kind)}
+                      aria-label={stopRowLabel(row.kind)}
+                      onClick={() => onCancel([row.id])}
+                      className={`shrink-0 text-faint/50 hover:text-risk ${ICON_FOCUS}`}
+                    >
+                      <X size={11} />
+                    </button>
+                  )
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly Job[] }) {
   const [nowTick, setNowTick] = useState(() => Date.now());
+  const [cancelling, setCancelling] = useState<Set<string>>(() => new Set());
   const commandIndexVersion = useSyncExternalStore(
     subscribeAgentCommandIndex,
     getAgentCommandIndexVersion,
@@ -82,6 +202,30 @@ export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly
     return out;
   }, [rows]);
 
+  const onCancel = (ids: string[]) => {
+    const unique = [...new Set(ids.filter(Boolean))];
+    if (!unique.length) return;
+    setCancelling((prev) => {
+      const next = new Set(prev);
+      for (const id of unique) next.add(id);
+      return next;
+    });
+    void Promise.allSettled(unique.map((id) => api.swarmCancel(id))).then((results) => {
+      setCancelling((prev) => {
+        const next = new Set(prev);
+        results.forEach((result, i) => {
+          const id = unique[i];
+          if (result.status === "rejected") {
+            next.delete(id);
+            return;
+          }
+          if (result.value.ok === false) next.delete(id);
+        });
+        return next;
+      });
+    });
+  };
+
   if (grouped.length === 0) return null;
 
   return (
@@ -91,50 +235,13 @@ export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly
     >
       <div className="divide-y divide-edge/50">
         {grouped.map((group) => (
-          <div key={group.kind} className="px-2 py-1">
-            <div className="mb-0.5 flex items-center justify-between">
-              <span className={`${COMPOSER_FAMILY_LABEL} font-medium`}>
-                {groupLabel(group.kind)}
-              </span>
-              <span className="text-[10.5px] font-mono text-muted">
-                {group.rows.length}
-              </span>
-            </div>
-            <div className="space-y-0.5">
-              {group.rows.map((row) => {
-                const onClick = () => {
-                  if (row.kind === "swarm") {
-                    openAgentSwarmJob(row.id);
-                    return;
-                  }
-                  openAgentCommand(row.command || row.label, {
-                    id: row.id,
-                    output: row.output || "",
-                  });
-                };
-
-                return (
-                  <button
-                    key={`${row.kind}:${row.id}`}
-                    type="button"
-                    onClick={onClick}
-                    title={row.title}
-                    className="flex w-full items-center gap-1.5 rounded-md border border-edge/50 bg-panel/60 px-1.5 py-1 text-left text-[10.5px] leading-4 text-txt transition hover:border-edge2 hover:bg-panel2/70 focus-visible:border-accent/60 focus-visible:outline-none"
-                  >
-                    <span className="flex h-[20px] shrink-0 items-center rounded-md border border-edge/30 bg-panel2/40 px-1 text-[10.5px] font-medium text-faint">
-                      {rowKindLabel(row.kind)}
-                    </span>
-                    <span className="min-w-0 flex-1 truncate">{row.label}</span>
-                    <span className="flex shrink-0 items-center gap-1 text-[10.5px] text-muted">
-                      {statusIcon(row)}
-                      <span>{rowActionLabel(row)}</span>
-                    </span>
-                    <ChevronRight size={11} className="shrink-0 text-faint" aria-hidden />
-                  </button>
-                );
-              })}
-            </div>
-          </div>
+          <StatusStackGroup
+            key={group.kind}
+            kind={group.kind}
+            rows={group.rows}
+            cancelling={cancelling}
+            onCancel={onCancel}
+          />
         ))}
       </div>
     </div>

--- a/webapp/src/components/conversation/composerStatusStackData.ts
+++ b/webapp/src/components/conversation/composerStatusStackData.ts
@@ -38,6 +38,21 @@ function timestampMs(value: unknown): number | null {
   return null;
 }
 
+function overlayExistingRow(
+  existing: ComposerStatusStackRow,
+  incoming: ComposerStatusStackRow,
+): ComposerStatusStackRow {
+  return {
+    ...existing,
+    state: incoming.state,
+    updatedAt: Math.max(existing.updatedAt, incoming.updatedAt),
+    output: existing.output || incoming.output,
+    command: existing.command || incoming.command,
+    label: existing.label || incoming.label,
+    title: existing.title || incoming.title,
+  };
+}
+
 function normalizeState(status: unknown): ComposerStatusStackState {
   const s = String(status || "").trim().toLowerCase();
   if (
@@ -47,6 +62,7 @@ function normalizeState(status: unknown): ComposerStatusStackState {
     || s.includes("dead")
     || s.includes("interrupt")
     || s.includes("cancel")
+    || s.includes("truncat")
     || /time(?:d)?[-_ ]?out/.test(s)
   ) {
     return "failed";
@@ -172,12 +188,15 @@ export function buildComposerStatusStackRows(
 
   for (const job of source.swarmJobs) {
     const id = String(job.id || "").trim();
-    if (id && seen.has(id)) continue;
     const row = visibleSwarmJob(job, nowMs) ?? visibleCommandJob(job, nowMs);
-    if (row) {
-      rows.push(row);
-      seen.add(row.id);
+    if (!row) continue;
+    if (id && seen.has(id)) {
+      const idx = rows.findIndex((item) => item.id === id);
+      if (idx >= 0) rows[idx] = overlayExistingRow(rows[idx], row);
+      continue;
     }
+    rows.push(row);
+    if (id) seen.add(id);
   }
 
   return rows.sort((a, b) => {


### PR DESCRIPTION
## Why

After the pilot finished, leftover `run_command` jobs could keep the composer Terminal stack spinning. `truncated` was classified as running because that word contains `run`. The send row showed Send, not Stop, so there was no way to kill those commands from that chrome.

## Scope

- Composer Terminal (and Puppetmaster) stack uses the same collapse chevron as the Parallel wave bar. Default open only while a row is running.
- Per-row X and group X call `POST /api/swarm/cancel` (`cancel_local_job`). Clicking X does not open the terminal.
- `truncated` maps to failed before the `run` substring check. A live job's terminal status overlays a stale running command session.

## Tradeoffs

Sketch A: reuse ComposerTasksPanel collapse and the existing cancel API. No second TerminalResultCard.

## Blast radius

ComposerStatusStack chrome only. Command execution and cancel semantics are unchanged. Swarm Tracker cancel is unchanged.

## Verification

- Local pytest: 5308 passed, 78 skipped.
- `npm test` in webapp: 1505 passed.
- Focused vitest: composerStatusStack, ComposerStatusStack, composerFamilyChrome.
- Live Electron GUI was not attached this session.

## Test plan

- [x] Local pytest + npm test
- [ ] Dest-into-main `tests` matrix (3.9, 3.11, Windows, frontend-build)
- [ ] After merge: `scripts/ci_release_gate.py require-green`, tag `v0.9.374` when `merge^{tree}` matches this PR tree