### PR TITLE
fix: remove dead space between Branches and Jobs

### DIFF
--- a/webapp/src/__tests__/LeftRail.layout.test.tsx
+++ b/webapp/src/__tests__/LeftRail.layout.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LeftRail from "../components/LeftRail";
+import { clearSWRCache } from "../lib/useStaleWhileRevalidate";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    getWorkspace: vi.fn().mockResolvedValue({
+      repo: "/workspace",
+      branch: "main",
+      is_git: true,
+      head_unborn: false,
+      codegraph_status: "ready",
+      recents: [],
+      home: "/home",
+    }),
+    workspaces: vi.fn().mockResolvedValue([
+      { name: "main", active: true, dirty: false },
+    ]),
+    sessions: vi.fn().mockResolvedValue([
+      { id: "session-1", title: "Current", active: true, repo: "/workspace" },
+    ]),
+    jobs: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../lib/usePolling", () => ({ usePolling: vi.fn() }));
+vi.mock("../lib/useOperationalDiagnostic", () => ({
+  useOperationalDiagnostic: () => null,
+}));
+
+describe("LeftRail branch layout", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearSWRCache();
+  });
+
+  it("keeps branch resizing without reserving empty list height", async () => {
+    render(<LeftRail jobsRefresh={0} />);
+
+    const branch = await screen.findByRole("button", { name: /main/ });
+    const branchList = branch.parentElement as HTMLElement;
+    expect(screen.getByRole("button", { name: "Jobs" })).toBeInTheDocument();
+    expect(screen.getByRole("separator", { name: "Resize branches list" })).toBeInTheDocument();
+    expect(branchList.style.height).toBe("");
+    expect(branchList.style.maxHeight).not.toBe("");
+    expect(branchList.parentElement?.parentElement?.className.split(" ")).not.toContain("flex-1");
+  });
+});

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -1319,7 +1319,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       </div>
       </div>
 
-      <div ref={upperSectionsRef} className={`flex-1 min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}>
+      <div ref={upperSectionsRef} className={`min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}>
       {/* Projects | Sessions toggle */}
       <div className="px-2.5 pt-2 flex items-center gap-0 border-b border-edge/35">
         <button
@@ -1843,7 +1843,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
           {filterBranchWorkspaces(workspaces).length === 0 && (
             <Empty>{workspaceInfo?.head_unborn ? "No commits yet" : "No branches"}</Empty>
           )}
-          <div className="space-y-0.5 overflow-y-auto" style={{ height: branchesHeight }}>
+          <div className="space-y-0.5 overflow-y-auto" style={{ maxHeight: branchesHeight }}>
             {filterBranchWorkspaces(workspaces).map((w) => {
               const linked = !!w.worktree_path;
               const linkKind = w.name.startsWith("pmworker-")


### PR DESCRIPTION
## Summary

- Removes the empty reservoir between **Branches** and **Jobs**.
- Treats the persisted Branches size as a maximum instead of mandatory empty height.
- Preserves branch resizing, persistence, bounded scrolling, the Projects reserve, and the independent Jobs allocation.
<img width="277" height="594" alt="Screenshot 2026-08-29 at 11 16 03 PM" src="https://github.com/user-attachments/assets/ccd9a2a6-684e-4ada-8406-e2d4197a2005" />



## Why

The upper rail filled all remaining height while Branches also enforced a fixed height. Short lists therefore left a large, resizable blank region above Jobs.

<img width="202" height="921" alt="Screenshot 2026-08-29 at 10 52 26 PM" src="https://github.com/user-attachments/assets/39e07ad9-449a-436a-a147-502aba9ac071" />


This keeps the original branch-heavy workflow: one branch stays compact; long branch/worktree lists remain scrollable and user-resizable.

## Validation

- Focused left-rail suite: **43 passed**.
- Production build passes.
- Mounted with 1 branch: natural 22px list, 0px gap before Jobs.
- Mounted with 16 branches: bounded 349px list, 0px gap before Jobs.
