### PR TITLE
Release v0.9.400

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.399, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.400, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.399"
+__version__ = "0.9.400"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.399"
+version = "0.9.400"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.399",
+  "version": "0.9.400",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.399",
+      "version": "0.9.400",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.399",
+  "version": "0.9.400",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CostBreakdown.test.tsx
+++ b/webapp/src/__tests__/CostBreakdown.test.tsx
@@ -38,6 +38,26 @@ describe("CostBreakdown receipt", () => {
     expect(screen.getByText("Compact tool outputs")).toBeTruthy();
   });
 
+  it("renders nothing when the app-run hero is omitted and there are no savings rows", () => {
+    const { container } = render(
+      <CostBreakdown data={{ tokens_used: 12_000, est_cost_usd: 0.12 }} hero={false} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("can omit the app-run hero and keep why-you-saved rows", () => {
+    render(<CostBreakdown data={baseData} hero={false} />);
+
+    expect(screen.queryByText("Spend")).toBeNull();
+    expect(screen.queryByText("Without savings")).toBeNull();
+    expect(screen.queryByText("Less spent")).toBeNull();
+    expect(screen.getByText("Why you saved")).toBeTruthy();
+    expect(screen.getByText("Prompt-cache value")).toBeTruthy();
+    expect(screen.getByText("Compact tool outputs")).toBeTruthy();
+    expect(screen.getByText(/since you opened Marionette/)).toBeTruthy();
+  });
+
   it("keeps context diagnostics and compaction controls out of Economics", () => {
     render(<CostBreakdown data={baseData} />);
 

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -477,6 +477,77 @@ describe("EconomicsPane", () => {
     expect(mockOpenAgentSwarmJob).toHaveBeenCalledWith("job_abcdef012345");
   });
 
+  it("keeps this-open spend off This repo even when receipts are unavailable", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: {
+        tokens_used: 229_800,
+        est_cost_usd: 0.62,
+        cost_source: "estimated",
+        estimated: true,
+        driver: "openai-codex:gpt-5.6-sol",
+        price_in: 1,
+        price_out: 1,
+        tokens_cached: 170_000,
+        prompt_cache_read_tokens: 170_000,
+        cache_savings_gross_usd: 5.22,
+        cache_savings_basis: "catalog",
+        tool_output_tokens_saved: 40_000,
+        tool_output_savings_usd: 0.40,
+      },
+      jobs: [],
+      session_total: { session_id: "s1", est_cost_usd: 0.62, input_tokens: 1, output_tokens: 1 },
+    });
+    mockGetEconomics.mockResolvedValue({
+      ...durablePayload,
+      counterfactual: null,
+      counterfactual_source: "unavailable",
+      counterfactual_status: "receipt_mismatch",
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText(/job reports do not agree/)).toBeTruthy();
+    expect(screen.queryByText("Spend")).toBeNull();
+    expect(screen.queryByText("Without savings")).toBeNull();
+    expect(screen.getByText("Why you saved")).toBeTruthy();
+    expect(screen.getByText("Prompt-cache value")).toBeTruthy();
+  });
+
+  it("does not stack a this-open spend hero on a scoped receipt hero", async () => {
+    mockGetUsage.mockResolvedValue({
+      session: {
+        tokens_used: 229_800,
+        est_cost_usd: 0.62,
+        cost_source: "estimated",
+        estimated: true,
+        driver: "openai-codex:gpt-5.6-sol",
+        price_in: 1,
+        price_out: 1,
+        tokens_cached: 170_000,
+        prompt_cache_read_tokens: 170_000,
+        prompt_cache_hit_ratio: 0.74,
+        cache_savings_gross_usd: 5.22,
+        cache_savings_basis: "catalog",
+        tool_output_tokens_saved: 40_000,
+        tool_output_savings_usd: 0.40,
+      },
+      jobs: [],
+      session_total: { session_id: "s1", est_cost_usd: 0.62, input_tokens: 1, output_tokens: 1 },
+    });
+
+    render(<EconomicsPane />);
+
+    expect(await screen.findByText("Measured usage cost")).toBeTruthy();
+    expect(screen.getByText("$0.32")).toBeTruthy();
+    expect(screen.getByText("Estimated frontier cost")).toBeTruthy();
+    expect(screen.queryByText("Without savings")).toBeNull();
+    expect(screen.queryByText("Less spent")).toBeNull();
+    expect(screen.getByText("Why you saved")).toBeTruthy();
+    expect(screen.getByText("Prompt-cache value")).toBeTruthy();
+    expect(screen.getByText("Compact tool outputs")).toBeTruthy();
+    expect(screen.getByText(/since you opened Marionette/)).toBeTruthy();
+  });
+
   it("shows this-open cache and compact value even when the session has no owned jobs", async () => {
     mockGetUsage.mockResolvedValue({
       session: {
@@ -511,6 +582,8 @@ describe("EconomicsPane", () => {
 
     expect(await screen.findByText("Prompt-cache value")).toBeTruthy();
     expect(screen.getByText("Compact tool outputs")).toBeTruthy();
+    expect(screen.getByText("Spend")).toBeTruthy();
+    expect(screen.getByText("Without savings")).toBeTruthy();
     expect(screen.getByText("No owned jobs for this session.")).toBeTruthy();
   });
 

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -385,7 +385,13 @@ function fmtTokens(num: number): string {
   return String(num);
 }
 
-export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
+export default function CostBreakdown({
+  data,
+  hero = true,
+}: {
+  data: CostBreakdownData;
+  hero?: boolean;
+}) {
   const est = isFinite(data.est_cost_usd) ? data.est_cost_usd : 0;
   const estimated = spendIsEstimated(data);
   const spendPrefix = estimated ? "~" : "";
@@ -444,12 +450,21 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
   const savingsPercent = withoutSavings > 0
     ? Math.max(0, Math.min(100, (valueTotal / withoutSavings) * 100))
     : null;
+  const showWhySaved = promptCacheSaved > 0
+    || modelSelectionSaved > 0
+    || showRoutingDecision
+    || compactSavings > 0;
+  const showUnknownRouting = routingUnknown
+    && typeof data.routing_saved_usd === "number"
+    && data.routing_saved_usd > 0;
+  if (!hero && !showWhySaved && !showUnknownRouting) return null;
 
   return (
     <div className="w-full min-h-0 px-3 py-3 text-[11px] text-txt">
       <p className="text-[10px] text-muted mb-2 leading-snug">
         Spend and savings since you opened Marionette.
       </p>
+      {hero ? (
       <div className="mb-3 rounded-md border border-edge/50 bg-panel2/20 px-2.5 py-2.5">
         <div className="grid grid-cols-2 gap-x-3 gap-y-2.5">
           <div className="min-w-0">
@@ -472,9 +487,10 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
           </div>
         </div>
       </div>
+      ) : null}
 
-      {(promptCacheSaved > 0 || modelSelectionSaved > 0 || showRoutingDecision || compactSavings > 0) ? (
-      <div className="mt-2 pt-2 border-t border-edge/50">
+      {showWhySaved ? (
+      <div className={hero ? "mt-2 pt-2 border-t border-edge/50" : undefined}>
       <div className="text-[10px] text-faint mb-1">Why you saved</div>
       <p className="text-[10px] text-muted mb-1.5 leading-snug">
         Each saving is shown once, so the total stays honest.
@@ -536,7 +552,7 @@ export default function CostBreakdown({ data }: { data: CostBreakdownData }) {
       </div>
       ) : null}
 
-      {routingUnknown && typeof data.routing_saved_usd === "number" && data.routing_saved_usd > 0 ? (
+      {showUnknownRouting ? (
         <div
           className="flex items-center justify-between mb-1 text-faint"
           title="Routing savings basis is unknown — refused as billed or measured value."

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -66,7 +66,9 @@ export default function EconomicsDurable({
     : receiptBasis === "measured_usage_x_registry_price"
       ? "Measured usage cost"
       : "Cost unavailable";
-  const hasReceipt = hasFiniteReceiptTotals(data);
+  const hasReceipt = isFiniteNumber(receiptSpend)
+    && isFiniteNumber(receiptReference)
+    && isFiniteNumber(receiptSavings);
   const savingsPercent = hasReceipt && receiptReference > 0
     ? Math.max(0, Math.min(100, (receiptSavings / receiptReference) * 100))
     : null;

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -13,6 +13,18 @@ function fmtUnknownMoney(value: number | null | undefined): string {
   return `$${value.toFixed(2)}`;
 }
 
+function hasFiniteReceiptTotals(data: EconomicsData | null): boolean {
+  return isFiniteNumber(data?.counterfactual?.actual_cost_usd)
+    && isFiniteNumber(data?.counterfactual?.naive_cost_usd)
+    && isFiniteNumber(data?.counterfactual?.avoided_usd);
+}
+
+/** True when EconomicsDurable will render the scoped 4-stat receipt hero. */
+export function durableReceiptHeroAvailable(data: EconomicsData | null): boolean {
+  if (!data || data.counterfactual_source === "routing_report") return false;
+  return hasFiniteReceiptTotals(data);
+}
+
 /** Headline total: measured + estimated when either is known; else legacy actual_marginal. */
 export function jobHeadlineTotal(job: Pick<EconomicsJobRow, "measured_cost_usd" | "estimated_cost_usd" | "actual_marginal_usd">): number | null {
   const measured = job.measured_cost_usd;
@@ -54,9 +66,7 @@ export default function EconomicsDurable({
     : receiptBasis === "measured_usage_x_registry_price"
       ? "Measured usage cost"
       : "Cost unavailable";
-  const hasReceipt = isFiniteNumber(receiptSpend)
-    && isFiniteNumber(receiptReference)
-    && isFiniteNumber(receiptSavings);
+  const hasReceipt = hasFiniteReceiptTotals(data);
   const savingsPercent = hasReceipt && receiptReference > 0
     ? Math.max(0, Math.min(100, (receiptSavings / receiptReference) * 100))
     : null;
@@ -80,7 +90,7 @@ export default function EconomicsDurable({
         </p>
       ) : null}
 
-      {hasReceipt && !isRoutingForecast ? (
+      {durableReceiptHeroAvailable(data) ? (
         <section className="mx-3 mb-3 rounded-md border border-edge/50 bg-panel2/20 px-3 py-2.5">
           <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">
             <div className="min-w-0">

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -9,7 +9,7 @@ import CostBreakdown, {
   listPriceValueTotal,
   usageToCostBreakdownData,
 } from "./CostBreakdown";
-import EconomicsDurable from "./EconomicsDurable";
+import EconomicsDurable, { durableReceiptHeroAvailable } from "./EconomicsDurable";
 
 type EconomicsPaneScope = Exclude<EconomicsScope, "window30">;
 
@@ -166,6 +166,8 @@ export default function EconomicsPane() {
       || listPriceValueTotal(processMeters) > 0
     ),
   );
+  const durableHero = economicsMatchesSelection && durableReceiptHeroAvailable(economics);
+  const processHero = scope === "conversation" && !durableHero;
   return (
     <div className="flex flex-col h-full overflow-hidden bg-transparent">
       <div className="shrink-0 flex items-center px-3 py-2 border-b border-[var(--shell-panel-border)] select-none">
@@ -212,7 +214,7 @@ export default function EconomicsPane() {
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto">
         {showProcessMeters && processMeters ? (
-          <CostBreakdown data={processMeters} />
+          <CostBreakdown data={processMeters} hero={processHero} />
         ) : null}
         {economicsMatchesSelection ? (
           <EconomicsDurable


### PR DESCRIPTION
## Summary
- Economics now shows one 4-stat spend hero. Scoped job receipts own it; this-open process meters stay as Why you saved rows.
- The process Spend grid only fills an empty This session, so This repo / All time no longer stacks a second conflicting card.
- Bump Marionette to v0.9.400.

## Test plan
- [x] Failing-before: `Without savings` still present with both `/api/usage` and `/api/economics` payloads
- [x] `npx vitest run src/__tests__/EconomicsPane.test.tsx src/__tests__/CostBreakdown.test.tsx src/__tests__/StatusBar.test.tsx` (55 passed)
- [x] `npx vitest run` (145 files, 1605 passed)
- [x] `npm run test:electron`
- [x] `.venv/bin/python -m pytest -q` (5581 passed, 78 skipped; one `test_ergonomics_session_compact` timeout flake, passed on rerun)
- [x] Independent review `job_c8eed75ca1b8` (cursor/grok-4-6 xhigh+fast)