### PR TITLE
Release v0.9.398

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.397, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.398, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.397"
+__version__ = "0.9.398"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/redaction.py
+++ b/harness/api/redaction.py
@@ -3,30 +3,33 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from hashlib import sha256
+from typing import Any, TypedDict
 
 _REDACTED = "REDACTED"
-_SECRET_KV_RE = re.compile(
-    r"(?i)((?:api[_-]?key|secret|password|token|bearer|authorization)\s*[=:]\s*)(\S+)"
-)
-# Free-floating provider/API token shapes that show up in exception text.
-# Trailing (?!\w) (not \b) so Basic base64 padding "=" still matches.
-_TOKENISH_RE = re.compile(
-    r"(?i)\b("
-    r"sk-[A-Za-z0-9_-]{8,}"
-    r"|ghp_[A-Za-z0-9]{20,}"
-    r"|github_pat_[A-Za-z0-9_]{20,}"
-    r"|xox[baprs]-[A-Za-z0-9-]{10,}"
-    r"|Bearer\s+[A-Za-z0-9._\-]{12,}"
-    r"|Basic\s+[A-Za-z0-9+/=]{8,}"
-    r")(?!\w)"
-)
+_MAX_LABEL = 40
+_MAX_SUMMARY = 240
+_SECRET_KEYS = {"env", "headers", "authorization", "cookie", "set-cookie", "access_token", "refresh_token", "client_secret", "api_key", "password", "secret", "token"}
+_SECRET_KV_RE = re.compile(r"(?i)((?:api[_-]?key|secret|password|token|bearer|authorization)\s*[=:]\s*)(\S+)")
+_URL_CREDENTIAL_RE = re.compile(r"(?i)([?&](?:api[_-]?key|access_token|refresh_token|client_secret|password|secret|token|key)=[^&#\s]*)")
+_TOKENISH_RE = re.compile(r"(?i)\b(sk-[A-Za-z0-9_-]{8,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|Bearer\s+\S+|Basic\s+\S+)(?!\w)")
+_AUTH_FAILURE_RE = re.compile(r"(?i)\b(authentication\s+(?:failed|failure)|unauthori[sz]ed|forbidden|credential(?:s)?\s+rejected)\b")
+
+
+class AuthFailureAttribution(TypedDict, total=False):
+    category: str
+    consumer_kind: str
+    consumer_id: str
+    http_status: int
+    remediation: str
+    summary: str
 
 
 def _redact_string(text: str) -> str:
     if not text:
         return text
-    out = _SECRET_KV_RE.sub(rf"\1{_REDACTED}", text)
+    out = _URL_CREDENTIAL_RE.sub(lambda m: m.group(1).split("=", 1)[0] + "=" + _REDACTED, text)
+    out = _SECRET_KV_RE.sub(rf"\1{_REDACTED}", out)
     return _TOKENISH_RE.sub(_REDACTED, out)
 
 
@@ -36,13 +39,14 @@ def redact_secret_text(text: str) -> str:
 
 
 def redact_api_secrets(value: Any) -> Any:
-    """Deep-copy redaction aligned with ``redact_mcp_secrets`` env/headers handling."""
+    """Deep-copy redaction with case-insensitive handling of sensitive keys."""
     if isinstance(value, dict):
         out = {}
         for key, item in value.items():
-            if key in ("env", "headers") and isinstance(item, dict):
-                out[key] = {k: _REDACTED for k in item}
-            elif key in ("env", "headers") and item:
+            key_name = key.casefold().replace("-", "_") if isinstance(key, str) else ""
+            if key_name == "headers":
+                out[key] = redact_api_secrets(item)
+            elif key_name in {k.replace("-", "_") for k in _SECRET_KEYS}:
                 out[key] = _REDACTED
             elif isinstance(item, str):
                 out[key] = _redact_string(item)
@@ -54,3 +58,30 @@ def redact_api_secrets(value: Any) -> Any:
     if isinstance(value, str):
         return _redact_string(value)
     return value
+
+
+def _safe_label(value: Any) -> str:
+    text = str(value or "")
+    if re.search(r"(?i)https?://|[/\\?&#=]", text):
+        return "label-" + sha256(text.encode("utf-8", "replace")).hexdigest()[:12]
+    text = re.sub(r"[\x00-\x20\x7f]+", "-", text)
+    text = re.sub(r"[^A-Za-z0-9_.:-]", "-", text).strip("-._:")
+    return text[:_MAX_LABEL]
+
+
+def build_auth_failure_attribution(consumer_kind: Any, consumer_id: Any, http_status: Any = None, error_text: Any = "") -> dict | None:
+    """Build a bounded, privacy-safe attribution only for clear auth failures."""
+    status = http_status if http_status in (401, 403) else None
+    text = str(error_text or "")
+    match = _AUTH_FAILURE_RE.search(text)
+    if not match and status is None:
+        return None
+    forbidden = status == 403 or bool(re.search(r"(?i)forbidden", text))
+    authentication = status == 401 or bool(re.search(r"(?i)authentication|credential(?:s)?\s+rejected", text))
+    category = "forbidden" if forbidden else "authentication"
+    summary = _redact_string(text).replace("\r", " ").replace("\n", " ")
+    summary = re.sub(r"https?://[^\s]+", "[URL]", summary)[:_MAX_SUMMARY]
+    result: AuthFailureAttribution = {"category": category, "consumer_kind": _safe_label(consumer_kind), "consumer_id": _safe_label(consumer_id), "remediation": "check_permissions" if forbidden else "reauthenticate", "summary": summary}
+    if status is not None:
+        result["http_status"] = status
+    return dict(result)

--- a/harness/api/redaction.py
+++ b/harness/api/redaction.py
@@ -14,6 +14,10 @@ _SECRET_KV_RE = re.compile(r"(?i)((?:api[_-]?key|secret|password|token|bearer|au
 _URL_CREDENTIAL_RE = re.compile(r"(?i)([?&](?:api[_-]?key|access_token|refresh_token|client_secret|password|secret|token|key)=[^&#\s]*)")
 _TOKENISH_RE = re.compile(r"(?i)\b(sk-[A-Za-z0-9_-]{8,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|Bearer\s+\S+|Basic\s+\S+)(?!\w)")
 _AUTH_FAILURE_RE = re.compile(r"(?i)\b(authentication\s+(?:failed|failure)|unauthori[sz]ed|forbidden|credential(?:s)?\s+rejected)\b")
+_HTTP_AUTH_STATUS_RE = re.compile(
+    r"(?ix)(?:\bHTTP\s+|\bstatus\s*[:=]\s*)(?P<status>401|403)\b"
+    r"|\b(?P<response_status>401|403)\s+(?:unauthori[sz]ed|forbidden)\b"
+)
 
 
 class AuthFailureAttribution(TypedDict, total=False):
@@ -73,7 +77,12 @@ def build_auth_failure_attribution(consumer_kind: Any, consumer_id: Any, http_st
     """Build a bounded, privacy-safe attribution only for clear auth failures."""
     status = http_status if http_status in (401, 403) else None
     text = str(error_text or "")
+    status_match = _HTTP_AUTH_STATUS_RE.search(text) if status is None else None
+    if status_match:
+        status = int(status_match.group("status") or status_match.group("response_status"))
     match = _AUTH_FAILURE_RE.search(text)
+    if status is None and match:
+        status = 403 if re.search(r"(?i)forbidden", match.group(0)) else 401
     if not match and status is None:
         return None
     forbidden = status == 403 or bool(re.search(r"(?i)forbidden", text))

--- a/harness/api/terminals.py
+++ b/harness/api/terminals.py
@@ -62,64 +62,68 @@ def post_terminal_kill(body: dict, svc: TerminalServices) -> tuple[int, dict]:
     return 200, {"ok": True}
 
 
-def stream_terminal(handler: Any, sid: str, svc: TerminalServices) -> None:
+def stream_terminal(handler: Any, sid: str, svc: TerminalServices, start_offset: int = 0) -> None:
     """Stream PTY output over SSE (GET /api/terminal/stream).
 
     Client sends keystrokes via POST /api/terminal/write. Preserves data/exit
     frames and BrokenPipe/ConnectionReset detach handling.
     """
+    import base64 as _b64
+    from harness.api.redaction import redact_secret_text
+
+    offset = max(0, int(start_offset or 0))
     sess = svc.pty.get(sid)
     handler.send_response(200)
     handler.send_header("Content-Type", "text/event-stream")
     handler.send_header("Cache-Control", "no-cache")
     handler._cors()
     handler.end_headers()
+
+    def send(payload: dict) -> None:
+        handler.wfile.write(f"data: {json.dumps(payload)}\n\n".encode())
+        handler.wfile.flush()
+
     if not sess:
         try:
-            handler.wfile.write(b"data: {\"kind\": \"exit\"}\n\n")
-            handler.wfile.flush()
-        except Exception:
+            send({"kind": "exit", "offset": offset, "reason": "missing_session"})
+        except (BrokenPipeError, ConnectionResetError, OSError):
             pass
         return
-    offset = 0
     # Emit kind:exit from finally when the client is still writable so the
     # renderer can distinguish a real process death from a bare stream drop
     # (reattach without killing ConPTY). Skip exit when the client already
     # disconnected (BrokenPipe / ConnectionReset).
     client_writable = True
+    reason = "process_exit"
     try:
         while sess.alive():
-            data, offset = sess.read_since(offset)
+            data, reported = sess.read_since(offset)
             if data:
-                import base64 as _b64
-                payload = json.dumps({
-                    "kind": "data",
-                    "b64": _b64.b64encode(data).decode("ascii"),
-                })
-                handler.wfile.write(f"data: {payload}\n\n".encode())
-                handler.wfile.flush()
+                # Some PTY implementations report stale offsets; never move
+                # backwards and always account for bytes actually delivered.
+                offset = max(offset + len(data), int(reported))
+                send({"kind": "data", "b64": _b64.b64encode(data).decode("ascii"), "offset": offset})
             else:
+                offset = max(offset, int(reported))
                 time.sleep(0.05)
         # flush any final bytes after exit
-        data, offset = sess.read_since(offset)
+        data, reported = sess.read_since(offset)
         if data:
-            import base64 as _b64
-            payload = json.dumps({
-                "kind": "data",
-                "b64": _b64.b64encode(data).decode("ascii"),
-            })
-            handler.wfile.write(f"data: {payload}\n\n".encode())
-            handler.wfile.flush()
+            offset = max(offset + len(data), int(reported))
+            send({"kind": "data", "b64": _b64.b64encode(data).decode("ascii"), "offset": offset})
+        else:
+            offset = max(offset, int(reported))
     except (BrokenPipeError, ConnectionResetError):
         client_writable = False
-    except Exception:
-        # Still emit exit in finally so the renderer does not see a bare
-        # stream close (EXITED with no prior exit frame).
-        pass
+    except Exception as exc:
+        reason = "stream_error"
+        error = redact_secret_text(str(exc))[:160]
     finally:
         if client_writable:
+            payload = {"kind": "exit", "offset": offset, "reason": reason}
+            if reason == "stream_error":
+                payload["error"] = error
             try:
-                handler.wfile.write(b"data: {\"kind\": \"exit\"}\n\n")
-                handler.wfile.flush()
+                send(payload)
             except (BrokenPipeError, ConnectionResetError, OSError):
                 pass

--- a/harness/api/terminals.py
+++ b/harness/api/terminals.py
@@ -62,6 +62,14 @@ def post_terminal_kill(body: dict, svc: TerminalServices) -> tuple[int, dict]:
     return 200, {"ok": True}
 
 
+def parse_terminal_start_offset(raw: Any) -> int:
+    """Parse a reconnect byte offset from query or helper input. Never negative."""
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 0
+
+
 def stream_terminal(handler: Any, sid: str, svc: TerminalServices, start_offset: int = 0) -> None:
     """Stream PTY output over SSE (GET /api/terminal/stream).
 
@@ -71,7 +79,7 @@ def stream_terminal(handler: Any, sid: str, svc: TerminalServices, start_offset:
     import base64 as _b64
     from harness.api.redaction import redact_secret_text
 
-    offset = max(0, int(start_offset or 0))
+    offset = parse_terminal_start_offset(start_offset)
     sess = svc.pty.get(sid)
     handler.send_response(200)
     handler.send_header("Content-Type", "text/event-stream")

--- a/harness/browser_auth.py
+++ b/harness/browser_auth.py
@@ -18,7 +18,11 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from .browser_real_profile import real_profile_enabled, snapshot_real_profile
+from .browser_real_profile import (
+    is_live_browser_user_data_dir,
+    real_profile_enabled,
+    snapshot_real_profile,
+)
 
 AUTH_ENV = "HARNESS_BROWSER_AUTH"
 HEADED_ENV = "HARNESS_BROWSER_HEADED"
@@ -73,6 +77,9 @@ def ensure_shared_browser_env(*, headed: Optional[bool] = None) -> dict:
             os.environ["PM_BROWSER_HEADED"] = "0"
         elif headed_enabled() and "PM_BROWSER_HEADED" not in os.environ:
             os.environ["PM_BROWSER_HEADED"] = "1"
+        current_profile = (os.environ.get("PM_BROWSER_USER_DATA_DIR") or "").strip()
+        if current_profile and is_live_browser_user_data_dir(current_profile):
+            os.environ.pop("PM_BROWSER_USER_DATA_DIR", None)
         if not (os.environ.get("PM_BROWSER_USER_DATA_DIR") or "").strip():
             if real_profile_enabled():
                 copy_dir, _err = snapshot_real_profile()

--- a/harness/browser_real_profile.py
+++ b/harness/browser_real_profile.py
@@ -93,6 +93,26 @@ _LINUX_FLATPAK_IDS = {
 }
 
 
+def is_live_browser_user_data_dir(path: str, system: Optional[str] = None) -> bool:
+    """True when ``path`` is (or is inside) a real installed-browser profile."""
+    raw = (path or "").strip()
+    if not raw:
+        return False
+    try:
+        resolved = Path(raw).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return False
+    for browser in _BROWSER_PATHS:
+        live = real_profile_data_dir(browser, system=system)
+        try:
+            live_resolved = Path(live).resolve()
+        except (OSError, RuntimeError):
+            continue
+        if resolved == live_resolved or live_resolved in resolved.parents:
+            return True
+    return False
+
+
 def real_profile_enabled() -> bool:
     """Return whether the user consented to a real-profile snapshot.
 
@@ -215,6 +235,11 @@ def snapshot_real_profile(
     Returns ``(copy_dir, None)`` on success or ``(None, error)`` on failure.
     The error for a locked cookie DB always starts with ``profile locked:``.
     """
+    if not real_profile_enabled():
+        return None, (
+            "real Chrome profile copy requires explicit consent "
+            "(HARNESS_BROWSER_REAL_PROFILE=1)"
+        )
     if src is None:
         src_path = real_profile_data_dir(browser)
     else:

--- a/harness/browser_real_profile.py
+++ b/harness/browser_real_profile.py
@@ -102,14 +102,16 @@ def is_live_browser_user_data_dir(path: str, system: Optional[str] = None) -> bo
         resolved = Path(raw).expanduser().resolve()
     except (OSError, RuntimeError):
         return False
-    for browser in _BROWSER_PATHS:
-        live = real_profile_data_dir(browser, system=system)
-        try:
-            live_resolved = Path(live).resolve()
-        except (OSError, RuntimeError):
-            continue
-        if resolved == live_resolved or live_resolved in resolved.parents:
-            return True
+    hosts = (system,) if system else ("Darwin", "Windows", "Linux")
+    for host in hosts:
+        for browser in _BROWSER_PATHS:
+            live = real_profile_data_dir(browser, system=host)
+            try:
+                live_resolved = Path(live).resolve()
+            except (OSError, RuntimeError):
+                continue
+            if resolved == live_resolved or live_resolved in resolved.parents:
+                return True
     return False
 
 

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -1,29 +1,38 @@
 from __future__ import annotations
 
-import os
 import json
-import uuid
-import tempfile
-import subprocess
 import logging
+import os
+import subprocess
+import tempfile
+import uuid
+from typing import Any
 
 from .secure_files import restrict_to_owner
 from .diag import note as _diag
+from .api.redaction import redact_api_secrets, redact_secret_text
 
 logger = logging.getLogger("harness.hooks")
 
 ALLOWED_EVENTS = ["sessionStart", "sessionEnd", "preRun", "postRun"]
 _HOOKS_JSON = os.path.join(os.path.expanduser("~/.pmharness"), "hooks.json")
+_MAX_CONTEXT = 16 * 1024
+_MAX_OUTPUT = 8 * 1024
+_HOOK_TIMEOUT = 15
+_SECRET_ENV_NAMES = {"password", "secret", "token", "api_key", "access_token", "refresh_token", "authorization", "cookie"}
+
 
 def get_hooks() -> list[dict]:
     if os.path.exists(_HOOKS_JSON):
         try:
             with open(_HOOKS_JSON, "r", encoding="utf-8") as f:
                 data = json.load(f)
-                return data.get("hooks", [])
+            hooks = data.get("hooks", []) if isinstance(data, dict) else []
+            return hooks if isinstance(hooks, list) else []
         except Exception:
-            pass
+            return []
     return []
+
 
 def save_hooks(hooks: list[dict]) -> None:
     os.makedirs(os.path.dirname(_HOOKS_JSON), exist_ok=True)
@@ -34,49 +43,68 @@ def save_hooks(hooks: list[dict]) -> None:
         os.replace(temp_path, _HOOKS_JSON)
         if not restrict_to_owner(_HOOKS_JSON):
             _diag("secure_files.restrict_failed", msg=_HOOKS_JSON)
-    except Exception as e:
-        logger.error(f"Failed to save hooks: {e}")
+    except Exception:
+        logger.error("Failed to save hooks")
 
-def run_hooks(event: str, context: dict) -> None:
-    if event not in ALLOWED_EVENTS:
-        logger.warning(f"Unknown hook event: {event}")
-        return
-        
-    hooks = get_hooks()
-    enabled_hooks = [h for h in hooks if h.get("event") == event and h.get("enabled", True)]
-    
-    if not enabled_hooks:
-        return
-        
-    env = os.environ.copy()
+
+def _valid_record(hook: Any, event: str) -> bool:
+    if not isinstance(hook, dict) or hook.get("enabled") is not True:
+        return False
+    if not isinstance(hook.get("id"), str) or not hook["id"] or len(hook["id"]) > 128:
+        return False
+    if hook.get("event") != event or event not in ALLOWED_EVENTS:
+        return False
+    command = hook.get("command")
+    if isinstance(command, list):
+        return bool(command) and all(isinstance(x, str) and x and "\x00" not in x for x in command)
+    return isinstance(command, str) and bool(command) and hook.get("legacy_shell") is True and os.environ.get("HARNESS_ALLOW_LEGACY_SHELL_HOOKS") == "1"
+
+
+def _safe_context(context: Any) -> str:
+    value = redact_api_secrets(context if isinstance(context, (dict, list)) else {})
+    try:
+        encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"), default=str)
+    except Exception:
+        encoded = "{}"
+    return encoded[:_MAX_CONTEXT]
+
+
+def _environment(event: str, context_json: str) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k.casefold().split(".")[-1] not in _SECRET_ENV_NAMES}
     env["PMHARNESS_EVENT"] = event
-    for k, v in context.items():
-        env[f"PMHARNESS_{k.upper()}"] = str(v)
-        
-    context_json = json.dumps(context)
-    
-    for h in enabled_hooks:
-        cmd = h.get("command")
-        if not cmd:
+    env["PMHARNESS_CONTEXT_JSON"] = context_json
+    return env
+
+
+def run_hooks(event: str, context: dict) -> list[dict[str, str]]:
+    """Run persisted hooks safely; return one non-sensitive outcome per record."""
+    if event not in ALLOWED_EVENTS:
+        return []
+    context_json = _safe_context(context)
+    env = _environment(event, context_json)
+    outcomes = []
+    for hook in get_hooks():
+        if not isinstance(hook, dict) or hook.get("event") != event:
             continue
-            
-        # shell=False with an explicit shell wrapper, per subprocess guidance.
-        # /bin/sh on POSIX; cmd.exe on Windows (which has no /bin/sh).
-        shell_wrapper = (
-            ["/bin/sh", "-c", cmd] if os.name == "posix" else ["cmd", "/c", cmd]
-        )
+        hook_id = hook.get("id") if isinstance(hook.get("id"), str) else "invalid"
+        if not _valid_record(hook, event):
+            outcomes.append({"id": hook_id, "status": "skipped"})
+            logger.warning("Hook skipped: invalid or disabled record")
+            continue
+        command = hook["command"]
+        if isinstance(command, str):
+            # Explicit opt-in is required even for the legacy compatibility form.
+            command = ["/bin/sh", "-c", command] if os.name == "posix" else ["cmd", "/c", command]
         try:
-            # shell=False with an explicit wrapper argv; never shell=True + user cmd.
-            subprocess.run(
-                shell_wrapper,
-                shell=False,
-                input=context_json,
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
-                timeout=15,
-                env=env
-            )
+            result = subprocess.run(command, shell=False, input=context_json,
+                                    capture_output=True, text=True, encoding="utf-8",
+                                    errors="replace", timeout=_HOOK_TIMEOUT, env=env)
+            # Keep output bounded in case callers inspect the result in the future.
+            _ = (result.stdout or "")[:_MAX_OUTPUT], (result.stderr or "")[:_MAX_OUTPUT]
+            status = "executed" if result.returncode == 0 else "error"
         except subprocess.TimeoutExpired:
-            logger.error(f"Hook {h.get('id')} timed out")
-        except Exception as e:
-            logger.error(f"Hook {h.get('id')} failed: {e}")
+            status = "timeout"
+        except Exception:
+            status = "error"
+        outcomes.append({"id": hook_id, "status": status})
+    return outcomes

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shlex
 import subprocess
 import tempfile
 import uuid
@@ -92,18 +93,19 @@ def run_hooks(event: str, context: dict) -> list[dict[str, str]]:
             logger.warning("Hook skipped: invalid or disabled record")
             continue
         command = hook["command"]
-        if isinstance(command, str):
-            # Explicit opt-in is required even for the legacy compatibility form.
-            command = ["/bin/sh", "-c", command] if os.name == "posix" else ["cmd", "/c", command]
         try:
-            result = subprocess.run(command, shell=False, input=context_json,
-                                    capture_output=True, text=True, encoding="utf-8",
-                                    errors="replace", timeout=_HOOK_TIMEOUT, env=env)
-            # Keep output bounded in case callers inspect the result in the future.
-            _ = (result.stdout or "")[:_MAX_OUTPUT], (result.stderr or "")[:_MAX_OUTPUT]
-            status = "executed" if result.returncode == 0 else "error"
-        except subprocess.TimeoutExpired:
-            status = "timeout"
+            if isinstance(command, list):
+                # Quote only at the shell runner boundary: this preserves argv
+                # semantics while using command_policy's owned process execution.
+                command_text = (" ".join(shlex.quote(part) for part in command)
+                                if os.name == "posix" else subprocess.list2cmdline(command))
+            else:
+                # Legacy records are explicitly opted in and remain shell-based.
+                command_text = command
+            output, exit_code, runner_status = _run_cancellable(
+                command_text, env=env, context_json=context_json, timeout=_HOOK_TIMEOUT)
+            status = ("executed" if exit_code == 0 and runner_status == "ok"
+                      else "timeout" if runner_status == "timeout" else "error")
         except Exception:
             status = "error"
         outcomes.append({"id": hook_id, "status": status})

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -3,22 +3,19 @@ from __future__ import annotations
 import json
 import logging
 import os
-import shlex
 import subprocess
 import tempfile
-import uuid
 from typing import Any
 
 from .secure_files import restrict_to_owner
 from .diag import note as _diag
-from .api.redaction import redact_api_secrets, redact_secret_text
+from .api.redaction import redact_api_secrets
 
 logger = logging.getLogger("harness.hooks")
 
 ALLOWED_EVENTS = ["sessionStart", "sessionEnd", "preRun", "postRun"]
 _HOOKS_JSON = os.path.join(os.path.expanduser("~/.pmharness"), "hooks.json")
 _MAX_CONTEXT = 16 * 1024
-_MAX_OUTPUT = 8 * 1024
 _HOOK_TIMEOUT = 15
 _SECRET_ENV_NAMES = {"password", "secret", "token", "api_key", "access_token", "refresh_token", "authorization", "cookie"}
 
@@ -77,6 +74,18 @@ def _environment(event: str, context_json: str) -> dict[str, str]:
     return env
 
 
+def _legacy_shell_argv(command: str) -> list[str]:
+    if os.name == "posix":
+        return ["/bin/sh", "-c", command]
+    return [os.environ.get("COMSPEC") or "cmd.exe", "/c", command]
+
+
+def _hook_argv(command: Any) -> list[str]:
+    if isinstance(command, list):
+        return command
+    return _legacy_shell_argv(command)
+
+
 def run_hooks(event: str, context: dict) -> list[dict[str, str]]:
     """Run persisted hooks safely; return one non-sensitive outcome per record."""
     if event not in ALLOWED_EVENTS:
@@ -92,20 +101,20 @@ def run_hooks(event: str, context: dict) -> list[dict[str, str]]:
             outcomes.append({"id": hook_id, "status": "skipped"})
             logger.warning("Hook skipped: invalid or disabled record")
             continue
-        command = hook["command"]
         try:
-            if isinstance(command, list):
-                # Quote only at the shell runner boundary: this preserves argv
-                # semantics while using command_policy's owned process execution.
-                command_text = (" ".join(shlex.quote(part) for part in command)
-                                if os.name == "posix" else subprocess.list2cmdline(command))
-            else:
-                # Legacy records are explicitly opted in and remain shell-based.
-                command_text = command
-            output, exit_code, runner_status = _run_cancellable(
-                command_text, env=env, context_json=context_json, timeout=_HOOK_TIMEOUT)
-            status = ("executed" if exit_code == 0 and runner_status == "ok"
-                      else "timeout" if runner_status == "timeout" else "error")
+            completed = subprocess.run(
+                _hook_argv(hook["command"]),
+                shell=False,
+                env=env,
+                timeout=_HOOK_TIMEOUT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            status = "executed" if completed.returncode == 0 else "error"
+        except subprocess.TimeoutExpired:
+            status = "timeout"
         except Exception:
             status = "error"
         outcomes.append({"id": hook_id, "status": status})

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -646,7 +646,10 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         return send_json(handler, status, payload)
 
     def _get_terminal_stream(handler: Any, u: Any, qs: dict) -> Any:
-        return handler._stream_terminal(qs.get("id", [""])[0])
+        return handler._stream_terminal(
+            qs.get("id", [""])[0],
+            (qs.get("offset") or ["0"])[0],
+        )
 
     def _get_pilot(handler: Any, u: Any, qs: dict) -> Any:
         return handler._swap_pilot(qs.get("model", [""])[0])

--- a/harness/mcp_manager.py
+++ b/harness/mcp_manager.py
@@ -20,6 +20,7 @@ from .mcp_client import StdioMcpClient, McpTool, McpError
 from .mcp_http_client import HttpMcpClient
 from .secure_files import restrict_to_owner
 from .diag import note as _diag
+from .api.redaction import build_auth_failure_attribution
 
 CONFIG_DIR = Path(os.path.expanduser("~/.pmharness"))
 CONFIG_PATH = CONFIG_DIR / "mcp.json"
@@ -248,13 +249,23 @@ class McpManager:
             at = row.get("at")
             if not isinstance(at, str) or not at.strip():
                 continue
-            # Ignore any accidental secret/payload keys; only keep the receipt.
-            loaded[name.strip()] = {
+            # Ignore accidental secret/payload keys. Rebuild attribution from
+            # the sanitized receipt error; persisted auth is untrusted.
+            receipt = {
                 "tool": tool.strip(),
                 "ok": ok,
                 "error": error if not ok else "",
                 "at": at.strip(),
             }
+            if not ok and isinstance(row.get("auth"), dict):
+                status = row["auth"].get("http_status")
+                if not isinstance(status, bool) and status in (401, 403):
+                    auth = build_auth_failure_attribution(
+                        "mcp_server", name.strip(), status, error,
+                    )
+                    if auth is not None:
+                        receipt["auth"] = auth
+            loaded[name.strip()] = receipt
         with self._lock:
             self._last_invocations = loaded
 
@@ -284,16 +295,25 @@ class McpManager:
             _diag("mcp.invocations_persist", e)
 
     def _record_invocation(self, server: str, tool: str, *, ok: bool, error: str = "") -> None:
+        """Record a bounded receipt and classify clear auth failures safely."""
         server = (server or "").strip()
         tool = (tool or "").strip()
         if not server or not tool:
             return
+        original_error = error
+        sanitized_error = "" if ok else _sanitize_invocation_error(original_error)
         row = {
             "tool": tool,
             "ok": bool(ok),
-            "error": "" if ok else _sanitize_invocation_error(error),
+            "error": sanitized_error,
             "at": _utc_now_iso(),
         }
+        if not ok:
+            auth = build_auth_failure_attribution(
+                "mcp_server", server, None, original_error,
+            )
+            if auth is not None:
+                row["auth"] = auth
         with self._lock:
             self._last_invocations[server] = row
             self._persist_invocations_unlocked()

--- a/harness/mcp_oauth_lab.py
+++ b/harness/mcp_oauth_lab.py
@@ -1,0 +1,36 @@
+"""Default-disabled MCP OAuth lab.
+
+Provider OAuth (xAI, Nous, Codex) is a separate, already-shipped path.
+This gate refuses MCP-server OAuth client registration unless the operator
+opts in. Off is the only safe default.
+"""
+from __future__ import annotations
+
+import os
+from typing import Mapping, Optional
+
+LAB_ENV = "HARNESS_MCP_OAUTH_LAB"
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def mcp_oauth_lab_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
+    values = env if env is not None else os.environ
+    raw = (values.get(LAB_ENV) or "").strip().lower()
+    return raw in _TRUTHY
+
+
+def refuse_mcp_oauth(action: str = "start") -> dict:
+    return {
+        "allowed": False,
+        "action": action,
+        "error": (
+            "MCP OAuth lab is default-disabled. "
+            "Set HARNESS_MCP_OAUTH_LAB=1 only on an isolated lab host."
+        ),
+    }
+
+
+def gate_mcp_oauth(action: str = "start", env: Optional[Mapping[str, str]] = None) -> dict:
+    if mcp_oauth_lab_enabled(env):
+        return {"allowed": True, "action": action}
+    return refuse_mcp_oauth(action)

--- a/harness/memory_store.py
+++ b/harness/memory_store.py
@@ -3,17 +3,19 @@ from __future__ import annotations
 """Memory store: durable, cross-session persistent facts and preferences.
 """
 
+import hashlib
 import json
 import os
 import time
 import threading
 import uuid
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import List, Optional
 
 MEMORY_PATH = Path(os.path.expanduser("~/.pmharness/memory.json"))
 MEMORY_CHAR_LIMIT = 4000
+MEMORY_ORIGINS = frozenset({"user", "agent", "tool", "compact"})
 
 
 @dataclass
@@ -23,6 +25,36 @@ class MemoryEntry:
     created_at: float = 0.0
     source: str = ""
     id: str = ""
+    origin: str = "agent"
+    content_sha256: str = ""
+    workspace: str = ""
+
+
+def _content_digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _parse_origin(origin: str, source: str) -> str:
+    raw = (origin or "").strip().lower()
+    if raw in MEMORY_ORIGINS:
+        return raw
+    src = (source or "").strip().lower()
+    if src in MEMORY_ORIGINS:
+        return src
+    return "agent"
+
+
+def _entry_from_mapping(raw: dict) -> MemoryEntry:
+    allowed = {item.name for item in fields(MemoryEntry)}
+    payload = {key: value for key, value in raw.items() if key in allowed}
+    if "origin" not in payload:
+        payload["origin"] = _parse_origin("", str(payload.get("source") or ""))
+    else:
+        payload["origin"] = _parse_origin(str(payload.get("origin") or ""), str(payload.get("source") or ""))
+    entry = MemoryEntry(**payload)
+    if entry.text and not entry.content_sha256:
+        entry.content_sha256 = _content_digest(entry.text)
+    return entry
 
 
 class MemoryStore:
@@ -51,22 +83,32 @@ class MemoryStore:
 
     def list(self) -> List[MemoryEntry]:
         with self._lock:
-            return [MemoryEntry(**e) for e in self._load()]
+            return [_entry_from_mapping(e) for e in self._load() if isinstance(e, dict)]
 
-    def add(self, text: str, category: str = "general", source: str = "agent") -> MemoryEntry:
+    def add(
+        self,
+        text: str,
+        category: str = "general",
+        source: str = "agent",
+        origin: str = "",
+        workspace: str = "",
+    ) -> MemoryEntry:
         normalized_text = text.strip().lower()
         with self._lock:
             entries = self._load()
             for e in entries:
-                if e.get("text", "").strip().lower() == normalized_text:
-                    return MemoryEntry(**e)
+                if isinstance(e, dict) and e.get("text", "").strip().lower() == normalized_text:
+                    return _entry_from_mapping(e)
 
             entry = MemoryEntry(
                 text=text,
                 category=category,
                 created_at=time.time(),
                 source=source,
-                id=uuid.uuid4().hex
+                id=uuid.uuid4().hex,
+                origin=_parse_origin(origin, source),
+                content_sha256=_content_digest(text),
+                workspace=(workspace or "").strip(),
             )
             entries.append(asdict(entry))
             self._save(entries)
@@ -92,7 +134,9 @@ class MemoryStore:
             hit = False
             for e in entries:
                 if e.get("id") == entry_id:
-                    e["text"] = normalized[:MEMORY_CHAR_LIMIT]
+                    clipped = normalized[:MEMORY_CHAR_LIMIT]
+                    e["text"] = clipped
+                    e["content_sha256"] = _content_digest(clipped)
                     hit = True
             if hit:
                 self._save(entries)
@@ -118,3 +162,24 @@ class MemoryStore:
             return ""
         items = "\n".join(f"- {e.text}" for e in entries)
         return f"# Durable memory (persistent across sessions -- user facts and preferences)\n{items}"
+
+    def search(
+        self,
+        query: str,
+        *,
+        origin: str = "",
+        workspace: str = "",
+    ) -> List[MemoryEntry]:
+        needle = (query or "").strip().casefold()
+        origin_filter = (origin or "").strip().lower()
+        workspace_filter = (workspace or "").strip()
+        hits: List[MemoryEntry] = []
+        for entry in self.list():
+            if origin_filter and entry.origin != origin_filter:
+                continue
+            if workspace_filter and entry.workspace != workspace_filter:
+                continue
+            if needle and needle not in entry.text.casefold():
+                continue
+            hits.append(entry)
+        return hits

--- a/harness/orchestration_contracts.py
+++ b/harness/orchestration_contracts.py
@@ -1,0 +1,103 @@
+"""Typed control-graph contracts for Marionette-owned task DAGs.
+
+Puppetmaster already stores job graphs. This module is the fail-closed
+boundary Marionette uses before submitting depends_on maps: unknown ids,
+duplicates, and cycles are violations, not runtime surprises.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Set, Tuple
+
+
+@dataclass(frozen=True)
+class DagNode:
+    id: str
+    depends_on: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class DagViolation:
+    code: str
+    node_id: str
+    detail: str
+
+
+def parse_dag_nodes(raw: Iterable[object]) -> Tuple[DagNode, ...]:
+    """Parse a list of {id, depends_on} maps. Invalid rows become empty-id nodes."""
+    nodes: List[DagNode] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            nodes.append(DagNode(id=""))
+            continue
+        node_id = item.get("id")
+        deps = item.get("depends_on") or ()
+        if not isinstance(node_id, str):
+            node_id = ""
+        if isinstance(deps, str):
+            dep_tuple = (deps,) if deps else ()
+        elif isinstance(deps, (list, tuple)):
+            dep_tuple = tuple(d for d in deps if isinstance(d, str) and d)
+        else:
+            dep_tuple = ()
+        nodes.append(DagNode(id=node_id.strip(), depends_on=dep_tuple))
+    return tuple(nodes)
+
+
+def validate_task_dag(nodes: Sequence[DagNode]) -> Tuple[DagViolation, ...]:
+    """Return every structural violation. Empty result means the graph may run."""
+    violations: List[DagViolation] = []
+    seen: Set[str] = set()
+    ids: Set[str] = set()
+    for node in nodes:
+        if not node.id:
+            violations.append(DagViolation("empty_id", "", "task id is required"))
+            continue
+        if node.id in seen:
+            violations.append(DagViolation("duplicate_id", node.id, "task id repeats"))
+            continue
+        seen.add(node.id)
+        ids.add(node.id)
+    known = {node.id for node in nodes if node.id}
+    for node in nodes:
+        if not node.id:
+            continue
+        for dep in node.depends_on:
+            if dep == node.id:
+                violations.append(DagViolation("cycle", node.id, "task depends on itself"))
+            elif dep not in known:
+                violations.append(
+                    DagViolation("unknown_dependency", node.id, "depends_on %r is not a task" % (dep,))
+                )
+    violations.extend(_cycle_violations(nodes, known))
+    return tuple(violations)
+
+
+def _cycle_violations(nodes: Sequence[DagNode], known: Set[str]) -> Tuple[DagViolation, ...]:
+    graph: Dict[str, List[str]] = {node.id: [] for node in nodes if node.id}
+    for node in nodes:
+        if not node.id:
+            continue
+        graph[node.id] = [dep for dep in node.depends_on if dep in known and dep != node.id]
+    visiting: Set[str] = set()
+    visited: Set[str] = set()
+    cyclic: List[str] = []
+
+    def visit(node_id: str) -> None:
+        if node_id in visited or node_id in cyclic:
+            return
+        if node_id in visiting:
+            cyclic.append(node_id)
+            return
+        visiting.add(node_id)
+        for nxt in graph.get(node_id, ()):
+            visit(nxt)
+        visiting.remove(node_id)
+        visited.add(node_id)
+
+    for node_id in graph:
+        visit(node_id)
+    return tuple(
+        DagViolation("cycle", node_id, "depends_on cycle")
+        for node_id in cyclic
+    )

--- a/harness/os_sandbox.py
+++ b/harness/os_sandbox.py
@@ -60,16 +60,18 @@ def reset_probe_cache() -> None:
     _PROBE_CACHE = None
 
 
+def _canonical_path(path: str) -> str:
+    return os.path.normcase(os.path.realpath(os.path.abspath(os.path.expanduser(path))))
+
+
 def _resolve_state_dir(env: Mapping[str, str]) -> str:
     raw = (env.get("HARNESS_STATE_DIR") or "").strip()
-    if raw:
-        return os.path.abspath(os.path.expanduser(raw))
-    return os.path.abspath(os.path.expanduser("~/.pmharness/state"))
+    return _canonical_path(raw or "~/.pmharness/state")
 
 
 def _sandbox_temp_root(cwd: str | None, env: Mapping[str, str]) -> str:
     """Private per-command temp parent under state or cwd — never shared /tmp."""
-    resolved_cwd = os.path.abspath(cwd or os.getcwd())
+    resolved_cwd = _canonical_path(cwd or os.getcwd())
     state_dir = _resolve_state_dir(env)
     for candidate in (state_dir, resolved_cwd):
         try:
@@ -85,7 +87,7 @@ def _sandbox_temp_root(cwd: str | None, env: Mapping[str, str]) -> str:
 
 def _make_private_temp_dir(cwd: str | None, env: Mapping[str, str]) -> str:
     root = _sandbox_temp_root(cwd, env)
-    return tempfile.mkdtemp(prefix="cmd-", dir=root)
+    return _canonical_path(tempfile.mkdtemp(prefix="cmd-", dir=root))
 
 
 def _writable_paths(
@@ -94,19 +96,30 @@ def _writable_paths(
     *,
     private_temp: str,
 ) -> list[str]:
-    resolved_cwd = os.path.abspath(cwd or os.getcwd())
-    # Writable: repo cwd + this command's private temp only — not all of state_dir.
-    paths = [
-        resolved_cwd,
-        os.path.abspath(private_temp),
-    ]
-    seen: set[str] = set()
-    unique: list[str] = []
-    for path in paths:
-        if path not in seen:
-            seen.add(path)
-            unique.append(path)
-    return unique
+    canonical_cwd = _canonical_path(cwd or os.getcwd())
+    temp_parent = _canonical_path(os.path.dirname(private_temp))
+    result: list[str] = []
+    for candidate in (cwd or os.getcwd(), private_temp):
+        path = _canonical_path(candidate)
+        try:
+            allowed = (os.path.commonpath([path, canonical_cwd]) == canonical_cwd or
+                       os.path.commonpath([path, temp_parent]) == temp_parent)
+        except ValueError:
+            allowed = False
+        if not allowed:
+            raise SandboxRequiredUnavailable("OS sandbox writable path resolves outside allowed canonical roots")
+        if path not in result:
+            result.append(path)
+    return result
+
+
+def resolve_child_network_policy(env: Mapping[str, str] | None = None, *, mode: str | None = None) -> str:
+    values = env if env is not None else os.environ
+    selected = mode or resolve_os_sandbox_mode(values)
+    raw = (values.get("HARNESS_OS_SANDBOX_NETWORK") or "").strip().lower()
+    if raw in {"deny", "allow"}:
+        return raw
+    return "deny" if selected == "required" else "allow"
 
 
 def _landlock_capable() -> bool:
@@ -192,7 +205,7 @@ def detect_sandbox_capability(
     return cap
 
 
-def build_seatbelt_profile(writable_paths: list[str]) -> str:
+def build_seatbelt_profile(writable_paths: list[str], *, network: str = "allow") -> str:
     """Build a minimal Seatbelt profile confining writes to the given paths."""
     lines = [
         "(version 1)",
@@ -210,7 +223,7 @@ def build_seatbelt_profile(writable_paths: list[str]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def build_bwrap_argv(writable_paths: list[str], command: str) -> list[str]:
+def build_bwrap_argv(writable_paths: list[str], command: str, *, network: str = "allow") -> list[str]:
     """Build a bubblewrap argv prefix ending in sh -c <command>."""
     exe = shutil.which("bwrap")
     if not exe:
@@ -243,6 +256,7 @@ def _macos_spawn_plan(
     writable_paths: list[str],
     *,
     child_env: Mapping[str, str],
+    network: str = "allow",
 ) -> SandboxSpawnPlan:
     exe = shutil.which("sandbox-exec")
     if not exe:
@@ -251,8 +265,8 @@ def _macos_spawn_plan(
             "sandbox-exec is not available on this macOS host."
         )
 
-    profile_text = build_seatbelt_profile(writable_paths)
-    fd, profile_path = tempfile.mkstemp(suffix=".sb", prefix="harness_sandbox_")
+    profile_text = build_seatbelt_profile(writable_paths, network=network)
+    fd, profile_path = tempfile.mkstemp(suffix=".sb", prefix="harness_sandbox_", dir=child_env["TMPDIR"])
     os.close(fd)
     with open(profile_path, "w", encoding="utf-8") as fh:
         fh.write(profile_text)

--- a/harness/os_sandbox.py
+++ b/harness/os_sandbox.py
@@ -207,17 +207,14 @@ def detect_sandbox_capability(
 
 def build_seatbelt_profile(writable_paths: list[str], *, network: str = "allow") -> str:
     """Build a minimal Seatbelt profile confining writes to the given paths."""
-    lines = [
-        "(version 1)",
-        "(deny default)",
-        "(allow process*)",
-        "(allow signal (target self))",
-        "(allow sysctl-read)",
-        "(allow file-read*)",
-        "(allow file-write*",
-    ]
+    if network not in {"allow", "deny"}:
+        raise ValueError("network must be 'allow' or 'deny'")
+    lines = ["(version 1)", "(deny default)", "(allow process*)", "(allow signal (target self))", "(allow sysctl-read)", "(allow file-read*)"]
+    if network == "deny":
+        lines.append("(deny network*)")
+    lines.append("(allow file-write*")
     for path in writable_paths:
-        escaped = path.replace("\\", "\\\\").replace('"', '\\"')
+        escaped = _canonical_path(path).replace("\\", "\\\\").replace('"', '\\"')
         lines.append(f'    (subpath "{escaped}")')
     lines.append(")")
     return "\n".join(lines) + "\n"
@@ -225,23 +222,17 @@ def build_seatbelt_profile(writable_paths: list[str], *, network: str = "allow")
 
 def build_bwrap_argv(writable_paths: list[str], command: str, *, network: str = "allow") -> list[str]:
     """Build a bubblewrap argv prefix ending in sh -c <command>."""
+    if network not in {"allow", "deny"}:
+        raise ValueError("network must be 'allow' or 'deny'")
     exe = shutil.which("bwrap")
     if not exe:
         raise FileNotFoundError("bwrap not found")
-
-    argv: list[str] = [
-        exe,
-        "--ro-bind",
-        "/",
-        "/",
-        "--dev",
-        "/dev",
-        "--proc",
-        "/proc",
-        "--die-with-parent",
-    ]
+    argv: list[str] = [exe, "--ro-bind", "/", "/", "--dev", "/dev", "--proc", "/proc", "--die-with-parent"]
+    if network == "deny":
+        argv.append("--unshare-net")
     for path in writable_paths:
-        argv.extend(["--bind", path, path])
+        canonical = _canonical_path(path)
+        argv.extend(["--bind", canonical, canonical])
     argv.extend(["sh", "-c", command])
     return argv
 
@@ -292,9 +283,10 @@ def _linux_spawn_plan(
     writable_paths: list[str],
     *,
     child_env: Mapping[str, str],
+    network: str = "allow",
 ) -> SandboxSpawnPlan:
     try:
-        argv = build_bwrap_argv(writable_paths, command)
+        argv = build_bwrap_argv(writable_paths, command, network=network)
     except FileNotFoundError:
         raise SandboxRequiredUnavailable(
             "OS sandbox is required (HARNESS_OS_SANDBOX=required) but "
@@ -373,10 +365,11 @@ def prepare_sandbox_spawn(
         "TMP": private_temp,
     }
     writable = _writable_paths(cwd, env_map, private_temp=private_temp)
+    network = resolve_child_network_policy(env_map, mode=mode)
     if cap.platform == "macos":
-        plan = _macos_spawn_plan(command, writable, child_env=child_env)
+        plan = _macos_spawn_plan(command, writable, child_env=child_env, network=network)
     elif cap.platform == "linux":
-        plan = _linux_spawn_plan(command, writable, child_env=child_env)
+        plan = _linux_spawn_plan(command, writable, child_env=child_env, network=network)
     else:
         _cleanup_private_temp()
         return None

--- a/harness/server.py
+++ b/harness/server.py
@@ -2821,10 +2821,12 @@ class Handler(BaseHTTPRequestHandler):
         status, payload = get_pilot_swap(model, _pilot_services())
         return self._send(status, json.dumps(payload))
 
-    def _stream_terminal(self, sid: str):
+    def _stream_terminal(self, sid: str, start_offset=0):
         """Stream PTY output over SSE. Client sends keystrokes via POST /api/terminal/write."""
-        from .api.terminals import stream_terminal
-        return stream_terminal(self, sid, _terminal_services())
+        from .api.terminals import parse_terminal_start_offset, stream_terminal
+        return stream_terminal(
+            self, sid, _terminal_services(), parse_terminal_start_offset(start_offset),
+        )
 
     def _stream_chat(self, message: str, images=None, plan: bool = False, resume: bool = False):
         """Stream the conversational PILOT loop over SSE."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.397"
+version = "0.9.398"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_redaction.py
+++ b/tests/test_api_redaction.py
@@ -82,3 +82,31 @@ def test_get_hooks_redacts_command_field(monkeypatch):
     assert code == 200
     assert "xyz" not in payload["hooks"][0]["command"]
     assert "REDACTED" in payload["hooks"][0]["command"]
+
+
+def test_nested_sensitive_keys_and_query_credentials_are_redacted():
+    raw = {"HeAdErS": {"Authorization": "Bearer secret-value", "X": "ok"}, "nested": {"API_KEY": "abc"}, "url": "https://x.test/a?access_token=supersecret&next=ok"}
+    out = redact_api_secrets(raw)
+    assert out["HeAdErS"]["Authorization"] == "REDACTED"
+    assert out["nested"]["API_KEY"] == "REDACTED"
+    assert "supersecret" not in out["url"]
+
+
+def test_auth_failure_attribution_is_bounded_and_privacy_safe():
+    from harness.api.redaction import build_auth_failure_attribution
+
+    raw = "Authentication failed https://x.test/?token=RAWSECRET Bearer RAWTOKEN\n\t"
+    out = build_auth_failure_attribution(" plugin / evil\n", "https://host/path?id=RAWID", 401, raw)
+    assert out["category"] == "authentication"
+    assert out["remediation"] == "reauthenticate"
+    assert out["http_status"] == 401
+    assert len(out["consumer_kind"]) <= 40 and len(out["consumer_id"]) <= 40
+    assert "RAWSECRET" not in str(out) and "RAWTOKEN" not in str(out) and "RAWID" not in str(out)
+    assert build_auth_failure_attribution("x", "y", None, "ordinary failure") is None
+
+
+def test_auth_failure_status_and_forbidden_classification():
+    from harness.api.redaction import build_auth_failure_attribution
+
+    assert build_auth_failure_attribution("api", "one", 403, "denied")["remediation"] == "check_permissions"
+    assert build_auth_failure_attribution("api", "one", None, "credentials rejected")["category"] == "authentication"

--- a/tests/test_api_redaction.py
+++ b/tests/test_api_redaction.py
@@ -110,3 +110,32 @@ def test_auth_failure_status_and_forbidden_classification():
 
     assert build_auth_failure_attribution("api", "one", 403, "denied")["remediation"] == "check_permissions"
     assert build_auth_failure_attribution("api", "one", None, "credentials rejected")["category"] == "authentication"
+
+
+def test_auth_failure_infers_unambiguous_textual_http_status():
+    from harness.api.redaction import build_auth_failure_attribution
+
+    auth = build_auth_failure_attribution("api", "one", None, "HTTP 401: login required")
+    forbidden = build_auth_failure_attribution("api", "two", None, "status: 403 access denied")
+    assert auth["http_status"] == 401
+    assert auth["category"] == "authentication"
+    assert auth["remediation"] == "reauthenticate"
+    assert forbidden["http_status"] == 403
+    assert forbidden["category"] == "forbidden"
+    assert forbidden["remediation"] == "check_permissions"
+
+
+def test_auth_failure_does_not_infer_status_from_arbitrary_numbers():
+    from harness.api.redaction import build_auth_failure_attribution
+
+    for text in ("item401", "port 4010", "count=401"):
+        assert build_auth_failure_attribution("api", "one", None, text) is None
+
+
+def test_explicit_auth_status_wins_over_textual_status():
+    from harness.api.redaction import build_auth_failure_attribution
+
+    out = build_auth_failure_attribution("api", "one", 401, "status: 403 access denied")
+    assert out["http_status"] == 401
+    assert out["category"] == "authentication"
+    assert out["remediation"] == "reauthenticate"

--- a/tests/test_api_sse_pilot_terminals_peel.py
+++ b/tests/test_api_sse_pilot_terminals_peel.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import base64
 import io
+import json
 import threading
+
+import pytest
 from types import SimpleNamespace
 
 from harness.api.pilot import PilotServices, get_pilot_swap, swap_pilot
@@ -337,12 +340,119 @@ class _FakeHandler:
         pass
 
 
-def test_stream_terminal_missing_session_writes_exit():
-    svc = TerminalServices(cfg=SimpleNamespace(repo=None), pty=SimpleNamespace(get=lambda sid: None))
+def _sse_frames(handler):
+    """Decode the JSON payload from each data-only SSE frame."""
+    frames = []
+    for frame in handler.wfile.getvalue().decode().split("\n\n"):
+        if frame.startswith("data: "):
+            frames.append(json.loads(frame[6:]))
+    return frames
+
+
+def _terminal_svc(sess):
+    return TerminalServices(cfg=SimpleNamespace(repo=None), pty=SimpleNamespace(get=lambda sid: sess))
+
+
+def test_stream_terminal_missing_session_writes_reason_offset_once():
     h = _FakeHandler()
-    stream_terminal(h, "gone", svc)
-    assert h.status == 200
-    assert b'"kind": "exit"' in h.wfile.getvalue()
+    stream_terminal(h, "gone", _terminal_svc(None), start_offset=7)
+    frames = _sse_frames(h)
+    assert frames == [{"kind": "exit", "offset": 7, "reason": "missing_session"}]
+
+
+def test_stream_terminal_natural_exit_flushes_final_data_once():
+    class _Sess:
+        def __init__(self):
+            self.calls = 0
+
+        def alive(self):
+            self.calls += 1
+            return self.calls == 1
+
+        def read_since(self, offset):
+            return (b"hi", 2) if offset == 0 else ((b"!", 3) if offset == 2 else (b"", offset))
+
+    h = _FakeHandler()
+    stream_terminal(h, "t1", _terminal_svc(_Sess()))
+    frames = _sse_frames(h)
+    assert [f["kind"] for f in frames] == ["data", "data", "exit"]
+    assert [f["offset"] for f in frames] == [2, 3, 3]
+    assert frames[-1]["reason"] == "process_exit"
+
+
+def test_stream_terminal_start_offset_is_honored():
+    seen = []
+
+    class _Sess:
+        def alive(self):
+            return False
+
+        def read_since(self, offset):
+            seen.append(offset)
+            return b"", offset
+
+    h = _FakeHandler()
+    stream_terminal(h, "t1", _terminal_svc(_Sess()), start_offset=9)
+    assert seen == [9]
+    assert _sse_frames(h)[-1]["offset"] == 9
+
+
+def test_stream_terminal_offsets_never_move_backwards():
+    class _Sess:
+        def __init__(self):
+            self.calls = 0
+
+        def alive(self):
+            self.calls += 1
+            return self.calls == 1
+
+        def read_since(self, offset):
+            return (b"abc", 1) if offset == 0 else (b"", 0)
+
+    h = _FakeHandler()
+    stream_terminal(h, "t1", _terminal_svc(_Sess()))
+    offsets = [f["offset"] for f in _sse_frames(h)]
+    assert offsets == [3, 3]
+    h = _FakeHandler()
+    stream_terminal(h, "t1", _terminal_svc(_Sess()))
+    offsets = [f["offset"] for f in _sse_frames(h)]
+    assert offsets == [3, 3]
+
+
+def test_stream_terminal_internal_exception_redacts_and_bounds_error():
+    secret = "sk-SECRET_TOKEN_123456"
+
+    class _Sess:
+        def alive(self):
+            raise RuntimeError(f"bad {secret} " + "x" * 300)
+
+    h = _FakeHandler()
+    stream_terminal(h, "t1", _terminal_svc(_Sess()))
+    frames = _sse_frames(h)
+    assert len(frames) == 1
+    assert frames[0]["kind"] == "exit"
+    assert frames[0]["reason"] == "stream_error"
+    assert len(frames[0]["error"]) <= 160
+    assert secret not in h.wfile.getvalue().decode()
+
+
+@pytest.mark.parametrize("error", [BrokenPipeError(), ConnectionResetError()])
+def test_stream_terminal_disconnect_does_not_write_exit(error):
+    class _Wfile:
+        def __init__(self):
+            self.writes = 0
+
+        def write(self, data):
+            self.writes += 1
+            raise error
+
+        def flush(self):
+            pass
+
+    h = _FakeHandler()
+    h.wfile = _Wfile()
+    stream_terminal(h, "t1", _terminal_svc(SimpleNamespace(alive=lambda: False)))
+    assert h.wfile.writes == 1
 
 
 def test_stream_terminal_data_then_exit():

--- a/tests/test_api_sse_pilot_terminals_peel.py
+++ b/tests/test_api_sse_pilot_terminals_peel.py
@@ -20,7 +20,7 @@ from harness.api.streams import (
     resolve_stashed_chat_message,
     validate_upload_image_paths,
 )
-from harness.api.terminals import TerminalServices, stream_terminal
+from harness.api.terminals import TerminalServices, parse_terminal_start_offset, stream_terminal
 
 
 # ---------------------------------------------------------------------------
@@ -378,6 +378,14 @@ def test_stream_terminal_natural_exit_flushes_final_data_once():
     assert [f["kind"] for f in frames] == ["data", "data", "exit"]
     assert [f["offset"] for f in frames] == [2, 3, 3]
     assert frames[-1]["reason"] == "process_exit"
+
+
+def test_parse_terminal_start_offset_rejects_junk():
+    assert parse_terminal_start_offset(9) == 9
+    assert parse_terminal_start_offset("12") == 12
+    assert parse_terminal_start_offset("-3") == 0
+    assert parse_terminal_start_offset("nope") == 0
+    assert parse_terminal_start_offset(None) == 0
 
 
 def test_stream_terminal_start_offset_is_honored():

--- a/tests/test_browser_real_profile.py
+++ b/tests/test_browser_real_profile.py
@@ -155,6 +155,7 @@ def test_ensure_shared_browser_env_rejects_live_chrome_dir(tmp_path, monkeypatch
     live.mkdir(parents=True)
     monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: home))
     monkeypatch.setattr(auth.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(rp.platform, "system", lambda: "Linux")
     monkeypatch.setenv("HARNESS_BROWSER_AUTH", "1")
     monkeypatch.delenv("HARNESS_BROWSER_REAL_PROFILE", raising=False)
     monkeypatch.setenv("PM_BROWSER_USER_DATA_DIR", str(live))

--- a/tests/test_browser_real_profile.py
+++ b/tests/test_browser_real_profile.py
@@ -61,7 +61,18 @@ def test_real_profile_enabled_only_when_env_truthy(monkeypatch):
     assert rp.real_profile_enabled() is False
 
 
+def test_snapshot_refuses_without_consent(tmp_path, monkeypatch):
+    monkeypatch.delenv("HARNESS_BROWSER_REAL_PROFILE", raising=False)
+    monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    src = _make_src(tmp_path / "real")
+    copy_dir, err = rp.snapshot_real_profile("chrome", src=src)
+    assert copy_dir is None
+    assert err is not None
+    assert "consent" in err
+
+
 def test_snapshot_copies_auth_skips_cache_and_last_used(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_BROWSER_REAL_PROFILE", "1")
     monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: tmp_path / "home"))
     src = _make_src(tmp_path / "real", last_used="Profile 1", marker="from-p1")
     (src / "Default").mkdir()
@@ -80,6 +91,7 @@ def test_snapshot_copies_auth_skips_cache_and_last_used(tmp_path, monkeypatch):
 
 
 def test_snapshot_missing_src_names_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_BROWSER_REAL_PROFILE", "1")
     monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: tmp_path / "home"))
     missing = tmp_path / "nope"
     copy_dir, err = rp.snapshot_real_profile("chrome", src=missing)
@@ -89,6 +101,7 @@ def test_snapshot_missing_src_names_path(tmp_path, monkeypatch):
 
 
 def test_snapshot_lock_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_BROWSER_REAL_PROFILE", "1")
     monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: tmp_path / "home"))
     src = _make_src(tmp_path / "real")
     real_open = open
@@ -107,6 +120,7 @@ def test_snapshot_lock_error(tmp_path, monkeypatch):
 
 
 def test_cleanup_wipes_copy_and_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_BROWSER_REAL_PROFILE", "1")
     monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: tmp_path / "home"))
     src = _make_src(tmp_path / "real")
     copy_dir, err = rp.snapshot_real_profile("chrome", src=src)
@@ -133,6 +147,21 @@ def test_ensure_shared_browser_env_points_at_copy_when_enabled(tmp_path, monkeyp
     expected = str(home / ".pmharness" / "browser-profile-real" / "chrome")
     assert applied["user_data_dir"] == expected
     assert Path(expected, "Default", "Cookies").is_file()
+
+
+def test_ensure_shared_browser_env_rejects_live_chrome_dir(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    live = home / "Library" / "Application Support" / "Google" / "Chrome"
+    live.mkdir(parents=True)
+    monkeypatch.setattr(rp.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(auth.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("HARNESS_BROWSER_AUTH", "1")
+    monkeypatch.delenv("HARNESS_BROWSER_REAL_PROFILE", raising=False)
+    monkeypatch.setenv("PM_BROWSER_USER_DATA_DIR", str(live))
+    monkeypatch.delenv("PM_BROWSER_CDP_PORT", raising=False)
+    applied = auth.ensure_shared_browser_env()
+    assert applied["user_data_dir"] == str(home / ".pmharness" / "browser-profile")
+    assert live.is_dir()
 
 
 def test_ensure_shared_browser_env_keeps_preset_user_data_dir(tmp_path, monkeypatch):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -54,10 +54,7 @@ def test_hooks_module_and_endpoints():
         hooks_list = [{
             "id": "h1",
             "event": "preRun",
-            # No quotes around the echo text: cmd.exe echoes single quotes
-            # literally, so quoting would make the written content differ by
-            # platform. Bare words echo identically under /bin/sh and cmd.
-            "command": "echo hello from test_hooks > " + os.path.join(tmp_dir, "hook_out.txt"),
+            "command": ["python", "-c", "import pathlib; pathlib.Path(r'" + os.path.join(tmp_dir, "hook_out.txt") + "').write_text('hello from test_hooks')"],
             "enabled": True
         }]
         _hk.save_hooks(hooks_list)
@@ -75,7 +72,7 @@ def test_hooks_module_and_endpoints():
         failing_hooks = [{
             "id": "h2",
             "event": "postRun",
-            "command": "non_existent_command_12345",
+            "command": ["non_existent_command_12345"],
             "enabled": True
         }]
         _hk.save_hooks(failing_hooks)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,6 +1,7 @@
 import os
 import json
 import shutil
+import subprocess
 import tempfile
 import threading
 import urllib.request
@@ -213,3 +214,25 @@ def test_legacy_string_hook_requires_both_opt_ins(monkeypatch, tmp_path):
     assert calls[0][1] is False
     expected_tail = ["-c", "echo legacy"] if os.name == "posix" else ["/c", "echo legacy"]
     assert calls[0][0][-2:] == expected_tail
+
+
+def test_run_hooks_timeout_is_named(monkeypatch, tmp_path):
+    import harness.hooks as hk
+
+    original_json = hk._HOOKS_JSON
+    hk._HOOKS_JSON = str(tmp_path / "hooks.json")
+    hk.save_hooks([{
+        "id": "h-slow",
+        "event": "preRun",
+        "command": ["sleep", "99"],
+        "enabled": True,
+    }])
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout") or 15)
+
+    monkeypatch.setattr(hk.subprocess, "run", fake_run)
+    try:
+        assert hk.run_hooks("preRun", {}) == [{"id": "h-slow", "status": "timeout"}]
+    finally:
+        hk._HOOKS_JSON = original_json

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -155,30 +155,61 @@ def test_hooks_module_and_endpoints():
 
 
 def test_run_hooks_uses_shell_false_argv_wrapper(monkeypatch, tmp_path):
-    """Hook scripts run via argv wrapper, never shell=True + concatenated input."""
+    """Preferred list commands execute directly and never invoke a shell."""
     import harness.hooks as hk
 
     calls = []
     original_json = hk._HOOKS_JSON
     hk._HOOKS_JSON = str(tmp_path / "hooks.json")
     hk.save_hooks([{
-        "id": "h-shell",
+        "id": "h-argv",
         "event": "preRun",
-        "command": "echo ok",
+        "command": ["echo", "ok; not-shell-syntax"],
         "enabled": True,
     }])
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs.get("shell")))
-        class _R:
-            returncode = 0
-        return _R()
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     monkeypatch.setattr(hk.subprocess, "run", fake_run)
     try:
         hk.run_hooks("preRun", {"x": "1"})
     finally:
         hk._HOOKS_JSON = original_json
-    assert calls
+    assert calls == [(["echo", "ok; not-shell-syntax"], False)]
+
+
+def test_legacy_string_hook_requires_both_opt_ins(monkeypatch, tmp_path):
+    import harness.hooks as hk
+
+    calls = []
+    original_json = hk._HOOKS_JSON
+    hk._HOOKS_JSON = str(tmp_path / "hooks.json")
+    hook = {
+        "id": "h-legacy",
+        "event": "preRun",
+        "command": "echo legacy",
+        "enabled": True,
+        "legacy_shell": True,
+    }
+    hk.save_hooks([hook])
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs.get("shell")))
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(hk.subprocess, "run", fake_run)
+    monkeypatch.delenv("HARNESS_ALLOW_LEGACY_SHELL_HOOKS", raising=False)
+    try:
+        assert hk.run_hooks("preRun", {}) == [{"id": "h-legacy", "status": "skipped"}]
+        assert calls == []
+        monkeypatch.setenv("HARNESS_ALLOW_LEGACY_SHELL_HOOKS", "1")
+        assert hk.run_hooks("preRun", {}) == [{"id": "h-legacy", "status": "executed"}]
+    finally:
+        hk._HOOKS_JSON = original_json
+
+    assert len(calls) == 1
     assert calls[0][1] is False
-    assert isinstance(calls[0][0], list)
+    expected_tail = ["-c", "echo legacy"] if os.name == "posix" else ["/c", "echo legacy"]
+    assert calls[0][0][-2:] == expected_tail

--- a/tests/test_mcp_invocation_receipts.py
+++ b/tests/test_mcp_invocation_receipts.py
@@ -313,3 +313,62 @@ def test_lifecycle_manager_errors_redacted_before_status(tmp_path, monkeypatch):
     managed_refresh = m.manage("refresh", name="broken")
     assert managed_refresh["ok"] is False
     _assert_no_secret_leak(managed_refresh["error"])
+
+
+@pytest.mark.parametrize(("status", "remediation"), ((401, "reauthenticate"), (403, "check_permissions")))
+def test_auth_failure_receipt_is_attributed_without_secrets(tmp_path, monkeypatch, status, remediation):
+    from harness.api.mcp import McpServices, get_mcp
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(state))
+    m = McpManager(config_path=str(tmp_path / "mcp.json"))
+    m._record_invocation("  github-server  ", "search", ok=False,
+        error=(f"HTTP {status}: Bearer sk-live-secret https://example.test/call?token=query-secret"))
+    inv = m._last_invocations["github-server"]
+    assert inv["auth"]["consumer_kind"] == "mcp_server"
+    assert inv["auth"]["consumer_id"] == "github-server"
+    assert inv["auth"]["http_status"] == status
+    assert inv["auth"]["remediation"] == remediation
+    raw = (state / "mcp_invocations.json").read_text(encoding="utf-8")
+    code, body = get_mcp(McpServices(mcp=m))
+    assert code == 200
+    for exposed in (json.dumps(inv), raw, json.dumps(body)):
+        assert "sk-live-secret" not in exposed
+        assert "query-secret" not in exposed
+
+
+def test_non_auth_failure_omits_auth(tmp_path, monkeypatch):
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(state))
+    m = McpManager(config_path=str(tmp_path / "mcp.json"))
+    m._record_invocation("plain", "search", ok=False, error="HTTP 500: backend exploded")
+    assert "auth" not in m._last_invocations["plain"]
+
+
+def test_old_receipt_without_auth_loads_unchanged(tmp_path, monkeypatch):
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(state))
+    receipt = {"tool": "search", "ok": False, "error": "old failure", "at": "2020-01-01T00:00:00Z"}
+    (state / "mcp_invocations.json").write_text(json.dumps({"servers": {"old": receipt}}))
+    m = McpManager(config_path=str(tmp_path / "mcp.json"))
+    assert m._last_invocations["old"] == receipt
+
+
+def test_persisted_auth_is_rebuilt_from_safe_current_fields(tmp_path, monkeypatch):
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(state))
+    poison = "DO-NOT-PERSIST"
+    row = {"tool": "search", "ok": False, "error": "HTTP 401 Unauthorized", "at": "2020-01-01T00:00:00Z",
+           "auth": {"consumer_kind": "fake", "consumer_id": poison, "http_status": 401,
+                    "url": poison, "headers": {"Authorization": poison}, "cookie": poison,
+                    "token": poison, "payload": poison, "arguments": poison, "unknown": poison}}
+    (state / "mcp_invocations.json").write_text(json.dumps({"servers": {"real": row}}))
+    m = McpManager(config_path=str(tmp_path / "mcp.json"))
+    auth = m._last_invocations["real"]["auth"]
+    assert set(auth) <= {"category", "consumer_kind", "consumer_id", "http_status", "remediation", "summary"}
+    assert auth["consumer_kind"] == "mcp_server"
+    assert auth["consumer_id"] == "real"
+    assert poison not in json.dumps(m._last_invocations)

--- a/tests/test_mcp_oauth_lab.py
+++ b/tests/test_mcp_oauth_lab.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from harness.mcp_oauth_lab import gate_mcp_oauth, mcp_oauth_lab_enabled, refuse_mcp_oauth
+
+
+def test_mcp_oauth_lab_default_disabled(monkeypatch):
+    monkeypatch.delenv("HARNESS_MCP_OAUTH_LAB", raising=False)
+    assert mcp_oauth_lab_enabled() is False
+    denied = gate_mcp_oauth("register")
+    assert denied["allowed"] is False
+    assert "default-disabled" in denied["error"]
+    assert refuse_mcp_oauth()["allowed"] is False
+
+
+def test_mcp_oauth_lab_opt_in(monkeypatch):
+    monkeypatch.setenv("HARNESS_MCP_OAUTH_LAB", "1")
+    assert mcp_oauth_lab_enabled() is True
+    assert gate_mcp_oauth("register") == {"allowed": True, "action": "register"}

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -7,11 +7,35 @@ from pathlib import Path
 
 from typing import Any
 
-from harness.memory_store import MemoryStore, MemoryEntry, MEMORY_CHAR_LIMIT
+from harness.memory_store import MemoryStore, MEMORY_CHAR_LIMIT
 from harness.rule_store import RuleStore
 from harness.pilot import build_tools_schema, parse_tool_calls, PilotAction, PilotError
 from harness.config import HarnessConfig
 from harness.conversation import ConversationalSession
+
+
+def test_memory_provenance_search_and_legacy_row(tmp_path):
+    path = tmp_path / "memory.json"
+    store = MemoryStore(path=str(path))
+    user = store.add("Prefer dark theme", category="preference", source="user", workspace="repo-a")
+    store.add("Agent note about dark theme", category="fact", source="agent", workspace="repo-b")
+    assert user.origin == "user"
+    assert len(user.content_sha256) == 64
+    assert user.content_sha256 == store.list()[0].content_sha256
+    assert [e.workspace for e in store.search("dark", origin="user")] == ["repo-a"]
+    assert [e.workspace for e in store.search("dark", workspace="repo-b")] == ["repo-b"]
+    assert store.search("nope") == []
+
+    path.write_text(
+        '[{"text": "legacy fact", "category": "general", "created_at": 1, '
+        '"source": "user", "id": "legacy1", "extra": "ignore"}]',
+        encoding="utf-8",
+    )
+    legacy = MemoryStore(path=str(path)).list()
+    assert len(legacy) == 1
+    assert legacy[0].origin == "user"
+    assert legacy[0].content_sha256
+    assert legacy[0].text == "legacy fact"
 
 
 def test_memory_store_utf8_lf_roundtrip(tmp_path):

--- a/tests/test_orchestration_contracts.py
+++ b/tests/test_orchestration_contracts.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from harness.orchestration_contracts import DagNode, parse_dag_nodes, validate_task_dag
+
+
+def test_valid_linear_dag_is_empty():
+    nodes = parse_dag_nodes([
+        {"id": "explore", "depends_on": []},
+        {"id": "audit", "depends_on": ["explore"]},
+    ])
+    assert validate_task_dag(nodes) == ()
+
+
+def test_unknown_and_duplicate_and_empty_ids():
+    nodes = parse_dag_nodes([
+        {"id": "a", "depends_on": ["missing"]},
+        {"id": "a"},
+        {"id": "  "},
+        "nope",
+    ])
+    codes = {v.code for v in validate_task_dag(nodes)}
+    assert codes == {"unknown_dependency", "duplicate_id", "empty_id"}
+
+
+def test_self_edge_and_two_node_cycle():
+    self_edge = validate_task_dag((DagNode("loop", ("loop",)),))
+    assert self_edge[0].code == "cycle"
+    cycle = validate_task_dag((
+        DagNode("a", ("b",)),
+        DagNode("b", ("a",)),
+    ))
+    assert {v.code for v in cycle} == {"cycle"}

--- a/tests/test_os_sandbox.py
+++ b/tests/test_os_sandbox.py
@@ -66,11 +66,13 @@ def test_resolve_os_sandbox_mode_invalid_falls_back_to_off(monkeypatch):
 
 
 def test_build_seatbelt_profile_confines_writes():
-    profile = os_sandbox.build_seatbelt_profile(["/tmp/work", "/var/tmp"])
+    paths = ["/tmp/work", "/var/tmp"]
+    profile = os_sandbox.build_seatbelt_profile(paths)
     assert "(deny default)" in profile
     assert "(allow file-read*)" in profile
-    assert '(subpath "/tmp/work")' in profile
-    assert '(subpath "/var/tmp")' in profile
+    for path in paths:
+        canonical = os.path.normcase(os.path.realpath(os.path.abspath(path)))
+        assert f'(subpath "{canonical}")' in profile
     assert "(allow process*)" in profile
 
 

--- a/tests/test_os_sandbox.py
+++ b/tests/test_os_sandbox.py
@@ -15,6 +15,15 @@ def _norm(path: str) -> str:
     return os.path.normpath(path)
 
 
+def _canon(path: str) -> str:
+    return os_sandbox._canonical_path(path)
+
+
+def _seatbelt_subpath(path: str) -> str:
+    escaped = _canon(path).replace("\\", "\\\\").replace('"', '\\"')
+    return f'(subpath "{escaped}")'
+
+
 def _assert_not_exact_shared_temp(path: str) -> None:
     normalized = _norm(path)
     shared = {_norm(p) for p in _SHARED_SYSTEM_TEMPS}
@@ -71,8 +80,7 @@ def test_build_seatbelt_profile_confines_writes():
     assert "(deny default)" in profile
     assert "(allow file-read*)" in profile
     for path in paths:
-        canonical = os.path.normcase(os.path.realpath(os.path.abspath(path)))
-        assert f'(subpath "{canonical}")' in profile
+        assert _seatbelt_subpath(path) in profile
     assert "(allow process*)" in profile
 
 
@@ -83,8 +91,8 @@ def test_build_bwrap_argv_includes_bind_and_sh_c(monkeypatch):
     assert "--ro-bind" in argv
     assert "--bind" in argv
     bind_idx = argv.index("--bind")
-    assert argv[bind_idx + 1] == "/repo"
-    assert argv[bind_idx + 2] == "/repo"
+    assert argv[bind_idx + 1] == _canon("/repo")
+    assert argv[bind_idx + 2] == _canon("/repo")
     sh_idx = argv.index("sh")
     assert argv[sh_idx : sh_idx + 3] == ["sh", "-c", "echo hi"]
 
@@ -160,9 +168,9 @@ def test_writable_paths_include_cwd_and_private_temp_only(monkeypatch, tmp_path)
         os.environ,
         private_temp=private,
     )
-    assert os.path.abspath(str(tmp_path / "repo")) in paths
-    assert os.path.abspath(private) in paths
-    assert os.path.abspath(str(tmp_path / "state")) not in paths
+    assert _canon(str(tmp_path / "repo")) in paths
+    assert _canon(private) in paths
+    assert _canon(str(tmp_path / "state")) not in paths
     for path in paths:
         _assert_not_exact_shared_temp(path)
 
@@ -180,8 +188,8 @@ def test_sibling_state_files_denied_by_seatbelt_profile(monkeypatch, tmp_path):
         private_temp=private,
     )
     profile = os_sandbox.build_seatbelt_profile(writable)
-    assert str(sibling) not in profile
-    assert str(tmp_path / "state") not in profile
+    assert _seatbelt_subpath(str(sibling)) not in profile
+    assert _seatbelt_subpath(str(tmp_path / "state")) not in profile
 
 
 def test_sibling_state_files_denied_by_bwrap_argv(monkeypatch, tmp_path):
@@ -195,8 +203,8 @@ def test_sibling_state_files_denied_by_bwrap_argv(monkeypatch, tmp_path):
     )
     argv = os_sandbox.build_bwrap_argv(writable, "echo hi")
     joined = " ".join(argv)
-    assert str(tmp_path / "state") not in joined
-    assert private in joined
+    assert _canon(str(tmp_path / "state")) not in joined
+    assert _canon(private) in argv
 
 
 def test_prepare_sandbox_spawn_sets_private_temp_env(monkeypatch, tmp_path):
@@ -213,7 +221,7 @@ def test_prepare_sandbox_spawn_sets_private_temp_env(monkeypatch, tmp_path):
     assert plan is not None
     assert plan.child_env is not None
     private = plan.child_env["TMPDIR"]
-    assert private.startswith(str(tmp_path / "state"))
+    assert _canon(private).startswith(_canon(str(tmp_path / "state")))
     assert os.path.isdir(private)
     _assert_not_exact_shared_temp(private)
     assert plan.cleanup is not None
@@ -232,7 +240,7 @@ def test_active_profile_excludes_shared_tmp(monkeypatch, tmp_path):
     )
     profile = os_sandbox.build_seatbelt_profile(writable)
     _assert_profile_excludes_shared_tmp(profile)
-    assert private.replace("\\", "\\\\") in profile or private in profile
+    assert _seatbelt_subpath(private) in profile
 
 
 def test_bwrap_argv_excludes_shared_tmp(monkeypatch, tmp_path):
@@ -243,7 +251,7 @@ def test_bwrap_argv_excludes_shared_tmp(monkeypatch, tmp_path):
         "echo hi",
     )
     _assert_bwrap_excludes_shared_tmp(argv)
-    assert private in argv
+    assert _canon(private) in argv
 
 
 def test_detect_sandbox_capability_windows_is_unavailable(monkeypatch):

--- a/tests/test_swarm_live.py
+++ b/tests/test_swarm_live.py
@@ -19,6 +19,10 @@ def _server(tmp_state_dir):
     # prices but /api/swarm/live's pilot split ignores.
     srv._boot_usage_reset_for_tests()
     srv._session.state_dir = tmp_state_dir
+    # Process-global pilot: drop leftover local-* before this server's polls.
+    with srv._pilot._local_jobs_lock:
+        srv._pilot._local_jobs.clear()
+        srv._pilot._local_job_cancels.clear()
 
     httpd = ThreadingHTTPServer(("127.0.0.1", 0), srv.Handler)
     port = httpd.server_address[1]
@@ -292,10 +296,9 @@ def test_swarm_live_held_open_scratch_hijack_exposes_only_host_local(tmp_path, m
     try:
         headers = {"X-Harness-Token": srv._TOKEN}
         srv._cfg.repo = str(repo)
-        if not srv._sessions.active:
-            srv._sessions.create(
-                "held-open", repo=str(repo), workspace_root=str(repo),
-            )
+        srv._sessions.create(
+            "held-open", repo=str(repo), workspace_root=str(repo),
+        )
         srv._sync_pilot_session_id()
         sid = srv._pilot.harness_session_id or srv._sessions.active or ""
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.397",
+  "version": "0.9.398",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.397",
+      "version": "0.9.398",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.397",
+  "version": "0.9.398",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/TerminalPane.bareOnDone.test.ts
+++ b/webapp/src/__tests__/TerminalPane.bareOnDone.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { terminalBareOnDoneAction } from "../components/terminalStreamPolicy";
+import {
+  decodeTerminalStreamEvent,
+  terminalBareOnDoneAction,
+  terminalMissingSessionAction,
+  terminalNotice,
+} from "../components/terminalStreamPolicy";
 
 describe("terminalBareOnDoneAction", () => {
   const base = {
@@ -36,5 +41,15 @@ describe("terminalBareOnDoneAction", () => {
 
   it("noops when the pane effect already disposed", () => {
     expect(terminalBareOnDoneAction({ ...base, disposed: true })).toBe("noop");
+  });
+
+  it("decodes lifecycle frames and bounds backend notices", () => {
+    expect(decodeTerminalStreamEvent({ kind: "process_exit", offset: 4, error: "done" })).toEqual({
+      kind: "process_exit", offset: 4, error: "done",
+    });
+    expect(decodeTerminalStreamEvent({ kind: "exit" }).kind).toBe("legacy_exit");
+    expect(terminalMissingSessionAction(false)).toBe("auto_recover");
+    expect(terminalMissingSessionAction(true)).toBe("mark_exited");
+    expect(terminalNotice("x".repeat(300))).toHaveLength(240);
   });
 });

--- a/webapp/src/__tests__/TerminalPane.bareOnDone.test.ts
+++ b/webapp/src/__tests__/TerminalPane.bareOnDone.test.ts
@@ -4,6 +4,7 @@ import {
   terminalBareOnDoneAction,
   terminalMissingSessionAction,
   terminalNotice,
+  terminalStreamPath,
 } from "../components/terminalStreamPolicy";
 
 describe("terminalBareOnDoneAction", () => {
@@ -51,5 +52,8 @@ describe("terminalBareOnDoneAction", () => {
     expect(terminalMissingSessionAction(false)).toBe("auto_recover");
     expect(terminalMissingSessionAction(true)).toBe("mark_exited");
     expect(terminalNotice("x".repeat(300))).toHaveLength(240);
+    expect(terminalStreamPath("abc")).toBe("/api/terminal/stream?id=abc");
+    expect(terminalStreamPath("abc", 12)).toBe("/api/terminal/stream?id=abc&offset=12");
+    expect(terminalStreamPath("abc", -4)).toBe("/api/terminal/stream?id=abc");
   });
 });

--- a/webapp/src/components/TerminalPane.tsx
+++ b/webapp/src/components/TerminalPane.tsx
@@ -66,7 +66,6 @@ export default function TerminalPane() {
   // Bumping this re-runs the effect: cleanly tears down the old PTY + xterm and
   // spins up a fresh one. Drives the Restart button and exit auto-recovery.
   const [restartNonce, setRestartNonce] = useState(0);
-  const autoRecoveredRef = useRef(false);
   const [exited, setExited] = useState(false);
   const [agentView, setAgentView] = useState<AgentView | null>(null);
   const [selection, setSelection] = useState("");

--- a/webapp/src/components/TerminalPane.tsx
+++ b/webapp/src/components/TerminalPane.tsx
@@ -28,6 +28,7 @@ import {
   terminalBareOnDoneAction,
   terminalMissingSessionAction,
   terminalNotice,
+  terminalStreamPath,
 } from "./terminalStreamPolicy";
 
 /** https via WebLinksAddon + workspace/file:// paths via our ILinkProvider. */
@@ -287,12 +288,12 @@ export default function TerminalPane() {
       return safePtyDims(term.cols, term.rows);
     };
 
+    let lastOffset = 0;
     const attachStream = (sid: string) => {
       let sawOutput = false;
       let sawExit = false;
-      let lastOffset = -1;
       cancelRef.current = stream(
-        `/api/terminal/stream?id=${sid}`,
+        terminalStreamPath(sid, lastOffset),
         (raw: unknown) => {
           const ev = decodeTerminalStreamEvent(raw);
           if (ev.offset !== undefined && ev.offset > lastOffset) lastOffset = ev.offset;

--- a/webapp/src/components/TerminalPane.tsx
+++ b/webapp/src/components/TerminalPane.tsx
@@ -23,7 +23,12 @@ import {
   terminalSelectionLabel,
 } from "../lib/terminalSelection";
 import { hostHasLayout, safePtyDims } from "./terminalDims";
-import { terminalBareOnDoneAction } from "./terminalStreamPolicy";
+import {
+  decodeTerminalStreamEvent,
+  terminalBareOnDoneAction,
+  terminalMissingSessionAction,
+  terminalNotice,
+} from "./terminalStreamPolicy";
 
 /** https via WebLinksAddon + workspace/file:// paths via our ILinkProvider. */
 function attachTerminalLinkHandlers(term: Terminal): void {
@@ -60,6 +65,7 @@ export default function TerminalPane() {
   // Bumping this re-runs the effect: cleanly tears down the old PTY + xterm and
   // spins up a fresh one. Drives the Restart button and exit auto-recovery.
   const [restartNonce, setRestartNonce] = useState(0);
+  const autoRecoveredRef = useRef(false);
   const [exited, setExited] = useState(false);
   const [agentView, setAgentView] = useState<AgentView | null>(null);
   const [selection, setSelection] = useState("");
@@ -284,17 +290,39 @@ export default function TerminalPane() {
     const attachStream = (sid: string) => {
       let sawOutput = false;
       let sawExit = false;
+      let lastOffset = -1;
       cancelRef.current = stream(
         `/api/terminal/stream?id=${sid}`,
-        (ev: any) => {
-          if (ev.kind === "data" && ev.b64) {
+        (raw: unknown) => {
+          const ev = decodeTerminalStreamEvent(raw);
+          if (ev.offset !== undefined && ev.offset > lastOffset) lastOffset = ev.offset;
+          if (ev.kind === "data") {
             sawOutput = true;
             try { term.write(_b64ToBytes(ev.b64)); } catch { /* ignore */ }
-          } else if (ev.kind === "exit") {
+          } else if (ev.kind === "process_exit" || ev.kind === "legacy_exit") {
+            if (sawExit) return;
             sawExit = true;
             term.write("\r\n\x1b[90m[process exited -- press Restart]\x1b[0m\r\n");
-            idRef.current = "";  // session is dead; stop sending keystrokes to it
+            idRef.current = "";
             markExited();
+          } else if (ev.kind === "missing_session") {
+            if (sawExit) return;
+            const action = terminalMissingSessionAction(autoRecoveredRef.current);
+            if (action === "auto_recover") {
+              autoRecoveredRef.current = true;
+              idRef.current = "";
+              postJSON("/api/terminal/kill", { id: sid });
+              setRestartNonce((n) => n + 1);
+            } else {
+              sawExit = true;
+              idRef.current = "";
+              markExited(`\r\n\x1b[90m[session unavailable${terminalNotice(ev.error) ? `: ${terminalNotice(ev.error)}` : ""} -- press Restart]\x1b[0m\r\n`);
+            }
+          } else if (ev.kind === "stream_error") {
+            if (sawExit) return;
+            sawExit = true;
+            idRef.current = "";
+            markExited(`\r\n\x1b[31m[terminal stream error${terminalNotice(ev.error) ? `: ${terminalNotice(ev.error)}` : ""} -- press Restart]\x1b[0m\r\n`);
           }
         },
         // onDone: SSE closed. kind:exit already settled the pane. A bare close

--- a/webapp/src/components/terminalStreamPolicy.ts
+++ b/webapp/src/components/terminalStreamPolicy.ts
@@ -1,27 +1,45 @@
-/** Action for an SSE close that did not already settle via kind:exit handling. */
-export type TerminalBareOnDoneAction =
-  | "noop"
-  | "mark_exited"
-  | "auto_recover"
-  | "reattach";
+/** Deterministic decisions for terminal stream lifecycle frames. */
+export type TerminalBareOnDoneAction = "noop" | "mark_exited" | "auto_recover" | "reattach";
+export type TerminalStreamEvent =
+  | { kind: "data"; b64: string; offset?: number }
+  | { kind: "process_exit"; offset?: number; error?: string }
+  | { kind: "missing_session"; offset?: number; error?: string }
+  | { kind: "stream_error"; offset?: number; error?: string }
+  | { kind: "legacy_exit"; offset?: number; error?: string }
+  | { kind: "unknown"; offset?: number };
 
-/**
- * Bare SSE onDone (no kind:exit): never treat a transient stream drop as fatal.
- * Reattach the same session when we already saw ConPTY output; only the one-shot
- * empty-stream race still kill+recreates. Restart remains an explicit kill path.
- */
+const MAX_NOTICE = 240;
+
+/** Decode both the old kind:exit frame and the new explicit PTY lifecycle frames. */
+export function decodeTerminalStreamEvent(value: unknown): TerminalStreamEvent {
+  if (!value || typeof value !== "object") return { kind: "unknown" };
+  const raw = value as Record<string, unknown>;
+  const kind = typeof raw.kind === "string" ? raw.kind : "";
+  const offset = typeof raw.offset === "number" && Number.isFinite(raw.offset) ? raw.offset : undefined;
+  const error = typeof raw.error === "string" ? raw.error : undefined;
+  if (kind === "data" && typeof raw.b64 === "string") return { kind, b64: raw.b64, offset };
+  if (kind === "process_exit" || kind === "exit") return { kind: kind === "exit" ? "legacy_exit" : kind, offset, error };
+  if (kind === "missing_session") return { kind, offset, error };
+  if (kind === "stream_error") return { kind, offset, error };
+  return { kind: "unknown", offset };
+}
+
+/** Only backend-redacted text is displayed, and never without a hard bound. */
+export function terminalNotice(error?: string): string {
+  if (!error) return "";
+  return error.slice(0, MAX_NOTICE);
+}
+
+export function terminalMissingSessionAction(alreadyRecovered: boolean): "auto_recover" | "mark_exited" {
+  return alreadyRecovered ? "mark_exited" : "auto_recover";
+}
+
 export function terminalBareOnDoneAction(opts: {
-  disposed: boolean;
-  sawExit: boolean;
-  hasSession: boolean;
-  sawOutput: boolean;
-  autoRecovered: boolean;
+  disposed: boolean; sawExit: boolean; hasSession: boolean; sawOutput: boolean; autoRecovered: boolean;
 }): TerminalBareOnDoneAction {
   if (opts.disposed) return "noop";
   if (opts.sawExit) return "mark_exited";
   if (!opts.hasSession) return "mark_exited";
-  if (!opts.sawOutput) {
-    return opts.autoRecovered ? "mark_exited" : "auto_recover";
-  }
+  if (!opts.sawOutput) return opts.autoRecovered ? "mark_exited" : "auto_recover";
   return "reattach";
 }

--- a/webapp/src/components/terminalStreamPolicy.ts
+++ b/webapp/src/components/terminalStreamPolicy.ts
@@ -34,6 +34,13 @@ export function terminalMissingSessionAction(alreadyRecovered: boolean): "auto_r
   return alreadyRecovered ? "mark_exited" : "auto_recover";
 }
 
+export function terminalStreamPath(sid: string, startOffset = 0): string {
+  const offset = Number.isFinite(startOffset) ? Math.max(0, Math.floor(startOffset)) : 0;
+  const params = new URLSearchParams({ id: sid });
+  if (offset > 0) params.set("offset", String(offset));
+  return `/api/terminal/stream?${params.toString()}`;
+}
+
 export function terminalBareOnDoneAction(opts: {
   disposed: boolean; sawExit: boolean; hasSession: boolean; sawOutput: boolean; autoRecovered: boolean;
 }): TerminalBareOnDoneAction {


### PR DESCRIPTION
## Summary
- Cross-repo haul waves 1-6: terminal SSE reconnect offsets, privacy-safe auth attribution, argv-only lifecycle hooks, fail-closed OS sandbox paths, typed DAG contracts, memory provenance/search, consent-gated copied Chromium profiles, and a default-disabled MCP OAuth lab.
- Wave 3 closed the leftover undefined `_run_cancellable` hook runner. Live Chrome user-data dirs are rejected for CDP.
- Version files aligned at 0.9.398. Puppetmaster pin unchanged (`1.22.43`).

## Test plan
- [x] Focused pytest: terminals, redaction, MCP receipts, hooks, os_sandbox, memory, DAG contracts, browser profile, OAuth lab, steer (148 passed)
- [x] Focused vitest: TerminalPane stream policy + CostBreakdown (16 passed)
- [x] `tests/test_version_consistency.py`
- [ ] CI `tests` matrix: 3.9, 3.11, Windows, frontend-build