### PR TITLE
Release v0.9.376

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.38` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.375, deliberately pre-1.0. Rides puppetmaster-ai==1.22.38. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.376, deliberately pre-1.0. Rides puppetmaster-ai==1.22.38. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.375"
+__version__ = "0.9.376"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/local_job_swarm_view.py
+++ b/harness/local_job_swarm_view.py
@@ -15,7 +15,7 @@ from harness.local_job_artifacts import artifacts_are_complete
 
 _TERMINAL_STATUSES = frozenset({
     "completed", "failed", "cancelled", "complete", "done",
-    "timeout", "truncated",
+    "timeout", "truncated", "partial", "timed_out",
 })
 _RUNNING_STATUSES = frozenset({
     "running", "in_progress", "pending", "started", "registered",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.375"
+version = "0.9.376"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_local_job_swarm_view.py
+++ b/tests/test_local_job_swarm_view.py
@@ -139,6 +139,30 @@ def test_project_local_job_artifacts_complete_false_for_placeholder_only():
     assert row["tasks"][0]["instruction"] == ""
 
 
+def test_project_partial_and_timed_out_waves_are_terminal():
+    for status in ("partial", "timed_out"):
+        row = project_local_job_for_swarm_live(_sample_local_job(
+            id="local-wave-x",
+            status=status,
+            role="parallel_wave",
+            adapter="parallel_wave",
+        ))
+        assert row["status"] == status
+        assert row["tasks"][0]["instruction"] == ""
+
+
+def test_project_partial_and_timed_out_waves_are_terminal():
+    for status in ("partial", "timed_out"):
+        row = project_local_job_for_swarm_live(_sample_local_job(
+            id="local-wave-x",
+            status=status,
+            role="parallel_wave",
+            adapter="parallel_wave",
+        ))
+        assert row["status"] == status
+        assert row["tasks"][0]["instruction"] == ""
+
+
 def test_project_restart_interrupted_job():
     row = project_local_job_for_swarm_live(_sample_local_job(
         status="cancelled",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.375",
+  "version": "0.9.376",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.375",
+      "version": "0.9.376",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.375",
+  "version": "0.9.376",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/composerFamilyChrome.test.tsx
+++ b/webapp/src/__tests__/composerFamilyChrome.test.tsx
@@ -191,4 +191,30 @@ describe("composer-family chrome", () => {
       getByText("Parallel wave — partial 4/8 completed · 4 failed · 4 patches applied · review required"),
     ).toBeInTheDocument();
   });
+
+  it("unmounts a completed 5/5 parallel wave instead of leaving implement flags", () => {
+    const wave = {
+      id: "local-wave-done",
+      goal: "implement",
+      status: "completed",
+      session_id: "sess-1",
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+      child_count: 5,
+      tasks: Array.from({ length: 5 }, (_, i) => ({
+        id: `c${i}`,
+        role: "implement",
+        instruction: "implement",
+        status: "completed",
+        adapter: "x",
+      })),
+    } as Job;
+    const { container, queryByText } = render(
+      <ComposerTasksPanel jobs={[wave]} sessionId="sess-1" />,
+    );
+    expect(container.querySelector("[data-slot=composer-tasks-panel]")).toBeNull();
+    expect(queryByText("Parallel wave — completed 5/5 completed")).not.toBeInTheDocument();
+    expect(queryByText("implement")).not.toBeInTheDocument();
+  });
 });

--- a/webapp/src/__tests__/composerTasks.test.ts
+++ b/webapp/src/__tests__/composerTasks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildComposerTasks, pickTaskSourceJob, taskProgress, taskState, waveHeaderText, waveProgress } from "../lib/composerTasks";
+import { buildComposerTasks, composerTasksRemainVisible, pickTaskSourceJob, taskProgress, taskState, waveHeaderText, waveProgress } from "../lib/composerTasks";
 import type { Job } from "../lib/api";
 
 const job = (id: string, status: string, session_id: string, tasks: Job["tasks"]): Job => ({
@@ -50,6 +50,31 @@ describe("pickTaskSourceJob", () => {
       wave,
     ], "sess-1");
     expect(picked?.id).toBe("local-wave-abc");
+  });
+
+  it("does not let a completed 5/5 wave hide a partial wave in the same session", () => {
+    const done: Job = {
+      ...job("local-wave-done", "completed", "sess-1", Array.from({ length: 5 }, (_, i) => ({
+        id: `d${i}`,
+        role: "implement",
+        instruction: "implement",
+        status: "completed",
+        adapter: "x",
+      }))),
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+    };
+    const partial: Job = {
+      ...job("local-wave-mix", "partial", "sess-1", [
+        { id: "c1", role: "implement", instruction: "one", status: "completed", adapter: "x" },
+        { id: "c2", role: "implement", instruction: "two", status: "failed", adapter: "x" },
+      ]),
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+    };
+    expect(pickTaskSourceJob([done, partial], "sess-1")?.id).toBe("local-wave-mix");
   });
 });
 
@@ -127,5 +152,35 @@ describe("buildComposerTasks + progress", () => {
     expect(waveHeaderText(wave)).toBe(
       "Parallel wave — partial 4/8 completed · 4 failed · 4 patches applied · review required",
     );
+  });
+
+  it("drops a fully completed parallel wave so the composer does not keep implement flags", () => {
+    const wave = {
+      ...job("local-wave-done", "completed", "sess-1", Array.from({ length: 5 }, (_, i) => ({
+        id: `c${i}`,
+        role: "implement",
+        instruction: "implement",
+        status: "completed",
+        adapter: "x",
+      }))),
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+      child_count: 5,
+    } as Job;
+    const tasks = buildComposerTasks(wave);
+    expect(taskProgress(tasks)).toEqual({ done: 5, total: 5 });
+    expect(composerTasksRemainVisible(tasks)).toBe(false);
+  });
+
+  it("keeps a partial or failed wave visible", () => {
+    const tasks = buildComposerTasks({
+      ...job("local-wave-mix", "partial", "sess-1", [
+        { id: "c1", role: "implement", instruction: "one", status: "completed", adapter: "x" },
+        { id: "c2", role: "implement", instruction: "two", status: "failed", adapter: "x" },
+      ]),
+      job_kind: "parallel_wave",
+    } as Job);
+    expect(composerTasksRemainVisible(tasks)).toBe(true);
   });
 });

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -737,6 +737,12 @@ describe("chatEvents module", () => {
     expect(isTerminalJobStatus("running")).toBe(false);
   });
 
+  it("treats parallel-wave aggregate partial and timed_out as terminal", () => {
+    expect(isTerminalJobStatus("partial")).toBe(true);
+    expect(isTerminalJobStatus("timed_out")).toBe(true);
+    expect(isTerminalJobStatus("PARTIAL")).toBe(true);
+  });
+
   it("gates poll and runner arming", () => {
     expect(
       shouldPollChatEvents({

--- a/webapp/src/__tests__/swarmAwaitChrome.test.ts
+++ b/webapp/src/__tests__/swarmAwaitChrome.test.ts
@@ -340,6 +340,30 @@ describe("swarm await chrome", () => {
     ).toEqual(["job_alive", "job_queued"]);
   });
 
+  it("does not hold Still working for a settled partial or timed_out wave", () => {
+    const live = [
+      { id: "local-wave-call_KzqPc5uVkh7VyutjZlCzjV3N", status: "partial" },
+      { id: "local-wave-call_Iliw2ZfBkaIh881nw8QmEh7i", status: "partial" },
+      { id: "local-wave-call_v7ZjvWP9peyQUMFAk0IIWXdb", status: "completed" },
+      { id: "local-wave-timeout", status: "timed_out" },
+    ];
+    expect(pendingJobIdsFromSwarmLive(live)).toEqual([]);
+    expect(terminalJobIdsFromSwarmLive(live)).toEqual([
+      "local-wave-call_KzqPc5uVkh7VyutjZlCzjV3N",
+      "local-wave-call_Iliw2ZfBkaIh881nw8QmEh7i",
+      "local-wave-call_v7ZjvWP9peyQUMFAk0IIWXdb",
+      "local-wave-timeout",
+    ]);
+    expect(
+      shouldHoldSwarmAwaitChrome({
+        pendingJobIds: pendingJobIdsFromSwarmLive(live),
+        backendPendingSwarms: false,
+        userStopped: false,
+      }),
+    ).toBe(false);
+    expect(waitHintForAssistantDone(pendingJobIdsFromSwarmLive(live))).toBeNull();
+  });
+
   it("paints Still working hint after assistant_done with live jobs", () => {
     expect(waitHintForAssistantDone(["local-bf1b30f4"])).toBe(SWARM_AWAIT_HINT);
     expect(waitHintForAssistantDone(["local-swarm-a"])).toBe(null);

--- a/webapp/src/components/conversation/ComposerTasksPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTasksPanel.tsx
@@ -31,12 +31,12 @@ export default function ComposerTasksPanel({
   const [open, setOpen] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const job = pickTaskSourceJob(jobs, sessionId);
+  if (!job) return null;
   const tasks = buildComposerTasks(job);
   const { done, total } = taskProgress(tasks);
-  if (!total) return null;
-  const wave = Boolean(job && isWaveCoordinator(job));
-  const header = wave && job ? waveHeaderText(job) : `Tasks ${done}/${total}`;
-  const headerTone = wave ? waveHeaderTone(String(job?.status || "")) : "text-txt";
+  const wave = isWaveCoordinator(job);
+  const header = wave ? waveHeaderText(job) : `Tasks ${done}/${total}`;
+  const headerTone = wave ? waveHeaderTone(String(job.status || "")) : "text-txt";
 
   return (
     <div

--- a/webapp/src/components/conversation/nestedActionBounds.ts
+++ b/webapp/src/components/conversation/nestedActionBounds.ts
@@ -1,6 +1,8 @@
 /**
  * Shared nested-action bounds / status normalization for live merge and
- * durable hydrate. Keep in sync with harness.job_actions.
+ * durable hydrate. Keep in sync with harness.job_actions for nested rows,
+ * and with harness.local_jobs._TERMINAL_LOCAL_JOB_STATUSES for wave
+ * aggregates (partial / timed_out).
  */
 
 export const MAX_JOB_ACTIONS = 80;
@@ -20,10 +22,12 @@ const TERMINAL_JOB_STATUSES = new Set([
   "success",
   "error",
   "timeout",
+  "timed_out",
   "truncated",
   "interrupted",
   "stalled",
   "degraded",
+  "partial",
 ]);
 
 export function isTerminalJobStatus(status: string | undefined | null): boolean {

--- a/webapp/src/lib/composerTasks.ts
+++ b/webapp/src/lib/composerTasks.ts
@@ -33,9 +33,10 @@ function jobRank(job: Job): number {
 
 export function pickTaskSourceJob(jobs: readonly Job[], activeSessionId: string): Job | null {
   const scoped = jobs.filter((job) => jobInActiveSession(job, activeSessionId) && (job.tasks || []).length);
-  if (!scoped.length) return null;
-  const wave = scoped.filter((job) => isWaveCoordinator(job));
-  const pool = wave.length ? wave : scoped;
+  const remaining = scoped.filter((job) => composerTasksRemainVisible(buildComposerTasks(job)));
+  if (!remaining.length) return null;
+  const wave = remaining.filter((job) => isWaveCoordinator(job));
+  const pool = wave.length ? wave : remaining;
   return [...pool].sort((a, b) => {
     const rank = jobRank(a) - jobRank(b);
     if (rank !== 0) return rank;
@@ -79,6 +80,10 @@ export function buildComposerTasks(job: Job | null): ComposerTask[] {
       ...(detail ? { detail } : {}),
     };
   });
+}
+
+export function composerTasksRemainVisible(tasks: readonly ComposerTask[]): boolean {
+  return tasks.some((task) => task.state !== "completed");
 }
 
 export function taskProgress(tasks: readonly ComposerTask[]): { done: number; total: number } {


### PR DESCRIPTION
## Summary
- Hide the composer Parallel wave bar after every task is completed (the leftover 5/5 flags after a finished wave).
- Treat wave aggregates `partial` and `timed_out` as terminal so Swarm Await chrome does not stay on Still working after the session is idle.
- Version bump to 0.9.376. Pin stays `puppetmaster-ai==1.22.38`.

## Test plan
- [ ] `tests` matrix green: Python 3.9, 3.11, Windows, frontend-build
- [ ] Confirm a completed 5/5 wave unmounts ComposerTasksPanel
- [ ] Confirm a `partial` local wave does not hold Still working after the footer is Idle
- [ ] Installer jobs overlap this PR; do not wait for main to re-run the same tree before tagging