### PR TITLE
Release v0.9.386

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.41` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.385, deliberately pre-1.0. Rides puppetmaster-ai==1.22.41. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.386, deliberately pre-1.0. Rides puppetmaster-ai==1.22.41. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.385"
+__version__ = "0.9.386"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -34,6 +34,7 @@ _PROVENANCE_STAGE_CODES = frozenset({
     "agentic_error",
     "worktree_create_failed",
     "agentic_orchestrator_failed",
+    "agentic_no_diff",
     "patch_capture_failed",
     "worker_cleanup_failed",
     "agentic_provider_rate_limited",
@@ -260,10 +261,7 @@ def _empty_implement_recovery_eligible(
         err = ""
     if not _is_empty_diff_implement_failure(res, expects_diff=True):
         return False
-    if err == "agentic_orchestrator_failed":
-        if not _worker_result_has_empty_worktree_marker(res):
-            return False
-    elif err.startswith("agentic_"):
+    if err.startswith("agentic_"):
         return False
     if err in (
         "worktree_create_failed",

--- a/harness/edit_engines.py
+++ b/harness/edit_engines.py
@@ -55,6 +55,7 @@ AGENTIC_ROUTE_FAILED = "agentic_route_failed"
 AGENTIC_ERROR = "agentic_error"
 WORKTREE_CREATE_FAILED = "worktree_create_failed"
 AGENTIC_ORCHESTRATOR_FAILED = "agentic_orchestrator_failed"
+AGENTIC_NO_DIFF = "agentic_no_diff"
 PATCH_CAPTURE_FAILED = "patch_capture_failed"
 WORKER_CLEANUP_FAILED = "worker_cleanup_failed"
 AGENTIC_PROVIDER_RATE_LIMITED = "agentic_provider_rate_limited"
@@ -114,6 +115,14 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
         "event_names": [],
         "job_status": "",
         "artifact_types": [],
+        "worker_failure": "",
+        "stop_reason": "",
+        "turns": 0,
+        "provider": "",
+        "model": "",
+        "submit_forced_budget": False,
+        "has_work": None,
+        "final_response_excerpt": "",
     }
     if store is None:
         return snap
@@ -237,6 +246,30 @@ def _agentic_store_failure_snapshot(store: Any, job_id: str = "") -> dict:
             tokens_in += int(payload.get("tokens_in") or 0)
         if not art_failure and payload.get("failure"):
             art_failure = str(payload.get("failure") or "").strip()
+        if not snap["worker_failure"] and payload.get("failure"):
+            snap["worker_failure"] = str(payload.get("failure") or "").strip()
+        if not snap["stop_reason"] and payload.get("stop_reason"):
+            snap["stop_reason"] = str(payload.get("stop_reason") or "").strip()
+        if not snap["turns"] and payload.get("turns"):
+            try:
+                snap["turns"] = int(payload.get("turns") or 0)
+            except (TypeError, ValueError):
+                pass
+        if not snap["provider"] and payload.get("provider"):
+            snap["provider"] = str(payload.get("provider") or "").strip()
+        if not snap["model"] and payload.get("model"):
+            snap["model"] = str(payload.get("model") or "").strip()
+        if payload.get("submit_forced_budget") is True:
+            snap["submit_forced_budget"] = True
+        if snap["has_work"] is None and isinstance(payload.get("has_work"), bool):
+            snap["has_work"] = payload.get("has_work")
+        if (
+            not snap["final_response_excerpt"]
+            and (payload.get("stop_reason") or isinstance(payload.get("has_work"), bool))
+            and payload.get("stdout")
+        ):
+            final_response = _redact_text(str(payload.get("stdout") or "")).strip()
+            snap["final_response_excerpt"] = final_response[-2000:]
     snap["tokens_in"] = tokens_in
     snap["tokens_out"] = tokens_out
     snap["usage_known"] = usage_known
@@ -273,6 +306,32 @@ def _format_agentic_engine_error(
     statuses = [str(item) for item in (snap.get("task_statuses") or []) if str(item).strip()]
     if statuses:
         parts.append("tasks: " + ", ".join(statuses))
+    worker_failure = redact_secret_text(
+        str(snap.get("worker_failure") or "").strip()
+    )
+    stop_reason = redact_secret_text(str(snap.get("stop_reason") or "").strip())
+    turns = snap.get("turns")
+    worker_details = []
+    if worker_failure:
+        worker_details.append(worker_failure)
+    if stop_reason:
+        worker_details.append(f"stop={stop_reason}")
+    if turns:
+        worker_details.append(f"turns={turns}")
+    provider = redact_secret_text(str(snap.get("provider") or "").strip())
+    model = redact_secret_text(str(snap.get("model") or "").strip())
+    route = "/".join(part for part in (provider, model) if part)
+    if route:
+        worker_details.append(f"route={route}")
+    if snap.get("submit_forced_budget") is True:
+        worker_details.append("budget-submit-forced")
+    if worker_details:
+        parts.append("worker: " + "; ".join(worker_details))
+    final_response = redact_secret_text(
+        str(snap.get("final_response_excerpt") or "").strip()
+    )
+    if final_response:
+        parts.append("final response: " + final_response)
     files = [str(path) for path in (files_changed or []) if str(path).strip()]
     if files:
         parts.append("unapplied worktree files: " + ", ".join(files))
@@ -313,6 +372,17 @@ def classify_agentic_exception(
         return AGENTIC_PROVIDER_RATE_LIMITED
     if isinstance(exc, TimeoutError):
         return AGENTIC_TIMEOUT
+    snapshot_data = snapshot or {}
+    snapshot_reason = str(snapshot_data.get("reason") or "").lower()
+    worker_failure = str(snapshot_data.get("worker_failure") or "").lower()
+    if (
+        "require_diff" in snapshot_reason
+        and (
+            worker_failure == "no_diff_produced"
+            or snapshot_data.get("has_work") is False
+        )
+    ):
+        return AGENTIC_NO_DIFF
     parts = [_redact_text(str(exc))]
     if snapshot:
         parts.append(str(snapshot.get("reason") or ""))
@@ -1362,6 +1432,8 @@ def run_agentic_edit(
                     tokens_in=int(usage["tokens_in"]),
                     usage_known=usage["usage_known"],
                     cost_known=usage["cost_known"],
+                    provider=str(failure_snap.get("provider") or ""),
+                    model=str(failure_snap.get("model") or ""),
                     worktree=wt_path,
                     managed_worktree_path=wt_path,
                     managed_worktree_mode="managed",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.385"
+version = "0.9.386"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_edit_engines.py
+++ b/tests/test_edit_engines.py
@@ -15,6 +15,7 @@ import pytest
 from harness.config import HarnessConfig
 from harness.edit_engines import (
     AGENTIC_ERROR,
+    AGENTIC_NO_DIFF,
     AGENTIC_ORCHESTRATOR_FAILED,
     AGENTIC_PROVIDER_RATE_LIMITED,
     AGENTIC_ROUTE_FAILED,
@@ -37,6 +38,7 @@ from harness.edit_engines import (
     _agentic_store_failure_snapshot,
     _format_agentic_engine_error,
     _summarize_agentic_result,
+    classify_agentic_exception,
     failure_is_retryable,
 )
 from harness.worker import ProviderWorker, WorkerResult
@@ -153,7 +155,18 @@ def test_agentic_store_failure_snapshot_prefers_gate_reason():
 
         def list_artifacts(self, job_id):
             art = type("A", (), {})()
-            art.payload = {"tokens_in": 40, "tokens_out": 12, "failure": "no_model"}
+            art.payload = {
+                "tokens_in": 40,
+                "tokens_out": 12,
+                "failure": "no_diff_produced",
+                "stop_reason": "submitted",
+                "turns": 9,
+                "provider": "openai-codex",
+                "model": "gpt-5.6-luna",
+                "submit_forced_budget": True,
+                "has_work": False,
+                "stdout": "Validated the current implementation but changed no files.",
+            }
             return [art]
 
     snap = _agentic_store_failure_snapshot(_Store())
@@ -164,6 +177,20 @@ def test_agentic_store_failure_snapshot_prefers_gate_reason():
     assert snap["tokens_out"] == 12
     assert snap["usage_known"] is True
     assert snap["task_ids"] == ["t1"]
+    assert snap["worker_failure"] == "no_diff_produced"
+    assert snap["stop_reason"] == "submitted"
+    assert snap["turns"] == 9
+    assert snap["provider"] == "openai-codex"
+    assert snap["model"] == "gpt-5.6-luna"
+    assert snap["submit_forced_budget"] is True
+    assert snap["has_work"] is False
+    assert snap["final_response_excerpt"] == (
+        "Validated the current implementation but changed no files."
+    )
+    assert classify_agentic_exception(
+        RuntimeError("swarm exited with incomplete tasks"),
+        snap,
+    ) == AGENTIC_NO_DIFF
     summary = _format_agentic_engine_error(
         RuntimeError("swarm exited with incomplete tasks"),
         snap,
@@ -172,6 +199,9 @@ def test_agentic_store_failure_snapshot_prefers_gate_reason():
     assert "incomplete tasks" in summary
     assert "require_diff: no PATCH artifact" in summary
     assert "tasks: implement=failed" in summary
+    assert "worker: no_diff_produced; stop=submitted; turns=9" in summary
+    assert "route=openai-codex/gpt-5.6-luna" in summary
+    assert "final response: Validated the current implementation" in summary
     assert "unapplied worktree files: src/lib/scoring/report.ts" in summary
 
 
@@ -196,6 +226,13 @@ def test_agentic_store_failure_snapshot_unknown_usage_is_not_measured_zero():
     assert snap["tokens_in"] == 0
     assert snap["tokens_out"] == 0
     assert snap["task_ids"] == ["t9"]
+
+
+def test_require_diff_without_worker_no_diff_evidence_stays_orchestrator_failure():
+    assert classify_agentic_exception(
+        RuntimeError("swarm exited with incomplete tasks"),
+        {"reason": "require_diff: no PATCH artifact"},
+    ) == AGENTIC_ORCHESTRATOR_FAILED
 
 
 def test_agentic_store_failure_snapshot_captures_events_when_reason_empty():

--- a/tests/test_worker_provenance.py
+++ b/tests/test_worker_provenance.py
@@ -271,22 +271,23 @@ def test_empty_diff_implement_failure_detector():
     assert _is_empty_diff_implement_failure(ok_patch, expects_diff=True) is False
 
 
-def test_agentic_empty_managed_implement_is_recovery_eligible():
-    result = WorkerResult(
-        ok=False,
-        error="agentic_orchestrator_failed",
-        summary="Worker produced no changes in disposable managed worktree",
-        patch="",
-        worktree_diff_empty=True,
-        managed_worktree_mode="managed",
-    )
+def test_agentic_empty_managed_implement_does_not_retry():
+    for error in ("agentic_orchestrator_failed", "agentic_no_diff"):
+        result = WorkerResult(
+            ok=False,
+            error=error,
+            summary="Worker produced no changes in disposable managed worktree",
+            patch="",
+            worktree_diff_empty=True,
+            managed_worktree_mode="managed",
+        )
 
-    assert _empty_implement_recovery_eligible(
-        result,
-        expects_diff=True,
-        live_dirty_before=["src/lib/db/schema.ts"],
-        cancelled=False,
-    ) is True
+        assert _empty_implement_recovery_eligible(
+            result,
+            expects_diff=True,
+            live_dirty_before=["src/lib/db/schema.ts"],
+            cancelled=False,
+        ) is False
 
 
 def test_agentic_orchestrator_failure_without_empty_worktree_evidence_does_not_retry():

--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -787,6 +787,8 @@ function registerUpdateBridge(ipcMain, app, shell, opts = {}) {
   // to inherit process.env (dev/CLI runs already have a full env).
   const getEnv = opts.getEnv || (() => process.env);
   const packagedUpdater = opts.packagedUpdater || null;
+  const checkSourceUpdate = opts.checkSourceUpdate || checkForUpdate;
+  const applySourceUpdate = opts.applySourceUpdate || applyUpdate;
   // Startup Puppetmaster parity result (puppetmaster-runtime.cjs). A stale
   // runtime is an update the user still owes, so the check payload carries it.
   const getRuntimeParity = opts.getRuntimeParity || (() => null);
@@ -806,7 +808,7 @@ function registerUpdateBridge(ipcMain, app, shell, opts = {}) {
     const currentVersion = app.getVersion();
     const repoRoot = getRepoRoot();
     const checkoutVersion = readCheckoutPackageVersion(repoRoot);
-    const gitRes = await checkForUpdate({ repoRoot, currentVersion, env: getEnv() });
+    const gitRes = await checkSourceUpdate({ repoRoot, currentVersion, env: getEnv() });
     let packagedRes = null;
     if (packagedUpdater && packagedUpdater.enabled) {
       try {
@@ -856,8 +858,8 @@ function registerUpdateBridge(ipcMain, app, shell, opts = {}) {
   ipcMain.handle("updates:apply", async (event, arg) => {
     if (applying) return { ok: false, error: "an update is already in progress" };
     applying = true;
-    // arg may be a strategy string ("ff"|"stash") or an options object.
-    const strategy = (arg && typeof arg === "object" ? arg.strategy : arg) || "ff";
+    // arg may be a strategy string ("auto"|"ff"|"stash") or an options object.
+    const strategy = (arg && typeof arg === "object" ? arg.strategy : arg) || "auto";
     const emit = (payload) => {
       try {
         if (event.sender && !event.sender.isDestroyed()) event.sender.send("updates:progress", payload);
@@ -873,7 +875,7 @@ function registerUpdateBridge(ipcMain, app, shell, opts = {}) {
       let checkoutVersion = readCheckoutPackageVersion(repoRoot);
       let skew = isPackaged && shellBehindCheckout({ shellVersion, checkoutVersion });
 
-      const gitRes = await checkForUpdate({
+      const gitRes = await checkSourceUpdate({
         repoRoot,
         currentVersion: shellVersion,
         env: getEnv(),
@@ -900,30 +902,24 @@ function registerUpdateBridge(ipcMain, app, shell, opts = {}) {
 
       let sourceResult = { ok: true, skipped: true, mainProcessChanged: false };
       if (plan.runSource) {
-        sourceResult = await applyUpdate({ repoRoot, strategy, env: getEnv() }, emit);
+        const sourceStrategy = strategy === "auto"
+          ? (gitRes.dirty ? "stash" : "ff")
+          : strategy;
+        sourceResult = await applySourceUpdate(
+          { repoRoot, strategy: sourceStrategy, env: getEnv() },
+          emit,
+        );
         if (!sourceResult.ok) {
-          // Source plane failed, but a packaged shell update can still finish
-          // the user-visible "update Marionette" path. Prefer that over opening
-          // GitHub when electron-updater already has a newer build ready.
-          const canContinueShell =
-            plan.runShell && packagedUpdater && packagedUpdater.enabled;
-          if (!canContinueShell) return sourceResult;
           appendUpdateLog(
-            `[apply] source failed (${sourceResult.code || "error"}); continuing with packaged shell install`
+            `[apply] source failed (${sourceResult.code || "error"}); packaged shell stage skipped`
           );
-          sourceResult = {
-            ok: true,
-            skipped: true,
-            mainProcessChanged: false,
-            sourceError: sourceResult.error || sourceResult.code || "source update failed",
-          };
-        } else {
-          checkoutVersion = readCheckoutPackageVersion(repoRoot);
-          skew = isPackaged && shellBehindCheckout({ shellVersion, checkoutVersion });
-          // After pull, main-process or version skew may newly require the installer.
-          if (isPackaged && (skew || sourceResult.mainProcessChanged)) {
-            plan = { ...plan, runShell: true, sequence: [...plan.sequence.filter((s) => s !== "shell"), "shell"] };
-          }
+          return sourceResult;
+        }
+        checkoutVersion = readCheckoutPackageVersion(repoRoot);
+        skew = isPackaged && shellBehindCheckout({ shellVersion, checkoutVersion });
+        // After pull, main-process or version skew may newly require the installer.
+        if (isPackaged && (skew || sourceResult.mainProcessChanged)) {
+          plan = { ...plan, runShell: true, sequence: [...plan.sequence.filter((s) => s !== "shell"), "shell"] };
         }
       }
 

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -117,6 +117,79 @@ test("checkForUpdate: only a fast-forwardable source checkout is actionable", as
   assert.equal(fork.available, false);
 });
 
+function registerUpdateApplyHarness({ dirty, sourceResult }) {
+  const handlers = {};
+  const observed = { sourceStrategies: [], shellInstalls: 0 };
+  const packagedUpdater = {
+    enabled: true,
+    check: async () => ({ available: true, latest: "0.9.386" }),
+    isDownloaded: () => false,
+    downloadAndInstall: async () => {
+      observed.shellInstalls += 1;
+      return { ok: true };
+    },
+  };
+
+  bridge.registerUpdateBridge(
+    {
+      handle(channel, handler) {
+        handlers[channel] = handler;
+      },
+    },
+    { isPackaged: true, getVersion: () => "0.9.385" },
+    { openExternal: async () => true },
+    {
+      getRepoRoot: () => path.join(os.tmpdir(), "marionette-update-test"),
+      packagedUpdater,
+      checkSourceUpdate: async () => ({
+        available: true,
+        dirty,
+        ahead: 0,
+      }),
+      applySourceUpdate: async ({ strategy }) => {
+        observed.sourceStrategies.push(strategy);
+        return sourceResult;
+      },
+    },
+  );
+
+  return {
+    apply: () => handlers["updates:apply"]({
+      sender: { isDestroyed: () => false, send() {} },
+    }),
+    observed,
+  };
+}
+
+test("updates:apply preserves dirty self-edits in the same source-to-shell transaction", async () => {
+  const update = registerUpdateApplyHarness({
+    dirty: true,
+    sourceResult: { ok: true, mainProcessChanged: false },
+  });
+
+  const result = await update.apply();
+
+  assert.deepEqual(update.observed.sourceStrategies, ["stash"]);
+  assert.equal(result.ok, true);
+  assert.equal(update.observed.shellInstalls, 1);
+});
+
+test("updates:apply does not install the packaged shell after a source failure", async () => {
+  const update = registerUpdateApplyHarness({
+    dirty: false,
+    sourceResult: {
+      ok: false,
+      code: "conflict",
+      error: "source update failed",
+    },
+  });
+
+  const result = await update.apply();
+
+  assert.equal(result.code, "conflict");
+  assert.equal(update.observed.shellInstalls, 0);
+});
+
 test("overallPercent: monotonic across the pipeline, clamped to 0..100", () => {
   assert.equal(steps.overallPercent("idle"), 0);
   const fetchEnd = steps.overallPercent("fetch", 1);

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.385",
+  "version": "0.9.386",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.385",
+      "version": "0.9.386",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.385",
+  "version": "0.9.386",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/LeftRail.layout.test.tsx
+++ b/webapp/src/__tests__/LeftRail.layout.test.tsx
@@ -41,10 +41,14 @@ describe("LeftRail branch layout", () => {
     await screen.findByRole("button", { name: /main/ });
     const branchList = container.querySelector<HTMLElement>("[data-slot=left-rail-branches-list]");
     const upperSections = container.querySelector<HTMLElement>("[data-slot=left-rail-upper-sections]");
+    const jobsPanel = container.querySelector<HTMLElement>("[data-slot=left-rail-jobs]");
+    const jobScopes = container.querySelector<HTMLElement>("[data-slot=left-rail-job-scopes]");
     expect(screen.getByRole("button", { name: "Jobs" })).toBeInTheDocument();
     expect(screen.getByRole("separator", { name: "Resize branches list" })).toBeInTheDocument();
     expect(branchList?.style.height).toBe("");
     expect(branchList?.style.maxHeight).not.toBe("");
     expect(upperSections?.className.split(" ")).not.toContain("flex-1");
+    expect(jobsPanel).toHaveClass("mt-auto");
+    expect(jobScopes).toHaveClass("grid", "grid-cols-3");
   });
 });

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -115,7 +115,6 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     window.addEventListener("harness-job-scope-changed", onScope);
     return () => window.removeEventListener("harness-job-scope-changed", onScope);
   }, []);
-  const [confirmClearJobs, setConfirmClearJobs] = useState(false);
   const [showAllJobs, setShowAllJobs] = useState(false);
   const [expandedJobs, setExpandedJobs] = useState<Record<string, boolean>>({});
   const [sessionJobsHeight, setSessionJobsHeight] = useState(loadSessionJobsHeight);
@@ -1232,7 +1231,6 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       for (const j of terminalVisibleJobs) next.add(j.id);
       return next;
     });
-    setConfirmClearJobs(false);
   };
 
   const restoreHiddenJobs = () => setHiddenJobIds(new Set());
@@ -1906,7 +1904,8 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
           session doesn't swallow the left rail. Vertically resizable via the
           grab handle above the header. */}
       <div
-        className="px-2 shrink-0 border-t border-edge/40 min-w-0 flex flex-col"
+        data-slot="left-rail-jobs"
+        className="mt-auto px-2 shrink-0 border-t border-edge/40 min-w-0 flex flex-col"
         style={sessionJobsCollapsed ? undefined : { height: sessionJobsHeight }}
       >
         {!sessionJobsCollapsed && (
@@ -1923,22 +1922,40 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
             <div className="w-8 h-0.5 rounded-full bg-edge/80 group-hover:bg-muted/80 transition-colors" />
           </div>
         )}
-        <div className={`h-7 flex items-center justify-between px-1.5 mb-1 gap-2 min-w-0 shrink-0 ${sessionJobsCollapsed ? "mt-2" : ""}`}>
-          <button
-            onClick={toggleSessionJobsCollapsed}
-            className="h-6 flex items-center gap-1 min-w-0 text-[11px] uppercase tracking-wider text-muted font-semibold hover:text-txt focus:outline-none"
-          >
-            {sessionJobsCollapsed ? <ChevronRight size={11} className="shrink-0" /> : <ChevronDown size={11} className="shrink-0" />}
-            <span className="truncate">Jobs</span>
-            {jobsValidating && !sessionJobsCollapsed && (
-              <Loader2 size={10} className="animate-spin text-muted shrink-0" />
+        <div
+          data-slot="left-rail-jobs-header"
+          className={`shrink-0 min-w-0 ${sessionJobsCollapsed ? "mt-2" : ""}`}
+        >
+          <div className="h-7 flex items-center justify-between px-1.5 gap-2 min-w-0">
+            <button
+              onClick={toggleSessionJobsCollapsed}
+              className="h-6 flex items-center gap-1 min-w-0 text-[11px] uppercase tracking-wider text-muted font-semibold hover:text-txt focus:outline-none"
+            >
+              {sessionJobsCollapsed ? <ChevronRight size={11} className="shrink-0" /> : <ChevronDown size={11} className="shrink-0" />}
+              <span className="truncate">Jobs</span>
+              {jobsValidating && !sessionJobsCollapsed && (
+                <Loader2 size={10} className="animate-spin text-muted shrink-0" />
+              )}
+              {visibleJobs.length > 0 && (
+                <span className="text-faint/70 normal-case tracking-normal shrink-0">({visibleJobs.length})</span>
+              )}
+            </button>
+            {!sessionJobsCollapsed && terminalVisibleJobs.length > 0 && (
+              <button
+                type="button"
+                aria-label="Clear finished jobs"
+                onClick={clearFinishedJobs}
+                className="h-6 w-6 shrink-0 grid place-items-center rounded text-faint hover:bg-panel2/60 hover:text-red-400 focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/70 transition-colors"
+              >
+                <Trash2 size={11} />
+              </button>
             )}
-            {visibleJobs.length > 0 && (
-              <span className="text-faint/70 normal-case tracking-normal shrink-0">({visibleJobs.length})</span>
-            )}
-          </button>
+          </div>
           {!sessionJobsCollapsed && (
-            <div className="flex h-5 overflow-hidden rounded border border-edge/70 shrink-0">
+            <div
+              data-slot="left-rail-job-scopes"
+              className="grid grid-cols-3 h-6 mx-1.5 mb-1 overflow-hidden rounded border border-edge/70"
+            >
               {(["session", "repo", "all"] as const).map((scope) => (
                 <button
                   key={scope}
@@ -1946,38 +1963,12 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                   aria-pressed={jobScope === scope}
                   aria-label={scope === "session" ? "This session" : scope === "repo" ? "This repo" : "All projects"}
                   onClick={(e) => { e.stopPropagation(); setJobScope(scope); saveJobScope(scope); }}
-                  className={`px-1.5 text-[9px] uppercase tracking-wider ${jobScope === scope ? "bg-accent/15 text-txt" : "text-muted hover:text-txt"}`}
+                  className={`min-w-0 text-[9px] uppercase tracking-wider ${jobScope === scope ? "bg-accent/15 text-txt" : "text-muted hover:text-txt"}`}
                 >
                   {scope === "session" ? "Session" : scope === "repo" ? "Repo" : "All"}
                 </button>
               ))}
             </div>
-          )}
-          {!sessionJobsCollapsed && terminalVisibleJobs.length > 0 && (
-            confirmClearJobs ? (
-              <div className="flex items-center gap-2 text-[10px] shrink-0">
-                <span className="text-muted">Clear all?</span>
-                <button
-                  onClick={clearFinishedJobs}
-                  className="text-red-400 font-semibold hover:underline"
-                >
-                  Yes
-                </button>
-                <button
-                  onClick={() => setConfirmClearJobs(false)}
-                  className="text-muted hover:underline"
-                >
-                  No
-                </button>
-              </div>
-            ) : (
-              <button
-                onClick={() => setConfirmClearJobs(true)}
-                className="text-[10px] text-faint hover:text-red-400 transition-colors shrink-0"
-              >
-                Clear jobs
-              </button>
-            )
           )}
         </div>
         {!sessionJobsCollapsed && (


### PR DESCRIPTION
## Summary
- make dirty-checkout source updates converge in one click before the packaged-shell stage
- restore the bottom-anchored, upward-expanding left Jobs panel and give its narrow header a dedicated scope row
- classify agentic no-diff outcomes truthfully, preserve bounded worker diagnostics, and prevent wasteful full-worker retries

## Test plan
- [x] `.venv/bin/python -m pytest -q` (5,351 passed, 78 skipped)
- [x] `npm test` (1,512 passed)
- [x] `npm run test:electron` (206 passed)
- [x] `npm run build`
- [x] `tests/test_version_consistency.py`
- [x] browser geometry check at narrow left-rail width: zero bottom gap and no scope overflow
- [ ] GitHub `tests` matrix green
- [ ] macOS, Windows, and Linux installer builds green