### PR TITLE
absorb #259: canonicalize workspace identity

### DIFF
--- a/harness/api/workspace.py
+++ b/harness/api/workspace.py
@@ -244,18 +244,11 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
     is_git = False
     branch = ""
     try:
-        from ..paths import git_toplevel
+        from ..paths import canonical_workspace_path, git_toplevel
         canonical_repo = git_toplevel(target_repo)
         if canonical_repo:
             is_git = True
-            if os.path.isdir(canonical_repo):
-                try:
-                    # Case aliases (macOS/Windows) share an inode with Git's
-                    # toplevel; nested dirs such as webapp do not.
-                    if os.path.samefile(target_repo, canonical_repo):
-                        target_repo = canonical_repo
-                except OSError:
-                    pass
+            target_repo = canonical_workspace_path(target_repo)
             proc_branch = subprocess.run(
                 ["git", "-C", target_repo, "rev-parse", "--abbrev-ref", "HEAD"],
                 capture_output=True,

--- a/harness/job_scoping.py
+++ b/harness/job_scoping.py
@@ -185,15 +185,25 @@ def job_repo_cwd(tasks: list) -> str:
 
 
 def cwd_under_repo(cwd: str, repo_root: str) -> bool:
-    """True when ``cwd`` sits under ``repo_root`` (longest-prefix / commonpath)."""
+    """True when ``cwd`` sits under ``repo_root`` (prefix, alias, or ancestor)."""
     if not cwd or not repo_root:
         return False
+    try:
+        repo_n = _norm_path(repo_root)
+        if os.path.commonpath([repo_n, _norm_path(cwd)]) == repo_n:
+            return True
+    except ValueError:
+        pass
     if same_workspace_path(cwd, repo_root):
         return True
-    try:
-        return os.path.commonpath([_norm_path(repo_root), _norm_path(cwd)]) == _norm_path(repo_root)
-    except ValueError:
-        return False
+    current = os.path.abspath(os.path.normpath(cwd))
+    while True:
+        parent = os.path.dirname(current)
+        if parent == current:
+            return False
+        current = parent
+        if os.path.exists(current) and same_workspace_path(current, repo_root):
+            return True
 
 
 _RUNNING_STATUSES = frozenset({"running", "in_progress", "pending", "started"})

--- a/harness/job_scoping.py
+++ b/harness/job_scoping.py
@@ -11,6 +11,8 @@ import json
 import os
 from typing import Any, Iterable, Optional
 
+from .paths import same_workspace_path
+
 ACCOUNTING_SCOPE_MARIONETTE = "marionette"
 ACCOUNTING_SCOPE_VISIBILITY = "visibility_only"
 
@@ -186,6 +188,8 @@ def cwd_under_repo(cwd: str, repo_root: str) -> bool:
     """True when ``cwd`` sits under ``repo_root`` (longest-prefix / commonpath)."""
     if not cwd or not repo_root:
         return False
+    if same_workspace_path(cwd, repo_root):
+        return True
     try:
         return os.path.commonpath([_norm_path(repo_root), _norm_path(cwd)]) == _norm_path(repo_root)
     except ValueError:

--- a/harness/paths.py
+++ b/harness/paths.py
@@ -216,6 +216,38 @@ def git_toplevel(repo: str) -> Optional[str]:
     return toplevel
 
 
+def canonical_workspace_path(path: str) -> str:
+    """Adopt Git's root spelling only when ``path`` is that exact directory."""
+    if not path:
+        return ""
+    normalized = os.path.normpath(os.path.abspath(path))
+    top = git_toplevel(normalized)
+    if top:
+        try:
+            if os.path.samefile(normalized, top):
+                return top
+        except OSError:
+            pass
+    return normalized
+
+
+def same_workspace_path(a: str, b: str) -> bool:
+    """True when two existing paths identify the same physical workspace."""
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    try:
+        if os.path.samefile(a, b):
+            return True
+    except OSError:
+        pass
+    try:
+        return os.path.normcase(_resolve(a)) == os.path.normcase(_resolve(b))
+    except Exception:
+        return False
+
+
 def resolve_workspace_path(repo: str, user_path: str) -> tuple[str, str]:
     """Resolve a user/editor path to ``(absolute_path, repo_relative_posix)``.
 

--- a/harness/server.py
+++ b/harness/server.py
@@ -665,17 +665,9 @@ def _norm_realpath(path: str) -> str:
 
 def _paths_same_workspace(a: str, b: str) -> bool:
     """True when two workspace roots refer to the same directory."""
-    if not a or not b:
-        return False
-    if a == b:
-        return True
-    try:
-        return _norm_realpath(a) == _norm_realpath(b)
-    except Exception:
-        # Fall back to slash/case fold when resolve fails.
-        na = os.path.normcase(a.replace("/", os.sep).replace("\\", os.sep)).rstrip(os.sep)
-        nb = os.path.normcase(b.replace("/", os.sep).replace("\\", os.sep)).rstrip(os.sep)
-        return na == nb
+    from .paths import same_workspace_path
+
+    return same_workspace_path(a, b)
 
 
 def _app_install_roots() -> list:
@@ -878,7 +870,9 @@ if not os.environ.get("HARNESS_REPO") and os.path.exists(_ws_boot_path):
             _ws_data = {}
         # Prefer last user project; never boot into the Marionette app
         # checkout even if an older build wrote it into workspace.json.
-        _boot_repo = _pick_boot_workspace(_ws_data)
+        from .paths import canonical_workspace_path
+
+        _boot_repo = canonical_workspace_path(_pick_boot_workspace(_ws_data))
         if _boot_repo:
             _cfg.repo = _boot_repo
             os.environ["HARNESS_REPO"] = _boot_repo

--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, asdict
 from typing import Optional, Any, List
 
 from .job_scoping import cwd_under_repo, _norm_path
+from .paths import same_workspace_path
 
 # Cap bytes read from a transcript when building list previews (OMP-style
 # cheap listing — avoid hydrating multi-MB histories for the sidebar).
@@ -628,7 +629,7 @@ def _same_root(a: str, b: str) -> bool:
         return True
     if not a or not b:
         return False
-    return _norm_path(a) == _norm_path(b)
+    return same_workspace_path(a, b)
 
 
 def _is_ephemeral_root(root: str) -> bool:
@@ -672,12 +673,12 @@ def session_visible_for_workspace(session: dict, workspace_root: str, state_dir:
         return True
     stored = session_stored_root(session)
     if stored:
-        if _norm_path(stored) == _norm_path(workspace_root):
+        if same_workspace_path(stored, workspace_root):
             return True
         return cwd_under_repo(stored, workspace_root) or cwd_under_repo(workspace_root, stored)
     inferred = infer_legacy_session_root(session, state_dir)
     if inferred:
-        if _norm_path(inferred) == _norm_path(workspace_root):
+        if same_workspace_path(inferred, workspace_root):
             return True
         return cwd_under_repo(inferred, workspace_root)
     return True

--- a/tests/test_api_workspace_peel.py
+++ b/tests/test_api_workspace_peel.py
@@ -243,7 +243,7 @@ def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
         "harness.paths.git_toplevel",
         lambda path: str(canonical),
     )
-    monkeypatch.setattr("harness.api.workspace.os.path.samefile", lambda a, b: True)
+    monkeypatch.setattr("harness.paths.os.path.samefile", lambda a, b: True)
     monkeypatch.setattr(
         "harness.api.workspace.subprocess.run",
         lambda args, **kwargs: SimpleNamespace(returncode=0, stdout="main\n"),

--- a/tests/test_session_job_scoping.py
+++ b/tests/test_session_job_scoping.py
@@ -386,13 +386,56 @@ def test_cwd_under_repo_longest_prefix():
     ]) == os.path.normcase(os.path.abspath("/work/a/deep/nested"))
 
 
-def test_jobs_api_lists_cwd_alias_under_canonical_workspace(tmp_path, monkeypatch):
+def _alias_or_symlink_root(tmp_path):
     repo = tmp_path / "marionette"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
     alias = tmp_path / "Marionette"
     if not alias.exists():
         alias.symlink_to(repo, target_is_directory=True)
+    return repo, alias
+
+
+def test_cwd_under_repo_nested_alias_under_canonical(tmp_path):
+    repo, alias = _alias_or_symlink_root(tmp_path)
+    nested = alias / "nested" / "child"
+    nested.mkdir(parents=True)
+    missing = alias / "nested" / "historical-gone"
+    other = tmp_path / "other-root" / "child"
+    other.mkdir(parents=True)
+
+    assert cwd_under_repo(str(nested), str(repo))
+    assert cwd_under_repo(str(missing), str(repo))
+    assert not cwd_under_repo(str(other), str(repo))
+
+    nested_tasks = [SimpleNamespace(payload={"cwd": str(nested)})]
+    assert job_visible_for_view(
+        session_id="",
+        label=None,
+        tasks=nested_tasks,
+        active_session_id="sess-b",
+        repo_root=str(repo),
+    )
+    missing_tasks = [SimpleNamespace(payload={"cwd": str(missing)})]
+    assert job_visible_for_view(
+        session_id="",
+        label=None,
+        tasks=missing_tasks,
+        active_session_id="sess-b",
+        repo_root=str(repo),
+    )
+    other_tasks = [SimpleNamespace(payload={"cwd": str(other)})]
+    assert not job_visible_for_view(
+        session_id="",
+        label=None,
+        tasks=other_tasks,
+        active_session_id="sess-b",
+        repo_root=str(repo),
+    )
+
+
+def test_jobs_api_lists_cwd_alias_under_canonical_workspace(tmp_path, monkeypatch):
+    repo, alias = _alias_or_symlink_root(tmp_path)
     store = create_store("sqlite", str(tmp_path / "state"))
     created = store.create_job("aliased job")
     _save_task(store, created.id, str(alias))

--- a/tests/test_session_job_scoping.py
+++ b/tests/test_session_job_scoping.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import threading
 import urllib.parse
@@ -383,6 +384,32 @@ def test_cwd_under_repo_longest_prefix():
         {"payload": {"cwd": "/work/a"}},
         {"payload": {"cwd": "/work/a/deep/nested"}},
     ]) == os.path.normcase(os.path.abspath("/work/a/deep/nested"))
+
+
+def test_jobs_api_lists_cwd_alias_under_canonical_workspace(tmp_path, monkeypatch):
+    repo = tmp_path / "marionette"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    alias = tmp_path / "Marionette"
+    if not alias.exists():
+        alias.symlink_to(repo, target_is_directory=True)
+    store = create_store("sqlite", str(tmp_path / "state"))
+    created = store.create_job("aliased job")
+    _save_task(store, created.id, str(alias))
+    httpd, port, srv = _api_server(str(tmp_path / "state"))
+
+    try:
+        monkeypatch.setattr(srv, "_jobs_snapshot", lambda: [
+            {"id": created.id, "goal": "aliased job", "status": "complete", "adapter": "agentic"},
+        ])
+        monkeypatch.setattr(srv._session, "state", lambda: SimpleNamespace(store=store))
+        srv._cfg.repo = str(repo)
+
+        jobs = json.loads(_api_get(port, "/api/jobs", srv._TOKEN).read().decode())
+
+        assert {job["id"] for job in jobs} == {created.id}
+    finally:
+        httpd.shutdown()
 
 
 def _api_server(tmp_state_dir):

--- a/tests/test_sessions_workspace_scoping.py
+++ b/tests/test_sessions_workspace_scoping.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import threading
 import urllib.error
 import urllib.request
@@ -82,6 +83,31 @@ def test_sessions_filtered_by_workspace_two_roots(tmp_path):
         resp_b = _get(port, "/api/sessions")
         sessions_b = json.loads(resp_b.read().decode())
         assert {s["id"] for s in sessions_b} == {meta_b["id"]}
+    finally:
+        httpd.shutdown()
+
+
+def test_sessions_api_lists_case_alias_under_canonical_workspace(tmp_path):
+    httpd, port, srv = _server()
+    repo = tmp_path / "marionette"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    alias = tmp_path / "Marionette"
+    if not alias.exists():
+        alias.symlink_to(repo, target_is_directory=True)
+    _setup_server(tmp_path, srv)
+
+    try:
+        aliased = srv._sessions.create(
+            "Aliased",
+            repo=str(alias),
+            workspace_root=str(alias),
+        )
+        srv._cfg.repo = str(repo)
+
+        sessions = json.loads(_get(port, "/api/sessions").read().decode())
+
+        assert {session["id"] for session in sessions} == {aliased["id"]}
     finally:
         httpd.shutdown()
 

--- a/tests/test_sessions_workspace_scoping.py
+++ b/tests/test_sessions_workspace_scoping.py
@@ -87,14 +87,19 @@ def test_sessions_filtered_by_workspace_two_roots(tmp_path):
         httpd.shutdown()
 
 
-def test_sessions_api_lists_case_alias_under_canonical_workspace(tmp_path):
-    httpd, port, srv = _server()
+def _alias_or_symlink_root(tmp_path):
     repo = tmp_path / "marionette"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
     alias = tmp_path / "Marionette"
     if not alias.exists():
         alias.symlink_to(repo, target_is_directory=True)
+    return repo, alias
+
+
+def test_sessions_api_lists_case_alias_under_canonical_workspace(tmp_path):
+    httpd, port, srv = _server()
+    repo, alias = _alias_or_symlink_root(tmp_path)
     _setup_server(tmp_path, srv)
 
     try:
@@ -108,6 +113,47 @@ def test_sessions_api_lists_case_alias_under_canonical_workspace(tmp_path):
         sessions = json.loads(_get(port, "/api/sessions").read().decode())
 
         assert {session["id"] for session in sessions} == {aliased["id"]}
+    finally:
+        httpd.shutdown()
+
+
+def test_sessions_api_lists_nested_alias_under_canonical_workspace(tmp_path):
+    httpd, port, srv = _server()
+    repo, alias = _alias_or_symlink_root(tmp_path)
+    nested = alias / "nested" / "child"
+    nested.mkdir(parents=True)
+    missing = alias / "nested" / "historical-gone"
+    other = tmp_path / "other-root"
+    other.mkdir()
+    _setup_server(tmp_path, srv)
+
+    try:
+        nested_session = srv._sessions.create(
+            "Nested alias",
+            repo=str(nested),
+            workspace_root=str(nested),
+        )
+        missing_session = srv._sessions.create(
+            "Historical nested",
+            repo=str(missing),
+            workspace_root=str(missing),
+        )
+        foreign = srv._sessions.create(
+            "Other root",
+            repo=str(other),
+            workspace_root=str(other),
+        )
+        srv._cfg.repo = str(repo)
+
+        sessions = json.loads(_get(port, "/api/sessions").read().decode())
+        ids = {session["id"] for session in sessions}
+        assert nested_session["id"] in ids
+        assert missing_session["id"] in ids
+        assert foreign["id"] not in ids
+
+        assert session_visible_for_workspace(nested_session, str(repo), str(tmp_path))
+        assert session_visible_for_workspace(missing_session, str(repo), str(tmp_path))
+        assert not session_visible_for_workspace(nested_session, str(other), str(tmp_path))
     finally:
         httpd.shutdown()
 

--- a/tests/test_workspace_boot_restore.py
+++ b/tests/test_workspace_boot_restore.py
@@ -140,9 +140,13 @@ def test_boot_restores_git_workspace_under_its_canonical_root(reload_server, tmp
 
     srv = reload_server(HARNESS_REPO=None)
 
-    assert srv._cfg.repo == str(repo)
-    assert os.environ.get("HARNESS_REPO") == str(repo)
-    assert json.loads((tmp_path / "workspace.json").read_text(encoding="utf-8"))["repo"] == str(repo)
+    assert os.path.samefile(srv._cfg.repo, repo)
+    assert os.path.samefile(os.environ["HARNESS_REPO"], repo)
+    persisted = json.loads((tmp_path / "workspace.json").read_text(encoding="utf-8"))["repo"]
+    assert os.path.samefile(persisted, repo)
+    other = tmp_path / "other-root"
+    other.mkdir()
+    assert not os.path.samefile(srv._cfg.repo, other)
 
 
 def test_boot_skips_workspace_when_harness_repo_already_set(reload_server, tmp_path):

--- a/tests/test_workspace_boot_restore.py
+++ b/tests/test_workspace_boot_restore.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import threading
 import time
@@ -123,6 +124,25 @@ def test_boot_restores_last_project_when_harness_repo_unset(reload_server, tmp_p
     srv = reload_server(HARNESS_REPO=None)
     assert srv._cfg.repo == str(repo)
     assert os.environ.get("HARNESS_REPO") == str(repo)
+
+
+def test_boot_restores_git_workspace_under_its_canonical_root(reload_server, tmp_path):
+    repo = tmp_path / "marionette"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    alias = tmp_path / "Marionette"
+    if not alias.exists():
+        alias.symlink_to(repo, target_is_directory=True)
+    (tmp_path / "workspace.json").write_text(
+        json.dumps({"repo": str(alias), "recents": [str(alias)]}),
+        encoding="utf-8",
+    )
+
+    srv = reload_server(HARNESS_REPO=None)
+
+    assert srv._cfg.repo == str(repo)
+    assert os.environ.get("HARNESS_REPO") == str(repo)
+    assert json.loads((tmp_path / "workspace.json").read_text(encoding="utf-8"))["repo"] == str(repo)
 
 
 def test_boot_skips_workspace_when_harness_repo_already_set(reload_server, tmp_path):


### PR DESCRIPTION
## Summary
- preserve the contributor's Git-root canonicalization across open, boot restore, sessions, and jobs
- extend identity through nested and historical descendants of a case alias or symlink root
- use physical identity in boot assertions so macOS `/var` and `/private/var` spellings remain portable

## Validation
- [x] focused workspace/session/job/path/worktree suite: 100 passed
- [x] production frontend build
- [x] independent Puppetmaster audit; its nested-alias and macOS assertion blockers are fixed
- [x] distinct-root negative coverage retained

Absorbs [#259](https://github.com/professorpalmer/marionette/pull/259) with contributor authorship preserved.