### PR TITLE
Release v0.9.396: restore status bar process spend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.395, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.396, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.395"
+__version__ = "0.9.396"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.395"
+version = "0.9.396"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_advisor.py
+++ b/tests/test_advisor.py
@@ -115,7 +115,7 @@ def test_session_surfaces_warnings_on_first_action_result(monkeypatch):
             def complete(self, prompt, system=None):
                 # The advisor call carries the advisor system prompt; answer
                 # it with a warning array. Pilot turns get the normal envelope.
-                if system and "advisor" in system:
+                if system and "code-review advisor" in system:
                     return FakeResponse(text=json.dumps(["writing outside src/"]))
                 self.calls += 1
                 if self.calls == 1:
@@ -152,7 +152,7 @@ def test_session_makes_no_advisor_call_when_disabled(monkeypatch):
                 self.calls = 0
 
             def complete(self, prompt, system=None):
-                if system and "advisor" in system:
+                if system and "code-review advisor" in system:
                     advisor_calls.append(prompt)
                     return FakeResponse(text="[]")
                 self.calls += 1

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.395",
+  "version": "0.9.396",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.395",
+      "version": "0.9.396",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.395",
+  "version": "0.9.396",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/StatusBar.test.tsx
+++ b/webapp/src/__tests__/StatusBar.test.tsx
@@ -13,6 +13,7 @@ import { publishTaskProfile } from "../lib/taskProfileChrome";
 
 vi.mock("../lib/api", () => ({
   api: {
+    getUsage: vi.fn(),
     getEconomics: vi.fn(),
     workspaces: vi.fn(),
     getSessionState: vi.fn(),
@@ -29,7 +30,26 @@ vi.mock("../lib/transport", () => ({
   isDesktop: () => false,
 }));
 
+const mockGetUsage = vi.mocked(api.getUsage);
 const mockGetEconomics = vi.mocked(api.getEconomics);
+
+const processUsage = {
+  session: {
+    tokens_used: 2700000,
+    est_cost_usd: 0.55,
+    cost_source: "provider" as const,
+    price_source: "live" as const,
+    estimated: false,
+    driver: "openrouter:z-ai/glm-5.3",
+    price_in: 1.4,
+    price_out: 4.4,
+    tokens_cached: 2500000,
+    cache_savings_gross_usd: 3.26,
+    tool_output_savings_usd: 3.41,
+  },
+  jobs: [],
+  session_total: { session_id: "sess-1", est_cost_usd: 33.6, input_tokens: 1, output_tokens: 1 },
+};
 const mockWorkspaces = vi.mocked(api.workspaces);
 const mockGetSessionState = vi.mocked(api.getSessionState);
 const mockSessions = vi.mocked(api.sessions);
@@ -39,6 +59,7 @@ const mockCompleteSessionGoal = vi.mocked(api.completeSessionGoal);
 const mockClearSessionGoal = vi.mocked(api.clearSessionGoal);
 
 beforeEach(() => {
+  mockGetUsage.mockResolvedValue(processUsage);
   mockGetEconomics.mockResolvedValue({
     available: true,
     scope: "conversation",
@@ -143,7 +164,7 @@ describe("StatusBar usage pills", () => {
     mockSessions.mockResolvedValue([]);
   });
 
-  it("shows canonical PM session cost and opens that same all-time scope", async () => {
+  it("shows process tokens and billed cash from /api/usage, not frozen job receipts", async () => {
     const onOpenEconomics = vi.fn();
     const selections: unknown[] = [];
     const onSelection = (event: Event) => selections.push((event as CustomEvent).detail);
@@ -165,8 +186,9 @@ describe("StatusBar usage pills", () => {
     try {
       render(<StatusBar {...statusBarProps} onOpenEconomics={onOpenEconomics} />);
 
-      const pill = await screen.findByRole("button", { name: "$2.31" });
-      expect(screen.queryByText("~$0.04")).toBeNull();
+      expect(await screen.findByText("2.7M tok")).toBeTruthy();
+      const pill = await screen.findByRole("button", { name: "$0.55" });
+      expect(screen.queryByRole("button", { name: "$2.31" })).toBeNull();
       fireEvent.click(pill);
       await waitFor(() => expect(selections).toEqual([{ scope: "conversation", period: "all" }]));
       expect(onOpenEconomics).toHaveBeenCalledTimes(1);
@@ -203,7 +225,7 @@ describe("StatusBar usage pills", () => {
     }));
 
     render(<Harness />);
-    fireEvent.click(await screen.findByRole("button", { name: "$2.31" }));
+    fireEvent.click(await screen.findByRole("button", { name: "$0.55" }));
 
     expect(await screen.findByLabelText("Economics ownership")).toHaveValue("conversation");
     expect(screen.getByLabelText("Economics period")).toHaveValue("all");

--- a/webapp/src/components/StatusBar.tsx
+++ b/webapp/src/components/StatusBar.tsx
@@ -15,7 +15,7 @@ import {
   Check,
   X,
 } from "lucide-react";
-import { api, type Config, type EconomicsData, type SessionGoal, type SessionState } from "../lib/api";
+import { api, type Config, type SessionGoal, type SessionState, type UsageData } from "../lib/api";
 import {
   subscribeTaskProfile,
   taskProfileTitle,
@@ -24,6 +24,13 @@ import {
 import { isDesktop } from "../lib/transport";
 import { usePolling } from "../lib/usePolling";
 
+import {
+  cacheHitDisplay,
+  delegationSavingsCredited,
+  listPriceValueTotal,
+  routingSavingsCredited,
+  spendIsEstimated,
+} from "./CostBreakdown";
 import { sanitizeUpdateMessage } from "../lib/updateMessages";
 import { shortPilotModelLabel } from "../lib/turnProgress";
 import type { UpdateAvailability } from "./UpdateBanner";
@@ -81,7 +88,7 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
   onOpenEconomics: () => void;
 }) {
   const [branch, setBranch] = useState("");
-  const [sessionEconomics, setSessionEconomics] = useState<EconomicsData | null>(null);
+  const [usage, setUsage] = useState<UsageData["session"] | null>(null);
   const [apply, setApply] = useState<{ stage: string; message: string; percent: number | null } | null>(null);
   const [toast, setToast] = useState<{
     message: string;
@@ -187,24 +194,31 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
     };
   }, []);
 
-  const economicsInFlight = useRef(false);
-  const fetchSessionEconomics = () => {
-    if (economicsInFlight.current) return;
-    economicsInFlight.current = true;
-    api.getEconomics("conversation", "all")
+  const usageInFlight = useRef(false);
+  const acceptZeroUsageRef = useRef(false);
+  const fetchUsage = () => {
+    if (usageInFlight.current) return;
+    usageInFlight.current = true;
+    api.getUsage()
       .then((data) => {
-        if (
-          data?.counterfactual_source === "job_financial_reports"
-          && data.counterfactual_status === "ok"
-          && data.counterfactual
-        ) {
-          setSessionEconomics(data);
-        } else {
-          setSessionEconomics(null);
+        if (data && data.session) {
+          setUsage((prev) => {
+            const next = data.session;
+            const nextZero =
+              (next.tokens_used ?? 0) === 0 && (next.est_cost_usd ?? 0) === 0;
+            const prevHadSpend =
+              !!prev && ((prev.tokens_used ?? 0) > 0 || (prev.est_cost_usd ?? 0) > 0);
+            if (acceptZeroUsageRef.current) {
+              acceptZeroUsageRef.current = false;
+              return next;
+            }
+            if (nextZero && prevHadSpend) return prev;
+            return next;
+          });
         }
       })
-      .catch((err) => console.error("Failed to load session Economics in StatusBar", err))
-      .finally(() => { economicsInFlight.current = false; });
+      .catch((err) => console.error("Failed to load usage in StatusBar", err))
+      .finally(() => { usageInFlight.current = false; });
   };
 
   useEffect(() => {
@@ -221,14 +235,17 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
   const runtimeStatus = deriveFooterRuntimeStatus(sessionState);
   const runtimeReady = runtimeStatus === "ready";
   const sessionGoal = sessionGoalForChip(sessionState?.goal);
-  usePolling(fetchSessionEconomics, 10000);
+  const usageBusy = runtimeStatus === "busy" || runtimeStatus === "thinking";
 
   useEffect(() => {
-    const onRefresh = () => fetchSessionEconomics();
+    fetchUsage();
+    const interval = setInterval(fetchUsage, usageBusy ? 2000 : 10000);
+    const onRefresh = () => fetchUsage();
     const onSessionChanged = () => {
-      setSessionEconomics(null);
+      acceptZeroUsageRef.current = true;
+      setUsage(null);
       setTaskProfile(null);
-      fetchSessionEconomics();
+      fetchUsage();
       // Session/view swaps carry a different sticky GOAL — refresh immediately
       // rather than waiting for the next 4s poll tick.
       void refreshSessionState();
@@ -239,13 +256,24 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
     window.addEventListener("harness-usage-refresh", onRefresh);
     window.addEventListener("harness-session-changed", onSessionChanged);
     return () => {
+      clearInterval(interval);
       window.removeEventListener("harness-config-changed", onRefresh);
       window.removeEventListener("harness-project-selected", onRefresh);
       window.removeEventListener("harness-new-session", onSessionChanged);
       window.removeEventListener("harness-usage-refresh", onRefresh);
       window.removeEventListener("harness-session-changed", onSessionChanged);
     };
-  }, []);
+  }, [usageBusy]);
+
+  const formatTokens = (num: number) => {
+    if (num >= 1000000) {
+      return (num / 1000000).toFixed(1).replace(/\.0$/, "") + "M";
+    }
+    if (num >= 1000) {
+      return (num / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+    }
+    return num.toString();
+  };
 
   const formatCost = (num: number) => {
     if (num === 0) return "$0.00";
@@ -258,21 +286,7 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
     return `$${num.toFixed(2)}`;
   };
 
-  const sessionReceipt = sessionEconomics?.counterfactual;
-  const sessionCost = typeof sessionReceipt?.actual_cost_usd === "number"
-    && Number.isFinite(sessionReceipt.actual_cost_usd)
-    ? sessionReceipt.actual_cost_usd
-    : null;
-  const sessionSavings = typeof sessionReceipt?.avoided_usd === "number"
-    && Number.isFinite(sessionReceipt.avoided_usd)
-    ? sessionReceipt.avoided_usd
-    : null;
-  const sessionBasis = sessionReceipt?.spend_basis;
-  const sessionCostLabel = sessionBasis === "plan"
-    ? "Included"
-    : sessionCost === null
-      ? ""
-      : `${sessionBasis === "estimated" || sessionBasis === "mixed" ? "~" : ""}${formatCost(sessionCost)}`;
+  const showUsage = usage && (usage.tokens_used > 0 || usage.est_cost_usd > 0);
   const openSessionEconomics = () => {
     // The panel can mount after this click's selection event. Keep the exact
     // destination available for that first render; the pane consumes it.
@@ -386,30 +400,81 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
           </button>
         </span>
       )}
-      {sessionCostLabel && (
+      {showUsage && usage && (
         <>
           <span className="w-px h-3 bg-edge/40 shrink-0" />
-          <span className="flex items-center gap-1.5 text-muted/80 min-w-0" title="This session · all time PM financial receipt">
+          <span
+            className="flex items-center gap-1.5 text-muted/80 min-w-0"
+            title="Pilot and worker spend since this app open (survives backend restart; resets on full quit). Click the dollar for this conversation's Puppetmaster receipts."
+          >
             <Coins size={10} className="text-faint shrink-0" />
-            {sessionSavings !== null && sessionSavings > 0 ? (
-              <button
-                type="button"
-                onClick={openSessionEconomics}
-                className="status-bar-optional-sm inline-flex items-center gap-1 px-1.5 py-px text-good/65 hover:text-good/80"
-                title="Estimated savings for this session · all time — click to open Economics"
-              >
-                ~{formatCost(sessionSavings)} saved
-              </button>
-            ) : null}
+            <span className="status-bar-optional-xs">{formatTokens(usage.tokens_used)} tok</span>
+            {(() => {
+              const savedUsd = listPriceValueTotal(usage);
+              const hit = cacheHitDisplay(usage);
+              if (savedUsd <= 0 && hit.percent == null) return null;
+              const cached = usage.tokens_cached || 0;
+              const compacted = usage.tool_output_tokens_saved || 0;
+              const cacheValue =
+                (typeof usage.cache_savings_gross_usd === "number"
+                  ? usage.cache_savings_gross_usd
+                  : usage.cache_savings_usd || 0)
+                + (usage.cache_saved_usd_swarm || 0);
+              const delegationUsd = delegationSavingsCredited(
+                usage.delegation_savings_basis,
+                usage.delegation_saved_usd,
+              );
+              const routingUsd = routingSavingsCredited(
+                usage.routing_savings_basis,
+                usage.routing_saved_usd,
+              );
+              const detail = [
+                hit.percent != null
+                  ? `${hit.percent} ${hit.label} hit`
+                  : "",
+                cached > 0
+                  ? `${formatTokens(cached)} prompt tokens from cache${
+                      cacheValue > 0 ? ` (~${formatCost(cacheValue)} list-price cache value)` : ""
+                    }`
+                  : "",
+                compacted > 0
+                  ? `${formatTokens(compacted)} tool-output tokens compacted${
+                      usage.tool_output_savings_usd ? ` (~${formatCost(usage.tool_output_savings_usd)})` : ""
+                    }`
+                  : "",
+                (delegationUsd || routingUsd)
+                  ? `model-selection list-price value (~${formatCost(delegationUsd || routingUsd)})`
+                  : "",
+              ].filter(Boolean).join("  ·  ");
+              return (
+                <button
+                  type="button"
+                  onClick={openSessionEconomics}
+                  className="status-bar-optional-sm inline-flex items-center gap-1 px-1.5 py-px text-good/65 hover:text-good/80"
+                  title={`List-price value, not a cash refund. ${detail}`}
+                >
+                  {hit.percent != null ? <span>{hit.percent} {hit.label}</span> : null}
+                  {hit.percent != null && savedUsd > 0 ? (
+                    <span className="text-good/50" aria-hidden="true">·</span>
+                  ) : null}
+                  {savedUsd > 0 ? `~${formatCost(savedUsd)} saved` : null}
+                </button>
+              );
+            })()}
             <button
               type="button"
               onClick={openSessionEconomics}
-              title="Cost for this session · all time — click to open Economics"
+              title={
+                !spendIsEstimated(usage)
+                  ? "Billed spend since app launch (pilot + workers). Click for this conversation's Puppetmaster receipts."
+                  : "Estimated spend since app launch (pilot + workers). Click for this conversation's Puppetmaster receipts."
+              }
               className="inline-flex items-center gap-1 px-1.5 py-px rounded-full bg-panel2 border border-edge text-txt/90 font-medium hover:border-edge hover:text-txt transition cursor-pointer"
             >
-              {sessionCostLabel}
+              {spendIsEstimated(usage) ? "~" : ""}
+              {formatCost(usage.est_cost_usd)}
             </button>
-            <span className="text-faint/70 normal-case font-sans tracking-normal status-bar-optional-lg">session</span>
+            <span className="text-faint/70 normal-case font-sans tracking-normal status-bar-optional-lg">process</span>
           </span>
         </>
       )}


### PR DESCRIPTION
## Why

The status bar glance was showing conversation-lifetime Puppetmaster receipts (`$2.26` / `~$19.65 saved`) instead of this-open pilot and worker spend from `/api/usage`. Click-through to Economics was the right destination; the glance meter was the wrong source.

## Scope

- Footer polls boot-scoped `/api/usage` again (tokens + billed `$`).
- Muted `saved` stays list-price value on that same usage object (cache/compact), not Opus job counterfactual.
- Click `$` still opens Economics at conversation / all time.
- Version bump to `0.9.396` (`pyproject.toml`, `harness/__init__.py`, `webapp/package.json`, lockfile, README).
- Advisor tests match `code-review advisor` so they no longer collide with the `conflict-auditor` role name in the pilot system prompt.

## Tradeoffs

Glance is this-open process spend, not conversation lifetime. Conversation receipts stay in the Economics pane.

## Blast radius

Status bar footer only, plus two advisor test string matches. No economics API or receipt store change.

## Verification

- StatusBar vitest: 25 passed (asserts `2.7M tok` / `$0.55`; click still selects conversation / all).
- `tests/test_version_consistency.py`: 3 passed.
- `tests/test_advisor.py`: 11 passed after the heuristic fix.
- Full local pytest: 5548 passed, 78 skipped; the two advisor failures above were the only red, then fixed.
- GitHub Actions `tests` matrix still running on this PR.