### PR TITLE
v0.9.384: precise activity and workspace identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.41` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.383, deliberately pre-1.0. Rides puppetmaster-ai==1.22.41. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.384, deliberately pre-1.0. Rides puppetmaster-ai==1.22.41. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.383"
+__version__ = "0.9.384"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/workspace.py
+++ b/harness/api/workspace.py
@@ -244,18 +244,11 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
     is_git = False
     branch = ""
     try:
-        from ..paths import git_toplevel
+        from ..paths import canonical_workspace_path, git_toplevel
         canonical_repo = git_toplevel(target_repo)
         if canonical_repo:
             is_git = True
-            if os.path.isdir(canonical_repo):
-                try:
-                    # Case aliases (macOS/Windows) share an inode with Git's
-                    # toplevel; nested dirs such as webapp do not.
-                    if os.path.samefile(target_repo, canonical_repo):
-                        target_repo = canonical_repo
-                except OSError:
-                    pass
+            target_repo = canonical_workspace_path(target_repo)
             proc_branch = subprocess.run(
                 ["git", "-C", target_repo, "rev-parse", "--abbrev-ref", "HEAD"],
                 capture_output=True,

--- a/harness/job_scoping.py
+++ b/harness/job_scoping.py
@@ -185,15 +185,25 @@ def job_repo_cwd(tasks: list) -> str:
 
 
 def cwd_under_repo(cwd: str, repo_root: str) -> bool:
-    """True when ``cwd`` sits under ``repo_root`` (longest-prefix / commonpath)."""
+    """True when ``cwd`` sits under ``repo_root`` (prefix, alias, or ancestor)."""
     if not cwd or not repo_root:
         return False
+    try:
+        repo_n = _norm_path(repo_root)
+        if os.path.commonpath([repo_n, _norm_path(cwd)]) == repo_n:
+            return True
+    except ValueError:
+        pass
     if same_workspace_path(cwd, repo_root):
         return True
-    try:
-        return os.path.commonpath([_norm_path(repo_root), _norm_path(cwd)]) == _norm_path(repo_root)
-    except ValueError:
-        return False
+    current = os.path.abspath(os.path.normpath(cwd))
+    while True:
+        parent = os.path.dirname(current)
+        if parent == current:
+            return False
+        current = parent
+        if os.path.exists(current) and same_workspace_path(current, repo_root):
+            return True
 
 
 _RUNNING_STATUSES = frozenset({"running", "in_progress", "pending", "started"})

--- a/harness/job_scoping.py
+++ b/harness/job_scoping.py
@@ -11,6 +11,8 @@ import json
 import os
 from typing import Any, Iterable, Optional
 
+from .paths import same_workspace_path
+
 ACCOUNTING_SCOPE_MARIONETTE = "marionette"
 ACCOUNTING_SCOPE_VISIBILITY = "visibility_only"
 
@@ -186,6 +188,8 @@ def cwd_under_repo(cwd: str, repo_root: str) -> bool:
     """True when ``cwd`` sits under ``repo_root`` (longest-prefix / commonpath)."""
     if not cwd or not repo_root:
         return False
+    if same_workspace_path(cwd, repo_root):
+        return True
     try:
         return os.path.commonpath([_norm_path(repo_root), _norm_path(cwd)]) == _norm_path(repo_root)
     except ValueError:

--- a/harness/paths.py
+++ b/harness/paths.py
@@ -216,6 +216,38 @@ def git_toplevel(repo: str) -> Optional[str]:
     return toplevel
 
 
+def canonical_workspace_path(path: str) -> str:
+    """Adopt Git's root spelling only when ``path`` is that exact directory."""
+    if not path:
+        return ""
+    normalized = os.path.normpath(os.path.abspath(path))
+    top = git_toplevel(normalized)
+    if top:
+        try:
+            if os.path.samefile(normalized, top):
+                return top
+        except OSError:
+            pass
+    return normalized
+
+
+def same_workspace_path(a: str, b: str) -> bool:
+    """True when two existing paths identify the same physical workspace."""
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    try:
+        if os.path.samefile(a, b):
+            return True
+    except OSError:
+        pass
+    try:
+        return os.path.normcase(_resolve(a)) == os.path.normcase(_resolve(b))
+    except Exception:
+        return False
+
+
 def resolve_workspace_path(repo: str, user_path: str) -> tuple[str, str]:
     """Resolve a user/editor path to ``(absolute_path, repo_relative_posix)``.
 

--- a/harness/server.py
+++ b/harness/server.py
@@ -665,17 +665,9 @@ def _norm_realpath(path: str) -> str:
 
 def _paths_same_workspace(a: str, b: str) -> bool:
     """True when two workspace roots refer to the same directory."""
-    if not a or not b:
-        return False
-    if a == b:
-        return True
-    try:
-        return _norm_realpath(a) == _norm_realpath(b)
-    except Exception:
-        # Fall back to slash/case fold when resolve fails.
-        na = os.path.normcase(a.replace("/", os.sep).replace("\\", os.sep)).rstrip(os.sep)
-        nb = os.path.normcase(b.replace("/", os.sep).replace("\\", os.sep)).rstrip(os.sep)
-        return na == nb
+    from .paths import same_workspace_path
+
+    return same_workspace_path(a, b)
 
 
 def _app_install_roots() -> list:
@@ -878,7 +870,9 @@ if not os.environ.get("HARNESS_REPO") and os.path.exists(_ws_boot_path):
             _ws_data = {}
         # Prefer last user project; never boot into the Marionette app
         # checkout even if an older build wrote it into workspace.json.
-        _boot_repo = _pick_boot_workspace(_ws_data)
+        from .paths import canonical_workspace_path
+
+        _boot_repo = canonical_workspace_path(_pick_boot_workspace(_ws_data))
         if _boot_repo:
             _cfg.repo = _boot_repo
             os.environ["HARNESS_REPO"] = _boot_repo

--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, asdict
 from typing import Optional, Any, List
 
 from .job_scoping import cwd_under_repo, _norm_path
+from .paths import same_workspace_path
 
 # Cap bytes read from a transcript when building list previews (OMP-style
 # cheap listing — avoid hydrating multi-MB histories for the sidebar).
@@ -628,7 +629,7 @@ def _same_root(a: str, b: str) -> bool:
         return True
     if not a or not b:
         return False
-    return _norm_path(a) == _norm_path(b)
+    return same_workspace_path(a, b)
 
 
 def _is_ephemeral_root(root: str) -> bool:
@@ -672,12 +673,12 @@ def session_visible_for_workspace(session: dict, workspace_root: str, state_dir:
         return True
     stored = session_stored_root(session)
     if stored:
-        if _norm_path(stored) == _norm_path(workspace_root):
+        if same_workspace_path(stored, workspace_root):
             return True
         return cwd_under_repo(stored, workspace_root) or cwd_under_repo(workspace_root, stored)
     inferred = infer_legacy_session_root(session, state_dir)
     if inferred:
-        if _norm_path(inferred) == _norm_path(workspace_root):
+        if same_workspace_path(inferred, workspace_root):
             return True
         return cwd_under_repo(inferred, workspace_root)
     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.383"
+version = "0.9.384"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_workspace_peel.py
+++ b/tests/test_api_workspace_peel.py
@@ -243,7 +243,7 @@ def test_workspace_open_uses_canonical_git_root(monkeypatch, tmp_path):
         "harness.paths.git_toplevel",
         lambda path: str(canonical),
     )
-    monkeypatch.setattr("harness.api.workspace.os.path.samefile", lambda a, b: True)
+    monkeypatch.setattr("harness.paths.os.path.samefile", lambda a, b: True)
     monkeypatch.setattr(
         "harness.api.workspace.subprocess.run",
         lambda args, **kwargs: SimpleNamespace(returncode=0, stdout="main\n"),

--- a/tests/test_session_job_scoping.py
+++ b/tests/test_session_job_scoping.py
@@ -386,13 +386,56 @@ def test_cwd_under_repo_longest_prefix():
     ]) == os.path.normcase(os.path.abspath("/work/a/deep/nested"))
 
 
-def test_jobs_api_lists_cwd_alias_under_canonical_workspace(tmp_path, monkeypatch):
+def _alias_or_symlink_root(tmp_path):
     repo = tmp_path / "marionette"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
     alias = tmp_path / "Marionette"
     if not alias.exists():
         alias.symlink_to(repo, target_is_directory=True)
+    return repo, alias
+
+
+def test_cwd_under_repo_nested_alias_under_canonical(tmp_path):
+    repo, alias = _alias_or_symlink_root(tmp_path)
+    nested = alias / "nested" / "child"
+    nested.mkdir(parents=True)
+    missing = alias / "nested" / "historical-gone"
+    other = tmp_path / "other-root" / "child"
+    other.mkdir(parents=True)
+
+    assert cwd_under_repo(str(nested), str(repo))
+    assert cwd_under_repo(str(missing), str(repo))
+    assert not cwd_under_repo(str(other), str(repo))
+
+    nested_tasks = [SimpleNamespace(payload={"cwd": str(nested)})]
+    assert job_visible_for_view(
+        session_id="",
+        label=None,
+        tasks=nested_tasks,
+        active_session_id="sess-b",
+        repo_root=str(repo),
+    )
+    missing_tasks = [SimpleNamespace(payload={"cwd": str(missing)})]
+    assert job_visible_for_view(
+        session_id="",
+        label=None,
+        tasks=missing_tasks,
+        active_session_id="sess-b",
+        repo_root=str(repo),
+    )
+    other_tasks = [SimpleNamespace(payload={"cwd": str(other)})]
+    assert not job_visible_for_view(
+        session_id="",
+        label=None,
+        tasks=other_tasks,
+        active_session_id="sess-b",
+        repo_root=str(repo),
+    )
+
+
+def test_jobs_api_lists_cwd_alias_under_canonical_workspace(tmp_path, monkeypatch):
+    repo, alias = _alias_or_symlink_root(tmp_path)
     store = create_store("sqlite", str(tmp_path / "state"))
     created = store.create_job("aliased job")
     _save_task(store, created.id, str(alias))

--- a/tests/test_session_job_scoping.py
+++ b/tests/test_session_job_scoping.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import threading
 import urllib.parse
@@ -383,6 +384,32 @@ def test_cwd_under_repo_longest_prefix():
         {"payload": {"cwd": "/work/a"}},
         {"payload": {"cwd": "/work/a/deep/nested"}},
     ]) == os.path.normcase(os.path.abspath("/work/a/deep/nested"))
+
+
+def test_jobs_api_lists_cwd_alias_under_canonical_workspace(tmp_path, monkeypatch):
+    repo = tmp_path / "marionette"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    alias = tmp_path / "Marionette"
+    if not alias.exists():
+        alias.symlink_to(repo, target_is_directory=True)
+    store = create_store("sqlite", str(tmp_path / "state"))
+    created = store.create_job("aliased job")
+    _save_task(store, created.id, str(alias))
+    httpd, port, srv = _api_server(str(tmp_path / "state"))
+
+    try:
+        monkeypatch.setattr(srv, "_jobs_snapshot", lambda: [
+            {"id": created.id, "goal": "aliased job", "status": "complete", "adapter": "agentic"},
+        ])
+        monkeypatch.setattr(srv._session, "state", lambda: SimpleNamespace(store=store))
+        srv._cfg.repo = str(repo)
+
+        jobs = json.loads(_api_get(port, "/api/jobs", srv._TOKEN).read().decode())
+
+        assert {job["id"] for job in jobs} == {created.id}
+    finally:
+        httpd.shutdown()
 
 
 def _api_server(tmp_state_dir):

--- a/tests/test_sessions_workspace_scoping.py
+++ b/tests/test_sessions_workspace_scoping.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import threading
 import urllib.error
 import urllib.request
@@ -82,6 +83,31 @@ def test_sessions_filtered_by_workspace_two_roots(tmp_path):
         resp_b = _get(port, "/api/sessions")
         sessions_b = json.loads(resp_b.read().decode())
         assert {s["id"] for s in sessions_b} == {meta_b["id"]}
+    finally:
+        httpd.shutdown()
+
+
+def test_sessions_api_lists_case_alias_under_canonical_workspace(tmp_path):
+    httpd, port, srv = _server()
+    repo = tmp_path / "marionette"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    alias = tmp_path / "Marionette"
+    if not alias.exists():
+        alias.symlink_to(repo, target_is_directory=True)
+    _setup_server(tmp_path, srv)
+
+    try:
+        aliased = srv._sessions.create(
+            "Aliased",
+            repo=str(alias),
+            workspace_root=str(alias),
+        )
+        srv._cfg.repo = str(repo)
+
+        sessions = json.loads(_get(port, "/api/sessions").read().decode())
+
+        assert {session["id"] for session in sessions} == {aliased["id"]}
     finally:
         httpd.shutdown()
 

--- a/tests/test_sessions_workspace_scoping.py
+++ b/tests/test_sessions_workspace_scoping.py
@@ -87,14 +87,19 @@ def test_sessions_filtered_by_workspace_two_roots(tmp_path):
         httpd.shutdown()
 
 
-def test_sessions_api_lists_case_alias_under_canonical_workspace(tmp_path):
-    httpd, port, srv = _server()
+def _alias_or_symlink_root(tmp_path):
     repo = tmp_path / "marionette"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
     alias = tmp_path / "Marionette"
     if not alias.exists():
         alias.symlink_to(repo, target_is_directory=True)
+    return repo, alias
+
+
+def test_sessions_api_lists_case_alias_under_canonical_workspace(tmp_path):
+    httpd, port, srv = _server()
+    repo, alias = _alias_or_symlink_root(tmp_path)
     _setup_server(tmp_path, srv)
 
     try:
@@ -108,6 +113,47 @@ def test_sessions_api_lists_case_alias_under_canonical_workspace(tmp_path):
         sessions = json.loads(_get(port, "/api/sessions").read().decode())
 
         assert {session["id"] for session in sessions} == {aliased["id"]}
+    finally:
+        httpd.shutdown()
+
+
+def test_sessions_api_lists_nested_alias_under_canonical_workspace(tmp_path):
+    httpd, port, srv = _server()
+    repo, alias = _alias_or_symlink_root(tmp_path)
+    nested = alias / "nested" / "child"
+    nested.mkdir(parents=True)
+    missing = alias / "nested" / "historical-gone"
+    other = tmp_path / "other-root"
+    other.mkdir()
+    _setup_server(tmp_path, srv)
+
+    try:
+        nested_session = srv._sessions.create(
+            "Nested alias",
+            repo=str(nested),
+            workspace_root=str(nested),
+        )
+        missing_session = srv._sessions.create(
+            "Historical nested",
+            repo=str(missing),
+            workspace_root=str(missing),
+        )
+        foreign = srv._sessions.create(
+            "Other root",
+            repo=str(other),
+            workspace_root=str(other),
+        )
+        srv._cfg.repo = str(repo)
+
+        sessions = json.loads(_get(port, "/api/sessions").read().decode())
+        ids = {session["id"] for session in sessions}
+        assert nested_session["id"] in ids
+        assert missing_session["id"] in ids
+        assert foreign["id"] not in ids
+
+        assert session_visible_for_workspace(nested_session, str(repo), str(tmp_path))
+        assert session_visible_for_workspace(missing_session, str(repo), str(tmp_path))
+        assert not session_visible_for_workspace(nested_session, str(other), str(tmp_path))
     finally:
         httpd.shutdown()
 

--- a/tests/test_workspace_boot_restore.py
+++ b/tests/test_workspace_boot_restore.py
@@ -140,9 +140,13 @@ def test_boot_restores_git_workspace_under_its_canonical_root(reload_server, tmp
 
     srv = reload_server(HARNESS_REPO=None)
 
-    assert srv._cfg.repo == str(repo)
-    assert os.environ.get("HARNESS_REPO") == str(repo)
-    assert json.loads((tmp_path / "workspace.json").read_text(encoding="utf-8"))["repo"] == str(repo)
+    assert os.path.samefile(srv._cfg.repo, repo)
+    assert os.path.samefile(os.environ["HARNESS_REPO"], repo)
+    persisted = json.loads((tmp_path / "workspace.json").read_text(encoding="utf-8"))["repo"]
+    assert os.path.samefile(persisted, repo)
+    other = tmp_path / "other-root"
+    other.mkdir()
+    assert not os.path.samefile(srv._cfg.repo, other)
 
 
 def test_boot_skips_workspace_when_harness_repo_already_set(reload_server, tmp_path):

--- a/tests/test_workspace_boot_restore.py
+++ b/tests/test_workspace_boot_restore.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import threading
 import time
@@ -123,6 +124,25 @@ def test_boot_restores_last_project_when_harness_repo_unset(reload_server, tmp_p
     srv = reload_server(HARNESS_REPO=None)
     assert srv._cfg.repo == str(repo)
     assert os.environ.get("HARNESS_REPO") == str(repo)
+
+
+def test_boot_restores_git_workspace_under_its_canonical_root(reload_server, tmp_path):
+    repo = tmp_path / "marionette"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    alias = tmp_path / "Marionette"
+    if not alias.exists():
+        alias.symlink_to(repo, target_is_directory=True)
+    (tmp_path / "workspace.json").write_text(
+        json.dumps({"repo": str(alias), "recents": [str(alias)]}),
+        encoding="utf-8",
+    )
+
+    srv = reload_server(HARNESS_REPO=None)
+
+    assert srv._cfg.repo == str(repo)
+    assert os.environ.get("HARNESS_REPO") == str(repo)
+    assert json.loads((tmp_path / "workspace.json").read_text(encoding="utf-8"))["repo"] == str(repo)
 
 
 def test_boot_skips_workspace_when_harness_repo_already_set(reload_server, tmp_path):

--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -468,7 +468,7 @@ async function checkForUpdate({ repoRoot, branch = DEFAULT_BRANCH, currentVersio
     );
 
     return {
-      available: behind > 0,
+      available: behind > 0 && ahead === 0,
       behind,
       latest,
       branch,

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -63,26 +63,37 @@ test("checkForUpdate: only a fast-forwardable source checkout is actionable", as
   const remoteDir = path.join(root, "remote.git");
   const behindOnly = path.join(root, "behind-only");
   const diverged = path.join(root, "diverged");
-  const git = (cwd, args) => execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  const gitEnv = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: os.devNull,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.invalid",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.invalid",
+  };
+  const runGit = (args) => execFileSync("git", args, { encoding: "utf8", env: gitEnv });
+  const git = (cwd, args) => runGit(["-C", cwd, "-c", "commit.gpgsign=false", ...args]);
 
   fs.mkdirSync(path.join(seed, "webapp"), { recursive: true });
   git(seed, ["init", "-q", "-b", "main"]);
-  git(seed, ["config", "user.name", "Test"]);
-  git(seed, ["config", "user.email", "test@example.invalid"]);
   fs.writeFileSync(
     path.join(seed, "webapp", "package.json"),
     JSON.stringify({ version: "0.9.383" }),
   );
   git(seed, ["add", "webapp/package.json"]);
   git(seed, ["commit", "-q", "-m", "base"]);
-  execFileSync("git", ["clone", "-q", "--bare", seed, remoteDir]);
-  execFileSync("git", ["clone", "-q", remoteDir, behindOnly]);
-  execFileSync("git", ["clone", "-q", remoteDir, diverged]);
-  git(diverged, ["config", "user.name", "Test"]);
-  git(diverged, ["config", "user.email", "test@example.invalid"]);
+  runGit(["clone", "-q", "--bare", seed, remoteDir]);
+  runGit(["clone", "-q", remoteDir, behindOnly]);
+  runGit(["clone", "-q", remoteDir, diverged]);
   git(diverged, ["commit", "--allow-empty", "-q", "-m", "local feature"]);
   git(seed, ["remote", "add", "origin", remoteDir]);
-  git(seed, ["commit", "--allow-empty", "-q", "-m", "upstream main"]);
+  fs.writeFileSync(
+    path.join(seed, "webapp", "package.json"),
+    JSON.stringify({ version: "0.9.384" }),
+  );
+  git(seed, ["add", "webapp/package.json"]);
+  git(seed, ["commit", "-q", "-m", "upstream main"]);
   git(seed, ["push", "-q", "origin", "main"]);
 
   const fastForward = await bridge.checkForUpdate({
@@ -98,10 +109,11 @@ test("checkForUpdate: only a fast-forwardable source checkout is actionable", as
 
   assert.equal(fastForward.behind, 1);
   assert.equal(fastForward.ahead, 0);
+  assert.equal(fastForward.latest, "0.9.384");
   assert.equal(fastForward.available, true);
   assert.equal(fork.behind, 1);
   assert.equal(fork.ahead, 1);
-  assert.equal(fork.latest, fork.currentVersion);
+  assert.equal(fork.latest, "0.9.384");
   assert.equal(fork.available, false);
 });
 

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -55,6 +55,56 @@ test("resolveBehindCount: shallow + no merge-base falls back to SHA compare", ()
   );
 });
 
+test("checkForUpdate: only a fast-forwardable source checkout is actionable", async (t) => {
+  const { execFileSync } = require("node:child_process");
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "marionette-update-availability-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const seed = path.join(root, "seed");
+  const remoteDir = path.join(root, "remote.git");
+  const behindOnly = path.join(root, "behind-only");
+  const diverged = path.join(root, "diverged");
+  const git = (cwd, args) => execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+
+  fs.mkdirSync(path.join(seed, "webapp"), { recursive: true });
+  git(seed, ["init", "-q", "-b", "main"]);
+  git(seed, ["config", "user.name", "Test"]);
+  git(seed, ["config", "user.email", "test@example.invalid"]);
+  fs.writeFileSync(
+    path.join(seed, "webapp", "package.json"),
+    JSON.stringify({ version: "0.9.383" }),
+  );
+  git(seed, ["add", "webapp/package.json"]);
+  git(seed, ["commit", "-q", "-m", "base"]);
+  execFileSync("git", ["clone", "-q", "--bare", seed, remoteDir]);
+  execFileSync("git", ["clone", "-q", remoteDir, behindOnly]);
+  execFileSync("git", ["clone", "-q", remoteDir, diverged]);
+  git(diverged, ["config", "user.name", "Test"]);
+  git(diverged, ["config", "user.email", "test@example.invalid"]);
+  git(diverged, ["commit", "--allow-empty", "-q", "-m", "local feature"]);
+  git(seed, ["remote", "add", "origin", remoteDir]);
+  git(seed, ["commit", "--allow-empty", "-q", "-m", "upstream main"]);
+  git(seed, ["push", "-q", "origin", "main"]);
+
+  const fastForward = await bridge.checkForUpdate({
+    repoRoot: behindOnly,
+    branch: "main",
+    currentVersion: "0.9.383",
+  });
+  const fork = await bridge.checkForUpdate({
+    repoRoot: diverged,
+    branch: "main",
+    currentVersion: "0.9.383",
+  });
+
+  assert.equal(fastForward.behind, 1);
+  assert.equal(fastForward.ahead, 0);
+  assert.equal(fastForward.available, true);
+  assert.equal(fork.behind, 1);
+  assert.equal(fork.ahead, 1);
+  assert.equal(fork.latest, fork.currentVersion);
+  assert.equal(fork.available, false);
+});
+
 test("overallPercent: monotonic across the pipeline, clamped to 0..100", () => {
   assert.equal(steps.overallPercent("idle"), 0);
   const fetchEnd = steps.overallPercent("fetch", 1);

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.383",
+  "version": "0.9.384",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.383",
+      "version": "0.9.384",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.383",
+  "version": "0.9.384",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/ComposerStatusStack.test.tsx
+++ b/webapp/src/__tests__/ComposerStatusStack.test.tsx
@@ -91,4 +91,40 @@ describe("ComposerStatusStack", () => {
     expect(api.swarmCancel).toHaveBeenCalledWith("local-cmd-b");
     expect(openAgentCommand).not.toHaveBeenCalled();
   });
+
+  it("omits the task-source Puppetmaster row and keeps Terminal collapsed until clicked", () => {
+    render(
+      <ComposerStatusStack
+        sessionId="sess-task-source"
+        swarmJobs={[
+          {
+            id: "job_impl_running",
+            goal: "Implement last-mile stack",
+            source: "harness",
+            status: "running",
+            updated_at: Date.now(),
+            job_kind: "run_implement",
+            role: "implementer",
+            adapter: "agentic",
+            session_id: "sess-task-source",
+            tasks: [{
+              id: "t1",
+              role: "impl",
+              instruction: "Edit the stack",
+              status: "running",
+              adapter: "x",
+            }],
+          } satisfies Job,
+          commandJob({ id: "local-cmd-beside-tasks", status: "running", session_id: "sess-task-source" }),
+        ]}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Puppetmaster" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Terminal" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: "Stop all commands" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Open terminal/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
+    expect(screen.getByRole("button", { name: "Terminal" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /Open terminal/ })).toBeInTheDocument();
+  });
 });

--- a/webapp/src/__tests__/ComposerTodoPanel.test.tsx
+++ b/webapp/src/__tests__/ComposerTodoPanel.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ComposerTodoPanel from "../components/conversation/ComposerTodoPanel";
+import { clearSessionTodos, publishSessionTodos } from "../lib/sessionTodos";
+
+vi.mock("../lib/api", () => ({
+  api: { getSessionState: vi.fn(async () => ({ todos: { phases: [] } })) },
+}));
+
+describe("ComposerTodoPanel", () => {
+  afterEach(() => {
+    clearSessionTodos();
+  });
+
+  it("collapses one phase's children without hiding another phase", () => {
+    publishSessionTodos({
+      phases: [
+        { name: "Wave One", tasks: [{ content: "first wave task", status: "pending" }] },
+        { name: "Wave Two", tasks: [{ content: "second wave task", status: "pending" }] },
+      ],
+    }, "sess-waves");
+
+    render(<ComposerTodoPanel sessionId="sess-waves" />);
+
+    const waveOne = screen.getByRole("button", { name: /I\. Wave One/ });
+    const waveTwo = screen.getByRole("button", { name: /II\. Wave Two/ });
+
+    expect(waveOne).toHaveAttribute("aria-expanded", "true");
+    expect(waveTwo).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("first wave task")).toBeInTheDocument();
+    expect(screen.getByText("second wave task")).toBeInTheDocument();
+
+    fireEvent.click(waveOne);
+    expect(waveOne).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("first wave task")).not.toBeInTheDocument();
+    expect(screen.getByText("second wave task")).toBeInTheDocument();
+    expect(waveTwo).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(waveOne);
+    expect(waveOne).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("first wave task")).toBeInTheDocument();
+    expect(screen.getByText("second wave task")).toBeInTheDocument();
+  });
+});

--- a/webapp/src/__tests__/LeftRail.layout.test.tsx
+++ b/webapp/src/__tests__/LeftRail.layout.test.tsx
@@ -36,14 +36,15 @@ describe("LeftRail branch layout", () => {
   });
 
   it("keeps branch resizing without reserving empty list height", async () => {
-    render(<LeftRail jobsRefresh={0} />);
+    const { container } = render(<LeftRail jobsRefresh={0} />);
 
-    const branch = await screen.findByRole("button", { name: /main/ });
-    const branchList = branch.parentElement as HTMLElement;
+    await screen.findByRole("button", { name: /main/ });
+    const branchList = container.querySelector<HTMLElement>("[data-slot=left-rail-branches-list]");
+    const upperSections = container.querySelector<HTMLElement>("[data-slot=left-rail-upper-sections]");
     expect(screen.getByRole("button", { name: "Jobs" })).toBeInTheDocument();
     expect(screen.getByRole("separator", { name: "Resize branches list" })).toBeInTheDocument();
-    expect(branchList.style.height).toBe("");
-    expect(branchList.style.maxHeight).not.toBe("");
-    expect(branchList.parentElement?.parentElement?.className.split(" ")).not.toContain("flex-1");
+    expect(branchList?.style.height).toBe("");
+    expect(branchList?.style.maxHeight).not.toBe("");
+    expect(upperSections?.className.split(" ")).not.toContain("flex-1");
   });
 });

--- a/webapp/src/__tests__/LeftRail.layout.test.tsx
+++ b/webapp/src/__tests__/LeftRail.layout.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LeftRail from "../components/LeftRail";
+import { clearSWRCache } from "../lib/useStaleWhileRevalidate";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    getWorkspace: vi.fn().mockResolvedValue({
+      repo: "/workspace",
+      branch: "main",
+      is_git: true,
+      head_unborn: false,
+      codegraph_status: "ready",
+      recents: [],
+      home: "/home",
+    }),
+    workspaces: vi.fn().mockResolvedValue([
+      { name: "main", active: true, dirty: false },
+    ]),
+    sessions: vi.fn().mockResolvedValue([
+      { id: "session-1", title: "Current", active: true, repo: "/workspace" },
+    ]),
+    jobs: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../lib/usePolling", () => ({ usePolling: vi.fn() }));
+vi.mock("../lib/useOperationalDiagnostic", () => ({
+  useOperationalDiagnostic: () => null,
+}));
+
+describe("LeftRail branch layout", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearSWRCache();
+  });
+
+  it("keeps branch resizing without reserving empty list height", async () => {
+    render(<LeftRail jobsRefresh={0} />);
+
+    const branch = await screen.findByRole("button", { name: /main/ });
+    const branchList = branch.parentElement as HTMLElement;
+    expect(screen.getByRole("button", { name: "Jobs" })).toBeInTheDocument();
+    expect(screen.getByRole("separator", { name: "Resize branches list" })).toBeInTheDocument();
+    expect(branchList.style.height).toBe("");
+    expect(branchList.style.maxHeight).not.toBe("");
+    expect(branchList.parentElement?.parentElement?.className.split(" ")).not.toContain("flex-1");
+  });
+});

--- a/webapp/src/__tests__/agentLinks.test.ts
+++ b/webapp/src/__tests__/agentLinks.test.ts
@@ -154,27 +154,38 @@ describe("agentLinks detection", () => {
       linkKind: "workspace",
       value: "C:\\Users\\me\\proj",
     });
-    // Worker goals often embed paths — never open the file editor for them.
     expect(classifyActionGoal(
       "run_implement",
       "Prefer C:\\Users\\pwall\\.marionette\\marionette over parent",
-    )).toEqual({
-      linkKind: "command",
-      value: "Prefer C:\\Users\\pwall\\.marionette\\marionette over parent",
-    });
+    ).linkKind).toBe("none");
     expect(classifyActionGoal(
       "run_parallel",
       "audit harness/send_loop_dispatch.py mode=analysis",
-    ).linkKind).toBe("command");
-    // Unknown kinds: shell-like never falls through to file.
+    ).linkKind).toBe("none");
+    expect(classifyActionGoal("run_swarm", "audit composer terminal ownership").linkKind).toBe("none");
+    expect(classifyActionGoal("route_task", "implement the terminal rail fix").linkKind).toBe("none");
     expect(classifyActionGoal(
       "search_codegraph",
       "custom OpenAI-compatible provider API base URL model configuration settings",
     ).linkKind).toBe("none");
     expect(classifyActionGoal("search_files", "base_url|api_base").linkKind).toBe("none");
+    expect(classifyActionGoal("query_wiki", "terminal process list").linkKind).toBe("none");
     expect(classifyActionGoal("custom_tool", "npm.cmd").linkKind).toBe("command");
     expect(classifyActionGoal("custom_tool", "git status").linkKind).toBe("command");
     expect(classifyActionGoal("custom_tool", "webapp/src/App.tsx").linkKind).toBe("file");
+  });
+
+  it("does not classify swarm, parallel, implement, or route cards as command", () => {
+    for (const kind of ["run_swarm", "run_parallel", "run_implement", "route_task"] as const) {
+      expect(classifyActionGoal(kind, "pytest -q").linkKind, kind).toBe("none");
+      expect(classifyActionGoal(kind, "sleep 999").linkKind, kind).toBe("none");
+    }
+    expect(classifyActionGoal("run_command", "pytest -q").linkKind).toBe("command");
+    expect(classifyActionGoal("search_codegraph", "pytest -q").linkKind).toBe("none");
+    expect(classifyActionGoal("web_search", "pytest -q").linkKind).toBe("none");
+    expect(classifyActionGoal("query_wiki", "pytest -q").linkKind).toBe("none");
+    expect(classifyActionGoal("puppetmaster_codegraph_search", "pytest -q").linkKind).toBe("none");
+    expect(classifyActionGoal("search_symbols", "git status").linkKind).toBe("none");
   });
 
   it("detects shell-like inline code separately from paths", () => {

--- a/webapp/src/__tests__/composerFamilyChrome.test.tsx
+++ b/webapp/src/__tests__/composerFamilyChrome.test.tsx
@@ -136,6 +136,7 @@ const swarmJob = {
   goal: "Audit composer stack",
   source: "harness",
   status: "running",
+  session_id: "sess-1",
   updated_at: Date.now(),
 } as Job;
 

--- a/webapp/src/__tests__/composerStatusStack.test.ts
+++ b/webapp/src/__tests__/composerStatusStack.test.ts
@@ -4,9 +4,10 @@ import {
   visibleCommandJob,
   visibleSwarmJob,
 } from "../components/conversation/composerStatusStackData";
+import type { Job } from "../lib/api";
 
 describe("composerStatusStack", () => {
-  it("filters to owned jobs and hides stale terminal rows", () => {
+  it("filters to owned jobs and ignores session-only commands", () => {
     const now = Date.parse("2026-08-23T12:00:00Z");
     const rows = buildComposerStatusStackRows({
       nowMs: now,
@@ -58,17 +59,141 @@ describe("composerStatusStack", () => {
       ],
     });
 
-    expect(rows.map((row) => row.id)).toEqual(["job_abc123def456", "cmd-1"]);
+    expect(rows.map((row) => row.id)).toEqual(["job_abc123def456"]);
     expect(rows[0]).toMatchObject({
       kind: "swarm",
       state: "running",
       label: "Audit composer stack",
     });
-    expect(rows[1]).toMatchObject({
-      kind: "terminal",
-      state: "running",
-      label: "pytest -q",
+  });
+
+  it("yields only a Puppetmaster row for a running swarm session plus swarm job", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const swarmJob = {
+      id: "job_abc123def456",
+      goal: "Audit composer stack",
+      source: "harness",
+      status: "running",
+      updated_at: now - 1000,
+      job_kind: "run_swarm",
+    } satisfies Job;
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [swarmJob],
+      commandSessions: [{
+        id: "job_abc123def456",
+        command: "Audit composer stack",
+        output: "working",
+        state: "running",
+        updatedAt: now - 200,
+      }],
     });
+    expect(rows.map((row) => ({ id: row.id, kind: row.kind }))).toEqual([
+      { id: "job_abc123def456", kind: "swarm" },
+    ]);
+  });
+
+  it("removes the Terminal row when the command job is gone", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const session = {
+      id: "local-cmd-e35cf193",
+      command: "sleep 999",
+      output: "still running",
+      state: "running" as const,
+      updatedAt: now - 200,
+    };
+    const commandJob = {
+      id: "local-cmd-e35cf193",
+      goal: "sleep 999",
+      source: "harness",
+      status: "running",
+      updated_at: now - 1000,
+      job_kind: "run_command",
+      role: "command",
+      adapter: "command",
+      command_preview: "sleep 999",
+    } satisfies Job;
+    expect(buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [commandJob],
+      commandSessions: [session],
+    }).map((row) => row.id)).toEqual(["local-cmd-e35cf193"]);
+    expect(buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [],
+      commandSessions: [session],
+    })).toEqual([]);
+  });
+
+  it("keeps two live command jobs with the same command text as separate rows", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [
+        {
+          id: "local-cmd-aaa",
+          goal: "pytest -q",
+          source: "harness",
+          status: "running",
+          updated_at: now - 1000,
+          job_kind: "run_command",
+          command_preview: "pytest -q",
+        } satisfies Job,
+        {
+          id: "local-cmd-bbb",
+          goal: "pytest -q",
+          source: "harness",
+          status: "running",
+          updated_at: now - 500,
+          job_kind: "run_command",
+          command_preview: "pytest -q",
+        } satisfies Job,
+      ],
+      commandSessions: [
+        {
+          id: "local-cmd-aaa",
+          command: "pytest -q",
+          output: "a",
+          state: "running",
+          updatedAt: now - 200,
+        },
+        {
+          id: "local-cmd-bbb",
+          command: "pytest -q",
+          output: "b",
+          state: "running",
+          updatedAt: now - 100,
+        },
+      ],
+    });
+    expect(rows.map((row) => ({ id: row.id, output: row.output }))).toEqual([
+      { id: "local-cmd-bbb", output: "b" },
+      { id: "local-cmd-aaa", output: "a" },
+    ]);
+  });
+
+  it("drops a completed command job after linger even if a session is still running", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [{
+        id: "local-cmd-stale",
+        goal: "sleep 1",
+        source: "harness",
+        status: "completed",
+        updated_at: now - 5_000,
+        job_kind: "run_command",
+        command_preview: "sleep 1",
+      } satisfies Job],
+      commandSessions: [{
+        id: "local-cmd-stale",
+        command: "sleep 1",
+        output: "ok",
+        state: "running",
+        updatedAt: now - 200,
+      }],
+    });
+    expect(rows).toEqual([]);
   });
 
 
@@ -84,7 +209,7 @@ describe("composerStatusStack", () => {
       role: "command",
       adapter: "command",
       command_preview: "sleep 999",
-    } as any;
+    } satisfies Job;
     const swarmJob = {
       id: "job_abc123def456",
       goal: "Audit composer stack",
@@ -378,7 +503,100 @@ describe("composerStatusStack", () => {
     });
     expect(rows).toHaveLength(1);
     expect(rows[0].state).toBe("done");
-    expect(rows[0].updatedAt).toBe(now - 3_000);
+    expect(rows[0].updatedAt).toBe(now - 200);
+  });
+
+  it("treats a recent blank command-job status as done", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const job = {
+      id: "local-cmd-blank-recent",
+      goal: "echo done",
+      source: "harness",
+      status: "",
+      updated_at: now - 1000,
+      job_kind: "run_command",
+      command_preview: "echo done",
+    } satisfies Job;
+    expect(visibleCommandJob(job, now)).toMatchObject({
+      id: "local-cmd-blank-recent",
+      kind: "terminal",
+      state: "done",
+      updatedAt: now - 1000,
+    });
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [job],
+      commandSessions: [],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "local-cmd-blank-recent",
+      state: "done",
+    });
+  });
+
+  it("drops an old blank command-job status without a session", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const job = {
+      id: "local-cmd-blank-old",
+      goal: "echo stale",
+      source: "harness",
+      status: "   ",
+      updated_at: now - 5_000,
+      job_kind: "run_command",
+      command_preview: "echo stale",
+    } satisfies Job;
+    expect(visibleCommandJob(job, now)).toBeNull();
+    expect(buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [job],
+      commandSessions: [],
+    })).toEqual([]);
+  });
+
+  it("lets a matching running session overlay a recent blank command job", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [{
+        id: "local-cmd-blank-live",
+        goal: "sleep 999",
+        source: "harness",
+        status: "",
+        updated_at: now - 1000,
+        job_kind: "run_command",
+        command_preview: "sleep 999",
+      } satisfies Job],
+      commandSessions: [{
+        id: "local-cmd-blank-live",
+        command: "sleep 999",
+        output: "still going",
+        state: "running",
+        updatedAt: now - 200,
+      }],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "local-cmd-blank-live",
+      state: "running",
+      output: "still going",
+    });
+  });
+
+  it("keeps explicit pending, queued, running, and active command statuses running", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    for (const status of ["pending", "queued", "running", "active"]) {
+      const job = {
+        id: `local-cmd-${status}`,
+        goal: "sleep 1",
+        source: "harness",
+        status,
+        updated_at: now - 5_000,
+        job_kind: "run_command",
+        command_preview: "sleep 1",
+      } satisfies Job;
+      expect(visibleCommandJob(job, now)?.state, status).toBe("running");
+    }
   });
 
   it("hides settled transcript history that was never observed running", () => {
@@ -398,7 +616,7 @@ describe("composerStatusStack", () => {
     expect(rows).toEqual([]);
   });
 
-  it("does not resurrect hidden transcript history from a stale live poll", () => {
+  it("lets a live command job own the row even when the session is rail-hidden", () => {
     const now = Date.parse("2026-08-23T12:00:00Z");
     const rows = buildComposerStatusStackRows({
       nowMs: now,
@@ -420,12 +638,39 @@ describe("composerStatusStack", () => {
         railVisible: false,
       }],
     });
-    expect(rows).toEqual([]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "local-cmd-aa11",
+      kind: "terminal",
+      state: "done",
+      output: "ok",
+    });
   });
 
-  it("keeps a settled command briefly when this process observed it running", () => {
+  it("keeps a settled command job briefly, then drops a session-only linger", () => {
     const now = Date.parse("2026-08-23T12:00:00Z");
-    const rows = buildComposerStatusStackRows({
+    const commandJob = {
+      id: "live-then-done",
+      goal: "brew install llama.cpp",
+      source: "harness",
+      status: "completed",
+      updated_at: now - 400,
+      job_kind: "run_command",
+      command_preview: "brew install llama.cpp",
+    } satisfies Job;
+    expect(buildComposerStatusStackRows({
+      nowMs: now,
+      swarmJobs: [commandJob],
+      commandSessions: [{
+        id: "live-then-done",
+        command: "brew install llama.cpp",
+        output: "ok",
+        state: "done",
+        updatedAt: now - 400,
+        railVisible: true,
+      }],
+    }).map((row) => row.id)).toEqual(["live-then-done"]);
+    expect(buildComposerStatusStackRows({
       nowMs: now,
       swarmJobs: [],
       commandSessions: [{
@@ -436,8 +681,7 @@ describe("composerStatusStack", () => {
         updatedAt: now - 400,
         railVisible: true,
       }],
-    });
-    expect(rows.map((row) => row.id)).toEqual(["live-then-done"]);
+    })).toEqual([]);
   });
 
   it("collapses command preview whitespace so the task bar does not stair-step", () => {

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -142,15 +142,9 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     const top = topChromeRef.current;
     const upper = upperSectionsRef.current;
     if (!rail || !top || !upper) return sessionJobsMinHeight();
-    // Measure the upper content's NATURAL height by summing its children --
-    // not upper.scrollHeight. The upper div is a flex-1 scroll container, and
-    // a scroll container's scrollHeight is never less than its rendered
-    // height, so with a short projects list the computed max collapsed to
-    // "whatever the jobs panel already has": dragging up crawled at the ~1px
-    // of layout rounding slack per event while dragging down ran free.
-    // Children inside an overflow container keep their natural height, so
-    // their sum is the true content bound in both the short and overflowing
-    // cases.
+    // A scroll container's scrollHeight cannot undercut its rendered height.
+    // Summing child heights preserves the natural content bound for both short
+    // and overflowing lists.
     const upperContent = Array.from(upper.children).reduce(
       (sum, el) => sum + (el as HTMLElement).offsetHeight,
       0,
@@ -1319,7 +1313,11 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       </div>
       </div>
 
-      <div ref={upperSectionsRef} className={`min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}>
+      <div
+        ref={upperSectionsRef}
+        data-slot="left-rail-upper-sections"
+        className={`min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}
+      >
       {/* Projects | Sessions toggle */}
       <div className="px-2.5 pt-2 flex items-center gap-0 border-b border-edge/35">
         <button
@@ -1843,7 +1841,11 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
           {filterBranchWorkspaces(workspaces).length === 0 && (
             <Empty>{workspaceInfo?.head_unborn ? "No commits yet" : "No branches"}</Empty>
           )}
-          <div className="space-y-0.5 overflow-y-auto" style={{ maxHeight: branchesHeight }}>
+          <div
+            data-slot="left-rail-branches-list"
+            className="space-y-0.5 overflow-y-auto"
+            style={{ maxHeight: branchesHeight }}
+          >
             {filterBranchWorkspaces(workspaces).map((w) => {
               const linked = !!w.worktree_path;
               const linkKind = w.name.startsWith("pmworker-")

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -1319,7 +1319,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       </div>
       </div>
 
-      <div ref={upperSectionsRef} className={`flex-1 min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}>
+      <div ref={upperSectionsRef} className={`min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}>
       {/* Projects | Sessions toggle */}
       <div className="px-2.5 pt-2 flex items-center gap-0 border-b border-edge/35">
         <button
@@ -1843,7 +1843,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
           {filterBranchWorkspaces(workspaces).length === 0 && (
             <Empty>{workspaceInfo?.head_unborn ? "No commits yet" : "No branches"}</Empty>
           )}
-          <div className="space-y-0.5 overflow-y-auto" style={{ height: branchesHeight }}>
+          <div className="space-y-0.5 overflow-y-auto" style={{ maxHeight: branchesHeight }}>
             {filterBranchWorkspaces(workspaces).map((w) => {
               const linked = !!w.worktree_path;
               const linkKind = w.name.startsWith("pmworker-")

--- a/webapp/src/components/conversation/ComposerStatusStack.tsx
+++ b/webapp/src/components/conversation/ComposerStatusStack.tsx
@@ -8,6 +8,7 @@ import {
   listAgentCommandSessions,
   subscribeAgentCommandIndex,
 } from "../../lib/agentCommandIndex";
+import { pickTaskSourceJob } from "../../lib/composerTasks";
 import { buildComposerStatusStackRows, type ComposerStatusStackRow } from "./composerStatusStackData";
 import { COMPOSER_FAMILY_LABEL, COMPOSER_FAMILY_SECTION } from "./composerFamily";
 
@@ -43,15 +44,17 @@ function StatusStackGroup({
   rows,
   cancelling,
   onCancel,
+  defaultCollapsed = false,
 }: {
   kind: ComposerStatusStackRow["kind"];
   rows: ComposerStatusStackRow[];
   cancelling: ReadonlySet<string>;
   onCancel: (ids: string[]) => void;
+  defaultCollapsed?: boolean;
 }) {
   const runningIds = rows.filter((row) => row.state === "running").map((row) => row.id);
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
-  const open = userOpen ?? runningIds.length > 0;
+  const open = userOpen ?? (!defaultCollapsed && runningIds.length > 0);
 
   return (
     <div>
@@ -157,14 +160,23 @@ export default function ComposerStatusStack({
     () => listAgentCommandSessions(sessionId),
     [commandIndexVersion, sessionId],
   );
+  const taskSource = useMemo(
+    () => pickTaskSourceJob(swarmJobs, sessionId),
+    [sessionId, swarmJobs],
+  );
+  const taskSourceId = taskSource?.id ?? "";
   const rows = useMemo(
-    () => buildComposerStatusStackRows({
-      swarmJobs,
-      commandSessions,
-      nowMs: nowTick,
-      sessionId,
-    }),
-    [commandSessions, nowTick, sessionId, swarmJobs],
+    () => {
+      const built = buildComposerStatusStackRows({
+        swarmJobs,
+        commandSessions,
+        nowMs: nowTick,
+        sessionId,
+      });
+      if (!taskSourceId) return built;
+      return built.filter((row) => row.kind !== "swarm" || row.id !== taskSourceId);
+    },
+    [commandSessions, nowTick, sessionId, swarmJobs, taskSourceId],
   );
 
   const hasTerminalRows = rows.some((row) => row.state !== "running");
@@ -228,6 +240,7 @@ export default function ComposerStatusStack({
             rows={group.rows}
             cancelling={cancelling}
             onCancel={onCancel}
+            defaultCollapsed={group.kind === "terminal" && Boolean(taskSource)}
           />
         ))}
       </div>

--- a/webapp/src/components/conversation/ComposerTodoPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTodoPanel.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { Ban, CheckCircle2, ChevronDown, ChevronRight, Circle, ListTree, Loader2, MinusCircle } from "lucide-react";
 import { api, type Job, type SessionTodoItem, type SessionTodoSnapshot } from "../../lib/api";
 import {
-  collapseTodoTasks,
   litTodoContents,
   liveJobTodoLabels,
   todoHasWork,
@@ -38,6 +37,10 @@ function taskTone(status: SessionTodoItem["status"], lit?: boolean): string {
   return "text-txt";
 }
 
+function todoPhaseKey(sessionId: string, phaseIndex: number, phaseName: string): string {
+  return `${sessionId}:${phaseIndex}:${phaseName}`;
+}
+
 export default function ComposerTodoPanel({
   jobs = [],
   sessionId,
@@ -56,7 +59,7 @@ export default function ComposerTodoPanel({
     getSessionTodosSessionId,
   );
   const [open, setOpen] = useState(true);
-  const [expandedPhase, setExpandedPhase] = useState<string | null>(null);
+  const [collapsedPhaseKeys, setCollapsedPhaseKeys] = useState<Set<string>>(() => new Set());
   const lit = useMemo(
     () => litTodoContents(snapshot, liveJobTodoLabels(jobs, sessionId)),
     [jobs, sessionId, snapshot],
@@ -94,16 +97,24 @@ export default function ComposerTodoPanel({
       </button>
       {open && (
         <div className="space-y-1 px-2 pb-1.5">
-          {snapshot.phases.map((phase, index) => (
-            <PhaseBlock
-              key={`${phase.name}-${index}`}
-              index={index + 1}
-              phase={phase}
-              expanded={expandedPhase === phase.name}
-              litContents={lit}
-              onToggle={() => setExpandedPhase((name) => (name === phase.name ? null : phase.name))}
-            />
-          ))}
+          {snapshot.phases.map((phase, index) => {
+            const key = todoPhaseKey(sessionId, index, phase.name);
+            return (
+              <PhaseBlock
+                key={key}
+                index={index + 1}
+                phase={phase}
+                expanded={!collapsedPhaseKeys.has(key)}
+                litContents={lit}
+                onToggle={() => setCollapsedPhaseKeys((current) => {
+                  const next = new Set(current);
+                  if (next.has(key)) next.delete(key);
+                  else next.add(key);
+                  return next;
+                })}
+              />
+            );
+          })}
         </div>
       )}
     </div>
@@ -124,13 +135,11 @@ function PhaseBlock({
   onToggle: () => void;
 }) {
   const { done, total } = todoPhaseProgress(phase);
-  const { items, hidden } = expanded
-    ? { items: phase.tasks, hidden: 0 }
-    : collapseTodoTasks(phase.tasks, litContents);
   return (
     <div>
       <button
         type="button"
+        aria-expanded={expanded}
         onClick={onToggle}
         className="flex w-full items-center gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[10.5px] leading-4 text-txt hover:bg-panel/30"
       >
@@ -139,34 +148,27 @@ function PhaseBlock({
           {toRoman(index)}. {phase.name} · {done}/{total}
         </span>
       </button>
-      <div className="pl-4 space-y-0.5">
-        {items.map((task) => {
-          const lit = litContents.has(task.content);
-          return (
-          <div
-            key={task.content}
-            title={task.blocker || task.content}
-            data-todo-lit={lit ? "1" : undefined}
-            className={`flex items-start gap-1.5 text-[10.5px] leading-4 ${taskTone(task.status, lit)}`}
-          >
-            <TaskMark status={task.status} lit={lit} />
-            <span className={expanded ? "whitespace-pre-wrap break-words" : "min-w-0 truncate"}>
-              {task.content}
-              {expanded && task.blocker ? <span className="mt-0.5 block text-faint">{task.blocker}</span> : null}
-            </span>
-          </div>
-          );
-        })}
-        {hidden > 0 ? (
-          <button
-            type="button"
-            onClick={onToggle}
-            className="text-[10.5px] leading-4 text-faint hover:text-txt"
-          >
-            ... {hidden} more todo{hidden === 1 ? "" : "s"}
-          </button>
-        ) : null}
-      </div>
+      {expanded ? (
+        <div className="pl-4 space-y-0.5">
+          {phase.tasks.map((task) => {
+            const lit = litContents.has(task.content);
+            return (
+              <div
+                key={task.content}
+                title={task.blocker || task.content}
+                data-todo-lit={lit ? "1" : undefined}
+                className={`flex items-start gap-1.5 text-[10.5px] leading-4 ${taskTone(task.status, lit)}`}
+              >
+                <TaskMark status={task.status} lit={lit} />
+                <span className="whitespace-pre-wrap break-words">
+                  {task.content}
+                  {task.blocker ? <span className="mt-0.5 block text-faint">{task.blocker}</span> : null}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/webapp/src/components/conversation/composerStatusStackData.ts
+++ b/webapp/src/components/conversation/composerStatusStackData.ts
@@ -44,6 +44,7 @@ function timestampMs(value: unknown): number | null {
 function overlayExistingRow(
   existing: ComposerStatusStackRow,
   incoming: ComposerStatusStackRow,
+  allowRunningOnDone = false,
 ): ComposerStatusStackRow {
   let state = existing.state;
   let updatedAt = existing.updatedAt;
@@ -53,20 +54,27 @@ function overlayExistingRow(
   } else if (incoming.state === "done" && existing.state === "running") {
     state = "done";
     updatedAt = incoming.updatedAt;
+  } else if (allowRunningOnDone && incoming.state === "running" && existing.state === "done") {
+    state = "running";
+    updatedAt = incoming.updatedAt;
   }
   return {
     ...existing,
     state,
     updatedAt,
-    output: existing.output || incoming.output,
-    command: existing.command || incoming.command,
+    output: incoming.output || existing.output,
+    command: incoming.command || existing.command,
     label: existing.label || incoming.label,
     title: existing.title || incoming.title,
   };
 }
 
-function normalizeState(status: unknown): ComposerStatusStackState {
+function normalizeState(
+  status: unknown,
+  emptyFallback: ComposerStatusStackState = "running",
+): ComposerStatusStackState {
   const s = String(status || "").trim().toLowerCase();
+  if (!s) return emptyFallback;
   if (
     s.includes("fail")
     || s.includes("error")
@@ -139,7 +147,7 @@ export function visibleSwarmJob(job: Job, nowMs: number): ComposerStatusStackRow
 export function visibleCommandJob(job: Job, nowMs: number): ComposerStatusStackRow | null {
   if (!jobAccountingOwned(job)) return null;
   if (!isCommandJob(job)) return null;
-  const state = normalizeState(job.status);
+  const state = normalizeState(job.status, "done");
   const updatedAt = jobUpdatedAt(job);
   if (!lingerAllows(state, updatedAt, nowMs, COMMAND_SUCCESS_LINGER_MS, COMMAND_FAILURE_LINGER_MS)) return null;
   const id = String(job.id || "").trim();
@@ -160,22 +168,15 @@ export function visibleCommandJob(job: Job, nowMs: number): ComposerStatusStackR
   };
 }
 
-function visibleCommandSession(
-  session: AgentCommandSession,
-  nowMs: number,
-): ComposerStatusStackRow | null {
+function commandSessionOverlay(session: AgentCommandSession): ComposerStatusStackRow | null {
   const id = String(session.id || "").trim();
   const command = String(session.command || "").trim();
   if (!id || !command) return null;
-  if (session.railVisible === false) return null;
-  const state = session.state || "running";
-  if (state === "done" && nowMs - session.updatedAt > COMMAND_SUCCESS_LINGER_MS) return null;
-  if (state === "failed" && nowMs - session.updatedAt > COMMAND_FAILURE_LINGER_MS) return null;
   return {
     id,
     kind: "terminal",
     label: oneLinePreview(command),
-    state,
+    state: session.state || "running",
     updatedAt: session.updatedAt,
     title: oneLinePreview(command),
     command,
@@ -190,18 +191,15 @@ export function buildComposerStatusStackRows(
   const rows: ComposerStatusStackRow[] = [];
   const seen = new Set<string>();
   const sessionId = String(source.sessionId || "").trim();
-
-  // Sessions first: they carry live stdout for the existing openAgentCommand path.
+  const sessionsById = new Map<string, AgentCommandSession>();
   for (const session of source.commandSessions) {
     if (sessionId && session.sessionId !== sessionId) continue;
     const id = String(session.id || "").trim();
-    if (id) seen.add(id);
-    const row = visibleCommandSession(session, nowMs);
-    if (row) {
-      rows.push(row);
-    }
+    if (id) sessionsById.set(id, session);
   }
 
+  // /api/swarm/live isCommandJob rows are the only Terminal authority.
+  // Matching sessions overlay output/state; they never mint a row alone.
   for (const job of source.swarmJobs) {
     if (sessionId && !jobInActiveSession(job, sessionId)) continue;
     const id = String(job.id || "").trim();
@@ -212,7 +210,14 @@ export function buildComposerStatusStackRows(
       if (idx >= 0) rows[idx] = overlayExistingRow(rows[idx], row);
       continue;
     }
-    rows.push(row);
+    if (row.kind === "terminal" && id) {
+      const overlay = sessionsById.get(id);
+      const incoming = overlay ? commandSessionOverlay(overlay) : null;
+      const blankCommandStatus = !String(job.status ?? "").trim();
+      rows.push(incoming ? overlayExistingRow(row, incoming, blankCommandStatus) : row);
+    } else {
+      rows.push(row);
+    }
     if (id) seen.add(id);
   }
 

--- a/webapp/src/lib/agentLinks.ts
+++ b/webapp/src/lib/agentLinks.ts
@@ -386,27 +386,28 @@ export function classifyActionGoal(
   if (k === "web_fetch") {
     return { linkKind: "url", value: g };
   }
-  // Search / wiki queries are prose. looksLikeShellCommand treats any
-  // spaced string as a command, which parked CodeGraph queries on the Term rail.
+  // Search and wiki inputs are prose even when their query looks shell-like.
+  // Keep these action families aligned with toolInputFieldKey.
   if (
-    k === "search_codegraph"
-    || k === "search_files"
-    || k === "search_state"
-    || k === "search_tools"
-    || k === "web_search"
+    k === "web_search"
     || k === "query_wiki"
+    || k.includes("codegraph")
+    || k.startsWith("search_")
   ) {
     return { linkKind: "none", value: g };
   }
-  // Worker / shell dispatches are processes, not files — even when the goal
-  // text embeds a path (looksLikeFilePath would otherwise open the editor).
+  // Orchestration cards belong on Puppetmaster / Tasks, not Terminal.
   if (
-    k === "run_command"
-    || k === "run_ipython"
-    || k === "run_implement"
+    k === "run_implement"
     || k === "run_parallel"
     || k === "run_swarm"
     || k === "route_task"
+  ) {
+    return { linkKind: "none", value: g };
+  }
+  if (
+    k === "run_command"
+    || k === "run_ipython"
     || k === "shell"
     || k === "bash"
     || k === "execute"


### PR DESCRIPTION
## Summary
- reserve Terminal activity for authoritative background-process jobs, suppress duplicate orchestration rows, and make Todo waves independently collapsible
- remove Left Rail dead space and canonicalize workspace identity across aliases, nested paths, session/job scoping, and boot restore
- hide source-update prompts for diverged branches while retaining newer-version metadata and fast-forward updates

## Test plan
- [x] `.venv/bin/python -m pytest -q`
- [x] `npm test`
- [x] `npm run test:electron` (204 tests)
- [x] `npm run build`
- [x] focused real-Git fast-forward/divergence regression
- [x] independent reviews of Terminal ownership, workspace identity, and update availability