### PR TITLE
Release v0.9.382

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.41` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.381, deliberately pre-1.0. Rides puppetmaster-ai==1.22.41. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.382, deliberately pre-1.0. Rides puppetmaster-ai==1.22.41. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.381"
+__version__ = "0.9.382"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.381"
+version = "0.9.382"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.381",
+  "version": "0.9.382",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.381",
+      "version": "0.9.382",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.381",
+  "version": "0.9.382",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/ComposerStatusStack.test.tsx
+++ b/webapp/src/__tests__/ComposerStatusStack.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import ComposerStatusStack from "../components/conversation/ComposerStatusStack";
 import { api } from "../lib/api";
 import { openAgentCommand } from "../lib/agentLinks";
+import { dismissAgentCommandSession } from "../lib/agentCommandIndex";
 import type { Job } from "../lib/api";
 
 vi.mock("../lib/api", () => ({
@@ -20,6 +21,7 @@ vi.mock("../lib/agentCommandIndex", () => ({
   getAgentCommandIndexVersion: () => 1,
   listAgentCommandSessions: () => [],
   registerAgentCommandSession: () => null,
+  dismissAgentCommandSession: vi.fn(() => true),
 }));
 
 function commandJob(partial: Partial<Job> & Pick<Job, "id" | "status">): Job {
@@ -39,6 +41,7 @@ describe("ComposerStatusStack", () => {
   beforeEach(() => {
     vi.mocked(api.swarmCancel).mockClear();
     vi.mocked(openAgentCommand).mockClear();
+    vi.mocked(dismissAgentCommandSession).mockClear();
   });
   it("collapses settled terminal rows behind a header like the wave bar", () => {
     render(
@@ -47,11 +50,11 @@ describe("ComposerStatusStack", () => {
       />,
     );
     expect(screen.getByRole("button", { name: "Terminal" })).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByText("Open terminal")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Open terminal/ })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
     expect(screen.getByRole("button", { name: "Terminal" })).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByText("Open terminal")).toBeInTheDocument();
-    expect(screen.getByText("Open terminal").closest("button")?.className).not.toMatch(/border-edge/);
+    expect(screen.getByRole("button", { name: /Open terminal/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Open terminal/ }).className).not.toMatch(/border-edge/);
     expect(screen.queryByRole("button", { name: "Stop command" })).not.toBeInTheDocument();
   });
 
@@ -62,8 +65,9 @@ describe("ComposerStatusStack", () => {
       />,
     );
     expect(screen.getByRole("button", { name: "Terminal" })).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByText("Open terminal")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Open terminal/ })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Stop command" }));
+    expect(dismissAgentCommandSession).toHaveBeenCalledWith("local-cmd-live");
     expect(api.swarmCancel).toHaveBeenCalledWith("local-cmd-live");
     expect(openAgentCommand).not.toHaveBeenCalled();
   });
@@ -79,8 +83,10 @@ describe("ComposerStatusStack", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
     expect(screen.getByRole("button", { name: "Terminal" })).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByText("Open terminal")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Open terminal/ })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Stop all commands" }));
+    expect(dismissAgentCommandSession).toHaveBeenCalledWith("local-cmd-a");
+    expect(dismissAgentCommandSession).toHaveBeenCalledWith("local-cmd-b");
     expect(api.swarmCancel).toHaveBeenCalledWith("local-cmd-a");
     expect(api.swarmCancel).toHaveBeenCalledWith("local-cmd-b");
     expect(openAgentCommand).not.toHaveBeenCalled();

--- a/webapp/src/__tests__/agentCommandIndex.test.ts
+++ b/webapp/src/__tests__/agentCommandIndex.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import {
   getAgentCommandIndexVersion,
+  dismissAgentCommandSession,
   listAgentCommandSessions,
   lookupAgentCommandSession,
   lookupAgentCommandSessionById,
@@ -51,5 +52,55 @@ describe("agentCommandIndex", () => {
     expect(registerAgentCommandSession({ id: "x", command: "   " })).toBeNull();
     expect(registerAgentCommandSession({ id: "x", command: "n".repeat(501) })).toBeNull();
     expect(lookupAgentCommandSession("echo hi")).toBeNull();
+  });
+
+  it("lists only the active chat when sessionId is passed", () => {
+    registerAgentCommandSession({
+      id: "old-chat",
+      command: "git checkout -- tsconfig.json",
+      state: "done",
+      sessionId: "sess-old",
+    });
+    registerAgentCommandSession({
+      id: "new-chat",
+      command: "echo hi",
+      state: "running",
+      sessionId: "sess-new",
+    });
+    registerAgentCommandSession({
+      id: "orphan",
+      command: "git status",
+      state: "done",
+    });
+    expect(listAgentCommandSessions("sess-new").map((s) => s.id)).toEqual(["new-chat"]);
+    expect(listAgentCommandSessions("")).toEqual([]);
+    expect(listAgentCommandSessions().map((s) => s.id).sort()).toEqual([
+      "new-chat",
+      "old-chat",
+      "orphan",
+    ]);
+  });
+
+  it("keeps sessionId on streaming updates so a later list still scopes", () => {
+    registerAgentCommandSession({
+      id: "cmd-1",
+      command: "pytest -q",
+      sessionId: "sess-1",
+    });
+    registerAgentCommandSession({ id: "cmd-1", command: "pytest -q", output: "ok\n" });
+    expect(lookupAgentCommandSessionById("cmd-1")?.sessionId).toBe("sess-1");
+    expect(listAgentCommandSessions("sess-1").map((s) => s.id)).toEqual(["cmd-1"]);
+  });
+
+  it("drops a dismissed session so X can clear a phantom Term row", () => {
+    registerAgentCommandSession({
+      id: "cg-1",
+      command: "custom OpenAI-compatible provider API base URL",
+      state: "running",
+      sessionId: "sess-1",
+    });
+    expect(dismissAgentCommandSession("cg-1")).toBe(true);
+    expect(lookupAgentCommandSessionById("cg-1")).toBeNull();
+    expect(listAgentCommandSessions("sess-1")).toEqual([]);
   });
 });

--- a/webapp/src/__tests__/agentLinks.test.ts
+++ b/webapp/src/__tests__/agentLinks.test.ts
@@ -167,6 +167,11 @@ describe("agentLinks detection", () => {
       "audit harness/send_loop_dispatch.py mode=analysis",
     ).linkKind).toBe("command");
     // Unknown kinds: shell-like never falls through to file.
+    expect(classifyActionGoal(
+      "search_codegraph",
+      "custom OpenAI-compatible provider API base URL model configuration settings",
+    ).linkKind).toBe("none");
+    expect(classifyActionGoal("search_files", "base_url|api_base").linkKind).toBe("none");
     expect(classifyActionGoal("custom_tool", "npm.cmd").linkKind).toBe("command");
     expect(classifyActionGoal("custom_tool", "git status").linkKind).toBe("command");
     expect(classifyActionGoal("custom_tool", "webapp/src/App.tsx").linkKind).toBe("file");

--- a/webapp/src/__tests__/composerFamilyChrome.test.tsx
+++ b/webapp/src/__tests__/composerFamilyChrome.test.tsx
@@ -25,6 +25,7 @@ vi.mock("../lib/agentCommandIndex", () => ({
   getAgentCommandIndexVersion: () => 1,
   listAgentCommandSessions: () => [],
   registerAgentCommandSession: () => null,
+  dismissAgentCommandSession: () => false,
 }));
 
 const noop = () => {};

--- a/webapp/src/__tests__/composerStatusStack.test.ts
+++ b/webapp/src/__tests__/composerStatusStack.test.ts
@@ -296,6 +296,65 @@ describe("composerStatusStack", () => {
     });
   });
 
+  it("hides leftover Term rows from another chat on a New session", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      sessionId: "sess-new",
+      swarmJobs: [
+        {
+          id: "local-cmd-foreign",
+          goal: "git checkout -- tsconfig.json",
+          source: "harness",
+          status: "completed",
+          session_id: "sess-old",
+          updated_at: now - 1000,
+          job_kind: "run_command",
+          command_preview: "git checkout -- tsconfig.json",
+        } as any,
+        {
+          id: "local-cmd-here",
+          goal: "echo hi",
+          source: "harness",
+          status: "running",
+          session_id: "sess-new",
+          updated_at: now - 1000,
+          job_kind: "run_command",
+          command_preview: "echo hi",
+        } as any,
+        {
+          id: "local-cmd-cli",
+          goal: "cursor leftover",
+          source: "cli",
+          status: "running",
+          session_id: "sess-new",
+          updated_at: now - 1000,
+          job_kind: "run_command",
+          command_preview: "cursor leftover",
+        } as any,
+      ],
+      commandSessions: [
+        {
+          id: "leftover-index",
+          command: "sqliteTable tournaments slug",
+          output: "done",
+          state: "done",
+          updatedAt: now - 500,
+          sessionId: "sess-old",
+        },
+        {
+          id: "orphan-index",
+          command: "git status --short",
+          output: "done",
+          state: "done",
+          updatedAt: now - 500,
+        },
+      ],
+    });
+    expect(rows.map((row) => row.id)).toEqual(["local-cmd-here"]);
+    expect(rows[0]).toMatchObject({ kind: "terminal", command: "echo hi" });
+  });
+
   it("collapses command preview whitespace so the task bar does not stair-step", () => {
     const now = Date.parse("2026-08-23T12:00:00Z");
     const job = {

--- a/webapp/src/__tests__/composerTasks.test.ts
+++ b/webapp/src/__tests__/composerTasks.test.ts
@@ -149,6 +149,17 @@ describe("buildComposerTasks + progress", () => {
     expect(tasks[2].state).toBe("in_progress");
   });
 
+  it("shows the role and a short stem, not the shared swarm brief", () => {
+    const brief = "Determine the exact current steps for configuring Marionette to use OrcaRouter's OpenAI-compatible API.";
+    const tasks = buildComposerTasks(job("j", "running", "sess-1", [
+      { id: "1", role: "explore", instruction: brief, status: "running", adapter: "x" },
+      { id: "2", role: "decision-explainer", instruction: brief, status: "pending", adapter: "x" },
+    ]));
+    expect(tasks.map((t) => t.content)).toEqual(["explore", "decision explainer"]);
+    expect(tasks.every((t) => !t.summary)).toBe(true);
+    expect(tasks[0].detail).toBe(brief);
+  });
+
   it("collapses a multi-line worker prompt onto one line", () => {
     const tasks = buildComposerTasks(job("j", "running", "sess-1", [
       {
@@ -159,9 +170,9 @@ describe("buildComposerTasks + progress", () => {
         adapter: "x",
       },
     ]));
-    expect(tasks[0].content).toBe(
-      "reviewer · Audit the Marionette harness Python backend under harness/. React UI under webapp/src/.",
-    );
+    expect(tasks[0].content).toBe("reviewer");
+    expect(tasks[0].summary).toBe("Audit the Marionette harness");
+    expect(tasks[0].detail).toContain("Python backend under harness/.");
     expect(tasks[0].content.includes("\n")).toBe(false);
   });
 

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -3658,6 +3658,7 @@ export default function Conversation({
           onAuthFailureRetry={handleAuthFailureRetry}
           showJumpToBottom={showJumpToBottom}
           onJumpToBottom={jumpToLatest}
+          sessionId={activeSessionId ?? ""}
           composerDock={(
       <ComposerDock
         config={config}

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -1228,7 +1228,7 @@ const VirtualTranscriptRow = memo(
 );
 
 /** Bind run_command cards even when Investigating is collapsed (Hermes procId). */
-function indexCardCommandSession(card: Card): void {
+function indexCardCommandSession(card: Card, sessionId?: string): void {
   const cliInput = resolveCardCliInput(card);
   const resultCommand = String(card.result?.command || "").trim();
   const inputKey = toolInputFieldKey(card.kind || "");
@@ -1260,12 +1260,13 @@ function indexCardCommandSession(card: Card): void {
     command: value,
     output: String(card.result?.output || ""),
     state,
+    sessionId,
   });
 }
 
-function indexTranscriptCommandSessions(items: Item[]): void {
+function indexTranscriptCommandSessions(items: Item[], sessionId?: string): void {
   for (const it of items) {
-    if (it.kind === "card") indexCardCommandSession(it.card);
+    if (it.kind === "card") indexCardCommandSession(it.card, sessionId);
   }
 }
 
@@ -1373,6 +1374,8 @@ export type TranscriptListProps = {
   onSecretRequest?: (item: SecretRequestItem, decision: { action: "save"; value: string } | { action: "dismiss" }) => void;
   /** Relaunch the failed turn after provider auth recovery (Settings still opens). */
   onAuthFailureRetry?: () => void;
+  /** Active harness chat — stamps command-index rows so the composer rail stays session-owned. */
+  sessionId?: string;
 };
 
 export const TranscriptList = memo(function TranscriptList({
@@ -1396,12 +1399,13 @@ export const TranscriptList = memo(function TranscriptList({
   onCommandApproval,
   onSecretRequest,
   onAuthFailureRetry,
+  sessionId,
 }: TranscriptListProps) {
   // Match Conversation's latch — awaiting_swarm plus holdSwarmAwait so
   // Investigating / mid-turn absorption / footer stay armed through idle flaps.
   useEffect(() => {
-    indexTranscriptCommandSessions(items);
-  }, [items]);
+    indexTranscriptCommandSessions(items, sessionId);
+  }, [items, sessionId]);
 
   const agentLoopOpen = isAgentLoopOpen(turnOpen, status) || holdSwarmAwait;
   // Pause-point: StatusPill prefers Still working… — seal sticky Investigating
@@ -3550,9 +3554,10 @@ function ActionCard({
       id: commandRevealId,
       command: goalValue,
       output: commandRevealOutput,
+      state: isErr ? "failed" : effectivelyRunning ? "running" : "done",
     });
     if (commandRevealOutput) syncAgentCommandOutput(commandRevealId, commandRevealOutput);
-  }, [linkKind, commandRevealId, goalValue, commandRevealOutput]);
+  }, [commandRevealId, commandRevealOutput, effectivelyRunning, goalValue, isErr, linkKind]);
 
   const openCommandReveal = (command: string) => {
     const cmd = (command || "").trim();

--- a/webapp/src/components/conversation/ComposerActivityRail.tsx
+++ b/webapp/src/components/conversation/ComposerActivityRail.tsx
@@ -27,12 +27,12 @@ export default function ComposerActivityRail({
     getAgentCommandIndexVersion,
   );
   const commandSessions = useMemo(
-    () => listAgentCommandSessions(),
-    [commandIndexVersion],
+    () => listAgentCommandSessions(sessionId),
+    [commandIndexVersion, sessionId],
   );
   const stackRows = useMemo(
-    () => buildComposerStatusStackRows({ swarmJobs: jobs, commandSessions }),
-    [commandSessions, jobs],
+    () => buildComposerStatusStackRows({ swarmJobs: jobs, commandSessions, sessionId }),
+    [commandSessions, jobs, sessionId],
   );
   const todos = useSyncExternalStore(subscribeSessionTodos, getSessionTodos, getSessionTodos);
   const showTodos = todoHasWork(todos);
@@ -47,7 +47,7 @@ export default function ComposerActivityRail({
       <div className={`divide-y ${COMPOSER_FAMILY_HAIRLINE}`}>
         <ComposerTodoPanel jobs={jobs} sessionId={sessionId} />
         <ComposerTasksPanel jobs={jobs} sessionId={sessionId} />
-        <ComposerStatusStack swarmJobs={jobs} />
+        <ComposerStatusStack swarmJobs={jobs} sessionId={sessionId} />
       </div>
     </div>
   );

--- a/webapp/src/components/conversation/ComposerStatusStack.tsx
+++ b/webapp/src/components/conversation/ComposerStatusStack.tsx
@@ -3,9 +3,9 @@ import { ChevronDown, ChevronRight, CheckCircle2, Loader2, X, XCircle } from "lu
 import { api, type Job } from "../../lib/api";
 import { openAgentCommand, openAgentSwarmJob } from "../../lib/agentLinks";
 import {
+  dismissAgentCommandSession,
   getAgentCommandIndexVersion,
   listAgentCommandSessions,
-  registerAgentCommandSession,
   subscribeAgentCommandIndex,
 } from "../../lib/agentCommandIndex";
 import { buildComposerStatusStackRows, type ComposerStatusStackRow } from "./composerStatusStackData";
@@ -24,15 +24,6 @@ function statusIcon(row: ComposerStatusStackRow) {
     return <XCircle size={11} className="text-risk" aria-hidden />;
   }
   return <CheckCircle2 size={11} className="text-good" aria-hidden />;
-}
-
-function rowKindLabel(kind: ComposerStatusStackRow["kind"]): string {
-  return kind === "swarm" ? "PM" : "Term";
-}
-
-function rowActionLabel(row: ComposerStatusStackRow): string {
-  if (row.kind === "swarm") return "Open swarm";
-  return "Open terminal";
 }
 
 function groupLabel(kind: ComposerStatusStackRow["kind"]): string {
@@ -97,9 +88,10 @@ function StatusStackGroup({
         )}
       </div>
       {open && (
-        <div className={`space-y-0.5 border-t ${COMPOSER_FAMILY_HAIRLINE} px-2 py-1`}>
+        <div className="space-y-0.5 px-2 pb-1.5">
           {rows.map((row) => {
             const stopping = cancelling.has(row.id);
+            const openLabel = row.kind === "swarm" ? "Open swarm" : "Open terminal";
             const onOpen = () => {
               if (row.kind === "swarm") {
                 openAgentSwarmJob(row.id);
@@ -116,17 +108,11 @@ function StatusStackGroup({
                 <button
                   type="button"
                   onClick={onOpen}
-                  title={row.title}
-                  className={`flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-[10.5px] leading-4 text-txt transition-colors hover:bg-panel/30 ${ROW_FOCUS}`}
+                  aria-label={`${openLabel}: ${row.label}`}
+                  className={`flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-[10.5px] leading-4 text-txt transition-colors hover:bg-panel/25 ${ROW_FOCUS}`}
                 >
-                  <span className="flex h-[20px] shrink-0 items-center px-0.5 text-[10.5px] font-medium text-faint">
-                    {rowKindLabel(row.kind)}
-                  </span>
+                  {statusIcon(row)}
                   <span className="min-w-0 flex-1 truncate">{row.label}</span>
-                  <span className="flex shrink-0 items-center gap-1 text-[10.5px] text-muted">
-                    {statusIcon(row)}
-                    <span>{rowActionLabel(row)}</span>
-                  </span>
                   <ChevronRight size={11} className="shrink-0 text-faint" aria-hidden />
                 </button>
                 {row.state === "running" && (
@@ -153,7 +139,13 @@ function StatusStackGroup({
   );
 }
 
-export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly Job[] }) {
+export default function ComposerStatusStack({
+  swarmJobs,
+  sessionId = "",
+}: {
+  swarmJobs: readonly Job[];
+  sessionId?: string;
+}) {
   const [nowTick, setNowTick] = useState(() => Date.now());
   const [cancelling, setCancelling] = useState<Set<string>>(() => new Set());
   const commandIndexVersion = useSyncExternalStore(
@@ -162,25 +154,19 @@ export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly
     getAgentCommandIndexVersion,
   );
   const commandSessions = useMemo(
-    () => listAgentCommandSessions(),
-    [commandIndexVersion],
+    () => listAgentCommandSessions(sessionId),
+    [commandIndexVersion, sessionId],
   );
   const rows = useMemo(
-    () => buildComposerStatusStackRows({ swarmJobs, commandSessions, nowMs: nowTick }),
-    [commandSessions, nowTick, swarmJobs],
+    () => buildComposerStatusStackRows({
+      swarmJobs,
+      commandSessions,
+      nowMs: nowTick,
+      sessionId,
+    }),
+    [commandSessions, nowTick, sessionId, swarmJobs],
   );
 
-  useEffect(() => {
-    for (const row of rows) {
-      if (row.kind !== "terminal" || !row.command) continue;
-      registerAgentCommandSession({
-        id: row.id,
-        command: row.command,
-        output: row.output || "",
-        state: row.state,
-      });
-    }
-  }, [rows]);
   const hasTerminalRows = rows.some((row) => row.state !== "running");
 
   useEffect(() => {
@@ -210,6 +196,7 @@ export default function ComposerStatusStack({ swarmJobs }: { swarmJobs: readonly
       for (const id of unique) next.add(id);
       return next;
     });
+    for (const id of unique) dismissAgentCommandSession(id);
     void Promise.allSettled(unique.map((id) => api.swarmCancel(id))).then((results) => {
       setCancelling((prev) => {
         const next = new Set(prev);

--- a/webapp/src/components/conversation/ComposerTasksPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTasksPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Circle, Loader2, ListChecks, XCircle } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Circle, ListChecks, Loader2, XCircle } from "lucide-react";
 import type { Job } from "../../lib/api";
 import { isWaveCoordinator } from "../../lib/jobClassification";
 import { buildComposerTasks, pickTaskSourceJob, taskProgress, waveHeaderText, type ComposerTask } from "../../lib/composerTasks";
@@ -28,15 +28,17 @@ export default function ComposerTasksPanel({
   jobs: readonly Job[];
   sessionId: string;
 }) {
-  const [open, setOpen] = useState(false);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
   const job = pickTaskSourceJob(jobs, sessionId);
+  const tasks = job ? buildComposerTasks(job) : [];
+  const live = tasks.some((task) => task.state === "in_progress");
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   if (!job) return null;
-  const tasks = buildComposerTasks(job);
   const { done, total } = taskProgress(tasks);
   const wave = isWaveCoordinator(job);
   const header = wave ? waveHeaderText(job) : `Tasks ${done}/${total}`;
   const headerTone = wave ? waveHeaderTone(String(job.status || "")) : "text-txt";
+  const open = userOpen ?? live;
 
   return (
     <div
@@ -46,30 +48,43 @@ export default function ComposerTasksPanel({
       <button
         type="button"
         aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[10.5px] leading-4 text-txt hover:bg-panel/35"
+        onClick={() => setUserOpen(!open)}
+        className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left hover:bg-panel/25 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-accent"
       >
-        {open ? <ChevronDown size={11} className="text-faint" /> : <ChevronRight size={11} className="text-faint" />}
-        <ListChecks size={11} className="text-faint" />
-        <span className={`font-medium ${headerTone}`}>{header}</span>
+        {open ? <ChevronDown size={11} className="shrink-0 text-faint" /> : <ChevronRight size={11} className="shrink-0 text-faint" />}
+        <ListChecks size={11} className="shrink-0 text-faint" />
+        <span className={`text-[10.5px] font-medium leading-4 ${headerTone}`}>{header}</span>
       </button>
       {open && (
-        <div className="border-t border-edge/50 px-2 py-1 space-y-0.5">
+        <div className="space-y-0.5 px-2 pb-1.5">
           {tasks.map((task) => {
             const expanded = expandedId === task.id;
+            const canExpand = Boolean(task.detail || task.summary);
             return (
               <button
                 key={task.id}
                 type="button"
-                title={task.content}
-                onClick={() => setExpandedId((id) => (id === task.id ? null : task.id))}
-                className="flex w-full items-start gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[10.5px] leading-4 hover:bg-panel/30"
+                aria-expanded={canExpand ? expanded : undefined}
+                onClick={() => {
+                  if (!canExpand) return;
+                  setExpandedId((id) => (id === task.id ? null : task.id));
+                }}
+                className="flex w-full items-start gap-1.5 rounded-md px-1.5 py-1 text-left hover:bg-panel/25 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-accent"
               >
-                <TaskIcon state={task.state} />
-                <span className={`${task.state === "pending" ? "text-faint" : "text-txt"} ${expanded ? "whitespace-pre-wrap break-words" : "min-w-0 truncate"}`}>
-                  {task.content}
-                  {expanded && task.detail ? (
-                    <span className="mt-0.5 block text-faint">{task.detail}</span>
+                <span className="mt-0.5">
+                  <TaskIcon state={task.state} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className={`block text-[10.5px] leading-4 ${task.state === "pending" ? "text-faint" : "text-txt"}`}>
+                    {task.content}
+                  </span>
+                  {!expanded && task.summary ? (
+                    <span className="block truncate text-[10.5px] leading-4 text-faint">{task.summary}</span>
+                  ) : null}
+                  {expanded && (task.detail || task.summary) ? (
+                    <span className="mt-0.5 block whitespace-pre-wrap break-words text-[10.5px] leading-4 text-faint">
+                      {task.detail || task.summary}
+                    </span>
                   ) : null}
                 </span>
               </button>

--- a/webapp/src/components/conversation/ConversationChatColumn.tsx
+++ b/webapp/src/components/conversation/ConversationChatColumn.tsx
@@ -43,6 +43,7 @@ export default function ConversationChatColumn({
   composerDock,
   showJumpToBottom = false,
   onJumpToBottom,
+  sessionId,
 }: {
   feedRef: RefObject<HTMLDivElement | null>;
   /** Direct child of the feed scrollport — observed for height-driven stick. */
@@ -72,6 +73,7 @@ export default function ConversationChatColumn({
   composerDock: ReactNode;
   showJumpToBottom?: boolean;
   onJumpToBottom?: () => void;
+  sessionId?: string;
 }) {
   const chromeRef = useRef<HTMLDivElement>(null);
   const [clearancePx, setClearancePx] = useState(96);
@@ -141,6 +143,7 @@ export default function ConversationChatColumn({
             onCommandApproval={onCommandApproval}
             onSecretRequest={onSecretRequest}
             onAuthFailureRetry={onAuthFailureRetry}
+            sessionId={sessionId}
           />
         </div>
       </div>

--- a/webapp/src/components/conversation/composerStatusStackData.ts
+++ b/webapp/src/components/conversation/composerStatusStackData.ts
@@ -1,6 +1,7 @@
 import type { Job } from "../../lib/api";
 import type { AgentCommandSession } from "../../lib/agentCommandIndex";
 import { isCommandJob, isTrackerJob } from "../../lib/jobClassification";
+import { jobInActiveSession } from "../../lib/jobScope";
 
 export type ComposerStatusStackKind = "swarm" | "terminal";
 export type ComposerStatusStackState = "running" | "done" | "failed";
@@ -20,6 +21,8 @@ export type ComposerStatusStackSource = {
   commandSessions: readonly AgentCommandSession[];
   nowMs?: number;
   swarmJobs: readonly Job[];
+  /** When set, Term/PM rows must belong to this chat. Unscoped leftovers drop. */
+  sessionId?: string;
 };
 
 const SWARM_SUCCESS_LINGER_MS = 4_000;
@@ -176,9 +179,11 @@ export function buildComposerStatusStackRows(
   const nowMs = source.nowMs ?? Date.now();
   const rows: ComposerStatusStackRow[] = [];
   const seen = new Set<string>();
+  const sessionId = String(source.sessionId || "").trim();
 
   // Sessions first: they carry live stdout for the existing openAgentCommand path.
   for (const session of source.commandSessions) {
+    if (sessionId && session.sessionId !== sessionId) continue;
     const row = visibleCommandSession(session, nowMs);
     if (row) {
       rows.push(row);
@@ -187,6 +192,7 @@ export function buildComposerStatusStackRows(
   }
 
   for (const job of source.swarmJobs) {
+    if (sessionId && !jobInActiveSession(job, sessionId)) continue;
     const id = String(job.id || "").trim();
     const row = visibleSwarmJob(job, nowMs) ?? visibleCommandJob(job, nowMs);
     if (!row) continue;

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -190,7 +190,7 @@ body {
 }
 
 .composer-family-hairline {
-  border-color: color-mix(in srgb, var(--edge, #2a2d31) 50%, transparent);
+  border-color: color-mix(in srgb, var(--edge, #2a2d31) 28%, transparent);
 }
 
 .composer-toolbar {

--- a/webapp/src/lib/agentCommandIndex.ts
+++ b/webapp/src/lib/agentCommandIndex.ts
@@ -11,6 +11,8 @@ export type AgentCommandSession = {
   output: string;
   state: "running" | "done" | "failed";
   updatedAt: number;
+  /** Harness chat that ran this command. Missing means unscoped leftover. */
+  sessionId?: string;
 };
 
 const byId = new Map<string, AgentCommandSession>();
@@ -54,12 +56,14 @@ export function registerAgentCommandSession(input: {
   command: string;
   output?: string;
   state?: AgentCommandSession["state"];
+  sessionId?: string;
 }): AgentCommandSession | null {
   const id = String(input.id || "").trim();
   const command = normalizeCommandKey(input.command);
   if (!id || !command || command.length > 500) return null;
   const output = String(input.output || "");
   const state = input.state;
+  const sessionId = String(input.sessionId || "").trim();
   const existing = byId.get(id);
   const now = Date.now();
   if (existing && existing.command === command) {
@@ -67,6 +71,7 @@ export function registerAgentCommandSession(input: {
     existing.output = output;
     existing.updatedAt = now;
     if (state) existing.state = state;
+    if (sessionId) existing.sessionId = sessionId;
     if (state && state !== prevState) {
       emit(true);
       rememberCommandId(command, id);
@@ -84,6 +89,7 @@ export function registerAgentCommandSession(input: {
     output,
     state: state || "running",
     updatedAt: now,
+    ...(sessionId ? { sessionId } : {}),
   };
   byId.set(id, session);
   rememberCommandId(command, id);
@@ -116,8 +122,22 @@ export function getAgentCommandIndexVersion(): number {
   return version;
 }
 
-export function listAgentCommandSessions(): AgentCommandSession[] {
-  return [...byId.values()].sort((a, b) => b.updatedAt - a.updatedAt);
+export function dismissAgentCommandSession(id: string): boolean {
+  const key = String(id || "").trim();
+  const existing = byId.get(key);
+  if (!existing) return false;
+  forgetCommandId(existing.command, key);
+  byId.delete(key);
+  emit(true);
+  return true;
+}
+
+export function listAgentCommandSessions(sessionId?: string): AgentCommandSession[] {
+  const all = [...byId.values()].sort((a, b) => b.updatedAt - a.updatedAt);
+  if (sessionId === undefined) return all;
+  const sid = sessionId.trim();
+  if (!sid) return [];
+  return all.filter((session) => session.sessionId === sid);
 }
 
 /** Test helper: wipe the index between cases. */

--- a/webapp/src/lib/agentLinks.ts
+++ b/webapp/src/lib/agentLinks.ts
@@ -386,6 +386,18 @@ export function classifyActionGoal(
   if (k === "web_fetch") {
     return { linkKind: "url", value: g };
   }
+  // Search / wiki queries are prose. looksLikeShellCommand treats any
+  // spaced string as a command, which parked CodeGraph queries on the Term rail.
+  if (
+    k === "search_codegraph"
+    || k === "search_files"
+    || k === "search_state"
+    || k === "search_tools"
+    || k === "web_search"
+    || k === "query_wiki"
+  ) {
+    return { linkKind: "none", value: g };
+  }
   // Worker / shell dispatches are processes, not files — even when the goal
   // text embeds a path (looksLikeFilePath would otherwise open the editor).
   if (

--- a/webapp/src/lib/composerTasks.ts
+++ b/webapp/src/lib/composerTasks.ts
@@ -8,6 +8,8 @@ export type ComposerTask = {
   id: string;
   content: string;
   state: ComposerTaskState;
+  /** Short unique stem. Omitted when every worker shares the same brief. */
+  summary?: string;
   detail?: string;
 };
 
@@ -65,13 +67,33 @@ export function pickTaskSourceJob(jobs: readonly Job[], activeSessionId: string)
   return pickRankedJob(waves.length ? waves : remaining);
 }
 
-function oneLineLabel(task: Task): string {
-  const role = String(task.role || "").replace(/\s+/g, " ").trim();
-  const instruction = String(task.instruction || "").replace(/\s+/g, " ").trim();
-  if (role && instruction && !instruction.toLowerCase().startsWith(role.toLowerCase())) {
-    return `${role} · ${instruction}`;
-  }
-  return instruction || role || String(task.id || "Task");
+function roleLabel(role: string): string {
+  return role.replace(/[-_]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function oneLineInstruction(instruction: string): string {
+  return instruction.replace(/\s+/g, " ").trim();
+}
+
+const STEM_MAX = 42;
+
+function instructionStem(instruction: string): string {
+  const firstLine = instruction.split(/\n/).map((line) => line.trim()).find(Boolean) || "";
+  if (firstLine && firstLine.length <= STEM_MAX) return firstLine;
+  const one = oneLineInstruction(instruction);
+  if (!one) return "";
+  const sentence = one.split(/(?<=[.!?])\s/)[0] || one;
+  if (sentence.length <= STEM_MAX) return sentence;
+  const cut = sentence.slice(0, STEM_MAX);
+  const at = cut.lastIndexOf(" ");
+  return `${(at > 16 ? cut.slice(0, at) : cut).trimEnd()}…`;
+}
+
+function taskCopy(task: Task): { role: string; instruction: string } {
+  return {
+    role: roleLabel(String(task.role || "")),
+    instruction: oneLineInstruction(String(task.instruction || "")),
+  };
 }
 
 function artifactLooksFailed(art: { result?: unknown; type?: unknown; failure?: unknown; task_id?: unknown }): boolean {
@@ -87,17 +109,27 @@ function artifactLooksFailed(art: { result?: unknown; type?: unknown; failure?: 
 
 export function buildComposerTasks(job: Job | null): ComposerTask[] {
   const arts = Array.isArray(job?.artifacts) ? job.artifacts as { result?: unknown; type?: unknown; failure?: unknown; task_id?: unknown }[] : [];
-  return (job?.tasks || []).map((task: Task, i) => {
+  const rows = job?.tasks || [];
+  const briefs = new Set(rows.map((task) => taskCopy(task).instruction).filter(Boolean));
+  const sharedBrief = briefs.size === 1 && rows.length > 1;
+  return rows.map((task: Task, i) => {
     let state = taskState(task.status);
     if (state === "completed") {
       const fail = arts.find((a) => String(a.task_id || "") === String(task.id || "") && artifactLooksFailed(a));
       if (fail) state = "degraded";
     }
-    const detail = waveChildDetail(task);
+    const { role, instruction } = taskCopy(task);
+    const failure = waveChildDetail(task);
+    const stem = instructionStem(String(task.instruction || ""));
+    const content = role || stem || String(task.id || "Task");
+    const summary = !sharedBrief && stem && stem !== content ? stem : undefined;
+    const brief = instruction && instruction !== stem ? instruction : undefined;
+    const detail = failure || brief;
     return {
       id: String(task.id || `${job?.id || "job"}-${i}`),
-      content: oneLineLabel(task),
+      content,
       state,
+      ...(summary ? { summary } : {}),
       ...(detail ? { detail } : {}),
     };
   });


### PR DESCRIPTION
## Why

A CodeGraph query on transcript `0e921de85b7b` became a spinning Term row. Opening it painted `$ custom OpenAI-compatible provider API base URL…`. X called swarm cancel on a tool-card id, so the row survived.

## Scope

- `search_codegraph` / `search_files` / wiki / web search classify as not-a-command before the spaced-string shell heuristic.
- Command index is session-scoped. Empty session id hides leftovers.
- X dismisses the index row even when cancel has no job to kill.
- ActionCard stamps `done`/`failed`/`running` so a finished search is not `running` by default.
- Tasks rows show the worker role. A shared swarm brief is detail, not four identical stems.
- Drop PM/Term prefixes and visible Open swarm / Open terminal chrome.
- Stamp `0.9.382`. Pin stays `puppetmaster-ai==1.22.41`.

## Tradeoffs

`looksLikeShellCommand` is still broad. Tool kind is now the guard for search/wiki cards.

## Blast radius

Composer Terminal / Tasks rail only. Real `run_command` and swarm rows still cancel through the existing API.

## Verification

- Transcript `0e921de85b7b` card `call_fzNLRaJTQwHLkZCGf6nRpYHr` is `search_codegraph`, 292ms, no job id.
- `npx vitest run` on agentCommandIndex, agentLinks, composerStatusStack, ComposerStatusStack, composerFamilyChrome, composerTasks: 84 passed.
- `.venv/bin/python -m pytest tests -q`: 5330 passed, 78 skipped.
- `pytest tests/test_version_consistency.py`: 2 passed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/professorpalmer/marionette/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->