### PR TITLE
feat: Goal Mode continue/complete/blocked (v0.9.401)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.400, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.401, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.400"
+__version__ = "0.9.401"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/goal_mode.py
+++ b/harness/goal_mode.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+"""Outer-loop Goal Mode: continue / complete / blocked around a fixed policy.
+
+Semantic acceptance is separate from resource caps. No LLM judge.
+"""
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional, Sequence
+
+from .swarm_run_facts import NOT_VERIFIED, VERIFIED
+
+
+class GoalVerdict(str, Enum):
+    CONTINUE = "continue"
+    COMPLETE = "complete"
+    BLOCKED = "blocked"
+
+
+GOAL_MODE_SOURCE = "swarm_criteria"
+GOAL_CONTINUE_PREFIX = "[goal-mode]"
+
+
+@dataclass(frozen=True)
+class GoalAssessment:
+    verdict: GoalVerdict
+    reason: str
+    sources: tuple[str, ...] = ()
+
+
+def goal_mode_continue_cap() -> int:
+    try:
+        return int(os.environ.get("HARNESS_GOAL_MODE_CONTINUE_MAX", "2"))
+    except ValueError:
+        return 2
+
+
+def assess_swarm_goal(facts: Any) -> GoalAssessment:
+    if facts is None:
+        return GoalAssessment(
+            GoalVerdict.COMPLETE, "no acceptance criteria", (),
+        )
+    criteria = tuple(getattr(facts, "criteria", None) or ())
+    if not criteria:
+        return GoalAssessment(
+            GoalVerdict.COMPLETE, "no acceptance criteria", (),
+        )
+    unverified = []
+    for item in criteria:
+        status = str(getattr(item, "status", "") or "").strip().lower()
+        if status == NOT_VERIFIED:
+            text = str(getattr(item, "text", "") or "").strip()
+            unverified.append(text or status)
+    if unverified:
+        return GoalAssessment(
+            GoalVerdict.CONTINUE,
+            "; ".join(unverified),
+            (GOAL_MODE_SOURCE,),
+        )
+    if all(
+        str(getattr(item, "status", "") or "").strip().lower() == VERIFIED
+        for item in criteria
+    ):
+        return GoalAssessment(
+            GoalVerdict.COMPLETE,
+            "acceptance criteria verified",
+            (GOAL_MODE_SOURCE,),
+        )
+    return GoalAssessment(
+        GoalVerdict.COMPLETE, "no acceptance criteria", (),
+    )
+
+
+def assess_turn_swarm_goals(facts_list: Optional[Sequence[Any]] = None) -> GoalAssessment:
+    rows = list(facts_list or ())
+    if not rows:
+        return GoalAssessment(
+            GoalVerdict.COMPLETE, "no acceptance criteria", (),
+        )
+    continue_reasons = []
+    saw_verified_criteria = False
+    for facts in rows:
+        assessment = assess_swarm_goal(facts)
+        if assessment.verdict == GoalVerdict.CONTINUE:
+            if assessment.reason:
+                continue_reasons.append(assessment.reason)
+        elif GOAL_MODE_SOURCE in assessment.sources:
+            saw_verified_criteria = True
+    if continue_reasons:
+        return GoalAssessment(
+            GoalVerdict.CONTINUE,
+            "; ".join(continue_reasons),
+            (GOAL_MODE_SOURCE,),
+        )
+    if saw_verified_criteria:
+        return GoalAssessment(
+            GoalVerdict.COMPLETE,
+            "acceptance criteria verified",
+            (GOAL_MODE_SOURCE,),
+        )
+    return GoalAssessment(
+        GoalVerdict.COMPLETE, "no acceptance criteria", (),
+    )
+
+
+def assess_session_goal_continuation(
+    *,
+    goal_active: bool,
+    budget_exceeded: bool,
+    gate_blocks_idle: bool,
+    swarm_assessment: GoalAssessment,
+) -> GoalAssessment:
+    """Whether sticky-goal auto-continue may enqueue after assistant_done."""
+    if not goal_active:
+        return GoalAssessment(
+            GoalVerdict.COMPLETE, "session goal inactive", (),
+        )
+    if budget_exceeded:
+        return GoalAssessment(
+            GoalVerdict.BLOCKED, "token_budget", ("cap",),
+        )
+    if gate_blocks_idle:
+        return GoalAssessment(
+            GoalVerdict.BLOCKED, "quality_gate", ("quality_gate",),
+        )
+    if swarm_assessment.verdict == GoalVerdict.CONTINUE:
+        return GoalAssessment(
+            GoalVerdict.CONTINUE,
+            swarm_assessment.reason,
+            swarm_assessment.sources or (GOAL_MODE_SOURCE,),
+        )
+    if (
+        swarm_assessment.verdict == GoalVerdict.COMPLETE
+        and GOAL_MODE_SOURCE in swarm_assessment.sources
+    ):
+        return GoalAssessment(
+            GoalVerdict.COMPLETE,
+            swarm_assessment.reason or "acceptance criteria verified",
+            swarm_assessment.sources,
+        )
+    return GoalAssessment(
+        GoalVerdict.CONTINUE, "legacy session-goal drain", (),
+    )
+
+
+def reset_turn_goal_state(session: Any) -> int:
+    """Clear per-turn Goal Mode state. Returns the continue cap."""
+    try:
+        session._turn_swarm_facts = []
+        session._goal_mode_skip_continue = False
+    except Exception:
+        pass
+    return goal_mode_continue_cap()
+
+
+def maybe_inject_goal_continue(session: Any, *, iters: int, cap: int) -> bool:
+    """Append a continue note when a prose-only step would otherwise finalize."""
+    note = goal_continue_note(session, iters=iters, cap=cap)
+    if not note:
+        return False
+    try:
+        session._history.append({"role": "user", "content": note})
+    except Exception:
+        return False
+    return True
+
+
+def stash_turn_swarm_facts(
+    session: Any,
+    facts: Any,
+    *,
+    skip_continue: bool = False,
+) -> None:
+    """Best-effort stash; never raises onto the send path."""
+    try:
+        prior = list(getattr(session, "_turn_swarm_facts", None) or [])
+        prior.append(facts)
+        session._turn_swarm_facts = prior
+        if skip_continue:
+            session._goal_mode_skip_continue = True
+    except Exception:
+        pass
+
+
+def goal_continue_note(
+    session: Any,
+    *,
+    iters: int,
+    cap: int,
+) -> Optional[str]:
+    """User-role inject when a prose-only step would otherwise finalize."""
+    if iters >= cap:
+        return None
+    if bool(getattr(session, "_goal_mode_skip_continue", False)):
+        return None
+    assessment = assess_turn_swarm_goals(
+        getattr(session, "_turn_swarm_facts", None) or [],
+    )
+    if assessment.verdict != GoalVerdict.CONTINUE:
+        return None
+    reason = assessment.reason or "unverified acceptance criteria"
+    return (
+        f"{GOAL_CONTINUE_PREFIX} Acceptance criteria are not verified:\n"
+        f"{reason}\n"
+        "Keep working toward those criteria. "
+        "Do not re-dispatch an identical swarm."
+    )
+
+
+def maybe_enqueue_session_goal_continuation(
+    session: Any,
+    *,
+    gate_blocks_idle: bool,
+) -> Optional[GoalAssessment]:
+    """Enqueue sticky-goal continuation only on CONTINUE. Never raises."""
+    try:
+        if not bool(getattr(session.config, "goal_auto_continue", False)):
+            return None
+        goal = getattr(session, "_session_goal", None)
+        assessment = assess_session_goal_continuation(
+            goal_active=bool(goal is not None and goal.is_active()),
+            budget_exceeded=bool(
+                getattr(goal, "budget_exceeded", False)
+            ) if goal is not None else False,
+            gate_blocks_idle=bool(gate_blocks_idle),
+            swarm_assessment=assess_turn_swarm_goals(
+                getattr(session, "_turn_swarm_facts", None) or [],
+            ),
+        )
+        if (
+            assessment.verdict == GoalVerdict.CONTINUE
+            and hasattr(session, "enqueue_goal_continuation")
+        ):
+            session.enqueue_goal_continuation()
+        return assessment
+    except Exception:
+        return None

--- a/harness/goal_mode.py
+++ b/harness/goal_mode.py
@@ -178,7 +178,10 @@ def stash_turn_swarm_facts(
         prior = list(getattr(session, "_turn_swarm_facts", None) or [])
         prior.append(facts)
         session._turn_swarm_facts = prior
-        if skip_continue:
+        # Any continueable swarm in the turn wins over a prior skip-class row.
+        if not skip_continue:
+            session._goal_mode_skip_continue = False
+        elif getattr(session, "_goal_mode_skip_continue", None) is not False:
             session._goal_mode_skip_continue = True
     except Exception:
         pass

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -92,6 +92,11 @@ from .send_loop_secrets import (
     iter_secret_action_turn,
     peel_secret_request_message,
 )
+from .goal_mode import (
+    maybe_enqueue_session_goal_continuation,
+    maybe_inject_goal_continue,
+    reset_turn_goal_state,
+)
 
 
 POST_SWARM_SYNTHESIS_NUDGE = (
@@ -800,16 +805,9 @@ class SendLoopMixin:
                                         ),
                                         "reason": "token_budget",
                                     })
-                                auto_continue = bool(
-                                    getattr(self.config, "goal_auto_continue", False)
+                                maybe_enqueue_session_goal_continuation(
+                                    self, gate_blocks_idle=gate_blocks_idle,
                                 )
-                                if (
-                                    auto_continue
-                                    and not gate_blocks_idle
-                                    and not getattr(goal, "budget_exceeded", False)
-                                    and hasattr(self, "enqueue_goal_continuation")
-                                ):
-                                    self.enqueue_goal_continuation()
                         except Exception:
                             pass
                         try:
@@ -1116,6 +1114,11 @@ class SendLoopMixin:
             _auto_verify_cap = int(os.environ.get("HARNESS_AUTO_VERIFY_MAX", "2"))
         except ValueError:
             _auto_verify_cap = 2
+        try:
+            _goal_mode_cap = reset_turn_goal_state(self)
+        except Exception:
+            _goal_mode_cap = 2
+        goal_mode_iters = 0
         # Step ceiling per user message, read LIVE from the env each turn so a
         # Settings change applies without a restart. 0 (or negative) means
         # UNLIMITED -- true autopilot: loop until the pilot is done, the budget
@@ -1570,6 +1573,16 @@ class SendLoopMixin:
                         "role": "assistant",
                         "text": fallback,
                     })
+                if synthesis_decision == "none":
+                    try:
+                        _did_goal = maybe_inject_goal_continue(
+                            self, iters=goal_mode_iters, cap=_goal_mode_cap,
+                        )
+                    except Exception:
+                        _did_goal = False
+                    if _did_goal:
+                        goal_mode_iters += 1
+                        continue
                 disposition, user_message = yield from drain_idle_turn(
                     self,
                     user_message=user_message,

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -1557,6 +1557,17 @@ class SendLoopMixin:
                     })
                     continue
 
+                if synthesis_decision in ("none", "fallback"):
+                    try:
+                        _did_goal = maybe_inject_goal_continue(
+                            self, iters=goal_mode_iters, cap=_goal_mode_cap,
+                        )
+                    except Exception:
+                        _did_goal = False
+                    if _did_goal:
+                        goal_mode_iters += 1
+                        continue
+
                 if synthesis_decision == "fallback":
                     fallback = POST_SWARM_SYNTHESIS_FALLBACK
                     if self._history and self._history[-1].get("role") == "assistant":
@@ -1573,16 +1584,6 @@ class SendLoopMixin:
                         "role": "assistant",
                         "text": fallback,
                     })
-                if synthesis_decision == "none":
-                    try:
-                        _did_goal = maybe_inject_goal_continue(
-                            self, iters=goal_mode_iters, cap=_goal_mode_cap,
-                        )
-                    except Exception:
-                        _did_goal = False
-                    if _did_goal:
-                        goal_mode_iters += 1
-                        continue
                 disposition, user_message = yield from drain_idle_turn(
                     self,
                     user_message=user_message,

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -26,6 +26,7 @@ from .swarm_run_facts import (
     normalize_execution_refs,
     render_evidence_boundary,
 )
+from .goal_mode import stash_turn_swarm_facts
 
 DISPATCH_ACTION_KINDS: frozenset[str] = frozenset({
     "run_swarm", "run_implement", "run_parallel", "route_task", "memory",
@@ -1195,14 +1196,25 @@ Yields the same ConvEvent stream. Generator return value is ``None``
     elif not _substantive:
         stall = '\n(THIN SWARM FINDINGS — the findings above are generic one-liners with no file-backed evidence, a known failure mode when the goal is too long/multi-part for the workers. Do NOT present these as a completed audit. Re-dispatch narrowed workers with tight single-domain objectives.)' + stall
     _pilot_via = 'refused demo substrate' if _demo_refused else f'via {_ui_adapter}'
-    evidence_boundary = render_evidence_boundary(build_swarm_run_facts(
+    swarm_facts = build_swarm_run_facts(
         job_id=_job_id_text,
         job_status=str(getattr(result, 'status', '') or ''),
         subject_cwd=_swarm_repo,
         state_root=getattr(session, 'state_dir', '') or '',
         artifacts=_all_arts,
         acceptance_criteria=_finish_criteria,
-    ))
+    )
+    evidence_boundary = render_evidence_boundary(swarm_facts)
+    try:
+        stash_turn_swarm_facts(
+            session,
+            swarm_facts,
+            skip_continue=bool(
+                _demo_refused or auth_failure or _ntc_note or (not _has_signal)
+            ),
+        )
+    except Exception:
+        pass
     _follow = (
         'Synthesize the available PM evidence. Artifact discovery is complete '
         'above; do not gather the result set with additional tools or rerun the swarm.'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.400"
+version = "0.9.401"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_goal_mode.py
+++ b/tests/test_goal_mode.py
@@ -134,6 +134,21 @@ def test_goal_continue_note_and_skip_flag():
     assert goal_continue_note(session, iters=0, cap=2) is None
 
 
+def test_stash_continueable_swarm_clears_skip_latch():
+    session = SimpleNamespace()
+    stash_turn_swarm_facts(
+        session, _facts(_criterion("demo", NOT_VERIFIED)), skip_continue=True,
+    )
+    assert session._goal_mode_skip_continue is True
+    stash_turn_swarm_facts(
+        session, _facts(_criterion("windows", NOT_VERIFIED)), skip_continue=False,
+    )
+    assert session._goal_mode_skip_continue is False
+    note = goal_continue_note(session, iters=0, cap=2)
+    assert note is not None
+    assert "windows" in note
+
+
 def test_stash_turn_swarm_facts_appends_and_skip():
     session = SimpleNamespace()
     facts = _facts(_criterion("x", NOT_VERIFIED))

--- a/tests/test_goal_mode.py
+++ b/tests/test_goal_mode.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from harness.goal_mode import (
+    GOAL_CONTINUE_PREFIX,
+    GOAL_MODE_SOURCE,
+    GoalVerdict,
+    assess_session_goal_continuation,
+    assess_swarm_goal,
+    assess_turn_swarm_goals,
+    goal_continue_note,
+    maybe_enqueue_session_goal_continuation,
+    stash_turn_swarm_facts,
+)
+from harness.session_goal import SessionGoal
+from harness.swarm_run_facts import NOT_VERIFIED, VERIFIED, CriterionFact, SwarmRunFacts
+
+
+def _facts(*criteria: CriterionFact) -> SwarmRunFacts:
+    return SwarmRunFacts(
+        job_id="job_test",
+        job_status="complete",
+        subject_cwd="/tmp/repo",
+        state_root="/tmp/state",
+        marionette_version="0.9.400",
+        puppetmaster_version="1.22.43",
+        artifact_total=1,
+        artifact_type_counts={"finding": 1},
+        non_routing_total=1,
+        direct_provenance_total=1,
+        criteria=criteria,
+    )
+
+
+def _criterion(text: str, status: str) -> CriterionFact:
+    return CriterionFact(text=text, status=status, basis="test")
+
+
+def test_assess_swarm_goal_empty_and_none():
+    empty = assess_swarm_goal(_facts())
+    assert empty.verdict == GoalVerdict.COMPLETE
+    assert empty.sources == ()
+    none = assess_swarm_goal(None)
+    assert none.verdict == GoalVerdict.COMPLETE
+    assert none.sources == ()
+
+
+def test_assess_swarm_goal_all_verified():
+    assessment = assess_swarm_goal(_facts(
+        _criterion("tests pass", VERIFIED),
+        _criterion("diff exists", VERIFIED),
+    ))
+    assert assessment.verdict == GoalVerdict.COMPLETE
+    assert GOAL_MODE_SOURCE in assessment.sources
+
+
+def test_assess_swarm_goal_mixed_not_verified():
+    assessment = assess_swarm_goal(_facts(
+        _criterion("tests pass", VERIFIED),
+        _criterion("windows path containment", NOT_VERIFIED),
+    ))
+    assert assessment.verdict == GoalVerdict.CONTINUE
+    assert "windows path containment" in assessment.reason
+    assert GOAL_MODE_SOURCE in assessment.sources
+
+
+def test_assess_turn_swarm_goals_any_continue_wins():
+    assessment = assess_turn_swarm_goals([
+        _facts(_criterion("a", VERIFIED)),
+        _facts(_criterion("b", NOT_VERIFIED)),
+    ])
+    assert assessment.verdict == GoalVerdict.CONTINUE
+    assert "b" in assessment.reason
+
+
+def test_session_goal_legacy_drain_without_swarm_sources():
+    assessment = assess_session_goal_continuation(
+        goal_active=True,
+        budget_exceeded=False,
+        gate_blocks_idle=False,
+        swarm_assessment=assess_swarm_goal(_facts()),
+    )
+    assert assessment.verdict == GoalVerdict.CONTINUE
+    assert assessment.sources == ()
+
+
+def test_session_goal_skips_enqueue_when_criteria_verified():
+    assessment = assess_session_goal_continuation(
+        goal_active=True,
+        budget_exceeded=False,
+        gate_blocks_idle=False,
+        swarm_assessment=assess_swarm_goal(_facts(_criterion("tests", VERIFIED))),
+    )
+    assert assessment.verdict == GoalVerdict.COMPLETE
+    assert GOAL_MODE_SOURCE in assessment.sources
+
+
+def test_session_goal_blocked_on_budget_and_gate():
+    budget = assess_session_goal_continuation(
+        goal_active=True,
+        budget_exceeded=True,
+        gate_blocks_idle=False,
+        swarm_assessment=assess_swarm_goal(_facts()),
+    )
+    assert budget.verdict == GoalVerdict.BLOCKED
+    gate = assess_session_goal_continuation(
+        goal_active=True,
+        budget_exceeded=False,
+        gate_blocks_idle=True,
+        swarm_assessment=assess_swarm_goal(_facts()),
+    )
+    assert gate.verdict == GoalVerdict.BLOCKED
+    idle = assess_session_goal_continuation(
+        goal_active=False,
+        budget_exceeded=False,
+        gate_blocks_idle=False,
+        swarm_assessment=assess_swarm_goal(_facts()),
+    )
+    assert idle.verdict == GoalVerdict.COMPLETE
+
+
+def test_goal_continue_note_and_skip_flag():
+    session = SimpleNamespace(
+        _turn_swarm_facts=[_facts(_criterion("windows", NOT_VERIFIED))],
+        _goal_mode_skip_continue=False,
+    )
+    note = goal_continue_note(session, iters=0, cap=2)
+    assert note is not None
+    assert note.startswith(GOAL_CONTINUE_PREFIX)
+    assert "windows" in note
+    assert goal_continue_note(session, iters=2, cap=2) is None
+    session._goal_mode_skip_continue = True
+    assert goal_continue_note(session, iters=0, cap=2) is None
+
+
+def test_stash_turn_swarm_facts_appends_and_skip():
+    session = SimpleNamespace()
+    facts = _facts(_criterion("x", NOT_VERIFIED))
+    stash_turn_swarm_facts(session, facts, skip_continue=True)
+    assert session._turn_swarm_facts == [facts]
+    assert session._goal_mode_skip_continue is True
+
+
+def test_maybe_enqueue_verified_criteria_does_not_enqueue():
+    session = SimpleNamespace(
+        config=SimpleNamespace(goal_auto_continue=True),
+        _session_goal=SessionGoal().set("Ship it"),
+        _turn_swarm_facts=[_facts(_criterion("tests", VERIFIED))],
+        enqueued=0,
+    )
+
+    def _enqueue():
+        session.enqueued += 1
+        return {}
+
+    session.enqueue_goal_continuation = _enqueue
+    maybe_enqueue_session_goal_continuation(session, gate_blocks_idle=False)
+    assert session.enqueued == 0
+
+
+def test_maybe_enqueue_empty_facts_still_drains():
+    session = SimpleNamespace(
+        config=SimpleNamespace(goal_auto_continue=True),
+        _session_goal=SessionGoal().set("Ship it"),
+        _turn_swarm_facts=[],
+        enqueued=0,
+    )
+
+    def _enqueue():
+        session.enqueued += 1
+        return {}
+
+    session.enqueue_goal_continuation = _enqueue
+    maybe_enqueue_session_goal_continuation(session, gate_blocks_idle=False)
+    assert session.enqueued == 1

--- a/tests/test_post_swarm_synthesis.py
+++ b/tests/test_post_swarm_synthesis.py
@@ -434,3 +434,33 @@ def test_prose_after_unverified_criteria_continues_once(monkeypatch):
     ]
     assert "Done." in texts
     assert "Still working." in texts
+
+
+def test_empty_synthesis_unverified_criteria_continues_instead_of_fallback(monkeypatch):
+    monkeypatch.setenv("HARNESS_GOAL_MODE_CONTINUE_MAX", "1")
+    pilot = _SequencePilot([
+        _pilot_envelope(actions=[{"kind": "run_swarm", "goal": "audit findings"}]),
+        _pilot_envelope(),
+        _pilot_envelope(),
+        _pilot_envelope(say="Still working."),
+    ])
+
+    session, events = _run_post_swarm_turn(
+        monkeypatch, pilot, execute_actions=_fake_execute_unverified_criteria,
+    )
+
+    notes = [
+        message["content"]
+        for message in session._history
+        if GOAL_CONTINUE_PREFIX in str(message.get("content") or "")
+    ]
+    assert len(notes) == 1
+    texts = [
+        event.data["text"]
+        for event in events
+        if event.kind == "message"
+    ]
+    assert POST_SWARM_SYNTHESIS_FALLBACK not in texts
+    assert "Still working." in texts
+    assert len(pilot.calls) == 4
+    assert events[-1].kind == "assistant_done"

--- a/tests/test_post_swarm_synthesis.py
+++ b/tests/test_post_swarm_synthesis.py
@@ -10,9 +10,15 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import harness.send_loop as send_loop
 from harness.config import HarnessConfig
 from harness.conversation import ConvEvent, ConversationalSession
+from harness.goal_mode import GOAL_CONTINUE_PREFIX, stash_turn_swarm_facts
 from harness.send_loop import (
     POST_SWARM_SYNTHESIS_FALLBACK,
     POST_SWARM_SYNTHESIS_NUDGE,
+)
+from harness.swarm_run_facts import (
+    NOT_VERIFIED,
+    CriterionFact,
+    SwarmRunFacts,
 )
 from pmharness.drivers.base import DriverResponse
 
@@ -354,3 +360,77 @@ def test_successful_post_swarm_synthesis_emits_one_message_before_done(monkeypat
     assert events[message_indexes[0]].data["text"] == "The audit found one issue."
     assert len(pilot.calls) == 2
     assert pilot.calls[1]["kwargs"]["tools"] == [{"name": "run_swarm"}]
+
+
+def _fake_execute_unverified_criteria(
+    session: ConversationalSession,
+    *,
+    turn: Any,
+    counters: dict[str, int],
+    turn_findings: list,
+    **_: Any,
+):
+    if not turn.actions:
+        return (None, [])
+    assert [action.kind for action in turn.actions] == ["run_swarm"]
+    counters["swarms"] += 1
+    counters["synchronous_swarms"] = counters.get("synchronous_swarms", 0) + 1
+    turn_findings.append({"kind": "finding", "headline": "one completed finding"})
+    session._history.append({
+        "role": "user",
+        "content": "[swarm result] one completed finding",
+    })
+    stash_turn_swarm_facts(
+        session,
+        SwarmRunFacts(
+            job_id="job_unverified",
+            job_status="complete",
+            subject_cwd="/tmp/repo",
+            state_root="/tmp/state",
+            marionette_version="0.9.400",
+            puppetmaster_version="1.22.43",
+            artifact_total=1,
+            artifact_type_counts={"finding": 1},
+            non_routing_total=1,
+            direct_provenance_total=1,
+            criteria=(
+                CriterionFact(
+                    text="windows path containment",
+                    status=NOT_VERIFIED,
+                    basis="test",
+                ),
+            ),
+        ),
+    )
+    yield ConvEvent("swarm_result", {"findings": 1})
+    return (None, [])
+
+
+def test_prose_after_unverified_criteria_continues_once(monkeypatch):
+    monkeypatch.setenv("HARNESS_GOAL_MODE_CONTINUE_MAX", "1")
+    pilot = _SequencePilot([
+        _pilot_envelope(actions=[{"kind": "run_swarm", "goal": "audit findings"}]),
+        _pilot_envelope(say="Done."),
+        _pilot_envelope(say="Still working."),
+    ])
+
+    session, events = _run_post_swarm_turn(
+        monkeypatch, pilot, execute_actions=_fake_execute_unverified_criteria,
+    )
+
+    notes = [
+        message["content"]
+        for message in session._history
+        if GOAL_CONTINUE_PREFIX in str(message.get("content") or "")
+    ]
+    assert len(notes) == 1
+    assert "windows path containment" in notes[0]
+    assert len(pilot.calls) == 3
+    assert events[-1].kind == "assistant_done"
+    texts = [
+        event.data["text"]
+        for event in events
+        if event.kind == "message"
+    ]
+    assert "Done." in texts
+    assert "Still working." in texts

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.400",
+  "version": "0.9.401",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.400",
+      "version": "0.9.401",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.400",
+  "version": "0.9.401",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Why

A synchronous swarm whose acceptance criteria stay `not_verified` could still finalize after pilot prose, and a sticky session goal kept draining after those criteria were already verified. Goal Mode is the outer loop around the existing pilot policy so semantic acceptance is separate from step budget, stagnation, and quality_gate.

## Scope

- New `harness/goal_mode.py`: `GoalVerdict` continue / complete / blocked; stash this-turn `SwarmRunFacts`; continue cap `HARNESS_GOAL_MODE_CONTINUE_MAX` (default 2).
- `send_loop_dispatch` stashes facts after `build_swarm_run_facts`. Skip-class (demo / auth / no_tool_calls / plumbing-only) does not continue; a later continueable swarm clears that latch.
- `send_loop` injects a `[goal-mode]` note instead of `assistant_done` when criteria are unverified, including silent synthesis fallback. Verified session goals skip `enqueue_goal_continuation`; empty criteria still legacy-drain.
- Version bump 0.9.400 -> 0.9.401 (pyproject, harness, webapp package + lock, README).

Not in this PR: LSP, Rails, Swarm Flow DSL, LLM-as-judge, enabling quality_gate by default.

## Tradeoffs

Kept Goal Verdict as a small outer type instead of a new `DeliveryMode.GOAL`. Continue after fallback skips the user-facing synthesis fallback when criteria are still unverified, so the transcript does not claim the swarm finished.

## Blast radius

Send-loop finalize and sticky session-goal enqueue only. Economics UI untouched. All new call sites are best-effort on the chat hot path.

## Verification

- `PYTHONPATH=<worktree> .venv/bin/python -m pytest tests -q` — 5594 passed, 78 skipped.
- After the review fixes: `tests/test_goal_mode.py`, `tests/test_post_swarm_synthesis.py`, `tests/test_send_loop_residual.py`, `tests/test_session_goal.py` — 29 passed (`_send_locked_inner` stayed under the 700-line fence).
- Cursor review `job_127edb3974e7` (cursor/grok-4-6, effort xhigh, fast) verdict was fix-before-ship; both FINDINGs are in this branch.