### PR TITLE
Release v0.9.393

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.392, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.393, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.392"
+__version__ = "0.9.393"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -135,20 +135,28 @@ def _prewarm_worker_imports() -> None:
     for mod in ("harness.worker", "harness.edit_engines"):
         try:
             importlib.import_module(mod)
-        except Exception:
+        except Exception as exc:
             essentials_ok = False
+            _diag_note("prewarm.essential_import", exc, msg=mod)
+
+    # Cap broad walk noise: one aggregate note with count + small sample, not
+    # one note per failed module (unbounded on a broken install).
+    _MODULE_FAIL_SAMPLE = 5
+    module_failures: list[str] = []
 
     for pkg_name in ("harness", "pmharness", "puppetmaster"):
         try:
             pkg = importlib.import_module(pkg_name)
-        except Exception:
+        except Exception as exc:
+            _diag_note("prewarm.package_import", exc, msg=pkg_name)
             continue
         pkg_path = getattr(pkg, "__path__", None)
         if not pkg_path:
             continue
         try:
             modules = list(pkgutil.walk_packages(pkg_path, prefix=pkg_name + "."))
-        except Exception:
+        except Exception as exc:
+            _diag_note("prewarm.walk_packages", exc, msg=pkg_name)
             continue
         for info in modules:
             name = info.name
@@ -157,10 +165,29 @@ def _prewarm_worker_imports() -> None:
             try:
                 importlib.import_module(name)
             except Exception:
-                pass
+                # Sanitize: module path only, no exception text (may be huge).
+                safe = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in name)[:120]
+                if safe:
+                    module_failures.append(safe)
+
+    if module_failures:
+        sample = module_failures[:_MODULE_FAIL_SAMPLE]
+        extra = len(module_failures) - len(sample)
+        sample_txt = ", ".join(sample)
+        if extra > 0:
+            sample_txt = f"{sample_txt} (+{extra} more)"
+        _diag_note(
+            "prewarm.module_import",
+            msg=f"{len(module_failures)} module(s) failed: {sample_txt}",
+        )
+
     if essentials_ok:
         _WORKER_IMPORTS_WARMED = True
-
+    else:
+        _diag_note(
+            "prewarm.essentials_incomplete",
+            msg="essential imports failed; warmed flag left false for retry",
+        )
 
 def _is_stub_tool_result(msg: dict) -> bool:
     """True for the synthesized "(no result: ...)" placeholder that

--- a/harness/diffreview.py
+++ b/harness/diffreview.py
@@ -1,5 +1,10 @@
 """Diff review parsing and reconstruction utilities."""
 
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping
+
+
 def extract_path(line: str, prefix: str) -> str:
     p = line[len(prefix):].strip()
     if p.startswith("a/") or p.startswith("b/"):
@@ -10,31 +15,115 @@ def extract_path(line: str, prefix: str) -> str:
         p = p[:-1]
     return p
 
+
+def hunk_content_fingerprint(path: str, header: str, lines: Any) -> str:
+    """Deterministic content fingerprint shared with the webapp fallback.
+
+    Built from path + header + body lines only — never from array position —
+    so reordering unrelated hunks cannot change an existing key.
+    """
+    parts = [str(path or ""), str(header or "")]
+    for line in lines or ():
+        parts.append(str(line).rstrip("\n"))
+    blob = "\n".join(parts).encode("utf-8", errors="replace")
+    # FNV-1a 64-bit (same algorithm as webapp/src/lib/reviewDecisions.ts).
+    h = 14695981039346656037
+    for b in blob:
+        h ^= b
+        h = (h * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return f"{h:016x}"
+
+
+def assign_decision_ids(files: list) -> list:
+    """Stamp a stable per-hunk ``decision_id`` derived from content.
+
+    Exact duplicate-content hunks get distinct keys via a per-fingerprint
+    ordinal (``fp#0``, ``fp#1``, …). Existing ``decision_id`` values are kept.
+    """
+    seen: dict[str, int] = {}
+    for f in files or []:
+        if not isinstance(f, Mapping):
+            continue
+        path = str(f.get("path") or "")
+        for hunk in f.get("hunks") or []:
+            if not isinstance(hunk, MutableMapping):
+                continue
+            existing = str(hunk.get("decision_id") or "").strip()
+            if existing:
+                # Reserve the ordinal so a later identical fingerprint cannot
+                # collide with a server-assigned id that used the same scheme.
+                if "#" in existing:
+                    base, _, suffix = existing.rpartition("#")
+                    if base and suffix.isdigit():
+                        seen[base] = max(seen.get(base, 0), int(suffix) + 1)
+                continue
+            fp = hunk_content_fingerprint(path, hunk.get("header") or "", hunk.get("lines") or [])
+            n = seen.get(fp, 0)
+            seen[fp] = n + 1
+            hunk["decision_id"] = f"{fp}#{n}"
+    return files
+
+
+def resolve_hunk_decision_id(
+    hunk: Mapping[str, Any],
+    path: str,
+    fingerprint_counts: dict[str, int],
+) -> str:
+    """Resolve the apply/UI decision key for one hunk.
+
+    Prefer the server-assigned ``decision_id``. Legacy reviews without it fall
+    back to a deterministic content fingerprint + same-fingerprint ordinal.
+    """
+    existing = str(hunk.get("decision_id") or "").strip()
+    if existing:
+        return existing
+    fp = hunk_content_fingerprint(path, hunk.get("header") or "", hunk.get("lines") or [])
+    n = fingerprint_counts.get(fp, 0)
+    fingerprint_counts[fp] = n + 1
+    return f"{fp}#{n}"
+
+
+def decision_for_hunk(decisions: dict, hunk: Mapping[str, Any], path: str = "", fingerprint_counts: dict[str, int] | None = None) -> str:
+    """Resolve accept/reject for one hunk via stable decision identity.
+
+    Prefer ``decision_id`` (or the legacy content-fingerprint fallback). Fall
+    back to plain ``id`` for payloads built before decision keys existed.
+    """
+    counts = fingerprint_counts if fingerprint_counts is not None else {}
+    did = resolve_hunk_decision_id(hunk, path, counts)
+    if did in decisions:
+        return decisions.get(did) or "reject"
+    hunk_id = str(hunk.get("id") or "")
+    if hunk_id and hunk_id in decisions:
+        return decisions.get(hunk_id) or "reject"
+    return "reject"
+
+
 def parse_unified_diff(diff_text: str) -> list:
     files = []
     current_file = None
     current_hunk = None
-    
+
     lines = diff_text.splitlines(keepends=True)
-    
+
     file_index = -1
     hunk_index = -1
-    
+
     i = 0
     while i < len(lines):
         line = lines[i]
-        
+
         if line.startswith("diff --git "):
             file_index += 1
             hunk_index = -1
-            
+
             path = ""
             parts = line.split(" ")
             if len(parts) >= 4:
                 b_part = parts[3]
                 if b_part.startswith("b/") or b_part.startswith("\"b/"):
                     path = extract_path(b_part, "b/") if b_part.startswith("b/") else extract_path(b_part, "\"b/")
-            
+
             current_file = {
                 "path": path,
                 "headers": [line],
@@ -44,7 +133,7 @@ def parse_unified_diff(diff_text: str) -> list:
             current_hunk = None
             i += 1
             continue
-            
+
         if current_file is not None and current_hunk is None:
             if line.startswith("@@ "):
                 hunk_index += 1
@@ -67,7 +156,7 @@ def parse_unified_diff(diff_text: str) -> list:
                 current_file["headers"].append(line)
             i += 1
             continue
-            
+
         if current_file is not None and current_hunk is not None:
             if line.startswith("@@ "):
                 hunk_index += 1
@@ -85,23 +174,30 @@ def parse_unified_diff(diff_text: str) -> list:
                 current_hunk["lines"].append(line)
             i += 1
             continue
-            
+
         i += 1
-        
-    return files
+
+    return assign_decision_ids(files)
+
 
 def reconstruct_diff(files: list, decisions: dict) -> str:
     out_lines = []
+    fingerprint_counts: dict[str, int] = {}
     for f in files:
-        accepted_hunks = [h for h in f["hunks"] if decisions.get(h["id"]) == "accept"]
+        path = str(f.get("path") or "")
+        accepted_hunks = []
+        for h in f["hunks"]:
+            dec = decision_for_hunk(decisions, h, path, fingerprint_counts)
+            if dec == "accept":
+                accepted_hunks.append(h)
         if not accepted_hunks:
             continue
-        
+
         for h_line in f["headers"]:
             if not h_line.endswith("\n"):
                 h_line += "\n"
             out_lines.append(h_line)
-            
+
         for hunk in accepted_hunks:
             h_header = hunk["header"]
             if not h_header.endswith("\n"):
@@ -111,5 +207,5 @@ def reconstruct_diff(files: list, decisions: dict) -> str:
                 if not hunk_line.endswith("\n"):
                     hunk_line += "\n"
                 out_lines.append(hunk_line)
-                
+
     return "".join(out_lines)

--- a/harness/local_job_swarm_view.py
+++ b/harness/local_job_swarm_view.py
@@ -20,6 +20,9 @@ _TERMINAL_STATUSES = frozenset({
 _RUNNING_STATUSES = frozenset({
     "running", "in_progress", "pending", "started", "registered",
 })
+_NONTERMINAL_TASK_STATUSES = frozenset({
+    "", "pending", "running", "in_progress", "started", "registered", "queued",
+})
 
 
 def _as_float(value: Any, default: float = 0.0) -> float:
@@ -51,18 +54,60 @@ def _artifacts_complete(raw: Any) -> bool:
     return artifacts_are_complete(_normalize_artifacts(raw))
 
 
-def _normalize_tasks(raw: Any, *, terminal: bool) -> list[dict]:
+def _receipt_child_status_by_id(job: dict) -> dict[str, str]:
+    """Map child id -> status from a durable terminal_receipt when present."""
+    out: dict[str, str] = {}
+    receipt = job.get("terminal_receipt")
+    if not isinstance(receipt, dict):
+        return out
+    children = receipt.get("children")
+    if not isinstance(children, list):
+        return out
+    for child in children:
+        if not isinstance(child, dict):
+            continue
+        cid = str(child.get("id") or "").strip()
+        status = str(child.get("status") or "").strip()
+        if cid and status:
+            out[cid] = status
+    return out
+
+
+def _parent_lifecycle_task_status(parent_status: str) -> str:
+    """Normalize a stale nonterminal child when the parent is already terminal."""
+    st = str(parent_status or "").strip().lower()
+    if st in {"failed", "cancelled", "timeout", "truncated", "timed_out"}:
+        return "failed"
+    if st in {"partial"}:
+        return "partial"
+    if st in {"completed", "complete", "done"}:
+        return "completed"
+    return "completed"
+
+
+def _normalize_tasks(raw: Any, *, terminal: bool, job: Optional[dict] = None) -> list[dict]:
     if not isinstance(raw, list):
         return []
+    parent_status = str((job or {}).get("status") or "")
+    receipt_by_id = _receipt_child_status_by_id(job or {})
     out: list[dict] = []
     for task in raw:
         if not isinstance(task, dict):
             continue
+        task_id = str(task.get("id") or "")
+        status = str(task.get("status") or "")
+        receipt_status = receipt_by_id.get(task_id.strip())
+        if receipt_status:
+            status = receipt_status
+        elif terminal and status.strip().lower() in _NONTERMINAL_TASK_STATUSES:
+            # Authoritative live projection: hollow/pending children must not
+            # disagree with a terminal parent (Composer Tasks / Swarm Tracker).
+            status = _parent_lifecycle_task_status(parent_status)
         entry = {
-            "id": str(task.get("id") or ""),
+            "id": task_id,
             "role": str(task.get("role") or ""),
             "instruction": "" if terminal else str(task.get("instruction") or ""),
-            "status": str(task.get("status") or ""),
+            "status": status,
             "adapter": str(task.get("adapter") or ""),
         }
         task_model = str(task.get("model") or "").strip()
@@ -168,10 +213,12 @@ def project_local_job_for_swarm_live(job: dict) -> dict:
         ),
         "artifacts": _normalize_artifacts(job.get("artifacts")),
         "artifacts_complete": _artifacts_complete(job.get("artifacts")),
-        "tasks": _normalize_tasks(job.get("tasks"), terminal=terminal),
+        "tasks": _normalize_tasks(job.get("tasks"), terminal=terminal, job=job),
         "source": str(job.get("source") or "harness"),
         "actions": _normalize_actions(job.get("actions")),
     }
+    if isinstance(job.get("terminal_receipt"), dict):
+        row["terminal_receipt"] = dict(job["terminal_receipt"])
     if isinstance(job.get("financial_receipt"), dict):
         row["financial_receipt"] = dict(job["financial_receipt"])
     if job.get("route_forecast_usd") is not None:

--- a/harness/review_memory.py
+++ b/harness/review_memory.py
@@ -41,21 +41,29 @@ class ReviewMemoryMixin:
 
         rejected_hunks = []
         all_hunks = []
+        from .diffreview import decision_for_hunk, reconstruct_diff
+        fingerprint_counts: dict[str, int] = {}
         for f in review["files"]:
+            path = str(f.get("path") or "")
             for h in f["hunks"]:
                 h_id = h["id"]
                 all_hunks.append(h_id)
-                dec = decisions.get(h_id, "reject")
+                dec = decision_for_hunk(decisions, h, path, fingerprint_counts)
                 if dec == "reject":
                     rejected_hunks.append(h_id)
 
         # Reconstruct the accepted subset diff
-        from .diffreview import reconstruct_diff
         accepted_diff = reconstruct_diff(review["files"], decisions)
 
         applied_files = []
+        fingerprint_counts = {}
         for f in review["files"]:
-            if any(decisions.get(h["id"]) == "accept" for h in f["hunks"]):
+            path = str(f.get("path") or "")
+            file_accepted = False
+            for h in f["hunks"]:
+                if decision_for_hunk(decisions, h, path, fingerprint_counts) == "accept":
+                    file_accepted = True
+            if file_accepted:
                 applied_files.append(f["path"])
 
         # If ALL hunks are rejected, do not apply anything, just remove the review

--- a/harness/swarm_run_facts.py
+++ b/harness/swarm_run_facts.py
@@ -256,13 +256,21 @@ def normalize_execution_refs(
     rewrite ``execution_ref.job_id``: an artifact that arrived without parent
     attribution must keep reading as unattributed, otherwise the provenance
     count would launder itself to N/N.
+
+    Oversized artifact batches and evidence collections are truncated so a
+    runaway worker cannot unbounded-expand the evidence surface.
     """
     current = str(job_id or "").strip()
     normalized: list[dict[str, Any]] = []
     for artifact in artifacts or ():
+        if len(normalized) >= _MAX_ARTIFACT_ROWS:
+            break
         if not isinstance(artifact, Mapping):
             continue
         row = dict(artifact)
+        evidence = row.get("evidence")
+        if isinstance(evidence, (list, tuple)) and len(evidence) > _MAX_EVIDENCE_ENTRIES:
+            row["evidence"] = list(evidence[:_MAX_EVIDENCE_ENTRIES])
         ref = row.get("execution_ref")
         ref = dict(ref) if isinstance(ref, Mapping) else {}
         ref.setdefault("job_id", "")
@@ -357,6 +365,9 @@ def _normalized_text(value: Any) -> str:
 
 
 _VERIFY_STATUSES = frozenset({"passed", "verified"})
+_FAIL_STATUSES = frozenset({"failed", "fail", "error", "blocked", "rejected"})
+_MAX_EVIDENCE_ENTRIES = 64
+_MAX_ARTIFACT_ROWS = 500
 
 
 def _criterion_text(value: Any) -> str:
@@ -380,16 +391,21 @@ def _record_evidence_locus(record: Mapping[str, Any]) -> str:
     return _extract_locus(evidence)
 
 
-def _verified_criterion_loci(artifact: Mapping[str, Any]) -> dict[str, str]:
-    """Normalized criterion keys an artifact verifies, mapped to their locus.
+def _criterion_status_loci(
+    artifact: Mapping[str, Any],
+) -> tuple[dict[str, str], set[str]]:
+    """Return ``(verified_loci, failed_keys)`` for one artifact.
 
     Bare string entries are ignored: a worker echoing the checklist or citing
     criteria in prose must not settle them, even when the artifact carries an
     unrelated path:line locus. Only structured status rows with an exact
-    criterion, ``passed``/``verified`` status, and concrete dispatch evidence
-    may contribute.
+    criterion and concrete dispatch evidence may contribute. A contradictory
+    failed/passed pair for the same criterion refuses verification rather than
+    last-wins green — both within one artifact and across artifacts at the
+    evaluator.
     """
     verified: dict[str, str] = {}
+    failed: set[str] = set()
     for item in artifact.get("acceptance_criteria") or ():
         if isinstance(item, str):
             continue
@@ -399,12 +415,26 @@ def _verified_criterion_loci(artifact: Mapping[str, Any]) -> dict[str, str]:
         if not key:
             continue
         status = str(item.get("status") or "").strip().lower()
+        if status in _FAIL_STATUSES:
+            failed.add(key)
+            verified.pop(key, None)
+            continue
         if status not in _VERIFY_STATUSES:
+            continue
+        if key in failed:
             continue
         locus = _record_evidence_locus(item)
         if not locus:
             continue
         verified[key] = locus
+    for key in failed:
+        verified.pop(key, None)
+    return verified, failed
+
+
+def _verified_criterion_loci(artifact: Mapping[str, Any]) -> dict[str, str]:
+    """Normalized criterion keys an artifact verifies, mapped to their locus."""
+    verified, _failed = _criterion_status_loci(artifact)
     return verified
 
 
@@ -532,6 +562,7 @@ def evaluate_acceptance_criteria(
         return ()
     current = str(job_id or "").strip()
     rows = []
+    failed_keys: set[str] = set()
     for artifact in artifacts or ():
         if not isinstance(artifact, Mapping):
             continue
@@ -542,11 +573,20 @@ def evaluate_acceptance_criteria(
         kind = str(artifact.get("type") or "").strip().lower()
         if kind not in {"finding", "risk", "decision", "verification"}:
             continue
-        rows.append((artifact, _verified_criterion_loci(artifact)))
+        verified, failed = _criterion_status_loci(artifact)
+        failed_keys |= failed
+        rows.append((artifact, verified))
 
     facts = []
     for criterion in clean:
         needle = _normalized_text(criterion)
+        if needle and needle in failed_keys:
+            facts.append(CriterionFact(
+                criterion,
+                NOT_VERIFIED,
+                "contradictory current-job pass/fail records for this criterion",
+            ))
+            continue
         basis = ""
         for artifact, verified in rows:
             locus = verified.get(needle) if needle else ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,20 +4,20 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.392"
+version = "0.9.393"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [
-    "pypdf"
+    "pypdf",
+    # Runtime ownership: a standalone `pip install pm-harness` must pull the
+    # pinned Puppetmaster bridge. Desktop/Electron still re-checks the same pin.
+    "puppetmaster-ai==1.22.43",
 ]
 
 [project.scripts]
 harness = "harness.cli:main"
 
 [project.optional-dependencies]
-# Puppetmaster is required to execute swarm intents (the bridge). Installed
-# editable from the local checkout in dev; not pinned here to avoid coupling
-# the research rig to a PyPI release of an internal tool.
 dev = [
     "pytest>=7",
     "pytest-xdist>=3.5",

--- a/tests/test_diff_review.py
+++ b/tests/test_diff_review.py
@@ -122,6 +122,74 @@ def test_reconstruct_diff_preserves_index_headers():
     assert "Line J.5" not in rebuilt
 
 
+def test_decision_id_assigned_and_stable_under_reorder():
+    from harness.diffreview import (
+        assign_decision_ids,
+        decision_for_hunk,
+        hunk_content_fingerprint,
+        parse_unified_diff,
+    )
+
+    diff_text = (
+        "diff --git a/a.txt b/a.txt\n"
+        "--- a/a.txt\n"
+        "+++ b/a.txt\n"
+        "@@ -1 +1 @@\n"
+        "+one\n"
+        "@@ -2 +2 @@\n"
+        "+two\n"
+        "@@ -1 +1 @@\n"
+        "+one\n"
+    )
+    parsed = parse_unified_diff(diff_text)
+    hunks = parsed[0]["hunks"]
+    assert all(h.get("decision_id") for h in hunks)
+    # Exact duplicate content gets distinct decision ids.
+    assert hunks[0]["decision_id"] != hunks[2]["decision_id"]
+    assert hunks[0]["decision_id"].rsplit("#", 1)[0] == hunks[2]["decision_id"].rsplit("#", 1)[0]
+    assert hunks[0]["decision_id"].endswith("#0")
+    assert hunks[2]["decision_id"].endswith("#1")
+
+    # Opposite decisions on duplicate-content hunks.
+    decisions = {
+        hunks[0]["decision_id"]: "accept",
+        hunks[1]["decision_id"]: "reject",
+        hunks[2]["decision_id"]: "reject",
+    }
+    assert decision_for_hunk(decisions, hunks[0], "a.txt") == "accept"
+    assert decision_for_hunk(decisions, hunks[2], "a.txt") == "reject"
+
+    # Reordering unrelated middle hunk must not change keys for A and the dup.
+    reordered = [
+        {
+            "path": "a.txt",
+            "headers": parsed[0]["headers"],
+            "hunks": [dict(hunks[0]), dict(hunks[2]), dict(hunks[1])],
+        }
+    ]
+    # Strip decision_ids to force reassignment from content.
+    for h in reordered[0]["hunks"]:
+        h.pop("decision_id", None)
+    assign_decision_ids(reordered)
+    ids = [h["decision_id"] for h in reordered[0]["hunks"]]
+    # First duplicate-content occurrence stays #0; second stays #1 regardless of
+    # where the unrelated hunk sits.
+    assert ids[0] == hunks[0]["decision_id"]
+    assert ids[1] == hunks[2]["decision_id"]
+    assert ids[2] == hunks[1]["decision_id"]
+
+    fp = hunk_content_fingerprint("a.txt", "@@ -1 +1 @@\n", ["+one\n"])
+    assert hunks[0]["decision_id"].startswith(fp)
+
+
+def test_legacy_plain_id_decisions_still_resolve():
+    from harness.diffreview import decision_for_hunk
+
+    hunk = {"id": "0:0", "header": "@@", "lines": ["+x"]}
+    assert decision_for_hunk({"0:0": "accept"}, hunk, "f.py") == "accept"
+    assert decision_for_hunk({}, hunk, "f.py") == "reject"
+
+
 def test_apply_review(temp_git_repo):
     cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
     cfg.repo = temp_git_repo

--- a/tests/test_local_job_swarm_view.py
+++ b/tests/test_local_job_swarm_view.py
@@ -326,6 +326,45 @@ def test_stable_id_through_projection():
     assert again["id"] == row["id"]
 
 
+def test_terminal_parent_reconciles_nonterminal_child_tasks():
+    """Authoritative /api/swarm/live projection normalizes stale pending children."""
+    job = _sample_local_job(
+        id="local-wave-done",
+        status="completed",
+        tasks=[
+            {"id": "w1", "role": "explore", "instruction": "a", "status": "complete", "adapter": "x"},
+            {"id": "w2", "role": "review", "instruction": "b", "status": "pending", "adapter": "x"},
+            {"id": "w3", "role": "audit", "instruction": "c", "status": "", "adapter": "x"},
+            {"id": "w4", "role": "map", "instruction": "d", "status": "running", "adapter": "x"},
+            {"id": "w5", "role": "tests", "instruction": "e", "status": "pending", "adapter": "x"},
+        ],
+        task_count=5,
+    )
+    row = project_local_job_for_swarm_live(job)
+    assert [t["status"] for t in row["tasks"]] == [
+        "complete", "completed", "completed", "completed", "completed",
+    ]
+
+    with_receipt = _sample_local_job(
+        id="local-wave-receipt",
+        status="completed",
+        tasks=[
+            {"id": "w1", "role": "explore", "instruction": "a", "status": "pending", "adapter": "x"},
+            {"id": "w2", "role": "review", "instruction": "b", "status": "pending", "adapter": "x"},
+        ],
+        terminal_receipt={
+            "status": "completed",
+            "children": [
+                {"id": "w1", "status": "completed"},
+                {"id": "w2", "status": "failed"},
+            ],
+        },
+    )
+    row2 = project_local_job_for_swarm_live(with_receipt)
+    assert [t["status"] for t in row2["tasks"]] == ["completed", "failed"]
+    assert isinstance(row2.get("terminal_receipt"), dict)
+
+
 def test_local_jobs_mixin_never_writes_swarm_store(monkeypatch):
     """LocalJobsMixin must not call create_store / add_job / store.write."""
     calls: list[str] = []

--- a/tests/test_prewarm_imports.py
+++ b/tests/test_prewarm_imports.py
@@ -59,17 +59,97 @@ def test_prewarm_retries_when_essential_import_fails(monkeypatch):
 
     conv._WORKER_IMPORTS_WARMED = False
     real = importlib.import_module
+    notes = []
 
     def boom(name, package=None):
         if name == "harness.worker":
             raise ImportError("simulated essential miss")
         return real(name, package)
 
+    def capture(where, exc=None, msg=""):
+        notes.append((where, repr(exc) if exc is not None else None, msg))
+
     monkeypatch.setattr(importlib, "import_module", boom)
+    monkeypatch.setattr(conv, "_diag_note", capture)
     conv._prewarm_worker_imports()
     assert conv._WORKER_IMPORTS_WARMED is False
+    assert any(where == "prewarm.essential_import" for where, _, _ in notes)
+    assert any(where == "prewarm.essentials_incomplete" for where, _, _ in notes)
 
     monkeypatch.setattr(importlib, "import_module", real)
     conv._prewarm_worker_imports()
     assert conv._WORKER_IMPORTS_WARMED is True
     assert "harness.worker" in sys.modules
+
+
+def test_prewarm_aggregates_broad_module_failures(monkeypatch):
+    import importlib
+    import pkgutil
+    import harness.conversation as conv
+
+    conv._WORKER_IMPORTS_WARMED = False
+    real = importlib.import_module
+    notes = []
+    failed_names = [f"harness.fake_mod_{i}" for i in range(12)]
+
+    def capture(where, exc=None, msg=""):
+        notes.append((where, repr(exc) if exc is not None else None, msg))
+
+    class FakePkg:
+        __path__ = ["unused"]
+
+    def fake_walk(path, prefix=""):
+        for name in failed_names:
+            yield type("Info", (), {"name": name})()
+
+    def import_mix(name, package=None):
+        if name in ("harness.worker", "harness.edit_engines"):
+            return real(name, package)
+        if name == "harness":
+            return FakePkg()
+        if name in ("pmharness", "puppetmaster"):
+            raise ImportError("skip other roots")
+        if name in failed_names or name.startswith("harness.fake_mod_"):
+            raise ImportError(f"boom {name}")
+        return real(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", import_mix)
+    monkeypatch.setattr(pkgutil, "walk_packages", fake_walk)
+    monkeypatch.setattr(conv, "_diag_note", capture)
+    conv._prewarm_worker_imports()
+
+    module_notes = [n for n in notes if n[0] == "prewarm.module_import"]
+    assert len(module_notes) == 1
+    msg = module_notes[0][2]
+    assert "12 module(s) failed" in msg
+    assert "harness.fake_mod_0" in msg
+    assert "+7 more" in msg
+    assert not any(n[0] == "prewarm.essential_import" for n in notes)
+    assert conv._WORKER_IMPORTS_WARMED is True
+
+
+def test_prewarm_package_and_walk_failures_stay_observable(monkeypatch):
+    import importlib
+    import harness.conversation as conv
+
+    conv._WORKER_IMPORTS_WARMED = False
+    real = importlib.import_module
+    notes = []
+
+    def capture(where, exc=None, msg=""):
+        notes.append((where, repr(exc) if exc is not None else None, msg))
+
+    def boom_pkg(name, package=None):
+        if name in ("harness.worker", "harness.edit_engines"):
+            return real(name, package)
+        if name == "pmharness":
+            raise ImportError("pkg missing")
+        return real(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", boom_pkg)
+    monkeypatch.setattr(conv, "_diag_note", capture)
+    conv._prewarm_worker_imports()
+    assert any(
+        where == "prewarm.package_import" and "pmharness" in (msg or "")
+        for where, _, msg in notes
+    )

--- a/tests/test_swarm_run_facts.py
+++ b/tests/test_swarm_run_facts.py
@@ -1019,3 +1019,147 @@ class TestSynchronousBoundary:
             criteria=["provenance chips cite a real baseline"],
         )
         assert "[not_verified] provenance chips cite a real baseline" in text
+
+
+class TestDuplicateContradictoryAndBoundedEvidence:
+    def test_duplicate_criteria_are_deduped_not_double_settled(self):
+        facts = evaluate_acceptance_criteria(
+            ["pyright is clean", "pyright is clean", "  pyright is clean  "],
+            [{
+                "type": "verification",
+                "headline": "checked harness/a.py:1",
+                "acceptance_criteria": [{
+                    "criterion": "pyright is clean",
+                    "status": "passed",
+                    "evidence": "harness/a.py:1",
+                }],
+                "execution_ref": {"job_id": CURRENT_JOB},
+            }],
+            CURRENT_JOB,
+        )
+        assert len(facts) == 1
+        assert facts[0].status == VERIFIED
+
+    def test_contradictory_pass_and_fail_refuse_verification(self):
+        facts = evaluate_acceptance_criteria(
+            ["tsc passes"],
+            [{
+                "type": "verification",
+                "headline": "checked harness/a.py:1",
+                "acceptance_criteria": [
+                    {
+                        "criterion": "tsc passes",
+                        "status": "passed",
+                        "evidence": "harness/a.py:1",
+                    },
+                    {
+                        "criterion": "tsc passes",
+                        "status": "failed",
+                        "evidence": "harness/a.py:2",
+                    },
+                ],
+                "execution_ref": {"job_id": CURRENT_JOB},
+            }],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == NOT_VERIFIED
+
+    def test_cross_artifact_contradiction_fails_closed(self):
+        facts = evaluate_acceptance_criteria(
+            ["tsc passes"],
+            [
+                {
+                    "type": "verification",
+                    "headline": "checked harness/a.py:1",
+                    "acceptance_criteria": [{
+                        "criterion": "tsc passes",
+                        "status": "passed",
+                        "evidence": "harness/a.py:1",
+                    }],
+                    "execution_ref": {"job_id": CURRENT_JOB},
+                },
+                {
+                    "type": "verification",
+                    "headline": "checked harness/b.py:1",
+                    "acceptance_criteria": [{
+                        "criterion": "tsc passes",
+                        "status": "failed",
+                        "evidence": "harness/b.py:1",
+                    }],
+                    "execution_ref": {"job_id": CURRENT_JOB},
+                },
+            ],
+            CURRENT_JOB,
+        )
+        assert facts[0].status == NOT_VERIFIED
+        assert "contradictory" in facts[0].basis
+
+    def test_oversized_evidence_collections_are_bounded(self):
+        from harness.swarm_run_facts import _MAX_EVIDENCE_ENTRIES
+
+        huge = [f"harness/mod_{i}.py:{i}" for i in range(_MAX_EVIDENCE_ENTRIES + 40)]
+        rows = normalize_execution_refs(
+            [{"type": "finding", "headline": "x", "evidence": huge}],
+            CURRENT_JOB,
+        )
+        assert len(rows) == 1
+        assert len(rows[0]["evidence"]) == _MAX_EVIDENCE_ENTRIES
+        assert rows[0]["evidence_locus"] == "harness/mod_0.py:0"
+
+    def test_hermetic_probe_to_artifact_path(self, stub_probe, tmp_path):
+        """Environment probe output must land via the production boundary helper."""
+        from harness.conversation_jobs import _background_evidence_boundary
+
+        subject = tmp_path / "subject"
+        subject.mkdir()
+        stub_probe(
+            tool_paths={"pyright": str(subject / "pyright"), "tsc": ""},
+            browser_path="",
+            puppetmaster_version="9.9.9",
+            mcp_server_names=["hermetic-probe"],
+        )
+        session = SimpleNamespace(
+            state_dir=str(tmp_path / "state"),
+            config=SimpleNamespace(repo=str(subject)),
+        )
+        artifacts = [{
+            "type": "verification",
+            "headline": "checked harness/a.py:1",
+            "acceptance_criteria": [{
+                "criterion": "pyright is clean",
+                "status": "passed",
+                "evidence": "harness/a.py:1",
+            }],
+            "execution_ref": {"job_id": CURRENT_JOB},
+            "job_id": CURRENT_JOB,
+        }]
+        res_job = {
+            "status": "completed",
+            "acceptance_criteria": ["pyright is clean"],
+            "artifacts": artifacts,
+        }
+        stamped = {
+            "cwd": str(subject),
+            "status": "completed",
+            "acceptance_criteria": ["pyright is clean"],
+            "artifacts": artifacts,
+        }
+        text = _background_evidence_boundary(session, CURRENT_JOB, res_job, stamped)
+        assert "9.9.9" in text
+        assert "hermetic-probe" in text
+        assert CURRENT_JOB in text
+        assert "pyright is clean" in text
+        # Direct builder still agrees with the boundary for the same inputs.
+        facts = build_swarm_run_facts(
+            job_id=CURRENT_JOB,
+            subject_cwd=str(subject),
+            state_root=str(tmp_path / "state"),
+            artifacts=normalize_execution_refs(artifacts, CURRENT_JOB),
+            acceptance_criteria=["pyright is clean"],
+        )
+        payload = facts.as_dict()
+        assert payload["puppetmaster_version"] == "9.9.9"
+        assert any(c["status"] == VERIFIED for c in payload["criteria"])
+        by_name = {r["name"]: r for r in payload["readiness"]}
+        assert by_name["pyright"]["status"] == VERIFIED
+        assert by_name["tsc"]["status"] == NOT_VERIFIED

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -51,3 +51,24 @@ def test_version_is_pep440_ish():
     placeholder like 0.0.0 or a leftover 0.1.0."""
     v = _package_json_version()
     assert re.match(r"^\d+\.\d+\.\d+([.\-+].+)?$", v), f"unexpected version format: {v}"
+
+
+def test_pyproject_declares_pinned_puppetmaster_runtime_dependency():
+    """Standalone ``pip install pm-harness`` must own the Puppetmaster pin.
+
+    Desktop/Electron also re-checks the pin, but a fresh isolated Python install
+    must not succeed while leaving ``import puppetmaster`` broken.
+    """
+    text = (ROOT / "pyproject.toml").read_text()
+    match = re.search(
+        r'(?ms)^dependencies\s*=\s*\[(.*?)\]',
+        text,
+    )
+    assert match, "no [project] dependencies = [...] in pyproject.toml"
+    deps = match.group(1)
+    pin = re.search(r'"puppetmaster-ai==(\d+\.\d+\.\d+)"', deps)
+    assert pin, (
+        "pyproject.toml runtime dependencies must pin puppetmaster-ai==X.Y.Z "
+        "(standalone install ownership)"
+    )
+    assert pin.group(1), "empty Puppetmaster pin"

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -318,6 +318,7 @@ test("operational Puppetmaster pins match DEFAULT_PUPPETMASTER_SPEC", () => {
     "scripts/doctor.ps1",
     "FINDINGS.md",
     "harness/diag_bundle.py",
+    "pyproject.toml",
     ".github/workflows/tests.yml",
     ".github/workflows/tests-full.yml",
     ".github/workflows/release.yml",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.392",
+  "version": "0.9.393",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.392",
+      "version": "0.9.393",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.392",
+  "version": "0.9.393",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api, type Config } from "./lib/api";
 import { subscribeDocumentMotionPolicy } from "./lib/motionPolicy";
-import { fromBackendDiagnostic } from "./lib/operationalDiagnostic";
+import { malformedBackendDiagnostic, parseBackendDiagnostic } from "./lib/operationalDiagnostic";
 import { clearDiagnostic, publishDiagnostic } from "./lib/operationalDiagnosticBus";
 import { setCorrelationId } from "./lib/correlationId";
 import LeftRail from "./components/LeftRail";
@@ -145,10 +145,10 @@ export default function App() {
     api.diagnostics()
       .then((res) => {
         if (res.correlation_id) setCorrelationId(res.correlation_id);
-        const diag = fromBackendDiagnostic(res.diagnostic as Record<string, unknown> | null);
-        if (diag) publishDiagnostic(diag);
-        else clearDiagnostic();
-      })
+        const parsed = parseBackendDiagnostic(res.diagnostic);
+        if (parsed.status === "ok") publishDiagnostic(parsed.diagnostic);
+        else if (parsed.status === "absent") clearDiagnostic();
+        else publishDiagnostic(malformedBackendDiagnostic(parsed.reason));      })
       .catch(() => {});
   };
 

--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -22,10 +22,11 @@ import {
   isDurableTerminalActionResult,
   isUpgradeableActionResult,
 } from "../components/Conversation";
-import { api } from "../lib/api";
+import { api, type StoreEventsSince } from "../lib/api";
+import type { ChatEventsReattachDeps } from "../components/conversation/chatEventsReattach";
 import { TranscriptList, type Item } from "../components/TranscriptList";
 import { chatEventsPath, sessionEventsPath } from "../lib/transport";
-import { nextStoreCursor, shouldApplyStoreEvent, storeCursorAfterBatch } from "../components/conversation/storeEvents";
+import { nextStoreCursor, shouldApplyStoreEvent, storeCursorAfterBatch, STORE_EVENTS_POLL_MS } from "../components/conversation/storeEvents";
 
 /**
  * Mid-turn chatEvents reattach contracts (cursor + poll gating), plus the
@@ -963,7 +964,7 @@ describe("mid-turn store-event cursor reattach", () => {
     vi.useRealTimers();
   });
 
-  function reattachDeps(overrides: Record<string, unknown> = {}) {
+  function reattachDeps(overrides: Partial<ChatEventsReattachDeps> = {}) {
     const chatEventsLiveCancelRef = { current: null as null | (() => void) };
     const chatEventsPollTimerRef = { current: null as number | null };
     const detachedBusyRef = { current: true };
@@ -973,7 +974,7 @@ describe("mid-turn store-event cursor reattach", () => {
     const localStreamActiveRef = { current: false };
     const transcriptLoadGenRef = { current: 1 };
     const applied: string[] = [];
-    const base = {
+    const base: ChatEventsReattachDeps = {
       cancelled: () => false,
       loadGen: 1,
       transcriptLoadGenRef,
@@ -999,6 +1000,7 @@ describe("mid-turn store-event cursor reattach", () => {
       maybeDrainQueueRef: { current: () => {} },
       clearChatEventsPoll: () => {
         if (chatEventsPollTimerRef.current != null) {
+          window.clearTimeout(chatEventsPollTimerRef.current);
           window.clearInterval(chatEventsPollTimerRef.current);
           chatEventsPollTimerRef.current = null;
         }
@@ -1039,12 +1041,12 @@ describe("mid-turn store-event cursor reattach", () => {
         kind: "stream",
         data: { cursor: 4, kind: "message_delta", data: { text: "hi" }, generation: 1 },
       }],
-    } as any);
+    });
     vi.spyOn(api, "getSessionState").mockResolvedValue({
       runners: { "sess-live": "running" },
-    } as any);
+    } as Awaited<ReturnType<typeof api.getSessionState>>);
 
-    const { startChatEventsReattach } = createChatEventsReattach(deps as any);
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
     await startChatEventsReattach();
     await Promise.resolve();
     await vi.advanceTimersByTimeAsync(0);
@@ -1060,6 +1062,112 @@ describe("mid-turn store-event cursor reattach", () => {
     expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
     expect(deps.applied).toEqual(["message_delta"]);
     expect(deps.lastAppliedCursorRef.current).toBe(4);
+  });
+
+  it("request-driven poll chain: no overlap, next arm only after prior settles", async () => {
+    vi.useFakeTimers();
+    const deps = reattachDeps();
+    let inflight = 0;
+    let maxInflight = 0;
+    const deferred: Array<(value: StoreEventsSince) => void> = [];
+    const readEventsSince = vi.spyOn(api, "readEventsSince").mockImplementation(
+      () => new Promise((resolve) => {
+        inflight += 1;
+        maxInflight = Math.max(maxInflight, inflight);
+        deferred.push((value) => {
+          inflight -= 1;
+          resolve(value);
+        });
+      }),
+    );
+    vi.spyOn(api, "getSessionState").mockResolvedValue({
+      runners: { "sess-live": "running" },
+    } as Awaited<ReturnType<typeof api.getSessionState>>);
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+    await Promise.resolve();
+
+    expect(readEventsSince).toHaveBeenCalledTimes(1);
+    expect(inflight).toBe(1);
+    // While the first pull is deferred, advancing the poll interval must not
+    // start a second overlapping read (no setInterval fan-out).
+    await vi.advanceTimersByTimeAsync(STORE_EVENTS_POLL_MS * 3);
+    expect(readEventsSince).toHaveBeenCalledTimes(1);
+    expect(maxInflight).toBe(1);
+
+    deferred.shift()!({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 1,
+      events: [],
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(STORE_EVENTS_POLL_MS);
+    expect(readEventsSince).toHaveBeenCalledTimes(2);
+    expect(maxInflight).toBe(1);
+    expect(inflight).toBe(1);
+
+    // Settle second pull so afterEach cleanup is clean.
+    deferred.shift()!({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 2,
+      events: [],
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it("cancellation stops the chain; restart with new generation re-owns polling", async () => {
+    vi.useFakeTimers();
+    let cancelled = false;
+    const deps = reattachDeps({
+      cancelled: () => cancelled,
+    });
+    vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 1,
+      events: [],
+    });
+    vi.spyOn(api, "getSessionState").mockResolvedValue({
+      runners: { "sess-live": "running" },
+    } as Awaited<ReturnType<typeof api.getSessionState>>);
+
+    const first = createChatEventsReattach(deps);
+    await first.startChatEventsReattach();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+
+    cancelled = true;
+    deps.clearChatEventsPoll();
+    expect(deps.chatEventsPollTimerRef.current).toBeNull();
+
+    // Advancing time after cancel must not resurrect the prior chain.
+    await vi.advanceTimersByTimeAsync(STORE_EVENTS_POLL_MS * 3);
+    expect(deps.chatEventsPollTimerRef.current).toBeNull();
+
+    // Fresh owner (new generation) can arm again.
+    let cancelled2 = false;
+    const deps2 = reattachDeps({
+      cancelled: () => cancelled2,
+      reattachGen: 2,
+    });
+    deps2.streamGenRef.current = 2;
+    const second = createChatEventsReattach(deps2);
+    await second.startChatEventsReattach();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deps2.chatEventsPollTimerRef.current).not.toBeNull();
+
+    cancelled2 = true;
+    deps2.clearChatEventsPoll();
+    expect(deps2.chatEventsPollTimerRef.current).toBeNull();
   });
 
   it("drops store stream events after session switch (no cross-session bleed)", async () => {

--- a/webapp/src/__tests__/DiffReviewPane.test.tsx
+++ b/webapp/src/__tests__/DiffReviewPane.test.tsx
@@ -116,7 +116,13 @@ describe("DiffReviewPane apply decision seeding + namespace", () => {
       files: [
         {
           path: "a.ts",
-          hunks: [{ id: "0:0", header: "@@", lines: ["+a"], status: "pending" }],
+          hunks: [{
+            id: "0:0",
+            decision_id: "fp_a#0",
+            header: "@@",
+            lines: ["+a"],
+            status: "pending",
+          }],
         },
       ],
     };
@@ -128,20 +134,26 @@ describe("DiffReviewPane apply decision seeding + namespace", () => {
       files: [
         {
           path: "b.ts",
-          hunks: [{ id: "0:0", header: "@@", lines: ["+b"], status: "pending" }],
+          hunks: [{
+            id: "0:0",
+            decision_id: "fp_b#0",
+            header: "@@",
+            lines: ["+b"],
+            status: "pending",
+          }],
         },
       ],
     };
 
-    expect(reviewHunkDecisionKey("rev-a", "0:0")).toBe("rev-a::0:0");
-    expect(reviewHunkDecisionKey("rev-b", "0:0")).toBe("rev-b::0:0");
+    expect(reviewHunkDecisionKey("rev-a", "fp_a#0")).toBe("rev-a::fp_a#0");
+    expect(reviewHunkDecisionKey("rev-b", "fp_b#0")).toBe("rev-b::fp_b#0");
 
     const decisions = {
-      [reviewHunkDecisionKey("rev-a", "0:0")]: "reject" as const,
+      [reviewHunkDecisionKey("rev-a", "fp_a#0")]: "reject" as const,
       // rev-b intentionally omitted — seed must paint accept to match UI
     };
-    expect(seedApplyDecisions(reviewA, decisions)).toEqual({ "0:0": "reject" });
-    expect(seedApplyDecisions(reviewB, decisions)).toEqual({ "0:0": "accept" });
+    expect(seedApplyDecisions(reviewA, decisions)).toEqual({ "fp_a#0": "reject" });
+    expect(seedApplyDecisions(reviewB, decisions)).toEqual({ "fp_b#0": "accept" });
   });
 
   it("Apply posts a fully seeded payload (no missing keys for harness reject default)", async () => {
@@ -163,8 +175,20 @@ describe("DiffReviewPane apply decision seeding + namespace", () => {
           {
             path: "a.ts",
             hunks: [
-              { id: "0:0", header: "@@ -1 +1 @@", lines: ["+one"], status: "pending" },
-              { id: "0:1", header: "@@ -2 +2 @@", lines: ["+two"], status: "pending" },
+              {
+                id: "0:0",
+                decision_id: "seed_one#0",
+                header: "@@ -1 +1 @@",
+                lines: ["+one"],
+                status: "pending",
+              },
+              {
+                id: "0:1",
+                decision_id: "seed_two#0",
+                header: "@@ -2 +2 @@",
+                lines: ["+two"],
+                status: "pending",
+              },
             ],
           },
         ],
@@ -176,8 +200,8 @@ describe("DiffReviewPane apply decision seeding + namespace", () => {
 
     await vi.waitFor(() => {
       expect(api.applyReview).toHaveBeenCalledWith("rev-seed", {
-        "0:0": "accept",
-        "0:1": "accept",
+        "seed_one#0": "accept",
+        "seed_two#0": "accept",
       });
     });
   });

--- a/webapp/src/__tests__/composerTasks.test.ts
+++ b/webapp/src/__tests__/composerTasks.test.ts
@@ -272,6 +272,51 @@ describe("buildComposerTasks + progress", () => {
     expect(composerTasksRemainVisible(tasks)).toBe(false);
   });
 
+  it("projects parent 5/5 completion from reconciled child rows", () => {
+    // /api/swarm/live already normalized nonterminal children when the parent
+    // is terminal — the renderer must not re-infer completion from parent status.
+    const swarm = job("job_done", "completed", "sess-1", [
+      { id: "w1", role: "explore", instruction: "a", status: "completed", adapter: "x" },
+      { id: "w2", role: "decision-explainer", instruction: "b", status: "completed", adapter: "x" },
+      { id: "w3", role: "conflict-auditor", instruction: "c", status: "completed", adapter: "x" },
+      { id: "w4", role: "pipeline-mapper", instruction: "d", status: "completed", adapter: "x" },
+      { id: "w5", role: "test-coverage-reviewer", instruction: "e", status: "completed", adapter: "x" },
+    ]);
+    const tasks = buildComposerTasks(swarm);
+    expect(taskProgress(tasks)).toEqual({ done: 5, total: 5 });
+    expect(tasks.every((t) => t.state === "completed")).toBe(true);
+    expect(composerTasksRemainVisible(tasks)).toBe(false);
+    expect(pickTaskSourceJob([swarm], "sess-1")).toBeNull();
+  });
+
+  it("does not paint stale pending children complete from parent status alone", () => {
+    const swarm = job("job_stale", "completed", "sess-1", [
+      { id: "w1", role: "explore", instruction: "a", status: "complete", adapter: "x" },
+      { id: "w2", role: "review", instruction: "b", status: "pending", adapter: "x" },
+    ]);
+    const tasks = buildComposerTasks(swarm);
+    expect(tasks.map((t) => t.state)).toEqual(["completed", "pending"]);
+    expect(taskProgress(tasks)).toEqual({ done: 1, total: 2 });
+  });
+
+  it("prefers terminal_receipt child status when projecting workers", () => {
+    const swarm = {
+      ...job("job_receipt", "completed", "sess-1", [
+        { id: "w1", role: "explore", instruction: "a", status: "pending", adapter: "x" },
+        { id: "w2", role: "review", instruction: "b", status: "pending", adapter: "x" },
+      ]),
+      terminal_receipt: {
+        status: "completed",
+        children: [
+          { id: "w1", status: "completed" },
+          { id: "w2", status: "failed" },
+        ],
+      },
+    } as Job;
+    const tasks = buildComposerTasks(swarm);
+    expect(tasks.map((t) => t.state)).toEqual(["completed", "failed"]);
+  });
+
   it("keeps a partial or failed wave visible", () => {
     const tasks = buildComposerTasks({
       ...job("local-wave-mix", "partial", "sess-1", [

--- a/webapp/src/__tests__/inFileReview.test.ts
+++ b/webapp/src/__tests__/inFileReview.test.ts
@@ -9,6 +9,10 @@ import {
   parseHunkHeader,
 } from "../lib/inFileReview";
 import {
+  forEachReviewHunkDecision,
+  hunkContentFingerprint,
+  hunkDecisionApplyKey,
+  resolveHunkDecisionId,
   reviewHunkDecisionKey,
   seedApplyDecisions,
 } from "../lib/reviewDecisions";
@@ -36,12 +40,14 @@ function makeReview(overrides?: Partial<PendingReview>): PendingReview {
         hunks: [
           {
             id: "0:0",
+            decision_id: "aaa1111111111111#0",
             header: "@@ -2,3 +2,4 @@",
             lines: [" context", "-old", "+new", " more"],
             status: "pending",
           },
           {
             id: "0:1",
+            decision_id: "bbb2222222222222#0",
             header: "@@ -20,1 +20,1 @@",
             lines: ["-bye", "+hi"],
             status: "pending",
@@ -53,6 +59,7 @@ function makeReview(overrides?: Partial<PendingReview>): PendingReview {
         hunks: [
           {
             id: "1:0",
+            decision_id: "ccc3333333333333#0",
             header: "@@ -1,1 +1,2 @@",
             lines: [" keep", "+extra"],
             status: "pending",
@@ -64,19 +71,107 @@ function makeReview(overrides?: Partial<PendingReview>): PendingReview {
   };
 }
 
-describe("review decision namespace helpers (shared with DiffReviewPane)", () => {
-  it("namespaces decisions per review", () => {
-    expect(reviewHunkDecisionKey("rev-a", "0:0")).toBe("rev-a::0:0");
-    expect(reviewHunkDecisionKey("rev-b", "0:0")).toBe("rev-b::0:0");
+describe("review decision identity helpers (shared with DiffReviewPane)", () => {
+  it("namespaces decisions per review and decision_id", () => {
+    expect(reviewHunkDecisionKey("rev-a", "fp#0")).toBe("rev-a::fp#0");
+    expect(reviewHunkDecisionKey("rev-b", "fp#0")).toBe("rev-b::fp#0");
   });
 
-  it("seedApplyDecisions fills every hunk id as accept by default", () => {
+  it("seedApplyDecisions fills every decision_id key as accept by default", () => {
     const review = makeReview();
     expect(seedApplyDecisions(review, {})).toEqual({
-      "0:0": "accept",
-      "0:1": "accept",
-      "1:0": "accept",
+      "aaa1111111111111#0": "accept",
+      "bbb2222222222222#0": "accept",
+      "ccc3333333333333#0": "accept",
     });
+  });
+
+  it("keeps duplicate hunk ids with opposite decisions as distinct keys", () => {
+    const review = makeReview({
+      files: [
+        {
+          path: "a.ts",
+          hunks: [
+            {
+              id: "dup",
+              decision_id: "samefpaaaaaaaaaa#0",
+              header: "@@ -1 +1 @@",
+              lines: ["+one"],
+              status: "pending",
+            },
+            {
+              id: "dup",
+              decision_id: "samefpaaaaaaaaaa#1",
+              header: "@@ -1 +1 @@",
+              lines: ["+one"],
+              status: "pending",
+            },
+          ],
+        },
+      ],
+    });
+    const decisions = {
+      [reviewHunkDecisionKey(review.id, "samefpaaaaaaaaaa#0")]: "reject" as const,
+      [reviewHunkDecisionKey(review.id, "samefpaaaaaaaaaa#1")]: "accept" as const,
+    };
+    expect(seedApplyDecisions(review, decisions)).toEqual({
+      "samefpaaaaaaaaaa#0": "reject",
+      "samefpaaaaaaaaaa#1": "accept",
+    });
+    const keys: string[] = [];
+    forEachReviewHunkDecision(review, (_hunk, decisionId) => {
+      keys.push(hunkDecisionApplyKey(decisionId));
+    });
+    expect(keys).toEqual(["samefpaaaaaaaaaa#0", "samefpaaaaaaaaaa#1"]);
+  });
+
+  it("reordering unrelated hunks does not change existing decision keys", () => {
+    const hunkA = {
+      id: "0:0",
+      header: "@@ -1 +1 @@",
+      lines: ["+alpha"],
+      status: "pending" as const,
+    };
+    const hunkB = {
+      id: "0:1",
+      header: "@@ -2 +2 @@",
+      lines: ["+beta"],
+      status: "pending" as const,
+    };
+    const hunkC = {
+      id: "0:2",
+      header: "@@ -3 +3 @@",
+      lines: ["+gamma"],
+      status: "pending" as const,
+    };
+    const order1 = makeReview({
+      files: [{ path: "x.ts", hunks: [hunkA, hunkB, hunkC] }],
+    });
+    const order2 = makeReview({
+      files: [{ path: "x.ts", hunks: [hunkC, hunkA, hunkB] }],
+    });
+    const keys1: string[] = [];
+    const keys2: string[] = [];
+    forEachReviewHunkDecision(order1, (_h, id) => keys1.push(id));
+    forEachReviewHunkDecision(order2, (_h, id) => keys2.push(id));
+    expect(new Set(keys1)).toEqual(new Set(keys2));
+    expect(keys1[0]).toBe(keys2[1]); // A moves but keeps its key
+    expect(keys1[1]).toBe(keys2[2]);
+    expect(keys1[2]).toBe(keys2[0]);
+  });
+
+  it("legacy reviews without decision_id get deterministic content fingerprints", () => {
+    const hunk = {
+      id: "0:0",
+      header: "@@ -1 +1 @@",
+      lines: ["+legacy"],
+      status: "pending" as const,
+    };
+    const counts = new Map<string, number>();
+    const id = resolveHunkDecisionId(hunk, "a.ts", counts);
+    const fp = hunkContentFingerprint("a.ts", "@@ -1 +1 @@", ["+legacy"]);
+    expect(id).toBe(`${fp}#0`);
+    expect(resolveHunkDecisionId({ ...hunk }, "a.ts", counts)).toBe(`${fp}#1`);
   });
 });
 
@@ -152,19 +247,19 @@ describe("buildInFileApplyDecisions + applyInFileHunkDecision", () => {
 
   it("Accept seeds all review hunk keys (never omits other files)", () => {
     const review = makeReview();
-    expect(buildInFileApplyDecisions(review, "0:0", "accept")).toEqual({
-      "0:0": "accept",
-      "0:1": "accept",
-      "1:0": "accept",
+    expect(buildInFileApplyDecisions(review, "aaa1111111111111#0", "accept")).toEqual({
+      "aaa1111111111111#0": "accept",
+      "bbb2222222222222#0": "accept",
+      "ccc3333333333333#0": "accept",
     });
   });
 
   it("Reject of one hunk still seeds sibling hunks as accept", () => {
     const review = makeReview();
-    expect(buildInFileApplyDecisions(review, "0:1", "reject")).toEqual({
-      "0:0": "accept",
-      "0:1": "reject",
-      "1:0": "accept",
+    expect(buildInFileApplyDecisions(review, "bbb2222222222222#0", "reject")).toEqual({
+      "aaa1111111111111#0": "accept",
+      "bbb2222222222222#0": "reject",
+      "ccc3333333333333#0": "accept",
     });
   });
 
@@ -178,12 +273,12 @@ describe("buildInFileApplyDecisions + applyInFileHunkDecision", () => {
     } as any);
 
     const review = makeReview();
-    const res = await applyInFileHunkDecision(review, "0:0", "accept");
+    const res = await applyInFileHunkDecision(review, "aaa1111111111111#0", "accept");
     expect(res.ok).toBe(true);
     expect(api.applyReview).toHaveBeenCalledWith("rev-a", {
-      "0:0": "accept",
-      "0:1": "accept",
-      "1:0": "accept",
+      "aaa1111111111111#0": "accept",
+      "bbb2222222222222#0": "accept",
+      "ccc3333333333333#0": "accept",
     });
 
     const kinds = vi.mocked(window.dispatchEvent).mock.calls.map(
@@ -203,11 +298,11 @@ describe("buildInFileApplyDecisions + applyInFileHunkDecision", () => {
     } as any);
 
     const review = makeReview();
-    await applyInFileHunkDecision(review, "0:0", "reject");
+    await applyInFileHunkDecision(review, "aaa1111111111111#0", "reject");
     expect(api.applyReview).toHaveBeenCalledWith("rev-a", {
-      "0:0": "reject",
-      "0:1": "accept",
-      "1:0": "accept",
+      "aaa1111111111111#0": "reject",
+      "bbb2222222222222#0": "accept",
+      "ccc3333333333333#0": "accept",
     });
   });
 });

--- a/webapp/src/__tests__/useInFileReview.test.tsx
+++ b/webapp/src/__tests__/useInFileReview.test.tsx
@@ -25,12 +25,14 @@ const review: PendingReview = {
       hunks: [
         {
           id: "0:0",
+          decision_id: "infile_a#0",
           header: "@@ -1,2 +1,2 @@",
           lines: [" keep", "-a", "+b"],
           status: "pending",
         },
         {
           id: "0:1",
+          decision_id: "infile_b#0",
           header: "@@ -8,1 +8,1 @@",
           lines: ["-x", "+y"],
           status: "pending",
@@ -67,14 +69,14 @@ describe("useInFileReview", () => {
     // Drive the same helper path the widget buttons use.
     const { applyInFileHunkDecision } = await import("../lib/inFileReview");
     await act(async () => {
-      await applyInFileHunkDecision(review, "0:0", "accept");
+      await applyInFileHunkDecision(review, "infile_a#0", "accept");
     });
 
     expect(api.applyReview).toHaveBeenCalledWith("rev-infile", {
-      "0:0": "accept",
-      "0:1": "accept",
+      "infile_a#0": "accept",
+      "infile_b#0": "accept",
     });
-    expect(reviewHunkDecisionKey("rev-infile", "0:0")).toBe("rev-infile::0:0");
+    expect(reviewHunkDecisionKey("rev-infile", "infile_a#0")).toBe("rev-infile::infile_a#0");
   });
 
   it("Reject seeds sibling hunks as accept so they are not silently dropped", async () => {
@@ -87,11 +89,11 @@ describe("useInFileReview", () => {
     } as any);
 
     const { applyInFileHunkDecision } = await import("../lib/inFileReview");
-    await applyInFileHunkDecision(review, "0:1", "reject");
+    await applyInFileHunkDecision(review, "infile_b#0", "reject");
 
     expect(api.applyReview).toHaveBeenCalledWith("rev-infile", {
-      "0:0": "accept",
-      "0:1": "reject",
+      "infile_a#0": "accept",
+      "infile_b#0": "reject",
     });
   });
 });

--- a/webapp/src/__tests__/wave4Operational.test.ts
+++ b/webapp/src/__tests__/wave4Operational.test.ts
@@ -1,11 +1,19 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AUTH_FAILURE,
   BACKEND_NOT_READY,
+  MALFORMED_DIAGNOSTIC_WIRE,
   authFailureDiagnostic,
   fromBackendDiagnostic,
+  malformedBackendDiagnostic,
+  parseBackendDiagnostic,
 } from "../lib/operationalDiagnostic";
+import { clearDiagnostic, getActiveDiagnostic, publishDiagnostic } from "../lib/operationalDiagnosticBus";
 import { executeDiagnosticRecovery } from "../lib/operationalRecovery";
+
+afterEach(() => {
+  clearDiagnostic();
+});
 
 describe("fromBackendDiagnostic", () => {
   it("parses GET /api/diagnostics wire payloads", () => {
@@ -55,6 +63,84 @@ describe("fromBackendDiagnostic", () => {
       summary: "x",
       severity: "fatal" as never,
     })).toBeNull();
+  });
+});
+
+describe("parseBackendDiagnostic", () => {
+  it("distinguishes absent from malformed", () => {
+    expect(parseBackendDiagnostic(null)).toEqual({ status: "absent" });
+    expect(parseBackendDiagnostic(undefined)).toEqual({ status: "absent" });
+    expect(parseBackendDiagnostic({})).toEqual({ status: "absent" });
+    const incomplete = parseBackendDiagnostic({ summary: "only summary" });
+    expect(incomplete.status).toBe("invalid");
+    if (incomplete.status === "invalid") {
+      expect(incomplete.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects invalid recovery and non-boolean retryable", () => {
+    expect(parseBackendDiagnostic({
+      scope: "backend",
+      operation: "doctor",
+      summary: "x",
+      severity: "error",
+      retryable: "maybe",
+    }).status).toBe("invalid");
+    expect(parseBackendDiagnostic({
+      scope: "backend",
+      operation: "doctor",
+      summary: "x",
+      severity: "error",
+      retryable: true,
+      recovery: { kind: "retry" },
+    }).status).toBe("invalid");
+    expect(parseBackendDiagnostic({
+      scope: "backend",
+      operation: "doctor",
+      summary: "x",
+      severity: "error",
+      retryable: true,
+      recovery: { kind: "warp", label: "Nope" },
+    }).status).toBe("invalid");
+  });
+
+  it("defaults missing recovery to none and accepts boolean-like retryable", () => {
+    const parsed = parseBackendDiagnostic({
+      scope: "backend",
+      operation: "doctor",
+      summary: "ok",
+      severity: "warning",
+      retryable: "0",
+    });
+    expect(parsed.status).toBe("ok");
+    if (parsed.status === "ok") {
+      expect(parsed.diagnostic.retryable).toBe(false);
+      expect(parsed.diagnostic.recovery).toEqual({ kind: "none" });
+    }
+  });
+
+  it("absent clears chrome while invalid publishes a malformed diagnostic (not healthy)", () => {
+    publishDiagnostic(authFailureDiagnostic("prior"));
+    expect(getActiveDiagnostic()?.code).toBe(AUTH_FAILURE);
+
+    const absent = parseBackendDiagnostic(null);
+    expect(absent.status).toBe("absent");
+    clearDiagnostic();
+    expect(getActiveDiagnostic()).toBeNull();
+
+    const invalid = parseBackendDiagnostic({ summary: "only summary" });
+    expect(invalid.status).toBe("invalid");
+    if (invalid.status === "invalid") {
+      const observed = malformedBackendDiagnostic(invalid.reason);
+      publishDiagnostic(observed);
+      const active = getActiveDiagnostic();
+      expect(active?.code).toBe(MALFORMED_DIAGNOSTIC_WIRE);
+      expect(active?.summary).toMatch(/malformed/i);
+      expect(active?.detail).toBeTruthy();
+      // Must not masquerade as a healthy clear / successful backend diagnostic.
+      expect(active?.severity).toBe("warning");
+      expect(fromBackendDiagnostic({ summary: "only summary" })).toBeNull();
+    }
   });
 });
 

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -163,7 +163,7 @@ import {
   type DirectoryEntryLike,
 } from "./conversation/composerInput";
 import { openAgentBusyDetail, openAgentWorkspace } from "../lib/agentLinks";
-import { AUTH_FAILURE, sharedReadinessNotice, fromBackendDiagnostic } from "../lib/operationalDiagnostic";
+import { AUTH_FAILURE, sharedReadinessNotice, malformedBackendDiagnostic, parseBackendDiagnostic } from "../lib/operationalDiagnostic";
 import { getActiveDiagnostic, publishDiagnostic } from "../lib/operationalDiagnosticBus";
 import {
   executeDiagnosticRecovery,
@@ -280,6 +280,7 @@ export default function Conversation({
 
   const clearChatEventsPoll = () => {
     if (chatEventsPollTimerRef.current != null) {
+      window.clearTimeout(chatEventsPollTimerRef.current);
       window.clearInterval(chatEventsPollTimerRef.current);
       chatEventsPollTimerRef.current = null;
     }
@@ -3555,9 +3556,10 @@ export default function Conversation({
       }
       try {
         const res = await api.diagnostics();
-        const diag = fromBackendDiagnostic(res.diagnostic as Record<string, unknown> | null);
-        if (!diag) clearDiagnosticAfterSuccess(operationalDiagnostic);
-        else publishDiagnostic(diag);
+        const parsed = parseBackendDiagnostic(res.diagnostic);
+        if (parsed.status === "ok") publishDiagnostic(parsed.diagnostic);
+        else if (parsed.status === "absent") clearDiagnosticAfterSuccess(operationalDiagnostic);
+        else publishDiagnostic(malformedBackendDiagnostic(parsed.reason));
         window.dispatchEvent(new Event("harness-config-changed"));
       } catch {
         /* keep diagnostic visible */

--- a/webapp/src/components/DiffReviewPane.tsx
+++ b/webapp/src/components/DiffReviewPane.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect } from "react";
 import { api, type PendingReview, type PendingReviewFile } from "../lib/api";
 import { Check, X, Eye, AlertCircle, RefreshCw } from "lucide-react";
 import {
+  forEachReviewHunkDecision,
+  hunkDecisionApplyKey,
+  resolveHunkDecisionId,
   reviewHunkDecisionKey,
   seedApplyDecisions,
 } from "../lib/reviewDecisions";
@@ -26,28 +29,38 @@ export default function DiffReviewPane({ reviews, onRefresh, loadError = null }:
   useEffect(() => {
     const initial: Record<string, "accept" | "reject"> = { ...decisions };
     reviews.forEach(rev => {
-      rev.files.forEach(file => {
-        file.hunks.forEach(hunk => {
-          const key = reviewHunkDecisionKey(rev.id, hunk.id);
-          if (!initial[key]) {
-            initial[key] = "accept";
-          }
-        });
+      forEachReviewHunkDecision(rev, (_hunk, decisionId) => {
+        const key = reviewHunkDecisionKey(rev.id, decisionId);
+        if (!initial[key]) {
+          initial[key] = "accept";
+        }
       });
     });
     setDecisions(initial);
   }, [reviews]);
 
-  const handleSetHunkDecision = (reviewId: string, hunkId: string, value: "accept" | "reject") => {
-    const key = reviewHunkDecisionKey(reviewId, hunkId);
+  const handleSetHunkDecision = (
+    reviewId: string,
+    decisionId: string,
+    value: "accept" | "reject",
+  ) => {
+    const key = reviewHunkDecisionKey(reviewId, decisionId);
     setDecisions(prev => ({ ...prev, [key]: value }));
   };
 
   const handleSetFileDecisions = (reviewId: string, file: PendingReviewFile, value: "accept" | "reject") => {
+    const review = reviews.find(r => r.id === reviewId);
+    if (!review) return;
     const updated = { ...decisions };
-    file.hunks.forEach(h => {
-      updated[reviewHunkDecisionKey(reviewId, h.id)] = value;
-    });
+    const fingerprintCounts = new Map<string, number>();
+    for (const f of review.files) {
+      for (const h of f.hunks) {
+        const decisionId = resolveHunkDecisionId(h, f.path, fingerprintCounts);
+        if (f === file) {
+          updated[reviewHunkDecisionKey(reviewId, decisionId)] = value;
+        }
+      }
+    }
     setDecisions(updated);
   };
 
@@ -63,13 +76,12 @@ export default function DiffReviewPane({ reviews, onRefresh, loadError = null }:
 
     // Identify all hunks in this review and their decisions
     const allHunks: { id: string; stateKey: string; decision: "accept" | "reject" }[] = [];
-    review.files.forEach(f => {
-      f.hunks.forEach(h => {
-        allHunks.push({
-          id: h.id,
-          stateKey: reviewHunkDecisionKey(reviewId, h.id),
-          decision: applyPayload[h.id] || "accept",
-        });
+    forEachReviewHunkDecision(review, (h, decisionId) => {
+      const applyKey = hunkDecisionApplyKey(decisionId);
+      allHunks.push({
+        id: h.id,
+        stateKey: reviewHunkDecisionKey(reviewId, decisionId),
+        decision: applyPayload[applyKey] || "accept",
       });
     });
 
@@ -295,15 +307,14 @@ export default function DiffReviewPane({ reviews, onRefresh, loadError = null }:
         // Calculate totals for this review
         let totalHunks = 0;
         let acceptedHunks = 0;
-        rev.files.forEach(f => {
-          f.hunks.forEach(h => {
-            totalHunks++;
-            if (decisions[reviewHunkDecisionKey(rev.id, h.id)] === "accept") {
-              acceptedHunks++;
-            }
-          });
+        forEachReviewHunkDecision(rev, (_h, decisionId) => {
+          totalHunks += 1;
+          if (decisions[reviewHunkDecisionKey(rev.id, decisionId)] === "accept") {
+            acceptedHunks += 1;
+          }
         });
 
+        const fingerprintCounts = new Map<string, number>();
         return (
           <div key={rev.id} className="bg-panel2/40 border border-edge rounded p-3 space-y-3">
             <div className="flex flex-col gap-1 border-b border-edge/60 pb-2">
@@ -356,7 +367,8 @@ export default function DiffReviewPane({ reviews, onRefresh, loadError = null }:
 
                   <div className="space-y-2">
                     {file.hunks.map(hunk => {
-                      const decisionKey = reviewHunkDecisionKey(rev.id, hunk.id);
+                      const decisionId = resolveHunkDecisionId(hunk, file.path, fingerprintCounts);
+                      const decisionKey = reviewHunkDecisionKey(rev.id, decisionId);
                       const isAccepted = decisions[decisionKey] === "accept";
                       const hState = hunkStates[decisionKey];
                       const isApplying = hState === "applying";
@@ -418,7 +430,7 @@ export default function DiffReviewPane({ reviews, onRefresh, loadError = null }:
                             <span className="text-[9px] font-mono text-faint">{hunk.header.trim()}</span>
                             <div className="flex gap-1">
                               <button
-                                onClick={() => handleSetHunkDecision(rev.id, hunk.id, "accept")}
+                                onClick={() => handleSetHunkDecision(rev.id, decisionId, "accept")}
                                 disabled={loading !== null}
                                 className={`p-1 rounded transition-colors ${
                                   isAccepted ? "bg-accent/20 text-accent" : "hover:bg-panel2 text-faint"
@@ -428,7 +440,7 @@ export default function DiffReviewPane({ reviews, onRefresh, loadError = null }:
                                 <Check size={10} />
                               </button>
                               <button
-                                onClick={() => handleSetHunkDecision(rev.id, hunk.id, "reject")}
+                                onClick={() => handleSetHunkDecision(rev.id, decisionId, "reject")}
                                 disabled={loading !== null}
                                 className={`p-1 rounded transition-colors ${
                                   !isAccepted ? "bg-risk/20 text-risk" : "hover:bg-panel2 text-faint"

--- a/webapp/src/components/conversation/chatEventsReattach.ts
+++ b/webapp/src/components/conversation/chatEventsReattach.ts
@@ -522,20 +522,31 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
   const startChatEventsPoll = () => {
     if (cancelled() || userStoppedRef.current) return;
     if (chatEventsPollTimerRef.current != null) return;
+
+    const armNext = (delayMs: number) => {
+      if (cancelled() || userStoppedRef.current) return;
+      if (streamGenRef.current !== reattachGen) return;
+      if (chatEventsPollTimerRef.current != null) return;
+      chatEventsPollTimerRef.current = window.setTimeout(() => {
+        chatEventsPollTimerRef.current = null;
+        void pullChatEvents().then((keepPolling) => {
+          if (!keepPolling || cancelled()) {
+            clearChatEventsPoll();
+            return;
+          }
+          if (streamGenRef.current !== reattachGen) return;
+          armNext(STORE_EVENTS_POLL_MS);
+        });
+      }, delayMs) as unknown as number;
+    };
+
+    // Non-overlapping request-driven chain: next poll only after the prior settles.
     void pullChatEvents().then((keepPolling) => {
       if (!keepPolling || cancelled()) return;
       if (streamGenRef.current !== reattachGen) return;
-      if (chatEventsPollTimerRef.current != null) return;
-      chatEventsPollTimerRef.current = window.setInterval(() => {
-        void pullChatEvents().then((cont) => {
-          if (!cont) clearChatEventsPoll();
-        });
-      }, STORE_EVENTS_POLL_MS);
+      armNext(STORE_EVENTS_POLL_MS);
     });
   };
-
-  /** Live watch collapsed — store cursor owns reattach. */
-  const startLiveChatEventsWatch = (): boolean => false;
 
   const startChatEventsReattach = async () => {
     if (cancelled() || userStoppedRef.current) return;
@@ -585,5 +596,5 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
     startChatEventsPoll();
   };
 
-  return { pullChatEvents, startChatEventsReattach, startLiveChatEventsWatch };
+  return { pullChatEvents, startChatEventsReattach };
 }

--- a/webapp/src/components/useInFileReview.ts
+++ b/webapp/src/components/useInFileReview.ts
@@ -51,7 +51,7 @@ export function useInFileReview(editorPath: string): {
     setApplyError(null);
     setApplyingKey(item.decisionKey);
     try {
-      const res = await applyInFileHunkDecision(item.review, item.hunk.id, "accept");
+      const res = await applyInFileHunkDecision(item.review, item.decisionId, "accept");
       if (!res.ok) setApplyError(res.message);
       else refresh();
     } catch (err: any) {
@@ -65,7 +65,7 @@ export function useInFileReview(editorPath: string): {
     setApplyError(null);
     setApplyingKey(item.decisionKey);
     try {
-      const res = await applyInFileHunkDecision(item.review, item.hunk.id, "reject");
+      const res = await applyInFileHunkDecision(item.review, item.decisionId, "reject");
       if (!res.ok) setApplyError(res.message);
       else refresh();
     } catch (err: any) {

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -164,6 +164,8 @@ export type AuthPoolsResponse = {
 
 export type PendingReviewHunk = {
   id: string;
+  /** Server-assigned stable decision identity (content fingerprint + dup ordinal). */
+  decision_id?: string;
   header: string;
   lines: string[];
   status: "pending" | "accept" | "reject";

--- a/webapp/src/lib/composerTasks.ts
+++ b/webapp/src/lib/composerTasks.ts
@@ -35,11 +35,35 @@ function jobRank(job: Job): number {
 
 function composerJobIsLive(job: Job): boolean {
   const st = taskState(job.status);
+  // Parent terminal owns the projection — do not treat stale pending children as live.
+  if (st === "completed" || st === "failed" || st === "degraded") return false;
   if (st === "in_progress" || st === "pending") return true;
   return (job.tasks || []).some((task) => {
     const ts = taskState(task.status);
     return ts === "in_progress" || ts === "pending";
   });
+}
+
+function receiptChildStatusById(job: Job): Map<string, string> {
+  const out = new Map<string, string>();
+  const children = job.terminal_receipt?.children;
+  if (!Array.isArray(children)) return out;
+  for (const child of children) {
+    const id = String(child?.id || "").trim();
+    if (!id) continue;
+    const status = String(child?.status || "").trim();
+    if (status) out.set(id, status);
+  }
+  return out;
+}
+
+function projectTaskLifecycle(job: Job, task: Task): ComposerTaskState {
+  const receipt = receiptChildStatusById(job);
+  const fromReceipt = receipt.get(String(task.id || "").trim());
+  // Prefer terminal_receipt child status; otherwise trust the projected row.
+  // Parent-terminal cosmetic completion lives on /api/swarm/live projection —
+  // do not re-infer it here.
+  return taskState(fromReceipt || task.status);
 }
 
 function pickRankedJob(pool: readonly Job[]): Job {
@@ -122,7 +146,7 @@ export function buildComposerTasks(job: Job | null): ComposerTask[] {
   const briefs = new Set(rows.map((task) => taskCopy(task).instruction).filter(Boolean));
   const sharedBrief = briefs.size === 1 && rows.length > 1;
   return rows.map((task: Task, i) => {
-    let state = taskState(task.status);
+    let state = job ? projectTaskLifecycle(job, task) : taskState(task.status);
     if (state === "completed") {
       const fail = arts.find((a) => String(a.task_id || "") === String(task.id || "") && artifactLooksFailed(a));
       if (fail) state = "degraded";

--- a/webapp/src/lib/inFileReview.ts
+++ b/webapp/src/lib/inFileReview.ts
@@ -5,7 +5,11 @@ import {
   type PendingReviewHunk,
 } from "./api";
 import { pathsReferToSameFile } from "./workspaceMutationEvents";
-import { reviewHunkDecisionKey, seedApplyDecisions } from "./reviewDecisions";
+import {
+  forEachReviewHunkDecision,
+  reviewHunkDecisionKey,
+  seedApplyDecisions,
+} from "./reviewDecisions";
 
 export type HunkLineKind = "context" | "add" | "del" | "meta";
 
@@ -94,6 +98,7 @@ export type InFilePendingHunk = {
   hunk: PendingReviewHunk;
   geometry: ParsedHunkGeometry;
   decisionKey: string;
+  decisionId: string;
 };
 
 /** Collect pending hunks whose file path matches the open editor path. */
@@ -105,21 +110,21 @@ export function collectInFilePendingHunks(
   if (!editorPath) return out;
 
   for (const review of reviews) {
-    for (const file of review.files || []) {
-      if (!pathsReferToSameFile(file.path, editorPath)) continue;
-      for (const hunk of file.hunks || []) {
-        if (hunk.status && hunk.status !== "pending") continue;
-        const geometry = parseHunkGeometry(hunk);
-        if (!geometry) continue;
-        out.push({
-          review,
-          file,
-          hunk,
-          geometry,
-          decisionKey: reviewHunkDecisionKey(review.id, hunk.id),
-        });
-      }
-    }
+    forEachReviewHunkDecision(review, (hunk, decisionId, fileIndex) => {
+      const file = review.files[fileIndex];
+      if (!file || !pathsReferToSameFile(file.path, editorPath)) return;
+      if (hunk.status && hunk.status !== "pending") return;
+      const geometry = parseHunkGeometry(hunk);
+      if (!geometry) return;
+      out.push({
+        review,
+        file,
+        hunk,
+        geometry,
+        decisionId,
+        decisionKey: reviewHunkDecisionKey(review.id, decisionId),
+      });
+    });
   }
 
   out.sort((a, b) => a.geometry.anchorOldLine - b.geometry.anchorOldLine);
@@ -133,11 +138,11 @@ export function collectInFilePendingHunks(
  */
 export function buildInFileApplyDecisions(
   review: PendingReview,
-  hunkId: string,
+  decisionId: string,
   decision: "accept" | "reject",
 ): Record<string, "accept" | "reject"> {
   const namespaced: Record<string, "accept" | "reject"> = {
-    [reviewHunkDecisionKey(review.id, hunkId)]: decision,
+    [reviewHunkDecisionKey(review.id, decisionId)]: decision,
   };
   return seedApplyDecisions(review, namespaced);
 }
@@ -150,10 +155,10 @@ export type InFileApplyResult = {
 /** Apply one in-file hunk decision via the shared apply_review API. */
 export async function applyInFileHunkDecision(
   review: PendingReview,
-  hunkId: string,
+  decisionId: string,
   decision: "accept" | "reject",
 ): Promise<InFileApplyResult> {
-  const payload = buildInFileApplyDecisions(review, hunkId, decision);
+  const payload = buildInFileApplyDecisions(review, decisionId, decision);
   const res = await api.applyReview(review.id, payload);
   if (!res.ok) {
     return { ok: false, message: res.message || "Failed to apply" };

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -61,6 +61,7 @@ export const BACKEND_NOT_READY = "backend_not_ready";
 export const BACKEND_WARNING = "backend_warning";
 export const AUTH_FAILURE = "provider_auth_failure";
 export const CONVERSATION_TURN_FAILURE = "conversation_turn_failure";
+export const MALFORMED_DIAGNOSTIC_WIRE = "malformed_diagnostic_wire";
 
 const SUMMARY_MAX = 160;
 const DETAIL_MAX = 280;
@@ -217,24 +218,34 @@ export function fromTransportFailure(input: {
   });
 }
 
-type BackendDiagnosticWire = {
-  scope?: DiagnosticScope;
-  operation?: string;
-  code?: string;
-  summary?: string;
-  detail?: string;
-  severity?: DiagnosticSeverity;
+/** Wire shape from GET /api/diagnostics — validated by parseBackendDiagnostic. */
+export type BackendDiagnosticWire = {
+  scope?: unknown;
+  operation?: unknown;
+  code?: unknown;
+  summary?: unknown;
+  detail?: unknown;
+  severity?: unknown;
   retryable?: unknown;
-  dataSafe?: boolean;
-  recovery?: DiagnosticRecovery;
-  sessionId?: string;
-  repo?: string;
-  jobId?: string;
-  taskId?: string;
-  id?: string;
-  createdAt?: number;
-  correlation_id?: string;
+  dataSafe?: unknown;
+  recovery?: unknown;
+  sessionId?: unknown;
+  repo?: unknown;
+  jobId?: unknown;
+  taskId?: unknown;
+  id?: unknown;
+  createdAt?: unknown;
+  correlation_id?: unknown;
 };
+
+/**
+ * Strict parse result so callers can tell absent (clear chrome) from malformed
+ * (keep prior chrome / surface a reason) instead of collapsing both to null.
+ */
+export type BackendDiagnosticParseResult =
+  | { status: "absent" }
+  | { status: "invalid"; reason: string }
+  | { status: "ok"; diagnostic: OperationalDiagnostic };
 
 /** Parse GET /api/diagnostics diagnostic payload into the renderer contract. */
 const DIAGNOSTIC_SCOPES = new Set<DiagnosticScope>([
@@ -252,38 +263,162 @@ const DIAGNOSTIC_SCOPES = new Set<DiagnosticScope>([
 ]);
 const DIAGNOSTIC_SEVERITIES = new Set<DiagnosticSeverity>(["info", "warning", "error"]);
 
-function parseWireBool(value: unknown): boolean {
+function parseWireBool(value: unknown): boolean | null {
+  if (value == null) return false;
   if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value === 1;
-  const text = String(value ?? "").trim().toLowerCase();
-  return text === "1" || text === "true" || text === "yes" || text === "on";
-}
-
-export function fromBackendDiagnostic(
-  wire: BackendDiagnosticWire | null | undefined,
-): OperationalDiagnostic | null {
-  if (!wire || !wire.summary || !wire.scope || !wire.operation || !wire.severity) {
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
     return null;
   }
-  if (!DIAGNOSTIC_SCOPES.has(wire.scope as DiagnosticScope)) return null;
-  if (!DIAGNOSTIC_SEVERITIES.has(wire.severity as DiagnosticSeverity)) return null;
+  if (typeof value === "string") {
+    const text = value.trim().toLowerCase();
+    if (text === "1" || text === "true" || text === "yes" || text === "on") return true;
+    if (text === "0" || text === "false" || text === "no" || text === "off" || text === "") return false;
+    return null;
+  }
+  return null;
+}
+
+function parseWireRecovery(value: unknown): DiagnosticRecovery | null {
+  if (value == null) return { kind: "none" };
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  const bag = value as Record<string, unknown>;
+  const kind = bag.kind;
+  if (kind === "none") return { kind: "none" };
+  if (kind === "retry" || kind === "relaunch") {
+    const label = typeof bag.label === "string" ? bag.label.trim() : "";
+    if (!label) return null;
+    return { kind, label: sanitizeDiagnosticText(label, 80) };
+  }
+  return null;
+}
+
+function parseOptionalWireString(value: unknown, field: string): { ok: true; value?: string } | { ok: false; reason: string } {
+  if (value == null) return { ok: true, value: undefined };
+  if (typeof value !== "string") return { ok: false, reason: `${field} must be a string` };
+  const trimmed = value.trim();
+  return { ok: true, value: trimmed || undefined };
+}
+
+/**
+ * Strict observable parse of backend diagnostic wire.
+ * Absent (null/undefined/empty) vs invalid (present but malformed) are distinct.
+ */
+export function parseBackendDiagnostic(
+  wire: BackendDiagnosticWire | null | undefined | unknown,
+): BackendDiagnosticParseResult {
+  if (wire == null) return { status: "absent" };
+  if (typeof wire !== "object" || Array.isArray(wire)) {
+    return { status: "invalid", reason: "diagnostic wire must be an object" };
+  }
+  const bag = wire as Record<string, unknown>;
+  const requiredPresent = ["summary", "scope", "operation", "severity"].some(
+    (key) => bag[key] != null && String(bag[key]).trim() !== "",
+  );
+  if (!requiredPresent) return { status: "absent" };
+
+  const summary = typeof bag.summary === "string" ? bag.summary.trim() : "";
+  if (!summary) return { status: "invalid", reason: "summary required" };
+  const operation = typeof bag.operation === "string" ? bag.operation.trim() : "";
+  if (!operation) return { status: "invalid", reason: "operation required" };
+  const scope = bag.scope;
+  if (typeof scope !== "string" || !DIAGNOSTIC_SCOPES.has(scope as DiagnosticScope)) {
+    return { status: "invalid", reason: "scope must be a known DiagnosticScope" };
+  }
+  const severity = bag.severity;
+  if (typeof severity !== "string" || !DIAGNOSTIC_SEVERITIES.has(severity as DiagnosticSeverity)) {
+    return { status: "invalid", reason: "severity must be info|warning|error" };
+  }
+  const retryable = parseWireBool(bag.retryable);
+  if (retryable == null) {
+    return { status: "invalid", reason: "retryable must be a boolean-like value" };
+  }
+  const recovery = parseWireRecovery(bag.recovery);
+  if (!recovery) {
+    return { status: "invalid", reason: "recovery must be none|retry|relaunch with label" };
+  }
+  let dataSafe: boolean | undefined;
+  if (bag.dataSafe != null) {
+    const parsed = parseWireBool(bag.dataSafe);
+    if (parsed == null) return { status: "invalid", reason: "dataSafe must be boolean-like" };
+    dataSafe = parsed;
+  }
+  const sessionId = parseOptionalWireString(bag.sessionId, "sessionId");
+  if (!sessionId.ok) return { status: "invalid", reason: sessionId.reason };
+  const repo = parseOptionalWireString(bag.repo, "repo");
+  if (!repo.ok) return { status: "invalid", reason: repo.reason };
+  const jobId = parseOptionalWireString(bag.jobId, "jobId");
+  if (!jobId.ok) return { status: "invalid", reason: jobId.reason };
+  const taskId = parseOptionalWireString(bag.taskId, "taskId");
+  if (!taskId.ok) return { status: "invalid", reason: taskId.reason };
+  const code = parseOptionalWireString(bag.code, "code");
+  if (!code.ok) return { status: "invalid", reason: code.reason };
+  const detail = parseOptionalWireString(bag.detail, "detail");
+  if (!detail.ok) return { status: "invalid", reason: detail.reason };
+  const id = parseOptionalWireString(bag.id, "id");
+  if (!id.ok) return { status: "invalid", reason: id.reason };
+  const correlationId = parseOptionalWireString(bag.correlation_id, "correlation_id");
+  if (!correlationId.ok) return { status: "invalid", reason: correlationId.reason };
+
+  let createdAt: number | undefined;
+  if (bag.createdAt != null) {
+    if (typeof bag.createdAt !== "number" || !Number.isFinite(bag.createdAt)) {
+      return { status: "invalid", reason: "createdAt must be a finite number" };
+    }
+    createdAt = bag.createdAt;
+  }
+
+  return {
+    status: "ok",
+    diagnostic: createOperationalDiagnostic({
+      id: id.value,
+      scope: scope as DiagnosticScope,
+      operation,
+      code: code.value,
+      summary,
+      detail: detail.value,
+      severity: severity as DiagnosticSeverity,
+      retryable,
+      dataSafe,
+      recovery,
+      sessionId: sessionId.value,
+      repo: repo.value,
+      jobId: jobId.value,
+      taskId: taskId.value,
+      createdAt,
+      correlationId: correlationId.value,
+    }),
+  };
+}
+
+/** Back-compat: ok → diagnostic; absent/invalid → null (use parseBackendDiagnostic to observe). */
+export function fromBackendDiagnostic(
+  wire: BackendDiagnosticWire | null | undefined | unknown,
+): OperationalDiagnostic | null {
+  const parsed = parseBackendDiagnostic(wire);
+  return parsed.status === "ok" ? parsed.diagnostic : null;
+}
+
+/**
+ * Observable operational diagnostic for malformed GET /api/diagnostics wire.
+ * Uses a static sanitized reason only — never the raw payload.
+ */
+export function malformedBackendDiagnostic(reason: string): OperationalDiagnostic {
+  const safe = sanitizeDiagnosticText(
+    String(reason || "invalid diagnostic fields").trim() || "invalid diagnostic fields",
+    DETAIL_MAX,
+  );
   return createOperationalDiagnostic({
-    id: wire.id,
-    scope: wire.scope as DiagnosticScope,
-    operation: wire.operation,
-    code: wire.code,
-    summary: wire.summary,
-    detail: wire.detail,
-    severity: wire.severity as DiagnosticSeverity,
-    retryable: parseWireBool(wire.retryable),
-    dataSafe: wire.dataSafe,
-    recovery: wire.recovery,
-    sessionId: wire.sessionId,
-    repo: wire.repo,
-    jobId: wire.jobId,
-    taskId: wire.taskId,
-    createdAt: wire.createdAt,
-    correlationId: wire.correlation_id,
+    scope: "backend",
+    operation: "diagnostics",
+    code: MALFORMED_DIAGNOSTIC_WIRE,
+    summary: "Backend diagnostic payload was malformed",
+    detail: safe,
+    severity: "warning",
+    retryable: true,
+    dataSafe: true,
+    recovery: { kind: "retry", label: "Retry" },
   });
 }
 

--- a/webapp/src/lib/reviewDecisions.ts
+++ b/webapp/src/lib/reviewDecisions.ts
@@ -1,25 +1,96 @@
-import type { PendingReview } from "./api";
+import type { PendingReview, PendingReviewHunk } from "./api";
 
-/** Namespace hunk decisions per review so concurrent pending reviews cannot collide. */
-export function reviewHunkDecisionKey(reviewId: string, hunkId: string): string {
-  return `${reviewId}::${hunkId}`;
+/** FNV-1a 64-bit — must match harness/diffreview.py hunk_content_fingerprint. */
+function fnv1a64Hex(blob: string): string {
+  let h = 14695981039346656037n;
+  const bytes = new TextEncoder().encode(blob);
+  for (const b of bytes) {
+    h ^= BigInt(b);
+    h = (h * 1099511628211n) & 0xffffffffffffffffn;
+  }
+  return h.toString(16).padStart(16, "0");
+}
+
+/** Deterministic content fingerprint (path + header + body). Never array index. */
+export function hunkContentFingerprint(
+  path: string,
+  header: string,
+  lines: readonly string[] | undefined,
+): string {
+  const parts = [String(path || ""), String(header || "")];
+  for (const line of lines || []) {
+    parts.push(String(line).replace(/\n$/, ""));
+  }
+  return fnv1a64Hex(parts.join("\n"));
 }
 
 /**
- * Build the apply_review payload: every hunk id is seeded to match the painted
- * UI default (accept). Harness defaults missing keys to reject — omitting keys
- * would silently drop hunks the pane still shows as accepted.
+ * Resolve the stable per-hunk decision identity.
+ * Prefer server-assigned decision_id; legacy reviews fall back to content fingerprint
+ * + same-fingerprint ordinal so exact duplicates stay distinct and reordering
+ * unrelated hunks cannot change existing keys.
+ */
+export function resolveHunkDecisionId(
+  hunk: PendingReviewHunk,
+  path: string,
+  fingerprintCounts: Map<string, number>,
+): string {
+  const existing = String(hunk.decision_id || "").trim();
+  if (existing) return existing;
+  const fp = hunkContentFingerprint(path, hunk.header || "", hunk.lines);
+  const n = fingerprintCounts.get(fp) || 0;
+  fingerprintCounts.set(fp, n + 1);
+  return `${fp}#${n}`;
+}
+
+/** Namespace decisions per review + stable decision identity. */
+export function reviewHunkDecisionKey(reviewId: string, decisionId: string): string {
+  return `${reviewId}::${decisionId}`;
+}
+
+/** Apply payload key: the stable decision identity (never a bare colliding hunk.id). */
+export function hunkDecisionApplyKey(decisionId: string): string {
+  return decisionId;
+}
+
+/**
+ * Build the apply_review payload: every hunk is seeded to match the painted UI
+ * default (accept). Keys are stable decision identities so duplicate hunk.id
+ * values cannot overwrite one another. Harness defaults missing keys to reject —
+ * omitting keys would silently drop hunks the pane still shows as accepted.
  */
 export function seedApplyDecisions(
   review: PendingReview,
   decisions: Record<string, "accept" | "reject">,
 ): Record<string, "accept" | "reject"> {
   const out: Record<string, "accept" | "reject"> = {};
+  const fingerprintCounts = new Map<string, number>();
   for (const file of review.files) {
     for (const hunk of file.hunks) {
-      const key = reviewHunkDecisionKey(review.id, hunk.id);
-      out[hunk.id] = decisions[key] ?? "accept";
+      const decisionId = resolveHunkDecisionId(hunk, file.path, fingerprintCounts);
+      const uiKey = reviewHunkDecisionKey(review.id, decisionId);
+      const legacyUiKey = `${review.id}::${hunk.id}`;
+      const applyKey = hunkDecisionApplyKey(decisionId);
+      out[applyKey] = decisions[uiKey] ?? decisions[legacyUiKey] ?? "accept";
     }
   }
   return out;
+}
+
+/** Walk every hunk in review order, yielding its stable decision identity. */
+export function forEachReviewHunkDecision(
+  review: PendingReview,
+  visit: (
+    hunk: PendingReview["files"][number]["hunks"][number],
+    decisionId: string,
+    fileIndex: number,
+  ) => void,
+): void {
+  const fingerprintCounts = new Map<string, number>();
+  review.files.forEach((file, fileIndex) => {
+    for (const hunk of file.hunks) {
+      const decisionId = resolveHunkDecisionId(hunk, file.path, fingerprintCounts);
+      visit(hunk, decisionId, fileIndex);
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- make duplicate diff-review decisions stable across renderer and backend apply paths
- harden diagnostic, prewarm, reattach, evidence, and terminal child-task lifecycle boundaries
- declare the pinned Puppetmaster runtime for standalone installs and bump Marionette to v0.9.393

## Test plan
- [x] `.venv/bin/python -m pytest -q` (5,407 passed, 78 skipped)
- [x] `npm test` (1,545 passed)
- [x] `npm run test:electron` (209 passed)
- [x] `npm run build`
- [x] `npm audit` (0 vulnerabilities)
- [x] independent Grok 4.6 xHigh/Fast Cursor review