### PR TITLE
Release Marionette v0.9.388

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.42` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.387, deliberately pre-1.0. Rides puppetmaster-ai==1.22.42. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.388, deliberately pre-1.0. Rides puppetmaster-ai==1.22.42. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.387"
+__version__ = "0.9.388"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/cost.py
+++ b/harness/api/cost.py
@@ -215,6 +215,7 @@ def _scoped_jobs_with_stores(repo_root: str | None = None) -> tuple[list, Any, A
         store,
         active_session_id=active_session_id,
         repo_root=effective_repo,
+        registered_job_ids=registered_job_ids,
     )
     try:
         merged, cli_store, cli_tasks = merge_scoped_cli_jobs(
@@ -223,6 +224,7 @@ def _scoped_jobs_with_stores(repo_root: str | None = None) -> tuple[list, Any, A
             active_session_id=active_session_id,
             repo_root=effective_repo,
             workspace_root=workspace_root,
+            registered_job_ids=registered_job_ids,
         )
         tasks_by_job = {**harness_tasks, **cli_tasks}
         tagged = annotate_jobs_accounting(
@@ -245,12 +247,11 @@ def _scoped_jobs_with_stores(repo_root: str | None = None) -> tuple[list, Any, A
 
 
 def _scoped_jobs_snapshot(repo_root: str | None = None) -> list:
-    """Jobs visible for the active harness session and open workspace.
+    """Marionette-owned jobs for /api/jobs and /api/swarm/live.
 
-    When ``repo_root`` is present and non-empty it overrides ``_cfg().repo`` for
-    legacy (unstamped) cwd filtering; stamped session jobs are unchanged.
-    Merges read-only CLI jobs from the Puppetmaster per-project store when
-    present (tagged ``source``: ``harness`` or ``cli``).
+    Admission is origin+session (or a registered job id), not cwd/repo match.
+    Merges read-only CLI jobs from the Puppetmaster per-project store only when
+    those rows are similarly owned (tagged ``source``: ``harness`` or ``cli``).
     """
     jobs, _, _ = _scoped_jobs_with_stores(repo_root)
     return jobs

--- a/harness/api/jobs.py
+++ b/harness/api/jobs.py
@@ -109,6 +109,182 @@ def canonical_job_outcome(raw_artifacts: list[Any]) -> dict[str, Any]:
         }
 
 
+def _job_access_owned(job_id: str, svc: JobServices) -> bool | None:
+    """True if owned, False if known-unowned, None if not found in known stores.
+
+    Harness/local registered-id healing applies only to the harness store.
+    A colliding id in a CLI store cannot inherit that registry.
+    """
+    from ..job_scoping import inspect_store_job_ownership
+
+    registered: list = []
+    try:
+        registered = list(getattr(svc.get_pilot(), "_session_job_ids", []) or [])
+    except Exception:
+        registered = []
+
+    harness_store = None
+    try:
+        harness_store = svc.get_session().state().store
+    except Exception:
+        harness_store = None
+    found = inspect_store_job_ownership(
+        harness_store,
+        job_id,
+        source="harness",
+        registered_job_ids=registered,
+        allow_registered_heal=True,
+    )
+    if found is not None:
+        return found
+
+    cli_store = None
+    try:
+        from ..cli_job_merge import open_cli_durable_state
+
+        cli_state = open_cli_durable_state(svc.cfg.repo or "")
+        cli_store = getattr(cli_state, "store", None) if cli_state is not None else None
+    except Exception:
+        cli_store = None
+    return inspect_store_job_ownership(
+        cli_store,
+        job_id,
+        source="cli",
+        registered_job_ids=None,
+        allow_registered_heal=False,
+    )
+
+
+def _inspect_sibling_job(job_id: str) -> tuple[bool | None, Any]:
+    """Inspect sibling-store ownership after a primary miss.
+
+    Returns ``(owned, durable)``. ``owned`` is True/False when the job is in
+    that store, else None. ``durable`` is the already-open sibling state so
+    cancel/artifacts can reuse it. Registered-id healing stays off.
+    """
+    from ..cli_job_merge import cross_project_scan_enabled, open_cli_durable_at
+    from ..job_scoping import inspect_store_job_ownership
+
+    if not cross_project_scan_enabled():
+        return None, None
+    try:
+        from puppetmaster.state import find_state_dir_for_job
+
+        state_dir = find_state_dir_for_job(job_id)
+    except Exception:
+        state_dir = None
+    if state_dir is None:
+        return None, None
+    try:
+        durable = open_cli_durable_at(str(state_dir))
+    except Exception:
+        durable = None
+    store = getattr(durable, "store", None) if durable is not None else None
+    if store is None:
+        return None, None
+    owned = inspect_store_job_ownership(
+        store,
+        job_id,
+        source="cli",
+        registered_job_ids=None,
+        allow_registered_heal=False,
+    )
+    return owned, durable
+
+
+def _inspect_local_job_ownership(job_id: str, svc: JobServices) -> bool | None:
+    """True if this session may cancel the local job, False if foreign, None if absent.
+
+    Cancel is session/registered-gated even though the tracker lists all
+    Marionette-owned locals. A row from another session is unknown.
+    """
+    try:
+        pilot = svc.get_pilot()
+    except Exception:
+        return None
+    if pilot is None:
+        return None
+
+    job = None
+    getter = getattr(pilot, "get_local_job", None)
+    if callable(getter):
+        try:
+            job = getter(job_id)
+        except Exception:
+            job = None
+    if not isinstance(job, dict):
+        live = getattr(pilot, "live_local_jobs", None)
+        if callable(live):
+            try:
+                for row in live() or []:
+                    if str((row or {}).get("id") or "") == job_id:
+                        job = row
+                        break
+            except Exception:
+                job = None
+    if not isinstance(job, dict):
+        return None
+
+    registered: list = []
+    try:
+        registered = list(getattr(pilot, "_session_job_ids", []) or [])
+    except Exception:
+        registered = []
+    if job_id in {str(x).strip() for x in registered if x}:
+        return True
+
+    active_session_id = ""
+    try:
+        active_session_id = (
+            getattr(svc.sessions, "active", None)
+            or getattr(pilot, "harness_session_id", "")
+            or ""
+        )
+    except Exception:
+        active_session_id = getattr(pilot, "harness_session_id", "") or ""
+    job_sid = str(job.get("session_id") or "").strip()
+    if job_sid and job_sid == str(active_session_id or "").strip():
+        return True
+    return False
+
+
+def _trip_owned_cancel(job_id: str, svc: JobServices) -> None:
+    """Trip the in-process kill switch only after positive ownership."""
+    try:
+        from puppetmaster.cancellation import request_cancel
+
+        request_cancel(job_id)
+    except Exception as e:
+        svc.diag("server.swarm_cancel_flag", e)
+
+
+def _unknown_job_refusal(job_id: str) -> tuple[int, dict]:
+    return 404, {"ok": False, "error": "unknown job_id", "job_id": job_id}
+
+
+def _artifacts_from_durable(durable: Any, job_id: str, svc: JobServices, state_obj: Any) -> list:
+    """Load formatted artifacts from an already-open DurableState-like object."""
+    if durable is None:
+        return []
+    if hasattr(durable, "job_artifacts"):
+        return list(svc.retry_on_locked(lambda: durable.job_artifacts(job_id)) or [])
+    store = getattr(durable, "store", None)
+    if store is None or not hasattr(store, "list_artifacts"):
+        return []
+    raw = svc.retry_on_locked(lambda: store.list_artifacts(job_id))
+    fmt = state_obj
+    if fmt is None or not hasattr(fmt, "format_artifacts"):
+        try:
+            fmt = svc.get_session().state()
+        except Exception:
+            fmt = durable
+    if hasattr(fmt, "format_artifacts"):
+        return list(fmt.format_artifacts(raw) or [])
+    if hasattr(durable, "format_artifacts"):
+        return list(durable.format_artifacts(raw) or [])
+    return []
+
+
 def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
     """Cooperative cancel for a swarm job. Best-effort and never raises.
 
@@ -120,27 +296,50 @@ def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
     if not job_id:
         return 400, {"ok": False, "error": "missing job_id"}
 
-    # 0) Trip the in-process kill switch FIRST: inline agentic workers
-    # check it mid-stream (per chunk) and per turn, so the swarm stops in
-    # seconds instead of "cancelling..." until the workers run out of
-    # turns naturally.
-    try:
-        from puppetmaster.cancellation import request_cancel
-        request_cancel(job_id)
-    except Exception as e:
-        svc.diag("server.swarm_cancel_flag", e)
+    local_owned = _inspect_local_job_ownership(job_id, svc)
+    if local_owned is False:
+        return _unknown_job_refusal(job_id)
+    if local_owned is True:
+        _trip_owned_cancel(job_id, svc)
+        try:
+            pilot = svc.get_pilot()
+            if hasattr(pilot, "cancel_local_job") and pilot.cancel_local_job(job_id):
+                return 200, {"ok": True, "job_id": job_id}
+        except Exception as e:
+            svc.diag("server.swarm_cancel_local", e)
 
-    # 1) Local provider-worker job on the live conversation.
-    try:
-        pilot = svc.get_pilot()
-        if hasattr(pilot, "cancel_local_job") and pilot.cancel_local_job(job_id):
-            return 200, {"ok": True, "job_id": job_id}
-    except Exception as e:
-        svc.diag("server.swarm_cancel_local", e)
+    owned = _job_access_owned(job_id, svc)
+    sibling_durable = None
+    if owned is False:
+        return _unknown_job_refusal(job_id)
+    if owned is None:
+        # Primary harness + primary CLI miss: inspect the sibling store
+        # ourselves. Do not fail-open into cancel_job_dual_store.
+        sibling_owned, sibling_durable = _inspect_sibling_job(job_id)
+        if sibling_owned is not True:
+            return _unknown_job_refusal(job_id)
+
+    _trip_owned_cancel(job_id, svc)
+
+    if sibling_durable is not None:
+        try:
+            from ..job_cancel import mark_store_job_cancelled
+
+            store = getattr(sibling_durable, "store", None)
+            return 200, {
+                "ok": True,
+                "job_id": job_id,
+                "durable": True,
+                "marked": mark_store_job_cancelled(store, job_id),
+            }
+        except Exception as e:
+            svc.diag("server.swarm_cancel_sibling", e)
+            return _unknown_job_refusal(job_id)
 
     # 2) Durable Puppetmaster store job -- best-effort mark cancelled.
     # Canonical dual-store seam (harness then CLI): shared with
     # BusyControlMixin.interrupt so membership/cancel cannot diverge.
+    # Primary-store hits only — sibling ids are handled above.
     try:
         from ..job_cancel import cancel_job_dual_store
 
@@ -163,44 +362,60 @@ def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
             return 200, result
     except Exception as e:
         svc.diag("server.swarm_cancel_durable", e)
-    return 404, {"ok": False, "error": "unknown job_id", "job_id": job_id}
+    return _unknown_job_refusal(job_id)
 
 
 def get_jobs(repo_override: str | None, svc: JobServices) -> tuple[int, list]:
-    """GET /api/jobs — workspace-scoped job list (harness + CLI merge)."""
+    """GET /api/jobs — Marionette-owned job list (harness + owned CLI merge)."""
     return 200, svc.scoped_jobs_snapshot(repo_root=repo_override or None)
 
 
 def get_artifacts(job_id: str | None, svc: JobServices) -> tuple[int, Any]:
-    """GET /api/artifacts — dual-store resolve (harness, then CLI durable)."""
-    if not (job_id or "").strip():
+    """GET /api/artifacts — owned dual-store resolve (harness, then CLI durable).
+
+    A primary miss inspects the sibling store and reads it only when owned.
+    Unknown or unowned ids return empty without reading by id.
+    """
+    jid = (job_id or "").strip()
+    if not jid:
         return 400, {"error": "missing job id"}
+    owned = _job_access_owned(jid, svc)
     artifacts: list = []
     state_obj = None
     try:
         state_obj = svc.get_session().state()
-        artifacts = svc.retry_on_locked(lambda: state_obj.job_artifacts(job_id))
     except Exception:
-        artifacts = []
-    if not artifacts:
+        state_obj = None
+    if owned is False:
+        return 200, []
+    if owned is None:
+        sibling_owned, sibling_durable = _inspect_sibling_job(jid)
+        if sibling_owned is not True:
+            return 200, []
         try:
-            from ..cli_job_merge import open_cli_durable_state
-            cli_state = open_cli_durable_state(svc.cfg.repo or "")
-            if cli_state is not None and hasattr(cli_state, "job_artifacts"):
-                artifacts = svc.retry_on_locked(lambda: cli_state.job_artifacts(job_id))
-            elif cli_state is not None and hasattr(cli_state, "store"):
-                raw = svc.retry_on_locked(lambda: cli_state.store.list_artifacts(job_id))
-                fmt = state_obj or svc.get_session().state()
-                if hasattr(fmt, "format_artifacts"):
-                    artifacts = fmt.format_artifacts(raw)
+            artifacts = _artifacts_from_durable(sibling_durable, jid, svc, state_obj)
         except Exception:
-            pass
+            artifacts = []
+    else:
+        try:
+            if state_obj is not None:
+                artifacts = svc.retry_on_locked(lambda: state_obj.job_artifacts(jid))
+        except Exception:
+            artifacts = []
+        if not artifacts:
+            try:
+                from ..cli_job_merge import open_cli_durable_state
+
+                cli_state = open_cli_durable_state(svc.cfg.repo or "")
+                artifacts = _artifacts_from_durable(cli_state, jid, svc, state_obj)
+            except Exception:
+                pass
     try:
         from ..session_fts import best_effort_index_job_artifacts
 
         best_effort_index_job_artifacts(
             svc.cfg.state_dir or "",
-            job_id,
+            jid,
             artifacts=artifacts,
             durable=state_obj,
         )
@@ -560,7 +775,7 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
                 "source": j.get("source", "harness"),
                 "label": j.get("label"),
                 "dispatch_id": parse_job_dispatch_id(j.get("label")),
-                "session_id": j.get("session_id") or parse_job_session_id(j.get("label"), []),
+                "session_id": j.get("session_id") or parse_job_session_id(j.get("label"), raw_tasks),
                 "accounting_scope": j.get("accounting_scope", "visibility_only"),
                 "accounting_owned": bool(j.get("accounting_owned")),
                 "cross_project": bool(j.get("cross_project")),
@@ -646,6 +861,7 @@ def get_swarm_live(repo_override: str | None, svc: JobServices) -> tuple[int, di
             pilot.live_local_jobs(),
             active_session_id=active_session_id,
             repo_root=scoped_repo,
+            registered_job_ids=registered_job_ids,
         )
         scoped_locals = [
             apply_job_economics_policy(

--- a/harness/api/jobs.py
+++ b/harness/api/jobs.py
@@ -175,10 +175,7 @@ def _inspect_sibling_job(job_id: str) -> tuple[bool | None, Any]:
         state_dir = None
     if state_dir is None:
         return None, None
-    try:
-        durable = open_cli_durable_at(str(state_dir))
-    except Exception:
-        durable = None
+    durable = open_cli_durable_at(str(state_dir))
     store = getattr(durable, "store", None) if durable is not None else None
     if store is None:
         return None, None
@@ -313,8 +310,6 @@ def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
     if owned is False:
         return _unknown_job_refusal(job_id)
     if owned is None:
-        # Primary harness + primary CLI miss: inspect the sibling store
-        # ourselves. Do not fail-open into cancel_job_dual_store.
         sibling_owned, sibling_durable = _inspect_sibling_job(job_id)
         if sibling_owned is not True:
             return _unknown_job_refusal(job_id)
@@ -336,10 +331,7 @@ def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
             svc.diag("server.swarm_cancel_sibling", e)
             return _unknown_job_refusal(job_id)
 
-    # 2) Durable Puppetmaster store job -- best-effort mark cancelled.
-    # Canonical dual-store seam (harness then CLI): shared with
-    # BusyControlMixin.interrupt so membership/cancel cannot diverge.
-    # Primary-store hits only — sibling ids are handled above.
+    # Durable Puppetmaster store job — harness then primary CLI only.
     try:
         from ..job_cancel import cancel_job_dual_store
 

--- a/harness/api/usage.py
+++ b/harness/api/usage.py
@@ -225,9 +225,8 @@ def _get_usage_body(repo_override: str, svc: UsageServices) -> tuple[int, JsonPa
     swarm_cached = 0
     swarm_input = 0
     try:
-        # Same merged, workspace-scoped job set the tracker uses
-        # (/api/swarm/live): harness store + per-project CLI store, so
-        # MCP/CLI-dispatched swarm spend reaches the status bar.
+        # Same merged, Marionette-owned job set the tracker uses
+        # (/api/swarm/live): harness store + owned CLI rows only.
         from ..cli_job_merge import (
             bulk_load_store_artifacts,
             cli_stores_by_job,

--- a/harness/cli_job_merge.py
+++ b/harness/cli_job_merge.py
@@ -216,13 +216,17 @@ def merge_running_cli_jobs_all_projects(
     *,
     seen_ids: set,
     primary_state_dir: str = "",
+    tasks_by_job: dict[str, list] | None = None,
 ) -> list[dict]:
-    """Surface live CLI/MCP jobs from recent sibling PM project stores.
+    """Scan recent sibling PM project stores for running jobs.
 
-    Cursor MCP and Marionette often resolve different workspace hashes
-    (``.marionette`` Home vs ``Projects/marionette``). Without a cross-project
-    live merge, the Swarm Tracker goes blank while chat still awaits a swarm.
-    Terminal jobs stay workspace-scoped via ``merge_scoped_cli_jobs``.
+    ``merge_scoped_cli_jobs`` applies Marionette ownership before any row is
+    listed. This helper is the bounded open/scan only — unstamped CLI and
+    foreign harness jobs must not appear on Marionette surfaces.
+
+    Tasks used for ownership/session stamps are loaded from the same open
+    store that listed the row. Callers pass ``tasks_by_job`` to collect them;
+    they stay off the live row.
 
     Bounded by recent ``state.sqlite3`` mtime, a max open count, and a short
     wall-clock budget so a bloated ``projects/`` tree cannot stall HTTP polls.
@@ -250,6 +254,8 @@ def merge_running_cli_jobs_all_projects(
             )
         except Exception:
             continue
+        store = getattr(durable, "store", None)
+        collected: list[dict] = []
         for job in rows or []:
             jid = job.get("id") if isinstance(job, dict) else getattr(job, "id", None)
             if not jid or jid in seen_ids:
@@ -274,9 +280,34 @@ def merge_running_cli_jobs_all_projects(
             row["source"] = "cli"
             row["cli_state_dir"] = state_dir
             row["cross_project"] = True
-            out.append(row)
+            collected.append(row)
             seen_ids.add(jid)
+        if tasks_by_job is not None and store is not None and collected:
+            jids = [str(row.get("id") or "") for row in collected if row.get("id")]
+            try:
+                loaded = bulk_load_store_tasks(store, jids)
+            except Exception:
+                loaded = {}
+            for jid in jids:
+                tasks = list(loaded.get(jid) or [])
+                if not tasks:
+                    try:
+                        tasks = list(store.list_tasks(jid) or [])
+                    except Exception:
+                        tasks = []
+                tasks_by_job[jid] = tasks
+        out.extend(collected)
     return out
+
+
+def cross_project_scan_enabled() -> bool:
+    """True when sibling PM project stores may be opened for live merge/actions.
+
+    Hermetic pytest sets ``HARNESS_CLI_CROSS_PROJECT=0`` so cancel/artifacts
+    cannot scan the developer's live project tree.
+    """
+    flag = (os.environ.get("HARNESS_CLI_CROSS_PROJECT") or "1").strip().lower()
+    return flag not in ("0", "false", "no", "off")
 
 
 def merge_scoped_cli_jobs(
@@ -286,16 +317,20 @@ def merge_scoped_cli_jobs(
     active_session_id: str,
     repo_root: str,
     workspace_root: str,
+    registered_job_ids: list | set | None = None,
 ) -> tuple[list[dict], Any | None, dict[str, list]]:
-    """Return harness jobs plus visible CLI jobs, tagged with ``source``.
+    """Return harness jobs plus Marionette-owned CLI jobs, tagged with ``source``.
 
-    Also merges **running** jobs from other Puppetmaster project stores so a
-    Cursor-MCP swarm started under a sibling cwd still appears in the tracker.
+    Cross-project running rows are admitted only when they carry Marionette
+    ownership (``origin=marionette`` plus a session stamp). Task payloads are
+    loaded before that check so a task-only stamp survives. Registered-id
+    healing never applies to CLI/sibling stores — a colliding id cannot admit
+    foreign store data. Unstamped CLI / sibling store jobs stay out.
 
     The third tuple element is ``tasks_by_job`` loaded while filtering CLI rows
     (harness tasks are loaded separately in ``filter_store_jobs_with_tasks``).
     """
-    from .job_scoping import filter_store_jobs_with_tasks
+    from .job_scoping import filter_store_jobs_with_tasks, job_visible_for_view, parse_job_session_id
 
     harness_ids = {j.get("id") for j in harness_jobs if j.get("id")}
     merged: list[dict] = []
@@ -313,11 +348,15 @@ def merge_scoped_cli_jobs(
     if cli_state is not None:
         try:
             cli_rows = _retry_on_locked(lambda: cli_state.list_jobs())
+            # Registered-id healing is harness/local only — never a sibling CLI store.
             visible, cli_tasks_by_job = filter_store_jobs_with_tasks(
                 cli_rows,
                 cli_state.store,
                 active_session_id=active_session_id,
                 repo_root=repo_root,
+                registered_job_ids=None,
+                source="cli",
+                allow_registered_heal=False,
             )
             for job in visible:
                 jid = job.get("id")
@@ -335,13 +374,35 @@ def merge_scoped_cli_jobs(
 
     # Opt-out for hermetic pytest (conftest sets HARNESS_CLI_CROSS_PROJECT=0)
     # and operators who want workspace-scoped tracker views only.
-    _cross = (os.environ.get("HARNESS_CLI_CROSS_PROJECT") or "1").strip().lower()
-    if _cross not in ("0", "false", "no", "off"):
+    if cross_project_scan_enabled():
         try:
+            sibling_tasks: dict[str, list] = {}
             for row in merge_running_cli_jobs_all_projects(
                 seen_ids=seen_ids,
                 primary_state_dir=primary_state_dir,
+                tasks_by_job=sibling_tasks,
             ):
+                jid = str(row.get("id") or "")
+                tasks = sibling_tasks.get(jid) or []
+                if jid and tasks:
+                    cli_tasks_by_job[jid] = tasks
+                if not job_visible_for_view(
+                    session_id=parse_job_session_id(row.get("label"), tasks),
+                    label=row.get("label"),
+                    tasks=tasks,
+                    active_session_id=active_session_id,
+                    repo_root=repo_root,
+                    status=row.get("status"),
+                    job_id=jid,
+                    registered_job_ids=None,
+                    origin=str(row.get("origin") or ""),
+                    source="cli",
+                    allow_registered_heal=False,
+                ):
+                    continue
+                stamped = parse_job_session_id(row.get("label"), tasks)
+                if stamped:
+                    row["session_id"] = stamped
                 merged.append(row)
         except Exception as exc:
             _log_merge_failure("cli_job_merge.merge_running_all", exc)

--- a/harness/cli_job_merge.py
+++ b/harness/cli_job_merge.py
@@ -348,7 +348,6 @@ def merge_scoped_cli_jobs(
     if cli_state is not None:
         try:
             cli_rows = _retry_on_locked(lambda: cli_state.list_jobs())
-            # Registered-id healing is harness/local only — never a sibling CLI store.
             visible, cli_tasks_by_job = filter_store_jobs_with_tasks(
                 cli_rows,
                 cli_state.store,

--- a/harness/internal_uri.py
+++ b/harness/internal_uri.py
@@ -74,6 +74,7 @@ class InternalUriContext:
     repo: Optional[str] = None
     session_id: Optional[str] = None
     live_jobs: Optional[list] = None
+    registered_job_ids: Optional[list] = None
 
     def store(self):
         if not self.state_dir:
@@ -124,7 +125,15 @@ def _local_jobs(ctx: InternalUriContext) -> list[dict]:
             valid,
             active_session_id=str(ctx.session_id or ""),
             repo_root=str(ctx.repo or ""),
+            registered_job_ids=ctx.registered_job_ids,
         )
+        # URI reads stay session-isolated even though tracker lists all owned jobs.
+        if ctx.session_id:
+            sid = str(ctx.session_id)
+            visible = [
+                job for job in visible
+                if str(job.get("session_id") or "") == sid
+            ]
         if ctx.repo:
             visible = [
                 job for job in visible
@@ -195,6 +204,67 @@ def _local_job_artifacts(job: dict) -> list[dict]:
 
 def _find_local_job(job_id: str, ctx: InternalUriContext) -> Optional[dict]:
     return next((job for job in _local_jobs(ctx) if job.get("id") == job_id), None)
+
+
+def _store_job_tasks(store, job_id: str) -> list:
+    try:
+        return list(store.list_tasks(job_id) or [])
+    except Exception:
+        return []
+
+
+def _durable_job_readable(job, store, ctx: InternalUriContext) -> bool:
+    """True when a durable store job passes ownership and the session read cut."""
+    from .job_scoping import job_owned_by_marionette, parse_job_session_id
+
+    jid = str(getattr(job, "id", "") or "")
+    if not jid:
+        return False
+    label = getattr(job, "label", None)
+    tasks = _store_job_tasks(store, jid)
+    if not job_owned_by_marionette(
+        session_id=parse_job_session_id(label, tasks),
+        label=label,
+        tasks=tasks,
+        job_id=jid,
+        registered_job_ids=ctx.registered_job_ids,
+        origin=str(getattr(job, "origin", "") or ""),
+        source="harness",
+        allow_registered_heal=True,
+    ):
+        return False
+    if ctx.session_id:
+        sid = parse_job_session_id(label, tasks)
+        if sid and sid != str(ctx.session_id):
+            return False
+        if not sid and jid not in {
+            str(x).strip() for x in (ctx.registered_job_ids or []) if x
+        }:
+            return False
+    return True
+
+
+def _iter_owned_store_jobs(store, ctx: InternalUriContext):
+    for job in store.list_jobs():
+        if _durable_job_readable(job, store, ctx):
+            yield job
+
+
+def _require_readable_store_job(store, job_id: str, ctx: InternalUriContext):
+    """Return the store job if readable; raise the same not-found shape otherwise."""
+    job = None
+    try:
+        job = store.get_job(job_id)
+    except Exception:
+        job = None
+    if job is None:
+        for candidate in store.list_jobs():
+            if getattr(candidate, "id", "") == job_id:
+                job = candidate
+                break
+    if job is None or not _durable_job_readable(job, store, ctx):
+        raise InternalUriError(f"job not found: {job_id}")
+    return job
 
 
 def is_internal_uri(path: str) -> bool:
@@ -338,7 +408,7 @@ def search_internal_uris(
         if len(hits) >= max_results:
             break
         if sch == "job":
-            for job in store.list_jobs():
+            for job in _iter_owned_store_jobs(store, ctx):
                 goal = getattr(job, "goal", "") or ""
                 jid = getattr(job, "id", "")
                 if needle in goal.lower() or needle in jid.lower():
@@ -355,7 +425,7 @@ def search_internal_uris(
                     if len(hits) >= max_results:
                         break
         elif sch == "artifact":
-            for job in store.list_jobs():
+            for job in _iter_owned_store_jobs(store, ctx):
                 for art in durable.format_artifacts(store.list_artifacts(job.id)):
                     headline = str(art.get("headline") or "")
                     aid = str(art.get("id") or "")
@@ -379,7 +449,7 @@ def search_internal_uris(
                         if len(hits) >= max_results:
                             break
         elif sch == "agent":
-            for job in store.list_jobs():
+            for job in _iter_owned_store_jobs(store, ctx):
                 for run in _list_runs(store, job.id):
                     blob = json.dumps(to_jsonable(run), sort_keys=True).lower()
                     if needle in blob:
@@ -462,12 +532,13 @@ def _resolve_job(parsed: ParsedInternalUri, ctx: InternalUriContext) -> Internal
 
     if not parsed.path:
         entries = [f"{job.id}\t{getattr(job, 'status', '')}\t{getattr(job, 'goal', '')[:80]}"
-                   for job in store.list_jobs()]
+                   for job in _iter_owned_store_jobs(store, ctx)]
         return _json_resource(url, entries, is_directory=True)
 
     parts = parsed.path.split("/")
     job_id = parts[0]
     _require_safe_id(job_id, "job id")
+    _require_readable_store_job(store, job_id, ctx)
 
     if len(parts) == 1:
         job = store.get_job(job_id)
@@ -572,6 +643,7 @@ def _resolve_artifact(parsed: ParsedInternalUri, ctx: InternalUriContext) -> Int
     job_id, artifact_id = parts[0], parts[1]
     _require_safe_id(job_id, "job id")
     _require_safe_id(artifact_id, "artifact id")
+    _require_readable_store_job(store, job_id, ctx)
     url = f"artifact://{parsed.path}"
 
     artifact = None
@@ -607,7 +679,7 @@ def _resolve_agent(parsed: ParsedInternalUri, ctx: InternalUriContext) -> Intern
 
     if not parsed.path:
         entries: list[str] = []
-        for job in store.list_jobs():
+        for job in _iter_owned_store_jobs(store, ctx):
             for run in _list_runs(store, job.id):
                 entries.append(
                     f"{job.id}/{run['id']}\t{run.get('role', '')}\t{run.get('status', '')}"
@@ -617,6 +689,7 @@ def _resolve_agent(parsed: ParsedInternalUri, ctx: InternalUriContext) -> Intern
     parts = parsed.path.split("/")
     job_id = parts[0]
     _require_safe_id(job_id, "job id")
+    _require_readable_store_job(store, job_id, ctx)
 
     if len(parts) == 1:
         runs = _list_runs(store, job_id)

--- a/harness/job_cancel.py
+++ b/harness/job_cancel.py
@@ -95,8 +95,6 @@ def cancel_job_dual_store(
             "marked": mark_store_job_cancelled(harness_store, job_id),
         }
 
-    # CLI durable store second (workspace-scoped). Sibling stores are
-    # resolved and ownership-checked by post_swarm_cancel, not here.
     for store in iter_dual_stores(None, repo_root=repo_root):
         if store is harness_store:
             continue

--- a/harness/job_cancel.py
+++ b/harness/job_cancel.py
@@ -73,10 +73,12 @@ def cancel_job_dual_store(
     harness_list_jobs=None,
     repo_root: str = "",
 ) -> Optional[dict]:
-    """Cancel ``job_id`` when it is a member of harness or CLI durable store.
+    """Cancel ``job_id`` when it is a member of harness or primary CLI store.
 
     Membership-gated (HTTP cancel): only the store that lists the job is
-    written. Returns ``{ok, job_id, durable, marked}`` or None if unknown.
+    written. Sibling project stores are resolved and ownership-checked by
+    ``post_swarm_cancel``, not here. Returns ``{ok, job_id, durable, marked}``
+    or None if unknown in these two stores.
     """
     job_id = (job_id or "").strip()
     if not job_id:
@@ -93,7 +95,8 @@ def cancel_job_dual_store(
             "marked": mark_store_job_cancelled(harness_store, job_id),
         }
 
-    # CLI durable store second (workspace-scoped).
+    # CLI durable store second (workspace-scoped). Sibling stores are
+    # resolved and ownership-checked by post_swarm_cancel, not here.
     for store in iter_dual_stores(None, repo_root=repo_root):
         if store is harness_store:
             continue
@@ -105,30 +108,6 @@ def cancel_job_dual_store(
             "durable": True,
             "marked": mark_store_job_cancelled(store, job_id),
         }
-
-    # Cross-project live jobs (Cursor MCP under a sibling cwd) land in another
-    # PM project store; resolve by job id so Cancel still works from the tracker.
-    try:
-        from puppetmaster.state import find_state_dir_for_job
-
-        foreign = find_state_dir_for_job(job_id)
-    except Exception:
-        foreign = None
-    if foreign is not None:
-        try:
-            from .cli_job_merge import open_cli_durable_at
-
-            durable = open_cli_durable_at(str(foreign))
-            store = getattr(durable, "store", None) if durable is not None else None
-            if store is not None and store_knows_job(store, job_id):
-                return {
-                    "ok": True,
-                    "job_id": job_id,
-                    "durable": True,
-                    "marked": mark_store_job_cancelled(store, job_id),
-                }
-        except Exception:
-            pass
     return None
 
 

--- a/harness/job_scoping.py
+++ b/harness/job_scoping.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-"""Session- and repo-scoped views over the durable Puppetmaster job store.
+"""Marionette-owned views over the durable Puppetmaster job store.
 
-Jobs are stamped with ``session_id`` at dispatch (job label + task payload).
-Repo membership is derived at read time from each task payload's ``cwd`` via
-longest-prefix match against the open workspace root — no store migration.
+Jobs are stamped with ``origin=marionette`` and ``session_id`` at dispatch
+(job label + task payload). Visibility requires that ownership proof, or a
+job id registered by the active session. cwd/repo match is not ownership.
 """
 
 import json
@@ -16,7 +16,7 @@ from .paths import same_workspace_path
 ACCOUNTING_SCOPE_MARIONETTE = "marionette"
 ACCOUNTING_SCOPE_VISIBILITY = "visibility_only"
 
-# Economic fields zeroed on visibility-only rows (tracker still shows the job).
+# Economic fields zeroed on owned-but-unbilled rows (accounting fail-closed).
 _JOB_ECONOMIC_FIELDS = (
     "tokens",
     "est_cost_usd",
@@ -213,6 +213,47 @@ def job_is_running(status: Any) -> bool:
     return str(status or "").strip().lower() in _RUNNING_STATUSES
 
 
+def job_owned_by_marionette(
+    *,
+    session_id: str = "",
+    label: Any = None,
+    tasks: list | None = None,
+    job_id: str = "",
+    registered_job_ids: Iterable[str] | None = None,
+    origin: str = "",
+    source: str = "",
+    allow_registered_heal: bool = True,
+) -> bool:
+    """Positive ownership proof for Marionette job surfaces.
+
+    Durable proof is ``origin=marionette`` plus a stamped session id.
+    A pre-origin row with a non-empty session id is owned only when it comes
+    from the harness/local sidecar (or its id is registered by that session).
+    A CLI/sibling-store row still requires ``origin=marionette``.
+    Registered-id healing applies only to the active harness/local store —
+    never a sibling CLI store, even when ids collide.
+    cwd/repo match, running state, and ``app_run_id`` are never ownership.
+    """
+    jid = str(job_id or "").strip()
+    source_norm = (source or "").strip().lower()
+    is_cli = source_norm == "cli"
+    # Colliding ids in a sibling CLI store must not inherit harness registry.
+    allow_heal = bool(allow_registered_heal) and not is_cli
+    registered = {str(x).strip() for x in (registered_job_ids or []) if x}
+    if allow_heal and jid and jid in registered:
+        return True
+    task_list = tasks or []
+    stamped = parse_job_session_id(label, task_list) or (session_id or "").strip()
+    parsed_origin = (origin or parse_job_origin(label, task_list) or "").strip()
+    if parsed_origin == "marionette" and stamped:
+        return True
+    if jid.startswith("local-") and stamped:
+        return True
+    if stamped and not is_cli:
+        return True
+    return False
+
+
 def job_visible_for_view(
     *,
     session_id: str,
@@ -221,35 +262,29 @@ def job_visible_for_view(
     active_session_id: str,
     repo_root: str,
     status: Any = None,
+    job_id: str = "",
+    registered_job_ids: Iterable[str] | None = None,
+    origin: str = "",
+    source: str = "",
+    allow_registered_heal: bool = True,
 ) -> bool:
     """Filter rule for /api/jobs and /api/swarm/live.
 
-    Visible when the stamped session matches the active session, OR the job is
-    an unstamped legacy row whose task cwd lies under the current workspace.
-    Running jobs use those same rules (they must not leak across open
-    directories). Narrow escape: a running job with no session stamp and no
-    cwd stays visible so true orphans remain cancellable.
+    Surfaces only Marionette-owned jobs. Repo/all scope is applied later on
+    that owned set. ``active_session_id``, ``repo_root``, and ``status`` are
+    kept for call-compat and are not admission keys.
     """
-    stamped = parse_job_session_id(label, tasks) or (session_id or "").strip()
-    cwd = job_repo_cwd(tasks)
-    if stamped:
-        if stamped == (active_session_id or ""):
-            return True
-        # Match filter_local_jobs: a running job under the open workspace stays
-        # visible across session switches so the tracker cannot go blank while
-        # chat still says a swarm is running (CLI + harness).
-        return bool(
-            job_is_running(status)
-            and repo_root
-            and cwd
-            and cwd_under_repo(cwd, repo_root)
-        )
-    if not cwd:
-        # Unstamped + no cwd: only running orphans stay visible (cancellable).
-        return job_is_running(status)
-    if not repo_root:
-        return False
-    return cwd_under_repo(cwd, repo_root)
+    del active_session_id, repo_root, status
+    return job_owned_by_marionette(
+        session_id=session_id,
+        label=label,
+        tasks=tasks,
+        job_id=job_id,
+        registered_job_ids=registered_job_ids,
+        origin=origin,
+        source=source,
+        allow_registered_heal=allow_registered_heal,
+    )
 
 
 def resolve_job_model(raw_arts, raw_tasks, adapter: str = "") -> str:
@@ -307,10 +342,11 @@ def resolve_job_accounting(
     app_run_id: str = "",
     cli_cost_merge: bool | None = None,
 ) -> dict[str, Any]:
-    """Decide whether a visible job may affect Marionette economic totals.
+    """Decide whether an admitted job may affect Marionette economic totals.
 
     Visibility (``job_visible_for_view``) and accounting ownership are split:
-    foreign/unstamped CLI jobs stay on the tracker but fail closed for money.
+    an owned row can still be unbilled (owned-but-unbilled) when CLI cost
+    merge is off or the process ``app_run_id`` does not match.
     """
     row = job or {}
     jid = str(row.get("id") or "").strip()
@@ -451,8 +487,11 @@ def filter_store_jobs_with_tasks(
     *,
     active_session_id: str,
     repo_root: str,
+    registered_job_ids: Iterable[str] | None = None,
+    source: str = "harness",
+    allow_registered_heal: bool = True,
 ) -> tuple[list[dict], dict[str, list]]:
-    """Return visible job rows plus task lists loaded for visibility filtering."""
+    """Return Marionette-owned job rows plus task lists used for ownership."""
     if not jobs:
         return [], {}
     jids = [j.get("id") for j in jobs if j.get("id")]
@@ -488,6 +527,11 @@ def filter_store_jobs_with_tasks(
             active_session_id=active_session_id,
             repo_root=repo_root,
             status=job.get("status"),
+            job_id=str(jid),
+            registered_job_ids=registered_job_ids if allow_registered_heal else None,
+            origin=str(job.get("origin") or ""),
+            source=str(job.get("source") or source or ""),
+            allow_registered_heal=allow_registered_heal,
         ):
             row = dict(job)
             if label is not None:
@@ -495,6 +539,18 @@ def filter_store_jobs_with_tasks(
             stamped_sid = parse_job_session_id(label, tasks)
             if stamped_sid:
                 row["session_id"] = stamped_sid
+            elif allow_registered_heal and str(jid) in {
+                str(x).strip() for x in (registered_job_ids or []) if x
+            }:
+                heal_sid = (active_session_id or "").strip()
+                if not heal_sid:
+                    continue
+                row["session_id"] = heal_sid
+            elif not (row.get("session_id") or "").strip():
+                continue
+            parsed_origin = parse_job_origin(label, tasks)
+            if parsed_origin:
+                row["origin"] = parsed_origin
             visible.append(row)
     return visible, tasks_by_job
 
@@ -505,48 +561,120 @@ def filter_store_jobs(
     *,
     active_session_id: str,
     repo_root: str,
+    registered_job_ids: Iterable[str] | None = None,
+    source: str = "harness",
+    allow_registered_heal: bool = True,
 ) -> list[dict]:
-    """Return ``jobs`` rows visible for the active session + workspace."""
+    """Return ``jobs`` rows owned by Marionette."""
     visible, _tasks = filter_store_jobs_with_tasks(
         jobs,
         store,
         active_session_id=active_session_id,
         repo_root=repo_root,
+        registered_job_ids=registered_job_ids,
+        source=source,
+        allow_registered_heal=allow_registered_heal,
     )
     return visible
 
 
-def filter_local_jobs(local_jobs: list[dict], *, active_session_id: str, repo_root: str) -> list[dict]:
-    """Apply the same visibility rule to in-process ``local-*`` worker rows.
+def filter_local_jobs(
+    local_jobs: list[dict],
+    *,
+    active_session_id: str,
+    repo_root: str,
+    registered_job_ids: Iterable[str] | None = None,
+) -> list[dict]:
+    """Apply the same ownership rule to in-process ``local-*`` worker rows.
 
-    Running locals whose cwd sits under the open workspace stay visible even
-    when the session stamp drifted (interrupt / mid-flight session switch) --
-    otherwise the chat can say "swarm running" while the tracker looks empty.
-    Terminal jobs still require an exact session match (or legacy cwd match
-    when unstamped).
+    Sidecar rows stamped with a session id stay owned (including after reload).
+    cwd match and running orphans are never admission.
     """
     visible: list[dict] = []
     for job in local_jobs or []:
         label = job.get("label")
         session_id = job.get("session_id") or parse_job_session_id(label, [])
-        cwd = (job.get("cwd") or "").strip()
-        if session_id:
-            if session_id == (active_session_id or ""):
-                visible.append(job)
-                continue
-            if (
-                job_is_running(job.get("status"))
-                and repo_root
-                and cwd
-                and cwd_under_repo(cwd, repo_root)
-            ):
-                visible.append(job)
-            continue
-        if not cwd:
-            # Unstamped + no cwd: only running orphans stay visible (cancellable).
-            if job_is_running(job.get("status")):
-                visible.append(job)
-            continue
-        if repo_root and cwd_under_repo(cwd, repo_root):
-            visible.append(job)
+        if job_visible_for_view(
+            session_id=session_id or "",
+            label=label,
+            tasks=[],
+            active_session_id=active_session_id,
+            repo_root=repo_root,
+            status=job.get("status"),
+            job_id=str(job.get("id") or ""),
+            registered_job_ids=registered_job_ids,
+            origin=str(job.get("origin") or ""),
+            source="harness",
+            allow_registered_heal=True,
+        ):
+            row = dict(job)
+            if session_id and not (row.get("session_id") or "").strip():
+                row["session_id"] = session_id
+            if not (row.get("session_id") or "").strip():
+                registered = {str(x).strip() for x in (registered_job_ids or []) if x}
+                heal_sid = (active_session_id or "").strip()
+                if str(row.get("id") or "") in registered and heal_sid:
+                    row["session_id"] = heal_sid
+                else:
+                    continue
+            visible.append(row)
     return visible
+
+
+def inspect_store_job_ownership(
+    store,
+    job_id: str,
+    *,
+    source: str = "harness",
+    registered_job_ids: Iterable[str] | None = None,
+    allow_registered_heal: bool = True,
+) -> bool | None:
+    """Return True/False when ``job_id`` is in ``store``, else None if absent.
+
+    Used by artifacts/cancel so a known unowned id is refused without leaking
+    that it exists. Missing ``list_tasks`` is treated as an empty task list.
+    """
+    jid = str(job_id or "").strip()
+    if store is None or not jid:
+        return None
+    job = None
+    try:
+        getter = getattr(store, "get_job", None)
+        if callable(getter):
+            try:
+                job = getter(jid)
+            except Exception:
+                job = None
+        if job is None:
+            for row in store.list_jobs() or []:
+                rid = row.get("id") if isinstance(row, dict) else getattr(row, "id", None)
+                if rid == jid:
+                    job = row
+                    break
+    except Exception:
+        return None
+    if job is None:
+        return None
+    label = job.get("label") if isinstance(job, dict) else getattr(job, "label", None)
+    tasks: list = []
+    try:
+        lister = getattr(store, "list_tasks", None)
+        if callable(lister):
+            tasks = list(lister(jid) or [])
+    except Exception:
+        tasks = []
+    origin = ""
+    if isinstance(job, dict):
+        origin = str(job.get("origin") or "")
+    else:
+        origin = str(getattr(job, "origin", "") or "")
+    return job_owned_by_marionette(
+        session_id=parse_job_session_id(label, tasks),
+        label=label,
+        tasks=tasks,
+        job_id=jid,
+        registered_job_ids=registered_job_ids,
+        origin=origin,
+        source=source,
+        allow_registered_heal=allow_registered_heal,
+    )

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -226,6 +226,7 @@ class ToolDispatchMixin:
             repo=self.config.repo or None,
             session_id=getattr(self, "harness_session_id", None) or None,
             live_jobs=live,
+            registered_job_ids=list(getattr(self, "_session_job_ids", []) or []),
         )
 
     def _do_read_file(self, act: PilotAction) -> tuple[bool, str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.387"
+version = "0.9.388"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_accounting_isolation.py
+++ b/tests/test_accounting_isolation.py
@@ -228,8 +228,8 @@ def _api_get(port, path, token):
     return urllib.request.urlopen(req, timeout=10)
 
 
-def test_api_swarm_live_cli_job_visible_zero_economics(tmp_path, monkeypatch):
-    """Regression: unstamped CLI job visible but contributes 0 to Marionette meters."""
+def test_api_swarm_live_cli_job_absent_not_just_zeroed(tmp_path, monkeypatch):
+    """Unstamped CLI jobs must not appear on /api/swarm/live."""
     repo = tmp_path / "repo"
     repo.mkdir()
     harness_dir = tmp_path / "harness-state"
@@ -284,15 +284,7 @@ def test_api_swarm_live_cli_job_visible_zero_economics(tmp_path, monkeypatch):
             _api_get(port, "/api/swarm/live", srv._TOKEN).read().decode()
         )
         cli_rows = [j for j in data["jobs"] if j.get("id") == cli_job_id]
-        assert len(cli_rows) == 1
-        row = cli_rows[0]
-        assert row["source"] == "cli"
-        assert row["accounting_owned"] is False
-        assert row["accounting_scope"] == ACCOUNTING_SCOPE_VISIBILITY
-        assert row["tokens"] == 0
-        assert row["est_cost_usd"] == 0.0
-        assert row["routing_saved_usd"] == 0.0
-        assert row["cache_saved_usd"] == 0.0
+        assert cli_rows == []
         # Pilot/session Codex meters must survive — not replaced by CLI artifacts.
         assert data["session"]["tokens_cached"] >= 4_000
         assert data["session"]["tokens_used"] >= 12_000

--- a/tests/test_artifacts_endpoint.py
+++ b/tests/test_artifacts_endpoint.py
@@ -8,12 +8,33 @@ import urllib.request
 from http.server import ThreadingHTTPServer
 
 from harness import server
+from harness.job_scoping import job_label_for_session
+
+
+_OWNED_JOB_ID = "j1"
+_OWNED_LABEL = job_label_for_session("sess-artifacts", origin="marionette")
+
+
+class _OwnedStore:
+    """Harness store row so GET /api/artifacts admits this id as owned."""
+
+    def get_job(self, job_id):
+        if job_id != _OWNED_JOB_ID:
+            return None
+        return {"id": job_id, "origin": "marionette", "label": _OWNED_LABEL}
+
+    def list_jobs(self):
+        return [self.get_job(_OWNED_JOB_ID)]
+
+    def list_tasks(self, _job_id):
+        return []
 
 
 class _State:
     def __init__(self, artifacts=None, exc=None):
         self._artifacts = artifacts
         self._exc = exc
+        self.store = _OwnedStore()
 
     def job_artifacts(self, job_id):
         if self._exc is not None:

--- a/tests/test_cli_job_merge.py
+++ b/tests/test_cli_job_merge.py
@@ -21,7 +21,7 @@ from harness.cli_job_merge import (
     resolve_cli_state_dir,
 )
 from harness.job_scoping import (
-    ACCOUNTING_SCOPE_VISIBILITY,
+    job_label_for_session,
     stamp_task_payload,
 )
 from harness.server import _job_swarm_accounting, _scoped_jobs_snapshot
@@ -164,8 +164,8 @@ def test_missing_cli_store_is_silent(monkeypatch):
     assert open_cli_durable_state("/no/such/workspace") is None
 
 
-def test_merge_running_cli_jobs_all_projects_surfaces_foreign_live(tmp_path, monkeypatch):
-    """A running job in another PM project store must appear in the tracker."""
+def test_merge_running_cli_jobs_all_projects_scans_foreign_live(tmp_path, monkeypatch):
+    """Low-level sibling scan still finds running rows; ownership is applied later."""
     foreign = tmp_path / "foreign-state"
     store = create_store("sqlite", str(foreign))
     job = store.create_job("foreign swarm")
@@ -186,6 +186,221 @@ def test_merge_running_cli_jobs_all_projects_surfaces_foreign_live(tmp_path, mon
     assert rows[0]["cli_state_dir"]
     assert rows[0]["cross_project"] is True
     assert job.id in seen
+
+
+def test_merge_scoped_cli_jobs_drops_unstamped_foreign_running(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    harness_store = create_store("sqlite", str(tmp_path / "harness-state"))
+    monkeypatch.setenv("HARNESS_CLI_CROSS_PROJECT", "1")
+
+    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda workspace_root="": None)
+    monkeypatch.setattr(
+        "harness.cli_job_merge.merge_running_cli_jobs_all_projects",
+        lambda **kwargs: [{
+            "id": "job_foreign_running",
+            "goal": "foreign swarm",
+            "status": "running",
+            "source": "cli",
+            "cross_project": True,
+            "cli_state_dir": str(tmp_path / "foreign"),
+        }],
+    )
+
+    merged, _, _ = merge_scoped_cli_jobs(
+        [],
+        harness_store=harness_store,
+        active_session_id="sess-x",
+        repo_root=str(repo),
+        workspace_root=str(repo),
+    )
+    assert merged == []
+
+
+def test_merge_scoped_cli_jobs_keeps_marionette_stamped_foreign(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    harness_store = create_store("sqlite", str(tmp_path / "harness-state"))
+    label = job_label_for_session("sess-x")
+    monkeypatch.setenv("HARNESS_CLI_CROSS_PROJECT", "1")
+
+    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda workspace_root="": None)
+    monkeypatch.setattr(
+        "harness.cli_job_merge.merge_running_cli_jobs_all_projects",
+        lambda **kwargs: [{
+            "id": "job_owned_foreign",
+            "goal": "owned sibling",
+            "status": "running",
+            "source": "cli",
+            "cross_project": True,
+            "label": label,
+            "cli_state_dir": str(tmp_path / "foreign"),
+        }],
+    )
+
+    merged, _, _ = merge_scoped_cli_jobs(
+        [],
+        harness_store=harness_store,
+        active_session_id="sess-x",
+        repo_root=str(repo),
+        workspace_root=str(repo),
+    )
+    assert [row["id"] for row in merged] == ["job_owned_foreign"]
+    assert merged[0].get("session_id") == "sess-x"
+
+
+def test_merge_scoped_cli_jobs_sibling_task_only_stamp_emits_session_id(tmp_path, monkeypatch):
+    """Sibling merge inspects tasks before ownership; live row carries session_id."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    harness_store = create_store("sqlite", str(tmp_path / "harness-state"))
+    foreign = tmp_path / "foreign-state"
+    store = create_store("sqlite", str(foreign))
+    job = store.create_job("sibling task stamp")
+    payload = stamp_task_payload(
+        {"cwd": str(repo)},
+        session_id="sess-x",
+        origin="marionette",
+    )
+    store.save_task(Task(
+        job_id=job.id,
+        role="implement",
+        instruction="do work",
+        adapter="agentic",
+        payload=payload,
+    ))
+    try:
+        store.update_job_status(job.id, "running")
+    except Exception:
+        store.set_job_status(job.id, "running")
+
+    monkeypatch.setenv("HARNESS_CLI_CROSS_PROJECT", "1")
+    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda workspace_root="": None)
+
+    def _fake_merge(*, seen_ids, primary_state_dir="", tasks_by_job=None):
+        row = {
+            "id": job.id,
+            "goal": "sibling task stamp",
+            "status": "running",
+            "source": "cli",
+            "cross_project": True,
+            "cli_state_dir": str(foreign),
+        }
+        if tasks_by_job is not None:
+            tasks_by_job[job.id] = store.list_tasks(job.id)
+        return [row]
+
+    monkeypatch.setattr(
+        "harness.cli_job_merge.merge_running_cli_jobs_all_projects",
+        _fake_merge,
+    )
+
+    merged, _, tasks_by_job = merge_scoped_cli_jobs(
+        [],
+        harness_store=harness_store,
+        active_session_id="sess-x",
+        repo_root=str(repo),
+        workspace_root=str(repo),
+        registered_job_ids=[job.id],
+    )
+    assert [row["id"] for row in merged] == [job.id]
+    assert merged[0]["session_id"] == "sess-x"
+    assert job.id in tasks_by_job
+    assert "tasks" not in merged[0]
+
+
+def test_registered_id_does_not_admit_sibling_cli_store(tmp_path, monkeypatch):
+    """A harness-registered id must not heal a colliding unstamped sibling row."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    harness_store = create_store("sqlite", str(tmp_path / "harness-state"))
+    foreign = tmp_path / "foreign-collide"
+    store = create_store("sqlite", str(foreign))
+    job = store.create_job("foreign collide")
+    _save_task(store, job.id, str(repo))
+    try:
+        store.update_job_status(job.id, "running")
+    except Exception:
+        store.set_job_status(job.id, "running")
+
+    monkeypatch.setenv("HARNESS_CLI_CROSS_PROJECT", "1")
+    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda workspace_root="": None)
+    monkeypatch.setattr(
+        "harness.cli_job_merge.merge_running_cli_jobs_all_projects",
+        lambda **kwargs: [{
+            "id": job.id,
+            "goal": "foreign collide",
+            "status": "running",
+            "source": "cli",
+            "cross_project": True,
+            "cli_state_dir": str(foreign),
+        }],
+    )
+
+    merged, _, _ = merge_scoped_cli_jobs(
+        [],
+        harness_store=harness_store,
+        active_session_id="sess-x",
+        repo_root=str(repo),
+        workspace_root=str(repo),
+        registered_job_ids=[job.id],
+    )
+    assert merged == []
+
+
+def test_sibling_task_only_stamp_uses_one_store_open(tmp_path, monkeypatch):
+    """Listing and task-stamp ownership must share one sibling store open."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    harness_store = create_store("sqlite", str(tmp_path / "harness-state"))
+    foreign = tmp_path / "foreign-one-open"
+    store = create_store("sqlite", str(foreign))
+    job = store.create_job("sibling one open")
+    payload = stamp_task_payload(
+        {"cwd": str(repo)},
+        session_id="sess-x",
+        origin="marionette",
+    )
+    store.save_task(Task(
+        job_id=job.id,
+        role="implement",
+        instruction="do work",
+        adapter="agentic",
+        payload=payload,
+    ))
+    try:
+        store.update_job_status(job.id, "running")
+    except Exception:
+        store.set_job_status(job.id, "running")
+
+    opens: list[str] = []
+    real_open = open_cli_durable_at
+
+    def _count_open(state_dir, **kwargs):
+        opens.append(str(state_dir))
+        return real_open(state_dir, **kwargs)
+
+    monkeypatch.setenv("HARNESS_CLI_CROSS_PROJECT", "1")
+    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda workspace_root="": None)
+    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_at", _count_open)
+    monkeypatch.setattr(
+        "puppetmaster.state.list_project_state_dirs",
+        lambda: [foreign],
+    )
+
+    merged, _, tasks_by_job = merge_scoped_cli_jobs(
+        [],
+        harness_store=harness_store,
+        active_session_id="sess-x",
+        repo_root=str(repo),
+        workspace_root=str(repo),
+    )
+    assert [row["id"] for row in merged] == [job.id]
+    assert merged[0]["session_id"] == "sess-x"
+    assert job.id in tasks_by_job
+    assert "tasks" not in merged[0]
+    sibling_opens = [path for path in opens if str(foreign) in path]
+    assert len(sibling_opens) == 1
 
 
 def test_foreign_state_dir_candidates_skips_stale_and_caps(tmp_path, monkeypatch):
@@ -334,7 +549,7 @@ def _api_get(port, path, token):
     return urllib.request.urlopen(req, timeout=10)
 
 
-def test_api_swarm_live_includes_cli_jobs_with_accounting(tmp_path, monkeypatch):
+def test_api_swarm_live_excludes_unstamped_cli_jobs(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
     harness_dir = tmp_path / "harness-state"
@@ -377,13 +592,7 @@ def test_api_swarm_live_includes_cli_jobs_with_accounting(tmp_path, monkeypatch)
             _api_get(port, f"/api/swarm/live?repo={scoped}", srv._TOKEN).read().decode()
         )
         cli_rows = [j for j in data["jobs"] if j.get("id") == cli_job_id]
-        assert len(cli_rows) == 1
-        row = cli_rows[0]
-        assert row["source"] == "cli"
-        assert row["accounting_owned"] is False
-        assert row["tokens"] == 0
-        assert row["est_cost_usd"] == 0.0
-        assert row["model"] == "worker-model"
+        assert cli_rows == []
     finally:
         httpd.shutdown()
 
@@ -410,8 +619,8 @@ def _seed_unstamped_cli_store(tmp_path, repo_root: str, goal: str = "external cl
     return store, str(cli_dir), job.id
 
 
-def test_scoped_jobs_snapshot_unstamped_external_cli_visibility_only(tmp_path, monkeypatch):
-    """External Cursor MCP row (cwd only) stays visible-only for accounting."""
+def test_scoped_jobs_snapshot_unstamped_external_cli_absent(tmp_path, monkeypatch):
+    """External Cursor MCP row (cwd only) must not appear on Marionette surfaces."""
     import harness.server as srv
 
     repo = tmp_path / "repo"
@@ -438,11 +647,7 @@ def test_scoped_jobs_snapshot_unstamped_external_cli_visibility_only(tmp_path, m
 
     rows = _scoped_jobs_snapshot(repo_root=str(repo))
     cli_rows = [r for r in rows if r.get("id") == cli_job_id]
-    assert len(cli_rows) == 1
-    row = cli_rows[0]
-    assert row["source"] == "cli"
-    assert row["accounting_owned"] is False
-    assert row["accounting_scope"] == ACCOUNTING_SCOPE_VISIBILITY
+    assert cli_rows == []
 
 
 def test_scoped_jobs_snapshot_task_only_marionette_stamp_owned(tmp_path, monkeypatch):
@@ -490,6 +695,7 @@ def test_scoped_jobs_snapshot_task_only_marionette_stamp_owned(tmp_path, monkeyp
     cli_rows = [r for r in rows if r.get("id") == job.id]
     assert len(cli_rows) == 1
     assert cli_rows[0]["accounting_owned"] is True
+    assert cli_rows[0]["session_id"] == "sess-live"
 
 
 def test_scoped_jobs_snapshot_merges_cli_source(tmp_path, monkeypatch):
@@ -516,6 +722,78 @@ def test_scoped_jobs_snapshot_merges_cli_source(tmp_path, monkeypatch):
     srv._pilot.harness_session_id = ""
 
     rows = _scoped_jobs_snapshot(repo_root=str(repo))
-    assert len(rows) == 1
-    assert rows[0]["id"] == cli_job_id
-    assert rows[0]["source"] == "cli"
+    assert [r["id"] for r in rows if r.get("id") == cli_job_id] == []
+
+
+def test_scoped_jobs_snapshot_keeps_marionette_cli_without_app_run_id(tmp_path, monkeypatch):
+    """Visibility uses origin+session, not the process app_run_id."""
+    import harness.server as srv
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    harness_dir = tmp_path / "harness-state"
+    harness_store = create_store("sqlite", str(harness_dir))
+    cli_dir = tmp_path / "cli-owned"
+    cli_store = create_store("sqlite", str(cli_dir))
+    job = cli_store.create_job("owned cli", label=job_label_for_session("sess-live", app_run_id="run-old"))
+    payload = stamp_task_payload(
+        {"cwd": str(repo)},
+        session_id="sess-live",
+        origin="marionette",
+        app_run_id="run-old",
+    )
+    cli_store.save_task(Task(
+        job_id=job.id,
+        role="implement",
+        instruction="do work",
+        adapter="agentic",
+        payload=payload,
+    ))
+
+    monkeypatch.setenv("HARNESS_APP_RUN_ID", "run-after-restart")
+    monkeypatch.setattr(srv, "_jobs_snapshot", lambda: [])
+    monkeypatch.setattr(srv._session, "state", lambda: SimpleNamespace(store=harness_store))
+    monkeypatch.setattr(
+        "harness.cli_job_merge.resolve_cli_state_dir",
+        lambda workspace_root="": str(cli_dir),
+    )
+    monkeypatch.setattr(
+        "harness.cli_job_merge.merge_running_cli_jobs_all_projects",
+        lambda **kwargs: [],
+    )
+    srv._cfg.repo = str(repo)
+    srv._sessions._active = "sess-live"
+    srv._pilot.harness_session_id = "sess-live"
+
+    rows = _scoped_jobs_snapshot(repo_root=str(repo))
+    assert [r["id"] for r in rows] == [job.id]
+
+
+def test_scoped_jobs_snapshot_keeps_registered_unstamped_harness_job(tmp_path, monkeypatch):
+    import harness.server as srv
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    harness_dir = tmp_path / "harness-state"
+    harness_store = create_store("sqlite", str(harness_dir))
+    job = harness_store.create_job("legacy heal")
+    _save_task(harness_store, job.id, str(repo))
+
+    monkeypatch.setattr(
+        srv,
+        "_jobs_snapshot",
+        lambda: [{"id": job.id, "goal": "legacy heal", "status": "running", "adapter": "agentic"}],
+    )
+    monkeypatch.setattr(srv._session, "state", lambda: SimpleNamespace(store=harness_store))
+    monkeypatch.setattr(
+        "harness.cli_job_merge.merge_running_cli_jobs_all_projects",
+        lambda **kwargs: [],
+    )
+    monkeypatch.setattr(srv._pilot, "_session_job_ids", [job.id], raising=False)
+    srv._cfg.repo = str(repo)
+    srv._sessions._active = "sess-live"
+    srv._pilot.harness_session_id = "sess-live"
+
+    rows = _scoped_jobs_snapshot(repo_root=str(repo))
+    assert [r["id"] for r in rows] == [job.id]
+    assert rows[0]["session_id"] == "sess-live"

--- a/tests/test_cli_job_merge.py
+++ b/tests/test_cli_job_merge.py
@@ -249,66 +249,6 @@ def test_merge_scoped_cli_jobs_keeps_marionette_stamped_foreign(tmp_path, monkey
     assert merged[0].get("session_id") == "sess-x"
 
 
-def test_merge_scoped_cli_jobs_sibling_task_only_stamp_emits_session_id(tmp_path, monkeypatch):
-    """Sibling merge inspects tasks before ownership; live row carries session_id."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    harness_store = create_store("sqlite", str(tmp_path / "harness-state"))
-    foreign = tmp_path / "foreign-state"
-    store = create_store("sqlite", str(foreign))
-    job = store.create_job("sibling task stamp")
-    payload = stamp_task_payload(
-        {"cwd": str(repo)},
-        session_id="sess-x",
-        origin="marionette",
-    )
-    store.save_task(Task(
-        job_id=job.id,
-        role="implement",
-        instruction="do work",
-        adapter="agentic",
-        payload=payload,
-    ))
-    try:
-        store.update_job_status(job.id, "running")
-    except Exception:
-        store.set_job_status(job.id, "running")
-
-    monkeypatch.setenv("HARNESS_CLI_CROSS_PROJECT", "1")
-    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda workspace_root="": None)
-
-    def _fake_merge(*, seen_ids, primary_state_dir="", tasks_by_job=None):
-        row = {
-            "id": job.id,
-            "goal": "sibling task stamp",
-            "status": "running",
-            "source": "cli",
-            "cross_project": True,
-            "cli_state_dir": str(foreign),
-        }
-        if tasks_by_job is not None:
-            tasks_by_job[job.id] = store.list_tasks(job.id)
-        return [row]
-
-    monkeypatch.setattr(
-        "harness.cli_job_merge.merge_running_cli_jobs_all_projects",
-        _fake_merge,
-    )
-
-    merged, _, tasks_by_job = merge_scoped_cli_jobs(
-        [],
-        harness_store=harness_store,
-        active_session_id="sess-x",
-        repo_root=str(repo),
-        workspace_root=str(repo),
-        registered_job_ids=[job.id],
-    )
-    assert [row["id"] for row in merged] == [job.id]
-    assert merged[0]["session_id"] == "sess-x"
-    assert job.id in tasks_by_job
-    assert "tasks" not in merged[0]
-
-
 def test_registered_id_does_not_admit_sibling_cli_store(tmp_path, monkeypatch):
     """A harness-registered id must not heal a colliding unstamped sibling row."""
     repo = tmp_path / "repo"
@@ -318,10 +258,7 @@ def test_registered_id_does_not_admit_sibling_cli_store(tmp_path, monkeypatch):
     store = create_store("sqlite", str(foreign))
     job = store.create_job("foreign collide")
     _save_task(store, job.id, str(repo))
-    try:
-        store.update_job_status(job.id, "running")
-    except Exception:
-        store.set_job_status(job.id, "running")
+    store.update_job_status(job.id, "running")
 
     monkeypatch.setenv("HARNESS_CLI_CROSS_PROJECT", "1")
     monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda workspace_root="": None)
@@ -368,10 +305,7 @@ def test_sibling_task_only_stamp_uses_one_store_open(tmp_path, monkeypatch):
         adapter="agentic",
         payload=payload,
     ))
-    try:
-        store.update_job_status(job.id, "running")
-    except Exception:
-        store.set_job_status(job.id, "running")
+    store.update_job_status(job.id, "running")
 
     opens: list[str] = []
     real_open = open_cli_durable_at

--- a/tests/test_implement_fanout_and_metrics.py
+++ b/tests/test_implement_fanout_and_metrics.py
@@ -308,8 +308,8 @@ def test_seed_baseline_excludes_seeded_files_from_finalize(tmp_path):
         remove_worktree(str(repo), wt_path, force=True)
 
 
-def test_filter_local_running_visible_on_session_drift(tmp_path):
-    # Session stamp drifted but cwd is under the open workspace -- still show.
+def test_filter_local_session_stamped_remain_owned_on_session_drift(tmp_path):
+    # Sidecar rows with a session stamp stay owned after a chat switch.
     rows = [
         {
             "id": "local-run",
@@ -323,12 +323,17 @@ def test_filter_local_running_visible_on_session_drift(tmp_path):
             "session_id": "old-sess",
             "cwd": str(tmp_path / "proj"),
         },
+        {
+            "id": "local-cwd-only",
+            "status": "running",
+            "cwd": str(tmp_path / "proj"),
+        },
     ]
     (tmp_path / "proj").mkdir()
     visible = filter_local_jobs(
         rows, active_session_id="new-sess", repo_root=str(tmp_path / "proj"),
     )
-    assert [j["id"] for j in visible] == ["local-run"]
+    assert [j["id"] for j in visible] == ["local-run", "local-done"]
 
 
 def test_preview_agentic_route_empty_on_bad_goal():

--- a/tests/test_internal_uri.py
+++ b/tests/test_internal_uri.py
@@ -10,6 +10,7 @@ import pytest
 
 from harness.config import HarnessConfig
 from harness.conversation import ConversationalSession
+from harness.job_scoping import job_label_for_session, stamp_task_payload
 from harness.internal_uri import (
     InternalUriContext,
     InternalUriError,
@@ -23,11 +24,19 @@ from puppetmaster.models import AgentRun, Artifact, ArtifactType, Task
 from puppetmaster.store_factory import create_store
 
 
-def _seed_store(state_dir: str) -> dict[str, str]:
+def _seed_store(state_dir: str, session_id: str = "sess-uri") -> dict[str, str]:
     store = create_store("sqlite", state_dir)
     store.init()
-    job = store.create_job("Find routing regressions in harness")
-    task = Task(job_id=job.id, role="conflict-auditor", instruction="scan")
+    job = store.create_job(
+        "Find routing regressions in harness",
+        label=job_label_for_session(session_id),
+    )
+    task = Task(
+        job_id=job.id,
+        role="conflict-auditor",
+        instruction="scan",
+        payload=stamp_task_payload({}, session_id=session_id),
+    )
     store.save_task(task)
     run = AgentRun(
         job_id=job.id,
@@ -195,6 +204,61 @@ class TestInternalUriResolution:
 
         art_hits = search_internal_uris("Router drops", ctx, scheme="artifact")
         assert f"artifact://{ids['job_id']}/{ids['artifact_id']}" in art_hits
+
+    def test_unstamped_store_job_absent_from_uri_surfaces(self, tmp_path):
+        state_dir = str(tmp_path)
+        store = create_store("sqlite", state_dir)
+        store.init()
+        job = store.create_job("foreign leftover")
+        task = Task(job_id=job.id, role="implement", instruction="scan")
+        store.save_task(task)
+        run = AgentRun(
+            job_id=job.id,
+            task_id=task.id,
+            role="implement",
+            worker_id="foreign-worker",
+        )
+        store.save_run(run)
+        artifact = Artifact(
+            job_id=job.id,
+            task_id=task.id,
+            type=ArtifactType.FINDING,
+            created_by=run.worker_id,
+            payload={"claim": "foreign leftover finding"},
+            confidence=0.5,
+            evidence=["foreign leftover"],
+        )
+        store.save_artifact(artifact)
+        ctx = InternalUriContext(state_dir=state_dir, repo=None)
+        listing = resolve_internal_uri("job://", ctx)
+        assert job.id not in listing.content
+        with pytest.raises(InternalUriError, match="not found"):
+            resolve_internal_uri(f"job://{job.id}", ctx)
+        with pytest.raises(InternalUriError, match="not found"):
+            resolve_internal_uri(f"artifact://{job.id}/{artifact.id}", ctx)
+        with pytest.raises(InternalUriError, match="not found"):
+            resolve_internal_uri(f"agent://{job.id}", ctx)
+        assert job.id not in search_internal_uris("foreign leftover", ctx, scheme="job")
+        assert job.id not in search_internal_uris("foreign leftover finding", ctx, scheme="artifact")
+        assert job.id not in search_internal_uris("foreign-worker", ctx, scheme="agent")
+
+    def test_uri_session_cut_hides_other_owned_session(self, tmp_path):
+        state_dir = str(tmp_path)
+        mine = _seed_store(state_dir, session_id="sess-a")
+        other = _seed_store(state_dir, session_id="sess-b")
+        ctx = InternalUriContext(state_dir=state_dir, session_id="sess-a")
+        listing = resolve_internal_uri("job://", ctx)
+        assert mine["job_id"] in listing.content
+        assert other["job_id"] not in listing.content
+        resolve_internal_uri(f"job://{mine['job_id']}", ctx)
+        resolve_internal_uri(f"artifact://{mine['job_id']}/{mine['artifact_id']}", ctx)
+        with pytest.raises(InternalUriError, match="not found"):
+            resolve_internal_uri(f"job://{other['job_id']}", ctx)
+        with pytest.raises(InternalUriError, match="not found"):
+            resolve_internal_uri(f"artifact://{other['job_id']}/{other['artifact_id']}", ctx)
+        with pytest.raises(InternalUriError, match="not found"):
+            resolve_internal_uri(f"agent://{other['job_id']}", ctx)
+        assert other["job_id"] not in search_internal_uris("routing regressions", ctx, scheme="job")
 
 
 class TestConflictUri:

--- a/tests/test_local_job_provenance.py
+++ b/tests/test_local_job_provenance.py
@@ -20,6 +20,7 @@ from harness.internal_uri import (
     InternalUriError,
     resolve_internal_uri,
 )
+from harness.job_scoping import job_label_for_session, stamp_task_payload
 from harness.local_job_artifacts import (
     artifacts_are_complete,
     resolve_execution_provenance,
@@ -367,8 +368,16 @@ def test_store_backed_job_ids_never_resolve_through_the_sidecar(session):
     sess, state_dir, repo = session
     store = create_store("sqlite", state_dir)
     store.init()
-    job = store.create_job("audit swarm artifact resolvability")
-    task = Task(job_id=job.id, role="audit", instruction="scan")
+    job = store.create_job(
+        "audit swarm artifact resolvability",
+        label=job_label_for_session("sess-a"),
+    )
+    task = Task(
+        job_id=job.id,
+        role="audit",
+        instruction="scan",
+        payload=stamp_task_payload({}, session_id="sess-a"),
+    )
     store.save_task(task)
     run = AgentRun(job_id=job.id, task_id=task.id, role="audit", worker_id="w-1")
     store.save_run(run)
@@ -391,8 +400,16 @@ def test_store_surfaced_artifacts_are_resolvable_and_counts_agree(session):
     sess, state_dir, repo = session
     store = create_store("sqlite", state_dir)
     store.init()
-    job = store.create_job("audit swarm artifact resolvability")
-    task = Task(job_id=job.id, role="audit", instruction="scan")
+    job = store.create_job(
+        "audit swarm artifact resolvability",
+        label=job_label_for_session("sess-a"),
+    )
+    task = Task(
+        job_id=job.id,
+        role="audit",
+        instruction="scan",
+        payload=stamp_task_payload({}, session_id="sess-a"),
+    )
     store.save_task(task)
     run = AgentRun(job_id=job.id, task_id=task.id, role="audit", worker_id="w-1")
     store.save_run(run)

--- a/tests/test_local_job_swarm_view.py
+++ b/tests/test_local_job_swarm_view.py
@@ -464,7 +464,7 @@ def test_project_preserves_accounting_fields():
 
 
 def test_swarm_live_session_savings_exclude_external_cli_jobs(tmp_path, monkeypatch):
-    """Visibility-only CLI rows stay visible but do not inflate session savings."""
+    """Unstamped CLI rows stay off Marionette live and do not inflate session savings."""
     repo = tmp_path / "repo"
     repo.mkdir()
     harness_dir = tmp_path / "harness-state"
@@ -510,9 +510,7 @@ def test_swarm_live_session_savings_exclude_external_cli_jobs(tmp_path, monkeypa
             _get(port, f"/api/swarm/live?repo={scoped}", {"X-Harness-Token": srv._TOKEN}).read().decode()
         )
         cli_rows = [j for j in data["jobs"] if j.get("id") == cli_job.id]
-        assert len(cli_rows) == 1
-        assert cli_rows[0]["accounting_owned"] is False
-        assert cli_rows[0]["routing_saved_usd"] == 0.0
+        assert cli_rows == []
         assert data["session"]["routing_saved_usd"] == 0.0
     finally:
         httpd.shutdown()

--- a/tests/test_safe_boundary_cancel_steer.py
+++ b/tests/test_safe_boundary_cancel_steer.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 import pytest
 
 from harness.api.jobs import make_job_services, post_swarm_cancel
+from harness.job_scoping import job_label_for_session
 from harness.busy_control import BusyControlMixin
 from harness.config import HarnessConfig
 from harness.conversation import ConversationalSession
@@ -43,6 +44,9 @@ class _FakeStore:
 
     def list_jobs(self):
         return list(self._jobs)
+
+    def list_tasks(self, job_id: str):
+        return []
 
     def cancel_job(self, job_id: str):
         if job_id not in self._known:
@@ -256,8 +260,9 @@ def test_interrupt_source_has_no_unsafe_thread_kill():
 
 def test_http_cancel_and_interrupt_share_dual_store_seam(monkeypatch):
     """Membership cancel (HTTP) and drain (interrupt) use the same helpers."""
-    harness = _FakeStore([{"id": "harness-only"}])
-    cli = _FakeStore([{"id": "cli-only"}])
+    label = job_label_for_session("sess-x")
+    harness = _FakeStore([{"id": "harness-only", "label": label}])
+    cli = _FakeStore([{"id": "cli-only", "label": label}])
     monkeypatch.setattr(
         "harness.cli_job_merge.open_cli_durable_state",
         lambda _repo="": SimpleNamespace(store=cli),
@@ -287,6 +292,33 @@ def test_http_cancel_and_interrupt_share_dual_store_seam(monkeypatch):
     assert code == 200
     assert body["ok"] is True
     assert harness.cancelled == ["harness-only"]
+
+
+def test_cancel_job_dual_store_does_not_resolve_sibling(monkeypatch):
+    """Sibling resolve is owned by post_swarm_cancel, not the dual-store helper."""
+    harness = _FakeStore([])
+    cli = _FakeStore([])
+    finds: list[str] = []
+
+    def _find(job_id):
+        finds.append(job_id)
+        return "/should-not-open"
+
+    monkeypatch.setattr(
+        "harness.cli_job_merge.open_cli_durable_state",
+        lambda _repo="": SimpleNamespace(store=cli),
+    )
+    monkeypatch.setattr("puppetmaster.state.find_state_dir_for_job", _find)
+    result = cancel_job_dual_store(
+        "job-sibling-only",
+        harness_store=harness,
+        harness_list_jobs=harness.list_jobs,
+        repo_root="/repo",
+    )
+    assert result is None
+    assert finds == []
+    assert harness.cancelled == []
+    assert cli.cancelled == []
 
 
 # --- S2: Stop ↔ steer boundary -------------------------------------------------

--- a/tests/test_server_cancel_membership.py
+++ b/tests/test_server_cancel_membership.py
@@ -12,16 +12,19 @@ from types import SimpleNamespace
 import pytest
 
 from harness.api.jobs import make_job_services, post_swarm_cancel
+from harness.job_scoping import job_label_for_session, stamp_task_payload
+from puppetmaster.models import Task
+from puppetmaster.store_factory import create_store
 
 
 def _noop(*_a, **_k):
     return None
 
 
-def _job_services(*, get_pilot, get_session, cfg_repo: str = "/repo"):
+def _job_services(*, get_pilot, get_session, cfg_repo: str = "/repo", session_id: str = ""):
     return make_job_services(
         cfg=SimpleNamespace(repo=cfg_repo),
-        sessions=SimpleNamespace(),
+        sessions=SimpleNamespace(active=session_id),
         get_pilot=get_pilot,
         get_session=get_session,
         diag=_noop,
@@ -49,6 +52,9 @@ class _FakeStore:
     def list_jobs(self):
         return list(self._jobs)
 
+    def list_tasks(self, job_id: str):
+        return []
+
     def cancel_job(self, job_id: str):
         if not self._cancelable:
             raise RuntimeError("cancel_job unavailable")
@@ -72,15 +78,37 @@ class _FakeSession:
 
 
 class _FakePilot:
-    def __init__(self, local_ids=None):
-        self._local_ids = set(local_ids or [])
+    def __init__(self, local_ids=None, *, session_id="", local_jobs=None, registered=None):
+        self.harness_session_id = session_id
+        self._session_job_ids = list(registered or [])
         self.cancelled_local: list[str] = []
+        self._local_jobs: dict = {}
+        for jid in local_ids or []:
+            self._local_jobs[jid] = {"id": jid, "session_id": session_id}
+        for job in local_jobs or []:
+            self._local_jobs[job["id"]] = dict(job)
+
+    def get_local_job(self, job_id: str):
+        job = self._local_jobs.get(job_id)
+        return dict(job) if job else None
+
+    def live_local_jobs(self):
+        return [dict(job) for job in self._local_jobs.values()]
 
     def cancel_local_job(self, job_id: str) -> bool:
-        if job_id in self._local_ids:
+        if job_id in self._local_jobs:
             self.cancelled_local.append(job_id)
             return True
         return False
+
+
+def _track_request_cancel(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "puppetmaster.cancellation.request_cancel",
+        lambda job_id: calls.append(job_id),
+    )
+    return calls
 
 
 @pytest.fixture(autouse=True)
@@ -102,7 +130,11 @@ def test_missing_job_id_is_bad_request():
 
 
 def test_harness_store_job_cancels_via_production_path(monkeypatch):
-    harness = _FakeStore([{"id": "job-a"}, {"id": "job-b"}])
+    label = job_label_for_session("sess-x")
+    harness = _FakeStore([
+        {"id": "job-a", "label": label},
+        {"id": "job-b", "label": label},
+    ])
     monkeypatch.setattr(
         "harness.cli_job_merge.open_cli_durable_state",
         lambda _repo="": None,
@@ -119,8 +151,9 @@ def test_harness_store_job_cancels_via_production_path(monkeypatch):
 
 def test_cli_store_only_job_cancels_not_404(monkeypatch):
     """CLI durable jobs must resolve through the same dual-store set as reads."""
-    harness = _FakeStore([{"id": "harness-only"}])
-    cli_store = _FakeStore([{"id": "cli-only"}, {}, {"goal": "x"}])
+    label = job_label_for_session("sess-x")
+    harness = _FakeStore([{"id": "harness-only", "label": label}])
+    cli_store = _FakeStore([{"id": "cli-only", "label": label}, {}, {"goal": "x"}])
     cli_state = SimpleNamespace(store=cli_store)
     monkeypatch.setattr(
         "harness.cli_job_merge.open_cli_durable_state",
@@ -141,8 +174,9 @@ def test_cli_store_only_job_cancels_not_404(monkeypatch):
 
 
 def test_unknown_job_id_returns_404(monkeypatch):
-    harness = _FakeStore([{"id": "job-a"}])
-    cli_store = _FakeStore([{"id": "cli-a"}])
+    label = job_label_for_session("sess-x")
+    harness = _FakeStore([{"id": "job-a", "label": label}])
+    cli_store = _FakeStore([{"id": "cli-a", "label": label}])
     monkeypatch.setattr(
         "harness.cli_job_merge.open_cli_durable_state",
         lambda _repo="": SimpleNamespace(store=cli_store),
@@ -157,7 +191,7 @@ def test_unknown_job_id_returns_404(monkeypatch):
 
 
 def test_malformed_rows_do_not_match_or_raise(monkeypatch):
-    harness = _FakeStore([{}, {"goal": "x"}, {"id": "real-job"}])
+    harness = _FakeStore([{}, {"goal": "x"}, {"id": "real-job", "label": job_label_for_session("sess-x")}])
     monkeypatch.setattr(
         "harness.cli_job_merge.open_cli_durable_state",
         lambda _repo="": None,
@@ -175,19 +209,54 @@ def test_malformed_rows_do_not_match_or_raise(monkeypatch):
     assert body_bad["ok"] is False
 
 
+def test_known_unowned_job_cancel_looks_unknown(monkeypatch):
+    harness = _FakeStore([{"id": "foreign-cli", "goal": "unstamped leftover"}])
+    monkeypatch.setattr(
+        "harness.cli_job_merge.open_cli_durable_state",
+        lambda _repo="": None,
+    )
+    svc = _job_services(
+        get_pilot=lambda: _FakePilot(),
+        get_session=lambda: _FakeSession(_FakeState(harness)),
+    )
+    code, body = post_swarm_cancel({"job_id": "foreign-cli"}, svc)
+    assert code == 404
+    assert body == {"ok": False, "error": "unknown job_id", "job_id": "foreign-cli"}
+    assert harness.cancelled == []
+
+
+def test_known_unowned_cli_job_cancel_looks_unknown(monkeypatch):
+    harness = _FakeStore([])
+    cli_store = _FakeStore([{"id": "cli-foreign", "goal": "unstamped leftover"}])
+    monkeypatch.setattr(
+        "harness.cli_job_merge.open_cli_durable_state",
+        lambda _repo="": SimpleNamespace(store=cli_store),
+    )
+    svc = _job_services(
+        get_pilot=lambda: _FakePilot(),
+        get_session=lambda: _FakeSession(_FakeState(harness)),
+    )
+    code, body = post_swarm_cancel({"job_id": "cli-foreign"}, svc)
+    assert code == 404
+    assert body == {"ok": False, "error": "unknown job_id", "job_id": "cli-foreign"}
+    assert cli_store.cancelled == []
+
+
 def test_local_pilot_cancel_short_circuits_before_stores(monkeypatch):
     harness = _FakeStore([{"id": "local-1"}])
     calls = {"cli": 0}
+    tripped = _track_request_cancel(monkeypatch)
 
     def _open_cli(_repo=""):
         calls["cli"] += 1
         return None
 
     monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", _open_cli)
-    pilot = _FakePilot(local_ids={"local-1"})
+    pilot = _FakePilot(local_ids={"local-1"}, session_id="sess-x")
     svc = _job_services(
         get_pilot=lambda: pilot,
         get_session=lambda: _FakeSession(_FakeState(harness)),
+        session_id="sess-x",
     )
     code, body = post_swarm_cancel({"job_id": "local-1"}, svc)
     assert code == 200
@@ -195,3 +264,154 @@ def test_local_pilot_cancel_short_circuits_before_stores(monkeypatch):
     assert pilot.cancelled_local == ["local-1"]
     assert harness.cancelled == []
     assert calls["cli"] == 0
+    assert tripped == ["local-1"]
+
+
+def _job_status(store, job_id: str) -> str:
+    job = store.get_job(job_id)
+    raw = getattr(job, "status", None)
+    return str(getattr(raw, "value", raw) or "")
+
+
+def _seed_sibling_store(tmp_path, *, owned: bool):
+    sibling = tmp_path / "sibling-state"
+    store = create_store("sqlite", str(sibling))
+    job = store.create_job("sibling job")
+    payload = (
+        stamp_task_payload({}, session_id="sess-x", origin="marionette")
+        if owned
+        else {"note": "unstamped leftover"}
+    )
+    store.save_task(Task(
+        job_id=job.id,
+        role="implement",
+        instruction="do work",
+        adapter="agentic",
+        payload=payload,
+    ))
+    store.update_job_status(job.id, "running")
+    return store, sibling, job.id
+
+
+def _sibling_cancel_svc(monkeypatch, sibling_dir, *, registered=None):
+    monkeypatch.setenv("HARNESS_CLI_CROSS_PROJECT", "1")
+    monkeypatch.setattr(
+        "harness.cli_job_merge.open_cli_durable_state",
+        lambda _repo="": None,
+    )
+    monkeypatch.setattr(
+        "puppetmaster.state.list_project_state_dirs",
+        lambda: [sibling_dir],
+    )
+
+    def _forbidden_dual(*_a, **_k):
+        raise AssertionError("cancel_job_dual_store must not run after a primary miss")
+
+    monkeypatch.setattr("harness.job_cancel.cancel_job_dual_store", _forbidden_dual)
+    harness = _FakeStore([])
+    pilot = _FakePilot()
+    if registered is not None:
+        pilot._session_job_ids = list(registered)
+    return _job_services(
+        get_pilot=lambda: pilot,
+        get_session=lambda: _FakeSession(_FakeState(harness)),
+    ), harness
+
+
+def test_foreign_sibling_cancel_refused_status_unchanged(tmp_path, monkeypatch):
+    store, sibling_dir, job_id = _seed_sibling_store(tmp_path, owned=False)
+    svc, _harness = _sibling_cancel_svc(monkeypatch, sibling_dir, registered=[job_id])
+    before = _job_status(store, job_id)
+    code, body = post_swarm_cancel({"job_id": job_id}, svc)
+    assert code == 404
+    assert body == {"ok": False, "error": "unknown job_id", "job_id": job_id}
+    assert _job_status(store, job_id) == before
+    assert _job_status(store, job_id) == "running"
+
+
+def test_owned_sibling_task_stamp_cancel_succeeds(tmp_path, monkeypatch):
+    store, sibling_dir, job_id = _seed_sibling_store(tmp_path, owned=True)
+    svc, harness = _sibling_cancel_svc(monkeypatch, sibling_dir)
+    tripped = _track_request_cancel(monkeypatch)
+    code, body = post_swarm_cancel({"job_id": job_id}, svc)
+    assert code == 200
+    assert body["ok"] is True
+    assert body["job_id"] == job_id
+    assert body["durable"] is True
+    assert body["marked"] is True
+    assert _job_status(store, job_id) == "cancelled"
+    assert harness.cancelled == []
+    assert tripped == [job_id]
+
+
+def test_unknown_job_does_not_trip_request_cancel(monkeypatch):
+    tripped = _track_request_cancel(monkeypatch)
+    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda _repo="": None)
+    svc = _job_services(
+        get_pilot=lambda: _FakePilot(),
+        get_session=lambda: _FakeSession(_FakeState(_FakeStore([]))),
+    )
+    code, body = post_swarm_cancel({"job_id": "job-zzz"}, svc)
+    assert code == 404
+    assert body == {"ok": False, "error": "unknown job_id", "job_id": "job-zzz"}
+    assert tripped == []
+
+
+def test_unowned_primary_does_not_trip_request_cancel(monkeypatch):
+    tripped = _track_request_cancel(monkeypatch)
+    harness = _FakeStore([{"id": "foreign-cli", "goal": "unstamped leftover"}])
+    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda _repo="": None)
+    svc = _job_services(
+        get_pilot=lambda: _FakePilot(),
+        get_session=lambda: _FakeSession(_FakeState(harness)),
+    )
+    code, _body = post_swarm_cancel({"job_id": "foreign-cli"}, svc)
+    assert code == 404
+    assert harness.cancelled == []
+    assert tripped == []
+
+
+def test_foreign_sibling_does_not_trip_request_cancel(tmp_path, monkeypatch):
+    store, sibling_dir, job_id = _seed_sibling_store(tmp_path, owned=False)
+    svc, _harness = _sibling_cancel_svc(monkeypatch, sibling_dir, registered=[job_id])
+    tripped = _track_request_cancel(monkeypatch)
+    code, _body = post_swarm_cancel({"job_id": job_id}, svc)
+    assert code == 404
+    assert tripped == []
+    assert _job_status(store, job_id) == "running"
+
+
+def test_foreign_local_session_does_not_trip_or_cancel(monkeypatch):
+    tripped = _track_request_cancel(monkeypatch)
+    harness = _FakeStore([])
+    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda _repo="": None)
+    pilot = _FakePilot(
+        local_jobs=[{"id": "local-other", "session_id": "sess-other"}],
+        session_id="sess-x",
+    )
+    svc = _job_services(
+        get_pilot=lambda: pilot,
+        get_session=lambda: _FakeSession(_FakeState(harness)),
+        session_id="sess-x",
+    )
+    code, body = post_swarm_cancel({"job_id": "local-other"}, svc)
+    assert code == 404
+    assert body == {"ok": False, "error": "unknown job_id", "job_id": "local-other"}
+    assert pilot.cancelled_local == []
+    assert tripped == []
+
+
+def test_owned_durable_trips_request_cancel(monkeypatch):
+    tripped = _track_request_cancel(monkeypatch)
+    label = job_label_for_session("sess-x")
+    harness = _FakeStore([{"id": "job-a", "label": label}])
+    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda _repo="": None)
+    svc = _job_services(
+        get_pilot=lambda: _FakePilot(),
+        get_session=lambda: _FakeSession(_FakeState(harness)),
+    )
+    code, body = post_swarm_cancel({"job_id": "job-a"}, svc)
+    assert code == 200
+    assert body["ok"] is True
+    assert harness.cancelled == ["job-a"]
+    assert tripped == ["job-a"]

--- a/tests/test_server_cancel_membership.py
+++ b/tests/test_server_cancel_membership.py
@@ -130,6 +130,7 @@ def test_missing_job_id_is_bad_request():
 
 
 def test_harness_store_job_cancels_via_production_path(monkeypatch):
+    tripped = _track_request_cancel(monkeypatch)
     label = job_label_for_session("sess-x")
     harness = _FakeStore([
         {"id": "job-a", "label": label},
@@ -147,10 +148,12 @@ def test_harness_store_job_cancels_via_production_path(monkeypatch):
     assert code == 200
     assert body == {"ok": True, "job_id": "job-b", "durable": True, "marked": True}
     assert harness.cancelled == ["job-b"]
+    assert tripped == ["job-b"]
 
 
 def test_cli_store_only_job_cancels_not_404(monkeypatch):
     """CLI durable jobs must resolve through the same dual-store set as reads."""
+    tripped = _track_request_cancel(monkeypatch)
     label = job_label_for_session("sess-x")
     harness = _FakeStore([{"id": "harness-only", "label": label}])
     cli_store = _FakeStore([{"id": "cli-only", "label": label}, {}, {"goal": "x"}])
@@ -171,9 +174,11 @@ def test_cli_store_only_job_cancels_not_404(monkeypatch):
     assert body["marked"] is True
     assert cli_store.cancelled == ["cli-only"]
     assert harness.cancelled == []
+    assert tripped == ["cli-only"]
 
 
 def test_unknown_job_id_returns_404(monkeypatch):
+    tripped = _track_request_cancel(monkeypatch)
     label = job_label_for_session("sess-x")
     harness = _FakeStore([{"id": "job-a", "label": label}])
     cli_store = _FakeStore([{"id": "cli-a", "label": label}])
@@ -188,6 +193,7 @@ def test_unknown_job_id_returns_404(monkeypatch):
     code, body = post_swarm_cancel({"job_id": "job-zzz"}, svc)
     assert code == 404
     assert body == {"ok": False, "error": "unknown job_id", "job_id": "job-zzz"}
+    assert tripped == []
 
 
 def test_malformed_rows_do_not_match_or_raise(monkeypatch):
@@ -210,6 +216,7 @@ def test_malformed_rows_do_not_match_or_raise(monkeypatch):
 
 
 def test_known_unowned_job_cancel_looks_unknown(monkeypatch):
+    tripped = _track_request_cancel(monkeypatch)
     harness = _FakeStore([{"id": "foreign-cli", "goal": "unstamped leftover"}])
     monkeypatch.setattr(
         "harness.cli_job_merge.open_cli_durable_state",
@@ -223,9 +230,11 @@ def test_known_unowned_job_cancel_looks_unknown(monkeypatch):
     assert code == 404
     assert body == {"ok": False, "error": "unknown job_id", "job_id": "foreign-cli"}
     assert harness.cancelled == []
+    assert tripped == []
 
 
 def test_known_unowned_cli_job_cancel_looks_unknown(monkeypatch):
+    tripped = _track_request_cancel(monkeypatch)
     harness = _FakeStore([])
     cli_store = _FakeStore([{"id": "cli-foreign", "goal": "unstamped leftover"}])
     monkeypatch.setattr(
@@ -240,6 +249,7 @@ def test_known_unowned_cli_job_cancel_looks_unknown(monkeypatch):
     assert code == 404
     assert body == {"ok": False, "error": "unknown job_id", "job_id": "cli-foreign"}
     assert cli_store.cancelled == []
+    assert tripped == []
 
 
 def test_local_pilot_cancel_short_circuits_before_stores(monkeypatch):
@@ -321,10 +331,12 @@ def _sibling_cancel_svc(monkeypatch, sibling_dir, *, registered=None):
 def test_foreign_sibling_cancel_refused_status_unchanged(tmp_path, monkeypatch):
     store, sibling_dir, job_id = _seed_sibling_store(tmp_path, owned=False)
     svc, _harness = _sibling_cancel_svc(monkeypatch, sibling_dir, registered=[job_id])
+    tripped = _track_request_cancel(monkeypatch)
     before = _job_status(store, job_id)
     code, body = post_swarm_cancel({"job_id": job_id}, svc)
     assert code == 404
     assert body == {"ok": False, "error": "unknown job_id", "job_id": job_id}
+    assert tripped == []
     assert _job_status(store, job_id) == before
     assert _job_status(store, job_id) == "running"
 
@@ -342,43 +354,6 @@ def test_owned_sibling_task_stamp_cancel_succeeds(tmp_path, monkeypatch):
     assert _job_status(store, job_id) == "cancelled"
     assert harness.cancelled == []
     assert tripped == [job_id]
-
-
-def test_unknown_job_does_not_trip_request_cancel(monkeypatch):
-    tripped = _track_request_cancel(monkeypatch)
-    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda _repo="": None)
-    svc = _job_services(
-        get_pilot=lambda: _FakePilot(),
-        get_session=lambda: _FakeSession(_FakeState(_FakeStore([]))),
-    )
-    code, body = post_swarm_cancel({"job_id": "job-zzz"}, svc)
-    assert code == 404
-    assert body == {"ok": False, "error": "unknown job_id", "job_id": "job-zzz"}
-    assert tripped == []
-
-
-def test_unowned_primary_does_not_trip_request_cancel(monkeypatch):
-    tripped = _track_request_cancel(monkeypatch)
-    harness = _FakeStore([{"id": "foreign-cli", "goal": "unstamped leftover"}])
-    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda _repo="": None)
-    svc = _job_services(
-        get_pilot=lambda: _FakePilot(),
-        get_session=lambda: _FakeSession(_FakeState(harness)),
-    )
-    code, _body = post_swarm_cancel({"job_id": "foreign-cli"}, svc)
-    assert code == 404
-    assert harness.cancelled == []
-    assert tripped == []
-
-
-def test_foreign_sibling_does_not_trip_request_cancel(tmp_path, monkeypatch):
-    store, sibling_dir, job_id = _seed_sibling_store(tmp_path, owned=False)
-    svc, _harness = _sibling_cancel_svc(monkeypatch, sibling_dir, registered=[job_id])
-    tripped = _track_request_cancel(monkeypatch)
-    code, _body = post_swarm_cancel({"job_id": job_id}, svc)
-    assert code == 404
-    assert tripped == []
-    assert _job_status(store, job_id) == "running"
 
 
 def test_foreign_local_session_does_not_trip_or_cancel(monkeypatch):
@@ -399,19 +374,3 @@ def test_foreign_local_session_does_not_trip_or_cancel(monkeypatch):
     assert body == {"ok": False, "error": "unknown job_id", "job_id": "local-other"}
     assert pilot.cancelled_local == []
     assert tripped == []
-
-
-def test_owned_durable_trips_request_cancel(monkeypatch):
-    tripped = _track_request_cancel(monkeypatch)
-    label = job_label_for_session("sess-x")
-    harness = _FakeStore([{"id": "job-a", "label": label}])
-    monkeypatch.setattr("harness.cli_job_merge.open_cli_durable_state", lambda _repo="": None)
-    svc = _job_services(
-        get_pilot=lambda: _FakePilot(),
-        get_session=lambda: _FakeSession(_FakeState(harness)),
-    )
-    code, body = post_swarm_cancel({"job_id": "job-a"}, svc)
-    assert code == 200
-    assert body["ok"] is True
-    assert harness.cancelled == ["job-a"]
-    assert tripped == ["job-a"]

--- a/tests/test_session_job_scoping.py
+++ b/tests/test_session_job_scoping.py
@@ -16,7 +16,9 @@ from harness.job_scoping import (
     cwd_under_repo,
     filter_local_jobs,
     filter_store_jobs,
+    inspect_store_job_ownership,
     job_label_for_session,
+    job_owned_by_marionette,
     job_repo_cwd,
     job_visible_for_view,
     parse_job_session_id,
@@ -85,9 +87,9 @@ def test_job_label_roundtrips_dispatch_identity():
     assert parse_job_dispatch_id(label) == "call_abc"
 
 
-def test_legacy_job_visible_only_in_matching_repo():
+def test_legacy_job_not_visible_via_cwd_match():
     tasks = [SimpleNamespace(payload={"cwd": "/work/a/project"})]
-    assert job_visible_for_view(
+    assert not job_visible_for_view(
         session_id="",
         label=None,
         tasks=tasks,
@@ -103,7 +105,7 @@ def test_legacy_job_visible_only_in_matching_repo():
     )
 
 
-def test_stamped_job_visible_only_for_matching_session():
+def test_stamped_marionette_job_visible_across_sessions():
     label = job_label_for_session("sess-a")
     tasks = [SimpleNamespace(payload={"cwd": "/work/a/project", "session_id": "sess-a"})]
     assert job_visible_for_view(
@@ -113,8 +115,9 @@ def test_stamped_job_visible_only_for_matching_session():
         active_session_id="sess-a",
         repo_root="/work/a",
     )
-    # Terminal + session mismatch stays hidden even under the open repo.
-    assert not job_visible_for_view(
+    # Ownership is origin+session stamp, not the active chat. Frontend session
+    # scope hides other chats; repo/all still list this owned row.
+    assert job_visible_for_view(
         session_id="sess-a",
         label=label,
         tasks=tasks,
@@ -125,7 +128,7 @@ def test_stamped_job_visible_only_for_matching_session():
 
 
 def test_running_stamped_job_visible_under_repo_across_sessions():
-    """Live work under the open workspace must not vanish on session switch."""
+    """Owned Marionette work stays listed after a session switch."""
     label = job_label_for_session("sess-a")
     tasks = [SimpleNamespace(payload={"cwd": "/work/a/project", "session_id": "sess-a"})]
     assert job_visible_for_view(
@@ -138,12 +141,10 @@ def test_running_stamped_job_visible_under_repo_across_sessions():
     )
 
 
-def test_running_job_always_visible_regardless_of_scope():
-    # Running jobs follow the same session/cwd scope as finished ones — a
-    # mismatch must hide them so live work does not leak across directories.
+def test_owned_job_visible_without_cwd_or_active_session_match():
     label = job_label_for_session("sess-a")
     tasks = [SimpleNamespace(payload={"cwd": "/somewhere/else", "session_id": "sess-a"})]
-    assert not job_visible_for_view(
+    assert job_visible_for_view(
         session_id="sess-a",
         label=label,
         tasks=tasks,
@@ -151,7 +152,7 @@ def test_running_job_always_visible_regardless_of_scope():
         repo_root="/work/b",
         status="running",
     )
-    assert not job_visible_for_view(
+    assert job_visible_for_view(
         session_id="sess-a",
         label=label,
         tasks=tasks,
@@ -174,9 +175,9 @@ def test_running_job_visible_when_session_matches():
     )
 
 
-def test_running_job_visible_when_legacy_cwd_matches():
+def test_running_job_not_visible_when_legacy_cwd_matches():
     tasks = [SimpleNamespace(payload={"cwd": "/work/a/project"})]
-    assert job_visible_for_view(
+    assert not job_visible_for_view(
         session_id="",
         label=None,
         tasks=tasks,
@@ -186,8 +187,8 @@ def test_running_job_visible_when_legacy_cwd_matches():
     )
 
 
-def test_running_orphan_visible_without_session_or_cwd():
-    assert job_visible_for_view(
+def test_running_orphan_not_visible_without_session_or_cwd():
+    assert not job_visible_for_view(
         session_id="",
         label=None,
         tasks=[],
@@ -197,23 +198,87 @@ def test_running_orphan_visible_without_session_or_cwd():
     )
 
 
-def test_running_local_job_always_visible():
-    # Wrong session AND cwd outside the open repo: stay hidden.
+def test_registered_job_id_visible_without_stamps():
+    assert job_visible_for_view(
+        session_id="",
+        label=None,
+        tasks=[],
+        active_session_id="sess-b",
+        repo_root="/work/b",
+        status="complete",
+        job_id="job_orphan",
+        registered_job_ids=["job_orphan"],
+    )
+    assert job_owned_by_marionette(job_id="local-heal", registered_job_ids=["local-heal"])
+
+
+def test_app_run_id_is_not_a_visibility_key(monkeypatch):
+    monkeypatch.setenv("HARNESS_APP_RUN_ID", "run-after-restart")
+    label = job_label_for_session("sess-a", app_run_id="run-before-restart")
+    assert job_visible_for_view(
+        session_id="sess-a",
+        label=label,
+        tasks=[],
+        active_session_id="sess-a",
+        repo_root="/work/a",
+        job_id="job_stamped",
+    )
+    unstamped = json.dumps({"app_run_id": "run-after-restart"})
+    assert not job_visible_for_view(
+        session_id="",
+        label=unstamped,
+        tasks=[],
+        active_session_id="sess-a",
+        repo_root="/work/a",
+        job_id="job_run_only",
+    )
+
+
+def test_origin_without_session_is_not_owned():
+    label = json.dumps({"origin": "marionette"})
+    assert not job_owned_by_marionette(label=label, job_id="job_origin_only")
+
+
+def test_pre_origin_session_owned_on_harness_not_cli():
+    label = json.dumps({"session_id": "sess-a"})
+    assert job_owned_by_marionette(label=label, session_id="sess-a", job_id="job_sess_only")
+    assert job_owned_by_marionette(
+        label=label, session_id="sess-a", job_id="job_sess_only", source="harness",
+    )
+    assert not job_owned_by_marionette(
+        label=label, session_id="sess-a", job_id="job_sess_only", source="cli",
+    )
+    assert job_owned_by_marionette(session_id="sess-a", job_id="local-persisted")
+    assert job_owned_by_marionette(
+        session_id="sess-a",
+        job_id="job_sess_only",
+        registered_job_ids=["job_sess_only"],
+    )
+    assert not job_owned_by_marionette(
+        session_id="sess-a",
+        job_id="job_sess_only",
+        source="cli",
+        registered_job_ids=["job_sess_only"],
+        allow_registered_heal=True,
+    )
+
+
+def test_running_local_job_owned_by_session_stamp():
     rows = [
         {"id": "local-1", "status": "running", "session_id": "sess-a", "cwd": "/elsewhere"},
         {"id": "local-2", "status": "complete", "session_id": "sess-a", "cwd": "/elsewhere"},
     ]
     visible = filter_local_jobs(rows, active_session_id="sess-b", repo_root="/work/b")
-    assert [j["id"] for j in visible] == []
+    assert [j["id"] for j in visible] == ["local-1", "local-2"]
 
 
-def test_running_local_job_visible_on_session_drift_when_cwd_matches():
+def test_session_stamped_local_jobs_remain_owned_across_sessions():
     rows = [
         {"id": "local-1", "status": "running", "session_id": "sess-a", "cwd": "/work/b/sub"},
         {"id": "local-2", "status": "completed", "session_id": "sess-a", "cwd": "/work/b/sub"},
     ]
     visible = filter_local_jobs(rows, active_session_id="sess-b", repo_root="/work/b")
-    assert [j["id"] for j in visible] == ["local-1"]
+    assert [j["id"] for j in visible] == ["local-1", "local-2"]
 
 
 def test_running_local_job_visible_when_session_matches():
@@ -224,23 +289,88 @@ def test_running_local_job_visible_when_session_matches():
     assert [j["id"] for j in visible] == ["local-1"]
 
 
-def test_running_local_job_visible_when_legacy_cwd_matches():
+def test_running_local_job_not_visible_when_legacy_cwd_matches():
     rows = [
         {"id": "local-1", "status": "running", "cwd": "/work/a/sub"},
     ]
     visible = filter_local_jobs(rows, active_session_id="sess-b", repo_root="/work/a")
-    assert [j["id"] for j in visible] == ["local-1"]
+    assert [j["id"] for j in visible] == []
 
 
-def test_running_local_orphan_visible_without_session_or_cwd():
+def test_running_local_orphan_not_visible_without_session_or_cwd():
     rows = [
         {"id": "local-orphan", "status": "running"},
     ]
     visible = filter_local_jobs(rows, active_session_id="sess-b", repo_root="/work/b")
-    assert [j["id"] for j in visible] == ["local-orphan"]
+    assert [j["id"] for j in visible] == []
 
 
-def test_filter_store_jobs_two_sessions_two_repos(tmp_path):
+def test_registered_local_job_visible_without_session_stamp():
+    rows = [
+        {"id": "local-heal", "status": "running"},
+    ]
+    visible = filter_local_jobs(
+        rows,
+        active_session_id="sess-b",
+        repo_root="/work/b",
+        registered_job_ids=["local-heal"],
+    )
+    assert [j["id"] for j in visible] == ["local-heal"]
+    assert visible[0]["session_id"] == "sess-b"
+
+
+def test_registered_heal_without_active_session_omits_sessionless_row(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = create_store("sqlite", str(tmp_path / "state"))
+    job = store.create_job("legacy heal")
+    _save_task(store, job.id, str(repo))
+    rows = [{"id": job.id, "goal": "legacy heal", "status": "running"}]
+    visible = filter_store_jobs(
+        rows,
+        store,
+        active_session_id="",
+        repo_root=str(repo),
+        registered_job_ids=[job.id],
+    )
+    assert visible == []
+    locals_visible = filter_local_jobs(
+        [{"id": "local-heal", "status": "running"}],
+        active_session_id="",
+        repo_root=str(repo),
+        registered_job_ids=["local-heal"],
+    )
+    assert locals_visible == []
+
+
+def test_inspect_store_job_ownership_owned_unowned_and_absent(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = create_store("sqlite", str(tmp_path / "state"))
+    owned = store.create_job("owned", label=job_label_for_session("sess-a"))
+    _save_task(store, owned.id, str(repo), session_id="sess-a")
+    leftover = store.create_job("leftover")
+    _save_task(store, leftover.id, str(repo))
+    assert inspect_store_job_ownership(store, owned.id, source="harness") is True
+    assert inspect_store_job_ownership(store, leftover.id, source="harness") is False
+    assert inspect_store_job_ownership(store, "missing", source="harness") is None
+    assert inspect_store_job_ownership(
+        store,
+        leftover.id,
+        source="cli",
+        registered_job_ids=[leftover.id],
+        allow_registered_heal=True,
+    ) is False
+    assert inspect_store_job_ownership(
+        store,
+        leftover.id,
+        source="harness",
+        registered_job_ids=[leftover.id],
+        allow_registered_heal=True,
+    ) is True
+
+
+def test_filter_store_jobs_keeps_owned_drops_legacy(tmp_path):
     repo_a = tmp_path / "repo-a"
     repo_b = tmp_path / "repo-b"
     repo_a.mkdir()
@@ -265,17 +395,36 @@ def test_filter_store_jobs_two_sessions_two_repos(tmp_path):
     scoped_a = filter_store_jobs(rows, store, active_session_id="sess-a", repo_root=str(repo_a))
     ids_a = {j["id"] for j in scoped_a}
     assert job_a.id in ids_a
-    assert legacy.id in ids_a
-    assert job_b.id not in ids_a
+    assert job_b.id in ids_a
+    assert legacy.id not in ids_a
 
     scoped_b = filter_store_jobs(rows, store, active_session_id="sess-b", repo_root=str(repo_b))
     ids_b = {j["id"] for j in scoped_b}
     assert job_b.id in ids_b
-    assert job_a.id not in ids_b
+    assert job_a.id in ids_b
     assert legacy.id not in ids_b
 
 
-def test_filter_local_jobs_respects_session_and_legacy_repo():
+def test_filter_store_jobs_keeps_pre_origin_harness_session(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = create_store("sqlite", str(tmp_path / "state"))
+    job = store.create_job("legacy sess", label=json.dumps({"session_id": "sess-a"}))
+    task = Task(
+        job_id=job.id,
+        role="implement",
+        instruction="do work",
+        adapter="agentic",
+        payload={"cwd": str(repo), "session_id": "sess-a"},
+    )
+    store.save_task(task)
+    rows = [{"id": job.id, "goal": "legacy sess", "status": "complete"}]
+    visible = filter_store_jobs(rows, store, active_session_id="sess-b", repo_root=str(repo))
+    assert [j["id"] for j in visible] == [job.id]
+    assert visible[0]["session_id"] == "sess-a"
+
+
+def test_filter_local_jobs_keeps_stamped_drops_legacy_cwd():
     local_a = {
         "id": "local-aaa",
         "session_id": "sess-a",
@@ -300,8 +449,8 @@ def test_filter_local_jobs_respects_session_and_legacy_repo():
     )
     ids = {j["id"] for j in visible}
     assert "local-aaa" in ids
-    assert "local-leg" in ids
-    assert "local-bbb" not in ids
+    assert "local-bbb" in ids
+    assert "local-leg" not in ids
 
 
 def test_session_meta_meter_accumulation(tmp_path):
@@ -409,7 +558,7 @@ def test_cwd_under_repo_nested_alias_under_canonical(tmp_path):
     assert not cwd_under_repo(str(other), str(repo))
 
     nested_tasks = [SimpleNamespace(payload={"cwd": str(nested)})]
-    assert job_visible_for_view(
+    assert not job_visible_for_view(
         session_id="",
         label=None,
         tasks=nested_tasks,
@@ -417,7 +566,7 @@ def test_cwd_under_repo_nested_alias_under_canonical(tmp_path):
         repo_root=str(repo),
     )
     missing_tasks = [SimpleNamespace(payload={"cwd": str(missing)})]
-    assert job_visible_for_view(
+    assert not job_visible_for_view(
         session_id="",
         label=None,
         tasks=missing_tasks,
@@ -434,16 +583,19 @@ def test_cwd_under_repo_nested_alias_under_canonical(tmp_path):
     )
 
 
-def test_jobs_api_lists_cwd_alias_under_canonical_workspace(tmp_path, monkeypatch):
+def test_jobs_api_lists_stamped_alias_job_not_cwd_only(tmp_path, monkeypatch):
     repo, alias = _alias_or_symlink_root(tmp_path)
     store = create_store("sqlite", str(tmp_path / "state"))
-    created = store.create_job("aliased job")
-    _save_task(store, created.id, str(alias))
+    created = store.create_job("aliased job", label=job_label_for_session("sess-a"))
+    _save_task(store, created.id, str(alias), session_id="sess-a")
+    legacy = store.create_job("legacy alias")
+    _save_task(store, legacy.id, str(alias))
     httpd, port, srv = _api_server(str(tmp_path / "state"))
 
     try:
         monkeypatch.setattr(srv, "_jobs_snapshot", lambda: [
             {"id": created.id, "goal": "aliased job", "status": "complete", "adapter": "agentic"},
+            {"id": legacy.id, "goal": "legacy alias", "status": "complete", "adapter": "agentic"},
         ])
         monkeypatch.setattr(srv._session, "state", lambda: SimpleNamespace(store=store))
         srv._cfg.repo = str(repo)
@@ -476,25 +628,28 @@ def _api_get(port, path, token):
 
 
 def _seed_two_repo_jobs(tmp_path):
-    """Legacy (unstamped) jobs under two repo roots in one store."""
+    """Marionette-stamped jobs under two repo roots plus an unstamped leftover."""
     repo_a = tmp_path / "repo-a"
     repo_b = tmp_path / "repo-b"
     repo_a.mkdir()
     repo_b.mkdir()
     store = create_store("sqlite", str(tmp_path / "state"))
 
-    job_a = store.create_job("job in repo a")
-    _save_task(store, job_a.id, str(repo_a))
+    job_a = store.create_job("job in repo a", label=job_label_for_session("sess-a"))
+    _save_task(store, job_a.id, str(repo_a), session_id="sess-a")
 
-    job_b = store.create_job("job in repo b")
-    _save_task(store, job_b.id, str(repo_b))
+    job_b = store.create_job("job in repo b", label=job_label_for_session("sess-b"))
+    _save_task(store, job_b.id, str(repo_b), session_id="sess-b")
 
-    return store, str(repo_a), str(repo_b), job_a.id, job_b.id
+    legacy = store.create_job("legacy leftover")
+    _save_task(store, legacy.id, str(repo_a))
+
+    return store, str(repo_a), str(repo_b), job_a.id, job_b.id, legacy.id
 
 
-def test_api_jobs_repo_query_overrides_cfg_repo(tmp_path, monkeypatch):
-    """?repo= scopes legacy jobs to the requested root instead of _cfg.repo."""
-    store, repo_a, repo_b, job_a_id, job_b_id = _seed_two_repo_jobs(tmp_path)
+def test_api_jobs_lists_owned_jobs_not_cwd_or_repo_query(tmp_path, monkeypatch):
+    """Owned Marionette jobs stay listed; cwd/?repo= cannot admit unstamped rows."""
+    store, repo_a, repo_b, job_a_id, job_b_id, legacy_id = _seed_two_repo_jobs(tmp_path)
     tmp_dir = tempfile.mkdtemp()
     try:
         httpd, port, srv = _api_server(str(tmp_path / "state"))
@@ -502,6 +657,7 @@ def test_api_jobs_repo_query_overrides_cfg_repo(tmp_path, monkeypatch):
             monkeypatch.setattr(srv, "_jobs_snapshot", lambda: [
                 {"id": job_a_id, "goal": "job in repo a", "status": "complete", "adapter": "agentic"},
                 {"id": job_b_id, "goal": "job in repo b", "status": "complete", "adapter": "agentic"},
+                {"id": legacy_id, "goal": "legacy leftover", "status": "complete", "adapter": "agentic"},
             ])
             monkeypatch.setattr(srv._session, "state", lambda: SimpleNamespace(store=store))
             srv._cfg.repo = repo_b
@@ -510,29 +666,32 @@ def test_api_jobs_repo_query_overrides_cfg_repo(tmp_path, monkeypatch):
             default_ids = {j["id"] for j in json.loads(
                 _api_get(port, "/api/jobs", headers_token).read().decode()
             )}
+            assert job_a_id in default_ids
             assert job_b_id in default_ids
-            assert job_a_id not in default_ids
+            assert legacy_id not in default_ids
 
             scoped_a = urllib.parse.quote(repo_a, safe="")
             override_ids = {j["id"] for j in json.loads(
                 _api_get(port, f"/api/jobs?repo={scoped_a}", headers_token).read().decode()
             )}
             assert job_a_id in override_ids
-            assert job_b_id not in override_ids
+            assert job_b_id in override_ids
+            assert legacy_id not in override_ids
         finally:
             httpd.shutdown()
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
-def test_api_jobs_missing_repo_param_falls_back_to_cfg_repo(tmp_path, monkeypatch):
-    store, repo_a, repo_b, job_a_id, job_b_id = _seed_two_repo_jobs(tmp_path)
+def test_api_jobs_missing_repo_param_still_drops_unstamped(tmp_path, monkeypatch):
+    store, repo_a, repo_b, job_a_id, job_b_id, legacy_id = _seed_two_repo_jobs(tmp_path)
     try:
         httpd, port, srv = _api_server(str(tmp_path / "state"))
         try:
             monkeypatch.setattr(srv, "_jobs_snapshot", lambda: [
                 {"id": job_a_id, "goal": "job in repo a", "status": "complete", "adapter": "agentic"},
                 {"id": job_b_id, "goal": "job in repo b", "status": "complete", "adapter": "agentic"},
+                {"id": legacy_id, "goal": "legacy leftover", "status": "complete", "adapter": "agentic"},
             ])
             monkeypatch.setattr(srv._session, "state", lambda: SimpleNamespace(store=store))
             srv._cfg.repo = repo_a
@@ -541,21 +700,23 @@ def test_api_jobs_missing_repo_param_falls_back_to_cfg_repo(tmp_path, monkeypatc
                 _api_get(port, "/api/jobs", srv._TOKEN).read().decode()
             )}
             assert job_a_id in ids
-            assert job_b_id not in ids
+            assert job_b_id in ids
+            assert legacy_id not in ids
         finally:
             httpd.shutdown()
     finally:
         pass
 
 
-def test_api_swarm_live_repo_query_scopes_jobs(tmp_path, monkeypatch):
-    store, repo_a, repo_b, job_a_id, job_b_id = _seed_two_repo_jobs(tmp_path)
+def test_api_swarm_live_lists_owned_jobs_not_cwd_scope(tmp_path, monkeypatch):
+    store, repo_a, repo_b, job_a_id, job_b_id, legacy_id = _seed_two_repo_jobs(tmp_path)
     try:
         httpd, port, srv = _api_server(str(tmp_path / "state"))
         try:
             monkeypatch.setattr(srv, "_jobs_snapshot", lambda: [
                 {"id": job_a_id, "goal": "job in repo a", "status": "complete", "adapter": "agentic"},
                 {"id": job_b_id, "goal": "job in repo b", "status": "complete", "adapter": "agentic"},
+                {"id": legacy_id, "goal": "legacy leftover", "status": "complete", "adapter": "agentic"},
             ])
             monkeypatch.setattr(srv._session, "state", lambda: SimpleNamespace(
                 store=store,
@@ -574,8 +735,40 @@ def test_api_swarm_live_repo_query_scopes_jobs(tmp_path, monkeypatch):
             )
             ids = {j["id"] for j in data["jobs"]}
             assert job_a_id in ids
-            assert job_b_id not in ids
+            assert job_b_id in ids
+            assert legacy_id not in ids
         finally:
             httpd.shutdown()
     finally:
         pass
+
+
+def test_api_jobs_and_swarm_live_keep_registered_legacy_job(tmp_path, monkeypatch):
+    store, repo_a, _repo_b, _job_a_id, _job_b_id, legacy_id = _seed_two_repo_jobs(tmp_path)
+    httpd, port, srv = _api_server(str(tmp_path / "state"))
+    try:
+        monkeypatch.setattr(srv, "_jobs_snapshot", lambda: [
+            {"id": legacy_id, "goal": "legacy leftover", "status": "running", "adapter": "agentic"},
+        ])
+        monkeypatch.setattr(srv._session, "state", lambda: SimpleNamespace(
+            store=store,
+            format_artifacts=lambda arts: [],
+            job_artifacts=lambda jid: [],
+        ))
+        monkeypatch.setattr(srv, "_swarm_registry", lambda: [])
+        monkeypatch.setattr(srv, "_job_swarm_accounting", lambda arts, registry: (0, 0.0))
+        monkeypatch.setattr(srv, "_job_savings_fields", lambda jid: {})
+        monkeypatch.setattr(srv._pilot, "live_local_jobs", lambda: [])
+        monkeypatch.setattr(srv._pilot, "_session_job_ids", [legacy_id], raising=False)
+        srv._cfg.repo = repo_a
+        srv._sessions._active = "sess-live"
+
+        jobs = json.loads(_api_get(port, "/api/jobs", srv._TOKEN).read().decode())
+        assert {j["id"] for j in jobs} == {legacy_id}
+        assert all(j.get("session_id") == "sess-live" for j in jobs)
+
+        live = json.loads(_api_get(port, "/api/swarm/live", srv._TOKEN).read().decode())
+        assert {j["id"] for j in live["jobs"]} == {legacy_id}
+        assert all(j.get("session_id") == "sess-live" for j in live["jobs"])
+    finally:
+        httpd.shutdown()

--- a/tests/test_state_scoping_invariants.py
+++ b/tests/test_state_scoping_invariants.py
@@ -8,6 +8,9 @@ from types import SimpleNamespace
 import pytest
 
 from harness.api.jobs import make_job_services, get_artifacts, post_swarm_cancel
+from harness.job_scoping import job_label_for_session, stamp_task_payload
+from puppetmaster.models import Artifact, ArtifactType, Task
+from puppetmaster.store_factory import create_store
 from harness.api.sessions import handle_session_delete, remove_session_transcript
 from harness.api.workspace import _persistable_recent_path, record_recent_workspace
 from harness.server import _job_status_is_terminal
@@ -37,6 +40,9 @@ class _FakeStore:
     def list_jobs(self):
         return list(self._jobs)
 
+    def list_tasks(self, job_id: str):
+        return []
+
     def cancel_job(self, job_id: str):
         if not self._cancelable:
             raise RuntimeError("cancel_job unavailable")
@@ -60,11 +66,30 @@ class _FakeSession:
 
 
 class _FakePilot:
-    def __init__(self, local_ids=None):
-        self._local_ids = set(local_ids or [])
+    def __init__(self, local_ids=None, *, session_id="", local_jobs=None, registered=None):
+        self.harness_session_id = session_id
+        self._session_job_ids = list(registered or [])
+        self._local_jobs: dict = {}
+        for jid in local_ids or []:
+            self._local_jobs[jid] = {"id": jid, "session_id": session_id}
+        for job in local_jobs or []:
+            self._local_jobs[job["id"]] = dict(job)
+
+    def get_local_job(self, job_id: str):
+        job = self._local_jobs.get(job_id)
+        return dict(job) if job else None
 
     def cancel_local_job(self, job_id: str) -> bool:
-        return job_id in self._local_ids
+        return job_id in self._local_jobs
+
+
+def _track_request_cancel(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "puppetmaster.cancellation.request_cancel",
+        lambda job_id: calls.append(job_id),
+    )
+    return calls
 
 
 # ---------------------------------------------------------------------------
@@ -214,7 +239,8 @@ def _silence_request_cancel(monkeypatch):
 
 
 def test_cancel_and_artifacts_both_resolve_cli_store(monkeypatch):
-    harness = _FakeStore([{"id": "harness-job"}])
+    label = job_label_for_session("sess-x")
+    harness = _FakeStore([{"id": "harness-job", "label": label}])
 
     class _CliStore(_FakeStore):
         def list_artifacts(self, job_id: str):
@@ -222,7 +248,7 @@ def test_cancel_and_artifacts_both_resolve_cli_store(monkeypatch):
                 return [{"type": "verification", "payload": {"check": "ok"}}]
             return []
 
-    cli_store = _CliStore([{"id": "cli-job"}])
+    cli_store = _CliStore([{"id": "cli-job", "label": label}])
 
     class _HarnessState(_FakeState):
         def job_artifacts(self, job_id: str):
@@ -257,17 +283,81 @@ def test_cancel_and_artifacts_both_resolve_cli_store(monkeypatch):
     assert arts[0]["type"] == "verification"
 
 
-def test_unknown_job_is_unknown_for_cancel_and_empty_for_artifacts(monkeypatch):
-    harness = _FakeStore([])
-    cli_store = _FakeStore([])
+def test_known_unowned_job_artifacts_and_cancel_look_unknown(monkeypatch):
+    harness = _FakeStore([{"id": "foreign-row", "goal": "unstamped leftover"}])
+    reads = {"harness": 0}
+    tripped = _track_request_cancel(monkeypatch)
 
     class _HarnessState(_FakeState):
-        def job_artifacts(self, _job_id: str):
-            return []
+        def job_artifacts(self, job_id: str):
+            reads["harness"] += 1
+            return [{"type": "finding", "headline": "should not leak"}]
 
     monkeypatch.setattr(
         "harness.cli_job_merge.open_cli_durable_state",
-        lambda _repo="": SimpleNamespace(store=cli_store, job_artifacts=lambda _j: []),
+        lambda _repo="": None,
+    )
+    svc = _job_services(
+        get_pilot=lambda: _FakePilot(),
+        get_session=lambda: _FakeSession(_HarnessState(harness)),
+    )
+    cancel_code, cancel_body = post_swarm_cancel({"job_id": "foreign-row"}, svc)
+    assert cancel_code == 404
+    assert cancel_body == {"ok": False, "error": "unknown job_id", "job_id": "foreign-row"}
+    assert harness.cancelled == []
+    assert tripped == []
+    art_code, arts = get_artifacts("foreign-row", svc)
+    assert art_code == 200
+    assert arts == []
+    assert reads["harness"] == 0
+
+
+def test_known_unowned_cli_job_artifacts_and_cancel_look_unknown(monkeypatch):
+    harness = _FakeStore([])
+    cli_store = _FakeStore([{"id": "cli-foreign", "goal": "unstamped leftover"}])
+
+    class _HarnessState(_FakeState):
+        def job_artifacts(self, job_id: str):
+            return [{"type": "finding", "headline": "should not leak"}]
+
+    monkeypatch.setattr(
+        "harness.cli_job_merge.open_cli_durable_state",
+        lambda _repo="": SimpleNamespace(
+            store=cli_store,
+            job_artifacts=lambda _j: [{"type": "finding", "headline": "cli leak"}],
+        ),
+    )
+    svc = _job_services(
+        get_pilot=lambda: _FakePilot(),
+        get_session=lambda: _FakeSession(_HarnessState(harness)),
+    )
+    cancel_code, cancel_body = post_swarm_cancel({"job_id": "cli-foreign"}, svc)
+    assert cancel_code == 404
+    assert cancel_body == {"ok": False, "error": "unknown job_id", "job_id": "cli-foreign"}
+    assert cli_store.cancelled == []
+    art_code, arts = get_artifacts("cli-foreign", svc)
+    assert art_code == 200
+    assert arts == []
+
+
+def test_unknown_job_is_unknown_for_cancel_and_empty_for_artifacts(monkeypatch):
+    harness = _FakeStore([])
+    cli_store = _FakeStore([])
+    reads = {"harness": 0, "cli": 0}
+    tripped = _track_request_cancel(monkeypatch)
+
+    class _HarnessState(_FakeState):
+        def job_artifacts(self, _job_id: str):
+            reads["harness"] += 1
+            return [{"type": "finding", "headline": "should not leak"}]
+
+    def _cli_artifacts(_job_id: str):
+        reads["cli"] += 1
+        return [{"type": "finding", "headline": "cli leak"}]
+
+    monkeypatch.setattr(
+        "harness.cli_job_merge.open_cli_durable_state",
+        lambda _repo="": SimpleNamespace(store=cli_store, job_artifacts=_cli_artifacts),
     )
     svc = _job_services(
         get_pilot=lambda: _FakePilot(),
@@ -275,9 +365,135 @@ def test_unknown_job_is_unknown_for_cancel_and_empty_for_artifacts(monkeypatch):
     )
     code, body = post_swarm_cancel({"job_id": "missing"}, svc)
     assert code == 404
+    assert tripped == []
     art_code, arts = get_artifacts("missing", svc)
     assert art_code == 200
     assert arts == []
+    assert reads["harness"] == 0
+    assert reads["cli"] == 0
+
+
+def _job_status(store, job_id: str) -> str:
+    job = store.get_job(job_id)
+    raw = getattr(job, "status", None)
+    return str(getattr(raw, "value", raw) or "")
+
+
+def _seed_sibling_store(tmp_path, *, owned: bool, with_artifact: bool = True):
+    sibling = tmp_path / "sibling-state"
+    store = create_store("sqlite", str(sibling))
+    job = store.create_job("sibling job")
+    payload = (
+        stamp_task_payload({}, session_id="sess-x", origin="marionette")
+        if owned
+        else {"note": "unstamped leftover"}
+    )
+    task = Task(
+        job_id=job.id,
+        role="implement",
+        instruction="do work",
+        adapter="agentic",
+        payload=payload,
+    )
+    store.save_task(task)
+    store.update_job_status(job.id, "running")
+    if with_artifact:
+        store.save_artifact(Artifact(
+            job_id=job.id,
+            task_id=task.id,
+            type=ArtifactType.FINDING,
+            created_by="worker",
+            payload={"claim": "sibling finding"},
+            confidence=0.9,
+            evidence=["test"],
+        ))
+    return store, sibling, job.id
+
+
+def _sibling_action_svc(monkeypatch, sibling_dir, *, registered=None):
+    monkeypatch.setenv("HARNESS_CLI_CROSS_PROJECT", "1")
+    monkeypatch.setattr(
+        "harness.cli_job_merge.open_cli_durable_state",
+        lambda _repo="": None,
+    )
+    monkeypatch.setattr(
+        "puppetmaster.state.list_project_state_dirs",
+        lambda: [sibling_dir],
+    )
+
+    def _forbidden_dual(*_a, **_k):
+        raise AssertionError("cancel_job_dual_store must not run after a primary miss")
+
+    monkeypatch.setattr("harness.job_cancel.cancel_job_dual_store", _forbidden_dual)
+
+    class _HarnessState(_FakeState):
+        def job_artifacts(self, _job_id: str):
+            return []
+
+        def format_artifacts(self, raw):
+            return list(raw)
+
+    harness = _FakeStore([])
+    pilot = _FakePilot()
+    if registered is not None:
+        pilot._session_job_ids = list(registered)
+    return _job_services(
+        get_pilot=lambda: pilot,
+        get_session=lambda: _FakeSession(_HarnessState(harness)),
+    ), harness
+
+
+def test_foreign_sibling_artifacts_hidden(tmp_path, monkeypatch):
+    store, sibling_dir, job_id = _seed_sibling_store(tmp_path, owned=False)
+    svc, _harness = _sibling_action_svc(monkeypatch, sibling_dir, registered=[job_id])
+    art_code, arts = get_artifacts(job_id, svc)
+    assert art_code == 200
+    assert arts == []
+    assert store.list_artifacts(job_id)
+
+
+def test_owned_sibling_task_stamp_artifacts_returned(tmp_path, monkeypatch):
+    _store, sibling_dir, job_id = _seed_sibling_store(tmp_path, owned=True)
+    svc, _harness = _sibling_action_svc(monkeypatch, sibling_dir)
+    art_code, arts = get_artifacts(job_id, svc)
+    assert art_code == 200
+    assert arts
+    assert any(
+        "sibling finding" in str(row.get("headline") or "")
+        for row in arts
+        if isinstance(row, dict)
+    )
+
+
+def test_foreign_sibling_cancel_refused_and_artifacts_hidden(tmp_path, monkeypatch):
+    store, sibling_dir, job_id = _seed_sibling_store(tmp_path, owned=False)
+    svc, _harness = _sibling_action_svc(monkeypatch, sibling_dir, registered=[job_id])
+    tripped = _track_request_cancel(monkeypatch)
+    before = _job_status(store, job_id)
+    cancel_code, cancel_body = post_swarm_cancel({"job_id": job_id}, svc)
+    assert cancel_code == 404
+    assert cancel_body == {"ok": False, "error": "unknown job_id", "job_id": job_id}
+    assert tripped == []
+    assert _job_status(store, job_id) == before
+    art_code, arts = get_artifacts(job_id, svc)
+    assert art_code == 200
+    assert arts == []
+
+
+def test_owned_sibling_cancel_succeeds_and_artifacts_returned(tmp_path, monkeypatch):
+    store, sibling_dir, job_id = _seed_sibling_store(tmp_path, owned=True)
+    svc, harness = _sibling_action_svc(monkeypatch, sibling_dir)
+    tripped = _track_request_cancel(monkeypatch)
+    art_code, arts = get_artifacts(job_id, svc)
+    assert art_code == 200
+    assert arts
+    cancel_code, cancel_body = post_swarm_cancel({"job_id": job_id}, svc)
+    assert cancel_code == 200
+    assert cancel_body["ok"] is True
+    assert cancel_body["marked"] is True
+    assert tripped == [job_id]
+    assert _job_status(store, job_id) == "cancelled"
+    assert harness.cancelled == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_state_scoping_invariants.py
+++ b/tests/test_state_scoping_invariants.py
@@ -284,9 +284,9 @@ def test_cancel_and_artifacts_both_resolve_cli_store(monkeypatch):
 
 
 def test_known_unowned_job_artifacts_and_cancel_look_unknown(monkeypatch):
+    tripped = _track_request_cancel(monkeypatch)
     harness = _FakeStore([{"id": "foreign-row", "goal": "unstamped leftover"}])
     reads = {"harness": 0}
-    tripped = _track_request_cancel(monkeypatch)
 
     class _HarnessState(_FakeState):
         def job_artifacts(self, job_id: str):
@@ -313,6 +313,7 @@ def test_known_unowned_job_artifacts_and_cancel_look_unknown(monkeypatch):
 
 
 def test_known_unowned_cli_job_artifacts_and_cancel_look_unknown(monkeypatch):
+    tripped = _track_request_cancel(monkeypatch)
     harness = _FakeStore([])
     cli_store = _FakeStore([{"id": "cli-foreign", "goal": "unstamped leftover"}])
 
@@ -335,6 +336,7 @@ def test_known_unowned_cli_job_artifacts_and_cancel_look_unknown(monkeypatch):
     assert cancel_code == 404
     assert cancel_body == {"ok": False, "error": "unknown job_id", "job_id": "cli-foreign"}
     assert cli_store.cancelled == []
+    assert tripped == []
     art_code, arts = get_artifacts("cli-foreign", svc)
     assert art_code == 200
     assert arts == []

--- a/tests/test_swarm_live.py
+++ b/tests/test_swarm_live.py
@@ -328,17 +328,14 @@ def test_swarm_live_held_open_scratch_hijack_exposes_only_host_local(tmp_path, m
         ids = [j.get("id") for j in data["jobs"]]
         assert "local-host-a" in ids
         assert "local-host-b" in ids
-        assert external.id in ids
-        assert foreign.id in ids
+        assert external.id not in ids
+        assert foreign.id not in ids
         assert scratch_job.id not in ids
         assert leaked_job.id not in ids
         locals_ = [j for j in data["jobs"] if str(j.get("id") or "").startswith("local-")]
         assert len(locals_) == 2
         assert all(j.get("model") == "" for j in locals_)
         assert all(j.get("source") == "harness" for j in locals_)
-        ext_row = next(j for j in data["jobs"] if j.get("id") == external.id)
-        assert ext_row["source"] == "cli"
-        assert ext_row["goal"] == goal
     finally:
         httpd.shutdown()
         srv._pilot._local_jobs.clear()

--- a/tests/test_tool_output_savings.py
+++ b/tests/test_tool_output_savings.py
@@ -549,10 +549,7 @@ def test_usage_and_swarm_live_pm_offloads_fail_closed_without_merge(tmp_path, mo
 
         swarm = _get_json(port, f"/api/swarm/live?repo={scoped}", headers=headers)
         swarm_rows = [j for j in swarm["jobs"] if j.get("id") == job.id]
-        assert len(swarm_rows) == 1
-        assert swarm_rows[0]["accounting_owned"] is False
-        assert swarm_rows[0]["tool_output_tokens_saved"] == 0
-        assert swarm_rows[0]["tool_output_savings_usd"] == 0.0
+        assert swarm_rows == []
     finally:
         httpd.shutdown()
         srv_mod._BOOT_REPOS.discard(str(repo))

--- a/tests/test_usage_status_bar_swarm.py
+++ b/tests/test_usage_status_bar_swarm.py
@@ -205,7 +205,7 @@ def test_cache_saved_usd_swarm_credits_real_cost_tasks():
 
 
 def test_api_usage_excludes_unowned_cli_store_jobs(tmp_path, monkeypatch):
-    """Unstamped CLI-store jobs stay visible on the tracker but not /api/usage."""
+    """Unstamped CLI-store jobs must not bill Marionette /api/usage."""
     repo = tmp_path / "repo"
     repo.mkdir()
     harness_dir = tmp_path / "harness-state"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.360"
+version = "0.9.388"
 source = { editable = "." }
 dependencies = [
     { name = "pypdf" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.387",
+  "version": "0.9.388",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.387",
+      "version": "0.9.388",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.387",
+  "version": "0.9.388",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -34,6 +34,7 @@ function liveJob(
         id: "job-1",
         goal: "Audit auth flow",
         status: "running",
+        session_id: "sess-test",
         ...jobOverrides,
       },
     ],
@@ -82,12 +83,12 @@ describe("SwarmPane sort and filter controls", () => {
     mockSwarmLive.mockResolvedValue({
       session: { tokens_used: 0, est_cost_usd: 0 },
       jobs: [
-        { id: "job-z", goal: "Older active audit", status: "running", created_at: "2026-01-01T00:00:00Z", model: "model-old" },
-        { id: "job-a", goal: "Newest active build", status: "running", created_at: "2026-03-01T00:00:00Z", model: "model-new" },
-        { id: "job-no-time", goal: "Active job without timestamp", status: "running" },
-        { id: "job-y", goal: "Older completed review", status: "complete", created_at: "2026-01-15T00:00:00Z" },
-        { id: "job-b", goal: "Newest failed review", status: "failed", created_at: "2026-02-15T00:00:00Z" },
-        { id: "job-c", goal: "Degraded architecture review", status: "complete", created_at: "2026-02-01T00:00:00Z", outcome: { quality: "degraded", trustworthy: false, reasons: ["only verification artifacts"] } },
+        { id: "job-z", goal: "Older active audit", status: "running", session_id: "sess-test", created_at: "2026-01-01T00:00:00Z", model: "model-old" },
+        { id: "job-a", goal: "Newest active build", status: "running", session_id: "sess-test", created_at: "2026-03-01T00:00:00Z", model: "model-new" },
+        { id: "job-no-time", goal: "Active job without timestamp", status: "running", session_id: "sess-test" },
+        { id: "job-y", goal: "Older completed review", status: "complete", session_id: "sess-test", created_at: "2026-01-15T00:00:00Z" },
+        { id: "job-b", goal: "Newest failed review", status: "failed", session_id: "sess-test", created_at: "2026-02-15T00:00:00Z" },
+        { id: "job-c", goal: "Degraded architecture review", status: "complete", session_id: "sess-test", created_at: "2026-02-01T00:00:00Z", outcome: { quality: "degraded", trustworthy: false, reasons: ["only verification artifacts"] } },
       ],
     });
   });
@@ -1508,6 +1509,36 @@ describe("SwarmPane findings section collapse", () => {
       expect(screen.getByText("lazy finding landed")).toBeInTheDocument();
     });
   });
+
+  it("does not replace an owned cross-project slim row with empty artifacts", async () => {
+    localStorage.setItem("marionette.jobScope.v1", "all");
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-sibling",
+        status: "complete",
+        goal: "Owned sibling slim",
+        session_id: "sess-x",
+        source: "cli",
+        cross_project: true,
+        artifacts_complete: false,
+        artifacts: [
+          { type: "FINDING", headline: "slim finding kept", confidence: 0.9 },
+        ],
+      }),
+    );
+    mockArtifacts.mockResolvedValue([]);
+
+    render(<SwarmPane />);
+    fireEvent.click(screen.getByRole("button", { name: "All projects" }));
+    await waitFor(() => expect(screen.getByText("Finished")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Finished"));
+    fireEvent.click(await screen.findByText("Owned sibling slim"));
+
+    await waitFor(() => {
+      expect(mockArtifacts).toHaveBeenCalledWith("job-sibling");
+    });
+    expect(screen.getByText("slim finding kept")).toBeInTheDocument();
+  });
 });
 
 describe("SwarmPane worker-owned routing surface", () => {
@@ -2131,7 +2162,7 @@ describe("SwarmPane tracker header", () => {
   });
 });
 
-describe("SwarmPane external (CLI) source badge", () => {
+describe("SwarmPane does not paint unowned CLI captions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
@@ -2141,11 +2172,31 @@ describe("SwarmPane external (CLI) source badge", () => {
     mockArtifacts.mockResolvedValue([]);
   });
 
-  it("labels CLI-merged jobs as external", async () => {
+  it("hides an unstamped CLI leak", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
         id: "job-cli",
         goal: "Cursor MCP implement",
+        session_id: "",
+        status: "running",
+        adapter: "cursor",
+        source: "cli",
+      }),
+    );
+
+    render(<SwarmPane />);
+    await waitFor(() => {
+      expect(screen.getByText("Swarm Tracker")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Cursor MCP implement")).toBeNull();
+  });
+
+  it("does not label an owned CLI row as external", async () => {
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-cli",
+        goal: "Cursor MCP implement",
+        session_id: "sess-test",
         status: "running",
         adapter: "cursor",
         source: "cli",
@@ -2164,16 +2215,16 @@ describe("SwarmPane external (CLI) source badge", () => {
     render(<SwarmPane />);
     await expandJob(/Cursor MCP implement/);
 
-    await waitFor(() => {
-      expect(
-        screen.getByTitle(
-          "Started outside Marionette (Cursor MCP or terminal Puppetmaster) for this workspace",
-        ),
-      ).toHaveTextContent("external");
-    });
+    expect(
+      screen.queryByTitle(
+        "Started outside Marionette (Cursor MCP or terminal Puppetmaster) for this workspace",
+      ),
+    ).toBeNull();
+    expect(screen.queryByText("visibility only")).toBeNull();
+    expect(screen.queryByText("external")).toBeNull();
   });
 
-  it("does not show the external chip for harness jobs", async () => {
+  it("does not show an origin chip for harness jobs", async () => {
     mockSwarmLive.mockResolvedValue(
       liveJob({
         source: "harness",
@@ -2195,12 +2246,36 @@ describe("SwarmPane external (CLI) source badge", () => {
     ).toBeNull();
   });
 
-  it("discloses cwd for cross-project CLI jobs instead of only external", async () => {
+  it("hides an unstamped cross-project leak", async () => {
     localStorage.setItem("marionette.jobScope.v1", "all");
     mockSwarmLive.mockResolvedValue(
       liveJob({
         id: "job-foreign",
         goal: "Foreign swarm",
+        session_id: "",
+        status: "running",
+        adapter: "cursor",
+        source: "cli",
+        cross_project: true,
+        cwd: "/Users/x/other-repo",
+      }),
+    );
+
+    render(<SwarmPane />);
+    fireEvent.click(screen.getByRole("button", { name: "All projects" }));
+    await waitFor(() => {
+      expect(screen.getByText("Swarm Tracker")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Foreign swarm")).toBeNull();
+  });
+
+  it("does not disclose a cross-project cwd caption", async () => {
+    localStorage.setItem("marionette.jobScope.v1", "all");
+    mockSwarmLive.mockResolvedValue(
+      liveJob({
+        id: "job-foreign",
+        goal: "Foreign swarm",
+        session_id: "sess-9",
         status: "running",
         adapter: "cursor",
         source: "cli",
@@ -2223,14 +2298,8 @@ describe("SwarmPane external (CLI) source badge", () => {
     fireEvent.click(screen.getByRole("button", { name: "All projects" }));
     await expandJob(/Foreign swarm/);
 
-    await waitFor(() => {
-      expect(screen.getByTitle("/Users/x/other-repo")).toHaveTextContent("/Users/x/other-repo");
-    });
-    expect(
-      screen.queryByTitle(
-        "Started outside Marionette (Cursor MCP or terminal Puppetmaster) for this workspace",
-      ),
-    ).toBeNull();
+    expect(screen.queryByTitle("/Users/x/other-repo")).toBeNull();
+    expect(screen.queryByText("visibility only")).toBeNull();
   });
 });
 
@@ -2320,16 +2389,17 @@ describe("SwarmPane repo-scoped dismiss", () => {
   it("keeps live jobs visible even when their id is in the dismiss store", async () => {
     localStorage.setItem(
       "swarm.dismissed.v2",
-      JSON.stringify({ [REPO_A]: ["live-cli-job", "old-finished"] }),
+      JSON.stringify({ [REPO_A]: ["live-owned-job", "old-finished"] }),
     );
     mockSwarmLive.mockResolvedValue({
       session: { tokens_used: 0, est_cost_usd: 0 },
       jobs: [
         {
-          id: "live-cli-job",
-          goal: "CLI swarm still running",
+          id: "live-owned-job",
+          goal: "Owned swarm still running",
           status: "running",
-          source: "cli",
+          source: "harness",
+          session_id: "sess-1",
         },
         {
           id: "old-finished",
@@ -2342,7 +2412,7 @@ describe("SwarmPane repo-scoped dismiss", () => {
     render(<SwarmPane />);
 
     await waitFor(() => {
-      expect(screen.getByText("CLI swarm still running")).toBeInTheDocument();
+      expect(screen.getByText("Owned swarm still running")).toBeInTheDocument();
     });
     // Finished accordion may list zero visible rows; dismissed finished stay hidden.
     expect(screen.queryByText("Previously cleared finished job")).not.toBeInTheDocument();
@@ -2352,27 +2422,28 @@ describe("SwarmPane repo-scoped dismiss", () => {
   it("keeps a previously dismissed job visible after it completes if it was seen live", async () => {
     localStorage.setItem(
       "swarm.dismissed.v2",
-      JSON.stringify({ [REPO_A]: ["live-cli-job"] }),
+      JSON.stringify({ [REPO_A]: ["live-owned-job"] }),
     );
     mockSwarmLive.mockResolvedValue({
       session: { tokens_used: 0, est_cost_usd: 0 },
       jobs: [
         {
-          id: "live-cli-job",
-          goal: "CLI swarm still running",
+          id: "live-owned-job",
+          goal: "Owned swarm still running",
           status: "running",
-          source: "cli",
+          source: "harness",
+          session_id: "sess-1",
         },
       ],
     });
     const { unmount } = render(<SwarmPane />);
     await waitFor(() => {
-      expect(screen.getByText("CLI swarm still running")).toBeInTheDocument();
+      expect(screen.getByText("Owned swarm still running")).toBeInTheDocument();
     });
     // Live sighting prunes the id from dismiss so completion cannot re-hide it.
     await waitFor(() => {
       const stored = JSON.parse(localStorage.getItem("swarm.dismissed.v2") || "{}");
-      expect(stored[REPO_A] || []).not.toContain("live-cli-job");
+      expect(stored[REPO_A] || []).not.toContain("live-owned-job");
     });
     unmount();
     clearSWRCache();
@@ -2381,17 +2452,18 @@ describe("SwarmPane repo-scoped dismiss", () => {
       session: { tokens_used: 0, est_cost_usd: 0 },
       jobs: [
         {
-          id: "live-cli-job",
-          goal: "CLI swarm completed",
+          id: "live-owned-job",
+          goal: "Owned swarm completed",
           status: "complete",
-          source: "cli",
+          source: "harness",
+          session_id: "sess-1",
         },
       ],
     });
     render(<SwarmPane />);
     await openFinishedSection();
     await waitFor(() => {
-      expect(screen.getByText("CLI swarm completed")).toBeInTheDocument();
+      expect(screen.getByText("Owned swarm completed")).toBeInTheDocument();
     });
   });
 
@@ -2408,8 +2480,8 @@ describe("SwarmPane repo-scoped dismiss", () => {
     mockSwarmLive.mockResolvedValue({
       session: { tokens_used: 0, est_cost_usd: 0 },
       jobs: [
-        { id: "old-a", goal: "Old finished A", status: "complete" },
-        { id: "new-peel", goal: "MCP surface audit peel", status: "complete" },
+        { id: "old-a", goal: "Old finished A", status: "complete", session_id: "sess-test" },
+        { id: "new-peel", goal: "MCP surface audit peel", status: "complete", session_id: "sess-test" },
       ],
     });
     render(<SwarmPane />);
@@ -3101,6 +3173,7 @@ describe("SwarmPane command vs swarm split", () => {
           id: "local-cmd-e35cf193",
           goal: "sleep 999",
           status: "running",
+          session_id: "sess-test",
           job_kind: "run_command",
           role: "command",
           adapter: "command",
@@ -3111,6 +3184,7 @@ describe("SwarmPane command vs swarm split", () => {
           id: "job_abc123def456",
           goal: "Audit auth flow",
           status: "running",
+          session_id: "sess-test",
           source: "harness",
         },
       ],
@@ -3125,13 +3199,14 @@ describe("SwarmPane command vs swarm split", () => {
     mockSwarmLive.mockResolvedValue({
       session: { tokens_used: 0, est_cost_usd: 0 },
       jobs: [
-        { id: "job_swarm", goal: "run_swarm audit", status: "running", source: "harness" },
-        { id: "job_impl", goal: "run_implement fix", status: "running", source: "harness", role: "implementer", adapter: "agentic" },
-        { id: "job_par", goal: "run_parallel wave", status: "running", source: "harness" },
+        { id: "job_swarm", goal: "run_swarm audit", status: "running", session_id: "sess-test", source: "harness" },
+        { id: "job_impl", goal: "run_implement fix", status: "running", session_id: "sess-test", source: "harness", role: "implementer", adapter: "agentic" },
+        { id: "job_par", goal: "run_parallel wave", status: "running", session_id: "sess-test", source: "harness" },
         {
           id: "local-cmdbatch-aa11bb22",
           goal: "echo batch",
           status: "running",
+          session_id: "sess-test",
           job_kind: "run_command_batch",
           role: "command_batch",
           adapter: "command_batch",
@@ -3176,6 +3251,7 @@ describe("SwarmPane command vs swarm split", () => {
           id: "local-wave-call_00_ET_S8G91HzE94famGY0TK0Q8637",
           goal: "Parallel wave (2 jobs)",
           status: "running",
+          session_id: "sess-test",
           job_kind: "parallel_wave",
           role: "parallel_wave",
           adapter: "parallel_wave",
@@ -3185,6 +3261,7 @@ describe("SwarmPane command vs swarm split", () => {
           id: "job_abc123def456",
           goal: "run_swarm audit",
           status: "running",
+          session_id: "sess-test",
           job_kind: "run_swarm",
           source: "harness",
         },
@@ -3192,6 +3269,7 @@ describe("SwarmPane command vs swarm split", () => {
           id: "local-impl-1",
           goal: "run_implement fix",
           status: "running",
+          session_id: "sess-test",
           job_kind: "run_implement",
           source: "harness",
         },
@@ -3259,8 +3337,8 @@ describe("SwarmPane v0.9.350 collapsed chrome", () => {
     mockSwarmLive.mockResolvedValue({
       session: { tokens_used: 0, est_cost_usd: 0 },
       jobs: [
-        { id: "job-a", goal: "First job", status: "running" },
-        { id: "job-b", goal: "Second job", status: "running" },
+        { id: "job-a", goal: "First job", status: "running", session_id: "sess-test" },
+        { id: "job-b", goal: "Second job", status: "running", session_id: "sess-test" },
       ],
     });
     render(<SwarmPane />);

--- a/webapp/src/__tests__/composerStatusStack.test.ts
+++ b/webapp/src/__tests__/composerStatusStack.test.ts
@@ -67,6 +67,46 @@ describe("composerStatusStack", () => {
     });
   });
 
+  it("ignores other-session running swarms when sessionId is set", () => {
+    const now = Date.parse("2026-08-23T12:00:00Z");
+    const rows = buildComposerStatusStackRows({
+      nowMs: now,
+      sessionId: "sess-here",
+      swarmJobs: [
+        {
+          id: "job_abc123def456",
+          goal: "This chat",
+          source: "harness",
+          status: "running",
+          session_id: "sess-here",
+          updated_at: now - 1000,
+        } as any,
+        {
+          id: "job_other999888777",
+          goal: "Other chat",
+          source: "harness",
+          status: "running",
+          session_id: "sess-other",
+          updated_at: now - 500,
+        } as any,
+        {
+          id: "job_orphan000111222",
+          goal: "Unstamped leftover",
+          source: "harness",
+          status: "running",
+          updated_at: now - 200,
+        } as any,
+      ],
+      commandSessions: [],
+    });
+    expect(rows.map((row) => row.id)).toEqual(["job_abc123def456"]);
+    expect(rows[0]).toMatchObject({
+      kind: "swarm",
+      state: "running",
+      label: "This chat",
+    });
+  });
+
   it("yields only a Puppetmaster row for a running swarm session plus swarm job", () => {
     const now = Date.parse("2026-08-23T12:00:00Z");
     const swarmJob = {

--- a/webapp/src/__tests__/composerTasks.test.ts
+++ b/webapp/src/__tests__/composerTasks.test.ts
@@ -134,6 +134,17 @@ describe("pickTaskSourceJob", () => {
     };
     expect(pickTaskSourceJob([wave, swarm], "sess-1")?.id).toBe("local-wave-live");
   });
+
+  it("ignores other-session and unstamped running jobs", () => {
+    expect(pickTaskSourceJob([
+      job("foreign", "running", "sess-2", [
+        { id: "t2", role: "impl", instruction: "other", status: "running", adapter: "x" },
+      ]),
+      job("orphan", "running", "", [
+        { id: "t0", role: "impl", instruction: "orphan", status: "running", adapter: "x" },
+      ]),
+    ], "sess-1")).toBeNull();
+  });
 });
 
 describe("taskSourceJobIds", () => {

--- a/webapp/src/__tests__/jobScope.test.ts
+++ b/webapp/src/__tests__/jobScope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { filterJobsByScope, jobInActiveSession } from "../lib/jobScope";
+import { filterJobsByScope, jobInActiveSession, jobIsForeignForScope, jobOwnedForScope } from "../lib/jobScope";
 
 const jobs = [
   { id: "a", session_id: "sess-1" },
@@ -16,6 +16,16 @@ describe("jobInActiveSession", () => {
   });
 });
 
+describe("jobOwnedForScope", () => {
+  it("requires a stamped session id", () => {
+    expect(jobOwnedForScope({ session_id: "sess-1" })).toBe(true);
+    expect(jobOwnedForScope({})).toBe(false);
+    expect(jobIsForeignForScope({ id: "foreign", session_id: "sess-9", cross_project: true })).toBe(true);
+    expect(jobIsForeignForScope({ id: "c" })).toBe(true);
+    expect(jobIsForeignForScope({ id: "b", session_id: "sess-2" })).toBe(false);
+  });
+});
+
 describe("filterJobsByScope", () => {
   it("session keeps only the active chat", () => {
     expect(filterJobsByScope(jobs, "session", "sess-1").map((j) => j.id)).toEqual(["a"]);
@@ -29,28 +39,33 @@ describe("filterJobsByScope", () => {
     expect(filterJobsByScope(jobs, "session", "sess-1").map((j) => j.id)).not.toContain("c");
   });
 
-  it("repo drops cross_project rows", () => {
-    expect(filterJobsByScope(jobs, "repo", "sess-1").map((j) => j.id)).toEqual(["a", "b", "c"]);
+  it("repo drops unstamped and cross_project rows", () => {
+    expect(filterJobsByScope(jobs, "repo", "sess-1").map((j) => j.id)).toEqual(["a", "b"]);
   });
 
-  it("all keeps cross_project rows", () => {
+  it("all keeps owned rows including owned cross_project", () => {
     expect(filterJobsByScope(jobs, "all", "sess-1").map((j) => j.id)).toEqual([
       "a",
       "b",
-      "c",
       "foreign",
     ]);
   });
 
-  it("includeJobIds resurrects a foreign id under session", () => {
+  it("includeJobIds does not resurrect a foreign or unstamped id", () => {
     expect(
       filterJobsByScope(jobs, "session", "sess-1", { includeJobIds: ["foreign"] }).map((j) => j.id),
-    ).toEqual(["a", "foreign"]);
-  });
-
-  it("includeJobIds resurrects a foreign id under repo", () => {
+    ).toEqual(["a"]);
     expect(
       filterJobsByScope(jobs, "repo", "sess-1", { includeJobIds: ["foreign"] }).map((j) => j.id),
-    ).toEqual(["a", "b", "c", "foreign"]);
+    ).toEqual(["a", "b"]);
+    expect(
+      filterJobsByScope(jobs, "session", "sess-1", { includeJobIds: ["c"] }).map((j) => j.id),
+    ).toEqual(["a"]);
+  });
+
+  it("includeJobIds can pin another owned session job", () => {
+    expect(
+      filterJobsByScope(jobs, "session", "sess-1", { includeJobIds: ["b"] }).map((j) => j.id),
+    ).toEqual(["a", "b"]);
   });
 });

--- a/webapp/src/__tests__/swarmAwaitChrome.test.ts
+++ b/webapp/src/__tests__/swarmAwaitChrome.test.ts
@@ -306,49 +306,67 @@ describe("swarm await chrome", () => {
       },
     ];
     const liveDone = [
-      { job_id: "job_old", status: "cancelled" },
-      { id: "job_from_transcript", status: "completed" },
-      { job_id: "job_interrupted", status: "interrupted" },
+      { job_id: "job_old", status: "cancelled", session_id: "sess-1" },
+      { id: "job_from_transcript", status: "completed", session_id: "sess-1" },
+      { job_id: "job_interrupted", status: "interrupted", session_id: "sess-1" },
     ];
     expect(
-      hydratePendingJobIdsAfterReload({ liveJobs: liveDone, items }),
+      hydratePendingJobIdsAfterReload({ liveJobs: liveDone, items, activeSessionId: "sess-1" }),
     ).toEqual([]);
     expect(
-      hydratePendingJobIdsAfterReload({ liveJobs: [], items }),
+      hydratePendingJobIdsAfterReload({ liveJobs: [], items, activeSessionId: "sess-1" }),
     ).toEqual([]);
     expect(
       shouldHoldSwarmAwaitChrome({
-        pendingJobIds: hydratePendingJobIdsAfterReload({ liveJobs: [], items }),
+        pendingJobIds: hydratePendingJobIdsAfterReload({ liveJobs: [], items, activeSessionId: "sess-1" }),
         backendPendingSwarms: false,
         userStopped: false,
       }),
     ).toBe(false);
     expect(
-      hydratePendingJobIdsAfterReload({ liveJobs: null, items }),
+      hydratePendingJobIdsAfterReload({ liveJobs: null, items, activeSessionId: "sess-1" }),
     ).toEqual(["job_old"]);
   });
 
   it("keeps only live non-terminal jobs after reload", () => {
     expect(
       pendingJobIdsFromSwarmLive([
-        { job_id: "job_alive", status: "running" },
-        { job_id: "job_done", status: "completed" },
-        { job_id: "job_complete", status: "complete" },
-        { id: "local-swarm-skip", status: "pending" },
-        { job_id: "job_queued", status: "queued" },
-      ]),
+        { job_id: "job_alive", status: "running", session_id: "sess-1" },
+        { job_id: "job_done", status: "completed", session_id: "sess-1" },
+        { job_id: "job_complete", status: "complete", session_id: "sess-1" },
+        { id: "local-swarm-skip", status: "pending", session_id: "sess-1" },
+        { job_id: "job_queued", status: "queued", session_id: "sess-1" },
+      ], "sess-1"),
     ).toEqual(["job_alive", "job_queued"]);
+  });
+
+  it("does not hold Still working for another session or unstamped live job", () => {
+    const live = [
+      { job_id: "job_other", status: "running", session_id: "sess-b" },
+      { job_id: "job_orphan", status: "running" },
+      { job_id: "job_here", status: "running", session_id: "sess-a" },
+    ];
+    expect(pendingJobIdsFromSwarmLive(live, "sess-a")).toEqual(["job_here"]);
+    expect(pendingJobIdsFromSwarmLive(live, "")).toEqual([]);
+    expect(pendingJobIdsFromSwarmLive(live.filter((j) => j.session_id !== "sess-a"), "sess-a")).toEqual([]);
+    expect(
+      shouldHoldSwarmAwaitChrome({
+        pendingJobIds: pendingJobIdsFromSwarmLive(live.filter((j) => j.session_id !== "sess-a"), "sess-a"),
+        backendPendingSwarms: false,
+        userStopped: false,
+      }),
+    ).toBe(false);
   });
 
   it("does not hold Still working for a settled partial or timed_out wave", () => {
     const live = [
-      { id: "local-wave-call_KzqPc5uVkh7VyutjZlCzjV3N", status: "partial" },
-      { id: "local-wave-call_Iliw2ZfBkaIh881nw8QmEh7i", status: "partial" },
-      { id: "local-wave-call_v7ZjvWP9peyQUMFAk0IIWXdb", status: "completed" },
-      { id: "local-wave-timeout", status: "timed_out" },
+      { id: "local-wave-call_KzqPc5uVkh7VyutjZlCzjV3N", status: "partial", session_id: "sess-1" },
+      { id: "local-wave-call_Iliw2ZfBkaIh881nw8QmEh7i", status: "partial", session_id: "sess-1" },
+      { id: "local-wave-call_v7ZjvWP9peyQUMFAk0IIWXdb", status: "completed", session_id: "sess-1" },
+      { id: "local-wave-timeout", status: "timed_out", session_id: "sess-1" },
     ];
-    expect(pendingJobIdsFromSwarmLive(live)).toEqual([]);
-    expect(terminalJobIdsFromSwarmLive(live)).toEqual([
+    expect(pendingJobIdsFromSwarmLive(live, "sess-1")).toEqual([]);
+    expect(terminalJobIdsFromSwarmLive(live, "sess-1")).toEqual([
       "local-wave-call_KzqPc5uVkh7VyutjZlCzjV3N",
       "local-wave-call_Iliw2ZfBkaIh881nw8QmEh7i",
       "local-wave-call_v7ZjvWP9peyQUMFAk0IIWXdb",
@@ -356,12 +374,12 @@ describe("swarm await chrome", () => {
     ]);
     expect(
       shouldHoldSwarmAwaitChrome({
-        pendingJobIds: pendingJobIdsFromSwarmLive(live),
+        pendingJobIds: pendingJobIdsFromSwarmLive(live, "sess-1"),
         backendPendingSwarms: false,
         userStopped: false,
       }),
     ).toBe(false);
-    expect(waitHintForAssistantDone(pendingJobIdsFromSwarmLive(live))).toBeNull();
+    expect(waitHintForAssistantDone(pendingJobIdsFromSwarmLive(live, "sess-1"))).toBeNull();
   });
 
   it("paints Still working hint after assistant_done with live jobs", () => {
@@ -571,13 +589,14 @@ describe("swarm await chrome", () => {
   it("prunes terminal swarm/live job ids from pendingJobIds", () => {
     expect(
       terminalJobIdsFromSwarmLive([
-        { job_id: "job_done", status: "completed" },
-        { job_id: "job_complete", status: "complete" },
-        { job_id: "job_alive", status: "running" },
-        { id: "local-x", status: "failed" },
-        { job_id: "job_cancel", status: "cancelled" },
-        { job_id: "job_interrupted", status: "interrupted" },
-      ]),
+        { job_id: "job_done", status: "completed", session_id: "sess-1" },
+        { job_id: "job_complete", status: "complete", session_id: "sess-1" },
+        { job_id: "job_alive", status: "running", session_id: "sess-1" },
+        { id: "local-x", status: "failed", session_id: "sess-1" },
+        { job_id: "job_cancel", status: "cancelled", session_id: "sess-1" },
+        { job_id: "job_interrupted", status: "interrupted", session_id: "sess-1" },
+        { job_id: "job_other", status: "completed", session_id: "sess-2" },
+      ], "sess-1"),
     ).toEqual(["job_done", "job_complete", "local-x", "job_cancel", "job_interrupted"]);
     expect(
       pruneTerminalJobIds(

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -2429,7 +2429,7 @@ export default function Conversation({
             const hasActions = jobs.some(
               (j) => Array.isArray(j.actions) && j.actions.length > 0,
             );
-            const terminalIds = terminalJobIdsFromSwarmLive(jobs, pollSid);
+            const terminalIds = terminalJobIdsFromSwarmLive(jobs, pollSid ?? "");
             const hasTerminal = terminalIds.length > 0;
             const recoveryIds = terminalJobIdsNeedingResultRecovery(
               pendingJobIdsRef.current,

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -2429,7 +2429,7 @@ export default function Conversation({
             const hasActions = jobs.some(
               (j) => Array.isArray(j.actions) && j.actions.length > 0,
             );
-            const terminalIds = terminalJobIdsFromSwarmLive(jobs);
+            const terminalIds = terminalJobIdsFromSwarmLive(jobs, pollSid);
             const hasTerminal = terminalIds.length > 0;
             const recoveryIds = terminalJobIdsNeedingResultRecovery(
               pendingJobIdsRef.current,

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -10,7 +10,7 @@ import {
   peekPendingSwarmOpenJob,
 } from "../lib/pendingSwarmOpenJob";
 import { useStaleWhileRevalidate } from "../lib/useStaleWhileRevalidate";
-import { filterJobsByScope, loadJobScope, saveJobScope, type JobScope } from "../lib/jobScope";
+import { filterJobsByScope, jobOwnedForScope, loadJobScope, saveJobScope, type JobScope } from "../lib/jobScope";
 import { isTrackerJob } from "../lib/jobClassification";
 import { jobHeadlineTotal } from "./EconomicsDurable";
 
@@ -920,22 +920,6 @@ function creditDelegationSavings(
   return 0;
 }
 
-function cliOriginCaption(job: Job): { text: string; title: string } {
-  if (job.cross_project) {
-    const cwd = String(job.cwd || "").trim();
-    const stateDir = String(job.cli_state_dir || "").trim();
-    const shown = cwd || (stateDir.replace(/[\\/]+$/, "").split(/[/\\]/).pop() || stateDir);
-    return {
-      text: shown || "other project",
-      title: cwd || stateDir || "Started in another project",
-    };
-  }
-  return {
-    text: "external",
-    title: "Started outside Marionette (Cursor MCP or terminal Puppetmaster) for this workspace",
-  };
-}
-
 /** Missing ownership is owned for harness/local rows; CLI/external fail closed. */
 export function jobAccountingOwned(j: Job): boolean {
   if (j.accounting_owned === true) return true;
@@ -1239,13 +1223,23 @@ export default function SwarmPane() {
       .then((arts) => {
         const prev = dataRef.current;
         if (!prev) return;
+        const incoming = Array.isArray(arts) ? arts : [];
         mutate({
           ...prev,
-          jobs: (prev.jobs || []).map((j) =>
-            j.id === job.id
-              ? { ...j, artifacts: Array.isArray(arts) ? arts : [], artifacts_complete: true }
-              : j,
-          ),
+          jobs: (prev.jobs || []).map((j) => {
+            if (j.id !== job.id) return j;
+            // Owned cross-project slim rows keep live artifacts when expand
+            // resolves empty (sibling-store miss must not wipe the row).
+            if (
+              incoming.length === 0
+              && (j.artifacts || []).length > 0
+              && j.cross_project
+              && jobOwnedForScope(j)
+            ) {
+              return j;
+            }
+            return { ...j, artifacts: incoming, artifacts_complete: true };
+          }),
         });
       })
       .catch(() => {
@@ -1473,9 +1467,9 @@ export default function SwarmPane() {
     (job) => isTrackerJob(job),
   );
   // Clear/dismiss is archive chrome for finished runs only. Live (and pending)
-  // jobs must stay visible even if their id was previously dismissed — otherwise
-  // a CLI-started swarm looks "gone" while workers are still running, and pilots
-  // burn tokens inventing recovery paths.
+  // owned jobs must stay visible even if their id was previously dismissed —
+  // otherwise a still-running Marionette swarm looks "gone", and pilots burn
+  // tokens inventing recovery paths.
   //
   // If a dismissed id reappears as live, drop it from the dismiss set so its
   // later terminal transition does not vanish again into "Show N hidden".
@@ -1748,7 +1742,7 @@ export default function SwarmPane() {
                 {jobIdentifier(j.id)}
               </button>
 
-              {(hasHeaderMeters || headerModel || showJobRoutingPlaceholder || adapter || j.source === "cli" || (workerCount === 0 && attestedPolicy === "explicit_pin")) && (
+              {(hasHeaderMeters || headerModel || showJobRoutingPlaceholder || adapter || (workerCount === 0 && attestedPolicy === "explicit_pin")) && (
                 <div className="flex items-center gap-x-2 gap-y-1 flex-wrap text-[9px]">
                   {hasHeaderMeters && (
                     <div className="inline-flex items-center gap-1 min-w-0 flex-wrap">
@@ -1851,14 +1845,6 @@ export default function SwarmPane() {
                   {adapter && adapter.toLowerCase() !== displayModel.toLowerCase() && (
                     <span className="text-faint lowercase">{adapter}</span>
                   )}
-                  {j.source === "cli" && (
-                    <span
-                      className="text-muted uppercase tracking-[0.1em]"
-                      title={cliOriginCaption(j).title}
-                    >
-                      {cliOriginCaption(j).text}
-                    </span>
-                  )}
                   {j.reuse_status && ["reused", "partial", "invalidated", "fresh"].includes(
                     String(j.reuse_status).toLowerCase(),
                   ) && (
@@ -1884,14 +1870,6 @@ export default function SwarmPane() {
                     >
                       {j.invalidated_paths.slice(0, 2).join(", ")}
                       {j.invalidated_paths.length > 2 ? ` +${j.invalidated_paths.length - 2}` : ""}
-                    </span>
-                  )}
-                  {!jobAccountingOwned(j) && (
-                    <span
-                      className="text-[9px] text-faint bg-panel2/30 border border-edge/40 px-1.5 py-0.5 rounded"
-                      title="Visible for cancellation only — does not affect Marionette session cost or savings"
-                    >
-                      visibility only
                     </span>
                   )}
                 </div>

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -1232,7 +1232,7 @@ export default function SwarmPane() {
             // resolves empty (sibling-store miss must not wipe the row).
             if (
               incoming.length === 0
-              && (j.artifacts || []).length > 0
+              && jobArtifactList(j).length > 0
               && j.cross_project
               && jobOwnedForScope(j)
             ) {

--- a/webapp/src/components/conversation/swarmPoll.ts
+++ b/webapp/src/components/conversation/swarmPoll.ts
@@ -7,12 +7,18 @@
  */
 
 import type { Item } from "../TranscriptList";
+import { jobInActiveSession } from "../../lib/jobScope";
 import { isTerminalJobStatus } from "./nestedActionBounds";
 import { isSwarmPendingTerminal } from "./swarmPendingIdentity";
 import { formatDistilledNotice, formatWikiAutoIngestNotice } from "./streamApply";
 
 /** One row from `/api/swarm/live` (id field names vary by store). */
-export type SwarmLiveJobRow = { job_id?: string; id?: string; status?: string };
+export type SwarmLiveJobRow = {
+  job_id?: string;
+  id?: string;
+  status?: string;
+  session_id?: string | null;
+};
 
 function liveJobId(job: SwarmLiveJobRow): string {
   return String(job?.job_id || job?.id || "").trim();
@@ -159,9 +165,12 @@ export function terminalJobIdsNeedingResultRecovery(
 /** Job ids from swarm/live rows whose status is already terminal. */
 export function terminalJobIdsFromSwarmLive(
   jobs: readonly SwarmLiveJobRow[],
+  activeSessionId = "",
 ): string[] {
   const out: string[] = [];
   for (const job of jobs) {
+    if (activeSessionId && !jobInActiveSession(job, activeSessionId)) continue;
+    if (!activeSessionId) continue;
     if (!isTerminalJobStatus(job?.status)) continue;
     const id = liveJobId(job);
     if (id) out.push(id);
@@ -171,14 +180,19 @@ export function terminalJobIdsFromSwarmLive(
 
 /**
  * Job ids that should still hold await chrome given a live snapshot.
- * Missing / terminal / local-swarm-* rows do not count.
+ * Missing / terminal / local-swarm-* rows do not count. Other Marionette
+ * sessions must not paint this conversation's chrome even if a backend leak
+ * regresses.
  */
 export function pendingJobIdsFromSwarmLive(
   jobs: readonly SwarmLiveJobRow[],
+  activeSessionId = "",
 ): string[] {
+  if (!(activeSessionId || "").trim()) return [];
   const out: string[] = [];
   const seen = new Set<string>();
   for (const job of jobs) {
+    if (!jobInActiveSession(job, activeSessionId)) continue;
     if (isTerminalJobStatus(job?.status)) continue;
     const id = liveJobId(job);
     if (!id || id.startsWith("local-swarm-") || seen.has(id)) continue;
@@ -196,8 +210,11 @@ export function pendingJobIdsFromSwarmLive(
 export function hydratePendingJobIdsAfterReload(opts: {
   liveJobs: readonly SwarmLiveJobRow[] | null;
   items: readonly Item[];
+  activeSessionId?: string;
 }): string[] {
-  if (opts.liveJobs) return pendingJobIdsFromSwarmLive(opts.liveJobs);
+  if (opts.liveJobs) {
+    return pendingJobIdsFromSwarmLive(opts.liveJobs, opts.activeSessionId || "");
+  }
   return seedPendingJobIdsFromHydrate({ items: opts.items });
 }
 

--- a/webapp/src/components/conversation/useSessionSwitch.ts
+++ b/webapp/src/components/conversation/useSessionSwitch.ts
@@ -527,7 +527,11 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
           }
           const jobs = Array.isArray(live?.jobs) ? live.jobs : [];
           setPendingJobIds(
-            hydratePendingJobIdsAfterReload({ liveJobs: jobs, items: loadedItems }),
+            hydratePendingJobIdsAfterReload({
+              liveJobs: jobs,
+              items: loadedItems,
+              activeSessionId,
+            }),
           );
           setItems((prev) => {
             if (!shouldApplySwarmLiveMerge({
@@ -561,7 +565,11 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
             return;
           }
           setPendingJobIds(
-            hydratePendingJobIdsAfterReload({ liveJobs: null, items: loadedItems }),
+            hydratePendingJobIdsAfterReload({
+              liveJobs: null,
+              items: loadedItems,
+              activeSessionId,
+            }),
           );
         });
 

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -227,7 +227,7 @@ export type Job = {
   cwd?: string;
   /** marionette | visibility_only — whether Marionette owns economic totals. */
   accounting_scope?: "marionette" | "visibility_only" | string;
-  /** False for external/CLI jobs that are visible but must not bill Marionette meters. */
+  /** False when an admitted job must not bill Marionette meters (owned-but-unbilled). */
   accounting_owned?: boolean;
   created_at?: string | null;
   updated_at?: number | string | null;

--- a/webapp/src/lib/jobScope.ts
+++ b/webapp/src/lib/jobScope.ts
@@ -1,4 +1,4 @@
-/** Ownership views over already-visible jobs: session, this repo, or all projects. */
+/** Ownership views over already-owned Marionette jobs: session, this repo, or all. */
 
 export type JobScope = "session" | "repo" | "all";
 
@@ -21,6 +21,16 @@ export function jobInActiveSession(job: ScopedJob, activeSessionId: string): boo
   return Boolean(sid && active && sid === active);
 }
 
+/** Stamped session id is the frontend ownership proof on an already-listed row. */
+export function jobOwnedForScope(job: ScopedJob): boolean {
+  return Boolean(jobSessionId(job));
+}
+
+/** Sibling-store or unstamped rows must not be pinned back into a narrower scope. */
+export function jobIsForeignForScope(job: ScopedJob): boolean {
+  return Boolean(job.cross_project) || !jobOwnedForScope(job);
+}
+
 export function filterJobsByScope<T extends ScopedJob>(
   jobs: readonly T[],
   scope: JobScope,
@@ -30,23 +40,24 @@ export function filterJobsByScope<T extends ScopedJob>(
   const includeIds = new Set(
     [...(opts?.includeJobIds || [])].map((id) => String(id || "").trim()).filter(Boolean),
   );
+  const owned = jobs.filter((job) => jobOwnedForScope(job));
   let filtered: T[];
   if (scope === "all") {
-    filtered = [...jobs];
+    filtered = [...owned];
   } else if (scope === "session") {
     if (!(activeSessionId || "").trim()) {
       filtered = [];
     } else {
-      filtered = jobs.filter((job) => jobInActiveSession(job, activeSessionId));
+      filtered = owned.filter((job) => jobInActiveSession(job, activeSessionId));
     }
   } else {
-    filtered = jobs.filter((job) => !job.cross_project);
+    filtered = owned.filter((job) => !job.cross_project);
   }
   if (includeIds.size === 0) return filtered;
   const kept = new Set(filtered.map((job) => String(job.id || "").trim()).filter(Boolean));
   const extras = jobs.filter((job) => {
     const id = String(job.id || "").trim();
-    return Boolean(id && includeIds.has(id) && !kept.has(id));
+    return Boolean(id && includeIds.has(id) && !kept.has(id) && !jobIsForeignForScope(job));
   });
   return extras.length ? [...filtered, ...extras] : filtered;
 }


### PR DESCRIPTION
## Summary
- Hide Puppetmaster jobs Marionette does not own from Swarm Tracker, jobs, composer chrome, artifacts, cancel, and Investigating / Still working. Durable proof is `origin=marionette` plus a stamped session id (harness/local registered-id heal only).
- v0.9.387 already shipped (PR #268). This follow-on cut is owned-job visibility. Puppetmaster pin stays `1.22.42`.
- Wiki ingest skipped.

## Test plan
- [x] Focused ownership / cancel / artifacts / URI tests
- [x] Full local pytest (artifacts HTTP fixture updated for owned rows)
- [x] `npm test`, `npm run test:electron`, `npm run build`
- [ ] CI `tests` matrix: 3.9, 3.11, Windows, frontend-build
- [ ] Tag `v0.9.388` after merge when `merge^{tree}` matches this PR tree