### PR TITLE
Release v0.9.377

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.38` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.376, deliberately pre-1.0. Rides puppetmaster-ai==1.22.38. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.377, deliberately pre-1.0. Rides puppetmaster-ai==1.22.38. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.376"
+__version__ = "0.9.377"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.376"
+version = "0.9.377"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.376",
+  "version": "0.9.377",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.376",
+      "version": "0.9.377",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.376",
+  "version": "0.9.377",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/composerFamilyChrome.test.tsx
+++ b/webapp/src/__tests__/composerFamilyChrome.test.tsx
@@ -217,4 +217,40 @@ describe("composer-family chrome", () => {
     expect(queryByText("Parallel wave — completed 5/5 completed")).not.toBeInTheDocument();
     expect(queryByText("implement")).not.toBeInTheDocument();
   });
+
+  it("unmounts a settled partial wave while an unrelated swarm is running", () => {
+    const wave = {
+      id: "local-wave-stale",
+      goal: "implement",
+      status: "partial",
+      session_id: "sess-1",
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+      child_count: 4,
+      tasks: [
+        { id: "c1", role: "implement", instruction: "implement", status: "completed", adapter: "x" },
+        { id: "c2", role: "implement", instruction: "implement", status: "failed", adapter: "x" },
+        { id: "c3", role: "implement", instruction: "implement", status: "completed", adapter: "x" },
+        { id: "c4", role: "implement", instruction: "implement", status: "completed", adapter: "x" },
+      ],
+    } as Job;
+    const swarm = {
+      id: "job_live_swarm",
+      goal: "Perform a fresh read-only validation",
+      status: "running",
+      session_id: "sess-1",
+      job_kind: "run_swarm",
+      tasks: [
+        { id: "w1", role: "decision-explainer", instruction: "Explain", status: "running", adapter: "agentic" },
+        { id: "w2", role: "explore", instruction: "Explore", status: "running", adapter: "agentic" },
+      ],
+    } as Job;
+    const { container, queryByText, getByText } = render(
+      <ComposerTasksPanel jobs={[wave, swarm]} sessionId="sess-1" />,
+    );
+    expect(queryByText("Parallel wave — partial 3/4 completed · 1 failed")).not.toBeInTheDocument();
+    expect(container.querySelector("[data-slot=composer-tasks-panel]")).toBeTruthy();
+    expect(getByText("Tasks 0/2")).toBeInTheDocument();
+  });
 });

--- a/webapp/src/__tests__/composerTasks.test.ts
+++ b/webapp/src/__tests__/composerTasks.test.ts
@@ -76,6 +76,64 @@ describe("pickTaskSourceJob", () => {
     };
     expect(pickTaskSourceJob([done, partial], "sess-1")?.id).toBe("local-wave-mix");
   });
+
+  it("does not keep a settled partial wave when a live swarm is in the same session", () => {
+    const wave: Job = {
+      ...job("local-wave-stale", "partial", "sess-1", [
+        { id: "c1", role: "implement", instruction: "implement", status: "completed", adapter: "x" },
+        { id: "c2", role: "implement", instruction: "implement", status: "failed", adapter: "x" },
+        { id: "c3", role: "implement", instruction: "implement", status: "completed", adapter: "x" },
+        { id: "c4", role: "implement", instruction: "implement", status: "completed", adapter: "x" },
+      ]),
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+    };
+    const swarm: Job = {
+      ...job("job_live_swarm", "running", "sess-1", [
+        { id: "w1", role: "decision-explainer", instruction: "Explain", status: "running", adapter: "agentic" },
+        { id: "w2", role: "explore", instruction: "Explore", status: "running", adapter: "agentic" },
+      ]),
+      job_kind: "run_swarm",
+    };
+    expect(pickTaskSourceJob([wave, swarm], "sess-1")?.id).toBe("job_live_swarm");
+  });
+
+  it("does not keep a settled partial wave when a live swarm has no task rows yet", () => {
+    const wave: Job = {
+      ...job("local-wave-stale", "partial", "sess-1", [
+        { id: "c1", role: "implement", instruction: "implement", status: "completed", adapter: "x" },
+        { id: "c2", role: "implement", instruction: "implement", status: "failed", adapter: "x" },
+      ]),
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+    };
+    const swarm: Job = {
+      ...job("job_live_swarm", "running", "sess-1", []),
+      job_kind: "run_swarm",
+    };
+    expect(pickTaskSourceJob([wave, swarm], "sess-1")).toBeNull();
+  });
+
+  it("still prefers a live wave over a live swarm", () => {
+    const wave: Job = {
+      ...job("local-wave-live", "running", "sess-1", [
+        { id: "c1", role: "implement", instruction: "one", status: "running", adapter: "x" },
+        { id: "c2", role: "implement", instruction: "two", status: "pending", adapter: "x" },
+      ]),
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+    };
+    const swarm: Job = {
+      ...job("job_live_swarm", "running", "sess-1", [
+        { id: "w1", role: "explore", instruction: "Explore", status: "running", adapter: "agentic" },
+      ]),
+      job_kind: "run_swarm",
+    };
+    expect(pickTaskSourceJob([wave, swarm], "sess-1")?.id).toBe("local-wave-live");
+  });
 });
 
 describe("buildComposerTasks + progress", () => {

--- a/webapp/src/lib/composerTasks.ts
+++ b/webapp/src/lib/composerTasks.ts
@@ -31,17 +31,38 @@ function jobRank(job: Job): number {
   return 3;
 }
 
-export function pickTaskSourceJob(jobs: readonly Job[], activeSessionId: string): Job | null {
-  const scoped = jobs.filter((job) => jobInActiveSession(job, activeSessionId) && (job.tasks || []).length);
-  const remaining = scoped.filter((job) => composerTasksRemainVisible(buildComposerTasks(job)));
-  if (!remaining.length) return null;
-  const wave = remaining.filter((job) => isWaveCoordinator(job));
-  const pool = wave.length ? wave : remaining;
+function composerJobIsLive(job: Job): boolean {
+  const st = taskState(job.status);
+  if (st === "in_progress" || st === "pending") return true;
+  return (job.tasks || []).some((task) => {
+    const ts = taskState(task.status);
+    return ts === "in_progress" || ts === "pending";
+  });
+}
+
+function pickRankedJob(pool: readonly Job[]): Job {
   return [...pool].sort((a, b) => {
     const rank = jobRank(a) - jobRank(b);
     if (rank !== 0) return rank;
     return String(b.updated_at || b.created_at || "").localeCompare(String(a.updated_at || a.created_at || ""));
   })[0];
+}
+
+export function pickTaskSourceJob(jobs: readonly Job[], activeSessionId: string): Job | null {
+  const inSession = jobs.filter((job) => jobInActiveSession(job, activeSessionId));
+  const remaining = inSession.filter(
+    (job) => (job.tasks || []).length && composerTasksRemainVisible(buildComposerTasks(job)),
+  );
+  if (!remaining.length) return null;
+  const liveRemaining = remaining.filter(composerJobIsLive);
+  const liveWaves = liveRemaining.filter((job) => isWaveCoordinator(job));
+  if (liveWaves.length) return pickRankedJob(liveWaves);
+  if (liveRemaining.length) return pickRankedJob(liveRemaining);
+  if (inSession.some((job) => composerJobIsLive(job) && !isWaveCoordinator(job))) {
+    return null;
+  }
+  const waves = remaining.filter((job) => isWaveCoordinator(job));
+  return pickRankedJob(waves.length ? waves : remaining);
 }
 
 function oneLineLabel(task: Task): string {


### PR DESCRIPTION
## Summary
- Composer no longer keeps a settled Parallel wave bar (for example partial 3/4) when a live swarm is running in the same session.
- Live waves still own the panel. Idle leftover partial/failed waves still show. Fully completed 5/5 waves still unmount.
- Version bump to 0.9.377. Pin stays `puppetmaster-ai==1.22.38`.

## Test plan
- [ ] `tests` matrix green: Python 3.9, Windows shards, frontend-build
- [ ] Confirm a leftover 3/4 partial wave does not paint while Swarm Tracker shows an unrelated running hire
- [ ] Confirm an idle session still shows a leftover partial/failed wave
- [ ] Installer jobs overlap this PR; do not wait for main to re-run the same tree before tagging