### PR TITLE
Release v0.9.395: secure local model hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.394, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.395, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.394"
+__version__ = "0.9.395"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/local_models.py
+++ b/harness/api/local_models.py
@@ -1,0 +1,170 @@
+"""Local-model HTTP route bodies (snapshot, commands, resumable events)."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Union
+
+from ..local_model_manager import LocalModelError, LocalModelManager
+from ..local_models import parse_command, redact_mapping
+from .sse import sse_write
+
+JsonPayload = Union[dict, list]
+EVENT_KEEPALIVE_SECONDS = 5.0
+
+
+@dataclass
+class LocalModelServices:
+    """Explicit deps for local-model HTTP handlers (injected by server.py)."""
+
+    manager: LocalModelManager
+    cfg: Any
+    rebuild_pilot_and_session: Callable[[], None]
+    save_workspace_driver: Callable[[Any, str], None]
+    resync_driver_after_model_curation: Callable[[], dict]
+
+
+def get_local_models(svc: LocalModelServices) -> tuple[int, JsonPayload]:
+    """GET /api/local-models — authoritative snapshot."""
+    return 200, svc.manager.snapshot()
+
+
+def post_local_models(body: dict, svc: LocalModelServices) -> tuple[int, JsonPayload]:
+    """POST /api/local-models — discriminated LocalModelCommand."""
+    try:
+        command = parse_command(body)
+    except ValueError as exc:
+        return 400, {"error": str(exc)}
+    manager = svc.manager
+    try:
+        kind = command["type"]
+        if kind == "probe":
+            payload = manager.probe(
+                command.get("url") or "",
+                api_key=command.get("api_key") or "",
+                accept_lan=bool(command.get("accept_lan")),
+                accept_remote=bool(command.get("accept_remote")),
+            )
+            return 200, payload
+        if kind == "save_external":
+            snapshot = manager.save_external(
+                command.get("url") or "",
+                api_key=command.get("api_key") or "",
+                accept_lan=bool(command.get("accept_lan")),
+                accept_remote=bool(command.get("accept_remote")),
+                model=command.get("model") or "",
+                name=command.get("name") or "",
+                context_length=command.get("context_length"),
+            )
+            return 200, snapshot
+        if kind == "install":
+            return 200, manager.install(
+                command.get("target") or "all",
+                model_id=command.get("model_id") or "",
+            )
+        if kind == "cancel":
+            return 200, manager.cancel(command.get("target") or "all")
+        if kind == "start":
+            return 200, manager.start()
+        if kind == "stop":
+            return 200, manager.stop()
+        if kind == "restart":
+            return 200, manager.restart()
+        if kind == "remove":
+            return 200, manager.remove(
+                command.get("target") or "all",
+                endpoint_id=command.get("endpoint_id") or "",
+            )
+        if kind == "activate":
+            snapshot = manager.activate(command["spec"])
+            spec = snapshot.get("active_spec") or command["spec"]
+            try:
+                svc.cfg.driver = spec
+                svc.rebuild_pilot_and_session()
+                svc.save_workspace_driver(getattr(svc.cfg, "repo", None), spec)
+            except Exception as exc:
+                return 500, {"error": "Activated, but the pilot could not swap: %s" % exc}
+            try:
+                svc.resync_driver_after_model_curation()
+            except Exception:
+                pass
+            return 200, snapshot
+        if kind == "verify_tool_calling":
+            return 200, manager.verify_tool_calling(command["spec"])
+        return 400, {"error": "Unknown local-model command"}
+    except LocalModelError as exc:
+        return 400, redact_mapping({"error": str(exc), "code": exc.code})
+    except Exception as exc:
+        return 500, redact_mapping({"error": str(exc)})
+
+
+def get_local_model_events(
+    svc: LocalModelServices,
+    since: str = "0",
+) -> tuple[int, JsonPayload]:
+    """GET /api/local-models/events — JSON replay of progress/state events."""
+    try:
+        cursor = int(since or 0)
+    except (TypeError, ValueError):
+        cursor = 0
+    events = svc.manager.events_since(cursor)
+    snapshot = svc.manager.snapshot()
+    return 200, {
+        "ok": True,
+        "events": events,
+        "cursor": snapshot.get("event_cursor") or 0,
+        "snapshot": snapshot,
+    }
+
+
+def stream_local_model_events(handler: Any, svc: LocalModelServices, since: str = "0") -> None:
+    """GET /api/local-models/events?watch=1 — push-first resumable SSE."""
+    try:
+        cursor = int(since or 0)
+    except (TypeError, ValueError):
+        cursor = 0
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream")
+    handler.send_header("Cache-Control", "no-cache")
+    handler._cors()
+    handler.end_headers()
+
+    def _write(payload: dict) -> bool:
+        frame = ("data: %s\n\n" % json.dumps(payload)).encode("utf-8")
+        return sse_write(handler.wfile, frame)
+
+    snapshot = svc.manager.snapshot()
+    if not _write({
+        "kind": "snapshot",
+        "cursor": int(snapshot.get("event_cursor") or 0),
+        "snapshot": snapshot,
+    }):
+        return
+    for event in svc.manager.events_since(cursor):
+        if not _write(event):
+            return
+        cursor = max(cursor, int(event.get("cursor") or 0))
+    cursor = max(cursor, int(snapshot.get("event_cursor") or 0))
+    while True:
+        nxt = svc.manager.wait_events_since(cursor, EVENT_KEEPALIVE_SECONDS)
+        if nxt:
+            snapshot = svc.manager.snapshot()
+            if not _write({
+                "kind": "snapshot",
+                "cursor": int(snapshot.get("event_cursor") or 0),
+                "snapshot": snapshot,
+            }):
+                return
+            for event in nxt:
+                if (
+                    event.get("kind") == "snapshot"
+                    and (event.get("data") or {}).get("reason") == "replay_unavailable"
+                ):
+                    cursor = max(cursor, int(event.get("cursor") or 0))
+                    continue
+                if not _write(event):
+                    return
+                cursor = max(cursor, int(event.get("cursor") or 0))
+        else:
+            if not _write({"kind": "keepalive", "cursor": cursor}):
+                return

--- a/harness/api/sse.py
+++ b/harness/api/sse.py
@@ -565,8 +565,12 @@ def sse_pump(
         ring.pinned = True
     try:
         for ev in gen:
-            if on_event is not None:
-                on_event(ev)
+            # Write the live SSE frame BEFORE on_event (transcript checkpoint).
+            # assistant_done used to force-checkpoint first; a slow sidecar
+            # write left the UI on Still working with the reply already painted.
+            if not detached:
+                if not sse_write(wfile, frame_for_event(ev)):
+                    detached = True
             if ring is not None:
                 try:
                     # Match SseEventRing.append: only None becomes {}. Do not use
@@ -579,10 +583,8 @@ def sse_pump(
                     )
                 except Exception as exc:
                     _diag_note("sse_pump.ring_append", exc)
-            if detached:
-                continue
-            if not sse_write(wfile, frame_for_event(ev)):
-                detached = True
+            if on_event is not None:
+                on_event(ev)
         if write_done and not detached:
             sse_write(wfile, b"data: {\"kind\": \"done\"}\n\n")
         if write_done and ring is not None:

--- a/harness/api/streams.py
+++ b/harness/api/streams.py
@@ -637,18 +637,17 @@ def stream_chat(
             write_done=False,
             ring=ring,
         )
-        # After a chat turn streams its events, also drain ready swarm results
-        # (retain + drop-write if the UI already detached).
+        # Drain swarm_result / pilot_resume onto the live client before
+        # framing done. Framing done is not itself detach.
         for ev in turn_pilot.drain_swarm_results():
             _maybe_checkpoint(ev)
+            if not detached:
+                if not sse_write(handler.wfile, _encode_chat_sse_frame(ev)):
+                    detached = True
             try:
                 ring.append(ev.kind, ev.data or {}, getattr(ev, "turn", None))
             except Exception as exc:
                 _diag_note("stream_chat.ring_append", exc)
-            if detached:
-                continue
-            if not sse_write(handler.wfile, _encode_chat_sse_frame(ev)):
-                detached = True
         if not detached:
             sse_write(handler.wfile, b"data: {\"kind\": \"done\"}\n\n")
         try:

--- a/harness/data/local_models_catalog.json
+++ b/harness/data/local_models_catalog.json
@@ -1,0 +1,79 @@
+{
+  "version": 1,
+  "runtime": {
+    "id": "llama.cpp",
+    "vendor": "ggml-org",
+    "release": "b10442",
+    "commit": "9b0a2ce859d3884252705e9ac7c93c98616bb238",
+    "published": "2026-08-15T14:58:24Z",
+    "binary": "llama-server",
+    "assets": {
+      "macos-arm64": {
+        "filename": "llama-b10442-bin-macos-arm64.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10442/llama-b10442-bin-macos-arm64.tar.gz",
+        "sha256": "10861c8a5405bf3a04889f1216505aafab6c48360446a5b73b9042e7bbe8d5b7",
+        "size": 11099940,
+        "archive": "tar.gz",
+        "backend": "metal"
+      },
+      "macos-x64": {
+        "filename": "llama-b10442-bin-macos-x64.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10442/llama-b10442-bin-macos-x64.tar.gz",
+        "sha256": "75b487d1c89048812a1d1c8fc99cfc0b75d1705cd6beddf6503e4edd1909bb71",
+        "size": 11379983,
+        "archive": "tar.gz",
+        "backend": "metal"
+      },
+      "linux-x64": {
+        "filename": "llama-b10442-bin-ubuntu-x64.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10442/llama-b10442-bin-ubuntu-x64.tar.gz",
+        "sha256": "a447495bdf503af09a1874ebbb450927171da2c84c68cc4eae27c9789ca37b0e",
+        "size": 16626482,
+        "archive": "tar.gz",
+        "backend": "cpu"
+      },
+      "linux-arm64": {
+        "filename": "llama-b10442-bin-ubuntu-arm64.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10442/llama-b10442-bin-ubuntu-arm64.tar.gz",
+        "sha256": "a3f8deaf74111bf508d2e8a071b1964dcfc16e15ecb56aeeb1ace40c238c2a8f",
+        "size": 13490908,
+        "archive": "tar.gz",
+        "backend": "cpu"
+      },
+      "windows-x64": {
+        "filename": "llama-b10442-bin-win-cpu-x64.zip",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10442/llama-b10442-bin-win-cpu-x64.zip",
+        "sha256": "67a5da01b254be88294bdb477f481b71bb482b838e8d7da013eef8b20a0cfa24",
+        "size": 18477132,
+        "archive": "zip",
+        "backend": "cpu"
+      },
+      "windows-arm64": {
+        "filename": "llama-b10442-bin-win-cpu-arm64.zip",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10442/llama-b10442-bin-win-cpu-arm64.zip",
+        "sha256": "5a1843d2995c106bcf7c796d89d3ed5f0a497aa641f0bf796c95ab868e8e43b8",
+        "size": 12310924,
+        "archive": "zip",
+        "backend": "cpu"
+      }
+    }
+  },
+  "models": [
+    {
+      "id": "qwen3-4b",
+      "name": "Qwen3 4B",
+      "quant": "Q4_K_M",
+      "filename": "Qwen3-4B-Q4_K_M.gguf",
+      "url": "https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/bc640142c66e1fdd12af0bd68f40445458f3869b/Qwen3-4B-Q4_K_M.gguf",
+      "revision": "bc640142c66e1fdd12af0bd68f40445458f3869b",
+      "sha256": "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5",
+      "size": 2497280256,
+      "context_length": 40960,
+      "min_ram_gb": 6,
+      "min_disk_bytes": 3200000000,
+      "source": "Qwen/Qwen3-4B-GGUF (Apache-2.0)",
+      "trust": "first-party",
+      "notes": "Pinned first-party GGUF at the stated revision. Real-machine install is not proven by the hermetic suite."
+    }
+  ]
+}

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -113,6 +113,7 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
     from .api import worktrees as _wt_api
     from .api import collab_presence as _collab_presence_api
     from .api import metaharness as _mh_api
+    from .api import local_models as _local_models_api
 
     routes: dict[str, PostHandler] = {
         "/api/browser/relay": post_json(_browser_api.post_browser_relay),
@@ -212,6 +213,8 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             _prov_api.post_models_toggle, services=svc.provider_services),
         "/api/models/set": post_json(
             _prov_api.post_models_set, services=svc.provider_services),
+        "/api/local-models": post_json(
+            _local_models_api.post_local_models, services=svc.local_model_services),
         "/api/skills/approve": post_json(
             _skills_api.post_skills_approve, services=svc.skills_services),
         "/api/skills/add": post_json(
@@ -494,6 +497,7 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
     from .api import worktrees as _wt_api
     from .api import collab_presence as _collab_presence_api
     from .api import metaharness as _mh_api
+    from .api import local_models as _local_models_api
 
     def _get_git_diff(handler: Any, u: Any, qs: dict) -> Any:
         staged = qs.get("staged", ["0"])[0].strip().lower() in ("1", "true", "yes")
@@ -534,6 +538,17 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         force = (qs.get("refresh", [""])[0] or "").strip().lower() in (
             "1", "true", "yes")
         status, payload = _prov_api.get_models_catalog(force=force)
+        return send_json(handler, status, payload)
+
+    def _get_local_model_events(handler: Any, u: Any, qs: dict) -> Any:
+        watch = (qs.get("watch", ["0"])[0] or "").strip().lower() in (
+            "1", "true", "yes")
+        since = (qs.get("since", ["0"])[0] or "0")
+        if watch:
+            return _local_models_api.stream_local_model_events(
+                handler, svc.local_model_services(), since)
+        status, payload = _local_models_api.get_local_model_events(
+            svc.local_model_services(), since)
         return send_json(handler, status, payload)
 
     def _get_auth_pools(handler: Any, u: Any, qs: dict) -> Any:
@@ -731,6 +746,9 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         "/api/workspace": get_json(
             _ws_api.get_workspace, services=svc.workspace_services),
         "/api/models/catalog": _get_models_catalog,
+        "/api/local-models": get_json(
+            _local_models_api.get_local_models, services=svc.local_model_services),
+        "/api/local-models/events": _get_local_model_events,
         "/api/codegraph": get_json(
             _cg_api.get_codegraph, services=svc.codegraph_services),
         "/api/config": get_json(

--- a/harness/keys.py
+++ b/harness/keys.py
@@ -108,11 +108,38 @@ def get_env_var_for_reach(reach: str) -> str:
     if reach == "bedrock":
         # Preferred simple path; access-key auth uses multiple env vars instead.
         return "AWS_BEARER_TOKEN_BEDROCK"
+    folded = (reach or "").strip().lower()
+    # Custom local-endpoint reaches must not inherit HARNESS_KEY_ENV or they
+    # collide with the session's active provider after restart.
+    if folded.startswith("local-"):
+        slug = re.sub(r"[^A-Za-z0-9]+", "_", folded).strip("_").upper()
+        return "%s_API_KEY" % (slug or "LOCAL_ENDPOINT")
     from .providers import get_provider
     p = get_provider(reach)
     if p and p.env_vars:
         return p.env_vars[0]
     return os.environ.get("HARNESS_KEY_ENV", "") or f"{reach.upper()}_API_KEY"
+
+
+def hydrate_reach_key(reach: str) -> bool:
+    """Restore a stored reach key into its env var. Never returns the secret."""
+    if not reach:
+        return False
+    try:
+        if reach in get_disconnected():
+            return False
+    except Exception:
+        pass
+    stored = _read_keys().get(reach, "")
+    if not isinstance(stored, str) or not stored.strip():
+        return False
+    if is_placeholder_credential(stored):
+        return False
+    env_var = get_env_var_for_reach(reach)
+    if not env_var:
+        return False
+    os.environ[env_var] = stored
+    return True
 
 
 # AWS Bedrock BYOK: multi-field credentials stored under keys.json["bedrock"]

--- a/harness/local_model_manager.py
+++ b/harness/local_model_manager.py
@@ -78,6 +78,10 @@ _CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00
 _DETACHED_PROCESS = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
 
 
+def _platform_name() -> str:
+    return os.name
+
+
 class LocalModelError(RuntimeError):
     def __init__(self, message: str, *, code: str = "error", http_status: Optional[int] = None) -> None:
         super().__init__(message)
@@ -294,7 +298,7 @@ def read_bounded(resp, limit: int = PROBE_MAX_BYTES) -> bytes:
 def spawn_popen_kwargs() -> dict:
     """POSIX new session; Windows process group + hidden console. Never DETACHED."""
     kwargs = {}
-    if os.name == "nt":
+    if _platform_name() == "nt":
         kwargs["creationflags"] = _CREATE_NEW_PROCESS_GROUP | _CREATE_NO_WINDOW
         startup = getattr(subprocess, "STARTUPINFO", None)
         if startup is not None:
@@ -312,7 +316,7 @@ def stop_process_tree(pid: int, proc: Any = None, *, grace: float = 5.0, sleeper
     sleep = sleeper or time.sleep
     if not pid or int(pid) <= 1:
         return
-    if os.name == "nt":
+    if _platform_name() == "nt":
         flags = _CREATE_NO_WINDOW
         try:
             subprocess.run(
@@ -467,7 +471,7 @@ def extract_archive(archive_path: str, dest_dir: str) -> str:
 
 
 def find_binary(root: str, name: str) -> Optional[str]:
-    expected = os.path.basename(name) + (".exe" if os.name == "nt" and not name.endswith(".exe") else "")
+    expected = os.path.basename(name) + (".exe" if _platform_name() == "nt" and not name.endswith(".exe") else "")
     root_real = os.path.realpath(root)
     for dirpath, _dirnames, filenames in os.walk(root):
         if expected not in filenames:
@@ -553,7 +557,7 @@ def _windows_pid_query(pid: int) -> Optional[dict]:
 def _pid_alive(pid: int) -> bool:
     if not pid or pid <= 0:
         return False
-    if os.name == "nt":
+    if _platform_name() == "nt":
         info = _windows_pid_query(int(pid))
         return bool(info and info.get("alive"))
     try:
@@ -569,7 +573,7 @@ def read_process_start_key(pid: int) -> str:
     """Best-effort process birth token without a third-party dependency."""
     if not pid:
         return ""
-    if os.name == "nt":
+    if _platform_name() == "nt":
         info = _windows_pid_query(int(pid))
         return str((info or {}).get("start_key") or "")
     stat_path = "/proc/%s/stat" % pid
@@ -601,7 +605,7 @@ def read_process_start_key(pid: int) -> str:
 def read_process_command(pid: int) -> str:
     if not pid:
         return ""
-    if os.name == "nt":
+    if _platform_name() == "nt":
         info = _windows_pid_query(int(pid))
         return str((info or {}).get("image") or "")
     if os.path.exists("/proc/%s/cmdline" % pid):
@@ -635,7 +639,7 @@ def process_matches_identity(pid: int, identity: dict) -> bool:
     alias = str(identity.get("alias") or "")
     nonce = str(identity.get("nonce") or "")
     model_name = os.path.basename(str(identity.get("model_path") or ""))
-    if os.name == "nt":
+    if _platform_name() == "nt":
         if not command or not live_birth or not expected_birth:
             return False
         if live_birth != expected_birth:

--- a/harness/local_model_manager.py
+++ b/harness/local_model_manager.py
@@ -76,6 +76,8 @@ _CONTENT_RANGE_RE = re.compile(r"bytes\s+(\d+)-(\d+)/(\d+|\*)", re.IGNORECASE)
 _CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
 _CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
 _DETACHED_PROCESS = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+_SIGTERM = getattr(signal, "SIGTERM", 15)
+_SIGKILL = getattr(signal, "SIGKILL", 9)
 
 
 def _platform_name() -> str:
@@ -354,10 +356,10 @@ def stop_process_tree(pid: int, proc: Any = None, *, grace: float = 5.0, sleeper
     except (OSError, AttributeError):
         pgid = int(pid)
     try:
-        os.killpg(pgid, signal.SIGTERM)
+        os.killpg(pgid, _SIGTERM)
     except (OSError, AttributeError):
         try:
-            os.kill(int(pid), signal.SIGTERM)
+            os.kill(int(pid), _SIGTERM)
         except OSError:
             pass
     waited = False
@@ -370,10 +372,10 @@ def stop_process_tree(pid: int, proc: Any = None, *, grace: float = 5.0, sleeper
     if waited:
         return
     try:
-        os.killpg(pgid, signal.SIGKILL)
+        os.killpg(pgid, _SIGKILL)
     except (OSError, AttributeError):
         try:
-            os.kill(int(pid), signal.SIGKILL)
+            os.kill(int(pid), _SIGKILL)
         except OSError:
             pass
 

--- a/harness/local_model_manager.py
+++ b/harness/local_model_manager.py
@@ -1,0 +1,1973 @@
+"""Sole writer for local-model downloads, llama-server ownership, and probes.
+
+Injection seams keep tests hermetic: callers supply urlopen / popen /
+probe_transport so the suite never hits the network or a real llama-server.
+Production install uses the dedicated HTTPS opener with no env gate.
+Identity-safe PID adoption never kills an unrelated process.
+"""
+from __future__ import annotations
+
+import atexit
+import hashlib
+import json
+import os
+import random
+import re
+import signal
+import shutil
+import socket
+import stat
+import subprocess
+import tarfile
+import threading
+import time
+import zipfile
+from typing import Any, Callable, Optional
+from urllib.parse import urlparse
+import urllib.error
+import urllib.request
+
+from .local_models import (
+    MANAGED_ENDPOINT_ID,
+    _ip_kind,
+    bound_plain_reason,
+    cached_catalog,
+    canonical_spec,
+    classify_tool_calling_payload,
+    curated_model,
+    empty_tool_calling,
+    detect_hardware,
+    detect_vendor_from_probe,
+    detect_vendor_from_url,
+    endpoint_id_for_url,
+    evaluate_endpoint_url,
+    extract_context_length,
+    extract_model_ids,
+    load_state,
+    local_secret_reach,
+    parse_local_spec,
+    redact_mapping,
+    resolve_local_endpoint,
+    runtime_asset_for_platform,
+    runtime_offload_layers,
+    save_state,
+    snapshot_from_state,
+    state_root,
+    tool_calling_error_reason,
+    tool_calling_request_body,
+    usable_local_specs,
+)
+from .url_safety import is_safe_url_pinned, normalize_url_for_request
+from .web_tools import _PinnedIP, _PinnedIPHTTPHandler, _PinnedIPHTTPSHandler
+
+UrlOpen = Callable[..., Any]
+PopenFactory = Callable[..., Any]
+
+PROBE_MAX_BYTES = 1024 * 1024
+DOWNLOAD_PROGRESS_BYTES = 4 * 1024 * 1024
+DOWNLOAD_PROGRESS_INTERVAL = 0.25
+DOWNLOAD_HOSTS = frozenset({
+    "github.com",
+    "objects.githubusercontent.com",
+    "release-assets.githubusercontent.com",
+    "huggingface.co",
+})
+_CONTENT_RANGE_RE = re.compile(r"bytes\s+(\d+)-(\d+)/(\d+|\*)", re.IGNORECASE)
+_CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+_CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+_DETACHED_PROCESS = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+
+
+class LocalModelError(RuntimeError):
+    def __init__(self, message: str, *, code: str = "error", http_status: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.http_status = http_status
+
+
+def download_host_allowed(host: str) -> bool:
+    folded = (host or "").lower().rstrip(".")
+    if not folded:
+        return False
+    if folded in DOWNLOAD_HOSTS:
+        return True
+    return folded == "hf.co" or folded.endswith(".hf.co")
+
+
+def validate_download_url(url: str) -> Optional[str]:
+    """HTTPS + allowlisted host + no private/metadata hop. Returns pinned IP."""
+    parsed = urlparse(url)
+    if (parsed.scheme or "").lower() != "https":
+        raise LocalModelError("Downloads must use HTTPS", code="unsafe_url")
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not download_host_allowed(host):
+        raise LocalModelError("Download host is not on the allowlist", code="unsafe_url")
+    ok, reason, pinned_ip = is_safe_url_pinned(url, allow_private=False)
+    if not ok:
+        raise LocalModelError(reason or "Download URL is blocked", code="unsafe_url")
+    if pinned_ip:
+        return pinned_ip.split("%")[0]
+    return None
+
+
+class AssetRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Re-validate every download hop: HTTPS, allowlist, no private/metadata."""
+
+    max_redirections = 5
+
+    def __init__(self, pin: Optional[_PinnedIP] = None, *args, **kwargs):
+        self._pin = pin
+        super().__init__(*args, **kwargs)
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        try:
+            pinned_ip = validate_download_url(newurl)
+        except LocalModelError as exc:
+            raise urllib.error.HTTPError(newurl, code, str(exc), headers, fp) from exc
+        if self._pin is not None and pinned_ip:
+            self._pin.ip = pinned_ip
+        return super().redirect_request(
+            req, fp, code, msg, headers, normalize_url_for_request(newurl),
+        )
+
+
+def asset_download_urlopen(req, timeout=None):
+    url = getattr(req, "full_url", None) or getattr(req, "get_full_url", lambda: req)()
+    pinned_ip = validate_download_url(str(url))
+    pin = _PinnedIP(pinned_ip)
+    opener = urllib.request.build_opener(
+        _PinnedIPHTTPSHandler(pin=pin),
+        AssetRedirectHandler(pin=pin),
+    )
+    return opener.open(req, timeout=timeout)
+
+
+def _default_urlopen(req, timeout=None):
+    return asset_download_urlopen(req, timeout=timeout)
+
+
+def parse_content_range(value: str) -> Optional[tuple]:
+    match = _CONTENT_RANGE_RE.match((value or "").strip())
+    if not match:
+        return None
+    start, end, total = match.group(1), match.group(2), match.group(3)
+    if total == "*":
+        return int(start), int(end), None
+    return int(start), int(end), int(total)
+
+
+def _response_status(resp) -> int:
+    for attr in ("status", "code"):
+        value = getattr(resp, attr, None)
+        if value is not None:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                pass
+    return 200
+
+
+def _response_header(resp, name: str) -> str:
+    headers = getattr(resp, "headers", None)
+    if headers is None:
+        return ""
+    getter = getattr(headers, "get", None)
+    if callable(getter):
+        return str(getter(name) or getter(name.lower()) or "")
+    if isinstance(headers, dict):
+        return str(headers.get(name) or headers.get(name.lower()) or "")
+    return ""
+
+
+def assert_probe_hop_safe(
+    url: str,
+    *,
+    accept_lan: bool = False,
+    accept_remote: bool = False,
+) -> dict:
+    """Classify *url* and refuse metadata / spoofed / unconfirmed hops."""
+    decision = evaluate_endpoint_url(
+        url, accept_lan=accept_lan, accept_remote=accept_remote,
+    )
+    if not decision.get("ok"):
+        raise LocalModelError(
+            decision.get("error") or "Unsafe endpoint",
+            code=str(decision.get("kind") or "url"),
+        )
+    allow_private = decision.get("kind") != "public"
+    ok, reason, pinned_ip = is_safe_url_pinned(url, allow_private=allow_private)
+    if not ok:
+        raise LocalModelError(reason or "Unsafe endpoint", code="url")
+    proven_ip = pinned_ip.split("%")[0] if pinned_ip else ""
+    if proven_ip:
+        kind = _ip_kind(proven_ip)
+        declared = str(decision.get("kind") or "")
+        if kind in {"metadata", "blocked"}:
+            raise LocalModelError(
+                "Endpoint resolved to a blocked address",
+                code=kind,
+            )
+        if declared == "loopback" and kind != "loopback":
+            raise LocalModelError(
+                "Endpoint resolved to a blocked address",
+                code=kind,
+            )
+        if declared == "public" and kind != "public":
+            raise LocalModelError(
+                "Remote endpoint resolved to a private or loopback address",
+                code=kind,
+            )
+        if declared in {"lan", "link_local"} and kind not in {"lan", "link_local"}:
+            raise LocalModelError(
+                "Endpoint resolved to a blocked address",
+                code=kind,
+            )
+        if kind == "public" and not accept_remote:
+            raise LocalModelError(
+                "Endpoint resolved to a blocked address",
+                code="public",
+            )
+        if kind in {"lan", "link_local"} and not accept_lan:
+            raise LocalModelError(
+                "This looks like a LAN address. Confirm it is a machine you trust.",
+                code=kind,
+            )
+    if not proven_ip:
+        raise LocalModelError("Endpoint address could not be pinned", code="url")
+    decision = dict(decision)
+    decision["pinned_ip"] = proven_ip
+    return decision
+
+
+class ProbeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse probe redirects. /models must not hop hosts, kinds, or Authorization."""
+
+    max_redirections = 0
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.HTTPError(
+            newurl, code, "Probe endpoints must not redirect", headers, fp,
+        )
+
+
+def probe_urlopen(
+    req,
+    timeout=None,
+    *,
+    accept_lan: bool = False,
+    accept_remote: bool = False,
+    pinned_ip: Optional[str] = None,
+):
+    """Connect using exactly one policy-validated pin. Never re-resolves DNS."""
+    url = getattr(req, "full_url", None) or getattr(req, "get_full_url", lambda: req)()
+    proven = str(pinned_ip or "").split("%")[0]
+    if not proven:
+        decision = assert_probe_hop_safe(
+            str(url), accept_lan=accept_lan, accept_remote=accept_remote,
+        )
+        proven = str(decision.get("pinned_ip") or "").split("%")[0]
+    if not proven:
+        raise LocalModelError("Endpoint address could not be pinned", code="url")
+    pin = _PinnedIP(proven)
+    opener = urllib.request.build_opener(
+        _PinnedIPHTTPHandler(pin=pin),
+        _PinnedIPHTTPSHandler(pin=pin),
+        ProbeRedirectHandler(),
+    )
+    return opener.open(req, timeout=timeout)
+
+
+def read_bounded(resp, limit: int = PROBE_MAX_BYTES) -> bytes:
+    chunks = []
+    total = 0
+    while True:
+        chunk = resp.read(min(64 * 1024, max(1, limit - total + 1)))
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > limit:
+            raise LocalModelError("Endpoint response exceeded size limit", code="probe")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def spawn_popen_kwargs() -> dict:
+    """POSIX new session; Windows process group + hidden console. Never DETACHED."""
+    kwargs = {}
+    if os.name == "nt":
+        kwargs["creationflags"] = _CREATE_NEW_PROCESS_GROUP | _CREATE_NO_WINDOW
+        startup = getattr(subprocess, "STARTUPINFO", None)
+        if startup is not None:
+            info = startup()
+            info.dwFlags |= getattr(subprocess, "STARTF_USESHOWWINDOW", 0)
+            info.wShowWindow = 0
+            kwargs["startupinfo"] = info
+    else:
+        kwargs["start_new_session"] = True
+    return kwargs
+
+
+def stop_process_tree(pid: int, proc: Any = None, *, grace: float = 5.0, sleeper=None) -> None:
+    """TERM/taskkill the owned tree, then force-kill after *grace*. Never raises."""
+    sleep = sleeper or time.sleep
+    if not pid or int(pid) <= 1:
+        return
+    if os.name == "nt":
+        flags = _CREATE_NO_WINDOW
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(int(pid)), "/T"],
+                capture_output=True,
+                timeout=15,
+                creationflags=flags,
+            )
+        except Exception:
+            pass
+        waited = False
+        if proc is not None:
+            try:
+                proc.wait(timeout=grace)
+                waited = True
+            except Exception:
+                waited = False
+        if not waited:
+            try:
+                sleep(min(max(grace, 0.0), 5.0) if proc is None else 0)
+            except Exception:
+                pass
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(int(pid)), "/T", "/F"],
+                    capture_output=True,
+                    timeout=15,
+                    creationflags=flags,
+                )
+            except Exception:
+                pass
+        return
+    try:
+        pgid = os.getpgid(int(pid))
+    except (OSError, AttributeError):
+        pgid = int(pid)
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except (OSError, AttributeError):
+        try:
+            os.kill(int(pid), signal.SIGTERM)
+        except OSError:
+            pass
+    waited = False
+    if proc is not None:
+        try:
+            proc.wait(timeout=grace)
+            waited = True
+        except Exception:
+            waited = False
+    if waited:
+        return
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (OSError, AttributeError):
+        try:
+            os.kill(int(pid), signal.SIGKILL)
+        except OSError:
+            pass
+
+
+def find_free_port(host: str = "127.0.0.1", preferred: Optional[int] = None) -> int:
+    if preferred:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            probe.bind((host, int(preferred)))
+            probe.close()
+            return int(preferred)
+        except OSError:
+            probe.close()
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind((host, 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return port
+
+
+def is_safe_archive_member(name: str) -> bool:
+    text = str(name or "").replace("\\", "/")
+    if not text or text.startswith("/") or text.startswith("../"):
+        return False
+    parts = [part for part in text.split("/") if part not in ("", ".")]
+    if any(part == ".." for part in parts):
+        return False
+    if os.path.isabs(name) or os.path.isabs(text):
+        return False
+    return True
+
+
+def zip_is_symlink(info: zipfile.ZipInfo) -> bool:
+    mode = (info.external_attr >> 16) & 0xFFFF
+    return bool(mode and stat.S_ISLNK(mode))
+
+
+def tar_member_rejected(member: tarfile.TarInfo) -> Optional[str]:
+    if not is_safe_archive_member(member.name):
+        return "escape"
+    if member.issym() or member.islnk():
+        return "link"
+    if member.ischr() or member.isblk() or member.isfifo() or member.isdev():
+        return "device"
+    if not (member.isfile() or member.isdir()):
+        return "type"
+    return None
+
+
+def extract_archive(archive_path: str, dest_dir: str) -> str:
+    """Validate then extract into staging; promote only after every member is safe."""
+    os.makedirs(os.path.dirname(dest_dir) or ".", exist_ok=True)
+    staging = dest_dir + ".extract"
+    if os.path.exists(staging):
+        shutil.rmtree(staging, ignore_errors=True)
+    os.makedirs(staging, exist_ok=True)
+    lower = archive_path.lower()
+    try:
+        if lower.endswith(".zip"):
+            with zipfile.ZipFile(archive_path) as zf:
+                members = []
+                for info in zf.infolist():
+                    if not is_safe_archive_member(info.filename):
+                        raise LocalModelError(
+                            "Archive member escapes the extract directory",
+                            code="unsafe_archive",
+                        )
+                    if zip_is_symlink(info):
+                        raise LocalModelError(
+                            "Archive contains a symbolic link",
+                            code="unsafe_archive",
+                        )
+                    members.append(info)
+                for info in members:
+                    zf.extract(info, staging)
+        else:
+            with tarfile.open(archive_path, "r:*") as tf:
+                members = []
+                for member in tf.getmembers():
+                    reason = tar_member_rejected(member)
+                    if reason:
+                        raise LocalModelError(
+                            "Archive member is not a regular file or directory",
+                            code="unsafe_archive",
+                        )
+                    members.append(member)
+                tf.extractall(staging, members=members)
+        if os.path.exists(dest_dir):
+            shutil.rmtree(dest_dir, ignore_errors=True)
+        os.replace(staging, dest_dir)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return dest_dir
+
+
+def find_binary(root: str, name: str) -> Optional[str]:
+    expected = os.path.basename(name) + (".exe" if os.name == "nt" and not name.endswith(".exe") else "")
+    root_real = os.path.realpath(root)
+    for dirpath, _dirnames, filenames in os.walk(root):
+        if expected not in filenames:
+            continue
+        path = os.path.join(dirpath, expected)
+        real = os.path.realpath(path)
+        if real != root_real and not real.startswith(root_real + os.sep):
+            continue
+        try:
+            mode = os.stat(path).st_mode
+            os.chmod(path, mode | stat.S_IXUSR)
+        except Exception:
+            pass
+        return path
+    return None
+
+
+def sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _windows_pid_query(pid: int) -> Optional[dict]:
+    """Non-signaling Windows process query. Returns None when identity is unproven."""
+    if not pid or int(pid) <= 0:
+        return None
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, int(pid))
+        if not handle:
+            return None
+        try:
+            code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return None
+            if int(code.value) != STILL_ACTIVE:
+                return {"alive": False, "image": "", "start_key": ""}
+
+            class _FILETIME(ctypes.Structure):
+                _fields_ = [
+                    ("dwLowDateTime", wintypes.DWORD),
+                    ("dwHighDateTime", wintypes.DWORD),
+                ]
+
+            created = _FILETIME()
+            exited = _FILETIME()
+            kernel = _FILETIME()
+            user = _FILETIME()
+            start_key = ""
+            if kernel32.GetProcessTimes(
+                handle,
+                ctypes.byref(created),
+                ctypes.byref(exited),
+                ctypes.byref(kernel),
+                ctypes.byref(user),
+            ):
+                start_key = "%08x%08x" % (
+                    int(created.dwHighDateTime), int(created.dwLowDateTime),
+                )
+            size = wintypes.DWORD(32768)
+            buf = ctypes.create_unicode_buffer(size.value)
+            image = ""
+            if kernel32.QueryFullProcessImageNameW(handle, 0, buf, ctypes.byref(size)):
+                image = buf.value or ""
+            return {"alive": True, "image": image, "start_key": start_key}
+        finally:
+            kernel32.CloseHandle(handle)
+    except Exception:
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    if not pid or pid <= 0:
+        return False
+    if os.name == "nt":
+        info = _windows_pid_query(int(pid))
+        return bool(info and info.get("alive"))
+    try:
+        os.kill(int(pid), 0)
+        return True
+    except OSError:
+        return False
+    except Exception:
+        return False
+
+
+def read_process_start_key(pid: int) -> str:
+    """Best-effort process birth token without a third-party dependency."""
+    if not pid:
+        return ""
+    if os.name == "nt":
+        info = _windows_pid_query(int(pid))
+        return str((info or {}).get("start_key") or "")
+    stat_path = "/proc/%s/stat" % pid
+    if os.path.exists(stat_path):
+        try:
+            with open(stat_path, encoding="utf-8", errors="replace") as handle:
+                text = handle.read()
+            close = text.rfind(")")
+            if close != -1:
+                fields = text[close + 2:].split()
+                if len(fields) >= 20:
+                    return fields[19]
+        except Exception:
+            pass
+    try:
+        proc = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if proc.returncode == 0:
+            return (proc.stdout or "").strip()
+    except Exception:
+        pass
+    return ""
+
+
+def read_process_command(pid: int) -> str:
+    if not pid:
+        return ""
+    if os.name == "nt":
+        info = _windows_pid_query(int(pid))
+        return str((info or {}).get("image") or "")
+    if os.path.exists("/proc/%s/cmdline" % pid):
+        try:
+            with open("/proc/%s/cmdline" % pid, "rb") as handle:
+                return handle.read().replace(b"\x00", b" ").decode("utf-8", "replace")
+        except Exception:
+            return ""
+    try:
+        proc = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "args="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if proc.returncode == 0:
+            return (proc.stdout or "").strip()
+    except Exception:
+        pass
+    return ""
+
+
+def process_matches_identity(pid: int, identity: dict) -> bool:
+    """True only when the live process still looks like our llama-server."""
+    if not _pid_alive(pid):
+        return False
+    command = read_process_command(pid)
+    expected_birth = str(identity.get("start_key") or "")
+    live_birth = read_process_start_key(pid)
+    exe = os.path.basename(str(identity.get("exe") or ""))
+    alias = str(identity.get("alias") or "")
+    nonce = str(identity.get("nonce") or "")
+    model_name = os.path.basename(str(identity.get("model_path") or ""))
+    if os.name == "nt":
+        if not command or not live_birth or not expected_birth:
+            return False
+        if live_birth != expected_birth:
+            return False
+        folded = command.lower()
+        if exe and exe.lower() not in folded and "llama-server" not in folded:
+            return False
+        return True
+    if not command:
+        return False
+    if alias and alias not in command:
+        return False
+    if nonce and nonce not in command:
+        return False
+    if exe and exe not in command and "llama-server" not in command:
+        return False
+    if model_name and model_name not in command:
+        return False
+    if expected_birth:
+        if live_birth and live_birth != expected_birth:
+            return False
+    return True
+
+
+class EventLog:
+    """In-memory resumable event log seeded from a durable cursor."""
+
+    def __init__(self, cap: int = 256, cursor: int = 0) -> None:
+        self.cap = cap
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._events = []
+        self.cursor = max(0, int(cursor or 0))
+
+    def append(self, kind: str, data: Optional[dict] = None) -> dict:
+        with self._cond:
+            self.cursor += 1
+            event = {
+                "cursor": self.cursor,
+                "kind": kind,
+                "data": redact_mapping(data or {}),
+                "ts": time.time(),
+            }
+            self._events.append(event)
+            if len(self._events) > self.cap:
+                self._events = self._events[-self.cap:]
+            self._cond.notify_all()
+            return event
+
+    def since(self, cursor: int) -> list:
+        with self._cond:
+            return list(self._since_unlocked(cursor))
+
+    def wait_since(self, cursor: int, timeout: float) -> list:
+        deadline = time.time() + max(0.0, float(timeout))
+        with self._cond:
+            while True:
+                events = self._since_unlocked(cursor)
+                if events:
+                    return list(events)
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    return []
+                self._cond.wait(timeout=remaining)
+
+    def _since_unlocked(self, cursor: int) -> list:
+        start = int(cursor or 0)
+        events = [event for event in self._events if event["cursor"] > start]
+        if start < self.cursor and not events:
+            return [{
+                "cursor": self.cursor,
+                "kind": "snapshot",
+                "data": {"reason": "replay_unavailable"},
+                "ts": time.time(),
+            }]
+        return events
+
+
+class LocalModelManager:
+    """Single-owner control plane for managed llama.cpp and external endpoints."""
+
+    def __init__(
+        self,
+        root: Optional[str] = None,
+        *,
+        catalog: Optional[dict] = None,
+        urlopen: Optional[UrlOpen] = None,
+        popen: Optional[PopenFactory] = None,
+        sleeper: Optional[Callable[[float], None]] = None,
+        clock: Optional[Callable[[], float]] = None,
+        ready_timeout: float = 90.0,
+        probe_transport: Optional[Callable[..., Any]] = None,
+    ) -> None:
+        self.root = root or state_root()
+        os.makedirs(self.root, exist_ok=True)
+        self.catalog = catalog if catalog is not None else cached_catalog()
+        self.urlopen = urlopen or _default_urlopen
+        self.popen = popen or subprocess.Popen
+        self.sleep = sleeper or time.sleep
+        self.clock = clock or time.time
+        self.ready_timeout = ready_timeout
+        self.probe_transport = probe_transport
+        seeded = 0
+        try:
+            seeded = max(0, int((load_state(self.root) or {}).get("event_cursor") or 0))
+        except Exception:
+            seeded = 0
+        self.events = EventLog(cursor=seeded)
+        self._lock = threading.RLock()
+        self._cancel = {key: threading.Event() for key in ("runtime", "model", "all")}
+        self._workers = {}
+        self._procs = {}
+        self._start_in_progress = False
+        self._install_in_progress = False
+        self._shutdown = False
+        if seeded > 0:
+            self._emit("snapshot", {"reason": "replay_unavailable"})
+
+    # -- paths -------------------------------------------------------------
+
+    def runtime_dir(self) -> str:
+        return os.path.join(self.root, "runtime")
+
+    def models_dir(self) -> str:
+        return os.path.join(self.root, "models")
+
+    def downloads_dir(self) -> str:
+        return os.path.join(self.root, "downloads")
+
+    def logs_dir(self) -> str:
+        return os.path.join(self.root, "logs")
+
+    def _state(self) -> dict:
+        with self._lock:
+            return load_state(self.root)
+
+    def _save(self, state: dict) -> dict:
+        with self._lock:
+            state["event_cursor"] = self.events.cursor
+            return save_state(state, self.root)
+
+    def _update_state(self, mutator: Optional[Callable[[dict], Any]] = None) -> dict:
+        """Load, mutate, and persist under one lock hold. *mutator* may be None."""
+        with self._lock:
+            state = load_state(self.root)
+            if mutator is not None:
+                mutator(state)
+            state["event_cursor"] = self.events.cursor
+            return save_state(state, self.root)
+
+    def _emit(self, kind: str, data: Optional[dict] = None) -> None:
+        with self._lock:
+            event = self.events.append(kind, data)
+            state = load_state(self.root)
+            state["event_cursor"] = event["cursor"]
+            save_state(state, self.root)
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            state = load_state(self.root)
+            hardware = detect_hardware(self.root, self.catalog)
+            return snapshot_from_state(
+                state,
+                catalog=self.catalog,
+                hardware=hardware,
+                events=self.events.since(max(0, int(state.get("event_cursor") or 0) - 32)),
+            )
+
+    def events_since(self, cursor: int) -> list:
+        return self.events.since(cursor)
+
+    def wait_events_since(self, cursor: int, timeout: float) -> list:
+        return self.events.wait_since(cursor, timeout)
+
+    # -- downloads ---------------------------------------------------------
+
+    def _part_path(self, filename: str) -> str:
+        os.makedirs(self.downloads_dir(), exist_ok=True)
+        return os.path.join(self.downloads_dir(), filename + ".part")
+
+    def _final_path(self, filename: str) -> str:
+        os.makedirs(self.downloads_dir(), exist_ok=True)
+        return os.path.join(self.downloads_dir(), filename)
+
+    def cancel(self, target: str = "all") -> dict:
+        with self._lock:
+            return self._cancel_unlocked(target)
+
+    def _cancel_unlocked(self, target: str = "all") -> dict:
+        if target == "all":
+            self._cancel["all"].set()
+        keys = ("runtime", "model") if target == "all" else (target,)
+        for key in keys:
+            self._cancel.setdefault(key, threading.Event()).set()
+            status = ((self._state().get("managed") or {}).get(key) or {}).get("status")
+            if status in {"downloading", "extracting"}:
+                self._set_component(key, status="paused", error=None)
+                downloads = (self._state().get("managed") or {}).get("downloads") or {}
+                row = downloads.get(key) if isinstance(downloads.get(key), dict) else {}
+                part = str((row or {}).get("part_path") or "")
+                if part and os.path.exists(part):
+                    updated = dict(row)
+                    updated["bytes"] = os.path.getsize(part)
+                    updated["phase"] = row.get("phase") or "download"
+                    self._set_download(key, updated)
+        self._emit("cancelled", {"target": target})
+        return self.snapshot()
+
+    def _clear_cancel(self, target: str) -> None:
+        if target == "all":
+            for key in ("runtime", "model", "all"):
+                self._cancel.setdefault(key, threading.Event()).clear()
+            return
+        self._cancel.setdefault(target, threading.Event()).clear()
+        self._cancel["all"].clear()
+
+    def _cancelled(self, target: str) -> bool:
+        return self._cancel.get(target, threading.Event()).is_set() or self._cancel["all"].is_set()
+
+    def download_asset(self, asset: dict, *, target: str) -> str:
+        filename = asset["filename"]
+        url = asset["url"]
+        expected = str(asset["sha256"]).lower()
+        total = int(asset.get("size") or 0)
+        if total <= 0:
+            raise LocalModelError("Catalog asset is missing a pinned size", code="download")
+        part = self._part_path(filename)
+        final = self._final_path(filename)
+        if os.path.exists(final) and os.path.getsize(final) == total:
+            if sha256_file(final) == expected:
+                self._set_download(target, {
+                    "filename": filename,
+                    "bytes": total,
+                    "total": total,
+                    "path": final,
+                    "phase": "verified",
+                })
+                return final
+            try:
+                os.remove(final)
+            except OSError:
+                pass
+        existing = os.path.getsize(part) if os.path.exists(part) else 0
+        if existing == total:
+            if sha256_file(part) == expected:
+                os.replace(part, final)
+                self._set_download(target, {
+                    "filename": filename,
+                    "bytes": total,
+                    "total": total,
+                    "path": final,
+                    "phase": "verified",
+                })
+                return final
+            try:
+                os.remove(part)
+            except OSError:
+                pass
+            existing = 0
+        elif existing <= 0 or existing >= total:
+            if existing:
+                try:
+                    os.remove(part)
+                except OSError:
+                    pass
+            existing = 0
+        if self._cancelled(target):
+            raise LocalModelError("Download cancelled", code="cancelled")
+        headers = {"User-Agent": "marionette-local-models"}
+        ranged = existing > 0
+        if ranged:
+            headers["Range"] = "bytes=%s-" % existing
+        req = urllib.request.Request(url, headers=headers)
+        self._emit("progress", {
+            "target": target,
+            "filename": filename,
+            "bytes": existing,
+            "total": total,
+            "phase": "download",
+        })
+        try:
+            resp = self.urlopen(req, timeout=60)
+        except LocalModelError:
+            raise
+        except Exception as exc:
+            raise LocalModelError("Download failed: %s" % exc, code="download") from exc
+        try:
+            status = _response_status(resp)
+            if ranged:
+                if status == 200:
+                    existing = 0
+                    mode = "wb"
+                elif status == 206:
+                    parsed = parse_content_range(_response_header(resp, "Content-Range"))
+                    if (
+                        parsed is None
+                        or parsed[0] != existing
+                        or parsed[2] != total
+                        or parsed[1] != total - 1
+                    ):
+                        raise LocalModelError(
+                            "Resume Content-Range does not match the pinned size",
+                            code="download",
+                        )
+                    mode = "ab"
+                else:
+                    raise LocalModelError(
+                        "Unexpected HTTP status for ranged download",
+                        code="download",
+                    )
+            else:
+                if status != 200:
+                    raise LocalModelError(
+                        "Unexpected HTTP status for download",
+                        code="download",
+                    )
+                mode = "wb"
+            written = existing
+            last_persist_bytes = existing
+            last_persist_at = self.clock()
+            with open(part, mode) as handle:
+                while True:
+                    if self._cancelled(target):
+                        self._set_download(target, {
+                            "filename": filename,
+                            "bytes": written,
+                            "total": total,
+                            "part_path": part,
+                            "phase": "download",
+                        })
+                        raise LocalModelError("Download cancelled", code="cancelled")
+                    chunk = resp.read(64 * 1024)
+                    if not chunk:
+                        break
+                    if written + len(chunk) > total:
+                        handle.close()
+                        try:
+                            os.remove(part)
+                        except OSError:
+                            pass
+                        raise LocalModelError(
+                            "Download exceeded the pinned size for %s" % filename,
+                            code="download",
+                        )
+                    handle.write(chunk)
+                    written = handle.tell()
+                    now = self.clock()
+                    if (
+                        written - last_persist_bytes >= DOWNLOAD_PROGRESS_BYTES
+                        or now - last_persist_at >= DOWNLOAD_PROGRESS_INTERVAL
+                        or written == total
+                    ):
+                        self._set_download(target, {
+                            "filename": filename,
+                            "bytes": written,
+                            "total": total,
+                            "part_path": part,
+                            "phase": "download",
+                        })
+                        self._emit("progress", {
+                            "target": target,
+                            "filename": filename,
+                            "bytes": written,
+                            "total": total,
+                            "phase": "download",
+                        })
+                        last_persist_bytes = written
+                        last_persist_at = now
+            existing = written
+        finally:
+            try:
+                resp.close()
+            except Exception:
+                pass
+        if existing != total:
+            if existing <= 0 or existing >= total:
+                try:
+                    os.remove(part)
+                except OSError:
+                    pass
+            raise LocalModelError(
+                "Download size does not match the pinned size for %s" % filename,
+                code="download",
+            )
+        self._emit("progress", {
+            "target": target, "filename": filename, "bytes": existing,
+            "total": total, "phase": "hash",
+        })
+        digest = sha256_file(part)
+        if digest != expected:
+            try:
+                os.remove(part)
+            except OSError:
+                pass
+            raise LocalModelError(
+                "SHA-256 mismatch for %s" % filename,
+                code="hash_mismatch",
+            )
+        os.replace(part, final)
+        self._set_download(target, {
+            "filename": filename,
+            "bytes": os.path.getsize(final),
+            "total": total,
+            "path": final,
+            "phase": "verified",
+        })
+        return final
+
+    def _set_download(self, target: str, payload: dict) -> None:
+        with self._lock:
+            state = self._state()
+            downloads = state["managed"].setdefault("downloads", {})
+            downloads[target] = payload
+            self._save(state)
+
+    def _set_component(self, kind: str, **fields: Any) -> None:
+        with self._lock:
+            state = self._state()
+            state["managed"].setdefault(kind, {}).update(fields)
+            self._save(state)
+
+    def install(self, target: str = "all", *, model_id: str = "", background: bool = True) -> dict:
+        chosen = ""
+        if target in ("model", "all"):
+            chosen = str(model_id or "").strip()
+            if not chosen:
+                raise LocalModelError("Install requires an explicit model_id", code="model_id")
+            if not curated_model(self.catalog, chosen):
+                raise LocalModelError("Unknown catalog model", code="unknown_model")
+        hardware = detect_hardware(self.root, self.catalog)
+        if not hardware.get("supported"):
+            raise LocalModelError(
+                hardware.get("unsupported_reason") or "This machine cannot host a catalog model",
+                code="unsupported",
+            )
+        overlapping = ("runtime", "model", "all") if target == "all" else (target, "all")
+        with self._lock:
+            for key in overlapping:
+                worker = self._workers.get(key)
+                if worker is not None and worker.is_alive():
+                    raise LocalModelError("An install is already running", code="busy")
+            if self._start_in_progress or self._install_in_progress:
+                raise LocalModelError(
+                    "An install or server start is already running",
+                    code="busy",
+                )
+            self._clear_cancel(target)
+            if background:
+                worker = threading.Thread(
+                    target=self._install_worker,
+                    args=(target, chosen),
+                    daemon=True,
+                )
+                self._workers[target] = worker
+                worker.start()
+                return self.snapshot()
+            self._install_in_progress = True
+        try:
+            self._install_worker(target, chosen)
+            return self.snapshot()
+        finally:
+            with self._lock:
+                self._install_in_progress = False
+
+    def _install_worker(self, target: str, model_id: str = "") -> None:
+        failed = None
+        try:
+            if target in ("runtime", "all"):
+                failed = "runtime"
+                self._install_runtime()
+                failed = None
+            if target in ("model", "all"):
+                failed = "model"
+                self._install_model(model_id)
+                failed = None
+            self._emit("ready", {"target": target})
+        except LocalModelError as exc:
+            kind = failed or ("model" if target == "model" else "runtime")
+            status = "paused" if exc.code == "cancelled" else "error"
+            if exc.code != "cancelled":
+                self._emit("error", {"target": kind, "error": str(exc), "code": exc.code})
+            else:
+                self._emit("paused", {"target": kind})
+            if kind in ("runtime", "model"):
+                self._set_component(
+                    kind,
+                    status=status,
+                    error=None if exc.code == "cancelled" else str(exc),
+                )
+        except Exception as exc:
+            kind = failed or target
+            self._emit("error", {"target": kind, "error": str(exc), "code": "error"})
+            if kind in ("runtime", "model"):
+                self._set_component(kind, status="error", error=str(exc))
+
+    def _install_runtime(self) -> None:
+        current = (self._state().get("managed") or {}).get("runtime") or {}
+        if current.get("status") == "ready" and current.get("path") and os.path.isfile(str(current["path"])):
+            return
+        if self._cancelled("runtime"):
+            raise LocalModelError("Download cancelled", code="cancelled")
+        asset = runtime_asset_for_platform(self.catalog)
+        if not asset:
+            raise LocalModelError("No runtime asset for this platform", code="unsupported")
+        self._set_component(
+            "runtime",
+            status="downloading",
+            platform=asset["platform"],
+            release=asset.get("release") or "",
+            error=None,
+        )
+        archive = self.download_asset(asset, target="runtime")
+        dest = os.path.join(self.runtime_dir(), asset.get("release") or "current")
+        self._set_component("runtime", status="extracting")
+        extract_archive(archive, dest)
+        binary = find_binary(dest, asset.get("binary") or "llama-server")
+        if not binary:
+            raise LocalModelError("llama-server was not found in the archive", code="extract")
+        self._set_component(
+            "runtime",
+            status="ready",
+            path=binary,
+            sha256=asset["sha256"],
+            error=None,
+        )
+        self._emit("runtime_ready", {"path": binary})
+
+    def _install_model(self, model_id: str = "") -> None:
+        model = curated_model(self.catalog, model_id or None)
+        if not model:
+            raise LocalModelError("Unknown catalog model", code="unknown_model")
+        current = (self._state().get("managed") or {}).get("model") or {}
+        if (
+            current.get("status") == "ready"
+            and current.get("id") == model["id"]
+            and current.get("path")
+            and os.path.isfile(str(current["path"]))
+        ):
+            return
+        if self._cancelled("model"):
+            raise LocalModelError("Download cancelled", code="cancelled")
+        self._set_component(
+            "model",
+            status="downloading",
+            id=model["id"],
+            error=None,
+        )
+        downloaded = self.download_asset(model, target="model")
+        os.makedirs(self.models_dir(), exist_ok=True)
+        dest = os.path.join(self.models_dir(), model["filename"])
+        os.replace(downloaded, dest)
+        self._set_component(
+            "model",
+            status="ready",
+            id=model["id"],
+            path=dest,
+            sha256=model["sha256"],
+            error=None,
+        )
+        self._emit("model_ready", {"path": dest, "id": model["id"]})
+
+    # -- process -----------------------------------------------------------
+
+    def _managed_paths(self) -> tuple:
+        state = self._state()
+        runtime = (state.get("managed") or {}).get("runtime") or {}
+        model = (state.get("managed") or {}).get("model") or {}
+        return str(runtime.get("path") or ""), str(model.get("path") or ""), str(model.get("id") or "")
+
+    def reconcile_process(self) -> dict:
+        """Adopt our llama-server or clear stale PID state without killing strangers."""
+        with self._lock:
+            state = self._state()
+            process = (state.get("managed") or {}).get("process")
+            if not process or not process.get("pid"):
+                return state
+            pid = int(process["pid"])
+            owned = int(pid) in self._procs
+            identity = dict(process)
+        matched = owned or process_matches_identity(pid, identity)
+        if matched:
+            identity["healthy"] = self._probe_health(
+                "http://%s:%s/v1" % (identity.get("host") or "127.0.0.1", identity.get("port")),
+                required_alias=str(identity.get("alias") or ""),
+            )
+            with self._lock:
+                state = self._state()
+                state["managed"]["process"] = identity
+                return self._save(state)
+        with self._lock:
+            state = self._state()
+            current = (state.get("managed") or {}).get("process") or {}
+            if current.get("pid") != pid:
+                return state
+            state["managed"]["process"] = None
+            self._emit("stale_pid_cleared", {"pid": pid})
+            return self._save(state)
+
+    def start(self) -> dict:
+        with self._lock:
+            if self._start_in_progress or self._install_in_progress:
+                raise LocalModelError("Server start is already running", code="busy")
+            for worker in self._workers.values():
+                if worker is not None and worker.is_alive():
+                    raise LocalModelError("An install is already running", code="busy")
+            self._start_in_progress = True
+        try:
+            return self._start_locked()
+        finally:
+            with self._lock:
+                self._start_in_progress = False
+
+    def _start_locked(self) -> dict:
+        self.reconcile_process()
+        state = self._state()
+        process = (state.get("managed") or {}).get("process")
+        pid = process.get("pid") if process else None
+        owned = bool(pid and int(pid) in self._procs)
+        matched = bool(pid and process_matches_identity(int(pid), process))
+        if process and pid and (owned or matched):
+            if process.get("healthy"):
+                return self.snapshot()
+            self.stop()
+            state = self._state()
+            process = (state.get("managed") or {}).get("process")
+        exe, model_path, model_id = self._managed_paths()
+        if not exe or not os.path.isfile(exe):
+            raise LocalModelError("Install the llama.cpp runtime before starting", code="missing_runtime")
+        if not model_path or not os.path.isfile(model_path):
+            raise LocalModelError("Install a catalog model before starting", code="missing_model")
+        host = "127.0.0.1"
+        preferred = process.get("port") if process else None
+        port = find_free_port(host, preferred)
+        nonce = "%08x" % random.SystemRandom().randint(0, 0xFFFFFFFF)
+        alias = "marionette-%s" % nonce
+        model = curated_model(self.catalog, model_id)
+        ctx = int((model or {}).get("context_length") or 8192)
+        runtime_meta = (state.get("managed") or {}).get("runtime") or {}
+        asset = runtime_asset_for_platform(
+            self.catalog, runtime_meta.get("platform") or None,
+        )
+        ngl = runtime_offload_layers(asset)
+        os.makedirs(self.logs_dir(), exist_ok=True)
+        log_path = os.path.join(self.logs_dir(), "llama-server.log")
+        log_handle = open(log_path, "ab")
+        argv = [
+            exe,
+            "-m", model_path,
+            "--host", host,
+            "--port", str(port),
+            "--jinja",
+            "-c", str(ctx),
+            "--alias", alias,
+            "-ngl", ngl,
+        ]
+        env = os.environ.copy()
+        env["MARIONETTE_LOCAL_NONCE"] = nonce
+        try:
+            proc = self.popen(
+                argv,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                env=env,
+                cwd=os.path.dirname(exe) or None,
+                **spawn_popen_kwargs(),
+            )
+        except Exception as exc:
+            log_handle.close()
+            raise LocalModelError("Failed to start llama-server: %s" % exc, code="spawn") from exc
+        identity = {
+            "pid": int(getattr(proc, "pid", 0) or 0),
+            "port": port,
+            "host": host,
+            "exe": exe,
+            "model_path": model_path,
+            "alias": alias,
+            "nonce": nonce,
+            "started_at": self.clock(),
+            "create_time": self.clock(),
+            "start_key": read_process_start_key(int(getattr(proc, "pid", 0) or 0)),
+            "healthy": False,
+            "context_length": ctx,
+        }
+        self._procs[identity["pid"]] = (proc, log_handle)
+
+        def _store_process(state: dict) -> None:
+            state["managed"]["process"] = identity
+
+        def _clear_process(state: dict) -> None:
+            state["managed"]["process"] = None
+
+        self._update_state(_store_process)
+        if not self._wait_ready(identity, proc):
+            self._release_spawn(identity["pid"], process=identity)
+            self._update_state(_clear_process)
+            raise LocalModelError("llama-server did not become ready", code="not_ready")
+        identity["healthy"] = True
+        self._update_state(_store_process)
+        self._emit("started", {"port": port, "pid": identity["pid"]})
+        return self.snapshot()
+
+    def _wait_ready(self, identity: dict, proc: Any = None) -> bool:
+        url = "http://%s:%s/v1" % (identity.get("host") or "127.0.0.1", identity.get("port"))
+        alias = str(identity.get("alias") or "")
+        deadline = self.clock() + self.ready_timeout
+        while self.clock() < deadline:
+            if proc is not None:
+                poll = getattr(proc, "poll", None)
+                if callable(poll) and poll() is not None:
+                    return False
+            if alias and self._probe_health(url, required_alias=alias):
+                return True
+            self.sleep(0.2)
+        return False
+
+    def _probe_health(self, base_url: str, required_alias: str = "") -> bool:
+        try:
+            result = self._http_json(base_url.rstrip("/") + "/models", timeout=2.0)
+            ids = extract_model_ids(result.get("payload"))
+            if required_alias:
+                return required_alias in ids
+            return bool(ids)
+        except Exception:
+            if required_alias:
+                return False
+            try:
+                parsed = urlparse(base_url)
+                health = "%s://%s/health" % (parsed.scheme, parsed.netloc)
+                result = self._http_json(health, timeout=2.0)
+                payload = result.get("payload")
+                if isinstance(payload, dict) and str(payload.get("status") or "").lower() in {"ok", "ready"}:
+                    return True
+            except Exception:
+                return False
+        return False
+
+    def _release_spawn(self, pid: int, process: Optional[dict] = None) -> None:
+        handle = self._procs.pop(int(pid), None) if pid else None
+        proc = log_handle = None
+        if handle:
+            proc, log_handle = handle
+        identity = process or {}
+        if handle:
+            try:
+                stop_process_tree(int(pid), proc, sleeper=self.sleep)
+            except Exception:
+                pass
+        elif pid and process_matches_identity(int(pid), identity):
+            try:
+                stop_process_tree(int(pid), proc, sleeper=self.sleep)
+            except Exception:
+                pass
+        elif proc is not None:
+            try:
+                poll = getattr(proc, "poll", None)
+                if callable(poll) and poll() is None:
+                    proc.kill()
+            except Exception:
+                pass
+        if log_handle is not None:
+            try:
+                log_handle.close()
+            except Exception:
+                pass
+
+    def _close_all_logs(self) -> None:
+        for pid in list(self._procs):
+            handle = self._procs.pop(pid, None)
+            if not handle:
+                continue
+            _proc, log_handle = handle
+            try:
+                log_handle.close()
+            except Exception:
+                pass
+
+    def shutdown(self) -> None:
+        """Idempotent stop of the owned process tree (atexit / harness exit)."""
+        with self._lock:
+            if self._shutdown:
+                return
+            self._shutdown = True
+            owned_pids = list(self._procs)
+            process = ((load_state(self.root).get("managed") or {}).get("process") or {})
+        if owned_pids:
+            for pid in owned_pids:
+                try:
+                    self._release_spawn(int(pid), process=process)
+                except Exception:
+                    pass
+            try:
+                def _clear_process(state: dict) -> None:
+                    state["managed"]["process"] = None
+                self._update_state(_clear_process)
+            except Exception:
+                pass
+        elif process.get("pid"):
+            try:
+                self.stop()
+            except Exception:
+                pass
+        self._close_all_logs()
+
+    def stop(self) -> dict:
+        with self._lock:
+            return self._stop_unlocked()
+
+    def _stop_unlocked(self) -> dict:
+        state = self._state()
+        process = (state.get("managed") or {}).get("process") or {}
+        pid = process.get("pid")
+        handle = self._procs.get(int(pid)) if pid else None
+        if handle:
+            proc, log_handle = handle
+            self._procs.pop(int(pid), None)
+            try:
+                stop_process_tree(int(pid), proc, sleeper=self.sleep)
+            except Exception:
+                pass
+            if log_handle is not None:
+                try:
+                    log_handle.close()
+                except Exception:
+                    pass
+        elif pid and process_matches_identity(int(pid), process):
+            try:
+                stop_process_tree(int(pid), None, sleeper=self.sleep)
+            except Exception:
+                pass
+        elif pid:
+            self._emit("stale_pid_cleared", {"pid": pid, "reason": "stop_unmatched"})
+            leftover = self._procs.pop(int(pid), None)
+            if leftover:
+                _proc, log_handle = leftover
+                try:
+                    log_handle.close()
+                except Exception:
+                    pass
+        state = self._state()
+        state["managed"]["process"] = None
+        self._save(state)
+        self._emit("stopped", {})
+        return self.snapshot()
+
+    def restart(self) -> dict:
+        self.stop()
+        return self.start()
+
+    def remove(self, target: str = "all", endpoint_id: str = "") -> dict:
+        with self._lock:
+            return self._remove_unlocked(target, endpoint_id)
+
+    def _remove_unlocked(self, target: str = "all", endpoint_id: str = "") -> dict:
+        if endpoint_id:
+            state = self._state()
+            state["externals"] = [
+                item for item in state.get("externals") or [] if item.get("id") != endpoint_id
+            ]
+            if str(state.get("active_spec") or "").startswith("local:%s/" % endpoint_id):
+                state["active_spec"] = ""
+            self._save(state)
+            try:
+                from .keys import clear_api_key
+                clear_api_key(local_secret_reach(endpoint_id))
+            except Exception:
+                pass
+            self._emit("removed", {"endpoint_id": endpoint_id})
+            return self.snapshot()
+        if target in ("runtime", "all"):
+            self.stop()
+            shutil.rmtree(self.runtime_dir(), ignore_errors=True)
+            self._set_component("runtime", status="absent", path="", sha256="", error=None)
+        if target in ("model", "all"):
+            shutil.rmtree(self.models_dir(), ignore_errors=True)
+            self._set_component("model", status="absent", path="", sha256="", error=None)
+        if target == "all":
+            shutil.rmtree(self.downloads_dir(), ignore_errors=True)
+            state = self._state()
+            state["managed"]["downloads"] = {}
+            if str(state.get("active_spec") or "").startswith("local:%s/" % MANAGED_ENDPOINT_ID):
+                state["active_spec"] = ""
+            self._save(state)
+        self._emit("removed", {"target": target})
+        return self.snapshot()
+
+    # -- external endpoints ------------------------------------------------
+
+    def _http_json(
+        self,
+        url: str,
+        *,
+        method: str = "GET",
+        headers: Optional[dict] = None,
+        body: Optional[bytes] = None,
+        timeout: float = 8.0,
+        api_key: str = "",
+        accept_lan: bool = False,
+        accept_remote: bool = False,
+        pinned_ip: Optional[str] = None,
+    ) -> dict:
+        req_headers = {"Accept": "application/json", "User-Agent": "marionette-local-models"}
+        if api_key:
+            req_headers["Authorization"] = "Bearer %s" % api_key
+        if body is not None:
+            req_headers.setdefault("Content-Type", "application/json")
+        if headers:
+            req_headers.update(headers)
+        if self.probe_transport is not None:
+            result = self.probe_transport(
+                url, method=method, headers=req_headers, body=body, timeout=timeout,
+            )
+            if not isinstance(result, dict):
+                raise LocalModelError("Endpoint probe failed", code="probe")
+            status = int(result.get("status") or 200)
+            if status in {401, 403}:
+                raise LocalModelError(
+                    "This endpoint rejected the API key (HTTP %s)." % status,
+                    code="auth",
+                    http_status=status,
+                )
+            if status >= 400 and status not in {404, 405}:
+                raise LocalModelError(
+                    "Endpoint returned HTTP %s" % status,
+                    code="probe",
+                    http_status=status,
+                )
+            return result
+        req = urllib.request.Request(url, data=body, headers=req_headers, method=method)
+        try:
+            with probe_urlopen(
+                req,
+                timeout=timeout,
+                accept_lan=accept_lan,
+                accept_remote=accept_remote,
+                pinned_ip=pinned_ip,
+            ) as resp:
+                raw = read_bounded(resp, PROBE_MAX_BYTES)
+                header_map = dict(getattr(resp, "headers", {}) or {})
+                payload = json.loads(raw.decode("utf-8", "replace") or "null")
+                return {"payload": payload, "headers": header_map, "status": getattr(resp, "status", 200)}
+        except urllib.error.HTTPError as exc:
+            try:
+                exc.read(PROBE_MAX_BYTES)
+            except Exception:
+                pass
+            status = int(exc.code)
+            if status in {401, 403}:
+                raise LocalModelError(
+                    "This endpoint rejected the API key (HTTP %s)." % status,
+                    code="auth",
+                    http_status=status,
+                ) from exc
+            raise LocalModelError(
+                "Endpoint returned HTTP %s" % status,
+                code="probe",
+                http_status=status,
+            ) from exc
+        except LocalModelError:
+            raise
+        except Exception:
+            raise LocalModelError("Endpoint probe failed", code="probe") from None
+
+    def probe(
+        self,
+        url: str,
+        *,
+        api_key: str = "",
+        accept_lan: bool = False,
+        accept_remote: bool = False,
+    ) -> dict:
+        decision = assert_probe_hop_safe(
+            url, accept_lan=accept_lan, accept_remote=accept_remote,
+        )
+        base = decision["normalized"]
+        pin = str(decision.get("pinned_ip") or "")
+        models_url = base.rstrip("/") + "/models"
+        models = []
+        context = None
+        headers = {}
+        payload = None
+        try:
+            result = self._http_json(
+                models_url,
+                api_key=api_key,
+                accept_lan=accept_lan,
+                accept_remote=accept_remote,
+                pinned_ip=pin,
+            )
+            status = int(result.get("status") or 200)
+            if status in {401, 403}:
+                raise LocalModelError(
+                    "This endpoint rejected the API key (HTTP %s)." % status,
+                    code="auth",
+                    http_status=status,
+                )
+            if status in {404, 405}:
+                payload = None
+            else:
+                payload = result.get("payload")
+                headers = result.get("headers") or {}
+                models = extract_model_ids(payload)
+                context = extract_context_length(payload)
+        except LocalModelError as exc:
+            if exc.code == "auth" or exc.http_status in {401, 403}:
+                if exc.code != "auth":
+                    raise LocalModelError(
+                        "This endpoint rejected the API key (HTTP %s)." % exc.http_status,
+                        code="auth",
+                        http_status=exc.http_status,
+                    ) from exc
+                raise
+            if exc.http_status not in {404, 405}:
+                raise
+        vendor = detect_vendor_from_probe(base, headers, payload)
+        if vendor == "openai-compatible":
+            vendor = detect_vendor_from_url(base)
+        if context is None:
+            try:
+                parsed = urlparse(base)
+                props = self._http_json(
+                    "%s://%s/props" % (parsed.scheme, parsed.netloc),
+                    api_key=api_key,
+                    accept_lan=accept_lan,
+                    accept_remote=accept_remote,
+                    pinned_ip=pin,
+                )
+                context = extract_context_length(props.get("payload"))
+            except Exception:
+                context = None
+        return redact_mapping({
+            "ok": True,
+            "url": base,
+            "vendor": vendor,
+            "kind": decision.get("kind"),
+            "models": models,
+            "context_length": context,
+            "requires_lan": bool(decision.get("requires_lan")),
+            "requires_remote": bool(decision.get("requires_remote")),
+        })
+
+    def save_external(
+        self,
+        url: str,
+        *,
+        api_key: str = "",
+        accept_lan: bool = False,
+        accept_remote: bool = False,
+        model: str = "",
+        name: str = "",
+        context_length: Optional[int] = None,
+    ) -> dict:
+        probed = self.probe(
+            url, api_key=api_key, accept_lan=accept_lan, accept_remote=accept_remote,
+        )
+        base = probed["url"]
+        endpoint_id = endpoint_id_for_url(base, probed.get("vendor") or "")
+        selected = str(model or "").strip() or ((probed.get("models") or [""])[0])
+        if not selected:
+            raise LocalModelError(
+                "Enter a model id; this endpoint did not list models",
+                code="no_models",
+            )
+        reach = local_secret_reach(endpoint_id)
+        stored_has_key = False
+        try:
+            from .keys import get_api_key_status
+            stored_has_key = bool(get_api_key_status(reach).get("has_key"))
+        except Exception:
+            stored_has_key = False
+        if api_key.strip():
+            try:
+                from .keys import set_api_key
+                set_api_key(reach, api_key.strip())
+            except Exception as exc:
+                raise LocalModelError("Could not persist the endpoint key", code="secret") from exc
+            has_key = True
+        else:
+            has_key = stored_has_key
+        kind = str(probed.get("kind") or "")
+        if not kind:
+            try:
+                kind = str(evaluate_endpoint_url(
+                    base, accept_lan=accept_lan, accept_remote=accept_remote,
+                ).get("kind") or "")
+            except Exception:
+                kind = ""
+        requires_key = kind == "public"
+        record = {
+            "id": endpoint_id,
+            "name": name or endpoint_id,
+            "vendor": probed.get("vendor") or "openai-compatible",
+            "base_url": base,
+            "models": probed.get("models") or [selected],
+            "selected_model": selected,
+            "context_length": context_length or probed.get("context_length"),
+            "has_key": has_key,
+            "lan_accepted": bool(accept_lan),
+            "remote_accepted": bool(accept_remote),
+            "kind": kind,
+            "requires_key": requires_key,
+            "last_error": None,
+            "healthy": True,
+            "tool_calling": empty_tool_calling(),
+        }
+        with self._lock:
+            state = self._state()
+            others = [item for item in state.get("externals") or [] if item.get("id") != endpoint_id]
+            if not has_key:
+                for item in state.get("externals") or []:
+                    if item.get("id") == endpoint_id and item.get("has_key"):
+                        record["has_key"] = True
+                        break
+            others.append(record)
+            state["externals"] = others
+            self._save(state)
+        self._emit("external_saved", {"id": endpoint_id, "model": selected})
+        return self.snapshot()
+
+    def activate(self, spec: str) -> dict:
+        parsed = parse_local_spec(spec)
+        if not parsed:
+            raise LocalModelError("Spec must look like local:<endpoint>/<model>", code="spec")
+        endpoint_id, model = parsed
+        state = self.reconcile_process()
+        if endpoint_id == MANAGED_ENDPOINT_ID:
+            if not ((state.get("managed") or {}).get("process") or {}).get("healthy"):
+                self.start()
+                state = self._state()
+            model_id = ((state.get("managed") or {}).get("model") or {}).get("id") or model
+            spec = canonical_spec(MANAGED_ENDPOINT_ID, model_id)
+        else:
+            found = None
+            for item in state.get("externals") or []:
+                if item.get("id") == endpoint_id:
+                    found = item
+                    break
+            if not found:
+                raise LocalModelError("Unknown external endpoint", code="unknown_endpoint")
+            if not found.get("healthy"):
+                raise LocalModelError("External endpoint is not healthy", code="unhealthy")
+            found["selected_model"] = model or found.get("selected_model")
+            spec = canonical_spec(endpoint_id, found["selected_model"])
+        with self._lock:
+            state = self._state()
+            if endpoint_id != MANAGED_ENDPOINT_ID:
+                for item in state.get("externals") or []:
+                    if item.get("id") == endpoint_id:
+                        item["selected_model"] = found["selected_model"]
+            state["active_spec"] = spec
+            self._save(state)
+        try:
+            from . import model_visibility as visibility
+            curated = visibility.get_enabled()
+            if curated:
+                visibility.toggle(spec, True)
+        except Exception:
+            pass
+        self._emit("activated", {"spec": spec})
+        return self.snapshot()
+
+    def resolve_spec(self, spec: str) -> Optional[dict]:
+        return resolve_local_endpoint(self.reconcile_process(), spec)
+
+    def usable_specs(self) -> list:
+        return usable_local_specs(self.reconcile_process(), self.catalog)
+
+    def _resolve_saved_api_key(self, record: dict) -> str:
+        """Stored secret for *record*. Never returned into state or events.
+
+        Public ``requires_key`` endpoints fail closed with no key. Keyless
+        loopback / trusted LAN use the same synthetic bearer as the driver.
+        """
+        reach = local_secret_reach(str(record.get("id") or ""))
+        key = ""
+        try:
+            from .keys import get_env_var_for_reach, hydrate_reach_key
+            hydrate_reach_key(reach)
+            env_name = get_env_var_for_reach(reach)
+            if env_name:
+                key = str(os.environ.get(env_name) or "").strip()
+        except Exception:
+            key = ""
+        if key:
+            return key
+        if record.get("requires_key"):
+            raise LocalModelError(
+                "This public endpoint requires an API key.",
+                code="requires_key",
+            )
+        return "local"
+
+    def _record_tool_calling(self, endpoint_id: str, status: str, reason: str) -> dict:
+        result = {
+            "status": status,
+            "reason": bound_plain_reason(reason),
+            "checked_at": self.clock(),
+        }
+
+        def _store(state: dict) -> None:
+            for item in state.get("externals") or []:
+                if item.get("id") == endpoint_id:
+                    item["tool_calling"] = result
+
+        self._update_state(_store)
+        self._emit("tool_calling_checked", {
+            "id": endpoint_id,
+            "status": result["status"],
+            "reason": result["reason"],
+        })
+        return self.snapshot()
+
+    def verify_tool_calling(self, spec: str) -> dict:
+        """Explicit capability check. Does not run during Probe or Save."""
+        parsed = parse_local_spec(spec)
+        if not parsed:
+            raise LocalModelError("Spec must look like local:<endpoint>/<model>", code="spec")
+        endpoint_id, model = parsed
+        if endpoint_id == MANAGED_ENDPOINT_ID:
+            raise LocalModelError(
+                "Tool-calling checks apply to saved external endpoints.",
+                code="managed",
+            )
+        state = self.reconcile_process()
+        found = None
+        for item in state.get("externals") or []:
+            if item.get("id") == endpoint_id:
+                found = item
+                break
+        if not found:
+            raise LocalModelError("Unknown external endpoint", code="unknown_endpoint")
+        if not found.get("healthy"):
+            raise LocalModelError("External endpoint is not healthy", code="unhealthy")
+        selected = str(model or found.get("selected_model") or "").strip()
+        if not selected:
+            raise LocalModelError(
+                "Enter a model id; this endpoint did not list models",
+                code="no_models",
+            )
+        base = str(found.get("base_url") or "").rstrip("/")
+        if not base:
+            raise LocalModelError("Unknown external endpoint", code="unknown_endpoint")
+        accept_lan = bool(found.get("lan_accepted"))
+        accept_remote = bool(found.get("remote_accepted"))
+        try:
+            api_key = self._resolve_saved_api_key(found)
+        except LocalModelError as exc:
+            return self._record_tool_calling(
+                endpoint_id, "error", tool_calling_error_reason(exc),
+            )
+        try:
+            decision = assert_probe_hop_safe(
+                base, accept_lan=accept_lan, accept_remote=accept_remote,
+            )
+            pin = str(decision.get("pinned_ip") or "")
+            result = self._http_json(
+                base + "/chat/completions",
+                method="POST",
+                headers={"Content-Type": "application/json"},
+                body=json.dumps(tool_calling_request_body(selected)).encode("utf-8"),
+                timeout=20.0,
+                api_key=api_key,
+                accept_lan=accept_lan,
+                accept_remote=accept_remote,
+                pinned_ip=pin,
+            )
+            http_status = int(result.get("status") or 200)
+            if http_status in {401, 403}:
+                raise LocalModelError(
+                    "This endpoint rejected the API key (HTTP %s)." % http_status,
+                    code="auth",
+                    http_status=http_status,
+                )
+            if http_status >= 400:
+                raise LocalModelError(
+                    "Endpoint returned HTTP %s" % http_status,
+                    code="probe",
+                    http_status=http_status,
+                )
+            status, reason = classify_tool_calling_payload(result.get("payload"))
+        except LocalModelError as exc:
+            status, reason = "error", tool_calling_error_reason(exc)
+        except Exception:
+            status, reason = "error", "The endpoint could not be reached."
+        if api_key and api_key != "local" and api_key in reason:
+            reason = reason.replace(api_key, "••••")
+        return self._record_tool_calling(endpoint_id, status, reason)
+
+
+_MANAGER = None
+_MANAGER_LOCK = threading.Lock()
+_ATEXIT_REGISTERED = False
+
+
+def _atexit_shutdown() -> None:
+    mgr = _MANAGER
+    if mgr is not None:
+        try:
+            mgr.shutdown()
+        except Exception:
+            pass
+
+
+def get_manager() -> LocalModelManager:
+    global _MANAGER, _ATEXIT_REGISTERED
+    root = state_root()
+    with _MANAGER_LOCK:
+        if _MANAGER is None or os.path.normcase(_MANAGER.root) != os.path.normcase(root):
+            if _MANAGER is not None:
+                try:
+                    _MANAGER.shutdown()
+                except Exception:
+                    pass
+            _MANAGER = LocalModelManager(root=root)
+            if not _ATEXIT_REGISTERED:
+                atexit.register(_atexit_shutdown)
+                _ATEXIT_REGISTERED = True
+        return _MANAGER
+
+
+def reset_manager_for_tests() -> None:
+    global _MANAGER
+    with _MANAGER_LOCK:
+        if _MANAGER is not None:
+            try:
+                _MANAGER.shutdown()
+            except Exception:
+                pass
+        _MANAGER = None
+
+
+def local_provider_available() -> bool:
+    try:
+        return bool(get_manager().usable_specs())
+    except Exception:
+        return False

--- a/harness/local_models.py
+++ b/harness/local_models.py
@@ -1,0 +1,1236 @@
+"""Local-inference domain: catalog, platform, hardware, endpoints, durable state.
+
+Stdlib-only, Python 3.9, JSON only. The manager is the sole writer; this module
+parses and serializes tagged shapes. Generated files live under
+``HARNESS_STATE_DIR`` / ``~/.pmharness/local-models``, never the repo.
+"""
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import os
+import platform
+import re
+import shutil
+import threading
+from typing import Any, Optional
+from urllib.parse import urlparse, urlunparse
+
+from .url_safety import METADATA_HOSTS, METADATA_IPS, sanitize_url_for_display
+
+STATE_VERSION = 1
+MANAGED_ENDPOINT_ID = "managed"
+LOCAL_PROVIDER = "local"
+LOCAL_KEY_ENV = "LOCAL_MODEL_API_KEY"
+LLAMA_CPP_KEY_ENV = "LLAMA_CPP_API_KEY"
+CATALOG_FILENAME = "local_models_catalog.json"
+STATE_FILENAME = "state.json"
+
+COMMAND_TYPES = (
+    "probe",
+    "save_external",
+    "install",
+    "cancel",
+    "start",
+    "stop",
+    "restart",
+    "remove",
+    "activate",
+    "verify_tool_calling",
+)
+TOOL_CALLING_STATUSES = (
+    "unverified",
+    "verified",
+    "unsupported",
+    "error",
+)
+TOOL_CALLING_FUNCTION_NAME = "marionette_capability_probe"
+TOOL_CALLING_REASON_LIMIT = 240
+INSTALL_TARGETS = ("runtime", "model", "all")
+REMOVE_TARGETS = ("model", "runtime", "all")
+VENDORS = (
+    "llama.cpp",
+    "ollama",
+    "lmstudio",
+    "omlx",
+    "vllm",
+    "openai-compatible",
+)
+LOOPBACK_NAMES = {"localhost", "ip6-localhost", "ip6-loopback"}
+_SENSITIVE_KEY_RE = re.compile(
+    r"(api[_-]?key|authorization|token|secret|password|passwd)",
+    re.IGNORECASE,
+)
+def state_root() -> str:
+    """Directory for runtime, models, logs, and state.json."""
+    explicit = os.environ.get("HARNESS_STATE_DIR")
+    if explicit:
+        base = explicit
+    else:
+        base = os.path.join(os.path.expanduser("~"), ".pmharness")
+    root = os.path.join(base, "local-models")
+    os.makedirs(root, exist_ok=True)
+    return root
+
+
+def state_path(root: Optional[str] = None) -> str:
+    return os.path.join(root or state_root(), STATE_FILENAME)
+
+
+def catalog_path() -> str:
+    return os.path.join(os.path.dirname(__file__), "data", CATALOG_FILENAME)
+
+
+def empty_state() -> dict:
+    return {
+        "version": STATE_VERSION,
+        "managed": {
+            "runtime": {
+                "status": "absent",
+                "platform": "",
+                "release": "",
+                "path": "",
+                "sha256": "",
+                "error": None,
+            },
+            "model": {
+                "status": "absent",
+                "id": "",
+                "path": "",
+                "sha256": "",
+                "error": None,
+            },
+            "process": None,
+            "downloads": {},
+        },
+        "externals": [],
+        "active_spec": "",
+        "event_cursor": 0,
+    }
+
+
+def _atomic_write_json(path: str, payload: dict) -> None:
+    parent = os.path.dirname(path)
+    os.makedirs(parent, exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def load_state(root: Optional[str] = None) -> dict:
+    path = state_path(root)
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            data = json.load(handle)
+        if isinstance(data, dict):
+            return migrate_state(data)
+    except FileNotFoundError:
+        pass
+    except Exception:
+        pass
+    return empty_state()
+
+
+def save_state(data: dict, root: Optional[str] = None) -> dict:
+    normalized = migrate_state(data)
+    _atomic_write_json(state_path(root), normalized)
+    return normalized
+
+
+def migrate_state(raw: Any) -> dict:
+    """Accept older or partial documents and return a v1 state dict."""
+    base = empty_state()
+    if not isinstance(raw, dict):
+        return base
+    version = raw.get("version")
+    try:
+        version = int(version)
+    except (TypeError, ValueError):
+        version = 0
+    if version > STATE_VERSION:
+        # Forward-unknown: keep what we understand, do not invent fields.
+        version = STATE_VERSION
+    managed = raw.get("managed") if isinstance(raw.get("managed"), dict) else {}
+    runtime = managed.get("runtime") if isinstance(managed.get("runtime"), dict) else {}
+    model = managed.get("model") if isinstance(managed.get("model"), dict) else {}
+    downloads = managed.get("downloads") if isinstance(managed.get("downloads"), dict) else {}
+    process = managed.get("process") if isinstance(managed.get("process"), dict) else None
+    externals = []
+    for item in raw.get("externals") or []:
+        if isinstance(item, dict) and str(item.get("id") or "").strip():
+            externals.append(_normalize_external(item))
+    cursor = raw.get("event_cursor")
+    try:
+        cursor = int(cursor or 0)
+    except (TypeError, ValueError):
+        cursor = 0
+    base["managed"]["runtime"].update({
+        "status": str(runtime.get("status") or "absent"),
+        "platform": str(runtime.get("platform") or ""),
+        "release": str(runtime.get("release") or ""),
+        "path": str(runtime.get("path") or ""),
+        "sha256": str(runtime.get("sha256") or ""),
+        "error": runtime.get("error"),
+    })
+    base["managed"]["model"].update({
+        "status": str(model.get("status") or "absent"),
+        "id": str(model.get("id") or ""),
+        "path": str(model.get("path") or ""),
+        "sha256": str(model.get("sha256") or ""),
+        "error": model.get("error"),
+    })
+    base["managed"]["downloads"] = {
+        key: value for key, value in downloads.items() if isinstance(value, dict)
+    }
+    base["managed"]["process"] = _normalize_process(process) if process else None
+    base["externals"] = externals
+    base["active_spec"] = str(raw.get("active_spec") or "")
+    base["event_cursor"] = max(0, cursor)
+    return base
+
+
+def _normalize_process(raw: dict) -> dict:
+    return {
+        "pid": int(raw["pid"]) if _is_intlike(raw.get("pid")) else None,
+        "port": int(raw["port"]) if _is_intlike(raw.get("port")) else None,
+        "host": str(raw.get("host") or "127.0.0.1"),
+        "exe": str(raw.get("exe") or ""),
+        "model_path": str(raw.get("model_path") or ""),
+        "alias": str(raw.get("alias") or ""),
+        "nonce": str(raw.get("nonce") or ""),
+        "started_at": raw.get("started_at"),
+        "create_time": raw.get("create_time"),
+        "start_key": str(raw.get("start_key") or ""),
+        "healthy": bool(raw.get("healthy")),
+        "context_length": int(raw["context_length"]) if _is_intlike(raw.get("context_length")) else None,
+    }
+
+
+def _normalize_external(raw: dict) -> dict:
+    models = []
+    for item in raw.get("models") or []:
+        text = str(item or "").strip()
+        if text and text not in models:
+            models.append(text)
+    return {
+        "id": str(raw.get("id") or "").strip(),
+        "name": str(raw.get("name") or raw.get("id") or "").strip(),
+        "vendor": normalize_vendor(raw.get("vendor")),
+        "base_url": str(raw.get("base_url") or "").rstrip("/"),
+        "models": models,
+        "selected_model": str(raw.get("selected_model") or (models[0] if models else "")),
+        "context_length": int(raw["context_length"]) if _is_intlike(raw.get("context_length")) else None,
+        "has_key": bool(raw.get("has_key")),
+        "lan_accepted": bool(raw.get("lan_accepted")),
+        "remote_accepted": bool(raw.get("remote_accepted")),
+        "kind": _external_kind(raw),
+        "requires_key": _external_requires_key(raw),
+        "last_error": raw.get("last_error"),
+        "healthy": bool(raw.get("healthy")),
+        "tool_calling": normalize_tool_calling(raw.get("tool_calling")),
+    }
+
+
+def empty_tool_calling() -> dict:
+    return {"status": "unverified", "reason": "", "checked_at": None}
+
+
+def bound_plain_reason(value: Any, limit: int = TOOL_CALLING_REASON_LIMIT) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) > limit:
+        return text[: max(1, limit - 3)].rstrip() + "..."
+    return text
+
+
+def normalize_tool_calling(raw: Any) -> dict:
+    base = empty_tool_calling()
+    if not isinstance(raw, dict):
+        return base
+    status = str(raw.get("status") or "").strip().lower()
+    if status not in TOOL_CALLING_STATUSES:
+        status = "unverified"
+    checked = raw.get("checked_at")
+    if checked is not None:
+        try:
+            checked = float(checked)
+        except (TypeError, ValueError):
+            checked = None
+    return {
+        "status": status,
+        "reason": bound_plain_reason(raw.get("reason") or ""),
+        "checked_at": checked,
+    }
+
+
+def tool_calling_request_body(model: str) -> dict:
+    """One bounded, non-streaming chat.completions probe. Never executed."""
+    return {
+        "model": str(model or "").strip(),
+        "stream": False,
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": (
+                "Call the function %s with ok set to true. "
+                "Do not reply with ordinary text."
+                % TOOL_CALLING_FUNCTION_NAME
+            ),
+        }],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": TOOL_CALLING_FUNCTION_NAME,
+                "description": "Report that this model can emit a tool call.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"ok": {"type": "boolean"}},
+                    "required": ["ok"],
+                },
+            },
+        }],
+        "tool_choice": {
+            "type": "function",
+            "function": {"name": TOOL_CALLING_FUNCTION_NAME},
+        },
+    }
+
+
+def classify_tool_calling_payload(payload: Any) -> tuple:
+    """Map a chat.completions body to verified | unsupported | error.
+
+    Reads ``choices[0].message.tool_calls`` only. ``verified`` requires the
+    exact requested ``TOOL_CALLING_FUNCTION_NAME``. Never executes a function
+    and does not infer vision, streaming, context, or swarm-worker eligibility.
+    """
+    if not isinstance(payload, dict):
+        return "error", "The endpoint returned a malformed completion payload."
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return "error", "The endpoint returned a completion without choices."
+    first = choices[0]
+    if not isinstance(first, dict):
+        return "error", "The endpoint returned a malformed completion payload."
+    message = first.get("message")
+    if not isinstance(message, dict):
+        return "error", "The endpoint returned a malformed completion payload."
+    raw_calls = message.get("tool_calls")
+    if raw_calls is not None:
+        if not isinstance(raw_calls, list):
+            return "error", "The endpoint returned malformed tool_calls."
+        names = []
+        for item in raw_calls:
+            if not isinstance(item, dict):
+                return "error", "The endpoint returned malformed tool_calls."
+            fn = item.get("function")
+            if not isinstance(fn, dict):
+                return "error", "The endpoint returned malformed tool_calls."
+            name = str(fn.get("name") or "").strip()
+            if not name:
+                return "error", "The endpoint returned malformed tool_calls."
+            names.append(name)
+        if names:
+            if TOOL_CALLING_FUNCTION_NAME in names:
+                return "verified", "This model returned a tool call."
+            return "unsupported", "This model returned a different function than requested."
+    content = message.get("content")
+    if isinstance(content, str) and content.strip():
+        return "unsupported", "This model replied with text instead of a tool call."
+    if isinstance(content, list) and content:
+        return "unsupported", "This model replied with text instead of a tool call."
+    return "error", "The endpoint returned a completion without tool_calls."
+
+
+def tool_calling_error_reason(exc: BaseException) -> str:
+    code = str(getattr(exc, "code", "") or "")
+    http_status = getattr(exc, "http_status", None)
+    try:
+        http_status = int(http_status) if http_status is not None else None
+    except (TypeError, ValueError):
+        http_status = None
+    if code == "requires_key":
+        return "This public endpoint requires an API key."
+    if code == "auth" or http_status in {401, 403}:
+        return "The endpoint rejected the API key."
+    if code in {"url", "public", "lan", "link_local", "metadata", "blocked", "scheme", "invalid"}:
+        return bound_plain_reason(str(exc))
+    message = str(exc or "")
+    if "malformed" in message.lower():
+        return "The endpoint returned a malformed completion payload."
+    if http_status in {404, 405}:
+        return "The endpoint has no chat completions route."
+    if http_status is not None and http_status >= 400:
+        return "The endpoint returned HTTP %s." % http_status
+    return "The endpoint could not be reached."
+
+
+def _is_intlike(value: Any) -> bool:
+    try:
+        int(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def _kind_from_host(host: str) -> str:
+    folded = (host or "").lower().rstrip(".")
+    kind = _ip_kind(folded)
+    if kind == "name":
+        if folded.endswith(".local") or folded.endswith(".lan"):
+            return "lan"
+        if folded in LOOPBACK_NAMES:
+            return "loopback"
+        return "public"
+    return kind
+
+
+def _external_kind(raw: dict) -> str:
+    stored = str(raw.get("kind") or "").strip().lower()
+    if stored in {"loopback", "lan", "link_local", "public"}:
+        return stored
+    try:
+        host = (urlparse(str(raw.get("base_url") or "")).hostname or "")
+    except ValueError:
+        host = ""
+    kind = _kind_from_host(host)
+    if kind in {"blocked", "metadata", "name", "empty"}:
+        return "public"
+    return kind
+
+
+def _external_requires_key(raw: dict) -> bool:
+    if "requires_key" in raw:
+        return bool(raw.get("requires_key"))
+    return _external_kind(raw) == "public"
+
+
+def load_catalog(path: Optional[str] = None) -> dict:
+    catalog_file = path or catalog_path()
+    with open(catalog_file, encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("local models catalog must be an object")
+    return parse_catalog(data)
+
+
+def parse_catalog(raw: dict) -> dict:
+    runtime = raw.get("runtime") if isinstance(raw.get("runtime"), dict) else {}
+    assets = {}
+    raw_assets = runtime.get("assets") if isinstance(runtime.get("assets"), dict) else {}
+    for key, item in raw_assets.items():
+        if not isinstance(item, dict):
+            continue
+        sha = str(item.get("sha256") or "").strip().lower()
+        if len(sha) != 64 or any(ch not in "0123456789abcdef" for ch in sha):
+            raise ValueError("catalog asset %s is missing a SHA-256 digest" % key)
+        assets[str(key)] = {
+            "filename": str(item.get("filename") or ""),
+            "url": str(item.get("url") or ""),
+            "sha256": sha,
+            "size": int(item.get("size") or 0),
+            "archive": str(item.get("archive") or "tar.gz"),
+            "backend": infer_runtime_backend(str(key), item),
+        }
+    models = []
+    for item in raw.get("models") or []:
+        if not isinstance(item, dict):
+            continue
+        sha = str(item.get("sha256") or "").strip().lower()
+        if len(sha) != 64:
+            raise ValueError("catalog model %s is missing a SHA-256 digest" % item.get("id"))
+        models.append({
+            "id": str(item.get("id") or "").strip(),
+            "name": str(item.get("name") or item.get("id") or "").strip(),
+            "quant": str(item.get("quant") or ""),
+            "filename": str(item.get("filename") or ""),
+            "url": str(item.get("url") or ""),
+            "revision": str(item.get("revision") or ""),
+            "sha256": sha,
+            "size": int(item.get("size") or 0),
+            "context_length": int(item.get("context_length") or 0),
+            "min_ram_gb": float(item.get("min_ram_gb") or 0),
+            "min_disk_bytes": int(item.get("min_disk_bytes") or 0),
+            "source": str(item.get("source") or ""),
+            "trust": str(item.get("trust") or ""),
+            "notes": str(item.get("notes") or ""),
+        })
+    return {
+        "version": int(raw.get("version") or 1),
+        "runtime": {
+            "id": str(runtime.get("id") or "llama.cpp"),
+            "vendor": str(runtime.get("vendor") or "ggml-org"),
+            "release": str(runtime.get("release") or ""),
+            "commit": str(runtime.get("commit") or ""),
+            "binary": str(runtime.get("binary") or "llama-server"),
+            "assets": assets,
+        },
+        "models": models,
+    }
+
+
+def infer_runtime_backend(platform_key: str, item: Optional[dict] = None) -> str:
+    """Catalog runtime backend: cpu / metal / cuda / vulkan."""
+    raw = str((item or {}).get("backend") or "").strip().lower()
+    if raw in {"cpu", "metal", "cuda", "vulkan"}:
+        return raw
+    filename = str((item or {}).get("filename") or "").lower()
+    key = str(platform_key or "").lower()
+    blob = " ".join((key, filename))
+    if "cuda" in blob or "cu12" in blob or "cu11" in blob:
+        return "cuda"
+    if "vulkan" in blob:
+        return "vulkan"
+    if "metal" in blob or key.startswith("macos-"):
+        return "metal"
+    return "cpu"
+
+
+def runtime_offload_layers(asset: Optional[dict]) -> str:
+    """llama-server -ngl value for a catalog runtime asset. CPU assets stay 0."""
+    backend = str((asset or {}).get("backend") or "cpu").strip().lower()
+    if backend in {"metal", "cuda", "vulkan"}:
+        return "99"
+    return "0"
+
+
+def detect_linux_libc(
+    *,
+    confstr: Optional[Any] = None,
+    maps_text: Optional[str] = None,
+    lib_names: Optional[list] = None,
+) -> str:
+    """Return glibc, musl, or unknown. Fail closed when glibc is not proven."""
+    getter = confstr if confstr is not None else getattr(os, "confstr", None)
+    if callable(getter):
+        try:
+            value = getter("CS_GNU_LIBC_VERSION")
+            if value:
+                return "glibc"
+        except (ValueError, OSError, AttributeError):
+            pass
+    text = maps_text
+    if text is None:
+        try:
+            with open("/proc/self/maps", encoding="utf-8", errors="replace") as handle:
+                text = handle.read()
+        except Exception:
+            text = ""
+    blob = str(text or "").lower()
+    if "ld-musl" in blob or "musl" in blob:
+        return "musl"
+    names = lib_names
+    if names is None:
+        names = []
+        for folder in ("/lib", "/lib64", "/usr/lib"):
+            try:
+                names.extend(os.listdir(folder))
+            except Exception:
+                pass
+    for name in names:
+        lower = str(name).lower()
+        if lower.startswith("ld-musl") or "musl" in lower:
+            return "musl"
+        if lower.startswith("ld-linux") or lower.startswith("libc-") or lower == "libc.so.6":
+            return "glibc"
+    return "unknown"
+
+
+def detect_platform_key(
+    system: Optional[str] = None,
+    machine: Optional[str] = None,
+    libc: Optional[str] = None,
+) -> str:
+    sys_name = (system or platform.system()).lower()
+    arch = (machine or platform.machine()).lower()
+    if arch in {"amd64", "x86_64", "x64"}:
+        arch = "x64"
+    elif arch in {"arm64", "aarch64"}:
+        arch = "arm64"
+    if sys_name == "darwin":
+        return "macos-%s" % arch
+    if sys_name.startswith("linux"):
+        resolved_libc = libc
+        if resolved_libc is None and system is None:
+            resolved_libc = detect_linux_libc()
+        if resolved_libc and resolved_libc != "glibc":
+            return "linux-%s-%s" % (arch, resolved_libc)
+        return "linux-%s" % arch
+    if sys_name.startswith("win"):
+        return "windows-%s" % arch
+    return "%s-%s" % (sys_name, arch)
+
+
+def runtime_asset_for_platform(catalog: dict, platform_key: Optional[str] = None) -> Optional[dict]:
+    key = platform_key or detect_platform_key()
+    assets = (catalog.get("runtime") or {}).get("assets") or {}
+    asset = assets.get(key)
+    if not asset:
+        return None
+    out = dict(asset)
+    out["platform"] = key
+    out["release"] = (catalog.get("runtime") or {}).get("release") or ""
+    out["binary"] = (catalog.get("runtime") or {}).get("binary") or "llama-server"
+    return out
+
+
+def curated_model(catalog: dict, model_id: Optional[str] = None) -> Optional[dict]:
+    models = catalog.get("models") or []
+    if model_id:
+        for item in models:
+            if item.get("id") == model_id:
+                return item
+        return None
+    return models[0] if models else None
+
+
+def _sysctl_int(name: str) -> Optional[int]:
+    try:
+        import subprocess
+        proc = subprocess.run(
+            ["sysctl", "-n", name],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if proc.returncode == 0:
+            return int((proc.stdout or "").strip())
+    except Exception:
+        return None
+    return None
+
+
+def detect_ram_bytes() -> Optional[int]:
+    if os.name == "posix" and platform.system() == "Darwin":
+        value = _sysctl_int("hw.memsize")
+        if value:
+            return value
+    if os.path.exists("/proc/meminfo"):
+        try:
+            with open("/proc/meminfo", encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    if line.startswith("MemTotal:"):
+                        parts = line.split()
+                        return int(parts[1]) * 1024
+        except Exception:
+            pass
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            class _MemStatus(ctypes.Structure):
+                _fields_ = [
+                    ("dwLength", ctypes.c_ulong),
+                    ("dwMemoryLoad", ctypes.c_ulong),
+                    ("ullTotalPhys", ctypes.c_ulonglong),
+                    ("ullAvailPhys", ctypes.c_ulonglong),
+                    ("ullTotalPageFile", ctypes.c_ulonglong),
+                    ("ullAvailPageFile", ctypes.c_ulonglong),
+                    ("ullTotalVirtual", ctypes.c_ulonglong),
+                    ("ullAvailVirtual", ctypes.c_ulonglong),
+                    ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+                ]
+
+            status = _MemStatus()
+            status.dwLength = ctypes.sizeof(_MemStatus)
+            if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):
+                return int(status.ullTotalPhys)
+        except Exception:
+            pass
+    return None
+
+
+def detect_accelerator() -> str:
+    sys_name = platform.system().lower()
+    arch = platform.machine().lower()
+    if sys_name == "darwin" and arch in {"arm64", "aarch64"}:
+        return "metal"
+    nvidia = shutil.which("nvidia-smi")
+    if nvidia:
+        return "cuda"
+    return "cpu"
+
+
+def detect_hardware(root: Optional[str] = None, catalog: Optional[dict] = None) -> dict:
+    platform_key = detect_platform_key()
+    ram_bytes = detect_ram_bytes()
+    disk_free = None
+    try:
+        disk_free = int(shutil.disk_usage(root or state_root()).free)
+    except Exception:
+        disk_free = None
+    models = (catalog or {}).get("models") or []
+    min_ram = min((float(item.get("min_ram_gb") or 0) for item in models), default=0)
+    min_disk = min((int(item.get("min_disk_bytes") or 0) for item in models), default=0)
+    ram_gb = (ram_bytes / (1024 ** 3)) if ram_bytes else None
+    runtime = runtime_asset_for_platform(catalog, platform_key) if catalog else None
+    supported = bool(runtime)
+    reason = ""
+    if not runtime:
+        supported = False
+        reason = "No official llama.cpp build is pinned for %s." % platform_key
+    elif ram_gb is not None and min_ram and ram_gb < min_ram:
+        supported = False
+        reason = "This machine has %.1f GB RAM; catalog models need at least %.0f GB." % (
+            ram_gb, min_ram,
+        )
+    elif disk_free is not None and min_disk and disk_free < min_disk:
+        supported = False
+        reason = "Free disk is below the %.1f GB the catalog install needs." % (
+            min_disk / (1024 ** 3),
+        )
+    return {
+        "os": platform.system(),
+        "arch": platform.machine(),
+        "platform_key": platform_key,
+        "ram_bytes": ram_bytes,
+        "disk_free_bytes": disk_free,
+        "accelerator": detect_accelerator(),
+        "supported": supported,
+        "unsupported_reason": reason,
+        "min_ram_gb": min_ram or None,
+        "runtime_available": bool(runtime),
+    }
+
+
+def normalize_vendor(value: Any) -> str:
+    text = str(value or "").strip().lower().replace("_", "").replace(" ", "")
+    aliases = {
+        "llamacpp": "llama.cpp",
+        "llama.cpp": "llama.cpp",
+        "ollama": "ollama",
+        "lmstudio": "lmstudio",
+        "lm-studio": "lmstudio",
+        "omlx": "omlx",
+        "mlx": "omlx",
+        "vllm": "vllm",
+        "openai": "openai-compatible",
+        "openaicompatible": "openai-compatible",
+        "openai-compatible": "openai-compatible",
+        "generic": "openai-compatible",
+        "runpod": "openai-compatible",
+    }
+    return aliases.get(text, "openai-compatible")
+
+
+def detect_vendor_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    path = (parsed.path or "").lower()
+    port = parsed.port
+    if port == 11434 or host.startswith("ollama") or "/api/tags" in path:
+        return "ollama"
+    if port == 1234 or "lmstudio" in host or "lmstudio" in path:
+        return "lmstudio"
+    if "omlx" in host or "omlx" in path or "/mlx" in path:
+        return "omlx"
+    if "vllm" in host or "vllm" in path:
+        return "vllm"
+    if "runpod" in host:
+        return "openai-compatible"
+    if port == 8080 or "llama" in host:
+        return "llama.cpp"
+    return "openai-compatible"
+
+
+def detect_vendor_from_probe(
+    url: str,
+    headers: Optional[dict] = None,
+    payload: Optional[Any] = None,
+) -> str:
+    header_blob = " ".join(
+        str(value) for value in (headers or {}).values()
+    ).lower()
+    body_blob = json.dumps(payload).lower() if payload is not None else ""
+    combined = header_blob + " " + body_blob
+    if "ollama" in combined:
+        return "ollama"
+    if "lmstudio" in combined or "lm studio" in combined:
+        return "lmstudio"
+    if "omlx" in combined or "mlx-community" in combined:
+        return "omlx"
+    if "vllm" in combined:
+        return "vllm"
+    if "llama.cpp" in combined or "llama-server" in combined:
+        return "llama.cpp"
+    return detect_vendor_from_url(url)
+
+
+def _is_metadata_host(host: str) -> bool:
+    folded = host.lower().rstrip(".")
+    if folded in METADATA_HOSTS or folded in METADATA_IPS:
+        return True
+    try:
+        return str(ipaddress.ip_address(folded)) in METADATA_IPS
+    except ValueError:
+        return False
+
+
+def _ip_kind(host: str) -> str:
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        if host.lower().rstrip(".") in LOOPBACK_NAMES:
+            return "loopback"
+        return "name"
+    if ip.is_loopback:
+        return "loopback"
+    if ip.is_unspecified or ip.is_multicast or ip.is_reserved:
+        return "blocked"
+    if str(ip) in METADATA_IPS:
+        return "metadata"
+    if ip.is_link_local:
+        return "link_local"
+    if ip.is_private:
+        return "lan"
+    return "public"
+
+
+def normalize_endpoint_url(url: str) -> str:
+    """Normalize localhost to IPv4 and ensure an OpenAI-compat ``/v1`` root."""
+    text = (url or "").strip()
+    if not text:
+        return ""
+    if "://" not in text:
+        text = "http://" + text
+    parsed = urlparse(text)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if host in LOOPBACK_NAMES or host == "::1":
+        host = "127.0.0.1"
+    port = parsed.port
+    netloc = host
+    if port:
+        netloc = "%s:%s" % (host, port)
+    path = parsed.path or ""
+    if path in ("", "/"):
+        path = "/v1"
+    elif path.rstrip("/") == "/v1":
+        path = "/v1"
+    elif not path.rstrip("/").endswith("/v1"):
+        # Keep vendor-specific roots (Ollama /api) but default OpenAI-compat to /v1.
+        if "/api" not in path:
+            path = path.rstrip("/") + "/v1"
+    return urlunparse((
+        parsed.scheme or "http",
+        netloc,
+        path.rstrip("/") or "/v1",
+        "",
+        "",
+        "",
+    ))
+
+
+def evaluate_endpoint_url(
+    url: str,
+    *,
+    accept_lan: bool = False,
+    accept_remote: bool = False,
+) -> dict:
+    """Classify a user-supplied inference URL. Never follows redirects."""
+    denied = {
+        "ok": False,
+        "error": "URL is required",
+        "normalized": "",
+        "kind": "empty",
+        "requires_lan": False,
+        "requires_remote": False,
+    }
+    text = (url or "").strip()
+    if not text:
+        return denied
+    if "://" not in text:
+        text = "http://" + text
+    try:
+        parsed = urlparse(text)
+    except ValueError:
+        denied.update({"error": "URL could not be parsed", "kind": "invalid"})
+        return denied
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        denied.update({
+            "error": "Only http and https endpoints are allowed",
+            "kind": "scheme",
+        })
+        return denied
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        denied.update({"error": "URL has no host", "kind": "invalid"})
+        return denied
+    if _is_metadata_host(host):
+        denied.update({
+            "error": "Cloud metadata endpoints are blocked",
+            "kind": "metadata",
+        })
+        return denied
+    kind = _ip_kind(host)
+    if kind == "name":
+        if host.endswith(".local") or host.endswith(".lan"):
+            kind = "lan"
+        else:
+            kind = "public"
+    if kind == "metadata":
+        denied.update({
+            "error": "Cloud metadata endpoints are blocked",
+            "kind": "metadata",
+        })
+        return denied
+    if kind == "blocked":
+        denied.update({
+            "error": "This host is not a usable local inference target",
+            "kind": "blocked",
+        })
+        return denied
+    if kind == "public":
+        denied.update({"kind": "public", "requires_remote": True})
+        if scheme != "https":
+            denied["error"] = "Remote endpoints must use HTTPS"
+            return denied
+        if not accept_remote:
+            denied["error"] = (
+                "This is a public remote host. Confirm you trust this HTTPS service."
+            )
+            return denied
+    requires_lan = kind in {"lan", "link_local"}
+    if requires_lan and not accept_lan:
+        denied.update({
+            "error": "This looks like a LAN address. Confirm it is a machine you trust.",
+            "kind": kind,
+            "requires_lan": True,
+        })
+        return denied
+    normalized = normalize_endpoint_url(text)
+    return {
+        "ok": True,
+        "error": None,
+        "normalized": normalized,
+        "kind": kind if kind != "name" else "loopback",
+        "requires_lan": requires_lan,
+        "requires_remote": kind == "public",
+        "vendor_guess": detect_vendor_from_url(normalized),
+    }
+
+
+def canonical_spec(endpoint_id: str, model: str) -> str:
+    end = str(endpoint_id or "").strip()
+    mid = str(model or "").strip()
+    if not end or not mid:
+        return ""
+    return "%s:%s/%s" % (LOCAL_PROVIDER, end, mid)
+
+
+def parse_local_spec(spec: str) -> Optional[tuple]:
+    text = str(spec or "").strip()
+    if not text.startswith(LOCAL_PROVIDER + ":"):
+        return None
+    rest = text[len(LOCAL_PROVIDER) + 1:]
+    if "/" not in rest:
+        return None
+    endpoint_id, model = rest.split("/", 1)
+    endpoint_id = endpoint_id.strip()
+    model = model.strip()
+    if not endpoint_id or not model:
+        return None
+    return endpoint_id, model
+
+
+def is_local_spec(spec: str) -> bool:
+    return parse_local_spec(spec) is not None
+
+
+def local_secret_reach(endpoint_id: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "-", str(endpoint_id or "").strip()).strip("-_")
+    return "local-%s" % (slug or "endpoint")
+
+
+def _safe_endpoint_slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_-]+", "-", str(value or "").strip()).strip("-_") or "endpoint"
+
+
+def endpoint_id_for_url(url: str, vendor: str = "") -> str:
+    """Stable ID from vendor plus normalized host/port/path.
+
+    Loopback stays readable (``ollama-127-0-0-1-11434``). Remote hosts that
+    share a name but differ by path (RunPod endpoint URLs) get a short
+    SHA-256 suffix so they do not collide.
+    """
+    parsed = urlparse(url or "")
+    host = (parsed.hostname or "local").lower().rstrip(".")
+    vendor_slug = _safe_endpoint_slug(normalize_vendor(vendor) or "openai-compatible")
+    path = (parsed.path or "").rstrip("/") or "/v1"
+    port = parsed.port
+    kind = _ip_kind(host)
+    is_loopback = kind == "loopback" or host in LOOPBACK_NAMES or host in {"127.0.0.1", "::1"}
+    if is_loopback:
+        host_slug = "127-0-0-1"
+        eid = "%s-%s" % (vendor_slug, host_slug)
+        if port:
+            eid = "%s-%s" % (eid, port)
+        return _safe_endpoint_slug(eid)
+    identity = "%s\n%s\n%s\n%s" % (vendor_slug, host, port or "", path.lower())
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:10]
+    host_slug = host.replace(".", "-")
+    return _safe_endpoint_slug("%s-%s-%s" % (vendor_slug, host_slug, digest))
+
+
+def redact_secret(value: Any) -> str:
+    text = str(value or "")
+    if not text:
+        return ""
+    if len(text) <= 8:
+        return "••••"
+    return "••••" + text[-4:]
+
+
+def redact_mapping(payload: Any) -> Any:
+    """Drop secrets from JSON/SSE/log payloads."""
+    if isinstance(payload, dict):
+        out = {}
+        for key, value in payload.items():
+            if _SENSITIVE_KEY_RE.search(str(key)):
+                if value:
+                    out[key] = redact_secret(value)
+                continue
+            if str(key) in {"url", "base_url", "log_tail"}:
+                out[key] = sanitize_url_for_display(str(value)) if value else value
+            else:
+                out[key] = redact_mapping(value)
+        return out
+    if isinstance(payload, list):
+        return [redact_mapping(item) for item in payload]
+    return payload
+
+
+def parse_command(body: Any) -> dict:
+    if not isinstance(body, dict):
+        raise ValueError("command must be a JSON object")
+    command_type = str(body.get("type") or body.get("command") or "").strip()
+    if command_type not in COMMAND_TYPES:
+        raise ValueError("Unknown local-model command")
+    command = {"type": command_type}
+    if command_type in {"probe", "save_external"}:
+        command["url"] = str(body.get("url") or "").strip()
+        command["api_key"] = str(body.get("api_key") or "")
+        command["accept_lan"] = bool(body.get("accept_lan"))
+        command["accept_remote"] = bool(
+            body.get("accept_remote") or body.get("trust_remote")
+        )
+        command["model"] = str(body.get("model") or "").strip()
+        command["name"] = str(body.get("name") or "").strip()
+        if _is_intlike(body.get("context_length")):
+            command["context_length"] = int(body["context_length"])
+    elif command_type in {"install", "cancel"}:
+        target = str(body.get("target") or "all").strip() or "all"
+        if target not in INSTALL_TARGETS:
+            raise ValueError("install target must be runtime, model, or all")
+        command["target"] = target
+        if command_type == "install":
+            command["model_id"] = str(body.get("model_id") or "").strip()
+    elif command_type == "remove":
+        target = str(body.get("target") or "all").strip() or "all"
+        command["target"] = target
+        command["endpoint_id"] = str(body.get("endpoint_id") or "").strip()
+    elif command_type == "activate":
+        spec = str(body.get("spec") or "").strip()
+        if not spec:
+            raise ValueError("activate requires a spec")
+        command["spec"] = spec
+    elif command_type == "verify_tool_calling":
+        spec = str(body.get("spec") or "").strip()
+        if not spec:
+            raise ValueError("verify_tool_calling requires a spec")
+        command["spec"] = spec
+    return command
+
+
+def extract_model_ids(payload: Any) -> list:
+    ids = []
+    data = payload.get("data") if isinstance(payload, dict) else payload
+    if isinstance(payload, dict) and isinstance(payload.get("models"), list):
+        data = payload.get("models")
+    if not isinstance(data, list):
+        return ids
+    seen = set()
+    for item in data:
+        if isinstance(item, dict):
+            mid = str(item.get("id") or item.get("name") or "").strip()
+        else:
+            mid = str(item or "").strip()
+        if mid and mid not in seen:
+            seen.add(mid)
+            ids.append(mid)
+    return ids
+
+
+def extract_context_length(payload: Any) -> Optional[int]:
+    if isinstance(payload, dict):
+        for key in (
+            "context_length",
+            "max_model_len",
+            "n_ctx_train",
+            "n_ctx",
+            "default_max_len",
+        ):
+            if _is_intlike(payload.get(key)) and int(payload[key]) > 0:
+                return int(payload[key])
+        default = payload.get("default_model_params")
+        if isinstance(default, dict) and _is_intlike(default.get("contextLength")):
+            return int(default["contextLength"])
+        for item in payload.get("data") or []:
+            if not isinstance(item, dict):
+                continue
+            meta = item.get("meta") if isinstance(item.get("meta"), dict) else {}
+            for key in ("context_length", "max_model_len", "n_ctx"):
+                if _is_intlike(item.get(key)) and int(item[key]) > 0:
+                    return int(item[key])
+                if _is_intlike(meta.get(key)) and int(meta[key]) > 0:
+                    return int(meta[key])
+    return None
+
+
+def managed_usable(state: dict) -> bool:
+    managed = (state or {}).get("managed") or {}
+    process = managed.get("process") or {}
+    runtime_ready = (managed.get("runtime") or {}).get("status") == "ready"
+    model_ready = (managed.get("model") or {}).get("status") == "ready"
+    return bool(
+        runtime_ready
+        and model_ready
+        and process.get("pid")
+        and process.get("healthy")
+        and process.get("port")
+    )
+
+
+def usable_local_specs(state: dict, catalog: Optional[dict] = None) -> list:
+    specs = []
+    managed = (state or {}).get("managed") or {}
+    model_id = (managed.get("model") or {}).get("id") or (
+        (curated_model(catalog or {}) or {}).get("id") if catalog else ""
+    )
+    if managed_usable(state) and model_id:
+        specs.append(canonical_spec(MANAGED_ENDPOINT_ID, model_id))
+    for item in (state or {}).get("externals") or []:
+        model = item.get("selected_model") or ""
+        if item.get("id") and model and item.get("base_url") and item.get("healthy"):
+            specs.append(canonical_spec(item["id"], model))
+    return specs
+
+
+def resolve_local_endpoint(state: dict, spec: str) -> Optional[dict]:
+    parsed = parse_local_spec(spec)
+    if not parsed:
+        return None
+    endpoint_id, model = parsed
+    if endpoint_id == MANAGED_ENDPOINT_ID:
+        if not managed_usable(state):
+            return None
+        process = ((state.get("managed") or {}).get("process") or {})
+        port = process.get("port")
+        host = process.get("host") or "127.0.0.1"
+        return {
+            "endpoint_id": endpoint_id,
+            "model": model,
+            "base_url": "http://%s:%s/v1" % (host, port),
+            "vendor": "llama.cpp",
+            "kind": "loopback",
+            "requires_key": False,
+            "has_key": False,
+            "secret_reach": local_secret_reach(endpoint_id),
+            "timeout": 600,
+        }
+    for item in state.get("externals") or []:
+        if item.get("id") == endpoint_id:
+            if not item.get("healthy"):
+                return None
+            kind = _external_kind(item)
+            requires_key = _external_requires_key(item)
+            return {
+                "endpoint_id": endpoint_id,
+                "model": model or item.get("selected_model") or "",
+                "base_url": item.get("base_url") or "",
+                "vendor": item.get("vendor") or "openai-compatible",
+                "kind": kind,
+                "requires_key": requires_key,
+                "has_key": bool(item.get("has_key")),
+                "secret_reach": local_secret_reach(endpoint_id),
+                "timeout": 600,
+            }
+    return None
+
+
+def local_provider_is_available(state: Optional[dict] = None) -> bool:
+    current = state if state is not None else load_state()
+    return bool(usable_local_specs(current))
+
+
+def local_send_stale_seconds(spec: str) -> float:
+    if is_local_spec(spec):
+        raw = os.environ.get("HARNESS_SEND_STALE_SECONDS")
+        if raw and str(raw).strip():
+            try:
+                return float(raw)
+            except ValueError:
+                pass
+        return 900.0
+    try:
+        return float(os.environ.get("HARNESS_SEND_STALE_SECONDS", "180") or 180)
+    except ValueError:
+        return 180.0
+
+
+def snapshot_from_state(
+    state: dict,
+    *,
+    catalog: Optional[dict] = None,
+    hardware: Optional[dict] = None,
+    events: Optional[list] = None,
+) -> dict:
+    cat = catalog if catalog is not None else load_catalog()
+    hw = hardware if hardware is not None else detect_hardware(catalog=cat)
+    managed = state.get("managed") or {}
+    model = curated_model(cat, (managed.get("model") or {}).get("id") or None)
+    runtime = runtime_asset_for_platform(cat, hw.get("platform_key"))
+    process = managed.get("process")
+    specs = usable_local_specs(state, cat)
+    return redact_mapping({
+        "hardware": hw,
+        "catalog": {
+            "runtime_release": (cat.get("runtime") or {}).get("release") or "",
+            "runtime": runtime,
+            "models": cat.get("models") or [],
+            "model": model,
+        },
+        "managed": {
+            "runtime": managed.get("runtime") or {},
+            "model": managed.get("model") or {},
+            "process": process,
+            "downloads": managed.get("downloads") or {},
+            "usable": managed_usable(state),
+            "spec": canonical_spec(MANAGED_ENDPOINT_ID, (model or {}).get("id") or "") if model else "",
+        },
+        "externals": state.get("externals") or [],
+        "active_spec": state.get("active_spec") or "",
+        "usable_specs": specs,
+        "event_cursor": int(state.get("event_cursor") or 0),
+        "events": events or [],
+    })
+
+
+_catalog_cache = None
+_catalog_lock = threading.Lock()
+
+
+def cached_catalog() -> dict:
+    global _catalog_cache
+    with _catalog_lock:
+        if _catalog_cache is None:
+            _catalog_cache = load_catalog()
+        return _catalog_cache
+
+
+def reset_catalog_cache() -> None:
+    global _catalog_cache
+    with _catalog_lock:
+        _catalog_cache = None

--- a/harness/model_visibility.py
+++ b/harness/model_visibility.py
@@ -218,6 +218,18 @@ def provider_models(p, *, force: bool = False) -> list:
     returns exactly those normalized ids (deduped); curated ids appear only
     when live fetch/cache yields nothing.
     """
+    if getattr(p, "name", "") == "local":
+        try:
+            from .local_model_manager import get_manager
+            from .local_models import parse_local_spec
+            models = []
+            for spec in get_manager().usable_specs():
+                parsed = parse_local_spec(spec)
+                if parsed:
+                    models.append("%s/%s" % parsed)
+            return list(dict.fromkeys(models))
+        except Exception:
+            return []
     curated = list(p.pilot_models)
     live = []
     keyed = False
@@ -321,6 +333,9 @@ def catalog(available_only: bool = True, *, force: bool = False) -> list:
             elif isinstance(provider_metadata.get("name"), str) and provider_metadata["name"].strip():
                 display_name = provider_metadata["name"].strip()
             pricing = provider_metadata.get("pricing") or {}
+            if p.name == "local":
+                pricing = {"prompt": 0, "completion": 0}
+                display_name = display_name or m
             out.append({
                 "provider": p.name,
                 "provider_display": p.display_name,

--- a/harness/pilot_tool_recovery.py
+++ b/harness/pilot_tool_recovery.py
@@ -175,8 +175,9 @@ def parse_native_tool_turn(
 
     ``schema`` is the exact tools schema sent on this step (or None when
     unknown). Visible-name repair and invalid carriers use that allowlist.
-    Inline function-call markup becomes synthetic tool_calls. Missing or
-    empty provider tool_call ids receive one portable synthetic id on a
+    Inline function-call markup in content *or* reasoning (Qwen ``<tool_call>``
+    / ``<function=...>`` thought dumps) becomes synthetic tool_calls. Missing
+    or empty provider tool_call ids receive one portable synthetic id on a
     deep copy *before* ``parse_tool_calls``, so assistant history and the
     PilotAction / tool result share that same identity. Raises on
     unexpected parse failures so the send loop can surface the same error.
@@ -189,7 +190,8 @@ def parse_native_tool_turn(
     catalog = getattr(session, "_tool_catalog", None) if session is not None else None
     allowed_names = expand_allowed_names_for_lazy_activate(
         allowed_names,
-        _tool_call_names(tool_calls, pure_content),
+        _tool_call_names(tool_calls, pure_content)
+        + _tool_call_names([], reasoning or ""),
         catalog,
     )
     used = _history_tool_call_ids(
@@ -205,10 +207,18 @@ def parse_native_tool_turn(
     def allocate_id() -> str:
         return next_synthetic_tool_call_id(session, used)
 
-    if not tool_calls and pure_content:
+    if not tool_calls:
+        inline_from_content = True
         inline_actions = parse_inline_tool_calls(
-            pure_content, allowed_names=allowed_names,
+            pure_content or "", allowed_names=allowed_names,
         )
+        # llama.cpp/Qwen often dump <tool_call> XML on the thought channel
+        # (inside <think> / reasoning_content) while content is narration.
+        if not inline_actions and (reasoning or "").strip():
+            inline_actions = parse_inline_tool_calls(
+                reasoning, allowed_names=allowed_names,
+            )
+            inline_from_content = False
         if inline_actions:
             synthetic_tool_calls = []
             for act in inline_actions:
@@ -233,7 +243,8 @@ def parse_native_tool_turn(
                 ):
                     act.tool_call_id = id_by_index[idx]
             actions = inline_actions
-            pure_content = strip_inline_tool_calls(pure_content)
+            if inline_from_content:
+                pure_content = strip_inline_tool_calls(pure_content)
         else:
             actions = parse_tool_calls(
                 tool_calls, allowed_names=allowed_names,

--- a/harness/providers.py
+++ b/harness/providers.py
@@ -163,6 +163,14 @@ class Provider:
 
     @property
     def available(self) -> bool:
+        if self._is_disconnected():
+            return False
+        if self.name == "local":
+            try:
+                from .local_model_manager import local_provider_available
+                return local_provider_available()
+            except Exception:
+                return False
         return self.key() is not None
 
     def resolved_base_url(self) -> str:
@@ -347,6 +355,13 @@ PROVIDERS = (
     # AWS Bedrock: auth is multi-env (bearer OR access-key pair + region).
     # Interactive pilot uses BedrockDriver (puppetmaster.bedrock.bedrock_chat);
     # Marionette stores credentials and injects AWS_* / BEDROCK_* into the env.
+    Provider(
+        name="local", aliases=("llama-cpp", "llamacpp", "local-llm"),
+        env_vars=("LOCAL_MODEL_API_KEY", "LLAMA_CPP_API_KEY"),
+        base_url="",
+        api_mode="chat_completions", display_name="Local",
+        pilot_models=(),
+    ),
     Provider(
         name="bedrock", aliases=("aws-bedrock", "aws"),
         env_vars=("AWS_BEARER_TOKEN_BEDROCK", "AWS_ACCESS_KEY_ID"),
@@ -626,14 +641,63 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
     bare = (model or "").lower().replace("_", "-")
     if any(tok in bare for tok in ("glm-5.3", "glm-5-3", "glm-5p3")):
         extra_body = _opencode_go.reasoning_body_extras(model) or None
+    timeout = 90
+    base_url = provider.resolved_base_url()
+    driver_name = spec
+    if provider.name == "local":
+        from .local_model_manager import get_manager
+        from .keys import get_env_var_for_reach
+        full_spec = spec if spec.startswith("local:") else "local:%s" % model
+        resolved = get_manager().resolve_spec(full_spec)
+        if not resolved or not resolved.get("base_url"):
+            raise ProviderError(
+                "local endpoint %r is not usable. Start the managed server or save an external endpoint."
+                % full_spec
+            )
+        base_url = resolved["base_url"]
+        model = resolved.get("model") or model
+        timeout = int(resolved.get("timeout") or 600)
+        secret_reach = resolved.get("secret_reach") or "local"
+        try:
+            from .keys import hydrate_reach_key
+            hydrate_reach_key(secret_reach)
+        except Exception:
+            pass
+        key_env = get_env_var_for_reach(secret_reach) or key_env or "LOCAL_MODEL_API_KEY"
+        vendor = str(resolved.get("vendor") or "")
+        if vendor == "llama.cpp":
+            driver_name = "llama-cpp:%s" % model
+        requires_key = bool(resolved.get("requires_key"))
+        if requires_key:
+            # Live env after hydrate only. Persisted has_key is stale metadata
+            # once the secret is cleared or hydration fails.
+            have_key = bool(os.environ.get(key_env, "").strip())
+            if not have_key:
+                raise ProviderError(
+                    "public local endpoint %r requires an API key" % full_spec
+                )
+        return _finalize_driver(
+            OpenAICompatDriver(
+                name=driver_name,
+                model=model,
+                base_url=base_url,
+                api_key_env=key_env,
+                max_tokens=max_tokens,
+                extra_body=extra_body,
+                timeout=timeout,
+                vendor=vendor,
+                allow_keyless=not requires_key,
+            )
+        )
     return _finalize_driver(
         OpenAICompatDriver(
-            name=spec,
+            name=driver_name,
             model=model,
-            base_url=provider.resolved_base_url(),
+            base_url=base_url,
             api_key_env=key_env,
             max_tokens=max_tokens,
             extra_body=extra_body,
+            timeout=timeout,
         )
     )
 

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -49,6 +49,7 @@ from .pilot_tool_recovery import (
     invalid_only_halt_reason,
     parse_native_tool_turn,
 )
+from .local_models import local_send_stale_seconds
 from .send_image_prep import prepare_turn_images
 from .send_loop_actions import execute_turn_actions
 from .repeat_tool_reminder import reset_repeat_chain
@@ -452,13 +453,8 @@ class SendLoopMixin:
             if not stale and self._busy_since and self._state in (
                 "thinking", "executing", "streaming",
             ):
-                try:
-                    send_stale_s = float(
-                        os.environ.get("HARNESS_SEND_STALE_SECONDS", "180").strip()
-                        or 180
-                    )
-                except ValueError:
-                    send_stale_s = 180.0
+                driver_spec = str(getattr(getattr(self, "cfg", None), "driver", "") or "")
+                send_stale_s = local_send_stale_seconds(driver_spec)
                 if send_stale_s > 0 and held_for > send_stale_s:
                     try:
                         pilot = getattr(self, "pilot", None)

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -1600,6 +1600,10 @@ def drain_stream_queue(q: Any, accumulator: Any = None) -> Iterator[Any]:
         elif kind == "done":
             for ev in _flush_all():
                 yield ev
+            # OpenAI-compat / llama-cpp never fire on_stream_item_done, so
+            # thinking + assistant bubbles stay streaming:true until a
+            # terminal. Empty stream_id seals every open surface.
+            yield ConvEvent("stream_item_done", {})
             reasoning = "".join(streamed_reasoning)
             if reasoning:
                 meta = getattr(val, "meta", None)

--- a/harness/server.py
+++ b/harness/server.py
@@ -1934,6 +1934,19 @@ def _provider_services():
     )
 
 
+def _local_model_services():
+    """Build LocalModelServices from live server module globals."""
+    from .api.local_models import LocalModelServices
+    from .local_model_manager import get_manager
+    return LocalModelServices(
+        manager=get_manager(),
+        cfg=_cfg,
+        rebuild_pilot_and_session=_rebuild_pilot_and_session,
+        save_workspace_driver=_save_workspace_driver,
+        resync_driver_after_model_curation=_resync_driver_after_model_curation,
+    )
+
+
 def _file_services():
     """Build FileServices from live server module globals (call-time lookup)."""
     from .api.files import FileServices
@@ -2522,6 +2535,7 @@ def _route_services():
         usage_services=_usage_services,
         economics_services=_economics_services,
         sse_services=_sse_services,
+        local_model_services=_local_model_services,
         handle_session_relocate=_handle_session_relocate,
         host_ok=_host_ok,
         diag=_diag,

--- a/pmharness/drivers/openai_compat.py
+++ b/pmharness/drivers/openai_compat.py
@@ -63,11 +63,15 @@ def _executable_stream_tool_calls(assembled: dict, finish_reason: str) -> list:
 
     Missing ids stay empty so the conversation layer can canonicalize them.
     Truncated arguments and length-capped / filtered streams never become
-    executable ``tool_calls``. A tool close is executable only when the
-    finish is ``tool_calls`` / ``function_call`` and arguments parse.
+    executable ``tool_calls``. A tool close is executable when the finish is
+    ``tool_calls`` / ``function_call`` *or* a clean ``stop`` (llama.cpp/Qwen
+    often emit native ``delta.tool_calls`` then ``finish_reason=stop``) and
+    arguments parse.
     """
     finish = _norm_chat_finish(finish_reason)
-    if finish not in _TOOL_CHAT_FINISH:
+    if finish in _LENGTH_CHAT_FINISH or finish in _FILTER_CHAT_FINISH or finish in _INCOMPLETE_CHAT_FINISH:
+        return []
+    if finish not in _TOOL_CHAT_FINISH and finish not in _SUCCESS_CHAT_FINISH:
         return []
     out = []
     for idx in sorted(assembled.keys(), key=lambda k: (isinstance(k, int), k)):
@@ -138,6 +142,14 @@ def _openai_chat_terminal(
             "but no executable tool calls",
         )
     if finish in _SUCCESS_CHAT_FINISH:
+        if executable:
+            return "tool_calls", None
+        if incomplete_tools:
+            return (
+                "incomplete",
+                f"OpenAI chat finished with finish_reason={finish_raw} "
+                "but tool arguments were truncated",
+            )
         return "stop", None
     if finish_raw:
         return (
@@ -173,10 +185,13 @@ class _OpenAIChatSseAccumulator:
         on_delta=None,
         on_reasoning_delta=None,
         on_tool_hint=None,
+        end_on_finish: bool = False,
     ) -> None:
         self.on_delta = on_delta
         self.on_reasoning_delta = on_reasoning_delta
         self.on_tool_hint = on_tool_hint
+        # llama.cpp may send finish_reason then keepalives without [DONE].
+        self.end_on_finish = bool(end_on_finish)
         self.full_text = ""
         self.reasoning_pieces: list = []
         self.assembled_tool_calls: dict = {}
@@ -315,6 +330,8 @@ class _OpenAIChatSseAccumulator:
         chunk_finish_reason = choice.get("finish_reason")
         if chunk_finish_reason:
             self.finish_reason = chunk_finish_reason
+            if self.end_on_finish:
+                return False
         return True
 
     def flush_scrubber(self) -> None:
@@ -380,12 +397,14 @@ def _consume_openai_chat_sse(
     on_reasoning_delta=None,
     on_tool_hint=None,
     transport_error: str | None = None,
+    end_on_finish: bool = False,
 ) -> dict:
     """Shared OpenAI chat Completions SSE parser used by every host."""
     acc = _OpenAIChatSseAccumulator(
         on_delta=on_delta,
         on_reasoning_delta=on_reasoning_delta,
         on_tool_hint=on_tool_hint,
+        end_on_finish=end_on_finish,
     )
     for line in lines:
         if not acc.feed(line):
@@ -415,6 +434,8 @@ class OpenAICompatDriver:
         extra_body: dict | None = None,
         enable_reasoning: bool = False,
         session_id: str | None = None,
+        vendor: str = "",
+        allow_keyless: bool = False,
     ) -> None:
         self.name = name
         self.model = model
@@ -429,6 +450,8 @@ class OpenAICompatDriver:
         self.extra_body = extra_body or {}
         self.enable_reasoning = enable_reasoning
         self.session_id = session_id
+        self.vendor = str(vendor or "")
+        self.allow_keyless = bool(allow_keyless)
         # Set by _key() when a credential-pool entry is selected.
         self._pool_provider: str | None = None
         self._pool_entry_id: str | None = None
@@ -448,8 +471,27 @@ class OpenAICompatDriver:
             pass
         key = os.environ.get(self.api_key_env, "").strip()
         if not key:
+            # Synthesize only for actual loopback or an explicit trusted-LAN
+            # opt-in. Vendor/name llama.cpp on a public host is not keyless.
+            if self.allow_keyless or self._is_loopback_base():
+                return "local"
             raise RuntimeError(f"missing API key in env var {self.api_key_env}")
         return key
+
+    def _is_llama_cpp_host(self) -> bool:
+        """True only for the llama.cpp driver/vendor, not every loopback host."""
+        vendor = str(getattr(self, "vendor", "") or "").strip().lower().replace(" ", "")
+        if vendor in {"llama.cpp", "llamacpp"}:
+            return True
+        name = str(self.name or "")
+        return name.startswith("llama-cpp")
+
+    def _is_loopback_base(self) -> bool:
+        try:
+            host = (urllib.parse.urlparse(self.base_url or "").hostname or "").lower()
+        except Exception:
+            return False
+        return host in {"127.0.0.1", "localhost", "::1"}
 
     def _uses_openai_gpt5_chat_parameters(self) -> bool:
         return (
@@ -1161,7 +1203,7 @@ class OpenAICompatDriver:
             system=system,
             session_id=session_id,
         )
-        if self._is_opencode_go_host():
+        if self._is_opencode_go_host() or self._is_llama_cpp_host():
             body.pop("stream_options", None)
         self._apply_openrouter_parallel_tool_calls(body, tools)
 
@@ -1216,6 +1258,7 @@ class OpenAICompatDriver:
                 on_delta=on_delta,
                 on_reasoning_delta=on_reasoning_delta,
                 on_tool_hint=on_tool_hint,
+                end_on_finish=self._is_llama_cpp_host(),
             )
 
             req = urllib.request.Request(url, data=data, headers=headers, method="POST")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.394"
+version = "0.9.395"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [
@@ -25,6 +25,9 @@ dev = [
 
 [tool.setuptools.packages.find]
 include = ["pmharness*", "harness*"]
+
+[tool.setuptools.package-data]
+harness = ["data/*.json"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_http_routes_table.py
+++ b/tests/test_http_routes_table.py
@@ -33,6 +33,8 @@ _SAMPLE_GUARDED_GET = (
     "/api/sessions",
     "/api/archive/status",
     "/api/providers",
+    "/api/local-models",
+    "/api/local-models/events",
     "/api/chat/events",
     "/api/collab/presence",
 )
@@ -56,6 +58,7 @@ _SAMPLE_GUARDED_POST = (
     "/api/session/snapcompact",
     "/api/mcp/refresh",
     "/api/collab/presence/heartbeat",
+    "/api/local-models",
 )
 
 

--- a/tests/test_local_model_manager.py
+++ b/tests/test_local_model_manager.py
@@ -579,10 +579,15 @@ def test_stop_never_signals_unmatched(tmp_path, monkeypatch):
     assert mgr._state()["managed"]["process"] is None
 
 
-def test_readiness_requires_alias(tmp_path):
+def test_readiness_requires_alias(tmp_path, monkeypatch):
     catalog, _, model_bytes = _tiny_catalog(tmp_path)
     root = tmp_path / "lm"
     ticks = {"n": 0}
+    stopped = []
+    monkeypatch.setattr(
+        "harness.local_model_manager.stop_process_tree",
+        lambda pid, *args, **kwargs: stopped.append(pid),
+    )
 
     def clock():
         ticks["n"] += 1
@@ -620,13 +625,19 @@ def test_readiness_requires_alias(tmp_path):
     with pytest.raises(LocalModelError) as exc:
         mgr.start()
     assert exc.value.code == "not_ready"
+    assert stopped == [77]
     assert mgr._state()["managed"]["process"] is None
     assert mgr._procs == {}
 
 
-def test_readiness_fails_if_child_exits(tmp_path):
+def test_readiness_fails_if_child_exits(tmp_path, monkeypatch):
     catalog, _, model_bytes = _tiny_catalog(tmp_path)
     root = tmp_path / "lm"
+    stopped = []
+    monkeypatch.setattr(
+        "harness.local_model_manager.stop_process_tree",
+        lambda pid, *args, **kwargs: stopped.append(pid),
+    )
     mgr = LocalModelManager(
         root=str(root), catalog=catalog, sleeper=lambda _s: None,
         clock=lambda: 1.0, ready_timeout=1.0,
@@ -658,6 +669,7 @@ def test_readiness_fails_if_child_exits(tmp_path):
     with pytest.raises(LocalModelError) as exc:
         mgr.start()
     assert exc.value.code == "not_ready"
+    assert stopped == [88]
     assert mgr._procs == {}
 
 

--- a/tests/test_local_model_manager.py
+++ b/tests/test_local_model_manager.py
@@ -5,7 +5,6 @@ import hashlib
 import io
 import json
 import os
-import signal
 import stat
 import subprocess
 import tarfile
@@ -29,6 +28,8 @@ from harness.local_model_manager import (
     _CREATE_NEW_PROCESS_GROUP,
     _CREATE_NO_WINDOW,
     _DETACHED_PROCESS,
+    _SIGKILL,
+    _SIGTERM,
     _pid_alive,
     assert_probe_hop_safe,
     download_host_allowed,
@@ -535,7 +536,7 @@ def test_posix_tree_stop_term_then_kill(monkeypatch):
     monkeypatch.setattr(os, "getpgid", lambda pid: 9001, raising=False)
     monkeypatch.setattr(os, "killpg", lambda pgid, sig: killed.append((pgid, sig)), raising=False)
     stop_process_tree(4242, proc=None, grace=0, sleeper=lambda _s: None)
-    assert killed == [(9001, signal.SIGTERM), (9001, signal.SIGKILL)]
+    assert killed == [(9001, _SIGTERM), (9001, _SIGKILL)]
 
 
 def test_windows_tree_stop_taskkill(monkeypatch):

--- a/tests/test_local_model_manager.py
+++ b/tests/test_local_model_manager.py
@@ -1,0 +1,1980 @@
+"""Hermetic download, extract, and process-ownership tests for local models."""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import signal
+import stat
+import subprocess
+import tarfile
+import threading
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+
+from harness.local_model_manager import (
+    AssetRedirectHandler,
+    DOWNLOAD_PROGRESS_BYTES,
+    DOWNLOAD_PROGRESS_INTERVAL,
+    EventLog,
+    LocalModelError,
+    LocalModelManager,
+    ProbeRedirectHandler,
+    _CREATE_NEW_PROCESS_GROUP,
+    _CREATE_NO_WINDOW,
+    _DETACHED_PROCESS,
+    _pid_alive,
+    assert_probe_hop_safe,
+    download_host_allowed,
+    extract_archive,
+    is_safe_archive_member,
+    parse_content_range,
+    probe_urlopen,
+    process_matches_identity,
+    read_process_command,
+    read_process_start_key,
+    sha256_file,
+    spawn_popen_kwargs,
+    stop_process_tree,
+    validate_download_url,
+    zip_is_symlink,
+)
+
+
+def _tiny_catalog(tmp_path, payload=b"runtime-bytes"):
+    digest = hashlib.sha256(payload).hexdigest()
+    model = b"gguf-bytes"
+    model_digest = hashlib.sha256(model).hexdigest()
+    return {
+        "version": 1,
+        "runtime": {
+            "id": "llama.cpp",
+            "release": "test",
+            "binary": "llama-server",
+            "assets": {
+                "macos-arm64": {
+                    "filename": "runtime.tar.gz",
+                    "url": "http://fixture.test/runtime.tar.gz",
+                    "sha256": digest,
+                    "size": len(payload),
+                    "archive": "tar.gz",
+                },
+                "macos-x64": {
+                    "filename": "runtime.tar.gz",
+                    "url": "http://fixture.test/runtime.tar.gz",
+                    "sha256": digest,
+                    "size": len(payload),
+                    "archive": "tar.gz",
+                },
+                "linux-x64": {
+                    "filename": "runtime.tar.gz",
+                    "url": "http://fixture.test/runtime.tar.gz",
+                    "sha256": digest,
+                    "size": len(payload),
+                    "archive": "tar.gz",
+                },
+                "linux-arm64": {
+                    "filename": "runtime.tar.gz",
+                    "url": "http://fixture.test/runtime.tar.gz",
+                    "sha256": digest,
+                    "size": len(payload),
+                    "archive": "tar.gz",
+                },
+                "windows-x64": {
+                    "filename": "runtime.tar.gz",
+                    "url": "http://fixture.test/runtime.tar.gz",
+                    "sha256": digest,
+                    "size": len(payload),
+                    "archive": "tar.gz",
+                },
+                "windows-arm64": {
+                    "filename": "runtime.tar.gz",
+                    "url": "http://fixture.test/runtime.tar.gz",
+                    "sha256": digest,
+                    "size": len(payload),
+                    "archive": "tar.gz",
+                },
+            },
+        },
+        "models": [{
+            "id": "qwen-test",
+            "name": "Qwen test",
+            "filename": "model.gguf",
+            "url": "http://fixture.test/model.gguf",
+            "revision": "abc",
+            "sha256": model_digest,
+            "size": len(model),
+            "context_length": 2048,
+            "min_ram_gb": 0,
+            "recommended_ram_gb": 1,
+            "min_disk_bytes": 1,
+        }],
+    }, payload, model
+
+
+class _RangeBody:
+    def __init__(self, data, start=0, status=200, headers=None, total=None):
+        self._buf = io.BytesIO(data[start:] if status == 206 else data)
+        self.status = status
+        hdrs = dict(headers or {})
+        if status == 206:
+            end = (total or len(data)) - 1
+            hdrs.setdefault(
+                "Content-Range",
+                "bytes %s-%s/%s" % (start, end, total if total is not None else len(data)),
+            )
+        self.headers = hdrs
+
+    def read(self, n=-1):
+        return self._buf.read(n)
+
+    def close(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_safe_archive_member_rejects_traversal():
+    assert is_safe_archive_member("bin/llama-server")
+    assert not is_safe_archive_member("../etc/passwd")
+    assert not is_safe_archive_member("/etc/passwd")
+    assert not is_safe_archive_member("foo/../../x")
+
+
+def test_extract_archive_rejects_zip_slip(tmp_path):
+    archive = tmp_path / "bad.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("../escape.txt", "nope")
+    with pytest.raises(LocalModelError) as exc:
+        extract_archive(str(archive), str(tmp_path / "out"))
+    assert exc.value.code == "unsafe_archive"
+
+
+def test_extract_archive_promotes_safe_tar(tmp_path):
+    archive = tmp_path / "ok.tar.gz"
+    payload = tmp_path / "payload"
+    payload.mkdir()
+    (payload / "llama-server").write_text("bin", encoding="utf-8")
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(payload / "llama-server", arcname="bin/llama-server")
+    dest = tmp_path / "runtime"
+    extract_archive(str(archive), str(dest))
+    assert (dest / "bin" / "llama-server").is_file()
+
+
+def test_download_resume_cancel_and_hash(tmp_path, monkeypatch):
+    catalog, runtime_bytes, _model = _tiny_catalog(tmp_path)
+    root = tmp_path / "lm"
+    calls = {"n": 0}
+
+    def urlopen(req, timeout=None):
+        calls["n"] += 1
+        start = 0
+        rng = req.headers.get("Range") or req.get_header("Range")
+        if rng and rng.startswith("bytes="):
+            start = int(rng.split("=")[1].split("-")[0] or 0)
+            return _RangeBody(runtime_bytes, start, status=206, total=len(runtime_bytes))
+        return _RangeBody(runtime_bytes, 0, status=200)
+
+    mgr = LocalModelManager(root=str(root), catalog=catalog, urlopen=urlopen)
+    asset = catalog["runtime"]["assets"]["linux-x64"]
+    # First pass: write part then cancel mid-way by pre-seeding part.
+    part = mgr._part_path(asset["filename"])
+    os.makedirs(os.path.dirname(part), exist_ok=True)
+    with open(part, "wb") as handle:
+        handle.write(runtime_bytes[:4])
+    path = mgr.download_asset(asset, target="runtime")
+    assert os.path.isfile(path)
+    assert sha256_file(path) == asset["sha256"]
+    assert calls["n"] == 1
+
+    bad = dict(asset, sha256="0" * 64)
+    with pytest.raises(LocalModelError) as exc:
+        mgr.download_asset(bad, target="runtime")
+    assert exc.value.code == "hash_mismatch"
+
+
+def test_download_cancel_does_not_promote(tmp_path):
+    catalog, runtime_bytes, _model = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    asset = catalog["runtime"]["assets"]["linux-x64"]
+
+    class _Chunked:
+        def __init__(self):
+            self.sent = False
+
+        def read(self, n=-1):
+            if not self.sent:
+                self.sent = True
+                mgr.cancel("runtime")
+                return runtime_bytes[:2]
+            return runtime_bytes[2:]
+
+        def close(self):
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    mgr.urlopen = lambda req, timeout=None: _Chunked()
+    with pytest.raises(LocalModelError) as exc:
+        mgr.download_asset(asset, target="runtime")
+    assert exc.value.code == "cancelled"
+    assert not os.path.exists(mgr._final_path(asset["filename"]))
+
+
+def test_stale_pid_never_kills_unrelated(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    killed = []
+    monkeypatch.setattr("harness.local_model_manager.os.kill", lambda pid, sig: killed.append((pid, sig)))
+    monkeypatch.setattr("harness.local_model_manager._pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        "harness.local_model_manager.read_process_command",
+        lambda pid: "/usr/bin/unrelated --port 9",
+    )
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    state = mgr._state()
+    state["managed"]["process"] = {
+        "pid": 4242,
+        "port": 9,
+        "host": "127.0.0.1",
+        "exe": "/tmp/llama-server",
+        "model_path": "/tmp/model.gguf",
+        "alias": "marionette-deadbeef",
+        "nonce": "deadbeef",
+        "healthy": True,
+    }
+    mgr._save(state)
+    mgr.reconcile_process()
+    assert mgr._state()["managed"]["process"] is None
+    assert killed == []
+
+
+def test_process_matches_identity_requires_alias():
+    identity = {
+        "alias": "marionette-abc",
+        "nonce": "abc",
+        "exe": "llama-server",
+        "model_path": "/tmp/qwen.gguf",
+    }
+    assert process_matches_identity(os.getpid(), identity) is False
+
+
+def test_start_uses_injected_popen_and_ready(tmp_path, monkeypatch):
+    catalog, _, model_bytes = _tiny_catalog(tmp_path)
+    root = tmp_path / "lm"
+    mgr = LocalModelManager(
+        root=str(root),
+        catalog=catalog,
+        urlopen=lambda *a, **k: (_ for _ in ()).throw(AssertionError("no download")),
+        sleeper=lambda _s: None,
+        clock=lambda: 1.0,
+        ready_timeout=1.0,
+    )
+    runtime = root / "runtime" / "test"
+    runtime.mkdir(parents=True)
+    exe = runtime / ("llama-server.exe" if os.name == "nt" else "llama-server")
+    exe.write_text("x", encoding="utf-8")
+    models = root / "models"
+    models.mkdir()
+    model_path = models / "model.gguf"
+    model_path.write_bytes(model_bytes)
+    mgr._set_component("runtime", status="ready", path=str(exe))
+    mgr._set_component("model", status="ready", path=str(model_path), id="qwen-test")
+
+    spawned = {}
+
+    class _Proc:
+        pid = 321
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            return None
+
+    def popen(argv, **kwargs):
+        spawned["argv"] = argv
+        spawned["kwargs"] = kwargs
+        return _Proc()
+
+    mgr.popen = popen
+    mgr._probe_health = lambda url, required_alias="": True
+    snap = mgr.start()
+    assert "--jinja" in spawned["argv"]
+    assert "--host" in spawned["argv"]
+    assert spawned["argv"][spawned["argv"].index("--host") + 1] == "127.0.0.1"
+    assert "--alias" in spawned["argv"]
+    assert snap["managed"]["process"]["healthy"] is True
+    assert snap["managed"]["process"]["alias"]
+    assert snap["managed"]["process"]["nonce"]
+    if os.name == "nt":
+        flags = spawned["kwargs"].get("creationflags") or 0
+        assert flags & _CREATE_NEW_PROCESS_GROUP
+        assert flags & _CREATE_NO_WINDOW
+        assert not (flags & _DETACHED_PROCESS)
+        assert "start_new_session" not in spawned["kwargs"]
+    else:
+        assert spawned["kwargs"].get("start_new_session") is True
+
+
+def test_probe_uses_injected_transport(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+
+    def transport(url, **kwargs):
+        return {
+            "payload": {"data": [{"id": "llama3", "max_model_len": 4096}]},
+            "headers": {"Server": "ollama"},
+            "status": 200,
+        }
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"),
+        catalog=catalog,
+        probe_transport=transport,
+    )
+    result = mgr.probe("http://127.0.0.1:11434")
+    assert result["vendor"] == "ollama"
+    assert result["models"] == ["llama3"]
+    assert result["context_length"] == 4096
+    assert "api_key" not in result
+
+
+def test_download_host_allowlist():
+    assert download_host_allowed("github.com")
+    assert download_host_allowed("objects.githubusercontent.com")
+    assert download_host_allowed("release-assets.githubusercontent.com")
+    assert download_host_allowed("huggingface.co")
+    assert download_host_allowed("cas-bridge.xethub.hf.co")
+    assert download_host_allowed("us.aws.cdn.hf.co")
+    assert not download_host_allowed("evil.example")
+    assert not download_host_allowed("169.254.169.254")
+
+
+def test_validate_download_url_https_allowlist(monkeypatch):
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "1.2.3.4"),
+    )
+    validate_download_url("https://github.com/ggml-org/llama.cpp/releases/download/b10442/x.tgz")
+    with pytest.raises(LocalModelError) as exc:
+        validate_download_url("http://github.com/ggml-org/llama.cpp/x")
+    assert exc.value.code == "unsafe_url"
+    with pytest.raises(LocalModelError):
+        validate_download_url("https://evil.example/x")
+
+
+def test_validate_download_rejects_private_ip(monkeypatch):
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (False, "blocked private or reserved IP address 10.0.0.5", None),
+    )
+    with pytest.raises(LocalModelError) as exc:
+        validate_download_url("https://huggingface.co/Qwen/x")
+    assert exc.value.code == "unsafe_url"
+
+
+def test_asset_redirect_max_and_https():
+    assert AssetRedirectHandler.max_redirections == 5
+    handler = AssetRedirectHandler()
+    req = urllib.request.Request("https://github.com/ggml-org/llama.cpp/x")
+    with pytest.raises(urllib.error.HTTPError):
+        handler.redirect_request(req, None, 302, "Found", {}, "http://github.com/x")
+
+
+def test_download_200_on_range_truncates(tmp_path):
+    catalog, runtime_bytes, _model = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    asset = catalog["runtime"]["assets"]["linux-x64"]
+    part = mgr._part_path(asset["filename"])
+    os.makedirs(os.path.dirname(part), exist_ok=True)
+    with open(part, "wb") as handle:
+        handle.write(b"XXXX")
+
+    def urlopen(req, timeout=None):
+        assert req.headers.get("Range") or req.get_header("Range")
+        return _RangeBody(runtime_bytes, status=200)
+
+    mgr.urlopen = urlopen
+    path = mgr.download_asset(asset, target="runtime")
+    assert sha256_file(path) == asset["sha256"]
+    assert os.path.getsize(path) == len(runtime_bytes)
+
+
+def test_download_range_mismatch_rejects_before_write(tmp_path):
+    catalog, runtime_bytes, _model = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    asset = catalog["runtime"]["assets"]["linux-x64"]
+    part = mgr._part_path(asset["filename"])
+    os.makedirs(os.path.dirname(part), exist_ok=True)
+    with open(part, "wb") as handle:
+        handle.write(runtime_bytes[:4])
+
+    def urlopen(req, timeout=None):
+        return _RangeBody(
+            runtime_bytes, start=0, status=206,
+            headers={"Content-Range": "bytes 0-10/999"},
+        )
+
+    mgr.urlopen = urlopen
+    with pytest.raises(LocalModelError) as exc:
+        mgr.download_asset(asset, target="runtime")
+    assert exc.value.code == "download"
+    assert os.path.getsize(part) == 4
+    assert not os.path.exists(mgr._final_path(asset["filename"]))
+
+
+def test_download_oversized_does_not_promote(tmp_path):
+    catalog, runtime_bytes, _model = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    asset = dict(catalog["runtime"]["assets"]["linux-x64"], size=4)
+
+    def urlopen(req, timeout=None):
+        return _RangeBody(runtime_bytes, status=200)
+
+    mgr.urlopen = urlopen
+    with pytest.raises(LocalModelError) as exc:
+        mgr.download_asset(asset, target="runtime")
+    assert exc.value.code == "download"
+    assert not os.path.exists(mgr._final_path(asset["filename"]))
+
+
+def test_download_partial_does_not_promote(tmp_path):
+    catalog, runtime_bytes, _model = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    asset = catalog["runtime"]["assets"]["linux-x64"]
+
+    def urlopen(req, timeout=None):
+        return _RangeBody(runtime_bytes[:4], status=200)
+
+    mgr.urlopen = urlopen
+    with pytest.raises(LocalModelError) as exc:
+        mgr.download_asset(asset, target="runtime")
+    assert exc.value.code == "download"
+    assert not os.path.exists(mgr._final_path(asset["filename"]))
+    part = mgr._part_path(asset["filename"])
+    assert os.path.exists(part)
+    assert 0 < os.path.getsize(part) < asset["size"]
+
+
+def test_parse_content_range_requires_total():
+    assert parse_content_range("bytes 10-20/100") == (10, 20, 100)
+    assert parse_content_range("bytes 10-20/*") == (10, 20, None)
+    assert parse_content_range("not-a-range") is None
+
+
+def test_extract_rejects_tar_symlink(tmp_path):
+    archive = tmp_path / "link.tar"
+    with tarfile.open(archive, "w") as tf:
+        info = tarfile.TarInfo("evil")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/passwd"
+        tf.addfile(info)
+    with pytest.raises(LocalModelError) as exc:
+        extract_archive(str(archive), str(tmp_path / "out"))
+    assert exc.value.code == "unsafe_archive"
+    assert not (tmp_path / "out").exists()
+
+
+def test_extract_rejects_tar_hardlink_and_fifo(tmp_path):
+    archive = tmp_path / "fifo.tar"
+    with tarfile.open(archive, "w") as tf:
+        info = tarfile.TarInfo("pipe")
+        info.type = tarfile.FIFOTYPE
+        tf.addfile(info)
+    with pytest.raises(LocalModelError) as exc:
+        extract_archive(str(archive), str(tmp_path / "out"))
+    assert exc.value.code == "unsafe_archive"
+
+
+def test_extract_rejects_zip_symlink(tmp_path):
+    archive = tmp_path / "link.zip"
+    info = zipfile.ZipInfo("link")
+    info.create_system = 3
+    info.external_attr = (stat.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr(info, "/etc/passwd")
+    assert zip_is_symlink(info)
+    with pytest.raises(LocalModelError) as exc:
+        extract_archive(str(archive), str(tmp_path / "out"))
+    assert exc.value.code == "unsafe_archive"
+
+
+def test_windows_spawn_flags(monkeypatch):
+    monkeypatch.setattr(os, "name", "nt")
+    kwargs = spawn_popen_kwargs()
+    flags = kwargs.get("creationflags") or 0
+    assert flags & _CREATE_NEW_PROCESS_GROUP
+    assert flags & _CREATE_NO_WINDOW
+    assert not (flags & _DETACHED_PROCESS)
+    assert "start_new_session" not in kwargs
+
+
+def test_posix_spawn_new_session(monkeypatch):
+    monkeypatch.setattr(os, "name", "posix")
+    kwargs = spawn_popen_kwargs()
+    assert kwargs.get("start_new_session") is True
+
+
+def test_posix_tree_stop_term_then_kill(monkeypatch):
+    killed = []
+    monkeypatch.setattr(os, "name", "posix")
+    monkeypatch.setattr(os, "getpgid", lambda pid: 9001, raising=False)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: killed.append((pgid, sig)), raising=False)
+    stop_process_tree(4242, proc=None, grace=0, sleeper=lambda _s: None)
+    assert killed == [(9001, signal.SIGTERM), (9001, signal.SIGKILL)]
+
+
+def test_windows_tree_stop_taskkill(monkeypatch):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr("harness.local_model_manager.subprocess.run", fake_run)
+    stop_process_tree(4242, proc=None, grace=0, sleeper=lambda _s: None)
+    assert calls[0][:4] == ["taskkill", "/PID", "4242", "/T"]
+    assert "/F" not in calls[0]
+    assert calls[1] == ["taskkill", "/PID", "4242", "/T", "/F"]
+
+
+def test_stop_never_signals_unmatched(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    signaled = []
+    monkeypatch.setattr(
+        "harness.local_model_manager.stop_process_tree",
+        lambda *a, **k: signaled.append(a),
+    )
+    monkeypatch.setattr("harness.local_model_manager._pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        "harness.local_model_manager.read_process_command",
+        lambda pid: "/usr/bin/unrelated",
+    )
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    state = mgr._state()
+    state["managed"]["process"] = {
+        "pid": 4242, "port": 9, "host": "127.0.0.1",
+        "exe": "/tmp/llama-server", "model_path": "/tmp/model.gguf",
+        "alias": "marionette-deadbeef", "nonce": "deadbeef",
+    }
+    mgr._save(state)
+    mgr.stop()
+    assert signaled == []
+    assert mgr._state()["managed"]["process"] is None
+
+
+def test_readiness_requires_alias(tmp_path):
+    catalog, _, model_bytes = _tiny_catalog(tmp_path)
+    root = tmp_path / "lm"
+    ticks = {"n": 0}
+
+    def clock():
+        ticks["n"] += 1
+        return float(ticks["n"])
+
+    mgr = LocalModelManager(
+        root=str(root), catalog=catalog, sleeper=lambda _s: None,
+        clock=clock, ready_timeout=2.0,
+    )
+    runtime = root / "runtime" / "test"
+    runtime.mkdir(parents=True)
+    exe = runtime / "llama-server"
+    exe.write_text("x", encoding="utf-8")
+    models = root / "models"
+    models.mkdir()
+    model_path = models / "model.gguf"
+    model_path.write_bytes(model_bytes)
+    mgr._set_component("runtime", status="ready", path=str(exe))
+    mgr._set_component("model", status="ready", path=str(model_path), id="qwen-test")
+
+    class _Proc:
+        pid = 77
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            return None
+
+    mgr.popen = lambda *a, **k: _Proc()
+    mgr._http_json = lambda *a, **k: {"payload": {"data": [{"id": "someone-else"}]}}
+    with pytest.raises(LocalModelError) as exc:
+        mgr.start()
+    assert exc.value.code == "not_ready"
+    assert mgr._state()["managed"]["process"] is None
+    assert mgr._procs == {}
+
+
+def test_readiness_fails_if_child_exits(tmp_path):
+    catalog, _, model_bytes = _tiny_catalog(tmp_path)
+    root = tmp_path / "lm"
+    mgr = LocalModelManager(
+        root=str(root), catalog=catalog, sleeper=lambda _s: None,
+        clock=lambda: 1.0, ready_timeout=1.0,
+    )
+    runtime = root / "runtime" / "test"
+    runtime.mkdir(parents=True)
+    exe = runtime / "llama-server"
+    exe.write_text("x", encoding="utf-8")
+    (root / "models").mkdir()
+    model_path = root / "models" / "model.gguf"
+    model_path.write_bytes(model_bytes)
+    mgr._set_component("runtime", status="ready", path=str(exe))
+    mgr._set_component("model", status="ready", path=str(model_path), id="qwen-test")
+
+    class _Dead:
+        pid = 88
+
+        def poll(self):
+            return 1
+
+        def wait(self, timeout=None):
+            return 1
+
+        def kill(self):
+            return None
+
+    mgr.popen = lambda *a, **k: _Dead()
+    mgr._http_json = lambda *a, **k: {"payload": {"data": [{"id": "marionette-x"}]}}
+    with pytest.raises(LocalModelError) as exc:
+        mgr.start()
+    assert exc.value.code == "not_ready"
+    assert mgr._procs == {}
+
+
+def test_shutdown_is_idempotent(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    mgr.shutdown()
+    mgr.shutdown()
+    assert mgr._shutdown is True
+
+
+def test_shutdown_stops_owned_handle_when_ps_fails(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    stopped = []
+    monkeypatch.setattr(
+        "harness.local_model_manager.stop_process_tree",
+        lambda pid, proc=None, **k: stopped.append((pid, proc)),
+    )
+    monkeypatch.setattr("harness.local_model_manager.read_process_command", lambda pid: "")
+    monkeypatch.setattr("harness.local_model_manager._pid_alive", lambda pid: True)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+
+    class _Proc:
+        pid = 4242
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            return None
+
+    log = open(os.path.join(str(tmp_path), "llama-shutdown.log"), "wb")
+    proc = _Proc()
+    mgr._procs[4242] = (proc, log)
+    state = mgr._state()
+    state["managed"]["process"] = {
+        "pid": 4242, "port": 9, "host": "127.0.0.1",
+        "exe": "/tmp/llama-server", "model_path": "/tmp/model.gguf",
+        "alias": "marionette-deadbeef", "nonce": "deadbeef",
+    }
+    mgr._save(state)
+    mgr.shutdown()
+    assert stopped
+    assert stopped[0][0] == 4242
+    assert log.closed
+    assert mgr._state()["managed"]["process"] is None
+
+
+def test_event_cursor_monotonic_across_restart(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    root = str(tmp_path / "lm")
+    first = LocalModelManager(root=root, catalog=catalog)
+    first._emit("progress", {"n": 1})
+    cursor = first.events.cursor
+    assert cursor > 0
+    second = LocalModelManager(root=root, catalog=catalog)
+    assert second.events.cursor >= cursor
+    replay = second.events_since(cursor - 1)
+    assert replay
+    assert replay[0]["kind"] == "snapshot"
+    assert replay[0]["data"]["reason"] == "replay_unavailable"
+    assert replay[0]["cursor"] >= cursor
+
+
+def test_event_log_gap_emits_snapshot():
+    log = EventLog(cursor=12)
+    events = log.since(3)
+    assert events[0]["kind"] == "snapshot"
+    assert events[0]["cursor"] == 12
+
+
+def test_probe_redirect_refuses_public():
+    handler = ProbeRedirectHandler()
+    req = urllib.request.Request("http://127.0.0.1:8080/v1/models")
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        handler.redirect_request(req, None, 302, "Found", {}, "https://example.com/steal")
+    assert "Public" in str(exc.value) or "blocked" in str(exc.value).lower() or exc.value.code == 302
+
+
+def test_probe_redirect_refuses_metadata():
+    handler = ProbeRedirectHandler()
+    req = urllib.request.Request("http://127.0.0.1:8080/v1/models")
+    with pytest.raises(urllib.error.HTTPError):
+        handler.redirect_request(
+            req, None, 302, "Found", {}, "http://169.254.169.254/latest/meta-data/",
+        )
+
+
+def test_assert_probe_hop_refuses_public_ip(monkeypatch):
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "8.8.8.8"),
+    )
+    with pytest.raises(LocalModelError) as exc:
+        assert_probe_hop_safe("http://127.0.0.1:8080/v1")
+    assert exc.value.code == "public"
+
+
+def test_install_requires_explicit_model_id(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    with pytest.raises(LocalModelError) as exc:
+        mgr.install("all", model_id="", background=False)
+    assert exc.value.code == "model_id"
+    with pytest.raises(LocalModelError) as exc:
+        mgr.install("all", model_id="missing", background=False)
+    assert exc.value.code == "unknown_model"
+
+
+def test_runpod_https_save_with_manual_model(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "1.2.3.4"),
+    )
+
+    def transport(url, **kwargs):
+        raise LocalModelError("Endpoint returned HTTP 404", code="probe", http_status=404)
+
+    monkeypatch.setattr("harness.keys.set_api_key", lambda *a, **k: None)
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"),
+        catalog=catalog,
+        probe_transport=transport,
+    )
+    snap = mgr.save_external(
+        "https://abc.proxy.runpod.net/v1",
+        accept_remote=True,
+        model="qwen3-4b",
+        name="runpod-box",
+        api_key="sk-secret-value",
+    )
+    blob = json.dumps(snap)
+    assert "sk-secret-value" not in blob
+    row = snap["externals"][0]
+    assert row["selected_model"] == "qwen3-4b"
+    assert row["name"] == "runpod-box"
+    assert row["vendor"] == "openai-compatible"
+    assert row["healthy"] is True
+    assert row["remote_accepted"] is True
+    assert row.get("api_key") in (None, "", "••••")
+    resolved = mgr.resolve_spec("local:%s/qwen3-4b" % row["id"])
+    assert resolved["base_url"].startswith("https://")
+    assert resolved["secret_reach"].startswith("local-")
+
+
+def test_runpod_rejected_without_confirmation(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    with pytest.raises(LocalModelError) as exc:
+        mgr.save_external(
+            "https://abc.proxy.runpod.net/v1",
+            accept_remote=False,
+            model="qwen3-4b",
+        )
+    assert exc.value.code == "public"
+
+
+def test_external_survives_manager_restart(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "1.2.3.4"),
+    )
+    root = str(tmp_path / "lm")
+    first = LocalModelManager(
+        root=root,
+        catalog=catalog,
+        probe_transport=lambda *a, **k: {
+            "payload": {"data": []},
+            "headers": {},
+            "status": 200,
+        },
+    )
+    first.save_external(
+        "https://abc.proxy.runpod.net/v1",
+        accept_remote=True,
+        model="manual-qwen",
+        name="kept",
+    )
+    second = LocalModelManager(root=root, catalog=catalog)
+    specs = second.usable_specs()
+    assert any(spec.endswith("/manual-qwen") for spec in specs)
+    row = second._state()["externals"][0]
+    resolved = second.resolve_spec("local:%s/manual-qwen" % row["id"])
+    assert resolved["base_url"]
+    assert resolved["secret_reach"] == lm_reach(row["id"])
+
+
+def lm_reach(endpoint_id):
+    from harness.local_models import local_secret_reach
+    return local_secret_reach(endpoint_id)
+
+
+def test_probe_redirect_refuses_public_even_when_remote_accepted():
+    handler = ProbeRedirectHandler()
+    req = urllib.request.Request("http://127.0.0.1:8080/v1/models")
+    with pytest.raises(urllib.error.HTTPError):
+        handler.redirect_request(req, None, 302, "Found", {}, "https://example.com/steal")
+
+
+def test_assert_probe_hop_allows_confirmed_public(monkeypatch):
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "1.2.3.4"),
+    )
+    decision = assert_probe_hop_safe(
+        "https://abc.proxy.runpod.net/v1",
+        accept_remote=True,
+    )
+    assert decision["ok"] is True
+    assert decision["kind"] == "public"
+
+
+def test_activate_rejects_unhealthy_external(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    state = mgr._state()
+    state["externals"] = [{
+        "id": "ollama-127-0-0-1-11434",
+        "selected_model": "llama3",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "healthy": False,
+    }]
+    mgr._save(state)
+    with pytest.raises(LocalModelError) as exc:
+        mgr.activate("local:ollama-127-0-0-1-11434/llama3")
+    assert exc.value.code == "unhealthy"
+
+
+def test_runpod_wrong_key_is_auth_error(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "1.2.3.4"),
+    )
+
+    def transport(url, **kwargs):
+        raise LocalModelError("Endpoint returned HTTP 401: unauthorized", code="probe", http_status=401)
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    with pytest.raises(LocalModelError) as exc:
+        mgr.probe(
+            "https://api.runpod.ai/v2/xxx/openai/v1",
+            api_key="wrong-key",
+            accept_remote=True,
+        )
+    assert exc.value.code == "auth"
+    assert exc.value.http_status == 401
+
+
+def test_runpod_missing_key_status_is_auth_error(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "1.2.3.4"),
+    )
+
+    def transport(url, **kwargs):
+        return {"payload": {"error": "unauthorized"}, "headers": {}, "status": 403}
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    with pytest.raises(LocalModelError) as exc:
+        mgr.probe("https://api.runpod.ai/v2/xxx/openai/v1", accept_remote=True)
+    assert exc.value.code == "auth"
+
+
+def test_runpod_distinct_paths_coexist(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "1.2.3.4"),
+    )
+
+    def transport(url, **kwargs):
+        return {"payload": {"data": []}, "headers": {}, "status": 200}
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    first = mgr.save_external(
+        "https://api.runpod.ai/v2/aaa/openai/v1",
+        accept_remote=True,
+        model="qwen-a",
+    )
+    second = mgr.save_external(
+        "https://api.runpod.ai/v2/bbb/openai/v1",
+        accept_remote=True,
+        model="qwen-b",
+    )
+    ids = [item["id"] for item in second["externals"]]
+    assert len(ids) == 2
+    assert ids[0] != ids[1]
+    assert first["externals"][0]["id"] in ids
+
+
+def test_download_range_end_must_be_total_minus_one(tmp_path):
+    catalog, runtime_bytes, _model = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    asset = catalog["runtime"]["assets"]["linux-x64"]
+    part = mgr._part_path(asset["filename"])
+    os.makedirs(os.path.dirname(part), exist_ok=True)
+    with open(part, "wb") as handle:
+        handle.write(runtime_bytes[:4])
+
+    def urlopen(req, timeout=None):
+        return _RangeBody(
+            runtime_bytes, start=4, status=206,
+            headers={"Content-Range": "bytes 4-10/%s" % len(runtime_bytes)},
+        )
+
+    mgr.urlopen = urlopen
+    with pytest.raises(LocalModelError) as exc:
+        mgr.download_asset(asset, target="runtime")
+    assert exc.value.code == "download"
+    assert os.path.getsize(part) == 4
+
+
+def test_download_reuses_verified_final(tmp_path):
+    catalog, runtime_bytes, _model = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    asset = catalog["runtime"]["assets"]["linux-x64"]
+    final = mgr._final_path(asset["filename"])
+    os.makedirs(os.path.dirname(final), exist_ok=True)
+    with open(final, "wb") as handle:
+        handle.write(runtime_bytes)
+    calls = {"n": 0}
+
+    def urlopen(req, timeout=None):
+        calls["n"] += 1
+        return _RangeBody(runtime_bytes, status=200)
+
+    mgr.urlopen = urlopen
+    path = mgr.download_asset(asset, target="runtime")
+    assert path == final
+    assert calls["n"] == 0
+
+
+def test_download_throttles_durable_progress(tmp_path):
+    payload = b"x" * (8 * 1024 * 1024)
+    digest = hashlib.sha256(payload).hexdigest()
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    catalog["runtime"]["assets"]["linux-x64"] = {
+        "filename": "big.bin",
+        "url": "http://fixture.test/big.bin",
+        "sha256": digest,
+        "size": len(payload),
+        "archive": "bin",
+    }
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog, clock=lambda: 1000.0)
+    writes = []
+    orig = mgr._set_download
+
+    def wrapped(target, payload_row):
+        writes.append(dict(payload_row))
+        return orig(target, payload_row)
+
+    mgr._set_download = wrapped
+    mgr.urlopen = lambda req, timeout=None: _RangeBody(payload, status=200)
+    mgr.download_asset(catalog["runtime"]["assets"]["linux-x64"], target="runtime")
+    chunk_count = len(payload) / (64 * 1024)
+    assert chunk_count > 20
+    assert len(writes) < 10
+    assert DOWNLOAD_PROGRESS_BYTES >= 4 * 1024 * 1024
+    assert DOWNLOAD_PROGRESS_INTERVAL <= 0.25
+
+
+def test_clear_cancel_all_clears_all_event(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    mgr.cancel("all")
+    assert mgr._cancel["all"].is_set()
+    assert mgr._cancelled("runtime")
+    mgr._clear_cancel("all")
+    assert not mgr._cancel["all"].is_set()
+    assert not mgr._cancelled("runtime")
+    assert not mgr._cancelled("model")
+
+
+def test_cancel_all_then_resume_download(tmp_path):
+    catalog, runtime_bytes, _model = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    asset = catalog["runtime"]["assets"]["linux-x64"]
+
+    class _Chunked:
+        def __init__(self):
+            self.sent = False
+
+        def read(self, n=-1):
+            if not self.sent:
+                self.sent = True
+                mgr.cancel("all")
+                return runtime_bytes[:2]
+            return runtime_bytes[2:]
+
+        def close(self):
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    mgr.urlopen = lambda req, timeout=None: _Chunked()
+    with pytest.raises(LocalModelError) as exc:
+        mgr.download_asset(asset, target="runtime")
+    assert exc.value.code == "cancelled"
+    part = mgr._part_path(asset["filename"])
+    assert os.path.exists(part)
+    mgr._clear_cancel("all")
+    mgr.urlopen = lambda req, timeout=None: _RangeBody(
+        runtime_bytes, start=os.path.getsize(part), status=206, total=len(runtime_bytes),
+    )
+    path = mgr.download_asset(asset, target="runtime")
+    assert sha256_file(path) == asset["sha256"]
+
+
+def test_cancelled_component_is_paused_not_error(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    mgr._install_runtime = lambda: mgr._set_component(
+        "runtime", status="ready", path="/bin/x", error=None,
+    )
+
+    def cancel_model(_model_id=""):
+        raise LocalModelError("Download cancelled", code="cancelled")
+
+    mgr._install_model = cancel_model
+    mgr._install_worker("all", "qwen-test")
+    state = mgr._state()
+    assert state["managed"]["runtime"]["status"] == "ready"
+    assert state["managed"]["model"]["status"] == "paused"
+    assert state["managed"]["runtime"]["status"] != "error"
+
+
+def test_model_failure_does_not_mark_runtime_error(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    mgr._install_runtime = lambda: mgr._set_component(
+        "runtime", status="ready", path="/bin/x", error=None,
+    )
+
+    def fail(_model_id=""):
+        raise LocalModelError("SHA-256 mismatch", code="hash_mismatch")
+
+    mgr._install_model = fail
+    mgr._install_worker("all", "qwen-test")
+    state = mgr._state()
+    assert state["managed"]["runtime"]["status"] == "ready"
+    assert state["managed"]["model"]["status"] == "error"
+
+
+def test_overlapping_install_is_rejected_while_running(tmp_path):
+    catalog, runtime_bytes, _ = _tiny_catalog(tmp_path)
+    started = threading.Event()
+    release = threading.Event()
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+
+    class _Blocked:
+        def read(self, n=-1):
+            started.set()
+            release.wait(2)
+            return runtime_bytes if not getattr(self, "sent", False) else b""
+
+        def close(self):
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        @property
+        def status(self):
+            return 200
+
+        headers = {}
+
+    def urlopen(req, timeout=None):
+        body = _Blocked()
+        return body
+
+    mgr.urlopen = urlopen
+    first = mgr.install("runtime", background=True)
+    assert started.wait(1)
+    with pytest.raises(LocalModelError) as exc:
+        mgr.install("runtime", background=True)
+    assert exc.value.code == "busy"
+    alive = [w for w in mgr._workers.values() if w is not None and w.is_alive()]
+    assert len(alive) == 1
+    release.set()
+    alive[0].join(2)
+    assert first["managed"]
+
+
+def test_stop_kills_owned_handle_when_ps_fails(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    stopped = []
+    monkeypatch.setattr(
+        "harness.local_model_manager.stop_process_tree",
+        lambda pid, proc=None, **k: stopped.append((pid, proc)),
+    )
+    monkeypatch.setattr("harness.local_model_manager.read_process_command", lambda pid: "")
+    monkeypatch.setattr("harness.local_model_manager._pid_alive", lambda pid: True)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+
+    class _Proc:
+        pid = 4242
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            return None
+
+    log = open(os.path.join(str(tmp_path), "llama.log"), "wb")
+    proc = _Proc()
+    mgr._procs[4242] = (proc, log)
+    state = mgr._state()
+    state["managed"]["process"] = {
+        "pid": 4242, "port": 9, "host": "127.0.0.1",
+        "exe": "/tmp/llama-server", "model_path": "/tmp/model.gguf",
+        "alias": "marionette-deadbeef", "nonce": "deadbeef",
+    }
+    mgr._save(state)
+    mgr.stop()
+    assert stopped
+    assert stopped[0][0] == 4242
+    assert log.closed
+
+
+def test_start_restarts_unhealthy_matching_process(tmp_path, monkeypatch):
+    catalog, _, model_bytes = _tiny_catalog(tmp_path)
+    root = tmp_path / "lm"
+    mgr = LocalModelManager(
+        root=str(root), catalog=catalog, sleeper=lambda _s: None,
+        clock=lambda: 1.0, ready_timeout=1.0,
+    )
+    runtime = root / "runtime" / "test"
+    runtime.mkdir(parents=True)
+    exe = runtime / "llama-server"
+    exe.write_text("x", encoding="utf-8")
+    (root / "models").mkdir()
+    model_path = root / "models" / "model.gguf"
+    model_path.write_bytes(model_bytes)
+    mgr._set_component("runtime", status="ready", path=str(exe))
+    mgr._set_component("model", status="ready", path=str(model_path), id="qwen-test")
+    monkeypatch.setattr(
+        "harness.local_model_manager.process_matches_identity",
+        lambda pid, ident: True,
+    )
+    monkeypatch.setattr(
+        "harness.local_model_manager.stop_process_tree",
+        lambda *a, **k: None,
+    )
+    state = mgr._state()
+    state["managed"]["process"] = {
+        "pid": 11, "port": 9, "host": "127.0.0.1",
+        "exe": str(exe), "model_path": str(model_path),
+        "alias": "marionette-old", "nonce": "old",
+        "healthy": False,
+    }
+    mgr._save(state)
+    spawned = []
+
+    class _Proc:
+        pid = 22
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            return None
+
+    def popen(*a, **k):
+        spawned.append(1)
+        return _Proc()
+
+    mgr.popen = popen
+    health = {"n": 0}
+
+    def probe(*a, **k):
+        health["n"] += 1
+        return health["n"] >= 2
+
+    mgr._probe_health = probe
+    snap = mgr.start()
+    assert spawned
+    assert snap["managed"]["process"]["pid"] == 22
+    assert snap["managed"]["process"]["healthy"] is True
+
+
+def test_event_log_wait_wakes_on_append():
+    log = EventLog()
+    seen = []
+
+    def waiter():
+        seen.extend(log.wait_since(0, timeout=2.0))
+
+    thread = threading.Thread(target=waiter)
+    thread.start()
+    time.sleep(0.05)
+    log.append("progress", {"n": 1})
+    thread.join(2)
+    assert seen
+    assert seen[0]["kind"] == "progress"
+
+
+def test_pid_alive_windows_does_not_signal(monkeypatch):
+    signaled = []
+
+    def fake_kill(pid, sig):
+        signaled.append((pid, sig))
+        raise AssertionError("Windows liveness must not call os.kill")
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(os, "kill", fake_kill)
+    monkeypatch.setattr(
+        "harness.local_model_manager._windows_pid_query",
+        lambda pid: {"alive": True, "image": r"C:\\llama-server.exe", "start_key": "abc"},
+    )
+    assert _pid_alive(4242) is True
+    assert signaled == []
+
+
+def test_windows_identity_fail_closed_without_query(monkeypatch):
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr("harness.local_model_manager._windows_pid_query", lambda pid: None)
+    assert _pid_alive(9) is False
+    assert read_process_command(9) == ""
+    assert read_process_start_key(9) == ""
+    assert process_matches_identity(9, {
+        "exe": "llama-server.exe", "start_key": "abc", "alias": "marionette-x",
+    }) is False
+
+
+def test_windows_identity_matches_start_key_and_image(monkeypatch):
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(
+        "harness.local_model_manager._windows_pid_query",
+        lambda pid: {
+            "alive": True,
+            "image": r"C:\\tools\\llama-server.exe",
+            "start_key": "deadbeefcafebabe",
+        },
+    )
+    identity = {
+        "exe": r"C:\\tools\\llama-server.exe",
+        "start_key": "deadbeefcafebabe",
+        "alias": "marionette-x",
+        "nonce": "x",
+        "model_path": r"C:\\models\\qwen.gguf",
+    }
+    assert process_matches_identity(11, identity) is True
+    identity["start_key"] = "other"
+    assert process_matches_identity(11, identity) is False
+
+
+def test_windows_helpers_never_call_wmic(monkeypatch):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        return SimpleNamespace(returncode=1, stdout="")
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr("harness.local_model_manager.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "harness.local_model_manager._windows_pid_query",
+        lambda pid: {"alive": True, "image": "llama-server.exe", "start_key": "1"},
+    )
+    assert read_process_command(3) == "llama-server.exe"
+    assert read_process_start_key(3) == "1"
+    assert not any("wmic" in " ".join(item).lower() for item in calls)
+
+
+def test_probe_refuses_all_redirects_including_public_origin():
+    handler = ProbeRedirectHandler()
+    req = urllib.request.Request("https://proxy.runpod.net/v1/models")
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        handler.redirect_request(
+            req, None, 302, "Found", {"Authorization": "Bearer secret"},
+            "https://evil.example/steal",
+        )
+    assert "must not redirect" in str(exc.value).lower()
+    assert "secret" not in str(exc.value).lower()
+
+
+def test_probe_refuses_dns_rebind_public_to_loopback(monkeypatch):
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "127.0.0.1"),
+    )
+    with pytest.raises(LocalModelError) as exc:
+        assert_probe_hop_safe("https://evil.example/v1", accept_remote=True)
+    assert exc.value.code == "loopback"
+
+
+def test_probe_http_error_does_not_echo_body(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+
+    def boom(req, timeout=None, **kwargs):
+        err = urllib.error.HTTPError(
+            "http://127.0.0.1:9/v1/models", 502, "bad", {}, io.BytesIO(b"internal-trace-secret"),
+        )
+        raise err
+
+    monkeypatch.setattr("harness.local_model_manager.probe_urlopen", boom)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    with pytest.raises(LocalModelError) as exc:
+        mgr.probe("http://127.0.0.1:9/v1")
+    assert "internal-trace-secret" not in str(exc.value)
+    assert "502" in str(exc.value)
+
+
+def test_empty_key_on_resave_preserves_vault_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    stored = {}
+
+    def set_key(reach, value):
+        stored[reach] = value
+
+    def status(reach):
+        value = stored.get(reach) or ""
+        return {"has_key": bool(value), "masked": "••••" if value else ""}
+
+    monkeypatch.setattr("harness.keys.set_api_key", set_key)
+    monkeypatch.setattr("harness.keys.get_api_key_status", status)
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"),
+        catalog=catalog,
+        probe_transport=lambda *a, **k: {
+            "payload": {"data": [{"id": "llama3"}]}, "headers": {}, "status": 200,
+        },
+    )
+    first = mgr.save_external(
+        "http://192.168.1.20:8080/v1",
+        api_key="sk-secret-value",
+        accept_lan=True,
+        model="llama3",
+    )
+    blob = json.dumps(first) + json.dumps(mgr.events.since(0))
+    assert "sk-secret-value" not in blob
+    assert first["externals"][0]["has_key"] is True
+    second = mgr.save_external(
+        "http://192.168.1.20:8080/v1",
+        api_key="",
+        accept_lan=True,
+        model="llama3",
+    )
+    row = second["externals"][0]
+    assert row["has_key"] is True
+    assert "sk-secret-value" not in json.dumps(second)
+    assert stored[lm_reach(row["id"])] == "sk-secret-value"
+
+
+def test_concurrent_install_and_start_rejected(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    monkeypatch.setattr(
+        "harness.local_model_manager.detect_hardware",
+        lambda *_a, **_k: {"supported": True},
+    )
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    hold = threading.Event()
+
+    def blocker():
+        hold.wait(2)
+
+    worker = threading.Thread(target=blocker, daemon=True)
+    worker.start()
+    mgr._workers["all"] = worker
+    with pytest.raises(LocalModelError) as exc:
+        mgr.install("all", model_id="qwen-test")
+    assert exc.value.code == "busy"
+    mgr._start_in_progress = True
+    with pytest.raises(LocalModelError) as exc:
+        mgr.start()
+    assert exc.value.code == "busy"
+    hold.set()
+    worker.join(1)
+
+
+def test_cpu_asset_keeps_ngl_zero_when_nvidia_present(tmp_path, monkeypatch):
+    catalog, _, model_bytes = _tiny_catalog(tmp_path)
+    for key, asset in catalog["runtime"]["assets"].items():
+        asset["backend"] = "cpu"
+        asset["platform"] = key
+    monkeypatch.setattr("harness.local_models.detect_accelerator", lambda: "cuda")
+    monkeypatch.setattr("harness.local_model_manager.shutil.which", lambda name: "/usr/bin/nvidia-smi")
+    root = tmp_path / "lm"
+    mgr = LocalModelManager(
+        root=str(root), catalog=catalog, sleeper=lambda _s: None,
+        clock=lambda: 1.0, ready_timeout=1.0,
+    )
+    runtime = root / "runtime" / "test"
+    runtime.mkdir(parents=True)
+    exe = runtime / "llama-server"
+    exe.write_text("x", encoding="utf-8")
+    (root / "models").mkdir()
+    model_path = root / "models" / "model.gguf"
+    model_path.write_bytes(model_bytes)
+    mgr._set_component("runtime", status="ready", path=str(exe), platform="linux-x64")
+    mgr._set_component("model", status="ready", path=str(model_path), id="qwen-test")
+    spawned = {}
+
+    class _Proc:
+        pid = 77
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            return None
+
+    mgr.popen = lambda argv, **kwargs: spawned.update(argv=argv) or _Proc()
+    mgr._probe_health = lambda *a, **k: True
+    mgr.start()
+    argv = spawned["argv"]
+    assert argv[argv.index("-ngl") + 1] == "0"
+
+
+def test_metal_asset_keeps_ngl_99(tmp_path, monkeypatch):
+    catalog, _, model_bytes = _tiny_catalog(tmp_path)
+    for key, asset in catalog["runtime"]["assets"].items():
+        asset["backend"] = "metal"
+    root = tmp_path / "lm"
+    mgr = LocalModelManager(
+        root=str(root), catalog=catalog, sleeper=lambda _s: None,
+        clock=lambda: 1.0, ready_timeout=1.0,
+    )
+    runtime = root / "runtime" / "test"
+    runtime.mkdir(parents=True)
+    exe = runtime / "llama-server"
+    exe.write_text("x", encoding="utf-8")
+    (root / "models").mkdir()
+    model_path = root / "models" / "model.gguf"
+    model_path.write_bytes(model_bytes)
+    mgr._set_component("runtime", status="ready", path=str(exe), platform="macos-arm64")
+    mgr._set_component("model", status="ready", path=str(model_path), id="qwen-test")
+    spawned = {}
+
+    class _Proc:
+        pid = 78
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            return None
+
+    mgr.popen = lambda argv, **kwargs: spawned.update(argv=argv) or _Proc()
+    mgr._probe_health = lambda *a, **k: True
+    mgr.start()
+    argv = spawned["argv"]
+    assert argv[argv.index("-ngl") + 1] == "99"
+
+
+def test_probe_uses_one_dns_pin(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    pins = []
+
+    def pinned(url, **k):
+        pins.append(url)
+        return True, "", "1.2.3.4"
+
+    monkeypatch.setattr("harness.local_model_manager.is_safe_url_pinned", pinned)
+
+    class _Resp:
+        status = 200
+        headers = {}
+
+        def __init__(self):
+            self._buf = io.BytesIO(b'{"data":[{"id":"qwen"}]}')
+
+        def read(self, n=-1):
+            return self._buf.read(n)
+
+        def close(self):
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    seen_pin = []
+
+    def fake_urlopen(req, timeout=None, **kwargs):
+        seen_pin.append(kwargs.get("pinned_ip"))
+        return _Resp()
+
+    monkeypatch.setattr("harness.local_model_manager.probe_urlopen", fake_urlopen)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    result = mgr.probe("https://models.example/v1", accept_remote=True)
+    assert result["ok"] is True
+    assert len(pins) == 1
+    assert seen_pin
+    assert all(ip == "1.2.3.4" for ip in seen_pin)
+
+
+def test_probe_urlopen_reuses_pin_without_second_dns(monkeypatch):
+    calls = []
+
+    def pinned(url, **k):
+        calls.append(url)
+        return True, "", "9.9.9.9"
+
+    monkeypatch.setattr("harness.local_model_manager.is_safe_url_pinned", pinned)
+    seen = []
+
+    class _Opener:
+        def open(self, req, timeout=None):
+            return SimpleNamespace(status=200)
+
+    def build_opener(*handlers):
+        for handler in handlers:
+            pin = getattr(handler, "_pin", None)
+            if pin is not None:
+                seen.append(getattr(pin, "ip", None))
+        return _Opener()
+
+    monkeypatch.setattr(urllib.request, "build_opener", build_opener)
+    req = urllib.request.Request("https://models.example/v1/models")
+    probe_urlopen(req, accept_remote=True, pinned_ip="1.2.3.4")
+    assert calls == []
+    assert "1.2.3.4" in seen
+
+
+def test_windows_unmatched_pid_does_not_taskkill(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr("harness.local_model_manager.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "harness.local_model_manager._windows_pid_query",
+        lambda pid: {
+            "alive": True,
+            "image": r"C:\\Windows\\notepad.exe",
+            "start_key": "ffff",
+        },
+    )
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    state = mgr._state()
+    state["managed"]["process"] = {
+        "pid": 4242, "port": 9, "host": "127.0.0.1",
+        "exe": r"C:\\tools\\llama-server.exe",
+        "model_path": r"C:\\models\\qwen.gguf",
+        "alias": "marionette-x",
+        "nonce": "x",
+        "start_key": "deadbeefcafebabe",
+    }
+    mgr._save(state)
+    mgr.stop()
+    assert calls == []
+    assert mgr._state()["managed"]["process"] is None
+
+
+def test_concurrent_start_second_is_busy(tmp_path, monkeypatch):
+    catalog, _, model_bytes = _tiny_catalog(tmp_path)
+    monkeypatch.setattr(
+        "harness.local_model_manager.detect_hardware",
+        lambda *_a, **_k: {"supported": True},
+    )
+    root = tmp_path / "lm"
+    mgr = LocalModelManager(
+        root=str(root), catalog=catalog, sleeper=lambda _s: None,
+        clock=lambda: 1.0, ready_timeout=1.0,
+    )
+    runtime = root / "runtime" / "test"
+    runtime.mkdir(parents=True)
+    exe = runtime / "llama-server"
+    exe.write_text("x", encoding="utf-8")
+    (root / "models").mkdir()
+    model_path = root / "models" / "model.gguf"
+    model_path.write_bytes(model_bytes)
+    mgr._set_component("runtime", status="ready", path=str(exe), platform="linux-x64")
+    mgr._set_component("model", status="ready", path=str(model_path), id="qwen-test")
+    started = threading.Event()
+    release = threading.Event()
+
+    class _Proc:
+        pid = 91
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            return None
+
+    def popen(*_a, **_k):
+        started.set()
+        release.wait(2)
+        return _Proc()
+
+    mgr.popen = popen
+    mgr._probe_health = lambda *_a, **_k: True
+    errors = []
+
+    def first():
+        mgr.start()
+
+    def second():
+        if not started.wait(1):
+            errors.append("first-never-started")
+            return
+        try:
+            mgr.start()
+        except LocalModelError as exc:
+            errors.append(exc.code)
+
+    t1 = threading.Thread(target=first)
+    t2 = threading.Thread(target=second)
+    t1.start()
+    t2.start()
+    t2.join(3)
+    release.set()
+    t1.join(3)
+    assert errors == ["busy"]
+
+
+def test_snapshot_and_save_do_not_deadlock(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "127.0.0.1"),
+    )
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"),
+        catalog=catalog,
+        probe_transport=lambda *_a, **_k: {
+            "payload": {"data": [{"id": "llama3"}]},
+            "headers": {},
+            "status": 200,
+        },
+    )
+    barrier = threading.Barrier(2)
+    done = []
+
+    def snap():
+        barrier.wait()
+        for _ in range(20):
+            mgr.snapshot()
+        done.append("snap")
+
+    def save():
+        barrier.wait()
+        for _ in range(8):
+            mgr.save_external("http://127.0.0.1:11434/v1", model="llama3")
+        done.append("save")
+
+    t1 = threading.Thread(target=snap)
+    t2 = threading.Thread(target=save)
+    t1.start()
+    t2.start()
+    t1.join(5)
+    t2.join(5)
+    assert not t1.is_alive() and not t2.is_alive()
+    assert sorted(done) == ["save", "snap"]
+
+
+def _seed_external(mgr, **fields):
+    state = mgr._state()
+    row = {
+        "id": "ollama-127-0-0-1-11434",
+        "name": "ollama",
+        "vendor": "ollama",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "models": ["llama3"],
+        "selected_model": "llama3",
+        "healthy": True,
+        "has_key": False,
+        "kind": "loopback",
+        "requires_key": False,
+        "lan_accepted": False,
+        "remote_accepted": False,
+    }
+    row.update(fields)
+    state["externals"] = [row]
+    mgr._save(state)
+    return row
+
+
+def _tool_call_payload(name="marionette_capability_probe", arguments="{\"ok\":true}"):
+    return {
+        "choices": [{
+            "message": {
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": name, "arguments": arguments},
+                }],
+            },
+        }],
+    }
+
+
+def test_probe_and_save_do_not_verify_tool_calling(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    urls = []
+
+    def transport(url, **kwargs):
+        urls.append(url)
+        return {"payload": {"data": [{"id": "llama3"}]}, "headers": {}, "status": 200}
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    mgr.probe("http://127.0.0.1:11434/v1")
+    snap = mgr.save_external("http://127.0.0.1:11434/v1", model="llama3")
+    assert all("/chat/completions" not in url for url in urls)
+    assert snap["externals"][0]["tool_calling"]["status"] == "unverified"
+
+
+def test_verify_tool_calling_verified_uses_synthetic_bearer(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    seen = []
+
+    def transport(url, **kwargs):
+        seen.append((url, kwargs))
+        body = json.loads(kwargs.get("body") or b"{}")
+        assert body["stream"] is False
+        assert kwargs.get("method") == "POST"
+        assert (kwargs.get("headers") or {}).get("Authorization") == "Bearer local"
+        return {"payload": _tool_call_payload(), "headers": {}, "status": 200}
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    _seed_external(mgr)
+    snap = mgr.verify_tool_calling("local:ollama-127-0-0-1-11434/llama3")
+    row = snap["externals"][0]
+    assert row["tool_calling"]["status"] == "verified"
+    assert row["healthy"] is True
+    assert row.get("last_error") in (None, "")
+    assert seen and "/chat/completions" in seen[0][0]
+
+
+def test_verify_tool_calling_unsupported_keeps_endpoint_healthy(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+
+    def transport(url, **kwargs):
+        return {
+            "payload": {"choices": [{"message": {"content": "I cannot call functions."}}]},
+            "headers": {},
+            "status": 200,
+        }
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    _seed_external(mgr)
+    snap = mgr.verify_tool_calling("local:ollama-127-0-0-1-11434/llama3")
+    row = snap["externals"][0]
+    assert row["tool_calling"]["status"] == "unsupported"
+    assert "text" in row["tool_calling"]["reason"]
+    assert row["healthy"] is True
+    usable = mgr.usable_specs()
+    assert "local:ollama-127-0-0-1-11434/llama3" in usable
+
+
+def test_verify_tool_calling_malformed_is_error(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+
+    def transport(url, **kwargs):
+        return {"payload": {"choices": [{"message": {"tool_calls": "nope"}}]}, "headers": {}, "status": 200}
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    _seed_external(mgr)
+    snap = mgr.verify_tool_calling("local:ollama-127-0-0-1-11434/llama3")
+    row = snap["externals"][0]
+    assert row["tool_calling"]["status"] == "error"
+    assert "malformed" in row["tool_calling"]["reason"].lower()
+    assert row["healthy"] is True
+
+
+def test_verify_tool_calling_auth_is_error(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+
+    def transport(url, **kwargs):
+        return {"payload": {}, "headers": {}, "status": 401}
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    _seed_external(mgr)
+    snap = mgr.verify_tool_calling("local:ollama-127-0-0-1-11434/llama3")
+    row = snap["externals"][0]
+    assert row["tool_calling"]["status"] == "error"
+    assert "API key" in row["tool_calling"]["reason"]
+    assert row["healthy"] is True
+
+
+def test_verify_tool_calling_transport_is_error(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+
+    def transport(url, **kwargs):
+        raise LocalModelError("Endpoint probe failed", code="probe")
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    _seed_external(mgr)
+    snap = mgr.verify_tool_calling("local:ollama-127-0-0-1-11434/llama3")
+    row = snap["externals"][0]
+    assert row["tool_calling"]["status"] == "error"
+    assert "could not be reached" in row["tool_calling"]["reason"]
+    assert row["healthy"] is True
+
+
+def test_verify_public_without_key_fails_closed(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    called = []
+
+    def transport(url, **kwargs):
+        called.append(url)
+        raise AssertionError("public verify must not send a request without a key")
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    _seed_external(
+        mgr,
+        id="runpod-box",
+        base_url="https://proxy.runpod.net/v1",
+        kind="public",
+        requires_key=True,
+        remote_accepted=True,
+        has_key=False,
+    )
+    snap = mgr.verify_tool_calling("local:runpod-box/llama3")
+    row = snap["externals"][0]
+    assert row["tool_calling"]["status"] == "error"
+    assert row["tool_calling"]["reason"] == "This public endpoint requires an API key."
+    assert row["healthy"] is True
+    assert called == []
+
+
+def test_verify_does_not_persist_or_echo_secret(tmp_path, monkeypatch):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "1.2.3.4"),
+    )
+    monkeypatch.setenv("LOCAL_RUNPOD_BOX_API_KEY", "sk-secret-value")
+    monkeypatch.setattr("harness.keys.hydrate_reach_key", lambda _reach: True)
+    monkeypatch.setattr(
+        "harness.keys.get_env_var_for_reach",
+        lambda _reach: "LOCAL_RUNPOD_BOX_API_KEY",
+    )
+
+    def transport(url, **kwargs):
+        assert "sk-secret-value" in (kwargs.get("headers") or {}).get("Authorization", "")
+        return {"payload": _tool_call_payload(), "headers": {}, "status": 200}
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    _seed_external(
+        mgr,
+        id="runpod-box",
+        base_url="https://proxy.runpod.net/v1",
+        kind="public",
+        requires_key=True,
+        remote_accepted=True,
+        has_key=True,
+    )
+    snap = mgr.verify_tool_calling("local:runpod-box/llama3")
+    blob = json.dumps(snap) + json.dumps(mgr.events.since(0))
+    assert "sk-secret-value" not in blob
+    assert snap["externals"][0]["tool_calling"]["status"] == "verified"
+    assert snap["externals"][0].get("api_key") in (None, "", "••••")
+
+
+def test_verify_never_executes_returned_function(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    arguments = "{\"cmd\":\"rm -rf /\",\"code\":\"__import__('os').system('id')\"}"
+
+    def transport(url, **kwargs):
+        return {
+            "payload": _tool_call_payload(arguments=arguments),
+            "headers": {},
+            "status": 200,
+        }
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "lm"), catalog=catalog, probe_transport=transport,
+    )
+    _seed_external(mgr)
+    snap = mgr.verify_tool_calling("local:ollama-127-0-0-1-11434/llama3")
+    blob = json.dumps(snap) + json.dumps(mgr.events.since(0))
+    assert snap["externals"][0]["tool_calling"]["status"] == "verified"
+    assert "rm -rf" not in blob
+    assert "__import__" not in blob
+    assert arguments not in blob
+
+
+def test_verify_rejects_managed_spec(tmp_path):
+    catalog, _, _ = _tiny_catalog(tmp_path)
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog)
+    with pytest.raises(LocalModelError) as exc:
+        mgr.verify_tool_calling("local:managed/qwen3-4b")
+    assert exc.value.code == "managed"

--- a/tests/test_local_model_manager.py
+++ b/tests/test_local_model_manager.py
@@ -514,7 +514,7 @@ def test_extract_rejects_zip_symlink(tmp_path):
 
 
 def test_windows_spawn_flags(monkeypatch):
-    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr("harness.local_model_manager._platform_name", lambda: "nt")
     kwargs = spawn_popen_kwargs()
     flags = kwargs.get("creationflags") or 0
     assert flags & _CREATE_NEW_PROCESS_GROUP
@@ -524,14 +524,14 @@ def test_windows_spawn_flags(monkeypatch):
 
 
 def test_posix_spawn_new_session(monkeypatch):
-    monkeypatch.setattr(os, "name", "posix")
+    monkeypatch.setattr("harness.local_model_manager._platform_name", lambda: "posix")
     kwargs = spawn_popen_kwargs()
     assert kwargs.get("start_new_session") is True
 
 
 def test_posix_tree_stop_term_then_kill(monkeypatch):
     killed = []
-    monkeypatch.setattr(os, "name", "posix")
+    monkeypatch.setattr("harness.local_model_manager._platform_name", lambda: "posix")
     monkeypatch.setattr(os, "getpgid", lambda pid: 9001, raising=False)
     monkeypatch.setattr(os, "killpg", lambda pgid, sig: killed.append((pgid, sig)), raising=False)
     stop_process_tree(4242, proc=None, grace=0, sleeper=lambda _s: None)
@@ -545,7 +545,7 @@ def test_windows_tree_stop_taskkill(monkeypatch):
         calls.append(list(argv))
         return SimpleNamespace(returncode=0)
 
-    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr("harness.local_model_manager._platform_name", lambda: "nt")
     monkeypatch.setattr("harness.local_model_manager.subprocess.run", fake_run)
     stop_process_tree(4242, proc=None, grace=0, sleeper=lambda _s: None)
     assert calls[0][:4] == ["taskkill", "/PID", "4242", "/T"]
@@ -1281,7 +1281,7 @@ def test_pid_alive_windows_does_not_signal(monkeypatch):
         signaled.append((pid, sig))
         raise AssertionError("Windows liveness must not call os.kill")
 
-    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr("harness.local_model_manager._platform_name", lambda: "nt")
     monkeypatch.setattr(os, "kill", fake_kill)
     monkeypatch.setattr(
         "harness.local_model_manager._windows_pid_query",
@@ -1292,7 +1292,7 @@ def test_pid_alive_windows_does_not_signal(monkeypatch):
 
 
 def test_windows_identity_fail_closed_without_query(monkeypatch):
-    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr("harness.local_model_manager._platform_name", lambda: "nt")
     monkeypatch.setattr("harness.local_model_manager._windows_pid_query", lambda pid: None)
     assert _pid_alive(9) is False
     assert read_process_command(9) == ""
@@ -1303,7 +1303,7 @@ def test_windows_identity_fail_closed_without_query(monkeypatch):
 
 
 def test_windows_identity_matches_start_key_and_image(monkeypatch):
-    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr("harness.local_model_manager._platform_name", lambda: "nt")
     monkeypatch.setattr(
         "harness.local_model_manager._windows_pid_query",
         lambda pid: {
@@ -1331,7 +1331,7 @@ def test_windows_helpers_never_call_wmic(monkeypatch):
         calls.append(list(argv))
         return SimpleNamespace(returncode=1, stdout="")
 
-    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr("harness.local_model_manager._platform_name", lambda: "nt")
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setattr("harness.local_model_manager.subprocess.run", fake_run)
     monkeypatch.setattr(
@@ -1604,7 +1604,7 @@ def test_windows_unmatched_pid_does_not_taskkill(tmp_path, monkeypatch):
         calls.append(list(argv))
         return SimpleNamespace(returncode=0)
 
-    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr("harness.local_model_manager._platform_name", lambda: "nt")
     monkeypatch.setattr("harness.local_model_manager.subprocess.run", fake_run)
     monkeypatch.setattr(
         "harness.local_model_manager._windows_pid_query",
@@ -1627,7 +1627,7 @@ def test_windows_unmatched_pid_does_not_taskkill(tmp_path, monkeypatch):
     }
     mgr._save(state)
     mgr.stop()
-    assert calls == []
+    assert not any(call and call[0] == "taskkill" for call in calls)
     assert mgr._state()["managed"]["process"] is None
 
 

--- a/tests/test_local_models.py
+++ b/tests/test_local_models.py
@@ -1,0 +1,402 @@
+"""Hermetic tests for local-model domain: state, catalog, URL policy, specs."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from harness import local_models as lm
+
+
+def test_packaged_catalog_pins_official_digests():
+    catalog = lm.load_catalog()
+    runtime = catalog["runtime"]
+    assert runtime["release"] == "b10442"
+    assert runtime["binary"] == "llama-server"
+    for key in (
+        "macos-arm64", "macos-x64", "linux-x64", "linux-arm64",
+        "windows-x64", "windows-arm64",
+    ):
+        asset = runtime["assets"][key]
+        assert asset["url"].startswith(
+            "https://github.com/ggml-org/llama.cpp/releases/download/b10442/"
+        )
+        assert len(asset["sha256"]) == 64
+        assert asset["size"] > 0
+    expected_hashes = {
+        "macos-arm64": "10861c8a5405bf3a04889f1216505aafab6c48360446a5b73b9042e7bbe8d5b7",
+        "macos-x64": "75b487d1c89048812a1d1c8fc99cfc0b75d1705cd6beddf6503e4edd1909bb71",
+        "linux-x64": "a447495bdf503af09a1874ebbb450927171da2c84c68cc4eae27c9789ca37b0e",
+        "linux-arm64": "a3f8deaf74111bf508d2e8a071b1964dcfc16e15ecb56aeeb1ace40c238c2a8f",
+        "windows-x64": "67a5da01b254be88294bdb477f481b71bb482b838e8d7da013eef8b20a0cfa24",
+        "windows-arm64": "5a1843d2995c106bcf7c796d89d3ed5f0a497aa641f0bf796c95ab868e8e43b8",
+    }
+    for key, digest in expected_hashes.items():
+        assert runtime["assets"][key]["sha256"] == digest
+    assert runtime["assets"]["macos-arm64"]["backend"] == "metal"
+    assert runtime["assets"]["linux-x64"]["backend"] == "cpu"
+    assert runtime["assets"]["windows-x64"]["backend"] == "cpu"
+    model = catalog["models"][0]
+    assert model["id"] == "qwen3-4b"
+    assert model["name"] == "Qwen3 4B"
+    assert model["filename"] == "Qwen3-4B-Q4_K_M.gguf"
+    assert model["revision"] == "bc640142c66e1fdd12af0bd68f40445458f3869b"
+    assert model["sha256"] == "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5"
+    assert model["size"] == 2497280256
+    assert model["context_length"] == 40960
+    assert "Hob-forge" not in model["url"]
+    assert model["url"].startswith("https://huggingface.co/Qwen/Qwen3-4B-GGUF/")
+
+
+def test_detect_platform_key_normalizes_arch():
+    assert lm.detect_platform_key("Darwin", "arm64") == "macos-arm64"
+    assert lm.detect_platform_key("Linux", "x86_64") == "linux-x64"
+    assert lm.detect_platform_key("Windows", "AMD64") == "windows-x64"
+
+
+def test_runtime_asset_missing_platform():
+    catalog = lm.load_catalog()
+    assert lm.runtime_asset_for_platform(catalog, "plan9-x64") is None
+
+
+def test_state_migration_fills_v1(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    raw = {"managed": {"runtime": {"status": "ready", "path": "/bin/llama-server"}}}
+    migrated = lm.migrate_state(raw)
+    assert migrated["version"] == 1
+    assert migrated["managed"]["runtime"]["status"] == "ready"
+    assert migrated["managed"]["model"]["status"] == "absent"
+    assert migrated["externals"] == []
+
+
+def test_state_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    state = lm.empty_state()
+    state["active_spec"] = "local:managed/qwen3-4b"
+    lm.save_state(state, str(tmp_path / "local-models"))
+    loaded = lm.load_state(str(tmp_path / "local-models"))
+    assert loaded["active_spec"] == "local:managed/qwen3-4b"
+
+
+def test_normalize_localhost_to_ipv4_and_v1():
+    assert lm.normalize_endpoint_url("http://localhost:11434") == "http://127.0.0.1:11434/v1"
+    assert lm.normalize_endpoint_url("http://127.0.0.1:8080/v1") == "http://127.0.0.1:8080/v1"
+
+
+def test_evaluate_url_blocks_metadata_and_public():
+    blocked = lm.evaluate_endpoint_url("http://169.254.169.254/latest")
+    assert blocked["ok"] is False
+    assert blocked["kind"] == "metadata"
+    public = lm.evaluate_endpoint_url("https://api.openai.com/v1")
+    assert public["ok"] is False
+    assert public["kind"] == "public"
+    assert public["requires_remote"] is True
+
+
+def test_evaluate_url_allows_https_public_with_accept_remote():
+    denied = lm.evaluate_endpoint_url("https://proxy.runpod.net/v1")
+    assert denied["ok"] is False
+    accepted = lm.evaluate_endpoint_url(
+        "https://proxy.runpod.net/v1", accept_remote=True,
+    )
+    assert accepted["ok"] is True
+    assert accepted["kind"] == "public"
+    assert accepted["normalized"].startswith("https://")
+    http = lm.evaluate_endpoint_url("http://proxy.runpod.net/v1", accept_remote=True)
+    assert http["ok"] is False
+    assert http["kind"] == "public"
+
+
+def test_evaluate_url_requires_explicit_lan():
+    lan = lm.evaluate_endpoint_url("http://192.168.1.20:8080/v1")
+    assert lan["ok"] is False
+    assert lan["requires_lan"] is True
+    accepted = lm.evaluate_endpoint_url("http://192.168.1.20:8080/v1", accept_lan=True)
+    assert accepted["ok"] is True
+    assert accepted["normalized"] == "http://192.168.1.20:8080/v1"
+    remote_only = lm.evaluate_endpoint_url(
+        "http://192.168.1.20:8080/v1", accept_remote=True,
+    )
+    assert remote_only["ok"] is False
+    assert remote_only["requires_lan"] is True
+    loopback = lm.evaluate_endpoint_url("http://127.0.0.1:8080/v1")
+    assert loopback["ok"] is True
+
+
+def test_canonical_spec_roundtrip():
+    spec = lm.canonical_spec("managed", "qwen3-4b")
+    assert spec == "local:managed/qwen3-4b"
+    assert lm.parse_local_spec(spec) == ("managed", "qwen3-4b")
+    assert lm.parse_local_spec("anthropic:claude") is None
+
+
+def test_redact_mapping_strips_keys():
+    out = lm.redact_mapping({"api_key": "sk-secret-value", "url": "http://127.0.0.1:8080/v1?token=abc"})
+    assert "sk-secret-value" not in json.dumps(out)
+    assert out["api_key"].startswith("••••")
+
+
+def test_parse_command_rejects_unknown():
+    with pytest.raises(ValueError):
+        lm.parse_command({"type": "explode"})
+    cmd = lm.parse_command({"type": "install", "target": "runtime"})
+    assert cmd == {"type": "install", "target": "runtime", "model_id": ""}
+    install = lm.parse_command({"type": "install", "target": "all", "model_id": "qwen3-4b"})
+    assert install["model_id"] == "qwen3-4b"
+    probe = lm.parse_command({
+        "type": "probe",
+        "url": "https://proxy.runpod.net/v1",
+        "trust_remote": True,
+    })
+    assert probe["accept_remote"] is True
+    verify = lm.parse_command({
+        "type": "verify_tool_calling",
+        "spec": "local:ollama-127-0-0-1-11434/llama3",
+    })
+    assert verify == {
+        "type": "verify_tool_calling",
+        "spec": "local:ollama-127-0-0-1-11434/llama3",
+    }
+    with pytest.raises(ValueError):
+        lm.parse_command({"type": "verify_tool_calling"})
+
+
+def test_extract_model_ids_and_context():
+    ids = lm.extract_model_ids({"data": [{"id": "qwen"}, "other"]})
+    assert ids == ["qwen", "other"]
+    ctx = lm.extract_context_length({"data": [{"id": "qwen", "max_model_len": 8192}]})
+    assert ctx == 8192
+
+
+def test_unhealthy_external_is_not_usable():
+    state = lm.empty_state()
+    state["externals"] = [{
+        "id": "ollama-127-0-0-1-11434",
+        "selected_model": "llama3",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "healthy": False,
+    }]
+    assert lm.usable_local_specs(state) == []
+    state["externals"][0]["healthy"] = True
+    assert lm.usable_local_specs(state) == ["local:ollama-127-0-0-1-11434/llama3"]
+
+
+def test_snapshot_exposes_catalog_models_without_recommendation():
+    catalog = lm.load_catalog()
+    snap = lm.snapshot_from_state(lm.empty_state(), catalog=catalog, hardware={
+        "os": "Darwin",
+        "arch": "arm64",
+        "platform_key": "macos-arm64",
+        "accelerator": "metal",
+        "supported": True,
+    })
+    assert "recommendation" not in snap["hardware"]
+    assert "recommended_ram_gb" not in snap["hardware"]
+    assert snap["catalog"]["models"][0]["id"] == "qwen3-4b"
+    assert snap["catalog"]["models"][0]["trust"] == "first-party"
+
+
+def test_detect_hardware_has_no_recommendation():
+    hw = lm.detect_hardware(catalog=lm.load_catalog())
+    assert "recommendation" not in hw
+    assert "recommended_ram_gb" not in hw
+
+
+def test_detect_vendor_runpod():
+    assert lm.detect_vendor_from_url("https://abc.proxy.runpod.net/v1") == "openai-compatible"
+    assert lm.normalize_vendor("runpod") == "openai-compatible"
+
+
+def test_catalog_rejects_missing_hash():
+    with pytest.raises(ValueError):
+        lm.parse_catalog({"runtime": {"assets": {"macos-arm64": {"url": "x", "sha256": "nope"}}}})
+
+
+def test_catalog_omits_recommended_ram():
+    catalog = lm.load_catalog()
+    assert "recommended_ram_gb" not in catalog["models"][0]
+    parsed = lm.parse_catalog({
+        "models": [{
+            "id": "x",
+            "name": "X",
+            "sha256": "a" * 64,
+            "recommended_ram_gb": 8,
+            "min_ram_gb": 4,
+        }],
+    })
+    assert "recommended_ram_gb" not in parsed["models"][0]
+
+
+def test_runpod_paths_get_distinct_ids():
+    first = lm.endpoint_id_for_url(
+        "https://api.runpod.ai/v2/aaa/openai/v1", "openai-compatible",
+    )
+    second = lm.endpoint_id_for_url(
+        "https://api.runpod.ai/v2/bbb/openai/v1", "openai-compatible",
+    )
+    assert first != second
+    assert first.startswith("openai-compatible-api-runpod-ai-")
+    loop = lm.endpoint_id_for_url("http://127.0.0.1:11434/v1", "ollama")
+    assert loop == "ollama-127-0-0-1-11434"
+
+
+def test_resolve_refuses_unhealthy_external():
+    state = lm.empty_state()
+    state["externals"] = [{
+        "id": "ollama-127-0-0-1-11434",
+        "selected_model": "llama3",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "healthy": False,
+    }]
+    assert lm.resolve_local_endpoint(state, "local:ollama-127-0-0-1-11434/llama3") is None
+    state["externals"][0]["healthy"] = True
+    resolved = lm.resolve_local_endpoint(state, "local:ollama-127-0-0-1-11434/llama3")
+    assert resolved is not None
+    assert resolved["base_url"] == "http://127.0.0.1:11434/v1"
+
+
+def test_resolve_refuses_unhealthy_managed():
+    state = lm.empty_state()
+    state["managed"]["runtime"]["status"] = "ready"
+    state["managed"]["model"]["status"] = "ready"
+    state["managed"]["model"]["id"] = "qwen3-4b"
+    state["managed"]["process"] = {
+        "pid": 9, "port": 8080, "host": "127.0.0.1", "healthy": False,
+    }
+    assert lm.managed_usable(state) is False
+    assert lm.resolve_local_endpoint(state, "local:managed/qwen3-4b") is None
+    state["managed"]["process"]["healthy"] = True
+    resolved = lm.resolve_local_endpoint(state, "local:managed/qwen3-4b")
+    assert resolved is not None
+    assert resolved["kind"] == "loopback"
+    assert resolved["requires_key"] is False
+
+
+def test_detect_linux_libc_fail_closed(monkeypatch):
+    assert lm.detect_linux_libc(
+        confstr=lambda _name: "glibc 2.39",
+        maps_text="",
+        lib_names=[],
+    ) == "glibc"
+
+    def _no_confstr(_name):
+        raise ValueError("not glibc")
+
+    assert lm.detect_linux_libc(
+        confstr=_no_confstr,
+        maps_text="/lib/ld-musl-x86_64.so.1",
+        lib_names=[],
+    ) == "musl"
+    assert lm.detect_linux_libc(
+        confstr=_no_confstr,
+        maps_text="",
+        lib_names=["ld-musl-aarch64.so.1"],
+    ) == "musl"
+    assert lm.detect_linux_libc(
+        confstr=_no_confstr,
+        maps_text="",
+        lib_names=["libfoo.so"],
+    ) == "unknown"
+
+
+def test_musl_linux_does_not_claim_ubuntu_runtime():
+    assert lm.detect_platform_key("Linux", "x86_64", libc="musl") == "linux-x64-musl"
+    catalog = lm.load_catalog()
+    assert lm.runtime_asset_for_platform(catalog, "linux-x64-musl") is None
+    assert lm.runtime_asset_for_platform(catalog, "linux-x64")["backend"] == "cpu"
+    assert lm.runtime_asset_for_platform(catalog, "macos-arm64")["backend"] == "metal"
+
+
+def test_runtime_offload_layers_follow_backend():
+    assert lm.runtime_offload_layers({"backend": "cpu"}) == "0"
+    assert lm.runtime_offload_layers({"backend": "metal"}) == "99"
+    assert lm.runtime_offload_layers({"backend": "cuda"}) == "99"
+    assert lm.runtime_offload_layers({}) == "0"
+
+
+def test_classify_tool_calling_payload_semantics():
+    verified, reason = lm.classify_tool_calling_payload({
+        "choices": [{
+            "message": {
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": lm.TOOL_CALLING_FUNCTION_NAME,
+                        "arguments": "{\"cmd\":\"rm -rf /\"}",
+                    },
+                }],
+            },
+        }],
+    })
+    assert verified == "verified"
+    assert "tool call" in reason
+    unsupported, _ = lm.classify_tool_calling_payload({
+        "choices": [{"message": {"content": "I cannot call tools."}}],
+    })
+    assert unsupported == "unsupported"
+    malformed, _ = lm.classify_tool_calling_payload({"choices": [{"message": {"tool_calls": "nope"}}]})
+    assert malformed == "error"
+    empty, _ = lm.classify_tool_calling_payload({"id": "cmpl"})
+    assert empty == "error"
+
+
+def test_classify_tool_calling_requires_requested_function():
+    other, reason = lm.classify_tool_calling_payload({
+        "choices": [{
+            "message": {
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "some_other_tool",
+                        "arguments": "{\"cmd\":\"rm -rf /\"}",
+                    },
+                }],
+            },
+        }],
+    })
+    assert other == "unsupported"
+    assert "different function" in reason
+    assert "rm -rf" not in reason
+    malformed, _ = lm.classify_tool_calling_payload({
+        "choices": [{"message": {"tool_calls": [{"function": {"name": ""}}]}}],
+    })
+    assert malformed == "error"
+
+
+def test_normalize_tool_calling_defaults_unverified():
+    row = lm._normalize_external({
+        "id": "ollama-127-0-0-1-11434",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "selected_model": "llama3",
+        "healthy": True,
+    })
+    assert row["tool_calling"] == {
+        "status": "unverified", "reason": "", "checked_at": None,
+    }
+
+
+def test_tool_calling_request_is_non_streaming():
+    body = lm.tool_calling_request_body("llama3")
+    assert body["stream"] is False
+    assert body["tool_choice"]["function"]["name"] == lm.TOOL_CALLING_FUNCTION_NAME
+
+
+def test_trusted_lan_is_keyless_public_requires_key():
+    lan = lm._normalize_external({
+        "id": "lan-box",
+        "base_url": "http://192.168.1.20:8080/v1",
+        "selected_model": "qwen",
+        "healthy": True,
+        "kind": "lan",
+    })
+    assert lan["requires_key"] is False
+    public = lm._normalize_external({
+        "id": "runpod",
+        "base_url": "https://proxy.runpod.net/v1",
+        "selected_model": "qwen",
+        "healthy": True,
+        "kind": "public",
+    })
+    assert public["requires_key"] is True

--- a/tests/test_local_models_api.py
+++ b/tests/test_local_models_api.py
@@ -1,0 +1,314 @@
+"""HTTP command/event surface for local models."""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from harness.api.local_models import (
+    LocalModelServices,
+    get_local_model_events,
+    get_local_models,
+    post_local_models,
+    stream_local_model_events,
+)
+from harness.local_model_manager import LocalModelManager
+
+
+def _svc(tmp_path, **kwargs):
+    catalog = {
+        "version": 1,
+        "runtime": {"id": "llama.cpp", "release": "t", "binary": "llama-server", "assets": {}},
+        "models": [{
+            "id": "qwen-test",
+            "name": "Qwen",
+            "filename": "m.gguf",
+            "url": "http://fixture/m.gguf",
+            "revision": "x",
+            "sha256": "a" * 64,
+            "size": 1,
+            "context_length": 1024,
+            "min_ram_gb": 0,
+            "recommended_ram_gb": 1,
+            "min_disk_bytes": 1,
+        }],
+    }
+    mgr = LocalModelManager(root=str(tmp_path / "lm"), catalog=catalog, **kwargs)
+    cfg = SimpleNamespace(driver="stub:ok", repo=str(tmp_path))
+    rebuilt = {"n": 0}
+    return LocalModelServices(
+        manager=mgr,
+        cfg=cfg,
+        rebuild_pilot_and_session=lambda: rebuilt.__setitem__("n", rebuilt["n"] + 1),
+        save_workspace_driver=lambda *_a: None,
+        resync_driver_after_model_curation=lambda: {},
+    ), rebuilt
+
+
+def test_get_snapshot(tmp_path):
+    svc, _ = _svc(tmp_path)
+    status, payload = get_local_models(svc)
+    assert status == 200
+    assert "hardware" in payload
+    assert "managed" in payload
+    assert payload["externals"] == []
+    assert payload["catalog"]["models"][0]["id"] == "qwen-test"
+    assert "recommendation" not in payload["hardware"]
+
+
+def test_post_unknown_command(tmp_path):
+    svc, _ = _svc(tmp_path)
+    status, payload = post_local_models({"type": "explode"}, svc)
+    assert status == 400
+    assert "error" in payload
+
+
+def test_post_probe_and_events(tmp_path):
+    def transport(url, **kwargs):
+        return {
+            "payload": {"data": [{"id": "phi", "context_length": 2048}]},
+            "headers": {"Server": "llama.cpp"},
+            "status": 200,
+        }
+
+    svc, _ = _svc(tmp_path, probe_transport=transport)
+    status, payload = post_local_models({
+        "type": "probe",
+        "url": "http://127.0.0.1:8080/v1",
+        "api_key": "secret-key",
+    }, svc)
+    assert status == 200
+    assert payload["models"] == ["phi"]
+    assert "secret-key" not in str(payload)
+
+    status, replay = get_local_model_events(svc, "0")
+    assert status == 200
+    assert replay["ok"] is True
+    assert isinstance(replay["events"], list)
+
+
+def test_activate_rebuilds_pilot(tmp_path):
+    svc, rebuilt = _svc(tmp_path)
+    state = svc.manager._state()
+    state["managed"]["runtime"] = {"status": "ready", "path": "/x"}
+    state["managed"]["model"] = {"status": "ready", "id": "qwen-test", "path": "/m"}
+    state["managed"]["process"] = {
+        "pid": 1, "port": 9, "host": "127.0.0.1", "healthy": True,
+        "alias": "marionette-x", "nonce": "x", "exe": "llama-server",
+        "model_path": "qwen-test",
+    }
+    svc.manager._save(state)
+    svc.manager.reconcile_process = lambda: svc.manager._state()
+    status, payload = post_local_models({
+        "type": "activate",
+        "spec": "local:managed/qwen-test",
+    }, svc)
+    assert status == 200
+    assert payload["active_spec"] == "local:managed/qwen-test"
+    assert rebuilt["n"] == 1
+    assert svc.cfg.driver == "local:managed/qwen-test"
+
+
+def test_post_install_requires_model_id(tmp_path):
+    svc, _ = _svc(tmp_path)
+    status, payload = post_local_models({"type": "install", "target": "all"}, svc)
+    assert status == 400
+    assert payload.get("code") == "model_id"
+    status, payload = post_local_models({
+        "type": "install", "target": "all", "model_id": "missing",
+    }, svc)
+    assert status == 400
+    assert payload.get("code") == "unknown_model"
+
+
+def test_post_runpod_requires_accept_remote(tmp_path):
+    def transport(url, **kwargs):
+        return {"payload": {"data": []}, "headers": {}, "status": 200}
+
+    svc, _ = _svc(tmp_path, probe_transport=transport)
+    status, payload = post_local_models({
+        "type": "save_external",
+        "url": "https://abc.proxy.runpod.net/v1",
+        "model": "qwen3-4b",
+    }, svc)
+    assert status == 400
+    assert payload.get("code") == "public"
+
+
+def test_post_verify_tool_calling(tmp_path):
+    def transport(url, **kwargs):
+        if str(url).endswith("/chat/completions"):
+            return {
+                "payload": {
+                    "choices": [{
+                        "message": {
+                            "tool_calls": [{
+                                "function": {"name": "marionette_capability_probe", "arguments": "{}"},
+                            }],
+                        },
+                    }],
+                },
+                "headers": {},
+                "status": 200,
+            }
+        return {"payload": {"data": [{"id": "llama3"}]}, "headers": {}, "status": 200}
+
+    svc, _ = _svc(tmp_path, probe_transport=transport)
+    state = svc.manager._state()
+    state["externals"] = [{
+        "id": "ollama-127-0-0-1-11434",
+        "vendor": "ollama",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "models": ["llama3"],
+        "selected_model": "llama3",
+        "healthy": True,
+        "kind": "loopback",
+        "requires_key": False,
+    }]
+    svc.manager._save(state)
+    status, payload = post_local_models({
+        "type": "verify_tool_calling",
+        "spec": "local:ollama-127-0-0-1-11434/llama3",
+    }, svc)
+    assert status == 200
+    row = payload["externals"][0]
+    assert row["tool_calling"]["status"] == "verified"
+    assert row["healthy"] is True
+
+
+def test_post_verify_public_without_key_is_error(tmp_path):
+    called = []
+
+    def transport(url, **kwargs):
+        called.append(url)
+        return {"payload": {}, "headers": {}, "status": 200}
+
+    svc, _ = _svc(tmp_path, probe_transport=transport)
+    state = svc.manager._state()
+    state["externals"] = [{
+        "id": "runpod-box",
+        "vendor": "openai-compatible",
+        "base_url": "https://proxy.runpod.net/v1",
+        "models": ["qwen"],
+        "selected_model": "qwen",
+        "healthy": True,
+        "kind": "public",
+        "requires_key": True,
+        "remote_accepted": True,
+        "has_key": False,
+    }]
+    svc.manager._save(state)
+    status, payload = post_local_models({
+        "type": "verify_tool_calling",
+        "spec": "local:runpod-box/qwen",
+    }, svc)
+    assert status == 200
+    assert payload["externals"][0]["tool_calling"]["status"] == "error"
+    assert payload["externals"][0]["tool_calling"]["reason"] == (
+        "This public endpoint requires an API key."
+    )
+    assert payload["externals"][0]["healthy"] is True
+    assert called == []
+
+
+def test_post_verify_redacts_secret(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "harness.keys.hydrate_reach_key",
+        lambda _reach: True,
+    )
+    monkeypatch.setenv("LOCAL_RUNPOD_BOX_API_KEY", "sk-secret-value")
+    monkeypatch.setattr(
+        "harness.keys.get_env_var_for_reach",
+        lambda _reach: "LOCAL_RUNPOD_BOX_API_KEY",
+    )
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "1.2.3.4"),
+    )
+
+    def transport(url, **kwargs):
+        assert "sk-secret-value" in (kwargs.get("headers") or {}).get("Authorization", "")
+        return {
+            "payload": {
+                "choices": [{
+                    "message": {
+                        "tool_calls": [{"function": {"name": "marionette_capability_probe"}}],
+                    },
+                }],
+            },
+            "headers": {},
+            "status": 200,
+        }
+
+    svc, _ = _svc(tmp_path, probe_transport=transport)
+    state = svc.manager._state()
+    state["externals"] = [{
+        "id": "runpod-box",
+        "vendor": "openai-compatible",
+        "base_url": "https://proxy.runpod.net/v1",
+        "models": ["qwen"],
+        "selected_model": "qwen",
+        "healthy": True,
+        "kind": "public",
+        "requires_key": True,
+        "remote_accepted": True,
+        "has_key": True,
+    }]
+    svc.manager._save(state)
+    status, payload = post_local_models({
+        "type": "verify_tool_calling",
+        "spec": "local:runpod-box/qwen",
+    }, svc)
+    assert status == 200
+    blob = json.dumps(payload)
+    assert "sk-secret-value" not in blob
+    assert payload["externals"][0]["tool_calling"]["status"] == "verified"
+
+
+def test_stream_events_snapshot_then_wait(tmp_path):
+    frames = []
+    waits = []
+
+    class _WFile:
+        def write(self, data):
+            frames.append(data)
+            if len(frames) > 2:
+                raise BrokenPipeError()
+            return len(data)
+
+        def flush(self):
+            return None
+
+    class _Handler:
+        def __init__(self):
+            self.wfile = _WFile()
+            self.headers = []
+
+        def send_response(self, _code):
+            return None
+
+        def send_header(self, *a):
+            self.headers.append(a)
+
+        def _cors(self):
+            return None
+
+        def end_headers(self):
+            return None
+
+    svc, _ = _svc(tmp_path)
+
+    def wait_since(cursor, timeout):
+        waits.append(timeout)
+        return []
+
+    svc.manager.wait_events_since = wait_since
+    try:
+        stream_local_model_events(_Handler(), svc, "0")
+    except BrokenPipeError:
+        pass
+    assert frames
+    first = json.loads(frames[0].decode("utf-8").split("data: ", 1)[1])
+    assert first["kind"] == "snapshot"
+    assert "snapshot" in first
+    assert waits
+    assert all(value >= 2.0 for value in waits)

--- a/tests/test_local_models_providers.py
+++ b/tests/test_local_models_providers.py
@@ -1,0 +1,318 @@
+"""Local models appear in the picker only while usable, at zero price."""
+from __future__ import annotations
+
+import json
+import os
+
+from harness.local_model_manager import LocalModelError, LocalModelManager, reset_manager_for_tests
+from harness.local_models import canonical_spec, local_secret_reach
+from harness import model_visibility as mv
+from harness import providers as prov
+
+
+def test_local_provider_hidden_until_usable(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    reset_manager_for_tests()
+    assert prov.get_provider("local").name == "local"
+    assert prov.get_provider("llama-cpp").name == "local"
+    names = [p.name for p in prov.available_providers()]
+    assert "local" not in names
+
+
+def test_usable_local_spec_is_zero_price(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    reset_manager_for_tests()
+    catalog = {
+        "version": 1,
+        "runtime": {"id": "llama.cpp", "release": "t", "binary": "llama-server", "assets": {}},
+        "models": [{
+            "id": "qwen-test",
+            "name": "Qwen",
+            "filename": "m.gguf",
+            "url": "http://fixture/m.gguf",
+            "revision": "x",
+            "sha256": "b" * 64,
+            "size": 1,
+            "context_length": 1024,
+            "min_ram_gb": 0,
+            "recommended_ram_gb": 1,
+            "min_disk_bytes": 1,
+        }],
+    }
+    mgr = LocalModelManager(root=str(tmp_path / "local-models"), catalog=catalog)
+    state = mgr._state()
+    state["externals"] = [{
+        "id": "ollama-127-0-0-1-11434",
+        "name": "ollama",
+        "vendor": "ollama",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "models": ["llama3"],
+        "selected_model": "llama3",
+        "context_length": 4096,
+        "has_key": False,
+        "healthy": True,
+    }]
+    mgr._save(state)
+    monkeypatch.setattr("harness.local_model_manager.get_manager", lambda: mgr)
+    monkeypatch.setattr(mv, "_store_path", lambda: str(tmp_path / "models.json"))
+    spec = canonical_spec("ollama-127-0-0-1-11434", "llama3")
+    assert spec in mgr.usable_specs()
+    rows = mv.catalog(available_only=True)
+    local_rows = [row for row in rows if row["provider"] == "local"]
+    assert local_rows
+    assert local_rows[0]["price_in"] == 0
+    assert local_rows[0]["price_out"] == 0
+    assert local_rows[0]["spec"] == spec
+    restarted = LocalModelManager(root=str(tmp_path / "local-models"), catalog=catalog)
+    resolved = restarted.resolve_spec(spec)
+    assert resolved["base_url"] == "http://127.0.0.1:11434/v1"
+    assert resolved["secret_reach"].startswith("local-")
+
+
+def test_unhealthy_external_cannot_resolve_or_build_pilot(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    reset_manager_for_tests()
+    catalog = {
+        "version": 1,
+        "runtime": {"id": "llama.cpp", "release": "t", "binary": "llama-server", "assets": {}},
+        "models": [],
+    }
+    mgr = LocalModelManager(root=str(tmp_path / "local-models"), catalog=catalog)
+    state = mgr._state()
+    state["externals"] = [{
+        "id": "ollama-127-0-0-1-11434",
+        "name": "ollama",
+        "vendor": "ollama",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "models": ["llama3"],
+        "selected_model": "llama3",
+        "healthy": False,
+    }]
+    mgr._save(state)
+    spec = canonical_spec("ollama-127-0-0-1-11434", "llama3")
+    assert mgr.resolve_spec(spec) is None
+    monkeypatch.setattr("harness.local_model_manager.get_manager", lambda: mgr)
+    try:
+        prov.build_pilot(spec)
+        raise AssertionError("unhealthy external must not build a driver")
+    except (prov.ProviderError, LocalModelError):
+        pass
+
+
+def test_remote_key_survives_env_clear_into_driver(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("HARNESS_KEY_ENV", "OPENROUTER_API_KEY")
+    reset_manager_for_tests()
+    from harness.keys import get_api_key_status, get_env_var_for_reach
+    catalog = {
+        "version": 1,
+        "runtime": {"id": "llama.cpp", "release": "t", "binary": "llama-server", "assets": {}},
+        "models": [],
+    }
+    monkeypatch.setattr(
+        "harness.local_model_manager.is_safe_url_pinned",
+        lambda url, **k: (True, "", "1.2.3.4"),
+    )
+
+    def transport(url, **kwargs):
+        return {"payload": {"data": [{"id": "qwen"}]}, "headers": {}, "status": 200}
+
+    mgr = LocalModelManager(
+        root=str(tmp_path / "local-models"),
+        catalog=catalog,
+        probe_transport=transport,
+    )
+    snap = mgr.save_external(
+        "https://api.runpod.ai/v2/abc/openai/v1",
+        accept_remote=True,
+        model="qwen",
+        api_key="sk-remote-secret-xyz",
+    )
+    row = snap["externals"][0]
+    reach = local_secret_reach(row["id"])
+    env_var = get_env_var_for_reach(reach)
+    assert env_var != "OPENROUTER_API_KEY"
+    assert os.environ.get(env_var) == "sk-remote-secret-xyz"
+    os.environ.pop(env_var, None)
+    assert not os.environ.get(env_var)
+    monkeypatch.setattr("harness.local_model_manager.get_manager", lambda: mgr)
+    driver = prov.build_pilot("local:%s/qwen" % row["id"])
+    assert driver._key() == "sk-remote-secret-xyz"
+    blob = json.dumps(mgr.snapshot())
+    assert "sk-remote-secret-xyz" not in blob
+    status = get_api_key_status(reach)
+    assert status["has_key"] is True
+    assert "sk-remote-secret-xyz" not in status["masked"]
+
+
+def test_disconnected_local_is_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    from harness.keys import mark_disconnected, unmark_disconnected
+    reset_manager_for_tests()
+    catalog = {
+        "version": 1,
+        "runtime": {"id": "llama.cpp", "release": "t", "binary": "llama-server", "assets": {}},
+        "models": [],
+    }
+    mgr = LocalModelManager(root=str(tmp_path / "local-models"), catalog=catalog)
+    state = mgr._state()
+    state["externals"] = [{
+        "id": "ollama-127-0-0-1-11434",
+        "name": "ollama",
+        "vendor": "ollama",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "models": ["llama3"],
+        "selected_model": "llama3",
+        "healthy": True,
+        "kind": "loopback",
+        "requires_key": False,
+    }]
+    mgr._save(state)
+    monkeypatch.setattr("harness.local_model_manager.get_manager", lambda: mgr)
+    try:
+        mark_disconnected("local")
+        assert prov.get_provider("local").available is False
+        try:
+            prov.build_pilot("local:ollama-127-0-0-1-11434/llama3")
+            raise AssertionError("disconnected local must not build a driver")
+        except prov.ProviderError:
+            pass
+    finally:
+        unmark_disconnected("local")
+
+
+def test_keyless_lan_builds_and_public_requires_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    reset_manager_for_tests()
+    catalog = {
+        "version": 1,
+        "runtime": {"id": "llama.cpp", "release": "t", "binary": "llama-server", "assets": {}},
+        "models": [],
+    }
+    mgr = LocalModelManager(root=str(tmp_path / "local-models"), catalog=catalog)
+    state = mgr._state()
+    state["externals"] = [{
+        "id": "lan-box",
+        "vendor": "ollama",
+        "base_url": "http://192.168.1.20:8080/v1",
+        "models": ["qwen"],
+        "selected_model": "qwen",
+        "healthy": True,
+        "has_key": False,
+        "kind": "lan",
+        "requires_key": False,
+        "lan_accepted": True,
+    }, {
+        "id": "runpod-box",
+        "vendor": "openai-compatible",
+        "base_url": "https://proxy.runpod.net/v1",
+        "models": ["qwen"],
+        "selected_model": "qwen",
+        "healthy": True,
+        "has_key": False,
+        "kind": "public",
+        "requires_key": True,
+        "remote_accepted": True,
+    }]
+    mgr._save(state)
+    monkeypatch.setattr("harness.local_model_manager.get_manager", lambda: mgr)
+    lan = prov.build_pilot("local:lan-box/qwen")
+    assert lan.allow_keyless is True
+    assert lan._key() == "local"
+    try:
+        prov.build_pilot("local:runpod-box/qwen")
+        raise AssertionError("public HTTPS without a key must fail closed")
+    except prov.ProviderError as exc:
+        assert "requires an API key" in str(exc)
+
+
+def test_loopback_llama_cpp_builds_keyless(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    reset_manager_for_tests()
+    catalog = {
+        "version": 1,
+        "runtime": {"id": "llama.cpp", "release": "t", "binary": "llama-server", "assets": {}},
+        "models": [],
+    }
+    mgr = LocalModelManager(root=str(tmp_path / "local-models"), catalog=catalog)
+    state = mgr._state()
+    state["externals"] = [{
+        "id": "llama-loop",
+        "vendor": "llama.cpp",
+        "base_url": "http://127.0.0.1:8080/v1",
+        "models": ["qwen"],
+        "selected_model": "qwen",
+        "healthy": True,
+        "has_key": False,
+        "kind": "loopback",
+        "requires_key": False,
+    }]
+    mgr._save(state)
+    monkeypatch.setattr("harness.local_model_manager.get_manager", lambda: mgr)
+    driver = prov.build_pilot("local:llama-loop/qwen")
+    assert driver.allow_keyless is True
+    assert driver._is_llama_cpp_host() is True
+    assert driver._key() == "local"
+
+
+def test_public_llama_cpp_stale_has_key_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    reset_manager_for_tests()
+    catalog = {
+        "version": 1,
+        "runtime": {"id": "llama.cpp", "release": "t", "binary": "llama-server", "assets": {}},
+        "models": [],
+    }
+    mgr = LocalModelManager(root=str(tmp_path / "local-models"), catalog=catalog)
+    state = mgr._state()
+    state["externals"] = [{
+        "id": "llama-public",
+        "vendor": "llama.cpp",
+        "base_url": "https://proxy.runpod.net/v1",
+        "models": ["qwen"],
+        "selected_model": "qwen",
+        "healthy": True,
+        "has_key": True,
+        "kind": "public",
+        "requires_key": True,
+        "remote_accepted": True,
+    }]
+    mgr._save(state)
+    monkeypatch.setattr("harness.local_model_manager.get_manager", lambda: mgr)
+    from harness.local_models import local_secret_reach
+    from harness.keys import get_env_var_for_reach
+    monkeypatch.delenv(get_env_var_for_reach(local_secret_reach("llama-public")), raising=False)
+    try:
+        prov.build_pilot("local:llama-public/qwen")
+        raise AssertionError("stale has_key must not open a public llama.cpp endpoint")
+    except prov.ProviderError as exc:
+        assert "requires an API key" in str(exc)
+
+
+def test_first_activate_does_not_collapse_empty_allowlist(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    reset_manager_for_tests()
+    monkeypatch.setattr(mv, "_store_path", lambda: str(tmp_path / "models.json"))
+    catalog = {
+        "version": 1,
+        "runtime": {"id": "llama.cpp", "release": "t", "binary": "llama-server", "assets": {}},
+        "models": [],
+    }
+    mgr = LocalModelManager(root=str(tmp_path / "local-models"), catalog=catalog)
+    state = mgr._state()
+    state["externals"] = [{
+        "id": "ollama-127-0-0-1-11434",
+        "vendor": "ollama",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "selected_model": "llama3",
+        "healthy": True,
+    }]
+    mgr._save(state)
+    assert mv.get_enabled() == []
+    mgr.activate("local:ollama-127-0-0-1-11434/llama3")
+    assert mv.get_enabled() == []
+    mv.set_enabled(["openrouter:foo"])
+    mgr.activate("local:ollama-127-0-0-1-11434/llama3")
+    enabled = mv.get_enabled()
+    assert "openrouter:foo" in enabled
+    assert "local:ollama-127-0-0-1-11434/llama3" in enabled

--- a/tests/test_openai_compat_stream_terminals.py
+++ b/tests/test_openai_compat_stream_terminals.py
@@ -627,3 +627,205 @@ def test_stream_finish_aliases_are_case_insensitive(monkeypatch, finish, termina
     assert resp.meta["finish_reason"] == finish
     assert resp.meta["stream_terminal"] == terminal
     assert "without a finish_reason" not in str(resp.error or "")
+
+
+def test_finish_reason_without_done_settles_when_end_on_finish():
+    """llama.cpp can send finish_reason=stop then keepalives with no [DONE]."""
+    def _lines():
+        yield _data({"choices": [{"delta": {"content": "pong"}, "finish_reason": "stop"}]})
+        n = 0
+        while True:
+            n += 1
+            if n > 50:
+                raise AssertionError("parser waited for [DONE] after finish_reason")
+            yield b": keepalive\n"
+
+    parsed = _consume_openai_chat_sse(_lines(), end_on_finish=True)
+    assert parsed["error"] is None
+    assert parsed["text"] == "pong"
+    assert parsed["finish_reason"] == "stop"
+    assert parsed["stream_terminal"] == "stop"
+    assert parsed["saw_done"] is False
+    assert parsed["stream_started"] is True
+
+
+def test_llama_cpp_omits_stream_options_and_stops_on_finish(monkeypatch):
+    captured = {}
+    hung = {"n": 0}
+
+    class _LazySse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def __iter__(self):
+            yield _data({
+                "choices": [{"delta": {"content": "pong"}, "finish_reason": "stop"}],
+            })
+            while True:
+                hung["n"] += 1
+                if hung["n"] > 50:
+                    raise AssertionError("llama-cpp parser waited for [DONE]")
+                yield b": keepalive\n"
+
+    def fake_urlopen(req, timeout=None):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _LazySse()
+
+    monkeypatch.setenv("LLAMA_CPP_API_KEY", "local-test-key")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    driver = OpenAICompatDriver(
+        name="llama-cpp:qwen38-cyber",
+        model="qwen38-cyber",
+        base_url="http://127.0.0.1:8080/v1",
+        api_key_env="LLAMA_CPP_API_KEY",
+    )
+    resp = driver.chat_stream(
+        [{"role": "user", "content": "ping"}],
+        on_delta=lambda _t: None,
+    )
+    assert "stream_options" not in captured["body"]
+    assert resp.error is None
+    assert resp.text == "pong"
+    assert resp.meta["finish_reason"] == "stop"
+    assert resp.meta["stream_terminal"] == "stop"
+    assert resp.meta["saw_done"] is False
+
+
+def test_stop_finish_with_complete_tool_calls_is_executable():
+    """llama.cpp/Qwen often emit delta.tool_calls then finish_reason=stop."""
+    def _lines():
+        yield _data({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_wiki",
+                        "type": "function",
+                        "function": {
+                            "name": "query_wiki",
+                            "arguments": '{"question":"prior findings on example service"}',
+                        },
+                    }, {
+                        "index": 1,
+                        "id": "call_fetch",
+                        "type": "function",
+                        "function": {
+                            "name": "web_fetch",
+                            "arguments": '{"url":"https://example.com/docs"}',
+                        },
+                    }],
+                },
+                "finish_reason": "stop",
+            }],
+        })
+        n = 0
+        while True:
+            n += 1
+            if n > 50:
+                raise AssertionError("parser waited for [DONE] after stop+tools")
+            yield b": keepalive\n"
+
+    parsed = _consume_openai_chat_sse(_lines(), end_on_finish=True)
+    assert parsed["error"] is None
+    assert parsed["finish_reason"] == "stop"
+    assert parsed["stream_terminal"] == "tool_calls"
+    names = [tc["function"]["name"] for tc in parsed["tool_calls"]]
+    assert names == ["query_wiki", "web_fetch"]
+    assert parsed["saw_done"] is False
+
+
+def test_stop_finish_with_truncated_tool_args_is_incomplete():
+    lines = [
+        _data({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "query_wiki",
+                            "arguments": '{"question":',
+                        },
+                    }],
+                },
+                "finish_reason": "stop",
+            }],
+        }),
+        b"data: [DONE]\n",
+    ]
+    parsed = _consume_openai_chat_sse(lines)
+    assert parsed["error"]
+    assert parsed["stream_terminal"] == "incomplete"
+    assert parsed["tool_calls"] == []
+    assert parsed["incomplete_tool_calls"][0]["function"]["name"] == "query_wiki"
+
+
+def test_ollama_loopback_keeps_stream_options_and_is_not_llama_cpp(monkeypatch):
+    captured = {}
+
+    class _DoneSse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def __iter__(self):
+            yield _data({
+                "choices": [{"delta": {"content": "pong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+            })
+            yield b"data: [DONE]\n"
+
+    def fake_urlopen(req, timeout=None):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _DoneSse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    driver = OpenAICompatDriver(
+        name="local:ollama-127-0-0-1-11434/llama3",
+        model="llama3",
+        base_url="http://127.0.0.1:11434/v1",
+        api_key_env="LOCAL_OLLAMA_11434_API_KEY",
+        vendor="ollama",
+        allow_keyless=True,
+    )
+    assert driver._is_llama_cpp_host() is False
+    assert driver._is_loopback_base() is True
+    resp = driver.chat_stream(
+        [{"role": "user", "content": "ping"}],
+        on_delta=lambda _t: None,
+    )
+    assert captured["body"]["stream_options"] == {"include_usage": True}
+    assert resp.error is None
+    assert resp.meta.get("raw_usage") is not None or resp.tokens_out or resp.tokens_in
+
+
+def test_public_llama_cpp_driver_key_fails_closed(monkeypatch):
+    monkeypatch.delenv("PUBLIC_LLAMA_KEY", raising=False)
+    driver = OpenAICompatDriver(
+        name="llama-cpp:qwen",
+        model="qwen",
+        base_url="https://proxy.runpod.net/v1",
+        api_key_env="PUBLIC_LLAMA_KEY",
+        vendor="llama.cpp",
+        allow_keyless=False,
+    )
+    with pytest.raises(RuntimeError, match="missing API key"):
+        driver._key()
+
+
+def test_loopback_llama_cpp_driver_synthesizes_local_key(monkeypatch):
+    monkeypatch.delenv("LOCAL_LLAMA_KEY", raising=False)
+    driver = OpenAICompatDriver(
+        name="llama-cpp:qwen",
+        model="qwen",
+        base_url="http://127.0.0.1:8080/v1",
+        api_key_env="LOCAL_LLAMA_KEY",
+        vendor="llama.cpp",
+        allow_keyless=False,
+    )
+    assert driver._key() == "local"

--- a/tests/test_send_loop_phases.py
+++ b/tests/test_send_loop_phases.py
@@ -605,6 +605,9 @@ def test_drain_stream_queue_usable_via_yield_from():
         return prose, r
 
     gen = _consume()
+    first = next(gen)
+    assert first.kind == "stream_item_done"
+    assert first.data == {}
     try:
         next(gen)
         raise AssertionError("expected StopIteration with return value")

--- a/tests/test_sse_pump_terminal.py
+++ b/tests/test_sse_pump_terminal.py
@@ -89,3 +89,95 @@ def test_sse_pump_clean_path_unchanged():
     assert detached is False
     assert wfile.kinds() == ["assistant_done", "done"]
     assert [e["kind"] for e in ring.since(0)["events"]] == ["assistant_done", "done"]
+
+
+def test_sse_pump_writes_before_blocking_on_event():
+    """Live SSE must not wait on checkpoint/on_event (Still working hang)."""
+    _sse_ring_clear_for_tests()
+    ring = SseEventRing("sess-write-first", generation=1, cap=32, ttl=60.0)
+    wfile = _Wfile()
+    seen = {"kinds_at_on_event": None}
+
+    def on_event(ev):
+        seen["kinds_at_on_event"] = list(wfile.kinds())
+        if ev.kind == "assistant_done" and not wfile.kinds():
+            raise AssertionError("assistant_done checkpoint ran before the SSE write")
+
+    def _ok():
+        yield SimpleNamespace(kind="message_delta", data={"text": "hi"}, turn=0)
+        yield SimpleNamespace(kind="assistant_done", data={"turns": 1}, turn=0)
+
+    detached = sse_pump(wfile, _ok(), _frame, on_event=on_event, ring=ring)
+    assert detached is False
+    assert wfile.kinds() == ["message_delta", "assistant_done", "done"]
+    assert seen["kinds_at_on_event"][-1] == "assistant_done"
+
+
+def test_stream_chat_writes_resume_before_done(monkeypatch):
+    from harness.api.sse import _sse_ring_clear_for_tests
+    from harness.api.streams import StreamServices, stream_chat
+    _sse_ring_clear_for_tests()
+
+    written = []
+
+    class _Wfile:
+        def write(self, payload):
+            written.append(payload)
+            return len(payload)
+
+        def flush(self):
+            return None
+
+    class _Handler:
+        def __init__(self):
+            self.wfile = _Wfile()
+
+        def send_response(self, *_a, **_k):
+            return None
+
+        def send_header(self, *_a, **_k):
+            return None
+
+        def end_headers(self):
+            return None
+
+        def _cors(self):
+            return None
+
+    class _Pilot:
+        harness_session_id = "s-resume"
+
+        def send(self, *_a, **_k):
+            yield SimpleNamespace(kind="assistant_done", data={"text": "hi"})
+
+        def drain_swarm_results(self):
+            yield SimpleNamespace(kind="swarm_result", data={"ok": True})
+            yield SimpleNamespace(kind="pilot_resume", data={"ok": True})
+
+    monkeypatch.setattr("harness.hooks.run_hooks", lambda *_a, **_k: None)
+    svc = StreamServices(
+        cfg=SimpleNamespace(repo=""),
+        sessions=SimpleNamespace(active="s-resume", set_title_if_default=lambda *_a: None),
+        get_pilot=lambda: _Pilot(),
+        get_session=lambda: None,
+        ensure_pilot_matches_driver=lambda: None,
+        maybe_refresh_codegraph=lambda *_a: None,
+        pilot_preflight=lambda: None,
+        checkpoint_transcript=lambda *_a: None,
+        finalize_turn=lambda *_a: None,
+        upload_dir="/tmp",
+        auto_budget_from_env=lambda: None,
+    )
+    stream_chat(_Handler(), "hello", None, svc)
+    kinds = []
+    for raw in written:
+        line = raw.decode()
+        if not line.startswith("data: "):
+            continue
+        kinds.append(json.loads(line[6:].strip()).get("kind"))
+    assert "swarm_result" in kinds
+    assert "pilot_resume" in kinds
+    assert "done" in kinds
+    assert kinds.index("swarm_result") < kinds.index("done")
+    assert kinds.index("pilot_resume") < kinds.index("done")
+    assert kinds[-1] == "done"

--- a/tests/test_stream_identity_batch.py
+++ b/tests/test_stream_identity_batch.py
@@ -272,7 +272,8 @@ def test_drain_batches_second_same_identity_answer_until_done(monkeypatch):
     assert q.get_calls == 3
 
     extras, (streamed, got) = _finish_gen(gen)
-    assert extras == []
+    assert [e.kind for e in extras] == ["stream_item_done"]
+    assert not (extras[0].data or {}).get("stream_id")
     assert streamed == "Hello world"
     assert got is resp
     assert q.get_calls == 3
@@ -303,7 +304,8 @@ def test_drain_batches_second_same_identity_reasoning_until_done(monkeypatch):
     assert q.get_calls == 3
 
     extras, (streamed, got) = _finish_gen(gen)
-    assert extras == []
+    assert [e.kind for e in extras] == ["stream_item_done"]
+    assert not (extras[0].data or {}).get("stream_id")
     assert streamed == ""
     assert got.meta["streamed_reasoning"] == "Why not"
     assert q.get_calls == 3
@@ -451,7 +453,8 @@ def test_drain_identity_change_after_first_frame_flushes_held_answer(monkeypatch
     assert q.get_calls == 3
 
     extras, (streamed, got) = _finish_gen(gen)
-    assert extras == []
+    assert [e.kind for e in extras] == ["stream_item_done"]
+    assert not (extras[0].data or {}).get("stream_id")
     assert streamed == "Hello worldOther"
     assert got is resp
 
@@ -492,7 +495,8 @@ def test_drain_answer_reasoning_interleave_preserves_order(monkeypatch):
     assert q.get_calls == 5
 
     extras, (streamed, got) = _finish_gen(gen)
-    assert extras == []
+    assert [e.kind for e in extras] == ["stream_item_done"]
+    assert not (extras[0].data or {}).get("stream_id")
     assert streamed == "A1A2"
     assert got.meta["streamed_reasoning"] == "R1R2"
     assert q.get_calls == 5
@@ -520,7 +524,8 @@ def test_drain_first_frame_answer_then_tool_hint_keeps_answer_before_prep(monkey
     assert q.get_calls == 2
 
     extras, (streamed, got) = _finish_gen(gen)
-    assert extras == []
+    assert [e.kind for e in extras] == ["stream_item_done"]
+    assert not (extras[0].data or {}).get("stream_id")
     assert streamed == "Hello"
     assert got is resp
     assert q.get_calls == 3
@@ -563,7 +568,8 @@ def test_drain_new_stream_id_after_tool_first_frames(monkeypatch):
     assert q.get_calls == 5
 
     extras, (streamed, got) = _finish_gen(gen)
-    assert extras == []
+    assert [e.kind for e in extras] == ["stream_item_done"]
+    assert not (extras[0].data or {}).get("stream_id")
     assert streamed == "HelloAfter tool"
     assert got is resp
 
@@ -610,6 +616,7 @@ def test_drain_dual_output_identities_each_first_frame(monkeypatch):
     assert q.get_calls == 4
 
     extras, (streamed, got) = _finish_gen(gen)
-    assert extras == []
+    assert [e.kind for e in extras] == ["stream_item_done"]
+    assert not (extras[0].data or {}).get("stream_id")
     assert streamed == "OneTwo more"
     assert got is resp

--- a/tests/test_tool_name_repair.py
+++ b/tests/test_tool_name_repair.py
@@ -583,3 +583,51 @@ def test_missing_provider_tool_call_ids_persist_paired_and_portable(
     assert len(set(out_ids)) == 4
     assert all(_PORTABLE_ID.match(i) for i in out_ids)
     _assert_adjacent_pairs_match(outbound)
+
+
+def test_parse_native_tool_turn_recovers_xml_from_thought():
+    """Qwen thought dumps <tool_call> XML; recover into the native executor."""
+    schema = [
+        {"type": "function", "function": {"name": "query_wiki"}},
+        {"type": "function", "function": {"name": "web_fetch"}},
+    ]
+    thought = (
+        "Next I will look up prior notes and fetch the docs.\n"
+        "<tool_call>\n"
+        '{"name": "query_wiki", "arguments": {"question": "prior findings on example service"}}\n'
+        "</tool_call>\n"
+        "<tool_call>\n"
+        '{"name": "web_fetch", "arguments": {"url": "https://example.com/docs"}}\n'
+        "</tool_call>\n"
+    )
+    turn, calls, content = parse_native_tool_turn(
+        "I'll look that up.", [], thought, schema,
+    )
+    assert [act.kind for act in turn.actions] == ["query_wiki", "web_fetch"]
+    assert turn.actions[0].arguments.get("question") == "prior findings on example service"
+    assert turn.actions[1].url == "https://example.com/docs"
+    assert [tc["function"]["name"] for tc in calls] == ["query_wiki", "web_fetch"]
+    assert content == "I'll look that up."
+    assert turn.say == "I'll look that up."
+    assert turn.thinking == thought
+
+
+def test_parse_native_tool_turn_native_array_still_wins():
+    schema = [
+        {"type": "function", "function": {"name": "query_wiki"}},
+        {"type": "function", "function": {"name": "web_fetch"}},
+    ]
+    raw = [_tc(
+        "query_wiki",
+        {"question": "prior findings on example service"},
+        tc_id="tc_wiki",
+    )]
+    thought = (
+        "<tool_call>\n"
+        '{"name": "web_fetch", "arguments": {"url": "https://example.com/docs"}}\n'
+        "</tool_call>"
+    )
+    turn, calls, content = parse_native_tool_turn("", raw, thought, schema)
+    assert [act.kind for act in turn.actions] == ["query_wiki"]
+    assert calls[0]["id"] == "tc_wiki"
+    assert content == ""

--- a/uv.lock
+++ b/uv.lock
@@ -80,9 +80,10 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.388"
+version = "0.9.395"
 source = { editable = "." }
 dependencies = [
+    { name = "puppetmaster-ai" },
     { name = "pypdf" },
 ]
 
@@ -95,11 +96,21 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "puppetmaster-ai", specifier = "==1.22.43" },
     { name = "pypdf" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "puppetmaster-ai"
+version = "1.22.43"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/f8/e9cbe9fc9a4b7eee32a240f6846c784b91eb8222912fb660654c8fc62093/puppetmaster_ai-1.22.43.tar.gz", hash = "sha256:9ebfaa955d2bdd7a29ebe04f6f1613d7a54f4651a7481047a360b8301b79babe", size = 1381446, upload-time = "2026-08-30T21:49:23.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/70/8f042b973e9d7c4ae1b3dd18cda5be7bd11781c9af588e5e350228eceba0/puppetmaster_ai-1.22.43-py3-none-any.whl", hash = "sha256:b080d53dbfef56c6b1cd67e536b582eede8df56c5adf91888b66fa40b67d414c", size = 958629, upload-time = "2026-08-30T21:49:21.442Z" },
+]
 
 [[package]]
 name = "pygments"

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.394",
+  "version": "0.9.395",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.394",
+      "version": "0.9.395",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.394",
+  "version": "0.9.395",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/LocalModelsSettingsPage.test.tsx
+++ b/webapp/src/__tests__/LocalModelsSettingsPage.test.tsx
@@ -1,0 +1,677 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LocalModelsSettingsPage from "../components/LocalModelsSettingsPage";
+import { api, type LocalModelsSnapshot } from "../lib/api";
+
+vi.mock("../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    api: {
+      getLocalModels: vi.fn(),
+      localModelCommand: vi.fn(),
+      getLocalModelEvents: vi.fn(),
+      watchLocalModelEvents: vi.fn(() => () => {}),
+    },
+  };
+});
+
+const getLocalModels = vi.mocked(api.getLocalModels);
+const localModelCommand = vi.mocked(api.localModelCommand);
+const getLocalModelEvents = vi.mocked(api.getLocalModelEvents);
+const watchLocalModelEvents = vi.mocked(api.watchLocalModelEvents);
+
+function snapshot(overrides: Partial<LocalModelsSnapshot> = {}): LocalModelsSnapshot {
+  return {
+    hardware: {
+      os: "Darwin",
+      arch: "arm64",
+      platform_key: "macos-arm64",
+      ram_bytes: 16 * 1024 ** 3,
+      disk_free_bytes: 40 * 1024 ** 3,
+      accelerator: "metal",
+      supported: true,
+    },
+    catalog: {
+      runtime_release: "b10442",
+      models: [{
+        id: "qwen3-4b",
+        name: "Qwen3 4B",
+        size: 2497280256,
+        context_length: 40960,
+        min_ram_gb: 6,
+        min_disk_bytes: 3200000000,
+        source: "Qwen/Qwen3-4B-GGUF (Apache-2.0)",
+        trust: "first-party",
+      }],
+      model: { id: "qwen3-4b", name: "Qwen3 4B", size: 2497280256, context_length: 40960 },
+    },
+    managed: {
+      runtime: { status: "absent" },
+      model: { status: "absent" },
+      process: null,
+      downloads: {},
+      usable: false,
+      spec: "local:managed/qwen3-4b",
+    },
+    externals: [],
+    active_spec: "",
+    usable_specs: [],
+    event_cursor: 0,
+    ...overrides,
+  };
+}
+
+describe("LocalModelsSettingsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    watchLocalModelEvents.mockImplementation(() => () => {});
+    getLocalModelEvents.mockResolvedValue({
+      ok: true,
+      events: [],
+      cursor: 0,
+      snapshot: snapshot(),
+    });
+  });
+
+  it("shows a neutral catalog selector with factual fields", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("local-models-hardware").textContent).toContain("macos-arm64");
+    });
+    expect(screen.getByTestId("local-models-page").textContent).not.toMatch(/Recommend/i);
+    expect(screen.getByTestId("local-models-catalog-select")).toBeTruthy();
+    expect(screen.getByTestId("local-models-catalog-facts").textContent).toContain("Qwen3 4B");
+    expect(screen.getByTestId("local-models-catalog-facts").textContent).toContain("first-party");
+    expect(screen.getByTestId("local-models-catalog-facts").textContent).toContain("40960");
+    expect(screen.getByTestId("local-models-remote-copy").textContent).toMatch(/RunPod/i);
+    expect(screen.getByRole("button", { name: /Install/i })).toBeTruthy();
+    expect(screen.getByTestId("local-models-empty-external").textContent).toMatch(/model id/i);
+  });
+
+  it("installs the selected catalog model_id", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    localModelCommand.mockResolvedValue(snapshot({
+      managed: {
+        runtime: { status: "downloading" },
+        model: { status: "downloading" },
+        downloads: { model: { bytes: 10, total: 100, phase: "download" } },
+        spec: "local:managed/qwen3-4b",
+      },
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByRole("button", { name: /Install/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Install/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({
+        type: "install",
+        target: "all",
+        model_id: "qwen3-4b",
+      });
+      expect(screen.getByTestId("local-models-progress")).toBeTruthy();
+      expect(screen.getByRole("button", { name: /Cancel/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({ type: "cancel", target: "all" });
+    });
+  });
+
+  it("starts a stopped ready install", async () => {
+    getLocalModels.mockResolvedValue(snapshot({
+      managed: {
+        runtime: { status: "ready" },
+        model: { status: "ready", id: "qwen3-4b" },
+        process: null,
+        usable: false,
+        spec: "local:managed/qwen3-4b",
+      },
+    }));
+    localModelCommand.mockResolvedValue(snapshot({
+      managed: {
+        runtime: { status: "ready" },
+        model: { status: "ready" },
+        process: { pid: 9, port: 8765, healthy: true, context_length: 40960 },
+        usable: true,
+        spec: "local:managed/qwen3-4b",
+      },
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByRole("button", { name: /Start/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Start/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({ type: "start" });
+    });
+  });
+
+  it("starts, activates, and removes a ready install", async () => {
+    getLocalModels.mockResolvedValue(snapshot({
+      managed: {
+        runtime: { status: "ready" },
+        model: { status: "ready", id: "qwen3-4b" },
+        process: { pid: 9, port: 8765, healthy: true, context_length: 40960 },
+        usable: true,
+        spec: "local:managed/qwen3-4b",
+      },
+    }));
+    localModelCommand.mockResolvedValue(snapshot({
+      managed: {
+        runtime: { status: "ready" },
+        model: { status: "ready" },
+        process: { pid: 9, port: 8765, healthy: true, context_length: 40960 },
+        spec: "local:managed/qwen3-4b",
+      },
+      active_spec: "local:managed/qwen3-4b",
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByRole("button", { name: /Activate/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Activate/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({
+        type: "activate",
+        spec: "local:managed/qwen3-4b",
+      });
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Stop/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({ type: "stop" });
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Restart/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({ type: "restart" });
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Remove all/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({ type: "remove", target: "all" });
+    });
+  });
+
+  it("probes, saves, activates, and deletes an external endpoint", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    localModelCommand
+      .mockResolvedValueOnce({
+        ok: true,
+        url: "http://127.0.0.1:11434/v1",
+        vendor: "ollama",
+        models: ["llama3"],
+        context_length: 4096,
+      })
+      .mockResolvedValue(snapshot({
+        externals: [{
+          id: "ollama-127-0-0-1-11434",
+          vendor: "ollama",
+          base_url: "http://127.0.0.1:11434/v1",
+          models: ["llama3"],
+          selected_model: "llama3",
+          healthy: true,
+        }],
+      }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByRole("button", { name: /Probe/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Probe/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("local-models-probe").textContent).toContain("ollama");
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("local-external-ollama-127-0-0-1-11434")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Activate$/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({
+        type: "activate",
+        spec: "local:ollama-127-0-0-1-11434/llama3",
+      });
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Delete/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({
+        type: "remove",
+        target: "all",
+        endpoint_id: "ollama-127-0-0-1-11434",
+      });
+    });
+  });
+
+  it("saves a RunPod HTTPS endpoint with confirmation and a manual model", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    localModelCommand.mockResolvedValue(snapshot({
+      externals: [{
+        id: "openai-compatible-proxy-runpod-net-8000",
+        name: "runpod-qwen",
+        vendor: "openai-compatible",
+        base_url: "https://proxy.runpod.net/v1",
+        models: ["qwen3-4b"],
+        selected_model: "qwen3-4b",
+        healthy: true,
+      }],
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByLabelText(/Endpoint URL/i));
+    fireEvent.change(screen.getByLabelText(/Endpoint URL/i), {
+      target: { value: "https://proxy.runpod.net/v1" },
+    });
+    fireEvent.change(screen.getByLabelText(/Display name/i), {
+      target: { value: "runpod-qwen" },
+    });
+    fireEvent.change(screen.getByLabelText(/Model id/i), {
+      target: { value: "qwen3-4b" },
+    });
+    fireEvent.click(screen.getByTestId("local-models-accept-remote").querySelector("input")!);
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({
+        type: "save_external",
+        url: "https://proxy.runpod.net/v1",
+        api_key: "",
+        accept_lan: false,
+        accept_remote: true,
+        model: "qwen3-4b",
+        name: "runpod-qwen",
+      });
+    });
+  });
+
+  it("surfaces rejection when a public remote is saved without confirmation", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    localModelCommand.mockRejectedValue(new Error("This is a public remote host. Confirm you trust this HTTPS service."));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByLabelText(/Model id/i));
+    fireEvent.change(screen.getByLabelText(/Endpoint URL/i), {
+      target: { value: "https://proxy.runpod.net/v1" },
+    });
+    fireEvent.change(screen.getByLabelText(/Model id/i), {
+      target: { value: "qwen3-4b" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("local-models-error").textContent).toMatch(/trust/i);
+    });
+    expect(localModelCommand).toHaveBeenCalledWith(expect.objectContaining({
+      type: "save_external",
+      accept_remote: false,
+    }));
+  });
+
+  it("never renders a pasted API key in the page", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    localModelCommand.mockResolvedValueOnce({
+      ok: true,
+      url: "http://127.0.0.1:8080/v1",
+      vendor: "llama.cpp",
+      models: ["phi"],
+    });
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByLabelText(/Optional API key/i));
+    fireEvent.change(screen.getByLabelText(/Optional API key/i), {
+      target: { value: "sk-secret-value" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Probe/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("local-models-probe")).toBeTruthy();
+    });
+    expect(screen.getByTestId("local-models-page").textContent).not.toContain("sk-secret-value");
+  });
+
+  it("shows unsupported hardware without an install button", async () => {
+    getLocalModels.mockResolvedValue(snapshot({
+      hardware: {
+        os: "Darwin",
+        arch: "arm64",
+        platform_key: "macos-arm64",
+        accelerator: "cpu",
+        supported: false,
+        unsupported_reason: "This machine has 4.0 GB RAM; catalog models need at least 6 GB.",
+      },
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("local-models-unsupported").textContent).toContain("4.0 GB RAM");
+    });
+    expect(screen.getByRole("button", { name: /Install/i })).toBeDisabled();
+  });
+
+  it("watches events without an interval owner and applies snapshots immediately", async () => {
+    watchLocalModelEvents.mockImplementation((opts) => {
+      opts.onEvent({
+        kind: "snapshot",
+        cursor: 1,
+        snapshot: snapshot({
+          managed: {
+            runtime: { status: "downloading" },
+            model: { status: "downloading" },
+            downloads: { model: { bytes: 50, total: 100, phase: "download" } },
+            spec: "local:managed/qwen3-4b",
+          },
+        }),
+      });
+      return () => {};
+    });
+    getLocalModels.mockResolvedValue(snapshot());
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("local-models-progress")).toBeTruthy();
+    });
+    expect(watchLocalModelEvents).toHaveBeenCalled();
+    expect(getLocalModelEvents).not.toHaveBeenCalled();
+  });
+
+  it("shows paused progress and a Resume action", async () => {
+    getLocalModels.mockResolvedValue(snapshot({
+      managed: {
+        runtime: { status: "ready" },
+        model: { status: "paused" },
+        downloads: { model: { bytes: 40, total: 100, phase: "download" } },
+        spec: "local:managed/qwen3-4b",
+      },
+    }));
+    localModelCommand.mockResolvedValue(snapshot());
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByRole("button", { name: /Resume/i }));
+    expect(screen.getByTestId("local-models-progress")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Resume/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({
+        type: "install",
+        target: "all",
+        model_id: "qwen3-4b",
+      });
+    });
+  });
+
+  it("offers separate remove actions when components exist", async () => {
+    getLocalModels.mockResolvedValue(snapshot({
+      managed: {
+        runtime: { status: "ready" },
+        model: { status: "ready", id: "qwen3-4b" },
+        process: null,
+        spec: "local:managed/qwen3-4b",
+      },
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByRole("button", { name: /Remove model/i }));
+    expect(screen.getByRole("button", { name: /Remove runtime/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Remove all/i })).toBeTruthy();
+  });
+
+  it("uses a nonempty manual model id over the discovered selection", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    localModelCommand
+      .mockResolvedValueOnce({
+        ok: true,
+        url: "http://127.0.0.1:11434/v1",
+        vendor: "ollama",
+        models: ["llama3"],
+      })
+      .mockResolvedValue(snapshot());
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByRole("button", { name: /Probe/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Probe/i }));
+    await waitFor(() => screen.getByTestId("local-models-probe"));
+    fireEvent.change(screen.getByLabelText(/Model id/i), {
+      target: { value: "custom-qwen" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith(expect.objectContaining({
+        type: "save_external",
+        model: "custom-qwen",
+      }));
+    });
+  });
+
+  it("clears the API key field after a successful save", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    localModelCommand.mockResolvedValue(snapshot({
+      externals: [{
+        id: "ollama-127-0-0-1-11434",
+        vendor: "ollama",
+        base_url: "http://127.0.0.1:11434/v1",
+        models: ["llama3"],
+        selected_model: "llama3",
+        healthy: true,
+      }],
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByLabelText(/Optional API key/i));
+    fireEvent.change(screen.getByLabelText(/Model id/i), {
+      target: { value: "llama3" },
+    });
+    fireEvent.change(screen.getByLabelText(/Optional API key/i), {
+      target: { value: "sk-secret-value" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+    await waitFor(() => {
+      expect((screen.getByLabelText(/Optional API key/i) as HTMLInputElement).value).toBe("");
+    });
+    expect(screen.getByTestId("local-models-page").textContent).not.toContain("sk-secret-value");
+  });
+
+  it("rejects older GET and SSE snapshots once a newer cursor is owned", async () => {
+    let onEvent: ((ev: { kind: string; cursor?: number; snapshot?: LocalModelsSnapshot }) => void) | undefined;
+    watchLocalModelEvents.mockImplementation((opts) => {
+      onEvent = opts.onEvent;
+      return () => {};
+    });
+    getLocalModels.mockResolvedValue(snapshot({ event_cursor: 0 }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByTestId("local-models-managed-status"));
+    onEvent?.({
+      kind: "snapshot",
+      cursor: 4,
+      snapshot: snapshot({
+        event_cursor: 4,
+        managed: {
+          runtime: { status: "ready" },
+          model: { status: "ready" },
+          process: { pid: 9, port: 1, healthy: true },
+          spec: "local:managed/qwen3-4b",
+        },
+      }),
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("local-models-managed-status").textContent).toMatch(/Server running/i);
+    });
+    onEvent?.({
+      kind: "snapshot",
+      cursor: 1,
+      snapshot: snapshot({
+        event_cursor: 1,
+        managed: {
+          runtime: { status: "absent" },
+          model: { status: "absent" },
+          spec: "local:managed/qwen3-4b",
+        },
+      }),
+    });
+    expect(screen.getByTestId("local-models-managed-status").textContent).toMatch(/Server running/i);
+  });
+
+  it("clears a stale load error when a live snapshot arrives", async () => {
+    getLocalModels.mockRejectedValue(new Error("Could not load local models"));
+    let onEvent: ((ev: { kind: string; cursor?: number; snapshot?: LocalModelsSnapshot }) => void) | undefined;
+    watchLocalModelEvents.mockImplementation((opts) => {
+      onEvent = opts.onEvent;
+      return () => {};
+    });
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("local-models-error").textContent).toMatch(/Could not load/i);
+    });
+    onEvent?.({
+      kind: "snapshot",
+      cursor: 2,
+      snapshot: snapshot({ event_cursor: 2 }),
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("local-models-error")).toBeNull();
+      expect(screen.getByTestId("local-models-hardware")).toBeTruthy();
+    });
+  });
+
+  it("surfaces managed background install errors in the existing alert", async () => {
+    getLocalModels.mockResolvedValue(snapshot({
+      managed: {
+        runtime: { status: "error", error: "checksum failed" },
+        model: { status: "absent" },
+        spec: "local:managed/qwen3-4b",
+      },
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("local-models-error").textContent).toContain("checksum failed");
+    });
+  });
+
+  it("cleans up poll fallback on unmount", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    let onError: (() => void) | undefined;
+    const stopWatch = vi.fn();
+    watchLocalModelEvents.mockImplementation((opts) => {
+      onError = opts.onError;
+      return stopWatch;
+    });
+    getLocalModelEvents.mockResolvedValue({
+      ok: true,
+      events: [],
+      cursor: 1,
+      snapshot: snapshot({ event_cursor: 1 }),
+    });
+    const { unmount } = render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByTestId("local-models-hardware"));
+    onError?.();
+    await waitFor(() => {
+      expect(getLocalModelEvents).toHaveBeenCalled();
+    });
+    const calls = getLocalModelEvents.mock.calls.length;
+    unmount();
+    expect(stopWatch).toHaveBeenCalled();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(getLocalModelEvents.mock.calls.length).toBe(calls);
+  });
+
+  it("starts polling fallback only once", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    let onError: (() => void) | undefined;
+    let onDone: (() => void) | undefined;
+    watchLocalModelEvents.mockImplementation((opts) => {
+      onError = opts.onError;
+      onDone = opts.onDone;
+      return () => {};
+    });
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByTestId("local-models-hardware"));
+    onError?.();
+    onDone?.();
+    onError?.();
+    await waitFor(() => {
+      expect(getLocalModelEvents).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("surfaces command errors in text, not color alone", async () => {
+    getLocalModels.mockResolvedValue(snapshot());
+    localModelCommand.mockRejectedValue(new Error("Cloud metadata endpoints are blocked"));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByRole("button", { name: /Probe/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Probe/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("local-models-error").textContent).toContain("metadata");
+    });
+  });
+
+  it("sends verify_tool_calling and renders capability status", async () => {
+    const saved = {
+      id: "ollama-127-0-0-1-11434",
+      vendor: "ollama",
+      base_url: "http://127.0.0.1:11434/v1",
+      models: ["llama3"],
+      selected_model: "llama3",
+      healthy: true,
+      tool_calling: { status: "unverified" as const, reason: "", checked_at: null },
+    };
+    getLocalModels.mockResolvedValue(snapshot({ externals: [saved] }));
+    localModelCommand.mockResolvedValue(snapshot({
+      externals: [{
+        ...saved,
+        tool_calling: {
+          status: "verified",
+          reason: "This model returned a tool call.",
+          checked_at: 1,
+        },
+      }],
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByTestId("local-external-ollama-127-0-0-1-11434"));
+    expect(screen.getByTestId("local-models-tool-calling-copy").textContent).toMatch(
+      /records whether the endpoint returned the requested tool call/i,
+    );
+    expect(screen.getByTestId("local-models-tool-calling-copy").textContent).toMatch(
+      /does not execute tools or enroll the model as a Puppetmaster swarm worker/i,
+    );
+    expect(screen.getByTestId("local-models-tool-calling-copy").textContent).not.toMatch(
+      /lets this pilot/i,
+    );
+    expect(screen.getByTestId("local-external-tool-calling-ollama-127-0-0-1-11434").textContent)
+      .toMatch(/Unverified/);
+    fireEvent.click(screen.getByRole("button", { name: /Test tool calling/i }));
+    await waitFor(() => {
+      expect(localModelCommand).toHaveBeenCalledWith({
+        type: "verify_tool_calling",
+        spec: "local:ollama-127-0-0-1-11434/llama3",
+      });
+      expect(screen.getByTestId("local-external-tool-calling-ollama-127-0-0-1-11434").textContent)
+        .toMatch(/Verified/);
+    });
+    expect(screen.getByTestId("local-models-page").textContent).not.toMatch(/Recommend/i);
+  });
+
+  it("renders unsupported and error without blocking activate", async () => {
+    getLocalModels.mockResolvedValue(snapshot({
+      externals: [{
+        id: "ollama-127-0-0-1-11434",
+        vendor: "ollama",
+        base_url: "http://127.0.0.1:11434/v1",
+        models: ["llama3"],
+        selected_model: "llama3",
+        healthy: true,
+        tool_calling: {
+          status: "unsupported",
+          reason: "This model replied with text instead of a tool call.",
+          checked_at: 1,
+        },
+      }],
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByTestId("local-external-tool-calling-ollama-127-0-0-1-11434"));
+    expect(screen.getByTestId("local-external-tool-calling-ollama-127-0-0-1-11434").textContent)
+      .toMatch(/Unsupported/);
+    expect(screen.getByTestId("local-external-tool-calling-ollama-127-0-0-1-11434").textContent)
+      .toMatch(/text instead of a tool call/);
+    expect(screen.getByRole("button", { name: /^Activate$/i })).not.toBeDisabled();
+  });
+
+  it("renders an error capability status with a concise reason", async () => {
+    getLocalModels.mockResolvedValue(snapshot({
+      externals: [{
+        id: "runpod-box",
+        vendor: "openai-compatible",
+        base_url: "https://proxy.runpod.net/v1",
+        models: ["qwen"],
+        selected_model: "qwen",
+        healthy: true,
+        tool_calling: {
+          status: "error",
+          reason: "This public endpoint requires an API key.",
+          checked_at: 2,
+        },
+      }],
+    }));
+    render(<LocalModelsSettingsPage />);
+    await waitFor(() => screen.getByTestId("local-external-tool-calling-runpod-box"));
+    expect(screen.getByTestId("local-external-tool-calling-runpod-box").textContent).toMatch(/Error/);
+    expect(screen.getByTestId("local-external-tool-calling-runpod-box").textContent).toMatch(/API key/);
+    expect(screen.getByRole("button", { name: /^Activate$/i })).not.toBeDisabled();
+  });
+});

--- a/webapp/src/__tests__/SettingsShell.localModels.test.tsx
+++ b/webapp/src/__tests__/SettingsShell.localModels.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import SettingsShell from "../components/SettingsShell";
+
+vi.mock("../components/ModelsSettingsPage", () => ({
+  default: () => <div data-testid="models-page" />,
+}));
+
+vi.mock("../components/LocalModelsSettingsPage", () => ({
+  default: () => <div data-testid="local-models-page" />,
+}));
+
+vi.mock("../components/SettingsPane", () => ({
+  default: ({ section }: { section: string }) => (
+    <div data-testid={`settings-section-${section}`} />
+  ),
+}));
+
+describe("SettingsShell Local Models nav", () => {
+  it("lists Models, General, then Local Models in the sidebar", () => {
+    render(<SettingsShell onClose={vi.fn()} onOpenWizard={vi.fn()} />);
+    const labels = screen
+      .getAllByRole("button")
+      .map((el) => el.textContent?.trim() ?? "")
+      .filter((label) => label.length > 0);
+    const modelsAt = labels.indexOf("Models");
+    expect(labels.slice(modelsAt, modelsAt + 3)).toEqual([
+      "Models",
+      "General",
+      "Local Models",
+    ]);
+  });
+
+  it("opens the Local Models page from the sidebar", () => {
+    render(<SettingsShell onClose={vi.fn()} onOpenWizard={vi.fn()} />);
+    expect(screen.getByTestId("models-page")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Local Models/i }));
+    expect(screen.getByTestId("local-models-page")).toBeTruthy();
+    expect(screen.queryByTestId("models-page")).toBeNull();
+  });
+});

--- a/webapp/src/__tests__/SettingsShell.providersFocus.test.tsx
+++ b/webapp/src/__tests__/SettingsShell.providersFocus.test.tsx
@@ -6,6 +6,10 @@ vi.mock("../components/ModelsSettingsPage", () => ({
   default: () => <div data-testid="models-page" />,
 }));
 
+vi.mock("../components/LocalModelsSettingsPage", () => ({
+  default: () => <div data-testid="local-models-page" />,
+}));
+
 vi.mock("../components/SettingsPane", () => ({
   default: ({ section }: { section: string }) => (
     <div data-testid={`settings-section-${section}`} />

--- a/webapp/src/components/LocalModelsSettingsPage.tsx
+++ b/webapp/src/components/LocalModelsSettingsPage.tsx
@@ -1,0 +1,688 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Download,
+  Pause,
+  Play,
+  RefreshCw,
+  Square,
+  Trash2,
+} from "lucide-react";
+import {
+  api,
+  parseLocalToolCalling,
+  type LocalCatalogModel,
+  type LocalExternalEndpoint,
+  type LocalModelCommand,
+  type LocalModelProbeResult,
+  type LocalModelStreamFrame,
+  type LocalModelsSnapshot,
+  type LocalToolCallingStatus,
+} from "../lib/api";
+
+const TOOL_CALLING_LABELS: Record<LocalToolCallingStatus, string> = {
+  unverified: "Unverified",
+  verified: "Verified",
+  unsupported: "Unsupported",
+  error: "Error",
+};
+
+function formatBytes(value?: number | null): string {
+  if (!value || value <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let size = value;
+  let unit = 0;
+  while (size >= 1024 && unit < units.length - 1) {
+    size /= 1024;
+    unit += 1;
+  }
+  return `${size.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function statusLabel(status: string, healthy?: boolean): string {
+  if (status === "ready" && healthy) return "Ready";
+  if (status === "ready") return "Installed";
+  if (status === "downloading") return "Downloading";
+  if (status === "extracting") return "Extracting";
+  if (status === "error") return "Error";
+  if (status === "paused") return "Paused";
+  if (status === "absent") return "Not installed";
+  return status || "Unknown";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isLocalModelsSnapshot(value: unknown): value is LocalModelsSnapshot {
+  return isRecord(value) && isRecord(value.managed) && isRecord(value.hardware);
+}
+
+function isLocalModelStreamFrame(value: unknown): value is LocalModelStreamFrame {
+  return isRecord(value) && typeof value.kind === "string";
+}
+
+function isProbeResult(value: unknown): value is LocalModelProbeResult {
+  if (!isRecord(value)) return false;
+  if (!("vendor" in value) || !("models" in value)) return false;
+  return typeof value.vendor === "string" && Array.isArray(value.models);
+}
+
+function catalogModels(snapshot: LocalModelsSnapshot | null): LocalCatalogModel[] {
+  const listed = snapshot?.catalog.models;
+  if (listed && listed.length > 0) return listed;
+  const one = snapshot?.catalog.model;
+  if (one?.id) {
+    return [{
+      id: one.id,
+      name: one.name || one.id,
+      quant: one.quant,
+      size: one.size,
+      context_length: one.context_length,
+    }];
+  }
+  return [];
+}
+
+function snapshotCursor(value: LocalModelsSnapshot | null | undefined): number {
+  const cursor = value?.event_cursor;
+  return typeof cursor === "number" && Number.isFinite(cursor) ? cursor : 0;
+}
+
+function shouldAcceptSnapshot(
+  incoming: LocalModelsSnapshot,
+  ownedCursor: number,
+  opts: { source: "get" | "live" | "command"; live: boolean },
+): boolean {
+  if (opts.source === "get" && opts.live) return false;
+  return snapshotCursor(incoming) >= ownedCursor;
+}
+
+function backgroundInstallError(snapshot: LocalModelsSnapshot | null | undefined): string {
+  const runtimeError = snapshot?.managed?.runtime?.error;
+  const modelError = snapshot?.managed?.model?.error;
+  const text = [runtimeError, modelError].find((item) => typeof item === "string" && item.trim());
+  return text ? String(text) : "";
+}
+
+export default function LocalModelsSettingsPage() {
+  const [snapshot, setSnapshot] = useState<LocalModelsSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const [url, setUrl] = useState("http://127.0.0.1:11434/v1");
+  const [apiKey, setApiKey] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [manualModel, setManualModel] = useState("");
+  const [acceptLan, setAcceptLan] = useState(false);
+  const [acceptRemote, setAcceptRemote] = useState(false);
+  const [probe, setProbe] = useState<LocalModelProbeResult | null>(null);
+  const [selectedDiscovered, setSelectedDiscovered] = useState("");
+  const [selectedCatalogId, setSelectedCatalogId] = useState("");
+  const liveSnapshot = useRef(false);
+  const eventCursorRef = useRef(0);
+  const pollStarted = useRef(false);
+  const loadErrorRef = useRef(false);
+
+  const acceptSnapshot = (
+    next: LocalModelsSnapshot,
+    source: "get" | "live" | "command",
+  ): boolean => {
+    if (!shouldAcceptSnapshot(next, eventCursorRef.current, {
+      source,
+      live: liveSnapshot.current,
+    })) {
+      return false;
+    }
+    eventCursorRef.current = Math.max(eventCursorRef.current, snapshotCursor(next));
+    if (source !== "get") liveSnapshot.current = true;
+    setSnapshot(next);
+    setLoading(false);
+    if (source === "live" && loadErrorRef.current) {
+      loadErrorRef.current = false;
+      setError("");
+    }
+    return true;
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const next = await api.getLocalModels();
+        if (cancelled) return;
+        if (acceptSnapshot(next, "get")) {
+          const models = catalogModels(next);
+          if (models[0]?.id) setSelectedCatalogId(models[0].id);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          loadErrorRef.current = true;
+          setError(err instanceof Error ? err.message : "Could not load local models");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let stopWatch: (() => void) | undefined;
+    let pollTimer: ReturnType<typeof setTimeout> | undefined;
+    let since = 0;
+
+    const startPollFallback = () => {
+      if (cancelled || pollStarted.current) return;
+      pollStarted.current = true;
+      const tick = () => {
+        void api.getLocalModelEvents(since).then((res) => {
+          if (cancelled) return;
+          if (res.snapshot && isLocalModelsSnapshot(res.snapshot)) {
+            acceptSnapshot(res.snapshot, "live");
+          }
+          since = Math.max(since, res.cursor || 0, snapshotCursor(res.snapshot));
+          pollTimer = window.setTimeout(tick, 4000);
+        }).catch(() => {
+          if (!cancelled) pollTimer = window.setTimeout(tick, 4000);
+        });
+      };
+      tick();
+    };
+
+    stopWatch = api.watchLocalModelEvents({
+      since: 0,
+      onEvent: (ev) => {
+        if (cancelled || !isLocalModelStreamFrame(ev)) return;
+        if (ev.kind === "snapshot" && ev.snapshot && isLocalModelsSnapshot(ev.snapshot)) {
+          acceptSnapshot(ev.snapshot, "live");
+          since = Math.max(since, ev.cursor ?? 0, snapshotCursor(ev.snapshot));
+        }
+      },
+      onError: () => {
+        if (!cancelled) startPollFallback();
+      },
+      onDone: () => {
+        if (!cancelled) startPollFallback();
+      },
+    });
+
+    return () => {
+      cancelled = true;
+      stopWatch?.();
+      if (pollTimer) window.clearTimeout(pollTimer);
+    };
+  }, []);
+
+  const run = async (command: LocalModelCommand, label: string) => {
+    setBusy(label);
+    setError("");
+    try {
+      const result = await api.localModelCommand(command);
+      if (isProbeResult(result)) {
+        setProbe(result);
+        setSelectedDiscovered(result.models[0] || "");
+      } else if (isLocalModelsSnapshot(result)) {
+        acceptSnapshot(result, "command");
+        if (command.type === "save_external") setApiKey("");
+        if (command.type === "activate" || command.type === "start") {
+          window.dispatchEvent(new Event("harness-config-changed"));
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Local model command failed";
+      setError(message);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading && !snapshot) {
+    return (
+      <div className="max-w-2xl" data-testid="local-models-page">
+        <h2 className="text-[15px] font-semibold text-txt mb-2">Local Models</h2>
+        <p className="text-[12px] text-faint">Loading hardware and install state...</p>
+      </div>
+    );
+  }
+
+  const hardware = snapshot?.hardware;
+  const managed = snapshot?.managed;
+  const runtimeStatus = managed?.runtime.status || "absent";
+  const modelStatus = managed?.model.status || "absent";
+  const alertText = error || backgroundInstallError(snapshot);
+  const process = managed?.process;
+  const installing = ["downloading", "extracting"].includes(runtimeStatus)
+    || ["downloading", "extracting"].includes(modelStatus);
+  const paused = runtimeStatus === "paused" || modelStatus === "paused";
+  const installed = runtimeStatus === "ready" && modelStatus === "ready";
+  const running = Boolean(process?.pid && process.healthy);
+  const download = managed?.downloads?.model || managed?.downloads?.runtime;
+  const progress = download?.total
+    ? Math.min(100, Math.round(((download.bytes || 0) / download.total) * 100))
+    : 0;
+  const spec = managed?.spec || "";
+  const active = snapshot?.active_spec || "";
+  const models = catalogModels(snapshot);
+  const selectedModel = models.find((item) => item.id === selectedCatalogId) || models[0] || null;
+  const attachModel = (manualModel.trim() || selectedDiscovered).trim();
+  const canSave = Boolean(url.trim() && attachModel);
+  const modelPresent = modelStatus !== "absent";
+  const runtimePresent = runtimeStatus !== "absent";
+
+  return (
+    <div className="max-w-2xl" data-testid="local-models-page">
+      <h2 className="text-[15px] font-semibold text-txt mb-1">Local Models</h2>
+      <p className="text-[12px] text-muted mb-4">
+        Choose a catalog model to install and run, or attach an existing OpenAI-compatible
+        service. Public remotes such as RunPod are supported over HTTPS after you confirm you
+        trust them.
+      </p>
+
+      {alertText ? (
+        <div
+          role="alert"
+          className="mb-3 flex items-start gap-2 rounded-md border border-edge/50 bg-panel2 px-3 py-2 text-[12px] text-txt"
+          data-testid="local-models-error"
+        >
+          <AlertCircle size={14} className="mt-0.5 text-faint shrink-0" aria-hidden="true" />
+          <span>{alertText}</span>
+        </div>
+      ) : null}
+
+      <section className="mb-6" data-testid="local-models-hardware">
+        <h3 className="text-[13px] font-semibold text-txt mb-1">This machine</h3>
+        <p className="text-[12px] text-muted">
+          {hardware?.platform_key || "unknown"} · {hardware?.accelerator || "cpu"}
+          {hardware?.ram_bytes ? ` · ${formatBytes(hardware.ram_bytes)} RAM` : ""}
+          {hardware?.disk_free_bytes ? ` · ${formatBytes(hardware.disk_free_bytes)} free` : ""}
+        </p>
+        {hardware?.supported ? (
+          <p className="text-[12px] text-txt mt-1 flex items-center gap-1.5">
+            <CheckCircle2 size={13} className="text-faint" aria-hidden="true" />
+            <span>A pinned llama.cpp runtime is available for this platform.</span>
+          </p>
+        ) : (
+          <p className="text-[12px] text-txt mt-1 flex items-center gap-1.5" data-testid="local-models-unsupported">
+            <AlertCircle size={13} className="text-faint" aria-hidden="true" />
+            <span>{hardware?.unsupported_reason || "Managed install is not available on this machine."}</span>
+          </p>
+        )}
+      </section>
+
+      <section className="mb-6" data-testid="local-models-managed">
+        <h3 className="text-[13px] font-semibold text-txt mb-2">Managed llama.cpp</h3>
+        <p className="text-[12px] text-muted mb-2">
+          Pick which catalog model to download and run on this machine.
+        </p>
+        {models.length > 0 ? (
+          <label className="block mb-3" data-testid="local-models-catalog-select">
+            <span className="text-[11px] text-muted">Available model</span>
+            <select
+              className="mt-1 w-full px-2 py-1.5 rounded-md bg-panel2 border border-edge/50 text-[12px] text-txt"
+              value={selectedModel?.id || ""}
+              onChange={(event) => setSelectedCatalogId(event.target.value)}
+            >
+              {models.map((item) => (
+                <option key={item.id} value={item.id}>{item.name || item.id}</option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <p className="text-[12px] text-faint mb-3">No catalog models are packaged in this build.</p>
+        )}
+        {selectedModel ? (
+          <dl className="mb-3 text-[12px] text-muted" data-testid="local-models-catalog-facts">
+            <div>{selectedModel.name}</div>
+            <div>Source: {selectedModel.source || "catalog"} · Trust: {selectedModel.trust || "catalog"}</div>
+            <div>
+              Size {formatBytes(selectedModel.size)}
+              {selectedModel.min_ram_gb ? ` · RAM ${selectedModel.min_ram_gb} GB` : ""}
+              {selectedModel.min_disk_bytes ? ` · Disk ${formatBytes(selectedModel.min_disk_bytes)}` : ""}
+              {selectedModel.context_length ? ` · Context ${selectedModel.context_length}` : ""}
+            </div>
+          </dl>
+        ) : null}
+        <p className="text-[12px] text-muted mb-2" data-testid="local-models-managed-status">
+          Runtime {statusLabel(runtimeStatus)} · Model {statusLabel(modelStatus)}
+          {running ? " · Server running" : installed ? " · Server stopped" : ""}
+          {process?.context_length ? ` · ${process.context_length} context` : ""}
+        </p>
+        {download && (installing || paused) ? (
+          <div className="mb-3" data-testid="local-models-progress">
+            <div className="h-1.5 rounded bg-panel2 overflow-hidden">
+              <div
+                className="h-full bg-accent motion-reduce:transition-none"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+            <p className="text-[11px] text-muted mt-1">
+              {download.phase || "download"} · {formatBytes(download.bytes)} / {formatBytes(download.total)}
+            </p>
+          </div>
+        ) : null}
+        <div className="flex flex-wrap gap-2">
+          {!installed && !installing && !paused ? (
+            <button
+              type="button"
+              className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              disabled={busy !== null || !hardware?.supported || !selectedModel?.id}
+              onClick={() => void run({
+                type: "install",
+                target: "all",
+                model_id: selectedModel?.id || "",
+              }, "install")}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Download size={13} aria-hidden="true" />
+                Install
+              </span>
+            </button>
+          ) : null}
+          {paused ? (
+            <button
+              type="button"
+              className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              disabled={busy !== null || !hardware?.supported || !selectedModel?.id}
+              onClick={() => void run({
+                type: "install",
+                target: "all",
+                model_id: selectedModel?.id || "",
+              }, "resume")}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Download size={13} aria-hidden="true" />
+                Resume
+              </span>
+            </button>
+          ) : null}
+          {runtimeStatus === "downloading" || modelStatus === "downloading" ? (
+            <button
+              type="button"
+              className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              disabled={busy !== null}
+              onClick={() => void run({ type: "cancel", target: "all" }, "cancel")}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Pause size={13} aria-hidden="true" />
+                Cancel
+              </span>
+            </button>
+          ) : null}
+          {installed && !running ? (
+            <button
+              type="button"
+              className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              disabled={busy !== null}
+              onClick={() => void run({ type: "start" }, "start")}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Play size={13} aria-hidden="true" />
+                Start
+              </span>
+            </button>
+          ) : null}
+          {running ? (
+            <>
+              <button
+                type="button"
+                className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                disabled={busy !== null}
+                onClick={() => void run({ type: "stop" }, "stop")}
+              >
+                <span className="inline-flex items-center gap-1.5">
+                  <Square size={13} aria-hidden="true" />
+                  Stop
+                </span>
+              </button>
+              <button
+                type="button"
+                className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                disabled={busy !== null}
+                onClick={() => void run({ type: "restart" }, "restart")}
+              >
+                <span className="inline-flex items-center gap-1.5">
+                  <RefreshCw size={13} aria-hidden="true" />
+                  Restart
+                </span>
+              </button>
+              <button
+                type="button"
+                className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                disabled={busy !== null || !spec}
+                onClick={() => void run({ type: "activate", spec }, "activate")}
+              >
+                {active === spec ? "Active in picker" : "Activate"}
+              </button>
+            </>
+          ) : null}
+          {modelPresent ? (
+            <button
+              type="button"
+              className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              disabled={busy !== null}
+              onClick={() => void run({ type: "remove", target: "model" }, "remove")}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Trash2 size={13} aria-hidden="true" />
+                Remove model
+              </span>
+            </button>
+          ) : null}
+          {runtimePresent ? (
+            <button
+              type="button"
+              className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              disabled={busy !== null}
+              onClick={() => void run({ type: "remove", target: "runtime" }, "remove")}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Trash2 size={13} aria-hidden="true" />
+                Remove runtime
+              </span>
+            </button>
+          ) : null}
+          {modelPresent && runtimePresent ? (
+            <button
+              type="button"
+              className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              disabled={busy !== null}
+              onClick={() => void run({ type: "remove", target: "all" }, "remove")}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Trash2 size={13} aria-hidden="true" />
+                Remove all
+              </span>
+            </button>
+          ) : null}
+        </div>
+      </section>
+
+      <section data-testid="local-models-external">
+        <h3 className="text-[13px] font-semibold text-txt mb-2">Existing or remote service</h3>
+        <p className="text-[12px] text-muted mb-2" data-testid="local-models-remote-copy">
+          RunPod or any remote OpenAI-compatible service, plus Ollama, LM Studio, omlx, vLLM,
+          and llama.cpp on this machine or LAN. HTTPS and an explicit trust confirmation are
+          required for public remotes.
+        </p>
+        <p className="text-[12px] text-muted mb-2" data-testid="local-models-tool-calling-copy">
+          The check records whether the endpoint returned the requested tool call. It does
+          not execute tools or enroll the model as a Puppetmaster swarm worker.
+        </p>
+        <label className="block text-[11px] text-muted mb-1" htmlFor="local-endpoint-url">
+          Endpoint URL
+        </label>
+        <input
+          id="local-endpoint-url"
+          value={url}
+          onChange={(event) => setUrl(event.target.value)}
+          className="w-full mb-2 px-2.5 py-1.5 rounded-md bg-panel2 border border-edge/50 text-[12px] text-txt outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+        />
+        <label className="block text-[11px] text-muted mb-1" htmlFor="local-endpoint-name">
+          Display name
+        </label>
+        <input
+          id="local-endpoint-name"
+          value={displayName}
+          onChange={(event) => setDisplayName(event.target.value)}
+          className="w-full mb-2 px-2.5 py-1.5 rounded-md bg-panel2 border border-edge/50 text-[12px] text-txt outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+        />
+        <label className="block text-[11px] text-muted mb-1" htmlFor="local-endpoint-model">
+          Model id
+        </label>
+        <input
+          id="local-endpoint-model"
+          value={manualModel}
+          onChange={(event) => setManualModel(event.target.value)}
+          placeholder="Required if the server does not list models"
+          className="w-full mb-2 px-2.5 py-1.5 rounded-md bg-panel2 border border-edge/50 text-[12px] text-txt outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+        />
+        <label className="block text-[11px] text-muted mb-1" htmlFor="local-endpoint-key">
+          Optional API key
+        </label>
+        <input
+          id="local-endpoint-key"
+          type="password"
+          value={apiKey}
+          onChange={(event) => setApiKey(event.target.value)}
+          className="w-full mb-2 px-2.5 py-1.5 rounded-md bg-panel2 border border-edge/50 text-[12px] text-txt outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+        />
+        <label className="flex items-center gap-2 text-[12px] text-txt mb-2">
+          <input
+            type="checkbox"
+            checked={acceptLan}
+            onChange={(event) => setAcceptLan(event.target.checked)}
+          />
+          This is a LAN machine I trust
+        </label>
+        <label className="flex items-center gap-2 text-[12px] text-txt mb-3" data-testid="local-models-accept-remote">
+          <input
+            type="checkbox"
+            checked={acceptRemote}
+            onChange={(event) => setAcceptRemote(event.target.checked)}
+          />
+          I trust this public HTTPS remote service (RunPod or similar)
+        </label>
+        <div className="flex flex-wrap gap-2 mb-3">
+          <button
+            type="button"
+            className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            disabled={busy !== null}
+            onClick={() => void run({
+              type: "probe",
+              url,
+              api_key: apiKey,
+              accept_lan: acceptLan,
+              accept_remote: acceptRemote,
+            }, "probe")}
+          >
+            Probe
+          </button>
+          <button
+            type="button"
+            className="px-2.5 py-1.5 rounded-md border border-edge/40 text-[12px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            disabled={busy !== null || !canSave}
+            onClick={() => void run({
+              type: "save_external",
+              url,
+              api_key: apiKey,
+              accept_lan: acceptLan,
+              accept_remote: acceptRemote,
+              model: attachModel,
+              name: displayName,
+            }, "save")}
+          >
+            Save
+          </button>
+        </div>
+        {probe ? (
+          <div className="mb-3 text-[12px] text-muted" data-testid="local-models-probe">
+            <p>Detected {probe.vendor}. {probe.models.length} model{probe.models.length === 1 ? "" : "s"}.</p>
+            {probe.models.length > 0 ? (
+              <label className="block mt-2">
+                <span className="text-[11px] text-muted">Discovered model</span>
+                <select
+                  className="mt-1 w-full px-2 py-1.5 rounded-md bg-panel2 border border-edge/50 text-[12px] text-txt"
+                  value={selectedDiscovered}
+                  onChange={(event) => setSelectedDiscovered(event.target.value)}
+                >
+                  {probe.models.map((model) => (
+                    <option key={model} value={model}>{model}</option>
+                  ))}
+                </select>
+              </label>
+            ) : (
+              <p className="mt-2">No models listed. Enter a model id above to save this endpoint.</p>
+            )}
+          </div>
+        ) : null}
+
+        {(snapshot?.externals || []).length === 0 ? (
+          <p className="text-[12px] text-faint" data-testid="local-models-empty-external">
+            No saved servers yet. Probe a URL or save one with a model id.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {(snapshot?.externals || []).map((endpoint: LocalExternalEndpoint) => {
+              const endpointSpec = `local:${endpoint.id}/${endpoint.selected_model || ""}`;
+              const toolCalling = parseLocalToolCalling(endpoint.tool_calling);
+              return (
+                <li
+                  key={endpoint.id}
+                  className="rounded-md border border-edge/40 px-3 py-2"
+                  data-testid={`local-external-${endpoint.id}`}
+                >
+                  <p className="text-[12px] text-txt">
+                    {endpoint.name || endpoint.id} · {endpoint.vendor}
+                    {endpoint.healthy ? " · reachable" : " · saved"}
+                  </p>
+                  <p className="text-[11px] text-muted truncate">{endpoint.base_url}</p>
+                  <p
+                    className="text-[11px] text-muted mt-1"
+                    data-testid={`local-external-tool-calling-${endpoint.id}`}
+                  >
+                    Tool calling {TOOL_CALLING_LABELS[toolCalling.status]}
+                    {toolCalling.reason ? ` · ${toolCalling.reason}` : ""}
+                  </p>
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    <button
+                      type="button"
+                      className="px-2 py-1 rounded-md border border-edge/40 text-[11px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                      disabled={busy !== null}
+                      onClick={() => void run({ type: "activate", spec: endpointSpec }, "activate")}
+                    >
+                      {active === endpointSpec ? "Active in picker" : "Activate"}
+                    </button>
+                    <button
+                      type="button"
+                      className="px-2 py-1 rounded-md border border-edge/40 text-[11px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                      disabled={busy !== null}
+                      onClick={() => void run({ type: "verify_tool_calling", spec: endpointSpec }, "verify")}
+                    >
+                      Test tool calling
+                    </button>
+                    <button
+                      type="button"
+                      className="px-2 py-1 rounded-md border border-edge/40 text-[11px] text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                      disabled={busy !== null}
+                      onClick={() => void run({ type: "remove", target: "all", endpoint_id: endpoint.id }, "remove")}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+      {busy ? (
+        <p className="sr-only" aria-live="polite">{busy}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/webapp/src/components/SettingsShell.tsx
+++ b/webapp/src/components/SettingsShell.tsx
@@ -1,17 +1,19 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { X, Cpu, SlidersHorizontal, ShieldCheck, Zap, Bell, Wrench, Info, Puzzle } from "lucide-react";
+import { X, Cpu, HardDrive, SlidersHorizontal, ShieldCheck, Zap, Bell, Wrench, Info, Puzzle } from "lucide-react";
 import ModelsSettingsPage from "./ModelsSettingsPage";
+import LocalModelsSettingsPage from "./LocalModelsSettingsPage";
 import SettingsPane, { type SettingsSection } from "./SettingsPane";
 import PluginsPane from "./PluginsPane";
 import { TITLEBAR_TRAFFIC_PAD_SM_PX } from "../lib/titlebarSafe";
 import { useOverlayFocus } from "../lib/overlayFocus";
 
-type PageId = "models" | SettingsSection | "about";
+type PageId = "models" | "local-models" | SettingsSection | "about";
 
 const NAV: { id: PageId; label: string; icon: any }[] = [
   { id: "models", label: "Models", icon: Cpu },
   { id: "general", label: "General", icon: SlidersHorizontal },
+  { id: "local-models", label: "Local Models", icon: HardDrive },
   { id: "safety", label: "Safety", icon: ShieldCheck },
   { id: "providers", label: "Accounts & Keys", icon: Zap },
   { id: "notifications", label: "Notifications", icon: Bell },
@@ -121,6 +123,7 @@ export default function SettingsShell({
         {/* content */}
         <div className="flex-1 min-w-0 overflow-y-auto px-8 py-6">
           {page === "models" && <ModelsSettingsPage />}
+          {page === "local-models" && <LocalModelsSettingsPage />}
           {page === "plugins" && (
             <div className="max-w-2xl">
               <h2 className="text-[15px] font-semibold text-txt mb-3">Plugins</h2>
@@ -133,7 +136,7 @@ export default function SettingsShell({
               <p>Marionette -- a desktop AI coding harness over Puppetmaster durable state.</p>
             </div>
           )}
-          {page !== "models" && page !== "about" && page !== "plugins" && (
+          {page !== "models" && page !== "local-models" && page !== "about" && page !== "plugins" && (
             <SettingsPane onOpenWizard={onOpenWizard} section={page as SettingsSection} />
           )}
         </div>

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1020,6 +1020,169 @@ export type ModelCatalogResponse = {
   enabled: string[];
 };
 
+export type LocalModelCommand =
+  | { type: "probe"; url: string; api_key?: string; accept_lan?: boolean; accept_remote?: boolean }
+  | {
+      type: "save_external";
+      url: string;
+      api_key?: string;
+      accept_lan?: boolean;
+      accept_remote?: boolean;
+      model?: string;
+      name?: string;
+      context_length?: number;
+    }
+  | { type: "install"; target?: "runtime" | "model" | "all"; model_id: string }
+  | { type: "cancel"; target?: "runtime" | "model" | "all" }
+  | { type: "start" }
+  | { type: "stop" }
+  | { type: "restart" }
+  | { type: "remove"; target: "model" | "runtime" | "all"; endpoint_id?: string }
+  | { type: "activate"; spec: string }
+  | { type: "verify_tool_calling"; spec: string };
+
+export const LOCAL_TOOL_CALLING_STATUSES = [
+  "unverified",
+  "verified",
+  "unsupported",
+  "error",
+] as const;
+
+export type LocalToolCallingStatus = (typeof LOCAL_TOOL_CALLING_STATUSES)[number];
+
+export type LocalToolCalling = {
+  status: LocalToolCallingStatus;
+  reason?: string;
+  checked_at?: number | null;
+};
+
+export function isLocalToolCallingStatus(value: unknown): value is LocalToolCallingStatus {
+  return typeof value === "string" && (LOCAL_TOOL_CALLING_STATUSES as readonly string[]).includes(value);
+}
+
+export function parseLocalToolCalling(value: unknown): LocalToolCalling {
+  if (typeof value !== "object" || value === null) {
+    return { status: "unverified", reason: "", checked_at: null };
+  }
+  const raw = value as Record<string, unknown>;
+  const status = isLocalToolCallingStatus(raw.status) ? raw.status : "unverified";
+  const reason = typeof raw.reason === "string" ? raw.reason : "";
+  const checkedAt = raw.checked_at;
+  const checked_at = typeof checkedAt === "number" && Number.isFinite(checkedAt) ? checkedAt : null;
+  return { status, reason, checked_at };
+}
+
+export type LocalCatalogModel = {
+  id: string;
+  name: string;
+  quant?: string;
+  size?: number;
+  context_length?: number;
+  min_ram_gb?: number;
+  min_disk_bytes?: number;
+  source?: string;
+  trust?: string;
+};
+
+export type LocalModelHardware = {
+  os: string;
+  arch: string;
+  platform_key: string;
+  ram_bytes?: number | null;
+  disk_free_bytes?: number | null;
+  accelerator: string;
+  supported: boolean;
+  unsupported_reason?: string;
+  min_ram_gb?: number;
+  runtime_available?: boolean;
+};
+
+export type LocalModelDownload = {
+  filename?: string;
+  bytes?: number;
+  total?: number;
+  phase?: string;
+};
+
+export type LocalManagedState = {
+  runtime: { status: string; path?: string; error?: string | null; platform?: string; release?: string };
+  model: { status: string; id?: string; path?: string; error?: string | null };
+  process?: {
+    pid?: number | null;
+    port?: number | null;
+    host?: string;
+    healthy?: boolean;
+    context_length?: number | null;
+  } | null;
+  downloads?: Record<string, LocalModelDownload>;
+  usable?: boolean;
+  spec?: string;
+};
+
+export type LocalExternalEndpoint = {
+  id: string;
+  name?: string;
+  vendor: string;
+  base_url: string;
+  models: string[];
+  selected_model?: string;
+  context_length?: number | null;
+  has_key?: boolean;
+  lan_accepted?: boolean;
+  remote_accepted?: boolean;
+  kind?: string;
+  requires_key?: boolean;
+  last_error?: string | null;
+  healthy?: boolean;
+  tool_calling?: LocalToolCalling;
+};
+
+export type LocalModelsSnapshot = {
+  hardware: LocalModelHardware;
+  catalog: {
+    runtime_release?: string;
+    runtime?: { filename?: string; size?: number; platform?: string; backend?: string } | null;
+    models?: LocalCatalogModel[];
+    model?: { id?: string; name?: string; size?: number; quant?: string; context_length?: number } | null;
+  };
+  managed: LocalManagedState;
+  externals: LocalExternalEndpoint[];
+  active_spec?: string;
+  usable_specs?: string[];
+  event_cursor?: number;
+  events?: LocalModelEvent[];
+  error?: string;
+  code?: string;
+};
+
+export type LocalModelEvent = {
+  cursor: number;
+  kind: string;
+  data?: Record<string, unknown>;
+  ts?: number;
+};
+
+export type LocalModelStreamFrame = {
+  kind: string;
+  cursor?: number;
+  snapshot?: LocalModelsSnapshot;
+  data?: Record<string, unknown>;
+  ts?: number;
+};
+
+export type LocalModelProbeResult = {
+  ok: boolean;
+  url: string;
+  vendor: string;
+  models: string[];
+  context_length?: number | null;
+  kind?: string;
+  requires_lan?: boolean;
+  requires_remote?: boolean;
+  error?: string;
+  code?: string;
+};
+
 export type CodegraphStatus = {
   indexed: boolean;
   status: "ready" | "indexing" | "unsupported" | "needs_scope" | "none";
@@ -1888,6 +2051,28 @@ export const api = {
   getScheduleHistory: (id: string, limit = 50) =>
     getJSON<{ id: string; runs: ScheduleRun[] }>(
       `/api/schedules/history?id=${encodeURIComponent(id)}&limit=${limit}`,
+    ),
+
+  getLocalModels: () => getJSON<LocalModelsSnapshot>("/api/local-models"),
+  localModelCommand: (command: LocalModelCommand) =>
+    postJSON<LocalModelsSnapshot | LocalModelProbeResult>("/api/local-models", command),
+  getLocalModelEvents: (since = 0) =>
+    getJSON<{ ok: boolean; events: LocalModelEvent[]; cursor: number; snapshot: LocalModelsSnapshot }>(
+      `/api/local-models/events?since=${encodeURIComponent(String(since))}`,
+    ),
+  watchLocalModelEvents: (opts: {
+    since?: number;
+    onEvent: (ev: LocalModelStreamFrame) => void;
+    onDone?: () => void;
+    onError?: (e: unknown) => void;
+  }) =>
+    stream(
+      `/api/local-models/events?watch=1&since=${encodeURIComponent(String(opts.since ?? 0))}`,
+      (ev) => {
+        opts.onEvent(ev as LocalModelStreamFrame);
+      },
+      opts.onDone,
+      opts.onError,
     ),
 
   getCodegraph: () => getJSON<CodegraphStatus>("/api/codegraph"),


### PR DESCRIPTION
## Summary
- add managed llama.cpp installation and lifecycle controls with a pinned Qwen GGUF catalog
- attach loopback, trusted LAN, and HTTPS public OpenAI-compatible services with strict transport and secret boundaries
- verify tool-calling capability explicitly without executing tools or enrolling local pilots as swarm workers
- harden local streaming, Qwen tool-call recovery, process ownership, event delivery, and cross-platform runtime behavior

## Test plan
- [x] Python: 5,550 passed, 78 skipped
- [x] Frontend: 1,590 passed
- [x] Electron: 209 passed
- [x] Focused local-model regressions: 296 passed
- [x] Production frontend build
- [x] Release wheel metadata and packaged catalog inspection
- [x] npm audit: 0 vulnerabilities
- [x] Independent Grok 4.6 Extra High + Fast review and key-policy closure review
- [ ] GitHub Actions `tests` matrix: Python 3.9, Python 3.11, Windows, frontend-build