### PR TITLE
Release v0.9.394: push-first chat reattachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.393, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.394, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.393"
+__version__ = "0.9.394"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/sse.py
+++ b/harness/api/sse.py
@@ -362,9 +362,10 @@ def stream_chat_events(
     """Live SSE watch over the chat-events ring (``GET /api/chat/events?watch=1``).
 
     Replays retained frames since ``since``, then tails new appends until a
-    terminal kind (or the ring ends). On miss/gap, returns JSON 409 so the
-    client can fall back to the 1Hz pull poll without inventing a second
-    transcript protocol.
+    terminal kind (or the ring ends). On open miss/gap, returns JSON 409 so
+    the client can fall back to the store poll. Mid-watch gap cannot change
+    the HTTP status, so the watch emits one ring_miss / cursor_gap SSE frame
+    and closes — same miss contract, no reconnect RTT.
     """
     _status, payload = get_chat_events(svc, session_id, since, generation)
     if not isinstance(payload, dict) or not payload.get("ok"):
@@ -434,8 +435,21 @@ def stream_chat_events(
             return
         batch = ring.since(cursor)
         if batch.pop("gap", False):
-            # Mid-watch hole: close without framing done so the client falls
-            # back to JSON poll + disk hydrate (same miss contract).
+            sse_write(
+                handler.wfile,
+                _encode_chat_events_watch_frame({
+                    "kind": "ring_miss",
+                    "data": {
+                        "ok": False,
+                        "missed": True,
+                        "available": False,
+                        "code": "cursor_gap",
+                        "generation": int(batch.get("generation") or 0),
+                        "cursor": int(batch.get("cursor") or 0),
+                        "session_id": sid,
+                    },
+                }),
+            )
             return
         events = batch.get("events") if isinstance(batch.get("events"), list) else []
         if events:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.393"
+version = "0.9.394"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_sse_pilot_terminals_peel.py
+++ b/tests/test_api_sse_pilot_terminals_peel.py
@@ -175,6 +175,68 @@ def test_stream_chat_events_replays_then_terminals():
     assert '"kind": "done"' in blob or '"kind":"done"' in blob
 
 
+def test_stream_chat_events_mid_watch_gap_emits_ring_miss_then_closes():
+    """Mid-watch cursor gap emits one ring_miss SSE frame, then closes."""
+    ring = SseEventRing("s1", 1)
+    ring.pinned = True
+    ring.append("message_delta", {"text": "a"})
+    original_since = ring.since
+    calls = {"n": 0}
+
+    def since_then_gap(cursor=0):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return original_since(cursor)
+        return {
+            "session_id": "s1",
+            "generation": 1,
+            "cursor": 9,
+            "events": [],
+            "retained": 1,
+            "gap": True,
+        }
+
+    ring.since = since_then_gap
+    svc = _sse_svc(rings={("s1", 1): ring}, gens={"s1": 1})
+    chunks: list[bytes] = []
+
+    class _WFile:
+        def write(self, data):
+            chunks.append(data)
+
+        def flush(self):
+            pass
+
+    class _Handler:
+        def __init__(self):
+            self.wfile = _WFile()
+            self.headers = []
+            self.code = None
+
+        def send_response(self, code):
+            self.code = code
+
+        def send_header(self, k, v):
+            self.headers.append((k, v))
+
+        def _cors(self):
+            pass
+
+        def end_headers(self):
+            pass
+
+        def _send(self, status, body):
+            raise AssertionError(f"unexpected JSON send {status}")
+
+    stream_chat_events(_Handler(), svc, "s1", 0, 1)
+    blob = b"".join(chunks).decode()
+    assert "message_delta" in blob
+    assert blob.count("ring_miss") == 1
+    assert "cursor_gap" in blob
+    assert '"missed": true' in blob or '"missed":true' in blob
+    assert '"available": false' in blob or '"available":false' in blob
+
+
 # ---------------------------------------------------------------------------
 # GET /api/pilot
 # ---------------------------------------------------------------------------

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.393",
+  "version": "0.9.394",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.393",
+      "version": "0.9.394",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.393",
+  "version": "0.9.394",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/Conversation.reattach.test.ts
+++ b/webapp/src/__tests__/Conversation.reattach.test.ts
@@ -22,6 +22,7 @@ import {
   isDurableTerminalActionResult,
   isUpgradeableActionResult,
 } from "../components/Conversation";
+import { beginChatStreamGeneration } from "../components/conversation/chatEvents";
 import { api, type StoreEventsSince } from "../lib/api";
 import type { ChatEventsReattachDeps } from "../components/conversation/chatEventsReattach";
 import { TranscriptList, type Item } from "../components/TranscriptList";
@@ -419,6 +420,7 @@ describe("detached-busy mid-tool-batch reattach", () => {
       localStreamActiveRef,
       userStoppedRef,
       lastAppliedCursorRef,
+      lastAppliedRingCursorRef: { current: 0 },
       ringGenerationRef,
       detachedBusyRef,
       runnerBusyPollGenRef,
@@ -506,6 +508,7 @@ describe("detached-busy mid-tool-batch reattach", () => {
       ],
     } as any);
 
+    const lastAppliedRingCursorRef = { current: 12 };
     const { pullChatEvents } = createChatEventsReattach({
       cancelled: () => false,
       loadGen: 1,
@@ -517,6 +520,7 @@ describe("detached-busy mid-tool-batch reattach", () => {
       localStreamActiveRef: { current: false },
       userStoppedRef: { current: false },
       lastAppliedCursorRef,
+      lastAppliedRingCursorRef,
       ringGenerationRef,
       detachedBusyRef,
       runnerBusyPollGenRef: { current: 0 },
@@ -543,6 +547,7 @@ describe("detached-busy mid-tool-batch reattach", () => {
     expect(readEventsSince).toHaveBeenCalledTimes(1);
     expect(applied).toEqual([]);
     expect(lastAppliedCursorRef.current).toBe(41);
+    expect(lastAppliedRingCursorRef.current).toBe(12);
     expect(ringGenerationRef.current).toBeUndefined();
     expect(detachedBusyRef.current).toBe(true);
     expect(
@@ -624,6 +629,7 @@ describe("detached-busy mid-tool-batch reattach", () => {
       localStreamActiveRef: { current: false },
       userStoppedRef: { current: false },
       lastAppliedCursorRef: { current: 5 },
+      lastAppliedRingCursorRef: { current: 0 },
       ringGenerationRef: { current: 1 as number | undefined },
       detachedBusyRef: { current: true },
       runnerBusyPollGenRef: { current: 0 },
@@ -845,6 +851,7 @@ describe("Wave 4 command-job reattach fences", () => {
       localStreamActiveRef: { current: false },
       userStoppedRef: { current: false },
       lastAppliedCursorRef: { current: 0 },
+      lastAppliedRingCursorRef: { current: 0 },
       ringGenerationRef: { current: 1 as number | undefined },
       detachedBusyRef: { current: true },
       runnerBusyPollGenRef: { current: 0 },
@@ -920,6 +927,7 @@ describe("Wave 4 command-job reattach fences", () => {
       localStreamActiveRef: { current: false },
       userStoppedRef: { current: false },
       lastAppliedCursorRef: { current: 0 },
+      lastAppliedRingCursorRef: { current: 0 },
       ringGenerationRef: { current: 1 as number | undefined },
       detachedBusyRef: { current: true },
       runnerBusyPollGenRef: { current: 0 },
@@ -971,6 +979,7 @@ describe("mid-turn store-event cursor reattach", () => {
     const streamGenRef = { current: 1 };
     const cachedSessionIdRef = { current: "sess-live" as string | null };
     const lastAppliedCursorRef = { current: 0 };
+    const lastAppliedRingCursorRef = { current: 0 };
     const localStreamActiveRef = { current: false };
     const transcriptLoadGenRef = { current: 1 };
     const applied: string[] = [];
@@ -985,6 +994,7 @@ describe("mid-turn store-event cursor reattach", () => {
       localStreamActiveRef,
       userStoppedRef: { current: false },
       lastAppliedCursorRef,
+      lastAppliedRingCursorRef,
       ringGenerationRef: { current: 1 as number | undefined },
       detachedBusyRef,
       runnerBusyPollGenRef: { current: 0 },
@@ -1025,25 +1035,533 @@ describe("mid-turn store-event cursor reattach", () => {
       streamGenRef,
       cachedSessionIdRef,
       lastAppliedCursorRef,
+      lastAppliedRingCursorRef,
     };
   }
 
-  it("arms store cursor poll on busy reattach (not live watch)", async () => {
+  function expectExclusiveChatEventsOwner(deps: {
+    chatEventsPollTimerRef: { current: number | null };
+    chatEventsLiveCancelRef: { current: null | (() => void) };
+  }) {
+    const poll = deps.chatEventsPollTimerRef.current != null;
+    const live = deps.chatEventsLiveCancelRef.current != null;
+    expect(poll && live).toBe(false);
+  }
+
+  function mockLiveWatch() {
+    const watches: Array<{
+      opts: { session?: string; since?: number; generation?: number };
+      onEvent: (e: { kind: string; data?: any; cursor?: number }) => void;
+      onDone?: () => void;
+      onError?: (e: any) => void;
+    }> = [];
+    const live = vi.spyOn(api, "chatEventsLive").mockImplementation(
+      (opts, onEvent, onDone, onError) => {
+        watches.push({ opts, onEvent, onDone, onError });
+        return () => {};
+      },
+    );
+    return { live, watches };
+  }
+
+  it("busy reattach starts exactly one live watch (no primary store pull)", async () => {
+    const deps = reattachDeps();
+    deps.lastAppliedRingCursorRef.current = 7;
+    const { live } = mockLiveWatch();
+    const readEventsSince = vi.spyOn(api, "readEventsSince");
+    vi.spyOn(api, "getSessionState").mockResolvedValue({
+      runners: { "sess-live": "running" },
+    } as Awaited<ReturnType<typeof api.getSessionState>>);
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+
+    expect(live).toHaveBeenCalledTimes(1);
+    expect(live.mock.calls[0][0]).toMatchObject({
+      session: "sess-live",
+      since: 7,
+      generation: 1,
+    });
+    expect(readEventsSince).not.toHaveBeenCalled();
+    expect(deps.chatEventsLiveCancelRef.current).not.toBeNull();
+    expect(deps.chatEventsPollTimerRef.current).toBeNull();
+    expectExclusiveChatEventsOwner(deps);
+  });
+
+  it("live and poll ownership never overlap across open-miss fallback", async () => {
     vi.useFakeTimers();
     const deps = reattachDeps();
+    const { live, watches } = mockLiveWatch();
+    const readEventsSince = vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 0,
+      events: [],
+    });
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+    expect(live).toHaveBeenCalledTimes(1);
+    expect(deps.chatEventsLiveCancelRef.current).not.toBeNull();
+    expect(deps.chatEventsPollTimerRef.current).toBeNull();
+    expectExclusiveChatEventsOwner(deps);
+
+    watches[0].onError?.(new Error("stream /api/chat/events?watch=1 -> 409"));
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(live).toHaveBeenCalledTimes(1);
+    expect(readEventsSince).toHaveBeenCalled();
+    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
+    expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+    expectExclusiveChatEventsOwner(deps);
+  });
+
+  it("live frame advances ring cursor and applies once under session/generation fence", async () => {
+    const deps = reattachDeps();
+    deps.lastAppliedRingCursorRef.current = 3;
+    const { watches } = mockLiveWatch();
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+
+    watches[0].onEvent({ kind: "message_delta", data: { text: "hi" }, cursor: 4 });
+    expect(deps.applied).toEqual(["message_delta"]);
+    expect(deps.lastAppliedRingCursorRef.current).toBe(4);
+    expect(deps.lastAppliedCursorRef.current).toBe(0);
+
+    deps.streamGenRef.current = 99;
+    watches[0].onEvent({ kind: "message_delta", data: { text: "stale" }, cursor: 5 });
+    expect(deps.applied).toEqual(["message_delta"]);
+    expect(deps.lastAppliedRingCursorRef.current).toBe(4);
+  });
+
+  it("terminal live frame settles and hands off to store poll without duplicate apply", async () => {
+    vi.useFakeTimers();
+    const deps = reattachDeps();
+    const { live, watches } = mockLiveWatch();
+    const readEventsSince = vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 12,
+      events: [{
+        id: 12,
+        kind: "stream",
+        data: {
+          cursor: 9,
+          kind: "assistant_done",
+          data: { stop_cause: "natural" },
+          generation: 1,
+        },
+      }],
+    });
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+    expect(live).toHaveBeenCalledTimes(1);
+
+    watches[0].onEvent({
+      kind: "assistant_done",
+      data: { stop_cause: "natural" },
+      cursor: 9,
+    });
+    watches[0].onDone?.();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(deps.applied).toEqual(["assistant_done"]);
+    expect(deps.lastAppliedRingCursorRef.current).toBe(9);
+    expect(deps.lastAppliedCursorRef.current).toBe(12);
+    expect(deps.detachedBusyRef.current).toBe(false);
+    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
+    expect(readEventsSince).toHaveBeenCalled();
+    expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+    expect(live).toHaveBeenCalledTimes(1);
+    expectExclusiveChatEventsOwner(deps);
+  });
+
+  it("store fallback skips mirrored live frames and still advances the store cursor", async () => {
+    vi.useFakeTimers();
+    const deps = reattachDeps();
+    const { live, watches } = mockLiveWatch();
+    const readEventsSince = vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 11,
+      events: [{
+        id: 11,
+        kind: "stream",
+        data: {
+          cursor: 4,
+          kind: "message_delta",
+          data: { text: "hi" },
+          generation: 1,
+        },
+      }],
+    });
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+    watches[0].onEvent({ kind: "message_delta", data: { text: "hi" }, cursor: 4 });
+    expect(deps.applied).toEqual(["message_delta"]);
+    expect(deps.lastAppliedRingCursorRef.current).toBe(4);
+
+    watches[0].onError?.(new Error("stream /api/chat/events?watch=1 -> 409"));
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(live).toHaveBeenCalledTimes(1);
+    expect(readEventsSince).toHaveBeenCalled();
+    expect(deps.applied).toEqual(["message_delta"]);
+    expect(deps.lastAppliedCursorRef.current).toBe(11);
+    expect(deps.lastAppliedRingCursorRef.current).toBe(4);
+    expectExclusiveChatEventsOwner(deps);
+  });
+
+  it("first store pull occupies the poll slot so a concurrent live watch cannot install", async () => {
+    vi.useFakeTimers();
+    const deps = reattachDeps();
+    deps.detachedBusyRef.current = false;
+    const deferred: Array<(value: StoreEventsSince) => void> = [];
+    const readEventsSince = vi.spyOn(api, "readEventsSince").mockImplementation(
+      () => new Promise((resolve) => {
+        deferred.push(resolve);
+      }),
+    );
+    const { live } = mockLiveWatch();
+    vi.spyOn(api, "getSessionState").mockResolvedValue({
+      runners: { "sess-live": "idle" },
+    } as Awaited<ReturnType<typeof api.getSessionState>>);
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+    await Promise.resolve();
+
+    expect(readEventsSince).toHaveBeenCalledTimes(1);
+    expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
+    expectExclusiveChatEventsOwner(deps);
+
+    deps.detachedBusyRef.current = true;
+    await startChatEventsReattach();
+    expect(live).not.toHaveBeenCalled();
+    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
+    expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+    expectExclusiveChatEventsOwner(deps);
+
+    deferred.shift()!({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 3,
+      events: [{
+        id: 3,
+        kind: "stream",
+        data: { cursor: 3, kind: "message_delta", data: { text: "late" }, generation: 1 },
+      }],
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(deps.applied).toEqual(["message_delta"]);
+    expect(live).not.toHaveBeenCalled();
+    expect(deps.lastAppliedCursorRef.current).toBe(3);
+    expectExclusiveChatEventsOwner(deps);
+  });
+
+  it("does not apply a store batch if live watch installed during the await", async () => {
+    const deps = reattachDeps();
+    vi.spyOn(api, "readEventsSince").mockImplementation(async () => {
+      deps.chatEventsLiveCancelRef.current = () => {};
+      return {
+        ok: true,
+        session_id: "sess-live",
+        cursor: 4,
+        events: [{
+          id: 4,
+          kind: "stream",
+          data: { cursor: 4, kind: "message_delta", data: { text: "dup" }, generation: 1 },
+        }],
+      };
+    });
+
+    const { pullChatEvents } = createChatEventsReattach(deps);
+    const keep = await pullChatEvents();
+    expect(keep).toBe(false);
+    expect(deps.applied).toEqual([]);
+  });
+
+  it("mid-watch ring-miss control frame falls back to store without reconnect or apply", async () => {
+    vi.useFakeTimers();
+    const deps = reattachDeps();
+    const { live, watches } = mockLiveWatch();
+    vi.spyOn(api, "sessionTranscript").mockResolvedValue({
+      display: [{ role: "user", text: "go" }],
+    } as Awaited<ReturnType<typeof api.sessionTranscript>>);
+    const readEventsSince = vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 2,
+      events: [],
+    });
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+    watches[0].onEvent({ kind: "message_delta", data: { text: "hi" }, cursor: 4 });
+    watches[0].onEvent({
+      kind: "ring_miss",
+      data: {
+        ok: false,
+        missed: true,
+        available: false,
+        code: "cursor_gap",
+        generation: 1,
+        cursor: 9,
+      },
+    });
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(deps.applied).toEqual(["message_delta"]);
+    expect(live).toHaveBeenCalledTimes(1);
+    expect(readEventsSince).toHaveBeenCalled();
+    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
+    expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+    expect(deps.lastAppliedRingCursorRef.current).toBe(4);
+    expectExclusiveChatEventsOwner(deps);
+  });
+
+  it("mid-watch ring-miss hydrates disk before one store fallback and keeps the live watermark", async () => {
+    vi.useFakeTimers();
+    const deps = reattachDeps();
+    const { live, watches } = mockLiveWatch();
+    let resolveHydrate: (value: { display: unknown[] }) => void = () => {};
+    const sessionTranscript = vi.spyOn(api, "sessionTranscript").mockImplementation(
+      () => new Promise((resolve) => {
+        resolveHydrate = resolve;
+      }),
+    );
+    const readEventsSince = vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 11,
+      events: [{
+        id: 11,
+        kind: "stream",
+        data: {
+          cursor: 4,
+          kind: "message_delta",
+          data: { text: "hi" },
+          generation: 1,
+        },
+      }],
+    });
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+    watches[0].onEvent({ kind: "message_delta", data: { text: "hi" }, cursor: 4 });
+    expect(deps.applied).toEqual(["message_delta"]);
+    expect(deps.lastAppliedRingCursorRef.current).toBe(4);
+
+    watches[0].onEvent({
+      kind: "ring_miss",
+      data: {
+        ok: false,
+        missed: true,
+        available: false,
+        code: "cursor_gap",
+        generation: 1,
+        cursor: 9,
+      },
+    });
+    watches[0].onDone?.();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(deps.applied).toEqual(["message_delta"]);
+    expect(sessionTranscript).toHaveBeenCalledTimes(1);
+    expect(sessionTranscript).toHaveBeenCalledWith("sess-live");
+    expect(readEventsSince).not.toHaveBeenCalled();
+    expect(live).toHaveBeenCalledTimes(1);
+    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
+    expect(deps.lastAppliedRingCursorRef.current).toBe(4);
+
+    resolveHydrate({ display: [{ role: "user", text: "go" }] });
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(readEventsSince).toHaveBeenCalledTimes(1);
+    expect(live).toHaveBeenCalledTimes(1);
+    expect(deps.applied).toEqual(["message_delta"]);
+    expect(deps.lastAppliedCursorRef.current).toBe(11);
+    expect(deps.lastAppliedRingCursorRef.current).toBe(4);
+    expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+    expectExclusiveChatEventsOwner(deps);
+  });
+
+  it("same-session send generation reset opens the next live watch at since 0 without a generation pin", async () => {
+    const deps = reattachDeps();
+    deps.lastAppliedRingCursorRef.current = 9;
+    deps.ringGenerationRef.current = 4;
+    const { live } = mockLiveWatch();
+    vi.spyOn(api, "getSessionState").mockResolvedValue({
+      runners: { "sess-live": "running" },
+    } as Awaited<ReturnType<typeof api.getSessionState>>);
+
+    const nextGen = beginChatStreamGeneration({
+      streamGenRef: deps.streamGenRef,
+      lastAppliedRingCursorRef: deps.lastAppliedRingCursorRef,
+      ringGenerationRef: deps.ringGenerationRef,
+    });
+    deps.clearChatEventsPoll();
+    const { startChatEventsReattach } = createChatEventsReattach({
+      ...deps,
+      reattachGen: nextGen,
+    });
+    await startChatEventsReattach();
+
+    expect(live).toHaveBeenCalledTimes(1);
+    expect(live.mock.calls[0][0]).toEqual({
+      session: "sess-live",
+      since: 0,
+    });
+  });
+
+  it("same-session Stop/abandon generation reset opens the next live watch at since 0 without a generation pin", async () => {
+    const deps = reattachDeps();
+    deps.lastAppliedRingCursorRef.current = 7;
+    deps.ringGenerationRef.current = 3;
+    const { live, watches } = mockLiveWatch();
+    vi.spyOn(api, "getSessionState").mockResolvedValue({
+      runners: { "sess-live": "running" },
+    } as Awaited<ReturnType<typeof api.getSessionState>>);
+
+    const first = createChatEventsReattach(deps);
+    await first.startChatEventsReattach();
+    watches[0].onEvent({ kind: "message_delta", data: { text: "hi" }, cursor: 7 });
+    expect(live.mock.calls[0][0]).toMatchObject({
+      session: "sess-live",
+      since: 7,
+      generation: 3,
+    });
+
+    deps.clearChatEventsPoll();
+    const nextGen = beginChatStreamGeneration({
+      streamGenRef: deps.streamGenRef,
+      lastAppliedRingCursorRef: deps.lastAppliedRingCursorRef,
+      ringGenerationRef: deps.ringGenerationRef,
+    });
+    const { startChatEventsReattach } = createChatEventsReattach({
+      ...deps,
+      reattachGen: nextGen,
+    });
+    await startChatEventsReattach();
+
+    expect(live).toHaveBeenCalledTimes(2);
+    expect(live.mock.calls[1][0]).toEqual({
+      session: "sess-live",
+      since: 0,
+    });
+  });
+
+  it("EOF before terminal reconnects once then falls back to store poll", async () => {
+    vi.useFakeTimers();
+    const deps = reattachDeps();
+    const { live, watches } = mockLiveWatch();
+    const readEventsSince = vi.spyOn(api, "readEventsSince").mockResolvedValue({
+      ok: true,
+      session_id: "sess-live",
+      cursor: 0,
+      events: [],
+    });
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+    expect(live).toHaveBeenCalledTimes(1);
+    expectExclusiveChatEventsOwner(deps);
+
+    watches[0].onDone?.();
+    expect(live).toHaveBeenCalledTimes(2);
+    expect(readEventsSince).not.toHaveBeenCalled();
+    expect(deps.chatEventsLiveCancelRef.current).not.toBeNull();
+    expect(deps.chatEventsPollTimerRef.current).toBeNull();
+    expectExclusiveChatEventsOwner(deps);
+
+    watches[1].onDone?.();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(live).toHaveBeenCalledTimes(2);
+    expect(readEventsSince).toHaveBeenCalled();
+    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
+    expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
+    expectExclusiveChatEventsOwner(deps);
+  });
+
+  it("Stop cancels the live owner and stale callbacks cannot resurrect polling", async () => {
+    const deps = reattachDeps();
+    const { watches } = mockLiveWatch();
+    const readEventsSince = vi.spyOn(api, "readEventsSince");
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+    expect(deps.chatEventsLiveCancelRef.current).not.toBeNull();
+
+    deps.clearChatEventsPoll();
+    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
+
+    watches[0].onEvent({ kind: "message_delta", data: { text: "late" }, cursor: 2 });
+    watches[0].onDone?.();
+    watches[0].onError?.(new Error("late"));
+    await Promise.resolve();
+
+    expect(deps.applied).toEqual([]);
+    expect(readEventsSince).not.toHaveBeenCalled();
+    expect(deps.chatEventsPollTimerRef.current).toBeNull();
+    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
+  });
+
+  it("session switch cancels live and stale callbacks cannot resurrect polling", async () => {
+    let cancelled = false;
+    const deps = reattachDeps({
+      cancelled: () => cancelled,
+    });
+    const { watches } = mockLiveWatch();
+    const readEventsSince = vi.spyOn(api, "readEventsSince");
+
+    const { startChatEventsReattach } = createChatEventsReattach(deps);
+    await startChatEventsReattach();
+
+    cancelled = true;
+    deps.cachedSessionIdRef.current = "sess-other";
+    deps.streamGenRef.current = 2;
+    deps.lastAppliedRingCursorRef.current = 0;
+    deps.clearChatEventsPoll();
+
+    watches[0].onEvent({ kind: "message_delta", data: { text: "stale" }, cursor: 8 });
+    watches[0].onDone?.();
+    watches[0].onError?.(new Error("stale"));
+    await Promise.resolve();
+
+    expect(deps.applied).toEqual([]);
+    expect(readEventsSince).not.toHaveBeenCalled();
+    expect(deps.chatEventsPollTimerRef.current).toBeNull();
+    expect(deps.chatEventsLiveCancelRef.current).toBeNull();
+  });
+
+  it("idle session uses store polling for runner reconciliation", async () => {
+    vi.useFakeTimers();
+    const deps = reattachDeps();
+    deps.detachedBusyRef.current = false;
     const live = vi.spyOn(api, "chatEventsLive");
     const readEventsSince = vi.spyOn(api, "readEventsSince").mockResolvedValue({
       ok: true,
       session_id: "sess-live",
-      cursor: 4,
-      events: [{
-        id: 4,
-        kind: "stream",
-        data: { cursor: 4, kind: "message_delta", data: { text: "hi" }, generation: 1 },
-      }],
+      cursor: 0,
+      events: [],
     });
     vi.spyOn(api, "getSessionState").mockResolvedValue({
-      runners: { "sess-live": "running" },
+      runners: { "sess-live": "idle" },
     } as Awaited<ReturnType<typeof api.getSessionState>>);
 
     const { startChatEventsReattach } = createChatEventsReattach(deps);
@@ -1053,20 +1571,15 @@ describe("mid-turn store-event cursor reattach", () => {
 
     expect(live).not.toHaveBeenCalled();
     expect(readEventsSince).toHaveBeenCalled();
-    expect(readEventsSince.mock.calls[0][0]).toMatchObject({
-      session: "sess-live",
-      since: 0,
-      generation: 1,
-    });
     expect(deps.chatEventsLiveCancelRef.current).toBeNull();
     expect(deps.chatEventsPollTimerRef.current).not.toBeNull();
-    expect(deps.applied).toEqual(["message_delta"]);
-    expect(deps.lastAppliedCursorRef.current).toBe(4);
+    expectExclusiveChatEventsOwner(deps);
   });
 
   it("request-driven poll chain: no overlap, next arm only after prior settles", async () => {
     vi.useFakeTimers();
     const deps = reattachDeps();
+    deps.detachedBusyRef.current = false;
     let inflight = 0;
     let maxInflight = 0;
     const deferred: Array<(value: StoreEventsSince) => void> = [];
@@ -1081,7 +1594,7 @@ describe("mid-turn store-event cursor reattach", () => {
       }),
     );
     vi.spyOn(api, "getSessionState").mockResolvedValue({
-      runners: { "sess-live": "running" },
+      runners: { "sess-live": "idle" },
     } as Awaited<ReturnType<typeof api.getSessionState>>);
 
     const { startChatEventsReattach } = createChatEventsReattach(deps);
@@ -1128,6 +1641,7 @@ describe("mid-turn store-event cursor reattach", () => {
     const deps = reattachDeps({
       cancelled: () => cancelled,
     });
+    deps.detachedBusyRef.current = false;
     vi.spyOn(api, "readEventsSince").mockResolvedValue({
       ok: true,
       session_id: "sess-live",
@@ -1135,7 +1649,7 @@ describe("mid-turn store-event cursor reattach", () => {
       events: [],
     });
     vi.spyOn(api, "getSessionState").mockResolvedValue({
-      runners: { "sess-live": "running" },
+      runners: { "sess-live": "idle" },
     } as Awaited<ReturnType<typeof api.getSessionState>>);
 
     const first = createChatEventsReattach(deps);
@@ -1158,6 +1672,7 @@ describe("mid-turn store-event cursor reattach", () => {
       cancelled: () => cancelled2,
       reattachGen: 2,
     });
+    deps2.detachedBusyRef.current = false;
     deps2.streamGenRef.current = 2;
     const second = createChatEventsReattach(deps2);
     await second.startChatEventsReattach();
@@ -1288,7 +1803,7 @@ describe("mid-turn store-event cursor reattach", () => {
       session_id: "sess-live",
       cursor: 0,
       events: [],
-    } as any);
+    });
     const getSessionState = vi.spyOn(api, "getSessionState").mockRejectedValue(
       new Error("network"),
     );

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -28,15 +28,22 @@ import {
   chatFrameToStreamEvent,
   cursorAfterReplayMiss,
   isChatEventReplayMiss,
+  isChatEventsLiveOpenMiss,
+  isChatEventsLiveRingMissFrame,
   isTerminalStreamKind,
+  liveWatchCloseDecision,
   nextAppliedCursor,
+  beginChatStreamGeneration,
+  ringCursorAfterLiveFrame,
   ringGenerationAfterReplayMiss,
   shouldAdvanceReplayCursor,
   shouldArmChatEventsFromRunners,
   shouldHydrateTranscriptOnReplayMiss,
   shouldPollChatEvents,
   shouldRetryRingAfterReplayMiss,
+  shouldStartLiveChatEventsWatch,
 } from "../components/conversation/chatEvents";
+import { shouldApplyStoreStreamAfterLive } from "../components/conversation/storeEvents";
 import {
   formatWorkspaceOpenLeaseExhaustedMessage,
   isWorkspaceOpenLeaseExhausted,
@@ -741,6 +748,116 @@ describe("chatEvents module", () => {
     expect(isTerminalJobStatus("partial")).toBe(true);
     expect(isTerminalJobStatus("timed_out")).toBe(true);
     expect(isTerminalJobStatus("PARTIAL")).toBe(true);
+  });
+
+  it("prefers live watch only for detached-busy mid-turn reattach", () => {
+    expect(shouldStartLiveChatEventsWatch({
+      detachedBusy: true,
+      localStreamActive: false,
+      userStopped: false,
+    })).toBe(true);
+    expect(shouldStartLiveChatEventsWatch({
+      detachedBusy: false,
+      localStreamActive: false,
+      userStopped: false,
+    })).toBe(false);
+    expect(shouldStartLiveChatEventsWatch({
+      detachedBusy: true,
+      localStreamActive: true,
+      userStopped: false,
+    })).toBe(false);
+    expect(shouldStartLiveChatEventsWatch({
+      detachedBusy: true,
+      localStreamActive: false,
+      userStopped: true,
+    })).toBe(false);
+  });
+
+  it("classifies live-watch close as settle, one reconnect, or store fallback", () => {
+    expect(liveWatchCloseDecision({
+      sawTerminal: true,
+      openMiss: false,
+      reconnectUsed: false,
+    })).toBe("settle");
+    expect(liveWatchCloseDecision({
+      sawTerminal: false,
+      openMiss: true,
+      reconnectUsed: false,
+    })).toBe("fallback");
+    expect(liveWatchCloseDecision({
+      sawTerminal: false,
+      openMiss: false,
+      reconnectUsed: false,
+    })).toBe("reconnect");
+    expect(liveWatchCloseDecision({
+      sawTerminal: false,
+      openMiss: false,
+      reconnectUsed: true,
+    })).toBe("fallback");
+    expect(isChatEventsLiveOpenMiss(new Error("stream /api/chat/events -> 409"))).toBe(true);
+    expect(isChatEventsLiveOpenMiss({ status: 409, code: "http_error" })).toBe(true);
+    expect(isChatEventsLiveOpenMiss(new Error("network"))).toBe(false);
+    expect(isChatEventsLiveOpenMiss({ status: 500, code: "backend_error" })).toBe(false);
+  });
+
+  it("same-session generation bump clears the live ring cursor and generation pin", () => {
+    const streamGenRef = { current: 2 };
+    const lastAppliedRingCursorRef = { current: 9 };
+    const ringGenerationRef = { current: 4 as number | undefined };
+    expect(beginChatStreamGeneration({
+      streamGenRef,
+      lastAppliedRingCursorRef,
+      ringGenerationRef,
+    })).toBe(3);
+    expect(streamGenRef.current).toBe(3);
+    expect(lastAppliedRingCursorRef.current).toBe(0);
+    expect(ringGenerationRef.current).toBeUndefined();
+  });
+
+  it("advances the ring cursor only from a newer live frame cursor", () => {
+    expect(ringCursorAfterLiveFrame(3, 4)).toBe(4);
+    expect(ringCursorAfterLiveFrame(4, 4)).toBe(4);
+    expect(ringCursorAfterLiveFrame(4, 2)).toBe(4);
+    expect(ringCursorAfterLiveFrame(4, undefined)).toBe(4);
+  });
+
+  it("skips store stream frames already accepted by the live ring cursor", () => {
+    expect(shouldApplyStoreStreamAfterLive({
+      ringCursor: 4,
+      lastAppliedRingCursor: 4,
+    })).toBe(false);
+    expect(shouldApplyStoreStreamAfterLive({
+      ringCursor: 3,
+      lastAppliedRingCursor: 4,
+    })).toBe(false);
+    expect(shouldApplyStoreStreamAfterLive({
+      ringCursor: 5,
+      lastAppliedRingCursor: 4,
+    })).toBe(true);
+    expect(shouldApplyStoreStreamAfterLive({
+      ringCursor: undefined,
+      lastAppliedRingCursor: 4,
+    })).toBe(true);
+  });
+
+  it("recognizes a live ring-miss control frame without treating it as chat", () => {
+    expect(isChatEventsLiveRingMissFrame({
+      kind: "ring_miss",
+      data: {
+        ok: false,
+        missed: true,
+        available: false,
+        code: "cursor_gap",
+      },
+    })).toBe(true);
+    expect(isChatEventsLiveRingMissFrame({
+      kind: "message_delta",
+      data: { text: "hi" },
+    })).toBe(false);
+    expect(isChatEventsLiveRingMissFrame({
+      kind: "ring_miss",
+      data: { ok: true, missed: false },
+    })).toBe(false);
   });
 
   it("gates poll and runner arming", () => {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -196,6 +196,7 @@ import SpillPreviewModal, {
   shouldApplySpillPreview,
   type SpillPreviewState,
 } from "./conversation/SpillPreviewModal";
+import { beginChatStreamGeneration } from "./conversation/chatEvents";
 import { useSessionSwitch } from "./conversation/useSessionSwitch";
 import { useRunnersBusyPoll } from "./conversation/useRunnersBusyPoll";
 import {
@@ -260,11 +261,13 @@ export default function Conversation({
   const streamGenRef = useRef(0);
   // Mid-turn reattach: last applied /api/session/events store cursor (unified).
   const lastAppliedCursorRef = useRef(0);
+  // Live ?watch=1 ring cursor; distinct from the store cursor.
+  const lastAppliedRingCursorRef = useRef(0);
   // Ring generation from the last successful stream event (pin subsequent polls).
   const ringGenerationRef = useRef<number | undefined>(undefined);
-  // setInterval handle for the single store-event cursor poll.
+  // setTimeout handle for the store-event cursor poll fallback.
   const chatEventsPollTimerRef = useRef<number | null>(null);
-  // Legacy live-watch cancel slot (store cursor owns reattach; kept for armed()).
+  // Live ?watch=1 cancel; never set at the same time as the poll timer.
   const chatEventsLiveCancelRef = useRef<null | (() => void)>(null);
   // Shared live-SSE + reattach event applicator (assigned where handlers live).
   const applyStreamEventRef = useRef<(ev: { kind: string; data?: any }) => void>(() => {});
@@ -1540,6 +1543,7 @@ export default function Conversation({
     streamGenRef,
     streamSessionIdRef,
     lastAppliedCursorRef,
+    lastAppliedRingCursorRef,
     ringGenerationRef,
     chatEventsPollTimerRef,
     chatEventsLiveCancelRef,
@@ -2648,7 +2652,11 @@ export default function Conversation({
     resumeQueuedRef.current = false;
     detachedBusyRef.current = false;
     clearChatEventsPoll();
-    streamGenRef.current += 1;
+    beginChatStreamGeneration({
+      streamGenRef,
+      lastAppliedRingCursorRef,
+      ringGenerationRef,
+    });
     cancelRef.current?.();
     cancelRef.current = null;
     localStreamActiveRef.current = false;
@@ -2784,7 +2792,11 @@ export default function Conversation({
     localStreamActiveRef.current = true;
     detachedBusyRef.current = false;
     const streamSid = activeSessionId;
-    const streamGen = ++streamGenRef.current;
+    const streamGen = beginChatStreamGeneration({
+      streamGenRef,
+      lastAppliedRingCursorRef,
+      ringGenerationRef,
+    });
     streamSessionIdRef.current = streamSid;
     const streamLive = () =>
       streamGenRef.current === streamGen
@@ -3334,7 +3346,11 @@ export default function Conversation({
     detachedBusyRef.current = false;
     clearChatEventsPoll();
     // Invalidate in-flight reattach pulls / late SSE frames.
-    streamGenRef.current += 1;
+    beginChatStreamGeneration({
+      streamGenRef,
+      lastAppliedRingCursorRef,
+      ringGenerationRef,
+    });
     cancelRef.current?.();
     cancelRef.current = null;
     localStreamActiveRef.current = false;

--- a/webapp/src/components/conversation/chatEvents.ts
+++ b/webapp/src/components/conversation/chatEvents.ts
@@ -185,5 +185,77 @@ export function shouldApplyReattachFrame(opts: {
   return opts.cachedSessionId === opts.reattachSid;
 }
 
+/** Prefer live ``?watch=1`` for detached-busy mid-turn reattach. */
+export function shouldStartLiveChatEventsWatch(opts: {
+  detachedBusy: boolean;
+  localStreamActive: boolean;
+  userStopped: boolean;
+}): boolean {
+  return opts.detachedBusy && !opts.localStreamActive && !opts.userStopped;
+}
+
+/** Live ``?watch=1`` control frame for a mid-watch ring miss / cursor gap. */
+export function isChatEventsLiveRingMissFrame(ev: {
+  kind?: string;
+  data?: ChatEventReplayMissFields | null;
+}): boolean {
+  if (ev.kind !== "ring_miss") return false;
+  const data = ev.data;
+  if (data == null || typeof data !== "object") return false;
+  return isChatEventReplayMiss(data);
+}
+
+/** Transport open-miss for live watch (JSON 409 from stream_chat_events). */
+export function isChatEventsLiveOpenMiss(error: unknown): boolean {
+  if (error != null && typeof error === "object") {
+    const status = (error as { status?: unknown }).status;
+    if (status === 409) return true;
+  }
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === "string" ? error : "";
+  return /\b409\b/.test(message);
+}
+
+export type LiveWatchCloseDecision = "settle" | "reconnect" | "fallback";
+
+/**
+ * How a live watch should close.
+ * Terminal settles without fallback. Open miss (409) goes straight to store
+ * poll. Other error/EOF gets one reconnect, then store poll.
+ */
+export function liveWatchCloseDecision(opts: {
+  sawTerminal: boolean;
+  openMiss: boolean;
+  reconnectUsed: boolean;
+}): LiveWatchCloseDecision {
+  if (opts.sawTerminal) return "settle";
+  if (opts.openMiss) return "fallback";
+  if (!opts.reconnectUsed) return "reconnect";
+  return "fallback";
+}
+
+/** Advance the live ring cursor only from an accepted newer frame cursor. */
+export function ringCursorAfterLiveFrame(
+  lastApplied: number,
+  frameCursor: number | undefined,
+): number {
+  if (typeof frameCursor === "number" && frameCursor > lastApplied) {
+    return frameCursor;
+  }
+  return lastApplied;
+}
+
+/** Start a stream generation with its fresh server ring. */
+export function beginChatStreamGeneration(opts: {
+  streamGenRef: { current: number };
+  lastAppliedRingCursorRef: { current: number };
+  ringGenerationRef: { current: number | undefined };
+}): number {
+  opts.lastAppliedRingCursorRef.current = 0;
+  opts.ringGenerationRef.current = undefined;
+  return ++opts.streamGenRef.current;
+}
+
 /** Bounded interval for mid-turn chatEvents reattach while detached-busy. */
 export const CHAT_EVENTS_POLL_MS = 1000;

--- a/webapp/src/components/conversation/chatEventsReattach.ts
+++ b/webapp/src/components/conversation/chatEventsReattach.ts
@@ -1,24 +1,32 @@
 /**
- * Unified store-event subscription for session-switch / reattach / busy.
- * One cursor via ``api.readEventsSince`` — not a third poller beside runners.
+ * Mid-turn chat-event reattach (Live-XOR-Store).
+ * Detached-busy prefers ``api.chatEventsLive``; ``api.readEventsSince`` is the
+ * bounded fallback for idle/unknown, runner snapshots, live open-miss,
+ * error/EOF before terminal, and reconnect exhaustion. Never both owners.
  */
 
 import { api } from "../../lib/api";
 import type { Item } from "../TranscriptList";
 import {
-  cursorAfterReplayMiss,
+  chatFrameToStreamEvent,
+  isChatEventsLiveOpenMiss,
+  isChatEventsLiveRingMissFrame,
   isChatEventsReattachArmed,
   isTerminalStreamKind,
+  liveWatchCloseDecision,
+  ringCursorAfterLiveFrame,
   ringGenerationAfterReplayMiss,
   shouldHydrateTranscriptOnReplayMiss,
   shouldPollChatEvents,
   shouldRetryRingAfterReplayMiss,
+  shouldStartLiveChatEventsWatch,
 } from "./chatEvents";
 import {
   STORE_EVENTS_POLL_MS,
   isStoreRingMissEvent,
   storeCursorAfterBatch,
   shouldApplyStoreEvent,
+  shouldApplyStoreStreamAfterLive,
   storeBatchSawTerminal,
   storeRingMissFields,
   storeStreamToStreamEvent,
@@ -44,6 +52,8 @@ import {
 } from "./swarmPoll";
 import type { SessionStatus } from "./useSessionSwitch";
 
+const CHAT_EVENTS_POLL_IN_FLIGHT = -1;
+
 export type ChatEventsReattachDeps = {
   cancelled: () => boolean;
   loadGen: number;
@@ -56,13 +66,15 @@ export type ChatEventsReattachDeps = {
   userStoppedRef: { current: boolean };
   /** Unified store cursor (read_events_since), not the SSE ring cursor. */
   lastAppliedCursorRef: { current: number };
+  /** Live ``?watch=1`` ring cursor; advance only from accepted live frames. */
+  lastAppliedRingCursorRef: { current: number };
   ringGenerationRef: { current: number | undefined };
   detachedBusyRef: { current: boolean };
   runnerBusyPollGenRef: { current: number };
   itemsRef: { current: Item[] };
   transcriptFpRef: { current: string };
   chatEventsPollTimerRef: { current: number | null };
-  /** Legacy live-watch cancel slot; store cursor owns the turn (kept for armed()). */
+  /** Live ``?watch=1`` cancel; never set at the same time as the poll timer. */
   chatEventsLiveCancelRef: { current: null | (() => void) };
   applyStreamEventRef: { current: (ev: { kind: string; data?: any }) => void };
   flushTypewriterRef: { current: () => void };
@@ -145,6 +157,7 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
     localStreamActiveRef,
     userStoppedRef,
     lastAppliedCursorRef,
+    lastAppliedRingCursorRef,
     ringGenerationRef,
     detachedBusyRef,
     runnerBusyPollGenRef,
@@ -406,12 +419,21 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
 
   const handleRingMiss = async (ev: {
     kind: string;
-    data?: any;
+    data?: {
+      ok?: boolean;
+      missed?: boolean;
+      available?: boolean;
+      code?: string;
+      generation?: number;
+    };
   }, missRetried: boolean): Promise<"retry" | "continue" | "stop"> => {
-    const replay = storeRingMissFields(ev as any);
+    const replay = storeRingMissFields({
+      id: 0,
+      kind: ev.kind,
+      data: ev.data ?? {},
+    });
     const prevGen = ringGenerationRef.current;
     ringGenerationRef.current = ringGenerationAfterReplayMiss(replay, prevGen);
-    void cursorAfterReplayMiss(replay, 0);
     if (shouldHydrateTranscriptOnReplayMiss(replay)) {
       await hydrateDurableTranscript();
     }
@@ -432,6 +454,10 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
     if (loadGen !== transcriptLoadGenRef.current) return false;
     if (!fenceOk()) return false;
     if (userStoppedRef.current) return false;
+    if (chatEventsLiveCancelRef.current != null) return false;
+    if (chatEventsPollTimerRef.current == null) {
+      chatEventsPollTimerRef.current = CHAT_EVENTS_POLL_IN_FLIGHT;
+    }
     try {
       const batch = await api.readEventsSince({
         session: reattachSid,
@@ -444,6 +470,7 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
       if (loadGen !== transcriptLoadGenRef.current) return false;
       if (!fenceOk()) return false;
       if (userStoppedRef.current) return false;
+      if (chatEventsLiveCancelRef.current != null) return false;
 
       const events = Array.isArray(batch.events) ? batch.events : [];
       let sawTerminal = false;
@@ -470,7 +497,7 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
           continue;
         }
         if (ev.kind === "stream") {
-          const frame = ev.data || {};
+          const frame = isPlainRecord(ev.data) ? ev.data : {};
           const terminal = isTerminalStreamKind(String(frame.kind || ""));
           // The durable cursor is the recovery path when a live SSE remains open
           // but misses its terminal frame. Ignore duplicate progress, not an
@@ -479,6 +506,13 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
             localStreamActiveRef.current
             && (!terminal || (turnSettledRef?.current ?? false))
           ) {
+            continue;
+          }
+          const ringCursor = typeof frame.cursor === "number" ? frame.cursor : undefined;
+          if (!shouldApplyStoreStreamAfterLive({
+            ringCursor,
+            lastAppliedRingCursor: lastAppliedRingCursorRef.current,
+          })) {
             continue;
           }
           if (typeof frame.generation === "number" && frame.generation > 0) {
@@ -519,22 +553,53 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
     }
   };
 
+  const releasePollInFlight = () => {
+    if (chatEventsPollTimerRef.current === CHAT_EVENTS_POLL_IN_FLIGHT) {
+      chatEventsPollTimerRef.current = null;
+    }
+  };
+
   const startChatEventsPoll = () => {
     if (cancelled() || userStoppedRef.current) return;
+    if (chatEventsLiveCancelRef.current != null) return;
     if (chatEventsPollTimerRef.current != null) return;
 
+    chatEventsPollTimerRef.current = CHAT_EVENTS_POLL_IN_FLIGHT;
+
     const armNext = (delayMs: number) => {
-      if (cancelled() || userStoppedRef.current) return;
-      if (streamGenRef.current !== reattachGen) return;
-      if (chatEventsPollTimerRef.current != null) return;
+      if (cancelled() || userStoppedRef.current) {
+        releasePollInFlight();
+        return;
+      }
+      if (streamGenRef.current !== reattachGen) {
+        releasePollInFlight();
+        return;
+      }
+      if (chatEventsLiveCancelRef.current != null) {
+        releasePollInFlight();
+        return;
+      }
+      if (
+        chatEventsPollTimerRef.current != null
+        && chatEventsPollTimerRef.current !== CHAT_EVENTS_POLL_IN_FLIGHT
+      ) {
+        return;
+      }
       chatEventsPollTimerRef.current = window.setTimeout(() => {
-        chatEventsPollTimerRef.current = null;
+        chatEventsPollTimerRef.current = CHAT_EVENTS_POLL_IN_FLIGHT;
         void pullChatEvents().then((keepPolling) => {
           if (!keepPolling || cancelled()) {
             clearChatEventsPoll();
             return;
           }
-          if (streamGenRef.current !== reattachGen) return;
+          if (streamGenRef.current !== reattachGen) {
+            releasePollInFlight();
+            return;
+          }
+          if (chatEventsLiveCancelRef.current != null) {
+            releasePollInFlight();
+            return;
+          }
           armNext(STORE_EVENTS_POLL_MS);
         });
       }, delayMs) as unknown as number;
@@ -542,15 +607,154 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
 
     // Non-overlapping request-driven chain: next poll only after the prior settles.
     void pullChatEvents().then((keepPolling) => {
-      if (!keepPolling || cancelled()) return;
-      if (streamGenRef.current !== reattachGen) return;
+      if (!keepPolling || cancelled()) {
+        releasePollInFlight();
+        return;
+      }
+      if (streamGenRef.current !== reattachGen) {
+        releasePollInFlight();
+        return;
+      }
+      if (chatEventsLiveCancelRef.current != null) {
+        releasePollInFlight();
+        return;
+      }
       armNext(STORE_EVENTS_POLL_MS);
     });
+  };
+
+  const settleLiveTerminal = () => {
+    flushTypewriterRef.current();
+    detachedBusyRef.current = false;
+    clearChatEventsPoll();
+    startChatEventsPoll();
+    maybeRunQueuedResumeRef.current();
+    maybeDrainQueueRef.current();
+  };
+
+  /**
+   * Prefer live ``?watch=1`` SSE while the turn is open.
+   * Returns true when this owner installed (or already owns) the live slot.
+   * Open miss / error / EOF before terminal reconnects once, then store poll.
+   */
+  const startLiveChatEventsWatch = (reconnectUsed = false): boolean => {
+    if (cancelled() || localStreamActiveRef.current || userStoppedRef.current) {
+      return false;
+    }
+    if (!fenceOk()) return false;
+    if (chatEventsLiveCancelRef.current != null) return true;
+    if (chatEventsPollTimerRef.current != null) return false;
+
+    let sawTerminal = false;
+    let settled = false;
+    let released = false;
+    let streamCancel: (() => void) | null = null;
+    const cancel = () => {
+      released = true;
+      streamCancel?.();
+    };
+    chatEventsLiveCancelRef.current = cancel;
+
+    const releaseOwner = () => {
+      released = true;
+      if (chatEventsLiveCancelRef.current === cancel) {
+        chatEventsLiveCancelRef.current = null;
+      }
+    };
+
+    const fallBackToPoll = () => {
+      if (released || settled || cancelled()) return;
+      if (!fenceOk()) return;
+      if (localStreamActiveRef.current || userStoppedRef.current) return;
+      if (sawTerminal) return;
+      releaseOwner();
+      startChatEventsPoll();
+    };
+
+    const fallBackAfterRingMissHydrate = async () => {
+      if (released || settled || cancelled()) return;
+      if (!fenceOk()) return;
+      if (localStreamActiveRef.current || userStoppedRef.current) return;
+      if (sawTerminal) return;
+      releaseOwner();
+      streamCancel?.();
+      await hydrateDurableTranscript();
+      if (cancelled() || settled || sawTerminal) return;
+      if (!fenceOk()) return;
+      if (localStreamActiveRef.current || userStoppedRef.current) return;
+      startChatEventsPoll();
+    };
+
+    const closeLive = (openMiss: boolean) => {
+      if (settled || cancelled() || released) {
+        releaseOwner();
+        return;
+      }
+      if (!fenceOk()) {
+        releaseOwner();
+        return;
+      }
+      const decision = liveWatchCloseDecision({
+        sawTerminal,
+        openMiss,
+        reconnectUsed,
+      });
+      if (decision === "settle") {
+        settled = true;
+        settleLiveTerminal();
+        return;
+      }
+      if (decision === "reconnect") {
+        releaseOwner();
+        startLiveChatEventsWatch(true);
+        return;
+      }
+      fallBackToPoll();
+    };
+
+    streamCancel = api.chatEventsLive(
+      {
+        session: reattachSid,
+        since: lastAppliedRingCursorRef.current,
+        ...(ringGenerationRef.current != null
+          ? { generation: ringGenerationRef.current }
+          : {}),
+      },
+      (ev) => {
+        if (released || settled || cancelled()) return;
+        if (!fenceOk()) return;
+        if (localStreamActiveRef.current || userStoppedRef.current) return;
+        const kind = String(ev?.kind || "");
+        if (kind === "done") return;
+        if (isChatEventsLiveRingMissFrame(ev)) {
+          void fallBackAfterRingMissHydrate();
+          return;
+        }
+        applyStreamEventRef.current(chatFrameToStreamEvent(ev));
+        lastAppliedRingCursorRef.current = ringCursorAfterLiveFrame(
+          lastAppliedRingCursorRef.current,
+          typeof ev.cursor === "number" ? ev.cursor : undefined,
+        );
+        if (isTerminalStreamKind(kind)) {
+          sawTerminal = true;
+          settled = true;
+          settleLiveTerminal();
+        }
+      },
+      () => {
+        closeLive(false);
+      },
+      (err) => {
+        closeLive(isChatEventsLiveOpenMiss(err));
+      },
+    );
+    return true;
   };
 
   const startChatEventsReattach = async () => {
     if (cancelled() || userStoppedRef.current) return;
     if (streamGenRef.current !== reattachGen) return;
+    if (chatEventsLiveCancelRef.current != null) return;
     if (!detachedBusyRef.current && !localStreamActiveRef.current) {
       const maxAttempts = 2;
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -593,6 +797,13 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
       }
     }
     if (streamGenRef.current !== reattachGen) return;
+    if (shouldStartLiveChatEventsWatch({
+      detachedBusy: detachedBusyRef.current,
+      localStreamActive: localStreamActiveRef.current,
+      userStopped: userStoppedRef.current,
+    })) {
+      if (startLiveChatEventsWatch()) return;
+    }
     startChatEventsPoll();
   };
 

--- a/webapp/src/components/conversation/storeEvents.ts
+++ b/webapp/src/components/conversation/storeEvents.ts
@@ -66,6 +66,18 @@ export function shouldApplyStoreEvent(opts: {
   return opts.cachedSessionId === opts.subscriptionSid;
 }
 
+/**
+ * Skip store stream frames the live watch already accepted.
+ * Missing ring cursor cannot prove a duplicate, so those frames still apply.
+ */
+export function shouldApplyStoreStreamAfterLive(opts: {
+  ringCursor: number | undefined;
+  lastAppliedRingCursor: number;
+}): boolean {
+  if (typeof opts.ringCursor !== "number") return true;
+  return opts.ringCursor > opts.lastAppliedRingCursor;
+}
+
 /** Map a store ``stream`` event payload to the live stream-event shape. */
 export function storeStreamToStreamEvent(data: {
   kind?: string;

--- a/webapp/src/components/conversation/useSessionSwitch.ts
+++ b/webapp/src/components/conversation/useSessionSwitch.ts
@@ -33,6 +33,7 @@ import {
   type ComposerAttachedImage,
 } from "./composerAttachmentCache";
 import type { MemoryProposal } from "./streamEventHandler";
+import { beginChatStreamGeneration } from "./chatEvents";
 import { createChatEventsReattach } from "./chatEventsReattach";
 import { cancelStreamPaint, cancelTypewriterWithoutFlush } from "./streamTypewriter";
 import { gatherSessionArtifacts } from "./sessionArtifacts";
@@ -74,6 +75,7 @@ export type UseSessionSwitchDeps = {
   streamGenRef: MutableRefObject<number>;
   streamSessionIdRef: MutableRefObject<string | null>;
   lastAppliedCursorRef: MutableRefObject<number>;
+  lastAppliedRingCursorRef: MutableRefObject<number>;
   ringGenerationRef: MutableRefObject<number | undefined>;
   chatEventsPollTimerRef: MutableRefObject<number | null>;
   chatEventsLiveCancelRef: MutableRefObject<null | (() => void)>;
@@ -151,6 +153,7 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
     streamGenRef,
     streamSessionIdRef,
     lastAppliedCursorRef,
+    lastAppliedRingCursorRef,
     ringGenerationRef,
     chatEventsPollTimerRef,
     chatEventsLiveCancelRef,
@@ -272,7 +275,11 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
     // Bump streamGen so any late onmessage from the closed stream is ignored.
     // Bump runnerBusyPollGen so an in-flight session-A transcript poll cannot
     // pass the shared shouldApplySwarmLiveMerge generation fence after switch.
-    streamGenRef.current += 1;
+    beginChatStreamGeneration({
+      streamGenRef,
+      lastAppliedRingCursorRef,
+      ringGenerationRef,
+    });
     runnerBusyPollGenRef.current += 1;
     streamSessionIdRef.current = null;
     if (cancelRef.current) {
@@ -302,7 +309,6 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
     // Reset mid-turn reattach cursor/poll so the next session starts clean.
     clearChatEventsPoll();
     lastAppliedCursorRef.current = 0;
-    ringGenerationRef.current = undefined;
     // Drop the typewriter loop without flushing into items (would race the
     // cache hydrate below). Authoritative text comes back via sessionTranscript.
     cancelTypewriterWithoutFlush(
@@ -607,6 +613,7 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
           localStreamActiveRef,
           userStoppedRef,
           lastAppliedCursorRef,
+          lastAppliedRingCursorRef,
           ringGenerationRef,
           detachedBusyRef,
           runnerBusyPollGenRef,

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1624,7 +1624,7 @@ export const api = {
   /**
    * Live ring watch for mid-turn reattach (``?watch=1``).
    * Returns cancel(); on open miss the transport errors so callers fall back
-   * to ``chatEvents`` JSON poll.
+   * to the unified session-event cursor.
    */
   chatEventsLive: (
     opts: { session?: string; since?: number; generation?: number },


### PR DESCRIPTION
## Summary
- make the existing chat-events SSE watch the primary detached-busy reattachment transport
- retain one non-overlapping store cursor fallback for gaps, runner state, and bounded transport recovery
- dedupe mirrored live/store frames, hydrate cursor gaps, and reset ring cursors for every stream generation

## Test plan
- [x] 5,408 Python tests passed; 78 skipped
- [x] 1,565 frontend tests passed
- [x] 209 Electron tests passed
- [x] production frontend build passed
- [x] generated wheel metadata reports v0.9.394 and puppetmaster-ai==1.22.43
- [x] npm audit reports zero vulnerabilities
- [x] final Grok 4.6 Extra High/Fast review found no release blocker