### PR TITLE
Release v0.9.397: economics meters, swarm-done fold, Codex title glue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.396, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.397, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.396"
+__version__ = "0.9.397"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.396"
+version = "0.9.397"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.396",
+  "version": "0.9.397",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.396",
+      "version": "0.9.397",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.396",
+  "version": "0.9.397",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CostBreakdown.test.tsx
+++ b/webapp/src/__tests__/CostBreakdown.test.tsx
@@ -22,7 +22,7 @@ const baseData: CostBreakdownData = {
 };
 
 describe("CostBreakdown receipt", () => {
-  it("shows one app-run receipt without a competing breakdown", () => {
+  it("shows one app-run receipt plus cache and compact line items", async () => {
     render(<CostBreakdown data={baseData} />);
 
     expect(screen.getByText("Spend")).toBeTruthy();
@@ -33,9 +33,9 @@ describe("CostBreakdown receipt", () => {
     expect(screen.getByText("~$0.06")).toBeTruthy();
     expect(screen.getByText("Less spent")).toBeTruthy();
     expect(screen.getByText("33.3%")).toBeTruthy();
-    expect(screen.queryByText("Why you saved")).toBeNull();
-    expect(screen.queryByText("Prompt-cache value")).toBeNull();
-    expect(screen.queryByText("Compact tool outputs")).toBeNull();
+    expect(screen.getByText("Why you saved")).toBeTruthy();
+    expect(screen.getByText("Prompt-cache value")).toBeTruthy();
+    expect(screen.getByText("Compact tool outputs")).toBeTruthy();
   });
 
   it("keeps context diagnostics and compaction controls out of Economics", () => {

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -8,14 +8,28 @@ import { dispatchProjectSelected } from "../lib/panelTransition";
 
 vi.mock("../lib/api", () => ({
   api: {
+    getUsage: vi.fn(),
     getEconomics: vi.fn(),
   },
 }));
 
 vi.mock("../lib/agentLinks", () => ({ openAgentSwarmJob: vi.fn() }));
 
+const mockGetUsage = vi.mocked(api.getUsage);
 const mockGetEconomics = vi.mocked(api.getEconomics);
 const mockOpenAgentSwarmJob = vi.mocked(openAgentSwarmJob);
+
+const emptyUsage = {
+  session: {
+    tokens_used: 0,
+    est_cost_usd: 0,
+    driver: "",
+    price_in: 0,
+    price_out: 0,
+  },
+  jobs: [],
+  session_total: { session_id: "", est_cost_usd: 0, input_tokens: 0, output_tokens: 0 },
+};
 
 const durablePayload = {
   available: true,
@@ -56,6 +70,7 @@ describe("EconomicsPane", () => {
     vi.clearAllMocks();
     clearSWRCache();
     dispatchProjectSelected("/repo-a");
+    mockGetUsage.mockResolvedValue(emptyUsage);
     mockGetEconomics.mockImplementation(async (scope = "repo") => ({
       ...durablePayload,
       scope,
@@ -439,6 +454,43 @@ describe("EconomicsPane", () => {
     render(<EconomicsPane />);
     fireEvent.click(await screen.findByRole("button", { name: "job_abcdef012345" }));
     expect(mockOpenAgentSwarmJob).toHaveBeenCalledWith("job_abcdef012345");
+  });
+
+  it("shows this-open cache and compact value even when the session has no owned jobs", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: {
+        tokens_used: 229_800,
+        est_cost_usd: 0.21,
+        cost_source: "estimated",
+        estimated: true,
+        driver: "openai-codex:gpt-5.6-sol",
+        price_in: 1,
+        price_out: 1,
+        tokens_cached: 170_000,
+        prompt_cache_read_tokens: 170_000,
+        prompt_cache_hit_ratio: 0.74,
+        cache_savings_gross_usd: 5.22,
+        cache_savings_basis: "catalog",
+        tool_output_tokens_saved: 40_000,
+        tool_output_savings_usd: 0.40,
+      },
+      jobs: [],
+      session_total: { session_id: "s1", est_cost_usd: 0.21, input_tokens: 1, output_tokens: 1 },
+    });
+    mockGetEconomics.mockResolvedValue({
+      available: true,
+      repo: "/repo-a",
+      scope: "conversation",
+      counterfactual: null,
+      recent_jobs: [],
+    });
+    (window as any).__pmPendingEconomicsSelection = { scope: "conversation", period: "all" };
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("Prompt-cache value")).toBeTruthy();
+    expect(screen.getByText("Compact tool outputs")).toBeTruthy();
+    expect(screen.getByText("No owned jobs for this session.")).toBeTruthy();
   });
 
   it("keeps conversation scope honest when no full comparison exists", async () => {

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   clearToolPrepPlaceholders,
   coalesceThinkingChunk,
+  looksLikeStatusHeadline,
   sanitizeThinkingStatusGlue,
   finalizeStreamingThinking,
   hoistCardsBeforeTrailingFinals,
@@ -658,6 +659,34 @@ describe("thinkingToolPrep module", () => {
     expect(coalesceThinkingChunk("Diagnosing…", "****Inspecting…")).toBe("Inspecting…");
     expect(sanitizeThinkingStatusGlue("Diagnosing…****Inspecting…")).toBe("Inspecting…");
     expect(sanitizeThinkingStatusGlue("hello****Inspecting…")).toBe("Inspecting…");
+  });
+
+  it("treats Codex gerund title frames as status headlines, not spoken glue", () => {
+    // e4826862bc69 stored these as assistant bubbles; they must replace, not concatenate.
+    expect(looksLikeStatusHeadline("Creating concise manifest summaries")).toBe(true);
+    expect(looksLikeStatusHeadline("Preparing audit manifest files")).toBe(true);
+    expect(
+      looksLikeStatusHeadline(
+        "**Creating concise manifest summaries****Preparing audit manifest files**",
+      ),
+    ).toBe(true);
+    expect(
+      sanitizeThinkingStatusGlue(
+        "**Creating concise manifest summaries****Preparing audit manifest files**",
+      ),
+    ).toBe("Preparing audit manifest files");
+    expect(
+      coalesceThinkingChunk(
+        "**Creating concise manifest summaries**",
+        "**Preparing audit manifest files**",
+      ),
+    ).toBe("Preparing audit manifest files");
+    expect(looksLikeStatusHeadline("Use **bold** in the real answer.")).toBe(false);
+    expect(
+      looksLikeStatusHeadline(
+        "**Summarizing Luna worker allocation****Confirming GPT-5.6 Luna pinning and source status**",
+      ),
+    ).toBe(true);
   });
 
   it("upsertStreamingThinking coalesceSnapshots uses coalesce; default strict-appends", () => {

--- a/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
+++ b/webapp/src/__tests__/stackedFolds.sessionTitle.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   TranscriptList,
@@ -8,6 +8,7 @@ import {
 import {
   partitionStackedActivity,
   ranCommandsLabel,
+  swarmDoneFoldLabel,
   thoughtFoldLabel,
   workFoldLabel,
   workedForLabel,
@@ -73,6 +74,9 @@ describe("stacked fold labels", () => {
     expect(thoughtFoldLabel({ durationMs: 8_000 })).toBe("Thought 8s");
     expect(ranCommandsLabel(1)).toBe("Ran 1 command");
     expect(ranCommandsLabel(3)).toBe("Ran 3 commands");
+    expect(swarmDoneFoldLabel(8, "done")).toBe("Swarm done · 8");
+    expect(swarmDoneFoldLabel(1, "done")).toBe("Swarm done");
+    expect(swarmDoneFoldLabel(2, "failed")).toBe("Swarm failed · 2");
   });
 
   it("work fold never falls through to spoken-prose Working...", () => {
@@ -103,6 +107,42 @@ describe("stacked fold labels", () => {
     if (rows[1]?.kind !== "commands") return;
     expect(rows[1].items).toHaveLength(3);
     expect(rows[1].items.filter((it) => it.kind === "thinking")).toHaveLength(1);
+  });
+
+  it("coalesces consecutive terminal swarm_pending into one Swarm done fold", () => {
+    const items = [
+      { kind: "thinking" as const },
+      { kind: "swarm_pending" as const, terminal: true },
+      { kind: "swarm_pending" as const, terminal: true },
+      { kind: "swarm_pending" as const, terminal: true },
+      { kind: "other" as const },
+      { kind: "swarm_pending" as const, terminal: true },
+    ];
+    const rows = partitionStackedActivity(items, (row) => ({
+      cardKind: null,
+      isThinking: row.kind === "thinking",
+      isTerminalSwarmPending: row.kind === "swarm_pending" && row.terminal,
+    }));
+    expect(rows.map((r) => r.kind)).toEqual([
+      "thought",
+      "swarms",
+      "item",
+      "item",
+    ]);
+    expect(rows[1]?.kind).toBe("swarms");
+    if (rows[1]?.kind === "swarms") {
+      expect(rows[1].items).toHaveLength(3);
+    }
+  });
+
+  it("leaves a single terminal swarm_pending as its own pill", () => {
+    const items = [{ kind: "swarm_pending" as const, terminal: true }];
+    const rows = partitionStackedActivity(items, (row) => ({
+      cardKind: null,
+      isThinking: false,
+      isTerminalSwarmPending: row.kind === "swarm_pending",
+    }));
+    expect(rows.map((r) => r.kind)).toEqual(["item"]);
   });
 
   it("coalesces consecutive Thought siblings into one fold", () => {
@@ -299,5 +339,49 @@ describe("session title lock", () => {
     // One session row — display stays the human title, never the wall.
     expect(displaySessionListTitle(userTitle)).toBe(userTitle);
     expect(displaySessionListTitle(headlines.join("\n"))).toBe("Untitled");
+  });
+});
+
+describe("stacked Swarm done fold", () => {
+  it("collapses eight terminal swarm pills behind Swarm done · 8", () => {
+    const pendings: Item[] = Array.from({ length: 8 }, (_, i) => ({
+      kind: "swarm_pending" as const,
+      job_ids: [`local-swarm-call_${i}`],
+      objective: `Audit the freshly fetched repo ${i}`,
+      status: "done" as const,
+      resolved: true,
+    }));
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "audit the agents" } },
+      {
+        kind: "card",
+        card: {
+          id: "c-swarm",
+          goal: "run swarm",
+          cwd: null,
+          kind: "run_swarm",
+          running: true,
+          open: false,
+        },
+      },
+      ...pendings,
+    ];
+
+    render(
+      <TranscriptList
+        {...listProps(items)}
+        status="executing"
+        turnOpen
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Investigating/i }));
+
+    const fold = screen.getByTestId("swarm-done-fold");
+    expect(fold.querySelector(".transcript-fold-chrome")?.textContent || "").toMatch(/Swarm done · 8/);
+    expect(screen.queryAllByText(/swarm done:/i)).toHaveLength(0);
+
+    fireEvent.click(within(fold).getByRole("button"));
+    expect(screen.getAllByText(/swarm done:/i).length).toBe(8);
   });
 });

--- a/webapp/src/__tests__/transcriptRowHeight.test.ts
+++ b/webapp/src/__tests__/transcriptRowHeight.test.ts
@@ -5,6 +5,7 @@ import {
   createTranscriptRowHeightCache,
   hasMarkdownCodeFence,
   hasMarkdownImage,
+  hasMarkdownTable,
   hasMermaidFence,
   rowMeasureSignal,
   rowNeedsDomMeasure,
@@ -71,11 +72,29 @@ describe("transcriptRowHeight", () => {
     expect(hasMarkdownCodeFence("```ts\nx\n```")).toBe(true);
     expect(hasMermaidFence("```mermaid\ngraph TD\n```")).toBe(true);
     expect(hasMarkdownImage("![alt](https://x/y.png)")).toBe(true);
+    expect(hasMarkdownTable("plain pipes | are not a table")).toBe(false);
+    expect(
+      hasMarkdownTable("| Repository | Audited ref |\n|---|---|\n| hermes-agent | main |"),
+    ).toBe(true);
+  });
+
+  it("hides Codex gerund title crumbs the way Investigating headlines already hide", () => {
+    expect(
+      assistantTextForMeasure(
+        "**Creating concise manifest summaries****Preparing audit manifest files**",
+      ),
+    ).toBe("");
+    expect(assistantTextForMeasure("Use **bold** in the real answer.")).toBe(
+      "Use **bold** in the real answer.",
+    );
   });
 
   it("classifies rows for Pretext vs DOM settle", () => {
     expect(rowNeedsDomMeasure(msg("user", "short note"))).toBe(false);
     expect(rowNeedsDomMeasure(msg("assistant", "```py\nprint(1)\n```"))).toBe(true);
+    expect(
+      rowNeedsDomMeasure(msg("assistant", "| A | B |\n|---|---|\n| 1 | 2 |")),
+    ).toBe(true);
     expect(rowNeedsDomMeasure(msg("user", "pic", {
       images: [{ path: "/a.png", name: "a", previewUrl: "blob:x" }],
     }))).toBe(true);

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -378,10 +378,67 @@ function fmtCost(num: number): string {
   return `$${num.toFixed(2)}`;
 }
 
+function fmtTokens(num: number): string {
+  if (!isFinite(num) || num <= 0) return "0";
+  if (num >= 1000000) return (num / 1000000).toFixed(1).replace(/\.0$/, "") + "M";
+  if (num >= 1000) return (num / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+  return String(num);
+}
+
 export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
   const est = isFinite(data.est_cost_usd) ? data.est_cost_usd : 0;
   const estimated = spendIsEstimated(data);
   const spendPrefix = estimated ? "~" : "";
+  const pilotCacheGross =
+    typeof data.cache_savings_gross_usd === "number" && isFinite(data.cache_savings_gross_usd)
+      ? data.cache_savings_gross_usd
+      : typeof data.cache_savings_usd === "number" && isFinite(data.cache_savings_usd)
+        ? data.cache_savings_usd
+        : 0;
+  const routingSaved = routingSavingsCredited(
+    data.routing_savings_basis,
+    data.routing_saved_usd,
+  );
+  const routingEstimated = data.routing_savings_basis === "estimated";
+  const routingUnknown = data.routing_savings_basis === "unknown";
+  const delegationSaved = delegationSavingsCredited(
+    data.delegation_savings_basis,
+    data.delegation_saved_usd,
+  );
+  const delegationMeasured = data.delegation_savings_basis === "actual_usage";
+  const modelSelectionSaved = delegationMeasured
+    ? delegationSaved
+    : (delegationSaved > 0 ? delegationSaved : routingSaved);
+  const showRoutingDecision =
+    routingSaved > 0
+    && (delegationMeasured || delegationSaved > 0)
+    && Math.abs(routingSaved - delegationSaved) > 0.0001;
+  const swarmCacheSaved =
+    typeof data.cache_saved_usd_swarm === "number" && isFinite(data.cache_saved_usd_swarm) && data.cache_saved_usd_swarm > 0
+      ? data.cache_saved_usd_swarm
+      : 0;
+  const swarmCacheUnpricedTokens =
+    typeof data.swarm_cache_unpriced_tokens === "number"
+    && isFinite(data.swarm_cache_unpriced_tokens)
+    && data.swarm_cache_unpriced_tokens > 0
+      ? data.swarm_cache_unpriced_tokens
+      : 0;
+  const swarmCachePartial =
+    swarmCacheSaved > 0
+    && (
+      data.swarm_cache_savings_basis === "unknown"
+      || swarmCacheUnpricedTokens > 0
+    );
+  const promptCacheSaved =
+    (pilotCacheGross > 0 ? pilotCacheGross : 0) + swarmCacheSaved;
+  const compactSavings =
+    typeof data.tool_output_savings_usd === "number" && isFinite(data.tool_output_savings_usd) && data.tool_output_savings_usd > 0
+      ? data.tool_output_savings_usd
+      : 0;
+  const compactTokens =
+    typeof data.tool_output_tokens_saved === "number" && isFinite(data.tool_output_tokens_saved) && data.tool_output_tokens_saved > 0
+      ? data.tool_output_tokens_saved
+      : 0;
   const valueTotal = listPriceValueTotal(data);
   const withoutSavings = est + valueTotal;
   const savingsPercent = withoutSavings > 0
@@ -416,9 +473,78 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
         </div>
       </div>
 
+      {(promptCacheSaved > 0 || modelSelectionSaved > 0 || showRoutingDecision || compactSavings > 0) ? (
+      <div className="mt-2 pt-2 border-t border-edge/50">
+      <div className="text-[10px] text-faint mb-1">Why you saved</div>
+      <p className="text-[10px] text-muted mb-1.5 leading-snug">
+        Each saving is shown once, so the total stays honest.
+      </p>
+      {promptCacheSaved > 0 ? (
+        <div
+          className="flex items-center justify-between mb-1"
+          title={
+            swarmCachePartial
+              ? swarmCacheUnpricedTokens > 0
+                ? `Partial avoided full-price input value; ${fmtTokens(swarmCacheUnpricedTokens)} swarm cache tokens could not be priced. Not a cash refund.`
+                : "Partial avoided full-price input value; not every swarm cache hit has a trustworthy list rate. Not a cash refund."
+              : "Gross avoided full-price input value from prompt-cache hits (catalog/list rate). Continues growing with cached tokens; not a cash refund and not capped to provider spend."
+          }
+        >
+          <span className="text-muted">
+            Prompt-cache value{swarmCachePartial ? " (partial)" : ""}
+          </span>
+          <span className="tabular-nums text-good/65">~{fmtCost(promptCacheSaved)}</span>
+        </div>
+      ) : null}
 
+      {modelSelectionSaved > 0 ? (
+        <div
+          className="flex items-center justify-between mb-1"
+          title={
+            delegationSaved > 0
+              ? "Full list-price value of choosing cheaper worker models vs a frontier-equivalent baseline on the same actual tokens (ignores prompt-cache discounts). Not a cash refund."
+              : routingEstimated
+                ? "Running estimate vs frontier-equivalent list price (preflight). Not a cash refund or billed spend."
+                : "List-price value vs a frontier-equivalent baseline on the same actual tokens. Not a cash refund."
+          }
+        >
+          <span className="text-muted">
+            Model selection value{routingEstimated && delegationSaved <= 0 ? " (est.)" : ""}
+          </span>
+          <span className="tabular-nums text-good/65">~{fmtCost(modelSelectionSaved)}</span>
+        </div>
+      ) : null}
 
+      {showRoutingDecision ? (
+        <div
+          className="flex items-center justify-between mb-1 text-faint"
+          title="Narrow router-decision delta (balanced/cheap policies only; includes prompt-cache discount in counterfactual). Shown separately from model-selection value. Not billed spend."
+        >
+          <span>Routing decision value{routingEstimated ? " (est.)" : ""}</span>
+          <span className="tabular-nums">~{fmtCost(routingSaved)}</span>
+        </div>
+      ) : null}
 
+      {compactSavings > 0 ? (
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-muted">Compact tool outputs</span>
+          <span className="tabular-nums text-good/65">
+            {compactTokens > 0 ? `${fmtTokens(compactTokens)} tok · ` : ""}~{fmtCost(compactSavings)}
+          </span>
+        </div>
+      ) : null}
+      </div>
+      ) : null}
+
+      {routingUnknown && typeof data.routing_saved_usd === "number" && data.routing_saved_usd > 0 ? (
+        <div
+          className="flex items-center justify-between mb-1 text-faint"
+          title="Routing savings basis is unknown — refused as billed or measured value."
+        >
+          <span>Routing decision value</span>
+          <span className="tabular-nums">unknown basis</span>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import { Coins } from "lucide-react";
-import { api, type EconomicsData, type EconomicsScope } from "../lib/api";
+import { api, type EconomicsData, type EconomicsScope, type UsageData } from "../lib/api";
 import { usePolling } from "../lib/usePolling";
 import { readSWRCache, writeSWRCache } from "../lib/useStaleWhileRevalidate";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
 import { repoPathsEqual } from "../lib/pathNormalize";
+import CostBreakdown, {
+  listPriceValueTotal,
+  usageToCostBreakdownData,
+} from "./CostBreakdown";
 import EconomicsDurable from "./EconomicsDurable";
 
 type EconomicsPaneScope = Exclude<EconomicsScope, "window30">;
@@ -49,7 +53,16 @@ export default function EconomicsPane() {
       ),
     ) ?? null,
   );
+  const [usage, setUsage] = useState<UsageData | null>(null);
   const economicsRequest = useRef(0);
+
+  const loadUsage = () => {
+    return Promise.resolve(api.getUsage())
+      .then((data) => {
+        if (data && data.session) setUsage(data);
+      })
+      .catch(() => {});
+  };
 
   const loadEconomics = (
     requestedScope = scope,
@@ -83,9 +96,13 @@ export default function EconomicsPane() {
   };
 
   usePolling(loadEconomics, 10000, { enabled: Boolean(projectRoot) });
+  usePolling(loadUsage, 10000);
 
   useEffect(() => {
-    const onUsageRefresh = () => { void loadEconomics(); };
+    const onUsageRefresh = () => {
+      void loadUsage();
+      void loadEconomics();
+    };
     const onSessionChanged = () => {
       if (scope === "conversation") void loadEconomics();
     };
@@ -138,6 +155,17 @@ export default function EconomicsPane() {
     && (periodDays === 30 ? economics.window_days === 30 : !economics.window_days),
   );
   const projectLabel = projectRoot.split(/[\\/]/).filter(Boolean).at(-1) || "this repo";
+  const processMeters = usage?.session
+    ? usageToCostBreakdownData(usage.session)
+    : null;
+  const showProcessMeters = Boolean(
+    processMeters
+    && (
+      (processMeters.tokens_used ?? 0) > 0
+      || (processMeters.est_cost_usd ?? 0) > 0
+      || listPriceValueTotal(processMeters) > 0
+    ),
+  );
   return (
     <div className="flex flex-col h-full overflow-hidden bg-transparent">
       <div className="shrink-0 flex items-center px-3 py-2 border-b border-[var(--shell-panel-border)] select-none">
@@ -183,6 +211,9 @@ export default function EconomicsPane() {
         </select>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto">
+        {showProcessMeters && processMeters ? (
+          <CostBreakdown data={processMeters} />
+        ) : null}
         {economicsMatchesSelection ? (
           <EconomicsDurable
             data={economics}

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -47,6 +47,7 @@ import {
   joinThoughtFoldText,
   partitionStackedActivity,
   ranCommandsLabel,
+  swarmDoneFoldLabel,
   resolveCardCliInput,
   shortenGoal,
   isWorkingEllipsisFallback,
@@ -928,6 +929,7 @@ const __activityOpen = new Map<string, boolean>();
 const __thinkingExpanded = new Map<string, boolean>();
 // Ran N command mid-fold expand preference (user click) survives remounts.
 const __commandFoldOpen = new Map<string, boolean>();
+const __swarmDoneFoldOpen = new Map<string, boolean>();
 // Alias every durable member of an investigation onto one canon key so a
 // thinking-only group does not remount when the first tool card arrives (and
 // the reverse). Streaming used to key off objKey(thinking) which changed every
@@ -943,6 +945,7 @@ export function clearActivityFoldPrefs(): void {
   __activityOpen.clear();
   __thinkingExpanded.clear();
   __commandFoldOpen.clear();
+  __swarmDoneFoldOpen.clear();
   __activityGroupCanon.clear();
 }
 
@@ -2657,6 +2660,9 @@ function ActivityGroup({
           {partitionStackedActivity(displayItems, (row) => ({
             cardKind: row.kind === "card" ? String(row.card.kind || "") : null,
             isThinking: row.kind === "thinking",
+            isTerminalSwarmPending: row.kind === "swarm_pending" && (
+              (row.status || (row.resolved ? "done" : "running")) !== "running"
+            ),
           })).map((row) => {
             if (row.kind === "thought") {
               const thoughts = row.items.filter(
@@ -2697,6 +2703,18 @@ function ActivityGroup({
                 />
               );
             }
+            if (row.kind === "swarms") {
+              const foldKey = `swarm-done-fold-${row.indexes[0]}`;
+              return (
+                <SwarmDoneFold
+                  key={foldKey}
+                  foldId={`${groupId}-${foldKey}`}
+                  items={row.items}
+                  indexes={row.indexes}
+                  renderInner={renderInner}
+                />
+              );
+            }
             if (row.kind === "shelf") {
               const shelfCards = row.items.filter(
                 (it): it is { kind: "card"; card: Card } => it.kind === "card",
@@ -2713,6 +2731,66 @@ function ActivityGroup({
             }
             return renderInner(row.item, row.index);
           })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+/** Collapsed swarm-lifecycle receipts. Expand shows one SwarmPendingPill per job. */
+function SwarmDoneFold({
+  foldId,
+  items,
+  indexes,
+  renderInner,
+}: {
+  foldId: string;
+  items: ActivityItem[];
+  indexes: number[];
+  renderInner: (it: ActivityItem, idx: number) => ReactNode;
+}) {
+  const [open, setOpen] = useState(() => {
+    if (__swarmDoneFoldOpen.has(foldId)) return Boolean(__swarmDoneFoldOpen.get(foldId));
+    return false;
+  });
+  const rootRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    requestFeedRowRemeasure(rootRef.current);
+  }, [open]);
+
+  const pendings = items.filter(
+    (it): it is SwarmPendingItem => it.kind === "swarm_pending",
+  );
+  const statuses = pendings.map((it) => it.status || (it.resolved ? "done" : "running"));
+  const outcome: "done" | "failed" | "partial" = statuses.every((s) => s === "failed")
+    ? "failed"
+    : statuses.every((s) => s === "done" || s === "ended")
+      ? "done"
+      : "partial";
+  const label = swarmDoneFoldLabel(pendings.length, outcome);
+
+  return (
+    <div className="flex flex-col w-full py-0.5 min-w-0" ref={rootRef} data-testid="swarm-done-fold">
+      <button
+        type="button"
+        onClick={() => {
+          setOpen((v) => {
+            const next = !v;
+            __swarmDoneFoldOpen.set(foldId, next);
+            return next;
+          });
+        }}
+        aria-expanded={open}
+        className="transcript-fold-chrome flex items-center gap-1.5 text-faint/65 hover:text-muted/90 transition font-sans font-normal text-[12px] text-left w-full min-w-0 select-none"
+        title={open ? "Collapse swarm receipts" : "Expand swarm receipts"}
+      >
+        {open ? <ChevronDown size={11} className="text-faint/55 shrink-0" /> : <ChevronRight size={11} className="text-faint/55 shrink-0" />}
+        <span className="shrink-0">{label}</span>
+      </button>
+      {open && (
+        <div className="mt-0.5 pl-2.5 ml-1 border-l border-edge/40 flex flex-col gap-0.5 w-full min-w-0">
+          {items.map((it, i) => renderInner(it, indexes[i] ?? i))}
         </div>
       )}
     </div>

--- a/webapp/src/components/conversation/thinkingToolPrep.ts
+++ b/webapp/src/components/conversation/thinkingToolPrep.ts
@@ -51,6 +51,21 @@ export function isTrivialAssistantCrumb(text: string): boolean {
 const STATUS_HEADLINE_RE =
   /^(Investigating|Explored|Diagnosing|Inspecting|Planning|Assessing|Searching|Looking|Thinking|Thought|Validating|Finalizing|Still working|Working)\b/i;
 
+/** Codex in-progress titles: "Creating concise manifest summaries". */
+const GERUND_TITLE_RE = /^[A-Z][A-Za-z]*ing\b/;
+
+function isTitleFrameCore(core: string): boolean {
+  if (!core) return false;
+  if (STATUS_HEADLINE_RE.test(core)) return true;
+  if (core.includes("\n")) return false;
+  // Sentence end, not version dots in "GPT-5.6 Luna pinning".
+  if (/[.!?](?:\s|$)/.test(core)) return false;
+  if (core.length > 96) return false;
+  const words = core.split(/\s+/).filter(Boolean);
+  if (words.length === 0 || words.length > 12) return false;
+  return GERUND_TITLE_RE.test(core);
+}
+
 /** Strip surrounding emphasis markers so `**Planning…**` compares as a title. */
 export function stripThinkingEmphasisChrome(text: string): string {
   let t = String(text || "").trim();
@@ -67,8 +82,16 @@ export function stripThinkingEmphasisChrome(text: string): string {
 }
 
 export function looksLikeStatusHeadline(text: string): boolean {
-  const core = stripThinkingEmphasisChrome(text);
-  return Boolean(core) && STATUS_HEADLINE_RE.test(core);
+  const raw = String(text || "");
+  const core = stripThinkingEmphasisChrome(raw);
+  if (isTitleFrameCore(core)) return true;
+  // `**Creating…****Preparing…**` — end-peel leaves **** in the middle.
+  if (!/\*{2,}|_{2,}/.test(raw)) return false;
+  const parts = raw
+    .split(/\*{2,}|_{2,}/)
+    .map((part) => stripThinkingEmphasisChrome(part))
+    .filter(Boolean);
+  return parts.length >= 2 && parts.every(isTitleFrameCore);
 }
 
 /**

--- a/webapp/src/components/conversation/transcriptRowHeight.ts
+++ b/webapp/src/components/conversation/transcriptRowHeight.ts
@@ -101,6 +101,11 @@ export function hasMarkdownImage(text: string): boolean {
   return /!\[[^\]]*\]\([^)]+\)/.test(text);
 }
 
+/** GFM table: a pipe row immediately followed by a delimiter row. */
+export function hasMarkdownTable(text: string): boolean {
+  return /\|.+\|[\t ]*\n[\t ]*\|?[\t ]*:?-{3,}/.test(text);
+}
+
 /** Strip assistant traceback noise — mirrors Bubble's cleanAssistantText (height-only). */
 export function assistantTextForMeasure(raw: string): string {
   const lines = raw.split("\n");
@@ -164,6 +169,7 @@ export function rowNeedsDomMeasure(item: GroupedItem): boolean {
       if (hasMarkdownCodeFence(text)) return true;
       if (hasMermaidFence(text)) return true;
       if (hasMarkdownImage(text)) return true;
+      if (hasMarkdownTable(text)) return true;
       return false;
     }
     case "activity_group":

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -514,6 +514,21 @@ export function ranCommandsLabel(count: number): string {
   return n === 1 ? "Ran 1 command" : `Ran ${n} commands`;
 }
 
+/** Mid-summary swarm-lifecycle fold — expand shows per-job SwarmPendingPill rows. */
+export function swarmDoneFoldLabel(
+  count: number,
+  outcome: "done" | "failed" | "partial" = "done",
+): string {
+  const n = Math.max(0, Math.floor(count));
+  const noun =
+    outcome === "failed"
+      ? "Swarm failed"
+      : outcome === "partial"
+        ? "Swarm results"
+        : "Swarm done";
+  return n <= 1 ? noun : `${noun} · ${n}`;
+}
+
 /** One expanded command row under Ran N — `Ran {goal}`. */
 export function ranGoalLine(goal: string): string {
   const g = String(goal || "").trim();
@@ -561,6 +576,7 @@ export function activityWorkDurationMs(
 export type StackedActivityRow<T> =
   | { kind: "thought"; items: T[]; indexes: number[] }
   | { kind: "commands"; items: T[]; indexes: number[] }
+  | { kind: "swarms"; items: T[]; indexes: number[] }
   | { kind: "shelf"; items: T[]; indexes: number[] }
   | { kind: "item"; item: T; index: number };
 
@@ -577,7 +593,11 @@ export function joinThoughtFoldText(texts: string[]): string {
  */
 export function partitionStackedActivity<T>(
   items: T[],
-  meta: (item: T) => { cardKind: string | null; isThinking: boolean },
+  meta: (item: T) => {
+    cardKind: string | null;
+    isThinking: boolean;
+    isTerminalSwarmPending?: boolean;
+  },
 ): StackedActivityRow<T>[] {
   const out: StackedActivityRow<T>[] = [];
   let i = 0;
@@ -650,6 +670,22 @@ export function partitionStackedActivity<T>(
         out.push({ kind: "shelf", items: group, indexes });
       } else {
         out.push({ kind: "item", item: group[0], index: start });
+      }
+      continue;
+    }
+
+    if (cur.isTerminalSwarmPending) {
+      const group: T[] = [];
+      const indexes: number[] = [];
+      while (i < items.length && meta(items[i]).isTerminalSwarmPending) {
+        group.push(items[i]);
+        indexes.push(i);
+        i += 1;
+      }
+      if (group.length >= 2) {
+        out.push({ kind: "swarms", items: group, indexes });
+      } else {
+        out.push({ kind: "item", item: group[0], index: indexes[0] });
       }
       continue;
     }


### PR DESCRIPTION
## Why

Three feed and economics bugs from live use, including transcript `e4826862bc69`. Economics looked empty while the footer showed cache savings. Parallel swarm-done pills stacked in Investigating. Codex gerund titles painted as `****`-glued spoken markdown, and GFM tables could clip until the rest of the bubble finished.

## Scope

- Restore CostBreakdown in Economics from this-open `/api/usage` (prompt-cache, model selection, compact tool outputs) above job receipts. Scope dropdown still filters owned jobs only.
- Collapse consecutive terminal swarm-pending pills (two or more) into a Swarm done fold, same shape as Ran N commands.
- Treat Codex gerund title frames as status headlines so they replace and never leak as spoken bubbles.
- DOM-measure GFM tables the same way as code fences after streaming ends.
- Version bump to `0.9.397` (`pyproject.toml`, `harness/__init__.py`, `webapp/package.json`, lockfile, README).

## Tradeoffs

Gerund title detection can hide a short unpunctuated answer that starts with Creating/Preparing/…. Spoken answers with a period stay. Economics process meters are this-open usage, not conversation-lifetime receipts.

## Blast radius

Economics pane, Investigating swarm pills, spoken-bubble filter, and transcript row height for tables. No receipt store or SSE protocol change.

## Verification

- Focused vitest: CostBreakdown, EconomicsPane, conversation.helpers, stackedFolds, transcriptRowHeight, thinkingStreamUx — 269 passed.
- `tests/test_version_consistency.py`: 3 passed.
- Full local pytest: 5549 passed, 78 skipped; `test_ergonomics_session_compact` timed out once then passed on retry (403 flake, outside this diff).
- GitHub Actions `tests` matrix still running on this PR.