### PR TITLE
absorb #257: remove the Branches reservoir

### DIFF
--- a/webapp/src/__tests__/LeftRail.layout.test.tsx
+++ b/webapp/src/__tests__/LeftRail.layout.test.tsx
@@ -36,14 +36,15 @@ describe("LeftRail branch layout", () => {
   });
 
   it("keeps branch resizing without reserving empty list height", async () => {
-    render(<LeftRail jobsRefresh={0} />);
+    const { container } = render(<LeftRail jobsRefresh={0} />);
 
-    const branch = await screen.findByRole("button", { name: /main/ });
-    const branchList = branch.parentElement as HTMLElement;
+    await screen.findByRole("button", { name: /main/ });
+    const branchList = container.querySelector<HTMLElement>("[data-slot=left-rail-branches-list]");
+    const upperSections = container.querySelector<HTMLElement>("[data-slot=left-rail-upper-sections]");
     expect(screen.getByRole("button", { name: "Jobs" })).toBeInTheDocument();
     expect(screen.getByRole("separator", { name: "Resize branches list" })).toBeInTheDocument();
-    expect(branchList.style.height).toBe("");
-    expect(branchList.style.maxHeight).not.toBe("");
-    expect(branchList.parentElement?.parentElement?.className.split(" ")).not.toContain("flex-1");
+    expect(branchList?.style.height).toBe("");
+    expect(branchList?.style.maxHeight).not.toBe("");
+    expect(upperSections?.className.split(" ")).not.toContain("flex-1");
   });
 });

--- a/webapp/src/__tests__/LeftRail.layout.test.tsx
+++ b/webapp/src/__tests__/LeftRail.layout.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LeftRail from "../components/LeftRail";
+import { clearSWRCache } from "../lib/useStaleWhileRevalidate";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    getWorkspace: vi.fn().mockResolvedValue({
+      repo: "/workspace",
+      branch: "main",
+      is_git: true,
+      head_unborn: false,
+      codegraph_status: "ready",
+      recents: [],
+      home: "/home",
+    }),
+    workspaces: vi.fn().mockResolvedValue([
+      { name: "main", active: true, dirty: false },
+    ]),
+    sessions: vi.fn().mockResolvedValue([
+      { id: "session-1", title: "Current", active: true, repo: "/workspace" },
+    ]),
+    jobs: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../lib/usePolling", () => ({ usePolling: vi.fn() }));
+vi.mock("../lib/useOperationalDiagnostic", () => ({
+  useOperationalDiagnostic: () => null,
+}));
+
+describe("LeftRail branch layout", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearSWRCache();
+  });
+
+  it("keeps branch resizing without reserving empty list height", async () => {
+    render(<LeftRail jobsRefresh={0} />);
+
+    const branch = await screen.findByRole("button", { name: /main/ });
+    const branchList = branch.parentElement as HTMLElement;
+    expect(screen.getByRole("button", { name: "Jobs" })).toBeInTheDocument();
+    expect(screen.getByRole("separator", { name: "Resize branches list" })).toBeInTheDocument();
+    expect(branchList.style.height).toBe("");
+    expect(branchList.style.maxHeight).not.toBe("");
+    expect(branchList.parentElement?.parentElement?.className.split(" ")).not.toContain("flex-1");
+  });
+});

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -142,15 +142,9 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     const top = topChromeRef.current;
     const upper = upperSectionsRef.current;
     if (!rail || !top || !upper) return sessionJobsMinHeight();
-    // Measure the upper content's NATURAL height by summing its children --
-    // not upper.scrollHeight. The upper div is a flex-1 scroll container, and
-    // a scroll container's scrollHeight is never less than its rendered
-    // height, so with a short projects list the computed max collapsed to
-    // "whatever the jobs panel already has": dragging up crawled at the ~1px
-    // of layout rounding slack per event while dragging down ran free.
-    // Children inside an overflow container keep their natural height, so
-    // their sum is the true content bound in both the short and overflowing
-    // cases.
+    // A scroll container's scrollHeight cannot undercut its rendered height.
+    // Summing child heights preserves the natural content bound for both short
+    // and overflowing lists.
     const upperContent = Array.from(upper.children).reduce(
       (sum, el) => sum + (el as HTMLElement).offsetHeight,
       0,
@@ -1319,7 +1313,11 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       </div>
       </div>
 
-      <div ref={upperSectionsRef} className={`min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}>
+      <div
+        ref={upperSectionsRef}
+        data-slot="left-rail-upper-sections"
+        className={`min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}
+      >
       {/* Projects | Sessions toggle */}
       <div className="px-2.5 pt-2 flex items-center gap-0 border-b border-edge/35">
         <button
@@ -1843,7 +1841,11 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
           {filterBranchWorkspaces(workspaces).length === 0 && (
             <Empty>{workspaceInfo?.head_unborn ? "No commits yet" : "No branches"}</Empty>
           )}
-          <div className="space-y-0.5 overflow-y-auto" style={{ maxHeight: branchesHeight }}>
+          <div
+            data-slot="left-rail-branches-list"
+            className="space-y-0.5 overflow-y-auto"
+            style={{ maxHeight: branchesHeight }}
+          >
             {filterBranchWorkspaces(workspaces).map((w) => {
               const linked = !!w.worktree_path;
               const linkKind = w.name.startsWith("pmworker-")

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -1319,7 +1319,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       </div>
       </div>
 
-      <div ref={upperSectionsRef} className={`flex-1 min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}>
+      <div ref={upperSectionsRef} className={`min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}>
       {/* Projects | Sessions toggle */}
       <div className="px-2.5 pt-2 flex items-center gap-0 border-b border-edge/35">
         <button
@@ -1843,7 +1843,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
           {filterBranchWorkspaces(workspaces).length === 0 && (
             <Empty>{workspaceInfo?.head_unborn ? "No commits yet" : "No branches"}</Empty>
           )}
-          <div className="space-y-0.5 overflow-y-auto" style={{ height: branchesHeight }}>
+          <div className="space-y-0.5 overflow-y-auto" style={{ maxHeight: branchesHeight }}>
             {filterBranchWorkspaces(workspaces).map((w) => {
               const linked = !!w.worktree_path;
               const linkKind = w.name.startsWith("pmworker-")


### PR DESCRIPTION
## Summary
- preserve the contributor's content-sized Branches fix and authorship
- treat the persisted Branches height as a maximum while retaining bounded scrolling and resize state
- strengthen the regression test with stable layout seams and refresh stale sizing commentary

## Validation
- [x] failing test reproduced against the old fixed-height layout
- [x] focused LeftRail suite: 33 passed
- [x] full frontend suite: 1,499 passed
- [x] production frontend build
- [x] independent Puppetmaster review: ship verdict

Absorbs [#257](https://github.com/professorpalmer/marionette/pull/257).