### PR TITLE
Release v0.9.379

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.39` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.378, deliberately pre-1.0. Rides puppetmaster-ai==1.22.39. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.379, deliberately pre-1.0. Rides puppetmaster-ai==1.22.39. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.378"
+__version__ = "0.9.379"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/session_control.py
+++ b/harness/api/session_control.py
@@ -392,6 +392,12 @@ def get_session_state(qs: dict, svc: SessionControlServices) -> tuple[int, JsonP
             goal = pilot.session_goal_dict() or {}
     except Exception:
         goal = {}
+    todos = {}
+    try:
+        if pilot is not None and hasattr(pilot, "todo_snapshot"):
+            todos = pilot.todo_snapshot() or {}
+    except Exception:
+        todos = {}
     return 200, {
         "state": state,
         "pending_swarms": pilot.has_pending_swarms(),
@@ -402,6 +408,7 @@ def get_session_state(qs: dict, svc: SessionControlServices) -> tuple[int, JsonP
         "active_view_id": runners.active_view_id,
         # Sticky session GOAL (chip-ready); distinct from Schedule.objective.
         "goal": goal,
+        "todos": todos,
     }
 
 
@@ -462,6 +469,24 @@ def post_session_goal(body: dict, svc: SessionControlServices) -> tuple[int, Jso
     except Exception as exc:
         return 500, {"ok": False, "error": str(exc)}
     return 200, {"ok": True, "goal": goal}
+
+
+def post_session_todo(body: dict, svc: SessionControlServices) -> tuple[int, JsonPayload]:
+    """POST /api/session/todo — local /todo slash (view/export/import/mutate)."""
+    pilot, err = _goal_pilot(svc)
+    if err is not None:
+        return err
+    command = str(body.get("command") or body.get("text") or "").strip()
+    workspace = str(getattr(svc.cfg, "repo", "") or "").strip()
+    try:
+        if not hasattr(pilot, "handle_todo_slash"):
+            return 404, {"ok": False, "error": "todo slash is unavailable"}
+        payload = pilot.handle_todo_slash(command, workspace_root=workspace)
+    except Exception as exc:
+        return 500, {"ok": False, "error": str(exc)}
+    if not isinstance(payload, dict):
+        return 500, {"ok": False, "error": "todo slash returned no payload"}
+    return 200, payload
 
 
 def get_session_context_at(

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -910,6 +910,10 @@ class ConversationalSession(
         from .session_scratch import SessionScratchStore
 
         self._scratch_store = SessionScratchStore(self.state_dir)
+        from .todo import SessionTodoStore
+
+        self._todo_store = SessionTodoStore(self.state_dir)
+        self._todo_phases = self._todo_store.load()
         # Host quality gate (optional; disabled when quality_gate_cmds empty).
         from .quality_gate import QualityGateRunner
 

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -282,6 +282,8 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             services=svc.session_control_services),
         "/api/session/goal": post_json(
             _sc_api.post_session_goal, services=svc.session_control_services),
+        "/api/session/todo": post_json(
+            _sc_api.post_session_todo, services=svc.session_control_services),
         "/api/refine": post_json(
             _skills_api.post_refine, services=svc.skills_services),
         "/api/refine/propose": post_json(

--- a/harness/pilot.py
+++ b/harness/pilot.py
@@ -55,6 +55,7 @@ ActionKind = Literal[
     "run_command_batch",
     "run_ipython",
     "wait",
+    "todo",
     "list_dir",
     "web_search",
     "web_fetch",
@@ -404,6 +405,12 @@ class PilotAction:
             raise PilotError("run_command action requires a 'command'")
         if self.kind == "run_ipython" and not (self.content or "").strip():
             raise PilotError("run_ipython action requires 'code' (or content)")
+        if self.kind == "todo":
+            from .todo import resolve_todo_params
+
+            _params, err = resolve_todo_params(self.arguments or {}, has_existing=False)
+            if err:
+                raise PilotError(err)
         if self.background and self.kind != "run_command":
             raise PilotError("background=true is only valid on run_command")
         if self.kind == "run_command_batch":
@@ -1191,6 +1198,67 @@ def build_tools_schema(
                     "job_id": {
                         "type": "string",
                         "description": "Optional job id to watch; omit to watch all pending jobs.",
+                    },
+                },
+            },
+        },
+    })
+
+    schema.append({
+        "type": "function",
+        "function": {
+            "name": "todo",
+            "description": (
+                "Maintain a nested session TODO tree (phases with child tasks). "
+                "Use this for multi-step work: init a phased list, start the "
+                "current task, mark done, append, block, or view. Tasks are "
+                "addressed by their full content text, not by ids. One task "
+                "is in_progress at a time. After init/start/done, keep working "
+                "the Next task from the result instead of restating the plan."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "op": {
+                        "type": "string",
+                        "enum": [
+                            "init", "start", "done", "rm", "drop",
+                            "block", "unblock", "append", "view",
+                        ],
+                        "description": "Operation to apply",
+                    },
+                    "list": {
+                        "type": "array",
+                        "description": "Phased task list for init: [{phase, items}]",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "phase": {"type": "string"},
+                                "items": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "minItems": 1,
+                                },
+                            },
+                            "required": ["phase", "items"],
+                        },
+                    },
+                    "task": {
+                        "type": "string",
+                        "description": "Task content to start/done/rm/block/unblock",
+                    },
+                    "phase": {
+                        "type": "string",
+                        "description": "Phase name (init/append/done/block target)",
+                    },
+                    "items": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Task contents for init or append",
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Blocker note (block op)",
                     },
                 },
             },
@@ -2652,6 +2720,7 @@ You have direct access to a local CodeGraph-indexed workspace and can explore/ed
 - `run_command_batch`: run 1-6 independent shell commands as one batch. Requires `commands`.
 - `run_ipython`: execute Python in a session-scoped persistent REPL (variables survive across turns). Prefer read_file/hash_edit/run_command/swarms for normal coding; use this for stateful probes. Requires `code`.
 - `wait`: stay on this turn while background jobs run (Cursor-style Await). Sleeps up to `seconds` (default 2, max 30) and returns whether jobs settled. After run_implement / run_parallel, call wait instead of ending the turn.
+- `todo`: nested phased checklist for multi-step work. `init` a `{list:[{phase, items}]}` tree, then `start` / `done` / `append` / `block` / `view`. Address tasks by their full content text. One in_progress task at a time; the result names Next. Do not restate the whole plan in prose.
 - `list_dir`: list the files and folders inside a directory. `path` is optional.
 - `run_swarm`: dispatch a parallel agent swarm for complex/broad investigations. Requires `goal`. One worker runs per role -- for a broad ask (audit, "review the platform", "find ways to improve quality/robustness/scale") pass SEVERAL `roles` (explore, pipeline-mapper, decision-explainer, conflict-auditor, test-coverage-reviewer) so it fans out into real parallel coverage; pass all five for a full audit. Omit roles only for a single narrow question. Prefer omitting `model` so the harness auto-routes among currently keyed agentic worker providers (ChatGPT Codex OAuth, OpenCode Go, OpenRouter, …). Pass `model` only when the user names a worker from the live agentic catalog in the tool schema; session pilot ids (openai-codex:…, cursor/…, codex/…) remap to matching worker rows when present. Unknown pins demote to auto-route; they do not fail the swarm. Prompt text alone does not pin a model. To audit a DIFFERENT checkout than the open workspace, pass `repo`=<absolute git path>: the workers read that subject, while your own writes/edits/commands stay in the open session workspace.
 - `run_implement`: dispatch an edit-capable worker that edits the repo in an isolated worktree and produces a reviewable patch. Requires `goal`. Default engine is standalone `agentic` (routes directly through your provider keys, no external CLI); pass `adapter` only to force a specific engine. Optional `mode` (`implement` default, or `analysis`/`review` for read-only reports).
@@ -2765,7 +2834,7 @@ Rules:
 """
 
 
-PLAN_SYSTEM_SUFFIX = """PLAN MODE: Do NOT call run_implement, run_parallel, write_file, edit_file, hash_edit, run_command, run_ipython, call_mcp, manage_mcp, memory, or any browser_* tool (navigate/click/type/snapshot/screenshot/…). Investigate read-only if needed (read_file, search_codegraph, query_wiki, list_dir, web_search), then output a clear, actionable, numbered implementation PLAN in markdown: goal restatement, the concrete steps (each with what/where/why), files likely touched, risks, and a suggested verification. End with a one-line summary. The user will review the plan before any execution."""
+PLAN_SYSTEM_SUFFIX = """PLAN MODE: Do NOT call run_implement, run_parallel, write_file, edit_file, hash_edit, run_command, run_ipython, call_mcp, manage_mcp, memory, or any browser_* tool (navigate/click/type/snapshot/screenshot/…). Investigate read-only if needed (read_file, search_codegraph, query_wiki, list_dir, web_search). You MAY use `todo` to structure a nested phased checklist. Then output a clear, actionable, numbered implementation PLAN in markdown: goal restatement, the concrete steps (each with what/where/why), files likely touched, risks, and a suggested verification. End with a one-line summary. The user will review the plan before any execution."""
 
 
 WORKER_SYSTEM = """You are an implementation worker. Be FAST and DECISIVE. Your job is to EDIT FILES to complete the task, not to investigate. Read ONLY the specific file(s) you must change (read_file once per file), then make the edit immediately with edit_file, then FINISH. To change an existing file, ALWAYS use edit_file with a small old_str/new_str snippet -- do NOT use write_file to rewrite an existing file (that wastes tokens and can truncate). Use write_file ONLY to create a brand-new file. Do NOT explore the wider codebase. Do NOT call search_codegraph (this workspace has no code index; it returns nothing and wastes time). Do NOT re-read a file you already read. Ideal small change = read target file once, edit the change, done. As soon as all required edits are made, STOP. Do not do extra investigation rounds.

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -93,7 +93,7 @@ STREAM_IDLE_STUCK_MESSAGE = (
 LOCAL_ACTION_KINDS: frozenset[str] = frozenset({
     "open_project", "relocate_session", "session_bank",
     "write_file", "edit_file", "hash_edit", "run_command",
-    "run_command_batch", "run_ipython", "wait",
+    "run_command_batch", "run_ipython", "wait", "todo",
     "search_tools", "search_state",
     "store_scratch", "load_scratch", "list_scratch", "clear_scratch",
     "bind_kernel", "show_kernel", "list_kernel", "clear_kernel",
@@ -1163,6 +1163,9 @@ def action_display_goal(act: PilotAction) -> Any:
         act_goal = act.query
     elif act.kind == "search_files":
         act_goal = act.query
+    elif act.kind == "todo":
+        _t = act.arguments or {}
+        act_goal = _t.get("op") or _t.get("task") or _t.get("phase") or "todo"
     elif act.kind == "search_state":
         act_goal = act.query
     elif act.kind == "session_bank":
@@ -2751,6 +2754,31 @@ def dispatch_local_action(
     if act.kind == "wait":
         from .pilot_wait import dispatch_wait_action
         yield from dispatch_wait_action(session, act, aid, is_native)
+        return
+
+    if act.kind == "todo":
+        try:
+            ok, status, val = session._do_todo(act)
+        except Exception as exc:
+            ok, status, val = False, "exception", str(exc)
+        if ok:
+            tree, payload = val
+            yield ConvEvent("action_result", {
+                "id": aid,
+                "kind": "todo",
+                "goal": act_goal,
+                "num": 1,
+                "types": ["todo"],
+                "adapter": "local",
+                "mode": "tool",
+                "session_id": getattr(session, "harness_session_id", "") or "",
+                "todos": payload,
+                "artifacts": [{"type": "todo", "headline": tree.splitlines()[0] if tree else "TODO"}],
+            })
+            session._append_action_result(act, aid, "(todo %s)\n%s" % (payload.get("op") or "view", tree), is_native)
+        else:
+            yield ConvEvent("action_result", {"id": aid, "error": val})
+            session._append_action_result(act, aid, "(todo failed: %s)" % val, is_native)
         return
 
     if act.kind == "request_secret":

--- a/harness/task_profile.py
+++ b/harness/task_profile.py
@@ -70,6 +70,7 @@ _MICRO_VISIBLE: FrozenSet[str] = frozenset(
         "run_command",
         "run_ipython",
         "wait",
+        "todo",
         "list_dir",
         "search_tools",
         "search_files",

--- a/harness/todo.py
+++ b/harness/todo.py
@@ -1,0 +1,915 @@
+from __future__ import annotations
+
+"""Session-owned nested todos — OMP phased tree, Marionette persistence.
+
+Steal the oh-my-pi contract (phases + incremental ops + one in-progress +
+next-actionable reminder). Do not clone the TUI. The transcript last-wins
+snapshot and a session sidecar are the durable unit.
+"""
+
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from .paths import resolve_workspace_path
+
+TODO_STATUSES = ("pending", "in_progress", "completed", "abandoned", "blocked")
+TODO_OPS = ("init", "start", "done", "rm", "drop", "block", "unblock", "append", "view")
+DEFAULT_INIT_PHASE = "Tasks"
+TODO_FILENAME = "session_todos.json"
+COLLAPSED_OPEN_CAP = 5
+COLLAPSED_CLOSED_CONTEXT = 2
+TODO_DESCRIPTION_MIN_OVERLAP = 6
+
+
+class TodoError(ValueError):
+    """Raised when a todo op cannot be applied."""
+
+
+@dataclass
+class TodoItem:
+    content: str
+    status: str = "pending"
+    blocker: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"content": self.content, "status": self.status}
+        if self.blocker:
+            out["blocker"] = self.blocker
+        return out
+
+
+@dataclass
+class TodoPhase:
+    name: str
+    tasks: List[TodoItem] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "tasks": [task.to_dict() for task in self.tasks]}
+
+    def progress(self) -> Tuple[int, int]:
+        done = sum(1 for task in self.tasks if task.status in ("completed", "abandoned"))
+        return done, len(self.tasks)
+
+
+def phases_to_dicts(phases: Sequence[TodoPhase]) -> List[Dict[str, Any]]:
+    return [phase.to_dict() for phase in phases]
+
+
+def clone_item(task: TodoItem) -> TodoItem:
+    return TodoItem(content=task.content, status=task.status, blocker=task.blocker)
+
+
+def clone_phases(phases: Sequence[TodoPhase]) -> List[TodoPhase]:
+    return [
+        TodoPhase(name=phase.name, tasks=[clone_item(task) for task in phase.tasks])
+        for phase in phases
+    ]
+
+
+def is_todo_phase(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if not isinstance(value.get("name"), str) or not isinstance(value.get("tasks"), list):
+        return False
+    for task in value["tasks"]:
+        if not isinstance(task, dict) or not isinstance(task.get("content"), str):
+            return False
+        if task.get("status") not in TODO_STATUSES:
+            return False
+    return True
+
+
+def phases_from_raw(raw: Any) -> List[TodoPhase]:
+    if not isinstance(raw, list):
+        return []
+    phases: List[TodoPhase] = []
+    for entry in raw:
+        if not is_todo_phase(entry):
+            continue
+        tasks = [
+            TodoItem(
+                content=str(task.get("content") or ""),
+                status=str(task.get("status") or "pending"),
+                blocker=(str(task["blocker"]).strip() or None) if task.get("blocker") else None,
+            )
+            for task in entry["tasks"]
+        ]
+        phases.append(TodoPhase(name=str(entry["name"]), tasks=tasks))
+    return phases
+
+
+def find_task_by_content(
+    phases: Sequence[TodoPhase], content: str
+) -> Optional[Tuple[TodoItem, TodoPhase]]:
+    for phase in phases:
+        for task in phase.tasks:
+            if task.content == content:
+                return task, phase
+    return None
+
+
+def find_phase_by_name(phases: Sequence[TodoPhase], name: str) -> Optional[TodoPhase]:
+    for phase in phases:
+        if phase.name == name:
+            return phase
+    return None
+
+
+def next_actionable_task(phases: Sequence[TodoPhase]) -> Optional[TodoItem]:
+    first_pending: Optional[TodoItem] = None
+    for phase in phases:
+        for task in phase.tasks:
+            if task.status == "in_progress":
+                return task
+            if first_pending is None and task.status == "pending":
+                first_pending = task
+    return first_pending
+
+
+def normalize_in_progress(phases: List[TodoPhase]) -> None:
+    ordered = [task for phase in phases for task in phase.tasks]
+    if not ordered:
+        return
+    in_progress = [task for task in ordered if task.status == "in_progress"]
+    for extra in in_progress[1:]:
+        extra.status = "pending"
+    if in_progress:
+        return
+    for task in ordered:
+        if task.status == "pending":
+            task.status = "in_progress"
+            return
+
+
+def infer_todo_op(args: Dict[str, Any], has_existing: bool) -> Optional[str]:
+    if isinstance(args.get("list"), list) and args["list"]:
+        return "init"
+    items = args.get("items")
+    if isinstance(items, list) and items:
+        phase = args.get("phase")
+        if isinstance(phase, str) and phase.strip():
+            return "append"
+        if not has_existing:
+            return "init"
+    return None
+
+
+def resolve_todo_params(raw: Any, has_existing: bool) -> Tuple[Optional[Dict[str, Any]], str]:
+    if not isinstance(raw, dict):
+        return None, "todo arguments must be an object"
+    args = dict(raw)
+    op = str(args.get("op") or "").strip().lower()
+    if not op:
+        inferred = infer_todo_op(args, has_existing)
+        if inferred:
+            op = inferred
+            args["op"] = inferred
+    if op not in TODO_OPS:
+        return None, "todo requires op: init|start|done|rm|drop|block|unblock|append|view"
+    return args, ""
+
+
+def _string_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    out: List[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if text:
+            out.append(text)
+    return out
+
+
+def _init_list_entries(entry: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw_list = entry.get("list")
+    if isinstance(raw_list, list) and raw_list:
+        parsed: List[Dict[str, Any]] = []
+        for row in raw_list:
+            if not isinstance(row, dict):
+                continue
+            phase = str(row.get("phase") or row.get("name") or "").strip()
+            items = _string_list(row.get("items") or row.get("tasks"))
+            if phase and items:
+                parsed.append({"phase": phase, "items": items})
+        return parsed
+    items = _string_list(entry.get("items"))
+    if items:
+        phase = str(entry.get("phase") or DEFAULT_INIT_PHASE).strip() or DEFAULT_INIT_PHASE
+        return [{"phase": phase, "items": items}]
+    return []
+
+
+def init_phases(entry: Dict[str, Any], errors: List[str]) -> List[TodoPhase]:
+    listing = _init_list_entries(entry)
+    if not listing:
+        errors.append("Missing list for init operation")
+        return []
+    seen_phases: set[str] = set()
+    seen_tasks: set[str] = set()
+    for row in listing:
+        if row["phase"] in seen_phases:
+            errors.append('Duplicate phase "%s" in init list' % row["phase"])
+        seen_phases.add(row["phase"])
+        for content in row["items"]:
+            if content in seen_tasks:
+                errors.append('Duplicate task "%s" in init list' % content)
+            seen_tasks.add(content)
+    if errors:
+        return []
+    return [
+        TodoPhase(
+            name=row["phase"],
+            tasks=[TodoItem(content=content) for content in row["items"]],
+        )
+        for row in listing
+    ]
+
+
+def _resolve_task(
+    phases: Sequence[TodoPhase], content: Optional[str], errors: List[str]
+) -> Optional[Tuple[TodoItem, TodoPhase]]:
+    if not content:
+        errors.append("Missing task content")
+        return None
+    hit = find_task_by_content(phases, content)
+    if hit is None:
+        if content.startswith("task-") and content[5:].isdigit():
+            errors.append(
+                'Task "%s" not found. Tasks are referenced by content, not by IDs — '
+                "pass the task's full text from the previous result." % content
+            )
+        else:
+            total = sum(len(phase.tasks) for phase in phases)
+            hint = " (todo list is empty — was it replaced or not yet created?)" if total == 0 else ""
+            errors.append('Task "%s" not found%s' % (content, hint))
+    return hit
+
+
+def _resolve_phase(
+    phases: Sequence[TodoPhase], name: Optional[str], errors: List[str]
+) -> Optional[TodoPhase]:
+    if not name:
+        errors.append("Missing phase name")
+        return None
+    phase = find_phase_by_name(phases, name)
+    if phase is None:
+        errors.append('Phase "%s" not found' % name)
+    return phase
+
+
+def _task_targets(
+    phases: Sequence[TodoPhase], entry: Dict[str, Any], errors: List[str]
+) -> List[TodoItem]:
+    task = str(entry.get("task") or "").strip()
+    phase_name = str(entry.get("phase") or "").strip()
+    if task:
+        hit = _resolve_task(phases, task, errors)
+        return [hit[0]] if hit else []
+    if phase_name:
+        phase = _resolve_phase(phases, phase_name, errors)
+        return list(phase.tasks) if phase else []
+    return [task for phase in phases for task in phase.tasks]
+
+
+def append_items(phases: List[TodoPhase], entry: Dict[str, Any], errors: List[str]) -> List[TodoPhase]:
+    phase_name = str(entry.get("phase") or "").strip()
+    items = _string_list(entry.get("items"))
+    if not phase_name:
+        errors.append("Missing phase name for append operation")
+        return phases
+    if not items:
+        errors.append("Missing items for append operation")
+        return phases
+    seen: set[str] = set()
+    duplicate = False
+    for content in items:
+        if content in seen or find_task_by_content(phases, content):
+            errors.append('Task "%s" already exists' % content)
+            duplicate = True
+        seen.add(content)
+    if duplicate:
+        return phases
+    phase = find_phase_by_name(phases, phase_name)
+    if phase is None:
+        phase = TodoPhase(name=phase_name, tasks=[])
+        phases.append(phase)
+    for content in items:
+        phase.tasks.append(TodoItem(content=content))
+    return phases
+
+
+def remove_tasks(phases: List[TodoPhase], entry: Dict[str, Any], errors: List[str]) -> List[TodoPhase]:
+    task = str(entry.get("task") or "").strip()
+    phase_name = str(entry.get("phase") or "").strip()
+    if task:
+        hit = _resolve_task(phases, task, errors)
+        if not hit:
+            return phases
+        item, phase = hit
+        phase.tasks = [candidate for candidate in phase.tasks if candidate is not item]
+        return phases
+    if phase_name:
+        phase = _resolve_phase(phases, phase_name, errors)
+        if not phase:
+            return phases
+        phase.tasks = []
+        return phases
+    for phase in phases:
+        phase.tasks = []
+    return phases
+
+
+def apply_entry(phases: List[TodoPhase], entry: Dict[str, Any], errors: List[str]) -> List[TodoPhase]:
+    op = str(entry.get("op") or "").strip().lower()
+    if op == "init":
+        return init_phases(entry, errors)
+    if op == "start":
+        hit = _resolve_task(phases, str(entry.get("task") or "").strip(), errors)
+        if not hit:
+            return phases
+        target, _phase = hit
+        for phase in phases:
+            for candidate in phase.tasks:
+                if candidate.status == "in_progress" and candidate is not target:
+                    candidate.status = "pending"
+        target.status = "in_progress"
+        return phases
+    if op == "done":
+        for task in _task_targets(phases, entry, errors):
+            task.status = "completed"
+        return phases
+    if op == "drop":
+        for task in _task_targets(phases, entry, errors):
+            task.status = "abandoned"
+        return phases
+    if op == "block":
+        if not str(entry.get("task") or "").strip() and not str(entry.get("phase") or "").strip():
+            errors.append("block requires a task or phase target")
+            return phases
+        reason = str(entry.get("reason") or "").replace("\n", " ")
+        reason = " ".join(reason.split()).strip() or None
+        for task in _task_targets(phases, entry, errors):
+            if task.status not in ("pending", "in_progress", "blocked"):
+                continue
+            task.status = "blocked"
+            task.blocker = reason
+        return phases
+    if op == "unblock":
+        if not str(entry.get("task") or "").strip() and not str(entry.get("phase") or "").strip():
+            errors.append("unblock requires a task or phase target")
+            return phases
+        for task in _task_targets(phases, entry, errors):
+            if task.status == "blocked":
+                task.status = "pending"
+                task.blocker = None
+        return phases
+    if op == "rm":
+        return remove_tasks(phases, entry, errors)
+    if op == "append":
+        return append_items(phases, entry, errors)
+    if op == "view":
+        return phases
+    errors.append("unknown todo op: %s" % op)
+    return phases
+
+
+def apply_todo_op(
+    current: Sequence[TodoPhase],
+    raw: Any,
+) -> Tuple[List[TodoPhase], List[str], str]:
+    """Apply one op. Returns (phases, errors, resolved_op)."""
+    params, err = resolve_todo_params(raw, bool(current))
+    if params is None:
+        return clone_phases(current), [err], ""
+    next_phases = clone_phases(current)
+    errors: List[str] = []
+    next_phases = apply_entry(next_phases, params, errors)
+    if errors:
+        return clone_phases(current), errors, str(params.get("op") or "")
+    normalize_in_progress(next_phases)
+    return next_phases, [], str(params.get("op") or "")
+
+
+def _is_closed(status: str) -> bool:
+    return status in ("completed", "abandoned")
+
+
+def _collapse_tasks(tasks: Sequence[TodoItem]) -> Tuple[List[TodoItem], int]:
+    closed = [task for task in tasks if _is_closed(task.status)]
+    open_tasks = [task for task in tasks if not _is_closed(task.status)]
+    lead = closed[-COLLAPSED_CLOSED_CONTEXT:]
+    if len(open_tasks) <= COLLAPSED_OPEN_CAP:
+        shown = lead + list(open_tasks)
+        hidden = len(tasks) - len(shown)
+        return shown, hidden
+    shown = lead + list(open_tasks[:COLLAPSED_OPEN_CAP])
+    hidden = len(tasks) - len(shown)
+    return shown, hidden
+
+
+def format_todo_tree(phases: Sequence[TodoPhase], *, collapsed: bool = True) -> str:
+    if not phases:
+        return "TODO (empty)"
+    total_done = 0
+    total = 0
+    lines = []
+    for index, phase in enumerate(phases, start=1):
+        done, count = phase.progress()
+        total_done += done
+        total += count
+        roman = _to_roman(index)
+        lines.append("%s. %s · %d/%d" % (roman, phase.name, done, count))
+        visible, hidden = _collapse_tasks(phase.tasks) if collapsed else (list(phase.tasks), 0)
+        for task in visible:
+            mark = {
+                "completed": "[x]",
+                "abandoned": "[-]",
+                "in_progress": "[>]",
+                "blocked": "[!]",
+            }.get(task.status, "[ ]")
+            extra = " — %s" % task.blocker if task.status == "blocked" and task.blocker else ""
+            lines.append("  %s %s%s" % (mark, task.content, extra))
+        if hidden:
+            lines.append("  ... %d more todo%s" % (hidden, "s" if hidden != 1 else ""))
+    header = "TODO %d/%d" % (total_done, total)
+    nxt = next_actionable_task(phases)
+    body = "\n".join([header] + lines)
+    if nxt:
+        body += "\nNext: %s" % nxt.content
+    return body
+
+
+def _to_roman(value: int) -> str:
+    table = (
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    )
+    remaining = max(1, int(value))
+    out = []
+    for arabic, glyph in table:
+        while remaining >= arabic:
+            out.append(glyph)
+            remaining -= arabic
+    return "".join(out)
+
+
+def snapshot_payload(phases: Sequence[TodoPhase], op: str = "") -> Dict[str, Any]:
+    nxt = next_actionable_task(phases)
+    return {
+        "op": op or None,
+        "phases": phases_to_dicts(phases),
+        "storage": "session",
+        "next": nxt.content if nxt else None,
+    }
+
+
+class SessionTodoStore:
+    """Load/save session todo JSON under a session state_dir."""
+
+    def __init__(self, state_dir: str) -> None:
+        self.state_dir = state_dir or ""
+        self.path = os.path.join(self.state_dir, TODO_FILENAME) if self.state_dir else ""
+
+    def load(self) -> List[TodoPhase]:
+        if not self.path or not os.path.isfile(self.path):
+            return []
+        try:
+            with open(self.path, "r", encoding="utf-8") as fh:
+                raw = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            return []
+        if isinstance(raw, dict):
+            raw = raw.get("phases")
+        return phases_from_raw(raw)
+
+    def save(self, phases: Sequence[TodoPhase]) -> None:
+        if not self.path or not self.state_dir:
+            return
+        os.makedirs(self.state_dir, exist_ok=True)
+        payload = {"phases": phases_to_dicts(phases)}
+        fd, tmp = tempfile.mkstemp(prefix="session_todos.", dir=self.state_dir)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2)
+                fh.write("\n")
+            os.replace(tmp, self.path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+
+DEFAULT_TODO_MARKDOWN = "TODO.md"
+
+STATUS_TO_MARKER = {
+    "pending": " ",
+    "in_progress": "/",
+    "completed": "x",
+    "abandoned": "-",
+    "blocked": "!",
+}
+
+MARKER_TO_STATUS = {
+    " ": "pending",
+    "": "pending",
+    "x": "completed",
+    "X": "completed",
+    "/": "in_progress",
+    ">": "in_progress",
+    "-": "abandoned",
+    "~": "abandoned",
+    "!": "blocked",
+}
+
+TODO_SLASH_USAGE = (
+    "Usage: /todo <verb> [args]\n"
+    "  /todo                              Show current todos\n"
+    "  /todo copy                         Print todos as Markdown\n"
+    "  /todo export [<path>]              Write todos to file (default: TODO.md)\n"
+    "  /todo import [<path>]              Replace todos from file (default: TODO.md)\n"
+    "  /todo append [<phase>] <task...>   Append a task\n"
+    "  /todo start  <task>                Mark task in_progress (fuzzy match)\n"
+    "  /todo done   [<task|phase>]        Mark task/phase/all completed\n"
+    "  /todo drop   [<task|phase>]        Mark task/phase/all abandoned\n"
+    "  /todo rm     [<task|phase>]        Remove task/phase/all\n"
+    "  /todo block  <task> [-- reason]    Block a task\n"
+    "  /todo unblock <task>               Unblock a task"
+)
+
+
+def normalize_for_todo_match(value: str) -> str:
+    chars: List[str] = []
+    for ch in (value or "").lower():
+        if ch.isalnum():
+            chars.append(ch)
+        elif chars and chars[-1] != " ":
+            chars.append(" ")
+    return "".join(chars).strip()
+
+
+def todo_matches_any_description(content: str, descriptions: Sequence[str]) -> bool:
+    target = normalize_for_todo_match(content)
+    if not target:
+        return False
+    for desc in descriptions:
+        candidate = normalize_for_todo_match(desc)
+        if not candidate:
+            continue
+        if target == candidate:
+            return True
+        if len(target) >= TODO_DESCRIPTION_MIN_OVERLAP and target in candidate:
+            return True
+        if len(candidate) >= TODO_DESCRIPTION_MIN_OVERLAP and candidate in target:
+            return True
+    return False
+
+
+def phases_to_markdown(phases: Sequence[TodoPhase]) -> str:
+    if not phases:
+        return "# Todos\n"
+    out: List[str] = []
+    for index, phase in enumerate(phases):
+        if index:
+            out.append("")
+        out.append("# %s" % phase.name)
+        for task in phase.tasks:
+            marker = STATUS_TO_MARKER.get(task.status, " ")
+            blocker = ""
+            if task.status == "blocked" and task.blocker:
+                blocker = " <!-- blocker: %s -->" % task.blocker
+            out.append("- [%s] %s%s" % (marker, task.content, blocker))
+    return "%s\n" % "\n".join(out)
+
+
+def markdown_to_phases(md: str) -> Tuple[List[TodoPhase], List[str]]:
+    errors: List[str] = []
+    phases: List[TodoPhase] = []
+    current: Optional[TodoPhase] = None
+    heading = re.compile(r"^#{1,6}\s+(.+?)\s*$")
+    task_re = re.compile(r"^[-*+]\s*\[(.?)\]\s+(.+?)\s*$")
+    blocker_re = re.compile(r"^(.*?)\s*<!--\s*blocker:\s*(.*?)\s*-->$")
+    for line_num, raw in enumerate((md or "").splitlines(), start=1):
+        trimmed = raw.strip()
+        if not trimmed:
+            continue
+        heading_match = heading.match(trimmed)
+        if heading_match:
+            current = TodoPhase(name=heading_match.group(1).strip(), tasks=[])
+            phases.append(current)
+            continue
+        task_match = task_re.match(trimmed)
+        if task_match:
+            if current is None:
+                current = TodoPhase(name="Todos", tasks=[])
+                phases.append(current)
+            marker = task_match.group(1)
+            status = MARKER_TO_STATUS.get(marker)
+            if status is None:
+                errors.append(
+                    'Line %d: unknown status marker "[%s]" (use [ ], [x], [/], [-], [!])'
+                    % (line_num, marker)
+                )
+                continue
+            raw_content = task_match.group(2).strip()
+            blocker_match = blocker_re.match(raw_content)
+            if status == "blocked" and blocker_match:
+                current.tasks.append(
+                    TodoItem(
+                        content=blocker_match.group(1).strip(),
+                        status=status,
+                        blocker=blocker_match.group(2).strip() or None,
+                    )
+                )
+            else:
+                current.tasks.append(TodoItem(content=raw_content, status=status))
+            continue
+        errors.append('Line %d: unrecognized syntax "%s"' % (line_num, trimmed))
+    normalize_in_progress(phases)
+    return phases, errors
+
+
+def resolve_todo_markdown_path(workspace_root: str, user_path: str) -> Tuple[str, str]:
+    raw = (user_path or "").strip() or DEFAULT_TODO_MARKDOWN
+    return resolve_workspace_path(workspace_root, raw)
+
+
+def export_todo_markdown(
+    phases: Sequence[TodoPhase], workspace_root: str, user_path: str = ""
+) -> Tuple[str, str]:
+    abs_path, rel = resolve_todo_markdown_path(workspace_root, user_path)
+    parent = os.path.dirname(abs_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(abs_path, "w", encoding="utf-8") as fh:
+        fh.write(phases_to_markdown(phases))
+    return abs_path, rel
+
+
+def import_todo_markdown(
+    workspace_root: str, user_path: str = ""
+) -> Tuple[List[TodoPhase], List[str], str]:
+    abs_path, rel = resolve_todo_markdown_path(workspace_root, user_path)
+    if not os.path.isfile(abs_path):
+        return [], ['Todo markdown not found: %s' % (rel or DEFAULT_TODO_MARKDOWN)], rel
+    with open(abs_path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    phases, errors = markdown_to_phases(text)
+    return phases, errors, rel
+
+
+def find_phase_fuzzy(phases: Sequence[TodoPhase], query: str) -> Optional[TodoPhase]:
+    normalized = (query or "").strip().lower()
+    if not normalized:
+        return None
+    exact = [phase for phase in phases if phase.name.lower() == normalized]
+    if len(exact) == 1:
+        return exact[0]
+    prefixes = [phase for phase in phases if phase.name.lower().startswith(normalized)]
+    if len(prefixes) == 1:
+        return prefixes[0]
+    substr = [phase for phase in phases if normalized in phase.name.lower()]
+    if len(substr) == 1:
+        return substr[0]
+    return None
+
+
+def find_task_fuzzy(
+    phases: Sequence[TodoPhase], query: str
+) -> Optional[Tuple[TodoItem, TodoPhase]]:
+    normalized = (query or "").strip().lower()
+    if not normalized:
+        return None
+    for phase in phases:
+        for task in phase.tasks:
+            if task.content.lower() == normalized:
+                return task, phase
+    matches: List[Tuple[TodoItem, TodoPhase]] = []
+    for phase in phases:
+        for task in phase.tasks:
+            if normalized in task.content.lower():
+                matches.append((task, phase))
+    if len(matches) == 1:
+        return matches[0]
+    active = [
+        hit for hit in matches if hit[0].status in ("in_progress", "pending")
+    ]
+    if len(active) == 1:
+        return active[0]
+    return None
+
+
+def _split_task_reason(rest: str) -> Tuple[str, str]:
+    if " -- " in rest:
+        task, reason = rest.split(" -- ", 1)
+        return task.strip(), reason.strip()
+    return rest.strip(), ""
+
+
+@dataclass
+class SlashTodoResult:
+    ok: bool
+    mutated: bool = False
+    phases: List[TodoPhase] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+    tree: str = ""
+    markdown: str = ""
+    notice: str = ""
+    path: str = ""
+    usage: str = ""
+
+    def public_dict(self) -> Dict[str, Any]:
+        payload = snapshot_payload(self.phases)
+        out: Dict[str, Any] = {
+            "ok": self.ok,
+            "mutated": self.mutated,
+            "tree": self.tree or format_todo_tree(self.phases),
+            "markdown": self.markdown or phases_to_markdown(self.phases),
+            "notice": self.notice,
+            "todos": payload,
+        }
+        if self.errors:
+            out["error"] = "; ".join(self.errors)
+        if self.path:
+            out["path"] = self.path
+        if self.usage:
+            out["usage"] = self.usage
+        return out
+
+
+def _slash_result(
+    phases: Sequence[TodoPhase],
+    *,
+    ok: bool = True,
+    mutated: bool = False,
+    errors: Optional[List[str]] = None,
+    notice: str = "",
+    path: str = "",
+    usage: str = "",
+    markdown: str = "",
+) -> SlashTodoResult:
+    cloned = clone_phases(phases)
+    return SlashTodoResult(
+        ok=ok,
+        mutated=mutated,
+        phases=cloned,
+        errors=list(errors or []),
+        tree=format_todo_tree(cloned),
+        markdown=markdown or phases_to_markdown(cloned),
+        notice=notice,
+        path=path,
+        usage=usage,
+    )
+
+
+def _apply_or_error(
+    current: Sequence[TodoPhase], raw: Dict[str, Any]
+) -> SlashTodoResult:
+    phases, errors, _op = apply_todo_op(current, raw)
+    if errors:
+        return _slash_result(current, ok=False, errors=errors)
+    return _slash_result(phases, mutated=True, notice=format_todo_tree(phases))
+
+
+def _slash_target_op(
+    current: Sequence[TodoPhase], verb: str, rest: str
+) -> SlashTodoResult:
+    query = (rest or "").strip()
+    payload: Dict[str, Any] = {"op": verb}
+    if query:
+        hit = find_task_fuzzy(current, query)
+        if hit:
+            payload["task"] = hit[0].content
+        else:
+            phase = find_phase_fuzzy(current, query)
+            if phase:
+                payload["phase"] = phase.name
+            else:
+                return _slash_result(
+                    current,
+                    ok=False,
+                    errors=['No unique task or phase matching "%s"' % query],
+                )
+    return _apply_or_error(current, payload)
+
+
+def handle_todo_slash_command(
+    raw: str,
+    current: Sequence[TodoPhase],
+    workspace_root: str = "",
+) -> SlashTodoResult:
+    text = (raw or "").strip()
+    if text.lower().startswith("/todo"):
+        text = text[5:].strip()
+    if not text or text.lower() in ("help", "-h", "--help"):
+        return _slash_result(
+            current,
+            notice=format_todo_tree(current) if current else TODO_SLASH_USAGE,
+            usage=TODO_SLASH_USAGE,
+        )
+    parts = text.split(None, 1)
+    verb = parts[0].lower()
+    rest = parts[1].strip() if len(parts) > 1 else ""
+    if verb in ("view", "show", "list"):
+        return _slash_result(current, notice=format_todo_tree(current))
+    if verb == "copy":
+        md = phases_to_markdown(current)
+        return _slash_result(current, markdown=md, notice=md.strip() or "No todos.")
+    if verb == "export":
+        if not (workspace_root or "").strip():
+            return _slash_result(current, ok=False, errors=["No open workspace"])
+        try:
+            _abs_path, rel = export_todo_markdown(current, workspace_root, rest)
+        except ValueError as exc:
+            return _slash_result(current, ok=False, errors=[str(exc)])
+        except OSError as exc:
+            return _slash_result(current, ok=False, errors=[str(exc)])
+        return _slash_result(
+            current,
+            notice="Wrote todos to %s" % (rel or DEFAULT_TODO_MARKDOWN),
+            path=rel or DEFAULT_TODO_MARKDOWN,
+        )
+    if verb == "import":
+        if not (workspace_root or "").strip():
+            return _slash_result(current, ok=False, errors=["No open workspace"])
+        try:
+            phases, errors, rel = import_todo_markdown(workspace_root, rest)
+        except ValueError as exc:
+            return _slash_result(current, ok=False, errors=[str(exc)])
+        except OSError as exc:
+            return _slash_result(current, ok=False, errors=[str(exc)])
+        if errors:
+            return _slash_result(current, ok=False, errors=errors, path=rel)
+        return _slash_result(
+            phases,
+            mutated=True,
+            notice="Imported todos from %s" % (rel or DEFAULT_TODO_MARKDOWN),
+            path=rel or DEFAULT_TODO_MARKDOWN,
+        )
+    if verb == "append":
+        if not rest:
+            return _slash_result(current, ok=False, errors=["Missing task for append"])
+        tokens = rest.split()
+        phase_name = current[-1].name if current else DEFAULT_INIT_PHASE
+        task_text = rest
+        if len(tokens) >= 2:
+            phase = find_phase_fuzzy(current, tokens[0])
+            phase_name = phase.name if phase is not None else tokens[0]
+            task_text = " ".join(tokens[1:]).strip()
+        return _apply_or_error(
+            current, {"op": "append", "phase": phase_name, "items": [task_text]}
+        )
+    if verb == "start":
+        if not rest:
+            return _slash_result(current, ok=False, errors=["Missing task for start"])
+        hit = find_task_fuzzy(current, rest)
+        if hit is None:
+            return _slash_result(
+                current, ok=False, errors=['No unique task matching "%s"' % rest]
+            )
+        return _apply_or_error(current, {"op": "start", "task": hit[0].content})
+    if verb in ("done", "drop", "rm"):
+        return _slash_target_op(current, verb, rest)
+    if verb == "block":
+        task_q, reason = _split_task_reason(rest)
+        if not task_q:
+            return _slash_result(current, ok=False, errors=["Missing task for block"])
+        hit = find_task_fuzzy(current, task_q)
+        if hit is None:
+            phase = find_phase_fuzzy(current, task_q)
+            if phase is None:
+                return _slash_result(
+                    current, ok=False, errors=['No unique task or phase matching "%s"' % task_q]
+                )
+            return _apply_or_error(
+                current, {"op": "block", "phase": phase.name, "reason": reason}
+            )
+        return _apply_or_error(
+            current, {"op": "block", "task": hit[0].content, "reason": reason}
+        )
+    if verb == "unblock":
+        if not rest:
+            return _slash_result(current, ok=False, errors=["Missing task for unblock"])
+        hit = find_task_fuzzy(current, rest)
+        if hit is None:
+            phase = find_phase_fuzzy(current, rest)
+            if phase is None:
+                return _slash_result(
+                    current, ok=False, errors=['No unique task or phase matching "%s"' % rest]
+                )
+            return _apply_or_error(current, {"op": "unblock", "phase": phase.name})
+        return _apply_or_error(current, {"op": "unblock", "task": hit[0].content})
+    return _slash_result(
+        current,
+        ok=False,
+        errors=["Unknown /todo verb: %s" % verb],
+        usage=TODO_SLASH_USAGE,
+    )

--- a/harness/tool_discovery.py
+++ b/harness/tool_discovery.py
@@ -81,6 +81,7 @@ _PILOT_EXTRAS: Set[str] = {
     "run_implement",
     "run_parallel",
     "wait",
+    "todo",
     "query_wiki",
 }
 

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -840,6 +840,59 @@ class ToolDispatchMixin:
         except Exception as exc:
             return False, "exception", str(exc)
 
+    def _get_todo_store(self):
+        store = getattr(self, "_todo_store", None)
+        if store is not None:
+            return store
+        from .todo import SessionTodoStore
+
+        state_dir = getattr(self, "state_dir", None) or getattr(self.config, "state_dir", "") or ""
+        store = SessionTodoStore(state_dir)
+        self._todo_store = store
+        if not getattr(self, "_todo_phases", None):
+            self._todo_phases = store.load()
+        return store
+
+    def todo_snapshot(self) -> dict:
+        from .todo import snapshot_payload
+
+        phases = getattr(self, "_todo_phases", None) or []
+        return snapshot_payload(phases)
+
+    def _do_todo(self, act: PilotAction) -> tuple[bool, str, Any]:
+        from .todo import apply_todo_op, format_todo_tree, snapshot_payload
+
+        store = self._get_todo_store()
+        current = getattr(self, "_todo_phases", None)
+        if current is None:
+            current = store.load()
+            self._todo_phases = current
+        phases, errors, op = apply_todo_op(current, act.arguments or {})
+        if errors:
+            return False, "invalid_arguments", "; ".join(errors)
+        self._todo_phases = phases
+        try:
+            store.save(phases)
+        except Exception as exc:
+            return False, "exception", str(exc)
+        tree = format_todo_tree(phases)
+        payload = snapshot_payload(phases, op)
+        return True, "success", (tree, payload)
+
+    def handle_todo_slash(self, raw: str, workspace_root: str = "") -> dict:
+        from .todo import handle_todo_slash_command
+
+        store = self._get_todo_store()
+        current = getattr(self, "_todo_phases", None)
+        if current is None:
+            current = store.load()
+            self._todo_phases = current
+        result = handle_todo_slash_command(raw, current, workspace_root)
+        if result.ok and result.mutated:
+            self._todo_phases = result.phases
+            store.save(result.phases)
+        return result.public_dict()
+
     def _do_clear_scratch(self, act: PilotAction) -> tuple[bool, str, str]:
         from .session_scratch import ScratchStoreCorrupt, ScratchStoreError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.378"
+version = "0.9.379"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_session_control_peel.py
+++ b/tests/test_api_session_control_peel.py
@@ -17,6 +17,7 @@ from harness.api.session_control import (
     post_session_queue_reorder,
     post_session_rewind,
     post_session_steer,
+    post_session_todo,
     prepare_session_restart,
 )
 
@@ -545,3 +546,23 @@ def test_context_at_and_swarm_results():
     code2, payload = get_session_swarm_results(svc)
     assert code2 == 200 and payload["results"][0]["kind"] == "swarm_done"
     assert ckpt["n"] == 1
+
+
+def test_post_session_todo_slash():
+    class _Pilot:
+        def handle_todo_slash(self, command, workspace_root=""):
+            return {
+                "ok": True,
+                "notice": "TODO 0/1",
+                "todos": {"phases": [{"name": "Tasks", "tasks": []}]},
+                "command": command,
+                "workspace": workspace_root,
+            }
+
+    svc = _svc(pilot=_Pilot())
+    svc.cfg.repo = "/repo"
+    code, payload = post_session_todo({"command": "/todo view"}, svc)
+    assert code == 200
+    assert payload["ok"] is True
+    assert payload["command"] == "/todo view"
+    assert payload["workspace"] == "/repo"

--- a/tests/test_native_tools.py
+++ b/tests/test_native_tools.py
@@ -32,6 +32,7 @@ def test_build_tools_schema():
     assert "read_pdf" in names
     assert "run_swarm" in names
     assert "wait" in names
+    assert "todo" in names
     assert "search_codegraph" in names
     assert "query_wiki" in names
 

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from harness.pilot import from_wire
+from harness.send_loop_phases import LOCAL_ACTION_KINDS
+from harness.todo import (
+    apply_todo_op,
+    export_todo_markdown,
+    format_todo_tree,
+    handle_todo_slash_command,
+    import_todo_markdown,
+    infer_todo_op,
+    markdown_to_phases,
+    next_actionable_task,
+    phases_from_raw,
+    phases_to_markdown,
+    SessionTodoStore,
+    todo_matches_any_description,
+)
+
+
+def _apply(phases, **kwargs):
+    nxt, errors, op = apply_todo_op(phases, kwargs)
+    return nxt, errors, op
+
+
+def test_init_list_and_normalize_first_pending():
+    phases, errors, op = _apply([], op="init", list=[
+        {"phase": "WP-02", "items": ["hosted pari", "service invariants"]},
+        {"phase": "WP-03", "items": ["cutover"]},
+    ])
+    assert errors == []
+    assert op == "init"
+    assert [p.name for p in phases] == ["WP-02", "WP-03"]
+    assert phases[0].tasks[0].status == "in_progress"
+    assert phases[0].tasks[1].status == "pending"
+    assert next_actionable_task(phases).content == "hosted pari"
+
+
+def test_init_flat_items_without_op():
+    phases, errors, op = apply_todo_op([], {"items": ["one", "two"]})
+    assert errors == []
+    assert op == "init"
+    assert phases[0].name == "Tasks"
+    assert [t.content for t in phases[0].tasks] == ["one", "two"]
+
+
+def test_start_keeps_one_in_progress():
+    phases, _, _ = _apply([], op="init", list=[
+        {"phase": "A", "items": ["first", "second"]},
+    ])
+    phases, errors, _ = _apply(phases, op="start", task="second")
+    assert errors == []
+    assert phases[0].tasks[0].status == "pending"
+    assert phases[0].tasks[1].status == "in_progress"
+
+
+def test_done_by_phase_then_next_advances():
+    phases, _, _ = _apply([], op="init", list=[
+        {"phase": "A", "items": ["first", "second"]},
+    ])
+    phases, errors, _ = _apply(phases, op="done", phase="A")
+    assert errors == []
+    assert all(t.status == "completed" for t in phases[0].tasks)
+    assert next_actionable_task(phases) is None
+
+
+def test_append_creates_phase_and_rejects_duplicates():
+    phases, _, _ = _apply([], op="init", items=["alpha"], phase="Core")
+    phases, errors, _ = _apply(phases, op="append", phase="UI", items=["button"])
+    assert errors == []
+    assert [p.name for p in phases] == ["Core", "UI"]
+    phases, errors, _ = _apply(phases, op="append", phase="UI", items=["button"])
+    assert errors == ['Task "button" already exists']
+
+
+def test_block_unblock_and_drop():
+    phases, _, _ = _apply([], op="init", items=["alpha", "beta"])
+    phases, errors, _ = _apply(phases, op="block", task="beta", reason="needs key")
+    assert errors == []
+    blocked = [t for t in phases[0].tasks if t.content == "beta"][0]
+    assert blocked.status == "blocked"
+    assert blocked.blocker == "needs key"
+    phases, _, _ = _apply(phases, op="unblock", task="beta")
+    assert [t for t in phases[0].tasks if t.content == "beta"][0].status == "pending"
+    phases, _, _ = _apply(phases, op="drop", task="beta")
+    assert [t for t in phases[0].tasks if t.content == "beta"][0].status == "abandoned"
+
+
+def test_infer_append_when_phase_and_items():
+    assert infer_todo_op({"items": ["x"], "phase": "Later"}, True) == "append"
+    assert infer_todo_op({"items": ["x"]}, False) == "init"
+    assert infer_todo_op({"task": "x"}, True) is None
+
+
+def test_format_tree_folds_overflow():
+    items = ["T%02d" % i for i in range(1, 8)]
+    phases, _, _ = _apply([], op="init", list=[{"phase": "WP-02", "items": items}])
+    text = format_todo_tree(phases)
+    assert "TODO 0/7" in text
+    assert "I. WP-02 · 0/7" in text
+    assert "[>] T01" in text
+    assert "... 2 more todos" in text
+    assert "Next: T01" in text
+
+
+def test_dispatch_persists_and_formats(tmp_path):
+    from types import SimpleNamespace
+
+    from harness.pilot import PilotAction
+    from harness.tool_dispatch import ToolDispatchMixin
+
+    host = SimpleNamespace(
+        config=SimpleNamespace(state_dir=str(tmp_path)),
+        state_dir=str(tmp_path),
+        _todo_store=None,
+        _todo_phases=None,
+    )
+    host._get_todo_store = ToolDispatchMixin._get_todo_store.__get__(host)
+    host.todo_snapshot = ToolDispatchMixin.todo_snapshot.__get__(host)
+    act = PilotAction(
+        kind="todo",
+        arguments={"op": "init", "list": [{"phase": "WP-02", "items": ["hosted pari", "invariants"]}]},
+    )
+    ok, status, val = ToolDispatchMixin._do_todo(host, act)
+    assert ok and status == "success"
+    tree, payload = val
+    assert "TODO 0/2" in tree
+    assert payload["next"] == "hosted pari"
+    assert host.todo_snapshot()["phases"][0]["name"] == "WP-02"
+    reloaded = SessionTodoStore(str(tmp_path)).load()
+    assert reloaded[0].tasks[0].content == "hosted pari"
+
+
+def test_todo_is_a_local_action_and_from_wire():
+    assert "todo" in LOCAL_ACTION_KINDS
+    act = from_wire("todo", {"op": "view"})
+    assert act.kind == "todo"
+    assert act.arguments.get("op") == "view"
+
+
+def test_store_round_trip(tmp_path):
+    store = SessionTodoStore(str(tmp_path))
+    phases, _, _ = _apply([], op="init", items=["one"])
+    store.save(phases)
+    loaded = store.load()
+    assert phases_from_raw([p.to_dict() for p in loaded])[0].tasks[0].content == "one"
+
+
+def test_markdown_round_trip_preserves_blockers():
+    phases, _, _ = _apply([], op="init", list=[
+        {"phase": "WP-02", "items": ["hosted pari", "cutover"]},
+    ])
+    phases, _, _ = _apply(phases, op="block", task="cutover", reason="needs key")
+    md = phases_to_markdown(phases)
+    assert "# WP-02" in md
+    assert "- [/] hosted pari" in md
+    assert "- [!] cutover <!-- blocker: needs key -->" in md
+    parsed, errors = markdown_to_phases(md)
+    assert errors == []
+    assert parsed[0].tasks[1].status == "blocked"
+    assert parsed[0].tasks[1].blocker == "needs key"
+
+
+def test_markdown_markers_and_unknown_syntax():
+    parsed, errors = markdown_to_phases(
+        "# A\n- [x] done\n- [>] live\n- [-] dropped\n- [?] bad\nnot a task\n"
+    )
+    assert [t.status for t in parsed[0].tasks] == ["completed", "in_progress", "abandoned"]
+    assert any("unknown status marker" in err for err in errors)
+    assert any("unrecognized syntax" in err for err in errors)
+
+
+def test_export_import_stays_workspace_confined(tmp_path):
+    phases, _, _ = _apply([], op="init", items=["alpha"])
+    _abs_path, rel = export_todo_markdown(phases, str(tmp_path), "notes/TODO.md")
+    assert rel == "notes/TODO.md"
+    assert (tmp_path / "notes" / "TODO.md").is_file()
+    imported, errors, rel2 = import_todo_markdown(str(tmp_path), "notes/TODO.md")
+    assert errors == []
+    assert rel2 == "notes/TODO.md"
+    assert imported[0].tasks[0].content == "alpha"
+    try:
+        export_todo_markdown(phases, str(tmp_path), "../escape.md")
+        raise AssertionError("escaped write")
+    except ValueError as exc:
+        assert "escapes workspace" in str(exc)
+
+
+def test_slash_view_done_and_fuzzy_start(tmp_path):
+    phases, _, _ = _apply([], op="init", list=[
+        {"phase": "WP-02", "items": ["hosted pari", "service invariants"]},
+    ])
+    viewed = handle_todo_slash_command("/todo", phases)
+    assert viewed.ok and "TODO 0/2" in viewed.tree
+    started = handle_todo_slash_command("/todo start invariants", phases)
+    assert started.ok and started.mutated
+    assert started.phases[0].tasks[1].status == "in_progress"
+    done = handle_todo_slash_command("/todo done hosted", started.phases)
+    assert done.phases[0].tasks[0].status == "completed"
+    exported = handle_todo_slash_command("/todo export TODO.md", done.phases, str(tmp_path))
+    assert exported.ok and exported.path == "TODO.md"
+    (tmp_path / "TODO.md").write_text("# Later\n- [ ] imported task\n", encoding="utf-8")
+    imported = handle_todo_slash_command("/todo import", done.phases, str(tmp_path))
+    assert imported.ok and imported.mutated
+    assert imported.phases[0].tasks[0].content == "imported task"
+    denied = handle_todo_slash_command("/todo export ../x.md", done.phases, str(tmp_path))
+    assert not denied.ok
+
+
+def test_todo_matches_live_job_label():
+    assert todo_matches_any_description("Sonnet #2: bug scan", ["Sonnet #2"]) is True
+    assert todo_matches_any_description("fix", ["fixture loader"]) is False
+
+
+def test_mixin_slash_persists(tmp_path):
+    from types import SimpleNamespace
+
+    from harness.tool_dispatch import ToolDispatchMixin
+
+    host = SimpleNamespace(
+        config=SimpleNamespace(state_dir=str(tmp_path), repo=str(tmp_path)),
+        state_dir=str(tmp_path),
+        _todo_store=None,
+        _todo_phases=None,
+    )
+    host._get_todo_store = ToolDispatchMixin._get_todo_store.__get__(host)
+    host.handle_todo_slash = ToolDispatchMixin.handle_todo_slash.__get__(host)
+    first = host.handle_todo_slash("/todo append WP-02 hosted pari", workspace_root=str(tmp_path))
+    assert first["ok"] and first["mutated"]
+    second = host.handle_todo_slash("/todo export TODO.md", workspace_root=str(tmp_path))
+    assert second["ok"]
+    assert (tmp_path / "TODO.md").is_file()
+    reloaded = SessionTodoStore(str(tmp_path)).load()
+    assert reloaded[0].tasks[0].content == "hosted pari"

--- a/tests/test_tool_dispatch_mixin.py
+++ b/tests/test_tool_dispatch_mixin.py
@@ -34,6 +34,7 @@ MOVED_METHODS = (
     "_do_edit_file",
     "_do_run_command",
     "_do_run_ipython",
+    "_do_todo",
 )
 
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.378",
+  "version": "0.9.379",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.378",
+      "version": "0.9.379",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.378",
+  "version": "0.9.379",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/composerFamilyChrome.test.tsx
+++ b/webapp/src/__tests__/composerFamilyChrome.test.tsx
@@ -1,14 +1,15 @@
 import { createRef } from "react";
 import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import ComposerActivityRail from "../components/conversation/ComposerActivityRail";
 import ComposerDock from "../components/conversation/ComposerDock";
 import ComposerTasksPanel from "../components/conversation/ComposerTasksPanel";
 import { COMPOSER_FAMILY_CLASS } from "../components/conversation/composerFamily";
 import type { Job } from "../lib/api";
+import { clearSessionTodos, publishSessionTodos } from "../lib/sessionTodos";
 
 vi.mock("../lib/api", () => ({
-  api: { swarmCancel: vi.fn() },
+  api: { swarmCancel: vi.fn(), getSessionState: vi.fn(async () => ({ todos: { phases: [] } })) },
 }));
 vi.mock("../components/PilotPicker", () => ({
   default: () => <div data-testid="pilot-picker" />,
@@ -138,6 +139,10 @@ const swarmJob = {
 } as Job;
 
 describe("composer-family chrome", () => {
+  afterEach(() => {
+    clearSessionTodos();
+  });
+
   it("puts the same class family and tokens on dock and the activity rail", () => {
     const dock = renderDock();
     const rail = render(
@@ -171,6 +176,56 @@ describe("composer-family chrome", () => {
       <ComposerActivityRail jobs={[]} sessionId="sess-1" />,
     );
     expect(rail.container.querySelector("[data-slot=composer-activity-rail]")).toBeNull();
+  });
+
+  it("renders a nested session TODO tree on the activity rail", () => {
+    publishSessionTodos({
+      phases: [
+        {
+          name: "WP-02",
+          tasks: [
+            { content: "hosted pari", status: "in_progress" },
+            { content: "service invariants", status: "pending" },
+          ],
+        },
+      ],
+      next: "hosted pari",
+    }, "sess-1");
+    const rail = render(
+      <ComposerActivityRail jobs={[]} sessionId="sess-1" />,
+    );
+    expect(rail.container.querySelector("[data-slot=composer-todo-panel]")).toBeTruthy();
+    expect(rail.getByText("TODO 0/2")).toBeInTheDocument();
+    expect(rail.getByText(/I\. WP-02 · 0\/2/)).toBeInTheDocument();
+    clearSessionTodos();
+  });
+
+  it("lights a pending session TODO from a live swarm label", () => {
+    publishSessionTodos({
+      phases: [
+        {
+          name: "WP-02",
+          tasks: [
+            { content: "hosted pari", status: "pending" },
+            { content: "unrelated cutover", status: "pending" },
+          ],
+        },
+      ],
+    }, "sess-1");
+    const job = {
+      id: "j-live",
+      goal: "nested lighting",
+      status: "running",
+      session_id: "sess-1",
+      tasks: [{ id: "t1", role: "explore", instruction: "hosted pari service", status: "running" }],
+    } as Job;
+    const rail = render(
+      <ComposerActivityRail jobs={[job]} sessionId="sess-1" />,
+    );
+    const lit = rail.container.querySelector("[data-todo-lit='1']");
+    expect(lit).toBeTruthy();
+    expect(lit?.textContent).toContain("hosted pari");
+    clearSessionTodos();
   });
 
   it("renders parallel wave partial header from child counts", () => {

--- a/webapp/src/__tests__/composerTodos.test.ts
+++ b/webapp/src/__tests__/composerTodos.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  collapseTodoTasks,
+  litTodoContents,
+  liveJobTodoLabels,
+  todoHasWork,
+  todoMatchesAnyDescription,
+  todoPhaseProgress,
+  todoSnapshotProgress,
+  toRoman,
+} from "../lib/composerTodos";
+import type { Job } from "../lib/api";
+import type { SessionTodoItem, SessionTodoSnapshot } from "../lib/api";
+
+const task = (content: string, status: SessionTodoItem["status"]): SessionTodoItem => ({
+  content,
+  status,
+});
+
+describe("composerTodos", () => {
+  it("rolls up phase and snapshot progress", () => {
+    const snapshot: SessionTodoSnapshot = {
+      phases: [
+        { name: "WP-02", tasks: [task("a", "completed"), task("b", "in_progress"), task("c", "pending")] },
+        { name: "WP-03", tasks: [task("d", "pending")] },
+      ],
+    };
+    expect(todoPhaseProgress(snapshot.phases[0])).toEqual({ done: 1, total: 3 });
+    expect(todoSnapshotProgress(snapshot)).toEqual({ done: 1, total: 4 });
+    expect(todoHasWork(snapshot)).toBe(true);
+    expect(todoHasWork({ phases: [] })).toBe(false);
+  });
+
+  it("folds overflow the way OMP does: two closed + five open", () => {
+    const tasks = [
+      task("old-1", "completed"),
+      task("old-2", "completed"),
+      task("old-3", "completed"),
+      ...Array.from({ length: 7 }, (_, i) => task(`open-${i + 1}`, i === 0 ? "in_progress" : "pending")),
+    ];
+    const { items, hidden } = collapseTodoTasks(tasks);
+    expect(items.map((row) => row.content)).toEqual([
+      "old-2",
+      "old-3",
+      "open-1",
+      "open-2",
+      "open-3",
+      "open-4",
+      "open-5",
+    ]);
+    expect(hidden).toBe(3);
+  });
+
+  it("formats roman phase indexes", () => {
+    expect(toRoman(1)).toBe("I");
+    expect(toRoman(2)).toBe("II");
+    expect(toRoman(4)).toBe("IV");
+  });
+
+  it("fuzzy-matches live job labels at six-character overlap", () => {
+    expect(todoMatchesAnyDescription("Sonnet #2: bug scan", ["Sonnet #2"])).toBe(true);
+    expect(todoMatchesAnyDescription("hosted pari", ["hosted pari service"])).toBe(true);
+    expect(todoMatchesAnyDescription("fix", ["fixture loader"])).toBe(false);
+  });
+
+  it("collects live session job labels and lights matching pending todos", () => {
+    const jobs = [
+      {
+        id: "j1",
+        goal: "nested todo lighting",
+        status: "running",
+        session_id: "sess-1",
+        tasks: [{ id: "t1", role: "explore", instruction: "hosted pari service", status: "running" }],
+      },
+    ] as Job[];
+    expect(liveJobTodoLabels(jobs, "sess-1")).toEqual([
+      "nested todo lighting",
+      "hosted pari service",
+      "explore",
+    ]);
+    const snapshot: SessionTodoSnapshot = {
+      phases: [
+        {
+          name: "WP-02",
+          tasks: [task("hosted pari", "pending"), task("unrelated cutover", "pending")],
+        },
+      ],
+    };
+    expect([...litTodoContents(snapshot, liveJobTodoLabels(jobs, "sess-1"))]).toEqual(["hosted pari"]);
+  });
+
+  it("keeps lit pending todos in the folded viewport", () => {
+    const tasks = [
+      task("old-1", "completed"),
+      ...Array.from({ length: 7 }, (_, i) => task(`open-${i + 1}`, "pending")),
+    ];
+    const { items } = collapseTodoTasks(tasks, new Set(["open-7"]));
+    expect(items.map((row) => row.content)).toContain("open-7");
+  });
+});

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -2694,6 +2694,13 @@ describe("composerSend module", () => {
     expect(
       classifyLocalSlashCommand({ message: "hello", isBuiltIn: builtIn, customNames: [] }).kind,
     ).toBe("none");
+    expect(
+      classifyLocalSlashCommand({
+        message: "/todo export TODO.md",
+        isBuiltIn: builtIn,
+        customNames: [],
+      }),
+    ).toEqual({ kind: "todo", text: "export TODO.md" });
   });
 
   it("classifies navigation slash commands as local (not sent to the model)", () => {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -29,6 +29,7 @@ import {
 } from "../lib/turnTerminal";
 import { renameDefaultSessionIfNeeded } from "../lib/sessionTitle";
 import { notifyWorkspaceMutated } from "../lib/workspaceMutationEvents";
+import { publishSessionTodos } from "../lib/sessionTodos";
 
 import { writeTranscriptCache } from "./conversation/transcriptCache";
 import {
@@ -3074,6 +3075,31 @@ export default function Conversation({
       setInput("");
       setEditingIndex(null);
       window.dispatchEvent(new Event("harness-new-session"));
+      return;
+    }
+    if (slash.kind === "todo") {
+      const command = msg.startsWith("/") ? msg : `/todo ${slash.text || ""}`.trim();
+      setInput("");
+      setEditingIndex(null);
+      void api.sessionTodo({ command })
+        .then((res) => {
+          if (res?.todos) publishSessionTodos(res.todos, activeSessionId || "");
+          const reply = !res?.ok
+            ? (res?.error || res?.usage || "Could not run /todo.")
+            : (res?.notice || res?.tree || res?.markdown || "No todos.");
+          setItems((p) => [
+            ...p,
+            { kind: "msg", msg: { role: "user", text: msg } },
+            { kind: "msg", msg: { role: "assistant", text: reply } },
+          ]);
+        })
+        .catch(() => {
+          setItems((p) => [
+            ...p,
+            { kind: "msg", msg: { role: "user", text: msg } },
+            { kind: "msg", msg: { role: "assistant", text: "Could not run /todo." } },
+          ]);
+        });
       return;
     }
     if (slash.kind === "refine") {

--- a/webapp/src/components/conversation/ComposerActivityRail.tsx
+++ b/webapp/src/components/conversation/ComposerActivityRail.tsx
@@ -6,8 +6,11 @@ import {
   subscribeAgentCommandIndex,
 } from "../../lib/agentCommandIndex";
 import { pickTaskSourceJob } from "../../lib/composerTasks";
+import { todoHasWork } from "../../lib/composerTodos";
+import { getSessionTodos, subscribeSessionTodos } from "../../lib/sessionTodos";
 import ComposerStatusStack from "./ComposerStatusStack";
 import ComposerTasksPanel from "./ComposerTasksPanel";
+import ComposerTodoPanel from "./ComposerTodoPanel";
 import { COMPOSER_FAMILY_HAIRLINE, COMPOSER_FAMILY_SURFACE } from "./composerFamily";
 import { buildComposerStatusStackRows } from "./composerStatusStackData";
 
@@ -31,8 +34,10 @@ export default function ComposerActivityRail({
     () => buildComposerStatusStackRows({ swarmJobs: jobs, commandSessions }),
     [commandSessions, jobs],
   );
+  const todos = useSyncExternalStore(subscribeSessionTodos, getSessionTodos, getSessionTodos);
+  const showTodos = todoHasWork(todos);
   const showTasks = !!pickTaskSourceJob(jobs, sessionId);
-  if (!showTasks && !stackRows.length) return null;
+  if (!showTasks && !showTodos && !stackRows.length) return null;
 
   return (
     <div
@@ -40,6 +45,7 @@ export default function ComposerActivityRail({
       data-slot="composer-activity-rail"
     >
       <div className={`divide-y ${COMPOSER_FAMILY_HAIRLINE}`}>
+        <ComposerTodoPanel jobs={jobs} sessionId={sessionId} />
         <ComposerTasksPanel jobs={jobs} sessionId={sessionId} />
         <ComposerStatusStack swarmJobs={jobs} />
       </div>

--- a/webapp/src/components/conversation/ComposerTodoPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTodoPanel.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { Ban, CheckCircle2, ChevronDown, ChevronRight, Circle, ListTree, Loader2, MinusCircle } from "lucide-react";
+import { api, type Job, type SessionTodoItem, type SessionTodoSnapshot } from "../../lib/api";
+import {
+  collapseTodoTasks,
+  litTodoContents,
+  liveJobTodoLabels,
+  todoHasWork,
+  todoPhaseProgress,
+  todoSnapshotProgress,
+  toRoman,
+} from "../../lib/composerTodos";
+import {
+  getSessionTodos,
+  getSessionTodosSessionId,
+  publishSessionTodos,
+  subscribeSessionTodos,
+} from "../../lib/sessionTodos";
+import { COMPOSER_FAMILY_SECTION } from "./composerFamily";
+
+function TaskMark({
+  status,
+  lit,
+}: {
+  status: SessionTodoItem["status"];
+  lit?: boolean;
+}) {
+  if (status === "completed") return <CheckCircle2 size={11} className="shrink-0 text-good" />;
+  if (status === "abandoned") return <MinusCircle size={11} className="shrink-0 text-faint" />;
+  if (status === "blocked") return <Ban size={11} className="shrink-0 text-warn" />;
+  if (status === "in_progress" || lit) return <Loader2 size={11} className="shrink-0 animate-spin text-accent" />;
+  return <Circle size={11} className="shrink-0 text-faint" />;
+}
+
+function taskTone(status: SessionTodoItem["status"], lit?: boolean): string {
+  if (status === "in_progress" || lit) return "text-accent";
+  if (status === "pending" || status === "abandoned") return "text-faint";
+  return "text-txt";
+}
+
+export default function ComposerTodoPanel({
+  jobs = [],
+  sessionId,
+}: {
+  jobs?: readonly Job[];
+  sessionId: string;
+}) {
+  const snapshot = useSyncExternalStore(
+    subscribeSessionTodos,
+    getSessionTodos,
+    getSessionTodos,
+  );
+  const storedSid = useSyncExternalStore(
+    subscribeSessionTodos,
+    getSessionTodosSessionId,
+    getSessionTodosSessionId,
+  );
+  const [open, setOpen] = useState(true);
+  const [expandedPhase, setExpandedPhase] = useState<string | null>(null);
+  const lit = useMemo(
+    () => litTodoContents(snapshot, liveJobTodoLabels(jobs, sessionId)),
+    [jobs, sessionId, snapshot],
+  );
+
+  useEffect(() => {
+    if (!sessionId) return;
+    if (storedSid === sessionId) return;
+    let cancelled = false;
+    api.getSessionState({ sessionId }).then((state) => {
+      if (cancelled) return;
+      publishSessionTodos(state.todos || { phases: [] }, sessionId);
+    }).catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, storedSid]);
+
+  if (!todoHasWork(snapshot) || (storedSid && storedSid !== sessionId)) return null;
+  const { done, total } = todoSnapshotProgress(snapshot);
+  const next = snapshot.next;
+
+  return (
+    <div className={COMPOSER_FAMILY_SECTION} data-slot="composer-todo-panel">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[10.5px] leading-4 text-txt hover:bg-panel/35"
+      >
+        {open ? <ChevronDown size={11} className="text-faint" /> : <ChevronRight size={11} className="text-faint" />}
+        <ListTree size={11} className="text-faint" />
+        <span className="font-medium tabular-nums">TODO {done}/{total}</span>
+        {next && !open ? <span className="min-w-0 truncate text-faint">{next}</span> : null}
+      </button>
+      {open && (
+        <div className="border-t border-edge/50 px-2 py-1 space-y-1">
+          {snapshot.phases.map((phase, index) => (
+            <PhaseBlock
+              key={`${phase.name}-${index}`}
+              index={index + 1}
+              phase={phase}
+              expanded={expandedPhase === phase.name}
+              litContents={lit}
+              onToggle={() => setExpandedPhase((name) => (name === phase.name ? null : phase.name))}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PhaseBlock({
+  index,
+  phase,
+  expanded,
+  litContents,
+  onToggle,
+}: {
+  index: number;
+  phase: SessionTodoSnapshot["phases"][number];
+  expanded: boolean;
+  litContents: ReadonlySet<string>;
+  onToggle: () => void;
+}) {
+  const { done, total } = todoPhaseProgress(phase);
+  const { items, hidden } = expanded
+    ? { items: phase.tasks, hidden: 0 }
+    : collapseTodoTasks(phase.tasks, litContents);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[10.5px] leading-4 text-txt hover:bg-panel/30"
+      >
+        {expanded ? <ChevronDown size={11} className="text-faint" /> : <ChevronRight size={11} className="text-faint" />}
+        <span className="font-medium tabular-nums">
+          {toRoman(index)}. {phase.name} · {done}/{total}
+        </span>
+      </button>
+      <div className="pl-4 space-y-0.5">
+        {items.map((task) => {
+          const lit = litContents.has(task.content);
+          return (
+          <div
+            key={task.content}
+            title={task.blocker || task.content}
+            data-todo-lit={lit ? "1" : undefined}
+            className={`flex items-start gap-1.5 text-[10.5px] leading-4 ${taskTone(task.status, lit)}`}
+          >
+            <TaskMark status={task.status} lit={lit} />
+            <span className={expanded ? "whitespace-pre-wrap break-words" : "min-w-0 truncate"}>
+              {task.content}
+              {expanded && task.blocker ? <span className="mt-0.5 block text-faint">{task.blocker}</span> : null}
+            </span>
+          </div>
+          );
+        })}
+        {hidden > 0 ? (
+          <button
+            type="button"
+            onClick={onToggle}
+            className="text-[10.5px] leading-4 text-faint hover:text-txt"
+          >
+            ... {hidden} more todo{hidden === 1 ? "" : "s"}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/conversation/composerSend.ts
+++ b/webapp/src/components/conversation/composerSend.ts
@@ -70,7 +70,7 @@ export function formatHelpSlashReply(
   return (
     "Available Slash Commands:\n\n"
     + commands.map((s) => `* \`${s.cmd}\` - ${s.desc}`).join("\n")
-    + "\n\nLocal chrome (not sent to the model): `/swarm` `/terminal` `/settings` `/memory` `/mcp` `/files` `/state` `/refine`."
+    + "\n\nLocal chrome (not sent to the model): `/swarm` `/terminal` `/settings` `/memory` `/mcp` `/files` `/state` `/refine` `/todo`."
     + "\n\nType @ to list and mention files in your message context."
   );
 }
@@ -356,6 +356,7 @@ export type LocalSlashAction =
   | { kind: "new" }
   | { kind: "compact" }
   | { kind: "refine"; text: string }
+  | { kind: "todo"; text: string }
   | { kind: "model" }
   | { kind: "help" }
   | { kind: "swarm" }
@@ -424,6 +425,9 @@ export function classifyLocalSlashCommand(opts: {
   if (cmd === "/compact") return { kind: "compact" };
   if (cmd === "/refine") {
     return { kind: "refine", text: msg.substring(cmd.length).trim() };
+  }
+  if (cmd === "/todo") {
+    return { kind: "todo", text: msg.substring(cmd.length).trim() };
   }
   if (cmd === "/model") return { kind: "model" };
   if (cmd === "/help") return { kind: "help" };

--- a/webapp/src/components/conversation/slashCommands.ts
+++ b/webapp/src/components/conversation/slashCommands.ts
@@ -3,6 +3,7 @@ export const SLASH_COMMANDS = [
   { cmd: "/new", desc: "Start a new session" },
   { cmd: "/compact", desc: "Trigger manual context compaction" },
   { cmd: "/refine", desc: "Propose a harness refine (existing controller)" },
+  { cmd: "/todo", desc: "View or edit the session nested TODO tree" },
   { cmd: "/model", desc: "Focus model picker to switch models" },
   { cmd: "/swarm", desc: "Focus Swarm tab" },
   { cmd: "/terminal", desc: "Focus Terminal" },

--- a/webapp/src/components/conversation/streamEventHandler.ts
+++ b/webapp/src/components/conversation/streamEventHandler.ts
@@ -66,6 +66,7 @@ import { clearDiagnostic } from "../../lib/operationalDiagnosticBus";
 import { notifyWorkspaceMutated } from "../../lib/workspaceMutationEvents";
 import { shouldRefreshBusyChrome } from "./streamTerminal";
 import { waitHintForAssistantDone } from "./swarmPoll";
+import { publishSessionTodos } from "../../lib/sessionTodos";
 import {
   hasPartialAssistantAnswer,
   settleFromAssistantDone,
@@ -490,6 +491,9 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
         setItems((p) => appendActionStartCard(p, d));
       }
     } else if (ev.kind === "action_result") {
+      if (d.todos && Array.isArray(d.todos.phases)) {
+        publishSessionTodos(d.todos, String(d.session_id || ""));
+      }
       clearWaitHintOnProgress();
       setCompactingStatus(null);
       // Late command/batch terminal receipts after assistant_done must update

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -561,6 +561,27 @@ export type SessionState = {
   active_view_id?: string | null;
   // Sticky session GOAL (chip-ready); distinct from Schedule.objective / Job.goal.
   goal?: SessionGoal;
+  todos?: SessionTodoSnapshot;
+};
+
+export type SessionTodoStatus = "pending" | "in_progress" | "completed" | "abandoned" | "blocked";
+
+export type SessionTodoItem = {
+  content: string;
+  status: SessionTodoStatus;
+  blocker?: string;
+};
+
+export type SessionTodoPhase = {
+  name: string;
+  tasks: SessionTodoItem[];
+};
+
+export type SessionTodoSnapshot = {
+  op?: string | null;
+  phases: SessionTodoPhase[];
+  storage?: string;
+  next?: string | null;
 };
 
 export type SwarmResultData = {
@@ -1292,6 +1313,18 @@ export const api = {
     postJSON<{ ok: boolean; goal: SessionGoal }>("/api/session/goal", { action: "complete" }),
   clearSessionGoal: () =>
     postJSON<{ ok: boolean; goal: SessionGoal }>("/api/session/goal", { action: "clear" }),
+  sessionTodo: (body: { command: string }) =>
+    postJSON<{
+      ok: boolean;
+      mutated?: boolean;
+      tree?: string;
+      markdown?: string;
+      notice?: string;
+      path?: string;
+      usage?: string;
+      error?: string;
+      todos?: SessionTodoSnapshot;
+    }>("/api/session/todo", body),
   refinePropose: (body: {
     text?: string;
     kind?: string;

--- a/webapp/src/lib/composerTodos.ts
+++ b/webapp/src/lib/composerTodos.ts
@@ -1,0 +1,132 @@
+import type { Job, SessionTodoItem, SessionTodoPhase, SessionTodoSnapshot } from "./api";
+import { taskState } from "./composerTasks";
+import { jobInActiveSession } from "./jobScope";
+
+export const TODO_OPEN_CAP = 5;
+export const TODO_CLOSED_CONTEXT = 2;
+
+const CLOSED = new Set(["completed", "abandoned"]);
+
+export function todoPhaseProgress(phase: SessionTodoPhase): { done: number; total: number } {
+  const total = phase.tasks.length;
+  const done = phase.tasks.filter((task) => CLOSED.has(task.status)).length;
+  return { done, total };
+}
+
+export function todoSnapshotProgress(snapshot: SessionTodoSnapshot | null | undefined): { done: number; total: number } {
+  const phases = snapshot?.phases || [];
+  return phases.reduce(
+    (acc, phase) => {
+      const { done, total } = todoPhaseProgress(phase);
+      acc.done += done;
+      acc.total += total;
+      return acc;
+    },
+    { done: 0, total: 0 },
+  );
+}
+
+export function collapseTodoTasks(
+  tasks: readonly SessionTodoItem[],
+  litContents?: ReadonlySet<string>,
+): {
+  items: SessionTodoItem[];
+  hidden: number;
+} {
+  const closed = tasks.filter((task) => CLOSED.has(task.status));
+  const open = tasks.filter((task) => !CLOSED.has(task.status));
+  const lead = closed.slice(-TODO_CLOSED_CONTEXT);
+  const lit = litContents
+    ? open.filter((task) => litContents.has(task.content))
+    : [];
+  const rest = litContents
+    ? open.filter((task) => !litContents.has(task.content))
+    : open;
+  const shownOpen = [...lit, ...rest].slice(0, TODO_OPEN_CAP);
+  const items = [...lead, ...shownOpen];
+  return { items, hidden: Math.max(0, tasks.length - items.length) };
+}
+
+export function normalizeForTodoMatch(value: string): string {
+  return (value || "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+}
+
+export function todoMatchesAnyDescription(
+  content: string,
+  descriptions: readonly string[],
+): boolean {
+  const target = normalizeForTodoMatch(content);
+  if (!target) return false;
+  for (const desc of descriptions) {
+    const candidate = normalizeForTodoMatch(desc);
+    if (!candidate) continue;
+    if (target === candidate) return true;
+    if (target.length >= TODO_DESCRIPTION_MIN_OVERLAP && candidate.includes(target)) return true;
+    if (candidate.length >= TODO_DESCRIPTION_MIN_OVERLAP && target.includes(candidate)) return true;
+  }
+  return false;
+}
+
+export const TODO_DESCRIPTION_MIN_OVERLAP = 6;
+
+export function liveJobTodoLabels(jobs: readonly Job[], sessionId: string): string[] {
+  const labels: string[] = [];
+  for (const job of jobs) {
+    if (!jobInActiveSession(job, sessionId)) continue;
+    const jobLive = taskState(job.status) === "in_progress" || taskState(job.status) === "pending";
+    const liveTasks = (job.tasks || []).filter((task) => {
+      const state = taskState(task.status);
+      return state === "in_progress" || state === "pending";
+    });
+    if (!jobLive && !liveTasks.length) continue;
+    if (job.goal) labels.push(job.goal);
+    if (job.role) labels.push(job.role);
+    for (const task of liveTasks) {
+      if (task.instruction) labels.push(String(task.instruction));
+      if (task.role) labels.push(String(task.role));
+    }
+  }
+  return labels;
+}
+
+export function litTodoContents(
+  snapshot: SessionTodoSnapshot | null | undefined,
+  descriptions: readonly string[],
+): Set<string> {
+  const lit = new Set<string>();
+  for (const phase of snapshot?.phases || []) {
+    for (const task of phase.tasks) {
+      if (task.status !== "pending") continue;
+      if (todoMatchesAnyDescription(task.content, descriptions)) {
+        lit.add(task.content);
+      }
+    }
+  }
+  return lit;
+}
+
+export function todoHasWork(snapshot: SessionTodoSnapshot | null | undefined): boolean {
+  return (snapshot?.phases || []).some((phase) => phase.tasks.length > 0);
+}
+
+export function toRoman(value: number): string {
+  const table: Array<[number, string]> = [
+    [10, "X"],
+    [9, "IX"],
+    [5, "V"],
+    [4, "IV"],
+    [1, "I"],
+  ];
+  let remaining = Math.max(1, Math.floor(value));
+  let out = "";
+  for (const [arabic, glyph] of table) {
+    while (remaining >= arabic) {
+      out += glyph;
+      remaining -= arabic;
+    }
+  }
+  return out;
+}

--- a/webapp/src/lib/sessionTodos.ts
+++ b/webapp/src/lib/sessionTodos.ts
@@ -1,0 +1,50 @@
+import type { SessionTodoSnapshot } from "./api";
+
+let snapshot: SessionTodoSnapshot = { phases: [] };
+let sessionId = "";
+let version = 0;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  version += 1;
+  listeners.forEach((fn) => fn());
+}
+
+export function publishSessionTodos(
+  next: SessionTodoSnapshot | null | undefined,
+  nextSessionId = "",
+): void {
+  const sid = String(nextSessionId || "").trim();
+  const phases = Array.isArray(next?.phases) ? next.phases : [];
+  snapshot = {
+    op: next?.op ?? null,
+    phases,
+    storage: next?.storage || "session",
+    next: next?.next ?? null,
+  };
+  if (sid) sessionId = sid;
+  emit();
+}
+
+export function clearSessionTodos(): void {
+  snapshot = { phases: [] };
+  sessionId = "";
+  emit();
+}
+
+export function getSessionTodos(): SessionTodoSnapshot {
+  return snapshot;
+}
+
+export function getSessionTodosSessionId(): string {
+  return sessionId;
+}
+
+export function getSessionTodosVersion(): number {
+  return version;
+}
+
+export function subscribeSessionTodos(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}


### PR DESCRIPTION
## Why

Pilots needed a session-owned nested TODO tree (OMP phased economics), not another projection of swarm job rows. ComposerTasks stays execution chrome.

## Scope

- `harness/todo.py`: phased tree, exact-content tool ops, markdown round-trip, `/todo` slash verbs, workspace-confined export/import.
- Pilot tool `todo` plus `POST /api/session/todo`. Session sidecar `session_todos.json` is the source of truth.
- Composer rail `ComposerTodoPanel`: Roman phases, fold, live-job lighting of pending todos (6-char normalized overlap). Does not write status.
- Stamp `0.9.379` in the four version files and README.

Core files: `harness/todo.py`, `harness/tool_dispatch.py`, `harness/api/session_control.py`, `webapp/src/lib/composerTodos.ts`, `webapp/src/components/conversation/ComposerTodoPanel.tsx`.

## Tradeoffs

Session JSON over workspace markdown as source of truth. Markdown is opt-in export/import so session switch cannot fight `TODO.md`. Slash fuzzy-matches; the tool stays exact content. Lighting is visual only.

## Blast radius

Session state grows a `todos` field. Writes to `TODO.md` stay under `resolve_workspace_path`. ComposerTasks leftover-wave invariants are unchanged.

## Verification

- `pytest tests/test_todo.py tests/test_api_session_control_peel.py tests/test_native_tools.py tests/test_tool_dispatch_mixin.py tests/test_paths.py tests/test_version_consistency.py` passed.
- Vitest: `composerTodos`, `composerFamilyChrome`, `conversation.helpers` (160 passed).
- Full local `pytest tests -q`: 5329 passed, 78 skipped. Pre-existing local fail `test_swarm_live.py::test_session_total_includes_swarm_store_job_cost` also fails on clean `main` (70b0b479); not in this diff.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/professorpalmer/marionette/pull/250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->