### PR TITLE
Release v0.9.385

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.41` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.384, deliberately pre-1.0. Rides puppetmaster-ai==1.22.41. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.385, deliberately pre-1.0. Rides puppetmaster-ai==1.22.41. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.384"
+__version__ = "0.9.385"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -121,6 +121,17 @@ def _enrich_worker_provenance(
     return provenance
 
 
+def _worker_result_has_empty_worktree_marker(res) -> bool:
+    try:
+        text = (
+            f"{getattr(res, 'summary', '') or ''} "
+            f"{getattr(res, 'error', '') or ''}"
+        ).lower()
+    except Exception:
+        return False
+    return any(marker in text for marker in _EMPTY_WORKTREE_MARKERS)
+
+
 def _is_empty_diff_implement_failure(res, *, expects_diff: bool) -> bool:
     """True when an implement worker left the managed worktree unchanged."""
     if not expects_diff or res is None:
@@ -135,14 +146,7 @@ def _is_empty_diff_implement_failure(res, *, expects_diff: bool) -> bool:
             return False
     except Exception:
         pass
-    try:
-        text = (
-            f"{getattr(res, 'summary', '') or ''} "
-            f"{getattr(res, 'error', '') or ''}"
-        ).lower()
-    except Exception:
-        return False
-    if not any(marker in text for marker in _EMPTY_WORKTREE_MARKERS):
+    if not _worker_result_has_empty_worktree_marker(res):
         return False
     try:
         return not bool(getattr(res, "ok", True))
@@ -254,17 +258,18 @@ def _empty_implement_recovery_eligible(
         err = str(getattr(res, "error", "") or "").strip().lower()
     except Exception:
         err = ""
-    # Engine crash / unavailable / route failure is not a seeded-worktree miss.
-    # Stamping worktree_diff_empty on AGENTIC_ERROR must not launch a second run.
-    if err.startswith("agentic_"):
+    if not _is_empty_diff_implement_failure(res, expects_diff=True):
+        return False
+    if err == "agentic_orchestrator_failed":
+        if not _worker_result_has_empty_worktree_marker(res):
+            return False
+    elif err.startswith("agentic_"):
         return False
     if err in (
         "worktree_create_failed",
         "patch_capture_failed",
         "worker_cleanup_failed",
     ):
-        return False
-    if not _is_empty_diff_implement_failure(res, expects_diff=True):
         return False
     if _worker_stopped_by_guard_or_budget(res):
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.384"
+version = "0.9.385"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_worker_provenance.py
+++ b/tests/test_worker_provenance.py
@@ -271,6 +271,42 @@ def test_empty_diff_implement_failure_detector():
     assert _is_empty_diff_implement_failure(ok_patch, expects_diff=True) is False
 
 
+def test_agentic_empty_managed_implement_is_recovery_eligible():
+    result = WorkerResult(
+        ok=False,
+        error="agentic_orchestrator_failed",
+        summary="Worker produced no changes in disposable managed worktree",
+        patch="",
+        worktree_diff_empty=True,
+        managed_worktree_mode="managed",
+    )
+
+    assert _empty_implement_recovery_eligible(
+        result,
+        expects_diff=True,
+        live_dirty_before=["src/lib/db/schema.ts"],
+        cancelled=False,
+    ) is True
+
+
+def test_agentic_orchestrator_failure_without_empty_worktree_evidence_does_not_retry():
+    result = WorkerResult(
+        ok=False,
+        error="agentic_orchestrator_failed",
+        summary="provider process exited unexpectedly",
+        patch="",
+        worktree_diff_empty=False,
+        managed_worktree_mode="managed",
+    )
+
+    assert _empty_implement_recovery_eligible(
+        result,
+        expects_diff=True,
+        live_dirty_before=["src/lib/db/schema.ts"],
+        cancelled=False,
+    ) is False
+
+
 def test_empty_managed_implement_triggers_one_recovery_when_live_dirty(monkeypatch):
     """Empty managed implement + dirty live tree re-invokes the edit engine once."""
     cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.384",
+  "version": "0.9.385",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.384",
+      "version": "0.9.385",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.384",
+  "version": "0.9.385",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/composerFamilyChrome.test.tsx
+++ b/webapp/src/__tests__/composerFamilyChrome.test.tsx
@@ -264,6 +264,54 @@ describe("composer-family chrome", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not repeat parallel-wave children in the Puppetmaster group", () => {
+    const childIds = ["local-60b0773c", "local-42c84d72", "local-f25dd421"];
+    const wave = {
+      id: "local-wave-call_3Du6fz",
+      goal: "Wave 2B",
+      status: "running",
+      session_id: "sess-1",
+      job_kind: "parallel_wave",
+      role: "parallel_wave",
+      adapter: "parallel_wave",
+      child_job_ids: childIds,
+      tasks: childIds.map((id, index) => ({
+        id,
+        role: "implement",
+        instruction: `slice ${index}`,
+        status: index === 0 ? "running" : index === 1 ? "completed" : "failed",
+        adapter: "agentic",
+      })),
+    } as Job;
+    const children = childIds.map((id, index) => ({
+      id,
+      goal: `slice ${index}`,
+      status: index === 0 ? "running" : index === 1 ? "completed" : "failed",
+      session_id: "sess-1",
+      job_kind: "run_implement",
+      source: "harness",
+      updated_at: Date.now(),
+    } as Job));
+    const unrelated = {
+      id: "job_unrelated",
+      goal: "Independent audit",
+      status: "running",
+      session_id: "sess-1",
+      job_kind: "run_swarm",
+      source: "harness",
+      updated_at: Date.now(),
+    } as Job;
+
+    const rail = render(
+      <ComposerActivityRail jobs={[wave, ...children, unrelated]} sessionId="sess-1" />,
+    );
+
+    expect(rail.getByText(/Parallel wave — running/)).toBeInTheDocument();
+    expect(rail.getByRole("button", { name: "Puppetmaster" })).toHaveTextContent("1");
+    expect(rail.queryByRole("button", { name: "Open swarm: slice 0" })).not.toBeInTheDocument();
+    expect(rail.getByText("Independent audit")).toBeInTheDocument();
+  });
+
   it("unmounts a completed 5/5 parallel wave instead of leaving implement flags", () => {
     const wave = {
       id: "local-wave-done",

--- a/webapp/src/__tests__/composerTasks.test.ts
+++ b/webapp/src/__tests__/composerTasks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildComposerTasks, composerTasksRemainVisible, pickTaskSourceJob, taskProgress, taskState, waveHeaderText, waveProgress } from "../lib/composerTasks";
+import { buildComposerTasks, composerTasksRemainVisible, pickTaskSourceJob, taskProgress, taskSourceJobIds, taskState, waveHeaderText, waveProgress } from "../lib/composerTasks";
 import type { Job } from "../lib/api";
 
 const job = (id: string, status: string, session_id: string, tasks: Job["tasks"]): Job => ({
@@ -133,6 +133,25 @@ describe("pickTaskSourceJob", () => {
       job_kind: "run_swarm",
     };
     expect(pickTaskSourceJob([wave, swarm], "sess-1")?.id).toBe("local-wave-live");
+  });
+});
+
+describe("taskSourceJobIds", () => {
+  it("includes the task source and every durable wave child", () => {
+    const wave = {
+      ...job("local-wave-call", "running", "sess-1", []),
+      child_job_ids: [" local-60 ", "local-42", "local-60"],
+      terminal_receipt: {
+        child_job_ids: ["local-f25", ""],
+      },
+    } as Job;
+
+    expect([...taskSourceJobIds(wave)]).toEqual([
+      "local-wave-call",
+      "local-60",
+      "local-42",
+      "local-f25",
+    ]);
   });
 });
 

--- a/webapp/src/components/conversation/ComposerStatusStack.tsx
+++ b/webapp/src/components/conversation/ComposerStatusStack.tsx
@@ -8,7 +8,7 @@ import {
   listAgentCommandSessions,
   subscribeAgentCommandIndex,
 } from "../../lib/agentCommandIndex";
-import { pickTaskSourceJob } from "../../lib/composerTasks";
+import { pickTaskSourceJob, taskSourceJobIds } from "../../lib/composerTasks";
 import { buildComposerStatusStackRows, type ComposerStatusStackRow } from "./composerStatusStackData";
 import { COMPOSER_FAMILY_LABEL, COMPOSER_FAMILY_SECTION } from "./composerFamily";
 
@@ -164,7 +164,7 @@ export default function ComposerStatusStack({
     () => pickTaskSourceJob(swarmJobs, sessionId),
     [sessionId, swarmJobs],
   );
-  const taskSourceId = taskSource?.id ?? "";
+  const taskSourceIds = useMemo(() => taskSourceJobIds(taskSource), [taskSource]);
   const rows = useMemo(
     () => {
       const built = buildComposerStatusStackRows({
@@ -173,10 +173,10 @@ export default function ComposerStatusStack({
         nowMs: nowTick,
         sessionId,
       });
-      if (!taskSourceId) return built;
-      return built.filter((row) => row.kind !== "swarm" || row.id !== taskSourceId);
+      if (!taskSourceIds.size) return built;
+      return built.filter((row) => row.kind !== "swarm" || !taskSourceIds.has(row.id));
     },
-    [commandSessions, nowTick, sessionId, swarmJobs, taskSourceId],
+    [commandSessions, nowTick, sessionId, swarmJobs, taskSourceIds],
   );
 
   const hasTerminalRows = rows.some((row) => row.state !== "running");

--- a/webapp/src/lib/composerTasks.ts
+++ b/webapp/src/lib/composerTasks.ts
@@ -67,6 +67,15 @@ export function pickTaskSourceJob(jobs: readonly Job[], activeSessionId: string)
   return pickRankedJob(waves.length ? waves : remaining);
 }
 
+export function taskSourceJobIds(job: Job | null): ReadonlySet<string> {
+  const ids = [
+    job?.id,
+    ...(job?.child_job_ids || []),
+    ...(job?.terminal_receipt?.child_job_ids || []),
+  ];
+  return new Set(ids.map((id) => String(id || "").trim()).filter(Boolean));
+}
+
 function roleLabel(role: string): string {
   return role.replace(/[-_]+/g, " ").replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
## Summary
- make Parallel wave Tasks the single activity-rail owner of its coordinator and child workers
- recover transcript-proven empty managed agentic implementations once against seeded dirty state
- keep generic agentic failures fail-closed and bump Marionette to v0.9.385

## Test plan
- [x] `.venv/bin/python -m pytest -q` (5,350 passed, 78 skipped)
- [x] `npm test` (1,512 passed)
- [x] `npm run test:electron` (204 passed)
- [x] `npm run build`
- [x] `.venv/bin/python -m pytest -q tests/test_version_consistency.py`