### PR TITLE
Release v0.9.399

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.398, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.399, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.398"
+__version__ = "0.9.399"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/economics.py
+++ b/harness/api/economics.py
@@ -563,25 +563,28 @@ def _owned_totals(rows: list) -> dict:
 
 
 def _aggregate_job_counterfactual(rows: list) -> tuple[Optional[dict], str]:
-    """Sum the same owned job reports projected into Recent jobs."""
+    """Sum comparable owned job reports; mark incomplete if any accountable row is malformed."""
     comparable = []
     references = set()
     measured_cost = 0.0
     estimated_cost = 0.0
     plan_jobs = 0
+    skipped_incomplete = False
     for row in filter_accountable_jobs(rows):
         if row.get("financial_error"):
-            return None, "incomplete"
+            skipped_incomplete = True
+            continue
         cf = row.get("counterfactual")
         try:
             priced_tasks = int(row.get("priced_tasks") or 0)
             row_measured = float(row.get("measured_cost_usd") or 0.0)
             row_estimated = float(row.get("estimated_cost_usd") or 0.0)
         except (TypeError, ValueError):
-            return None, "incomplete"
+            skipped_incomplete = True
+            continue
         if not isinstance(cf, dict) or cf.get("reference_priced") is not True:
             if priced_tasks > 0 or row_measured > 0 or row_estimated > 0:
-                return None, "incomplete"
+                skipped_incomplete = True
             continue
         reference = str(cf.get("reference_model_id") or "").strip()
         try:
@@ -590,8 +593,14 @@ def _aggregate_job_counterfactual(rows: list) -> tuple[Optional[dict], str]:
             avoided = float(cf["avoided_usd"])
             tasks = int(cf.get("tasks") or row.get("priced_tasks") or 0)
         except (KeyError, TypeError, ValueError):
+            skipped_incomplete = True
             continue
-        if not reference or tasks <= 0:
+        if not reference:
+            skipped_incomplete = True
+            continue
+        if tasks <= 0:
+            if priced_tasks > 0 or row_measured > 0 or row_estimated > 0:
+                skipped_incomplete = True
             continue
         if abs((row_measured + row_estimated) - actual) > 0.000001:
             return None, "receipt_mismatch"
@@ -604,7 +613,7 @@ def _aggregate_job_counterfactual(rows: list) -> tuple[Optional[dict], str]:
     if len(references) > 1:
         return None, "mixed_reference"
     if not comparable:
-        return None, "unavailable"
+        return None, "incomplete" if skipped_incomplete else "unavailable"
     return {
         "reference_model_id": next(iter(references)),
         "reference_priced": True,
@@ -622,7 +631,7 @@ def _aggregate_job_counterfactual(rows: list) -> tuple[Optional[dict], str]:
             else COST_BASIS
         ),
         "label": COUNTERFACTUAL_LABEL,
-    }, "ok"
+    }, ("incomplete" if skipped_incomplete else "ok")
 
 
 def _scoped_job_rows(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.398"
+version = "0.9.399"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_economics_peel.py
+++ b/tests/test_api_economics_peel.py
@@ -1,9 +1,11 @@
 """Characterization tests for the economics API peel."""
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 from harness.api.economics import (
+    RECENT_JOB_LIMIT,
     EconomicsServices,
     _PrefetchedArtifacts,
     _aggregate_job_counterfactual,
@@ -979,6 +981,170 @@ def test_aggregate_fails_closed_on_mixed_reference_or_receipt_mismatch():
     ])
     assert report is None
     assert status == "incomplete"
+
+
+def _comparable_owned_row(*, avoided=1.0, actual=1.0, naive=2.0, tasks=1):
+    return {
+        "accounting_owned": True,
+        "priced_tasks": tasks,
+        "measured_cost_usd": actual,
+        "estimated_cost_usd": 0.0,
+        "counterfactual": {
+            "reference_model_id": "codex/gpt-5-5",
+            "reference_priced": True,
+            "naive_cost_usd": naive,
+            "actual_cost_usd": actual,
+            "avoided_usd": avoided,
+            "tasks": tasks,
+        },
+    }
+
+
+def test_aggregate_sums_comparable_rows_when_one_owned_report_is_incomplete():
+    complete = [_comparable_owned_row(avoided=1.5, actual=0.5, naive=2.0) for _ in range(3)]
+    hidden_incomplete = {
+        "accounting_owned": True,
+        "financial_error": True,
+        "priced_tasks": 1,
+        "measured_cost_usd": 4.0,
+        "estimated_cost_usd": 0.0,
+    }
+    report, status = _aggregate_job_counterfactual([*complete, hidden_incomplete])
+    assert status == "incomplete"
+    assert report is not None
+    assert report["jobs"] == 3
+    assert report["actual_cost_usd"] == 1.5
+    assert report["avoided_usd"] == 4.5
+    assert report["naive_cost_usd"] == 6.0
+
+    priced_without_reference = {
+        "accounting_owned": True,
+        "priced_tasks": 2,
+        "measured_cost_usd": 3.0,
+        "estimated_cost_usd": 0.0,
+        "counterfactual": None,
+    }
+    report, status = _aggregate_job_counterfactual([*complete, priced_without_reference])
+    assert status == "incomplete"
+    assert report is not None
+    assert report["jobs"] == 3
+    assert report["actual_cost_usd"] == 1.5
+
+    report, status = _aggregate_job_counterfactual([
+        hidden_incomplete,
+        priced_without_reference,
+    ])
+    assert report is None
+    assert status == "incomplete"
+
+
+def test_aggregate_keeps_partial_hero_for_each_malformed_accountable_shape():
+    valid = _comparable_owned_row(avoided=1.5, actual=0.5, naive=2.0)
+    float_parse = _comparable_owned_row()
+    float_parse["counterfactual"] = {
+        **float_parse["counterfactual"],
+        "naive_cost_usd": "not-a-number",
+    }
+    int_parse = _comparable_owned_row()
+    int_parse["counterfactual"] = {
+        **int_parse["counterfactual"],
+        "tasks": "nope",
+    }
+    missing_reference = _comparable_owned_row()
+    missing_reference["counterfactual"] = {
+        **missing_reference["counterfactual"],
+        "reference_model_id": "",
+    }
+    zero_tasks = _comparable_owned_row(actual=1.0, tasks=0)
+    malformed_shapes = (
+        {
+            "accounting_owned": True,
+            "financial_error": True,
+            "priced_tasks": 1,
+            "measured_cost_usd": 4.0,
+            "estimated_cost_usd": 0.0,
+        },
+        {
+            "accounting_owned": True,
+            "priced_tasks": 2,
+            "measured_cost_usd": 3.0,
+            "estimated_cost_usd": 0.0,
+            "counterfactual": None,
+        },
+        float_parse,
+        int_parse,
+        missing_reference,
+        zero_tasks,
+    )
+    for malformed in malformed_shapes:
+        report, status = _aggregate_job_counterfactual([valid, malformed])
+        assert status == "incomplete"
+        assert report is not None
+        assert report["jobs"] == 1
+        assert report["actual_cost_usd"] == 0.5
+        assert report["avoided_usd"] == 1.5
+        assert report["naive_cost_usd"] == 2.0
+
+
+def test_aggregate_unpriced_zero_task_report_is_unavailable_not_incomplete():
+    empty = {
+        "accounting_owned": True,
+        "priced_tasks": 0,
+        "measured_cost_usd": 0.0,
+        "estimated_cost_usd": 0.0,
+        "counterfactual": {
+            "reference_model_id": "cheap",
+            "reference_priced": True,
+            "naive_cost_usd": 0.0,
+            "actual_cost_usd": 0.0,
+            "avoided_usd": 0.0,
+            "tasks": 0,
+        },
+    }
+    report, status = _aggregate_job_counterfactual([empty])
+    assert report is None
+    assert status == "unavailable"
+
+
+def test_hidden_incomplete_owned_row_does_not_blank_scope_hero(monkeypatch):
+    assert RECENT_JOB_LIMIT == 12
+    base = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    jobs = [
+        {
+            "id": f"job_{index:03d}",
+            "status": "complete",
+            "source": "harness",
+            "accounting_owned": True,
+            "accounting_scope": "marionette",
+            "created_at": (base + timedelta(minutes=index)).isoformat(),
+        }
+        for index in range(1, 145)
+    ]
+    _patch_pm(monkeypatch)
+    real_builder = __import__(
+        "puppetmaster.cost", fromlist=["build_cost_report"]
+    ).build_cost_report
+
+    def fail_hidden(store, job_id, registry=None):
+        if job_id == "job_050":
+            raise RuntimeError("hidden receipt incomplete")
+        return real_builder(store, job_id, registry=registry)
+
+    monkeypatch.setattr("puppetmaster.cost.build_cost_report", fail_hidden)
+
+    code, payload = get_economics({"scope": ["repo"]}, _svc(jobs=jobs))
+
+    assert code == 200
+    assert isinstance(payload, dict)
+    assert payload["counterfactual_source"] == "job_financial_reports"
+    assert payload["counterfactual_status"] == "incomplete"
+    assert payload["counterfactual"] is not None
+    assert payload["counterfactual"]["jobs"] == 143
+    assert payload["counterfactual"]["actual_cost_usd"] == 1.25 * 143
+    assert payload["counterfactual"]["avoided_usd"] == 2.75 * 143
+    recent_ids = [row["job_id"] for row in payload["recent_jobs"]]
+    assert recent_ids == [f"job_{index:03d}" for index in range(144, 132, -1)]
+    assert "job_050" not in recent_ids
 
 
 def test_aggregate_preserves_plan_included_basis():

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.398",
+  "version": "0.9.399",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.398",
+      "version": "0.9.399",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.398",
+  "version": "0.9.399",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -349,6 +349,27 @@ describe("EconomicsPane", () => {
     expect(row.queryByText("Cost unavailable")).toBeNull();
   });
 
+  it("shows a partial hero and warns when some job reports are incomplete", async () => {
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      counterfactual_status: "incomplete",
+      counterfactual: {
+        ...durablePayload.counterfactual,
+        jobs: 143,
+        tasks: 143,
+      },
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("Estimated savings")).toBeTruthy();
+    expect(screen.getByText("~$3.92")).toBeTruthy();
+    expect(screen.getByText("143 jobs considered")).toBeTruthy();
+    expect(screen.getByText(/complete reports were used/i)).toBeTruthy();
+    expect(screen.getByText(/incomplete reports were excluded/i)).toBeTruthy();
+    expect(screen.queryByText(/Savings unavailable because one or more job reports are incomplete/)).toBeNull();
+  });
+
   it("shows an honest warning when job reports do not reconcile", async () => {
     mockGetEconomics.mockResolvedValue({
       ...durablePayload,

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -230,6 +230,7 @@ import {
 } from "../components/conversation/openFileTabs";
 import {
   preserveOrThinking,
+  RUNNERS_IDLE_CONFIRM_POLLS,
   runnersBusyTickDecision,
   staleLocalStreamTickDecision,
   userStoppedBusyChrome,
@@ -3353,6 +3354,49 @@ describe("queueOps / openFileTabs / runnersBusy", () => {
       }).kind,
     ).toBe("noop");
   });
+
+  it("detached idle does not hold solely because of leftover tool_prep", () => {
+    const stalePrep: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "go" } },
+      {
+        kind: "card",
+        card: {
+          id: "a1",
+          goal: "foo.ts",
+          kind: "read_file",
+          running: false,
+          open: false,
+          result: { status: "ok" },
+        },
+      },
+      { kind: "tool_prep", name: "grep" },
+    ];
+    expect(
+      runnersBusyTickDecision({
+        userStopped: false,
+        localStreamActive: false,
+        runnerBusy: false,
+        detachedBusy: true,
+        chatEventsPollArmed: false,
+        items: stalePrep,
+        consecutiveIdlePolls: RUNNERS_IDLE_CONFIRM_POLLS,
+      }).kind,
+    ).toBe("finalize_idle_refresh");
+    expect(
+      runnersBusyTickDecision({
+        userStopped: false,
+        localStreamActive: false,
+        runnerBusy: false,
+        detachedBusy: true,
+        chatEventsPollArmed: false,
+        items: [
+          { kind: "msg", msg: { role: "user", text: "go" } },
+          { kind: "msg", msg: { role: "assistant", text: "partial…", streaming: true } },
+        ],
+        consecutiveIdlePolls: RUNNERS_IDLE_CONFIRM_POLLS,
+      }).kind,
+    ).toBe("hold_live_investigation");
+  });
 });
 
 describe("completionNotify / feedScroll / streamTerminal / swarmPoll", () => {
@@ -4670,6 +4714,62 @@ describe("investigation terminal reconciliation + live ordering", () => {
     expect((row?.goal || "").length).toBeLessThanOrEqual(MAX_ACTION_GOAL_CHARS);
     expect((row?.error || "").length).toBeLessThanOrEqual(240);
     expect(boundActionField(hugeGoal, MAX_ACTION_GOAL_CHARS).endsWith("…")).toBe(true);
+  });
+
+  it("applyActionResultCard preserves a newer tool_prep when an earlier card settles", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "go" } },
+      {
+        kind: "card",
+        card: {
+          id: "a1",
+          goal: "a.ts",
+          kind: "read_file",
+          running: true,
+          open: false,
+        },
+      },
+      { kind: "tool_prep", name: "grep" },
+    ];
+    const next = applyActionResultCard(items, {
+      id: "a1",
+      kind: "read_file",
+      goal: "a.ts",
+      status: "complete",
+    });
+    const prep = next.find((it) => it.kind === "tool_prep") as Extract<Item, { kind: "tool_prep" }>;
+    expect(prep?.name).toBe("grep");
+    const card = next.find((it) => it.kind === "card") as Extract<Item, { kind: "card" }>;
+    expect(card.card.running).toBe(false);
+  });
+
+  it("terminal reconciliation removes leftover tool_prep after the answer seals", () => {
+    const items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "go" } },
+      {
+        kind: "card",
+        card: {
+          id: "a1",
+          goal: "a.ts",
+          kind: "read_file",
+          running: false,
+          open: false,
+          result: { status: "complete" },
+        },
+      },
+      { kind: "tool_prep", name: "read_file" },
+      { kind: "msg", msg: { role: "assistant", text: "Here is the answer." } },
+    ];
+    const liveIds: string[] = [];
+    const next = reconcileOrphanInvestigationCards(
+      finalizeOrphanSwarmPills(
+        hoistCardsBeforeTrailingFinals(sealOpenStreamSurfaces(items)),
+        liveIds,
+      ),
+      liveIds,
+    );
+    expect(next.some((it) => it.kind === "tool_prep")).toBe(false);
+    expect(next.some((it) => it.kind === "card")).toBe(true);
   });
 
   it("applyActionResultCard settles nested running rows on the matched card", () => {

--- a/webapp/src/__tests__/turnProgress.test.ts
+++ b/webapp/src/__tests__/turnProgress.test.ts
@@ -30,6 +30,8 @@ import {
   looksLikeFinalAnswer,
   hoistCardsBeforeTrailingFinals,
 } from "../components/Conversation";
+import { derivePillStatus } from "../components/conversation/pillStatus";
+import { statusPillLabel } from "../components/conversation/StatusPill";
 import type { Item } from "../components/TranscriptList";
 
 function card(id: string, goal: string, kind = "read_file", running = false): Item {
@@ -276,6 +278,29 @@ describe("turnHasLiveInvestigation", () => {
       card("1", "a.ts", "read_file", false),
     ];
     expect(turnHasLiveInvestigation(items, true)).toBe(true);
+  });
+
+  it("leftover tool_prep is live only while the agent loop is open", () => {
+    const items: Item[] = [
+      msg("user", "go"),
+      card("1", "a.ts", "read_file", false),
+      { kind: "tool_prep", name: "read_file" },
+      msg("assistant", "Here is the answer."),
+    ];
+    expect(turnHasLiveInvestigation(items, true)).toBe(true);
+    expect(turnHasLiveInvestigation(items, false)).toBe(false);
+    expect(
+      statusPillLabel(
+        derivePillStatus({
+          transcriptStale: false,
+          answerChromeIdle: false,
+          liveInvestigation: turnHasLiveInvestigation(items, false),
+          turnOpen: false,
+          status: "idle",
+          agentLoopOpen: false,
+        }),
+      ),
+    ).toBe("Ready");
   });
 
   it("is true while nested worker actions are still running", () => {

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -65,7 +65,11 @@ export default function EconomicsDurable({
     : data?.counterfactual_status === "receipt_mismatch"
       ? "Savings unavailable because the job reports do not agree."
       : data?.counterfactual_status === "incomplete"
-        ? "Savings unavailable because one or more job reports are incomplete."
+        ? (
+          hasReceipt
+            ? "Complete reports were used; incomplete reports were excluded."
+            : "Savings unavailable because one or more job reports are incomplete."
+        )
         : "";
 
   return (
@@ -127,6 +131,9 @@ export default function EconomicsDurable({
             <div className="mt-2 text-[10px] text-faint">Based on measured usage and current model prices.</div>
           ) : receiptBasis === "mixed" ? (
             <div className="mt-2 text-[10px] text-faint">Includes measured and estimated usage.</div>
+          ) : null}
+          {financialIssue ? (
+            <p className="mt-2 text-[10px] leading-snug text-warn">{financialIssue}</p>
           ) : null}
         </section>
       ) : isRoutingForecast && hasReceipt ? (

--- a/webapp/src/components/conversation/runnersBusy.ts
+++ b/webapp/src/components/conversation/runnersBusy.ts
@@ -120,10 +120,9 @@ export function runnersBusyTickDecision(opts: {
   }
 
   if (opts.detachedBusy) {
-    // Runner already idle: only hold while a surface is actually live
-    // (running card / tool_prep / streaming). Completed cards must NOT keep
-    // Stop forever — sticky-between-batches applies while runnerBusy is true.
-    if (turnHasVisibleBusySurface(opts.items)) {
+    // Runner already idle: hold only for a live running card or streaming
+    // surface. Leftover tool_prep must not keep detached busy after idle.
+    if (turnHasVisibleBusySurface(opts.items, { includeToolPrep: false })) {
       return { kind: "hold_live_investigation" };
     }
     // Resist a single transient false idle poll before clearing Stop.

--- a/webapp/src/components/conversation/streamApply.ts
+++ b/webapp/src/components/conversation/streamApply.ts
@@ -467,6 +467,10 @@ export function reconcileOrphanInvestigationCards(
   let changed = false;
   const next: Item[] = [];
   for (const it of items) {
+    if (it.kind === "tool_prep") {
+      changed = true;
+      continue;
+    }
     if (it.kind !== "card") {
       next.push(it);
       continue;

--- a/webapp/src/lib/turnProgress.ts
+++ b/webapp/src/lib/turnProgress.ts
@@ -1098,7 +1098,10 @@ export function turnHasLiveInvestigation(
         return true;
       }
     }
-    if (it.kind === "tool_prep") return true;
+    if (it.kind === "tool_prep") {
+      if (agentLoopOpen) return true;
+      continue;
+    }
     if (
       it.kind === "thinking"
       && (it as { streaming?: boolean; text?: string }).streaming
@@ -1120,7 +1123,11 @@ export function turnHasLiveInvestigation(
  * Durable background jobs are pollable card UI — they must not hold Stop/Steer
  * after the pilot runner has gone idle.
  */
-export function turnHasVisibleBusySurface(items: TurnItem[]): boolean {
+export function turnHasVisibleBusySurface(
+  items: TurnItem[],
+  opts: { includeToolPrep?: boolean } = {},
+): boolean {
+  const includeToolPrep = opts.includeToolPrep !== false;
   for (const it of itemsInCurrentTurn(items)) {
     if (it.kind === "card") {
       const card = (it as { card: TurnCard }).card || ({} as TurnCard);
@@ -1128,7 +1135,10 @@ export function turnHasVisibleBusySurface(items: TurnItem[]): boolean {
         return true;
       }
     }
-    if (it.kind === "tool_prep") return true;
+    if (it.kind === "tool_prep") {
+      if (includeToolPrep) return true;
+      continue;
+    }
     if (it.kind === "thinking" && (it as { streaming?: boolean }).streaming === true) {
       return true;
     }


### PR DESCRIPTION
## Summary
- keep Economics totals visible from complete receipts while clearly excluding incomplete reports
- settle stale Investigating chrome at terminal boundaries without dropping next-batch tool hints
- bump Marionette to v0.9.399

## Test plan
- [x] `.venv/bin/python -m pytest -q` (5,582 passed, 78 skipped)
- [x] `npm test`
- [x] `npm run test:electron` (209 passed)
- [x] `npm run build`
- [x] baseline regression worktree fails 3 Economics and 4 frontend checks; patched tree passes
- [x] real 141-job API scope returns a non-null partial hero with 12 recent receipts and `counterfactual_status=incomplete`