### PR TITLE
Absorb #261: hide impossible source updates

### DIFF
--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -468,7 +468,7 @@ async function checkForUpdate({ repoRoot, branch = DEFAULT_BRANCH, currentVersio
     );
 
     return {
-      available: behind > 0,
+      available: behind > 0 && ahead === 0,
       behind,
       latest,
       branch,

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -63,26 +63,37 @@ test("checkForUpdate: only a fast-forwardable source checkout is actionable", as
   const remoteDir = path.join(root, "remote.git");
   const behindOnly = path.join(root, "behind-only");
   const diverged = path.join(root, "diverged");
-  const git = (cwd, args) => execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  const gitEnv = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: os.devNull,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.invalid",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.invalid",
+  };
+  const runGit = (args) => execFileSync("git", args, { encoding: "utf8", env: gitEnv });
+  const git = (cwd, args) => runGit(["-C", cwd, "-c", "commit.gpgsign=false", ...args]);
 
   fs.mkdirSync(path.join(seed, "webapp"), { recursive: true });
   git(seed, ["init", "-q", "-b", "main"]);
-  git(seed, ["config", "user.name", "Test"]);
-  git(seed, ["config", "user.email", "test@example.invalid"]);
   fs.writeFileSync(
     path.join(seed, "webapp", "package.json"),
     JSON.stringify({ version: "0.9.383" }),
   );
   git(seed, ["add", "webapp/package.json"]);
   git(seed, ["commit", "-q", "-m", "base"]);
-  execFileSync("git", ["clone", "-q", "--bare", seed, remoteDir]);
-  execFileSync("git", ["clone", "-q", remoteDir, behindOnly]);
-  execFileSync("git", ["clone", "-q", remoteDir, diverged]);
-  git(diverged, ["config", "user.name", "Test"]);
-  git(diverged, ["config", "user.email", "test@example.invalid"]);
+  runGit(["clone", "-q", "--bare", seed, remoteDir]);
+  runGit(["clone", "-q", remoteDir, behindOnly]);
+  runGit(["clone", "-q", remoteDir, diverged]);
   git(diverged, ["commit", "--allow-empty", "-q", "-m", "local feature"]);
   git(seed, ["remote", "add", "origin", remoteDir]);
-  git(seed, ["commit", "--allow-empty", "-q", "-m", "upstream main"]);
+  fs.writeFileSync(
+    path.join(seed, "webapp", "package.json"),
+    JSON.stringify({ version: "0.9.384" }),
+  );
+  git(seed, ["add", "webapp/package.json"]);
+  git(seed, ["commit", "-q", "-m", "upstream main"]);
   git(seed, ["push", "-q", "origin", "main"]);
 
   const fastForward = await bridge.checkForUpdate({
@@ -98,10 +109,11 @@ test("checkForUpdate: only a fast-forwardable source checkout is actionable", as
 
   assert.equal(fastForward.behind, 1);
   assert.equal(fastForward.ahead, 0);
+  assert.equal(fastForward.latest, "0.9.384");
   assert.equal(fastForward.available, true);
   assert.equal(fork.behind, 1);
   assert.equal(fork.ahead, 1);
-  assert.equal(fork.latest, fork.currentVersion);
+  assert.equal(fork.latest, "0.9.384");
   assert.equal(fork.available, false);
 });
 

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -55,6 +55,56 @@ test("resolveBehindCount: shallow + no merge-base falls back to SHA compare", ()
   );
 });
 
+test("checkForUpdate: only a fast-forwardable source checkout is actionable", async (t) => {
+  const { execFileSync } = require("node:child_process");
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "marionette-update-availability-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const seed = path.join(root, "seed");
+  const remoteDir = path.join(root, "remote.git");
+  const behindOnly = path.join(root, "behind-only");
+  const diverged = path.join(root, "diverged");
+  const git = (cwd, args) => execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+
+  fs.mkdirSync(path.join(seed, "webapp"), { recursive: true });
+  git(seed, ["init", "-q", "-b", "main"]);
+  git(seed, ["config", "user.name", "Test"]);
+  git(seed, ["config", "user.email", "test@example.invalid"]);
+  fs.writeFileSync(
+    path.join(seed, "webapp", "package.json"),
+    JSON.stringify({ version: "0.9.383" }),
+  );
+  git(seed, ["add", "webapp/package.json"]);
+  git(seed, ["commit", "-q", "-m", "base"]);
+  execFileSync("git", ["clone", "-q", "--bare", seed, remoteDir]);
+  execFileSync("git", ["clone", "-q", remoteDir, behindOnly]);
+  execFileSync("git", ["clone", "-q", remoteDir, diverged]);
+  git(diverged, ["config", "user.name", "Test"]);
+  git(diverged, ["config", "user.email", "test@example.invalid"]);
+  git(diverged, ["commit", "--allow-empty", "-q", "-m", "local feature"]);
+  git(seed, ["remote", "add", "origin", remoteDir]);
+  git(seed, ["commit", "--allow-empty", "-q", "-m", "upstream main"]);
+  git(seed, ["push", "-q", "origin", "main"]);
+
+  const fastForward = await bridge.checkForUpdate({
+    repoRoot: behindOnly,
+    branch: "main",
+    currentVersion: "0.9.383",
+  });
+  const fork = await bridge.checkForUpdate({
+    repoRoot: diverged,
+    branch: "main",
+    currentVersion: "0.9.383",
+  });
+
+  assert.equal(fastForward.behind, 1);
+  assert.equal(fastForward.ahead, 0);
+  assert.equal(fastForward.available, true);
+  assert.equal(fork.behind, 1);
+  assert.equal(fork.ahead, 1);
+  assert.equal(fork.latest, fork.currentVersion);
+  assert.equal(fork.available, false);
+});
+
 test("overallPercent: monotonic across the pipeline, clamped to 0..100", () => {
   assert.equal(steps.overallPercent("idle"), 0);
   const fetchEnd = steps.overallPercent("fetch", 1);


### PR DESCRIPTION
## Summary
- preserve the contributor's fast-forward-only update predicate
- make the real-Git regression hermetic across host Git configurations
- prove a diverged checkout stays non-actionable even when the remote advertises a newer version

## Validation
- `node --test --test-name-pattern='checkForUpdate: only a fast-forwardable' electron/update.test.cjs`
- `npm run test:electron` (204 tests)
- `npm run build`

Absorbs #261 with original authorship preserved.