### PR TITLE
Fix stale Investigating after external swarm completion

### DIFF
--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -1,3 +1,5 @@
+import { createElement } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi, afterEach } from "vitest";
 import {
   chatFrameToStreamEvent,
@@ -21,13 +23,13 @@ import {
   isUpgradeableActionResult,
 } from "../components/Conversation";
 import { api } from "../lib/api";
-import type { Item } from "../components/TranscriptList";
+import { TranscriptList, type Item } from "../components/TranscriptList";
 import { chatEventsPath, sessionEventsPath } from "../lib/transport";
 import { nextStoreCursor, shouldApplyStoreEvent } from "../components/conversation/storeEvents";
 
 /**
- * Mid-turn chatEvents reattach contracts (cursor + poll gating).
- * Does not mount Conversation — covers pure helpers only.
+ * Mid-turn chatEvents reattach contracts (cursor + poll gating), plus the
+ * mounted transcript boundary for terminal reconciliation.
  */
 
 describe("chatEvents reattach cursor", () => {
@@ -940,6 +942,7 @@ describe("Wave 4 command-job reattach fences", () => {
 
 describe("mid-turn store-event cursor reattach", () => {
   afterEach(() => {
+    cleanup();
     vi.restoreAllMocks();
     vi.useRealTimers();
   });
@@ -1177,6 +1180,170 @@ describe("mid-turn store-event cursor reattach", () => {
     expect(setStatus).not.toHaveBeenCalled();
     expect(live).not.toHaveBeenCalled();
     expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+  });
+
+  it("clears mounted Investigating when an external stream misses the terminal", async () => {
+    let items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "review the claim" } },
+      {
+        kind: "card",
+        card: {
+          id: "swarm-call",
+          goal: "review the claim",
+          cwd: null,
+          kind: "run_swarm",
+          running: true,
+          open: false,
+        },
+      },
+    ];
+    const itemsRef = { current: items };
+    let turnOpen = false;
+    let status: "idle" | "thinking" = "idle";
+    const deps = reattachDeps({
+      itemsRef,
+      transcriptFpRef: { current: "" },
+      setItems: (next: Item[] | ((prev: Item[]) => Item[])) => {
+        items = typeof next === "function" ? next(items) : next;
+        itemsRef.current = items;
+      },
+      setTurnOpen: (next: boolean) => { turnOpen = next; },
+      setStatus: (next: any) => {
+        status = typeof next === "function" ? next(status) : next;
+      },
+    });
+    deps.detachedBusyRef.current = false;
+
+    const readEventsSince = vi.spyOn(api, "readEventsSince")
+      .mockResolvedValueOnce({
+        cursor: 1,
+        events: [{
+          id: 1,
+          kind: "runners",
+          data: { state: "running", runners: { "sess-live": "running" } },
+        }],
+      } as any)
+      .mockResolvedValue({
+        cursor: 2,
+        events: [{
+          id: 2,
+          kind: "runners",
+          data: { state: "idle", runners: { "sess-live": "idle" } },
+        }],
+      } as any);
+    const sessionTranscript = vi.spyOn(api, "sessionTranscript").mockResolvedValue({
+      display: [
+        { role: "user", text: "review the claim" },
+        {
+          type: "card",
+          id: "swarm-call",
+          goal: "review the claim",
+          kind: "run_swarm",
+          result: { job_id: "job_done", status: "complete" },
+        },
+        { role: "assistant", text: "The review is complete." },
+      ],
+    } as any);
+
+    const { pullChatEvents } = createChatEventsReattach(deps as any);
+    await pullChatEvents();
+
+    const transcriptProps = () => ({
+      items,
+      status,
+      compactingStatus: null,
+      editingIndex: null,
+      auto: false,
+      plan: false,
+      turnOpen,
+      holdSwarmAwait: false,
+      scrollContainerRef: { current: null },
+      onEditMessage: vi.fn(),
+      onExecuteSend: vi.fn(),
+      onImageClick: vi.fn(),
+      onSetCard: vi.fn(),
+      onExecutePlan: vi.fn(),
+      onCommandApproval: vi.fn(),
+    });
+    const mounted = render(createElement(TranscriptList, transcriptProps()));
+    expect(screen.getByText(/Investigating/i)).toBeTruthy();
+
+    await pullChatEvents();
+    await pullChatEvents();
+    mounted.rerender(createElement(TranscriptList, transcriptProps()));
+
+    expect(readEventsSince).toHaveBeenCalledTimes(3);
+    expect(sessionTranscript).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("The review is complete.")).toBeTruthy();
+    expect(screen.queryByText(/Investigating/i)).toBeNull();
+  });
+
+  it("keeps an unrelated active swarm whose call id only cross-matches a terminal", async () => {
+    let items: Item[] = [{
+      kind: "card",
+      card: {
+        id: "active-card",
+        call_id: "terminal-card",
+        goal: "still active",
+        cwd: null,
+        kind: "run_swarm",
+        running: true,
+        open: false,
+      },
+    }];
+    const itemsRef = { current: items };
+    const deps = reattachDeps({
+      itemsRef,
+      transcriptFpRef: { current: "" },
+      setItems: (next: Item[] | ((prev: Item[]) => Item[])) => {
+        items = typeof next === "function" ? next(items) : next;
+        itemsRef.current = items;
+      },
+    });
+    vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      cursor: 2,
+      events: [{
+        id: 2,
+        kind: "runners",
+        data: { state: "idle", runners: { "sess-live": "idle" } },
+      }],
+    } as any);
+    vi.spyOn(api, "sessionTranscript").mockResolvedValue({
+      display: [{
+        type: "card",
+        id: "terminal-card",
+        call_id: "different-terminal-call",
+        goal: "finished elsewhere",
+        kind: "run_swarm",
+        result: { job_id: "job_done", status: "complete" },
+      }],
+    } as any);
+
+    const { pullChatEvents } = createChatEventsReattach(deps as any);
+    await pullChatEvents();
+    await pullChatEvents();
+
+    expect(items.some(
+      (item) => item.kind === "card" && item.card.id === "active-card" && item.card.running,
+    )).toBe(true);
+    render(createElement(TranscriptList, {
+      items,
+      status: "thinking",
+      compactingStatus: null,
+      editingIndex: null,
+      auto: false,
+      plan: false,
+      turnOpen: true,
+      holdSwarmAwait: false,
+      scrollContainerRef: { current: null },
+      onEditMessage: vi.fn(),
+      onExecuteSend: vi.fn(),
+      onImageClick: vi.fn(),
+      onSetCard: vi.fn(),
+      onExecutePlan: vi.fn(),
+      onCommandApproval: vi.fn(),
+    }));
+    expect(screen.getByText(/Investigating/i)).toBeTruthy();
   });
 
   it("sessionEventsPath builds the store cursor URL", () => {

--- a/webapp/src/components/conversation/chatEventsReattach.ts
+++ b/webapp/src/components/conversation/chatEventsReattach.ts
@@ -170,6 +170,14 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
         return;
       }
       if (localStreamActiveRef.current) return;
+      const terminalSwarmCalls = (Array.isArray(tres.display) ? tres.display : [])
+        .filter((row: any) => row?.type === "card" && row?.kind === "run_swarm" && row?.result != null)
+        .map((row: any) => {
+          const id = String(row.id || "").trim();
+          const callId = String(row.call_id || row.id || "").trim();
+          return { id, callId };
+        })
+        .filter((row) => row.id && row.callId);
       const loadedItems = transcriptResponseToItems(tres);
       let applied = false;
       setItems((prev) => {
@@ -183,7 +191,15 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
           return prev;
         }
         if (localStreamActiveRef.current) return prev;
-        const next = mergeTranscriptItems(prev, loadedItems);
+        const local = prev.filter((item) => {
+          if (item.kind !== "card" || item.card.kind !== "run_swarm") return true;
+          const id = String(item.card.id || "").trim();
+          const callId = String(item.card.call_id || item.card.id || "").trim();
+          return !terminalSwarmCalls.some(
+            (terminal) => terminal.id === id && terminal.callId === callId,
+          );
+        });
+        const next = mergeTranscriptItems(local, loadedItems);
         const fp = transcriptFingerprint(next);
         if (fp === transcriptFpRef.current) return prev;
         transcriptFpRef.current = fp;
@@ -287,7 +303,8 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
 
     if (detachedBusyRef.current) {
       consecutiveIdlePolls += 1;
-      const tick = runnersBusyTickDecision({
+      let refreshedAfterConfirmedIdle = false;
+      let tick = runnersBusyTickDecision({
         userStopped: userStoppedRef.current,
         localStreamActive: localStreamActiveRef.current,
         runnerBusy: false,
@@ -297,6 +314,26 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
         consecutiveIdlePolls,
         idleConfirmPolls: RUNNERS_IDLE_CONFIRM_POLLS,
       });
+      if (
+        tick.kind === "hold_live_investigation"
+        && consecutiveIdlePolls >= RUNNERS_IDLE_CONFIRM_POLLS
+      ) {
+        // A missed terminal can leave the local card running forever. Once the
+        // backend is durably idle, refresh its completed transcript before
+        // deciding whether the investigation is still live.
+        await refreshTranscriptFromDisk(sid);
+        refreshedAfterConfirmedIdle = true;
+        tick = runnersBusyTickDecision({
+          userStopped: userStoppedRef.current,
+          localStreamActive: localStreamActiveRef.current,
+          runnerBusy: false,
+          detachedBusy: true,
+          chatEventsPollArmed: chatEventsReattachArmed(),
+          items: itemsRef.current,
+          consecutiveIdlePolls,
+          idleConfirmPolls: RUNNERS_IDLE_CONFIRM_POLLS,
+        });
+      }
       if (
         tick.kind === "hold_live_investigation"
         || tick.kind === "hold_idle_unconfirmed"
@@ -310,7 +347,9 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
       setStatus("idle");
       setCompactingStatus?.(null);
       setBackendPendingSwarms?.(false);
-      await refreshTranscriptFromDisk(sid);
+      if (!refreshedAfterConfirmedIdle) {
+        await refreshTranscriptFromDisk(sid);
+      }
       return true;
     }
 


### PR DESCRIPTION
## Summary

- Settles stale `Investigating` after an externally initiated `run_swarm` misses its terminal stream frame.
- Refreshes the durable transcript only after the backend is confirmed idle.
- Removes only the terminal local swarm card matching the durable `(id, call_id)` pair before the existing transcript merge.

## Problem

A turn could be fully complete while Marionette remained stuck on `Investigating`:

```text
backend idle
+ no pending swarm
+ durable final answer and assistant_done
+ local run_swarm ActionCard still marked running
```

The previous missed-terminal fix replayed a stored terminal frame when that frame remained available. This case had already advanced past it. Durable transcript hydration also intentionally suppresses `run_swarm` ActionCards because `SwarmResultCard` owns terminal results, so the stale local card had no remote counterpart to settle it.

That formed a loop: the running local card blocked idle settlement, while idle settlement was required to refresh the transcript that proved the card terminal.

## Change

After the existing confirmed-idle gate:

1. Read the durable transcript once.
2. Find terminal `run_swarm` cards with non-null results.
3. Correlate them to local cards by the exact normalized `(id, call_id)` pair.
4. Remove only those stale local ActionCards before merging the durable transcript.
5. Re-run the existing activity decision and settle through the existing status/`turnOpen` owner.

No timeout, new state owner, endpoint, timer, component, or broad recovery path.

## Proof

The mounted RED reproduces the public sequence:

```text
external runner becomes busy
→ run_swarm paints Investigating
→ terminal frame is missed
→ backend becomes durably idle
→ transcript contains terminal run_swarm + final answer
→ final answer paints
→ Investigating disappears
```

A second mounted regression cross-matches one identifier and proves an unrelated active swarm remains visible.

- Focused reattach/fold matrix: **41 passed**
- Oxlint: clean
- TypeScript/Vite production build: passed
- Mounted branch proof on the original affected session:
  - durable final answer visible
  - exact review job visible
  - header `Ready`
  - **0 live Investigating folds**
- Original workspace and settled transcript restored after proof

Existing jsdom canvas and Vite chunk-size warnings remain unchanged.
