### PR TITLE
Release v0.9.402

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.401, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.402, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.401"
+__version__ = "0.9.402"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/api/session_control.py
+++ b/harness/api/session_control.py
@@ -13,6 +13,20 @@ import tempfile as _tf
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
+from ..delivery_mode import apply_delivery, normalize_delivery_mode, realized_steer_action
+from ..session_actions import (
+    ActionKind,
+    SessionActionIllegalTransition,
+    SessionActionStore,
+    normalize_turn_input_mode,
+)
+from ..session_loop import (
+    SessionLoopError,
+    session_loop_snapshot,
+    start_session_loop,
+    stop_session_loop,
+)
+
 
 @dataclass
 class SessionControlServices:
@@ -477,6 +491,60 @@ def post_session_goal(body: dict, svc: SessionControlServices) -> tuple[int, Jso
     return 200, {"ok": True, "goal": goal}
 
 
+def get_session_loop(svc: SessionControlServices) -> tuple[int, JsonPayload]:
+    """GET /api/session/loop — in-session interval/self-paced loop, not cron."""
+    pilot, err = _goal_pilot(svc)
+    if err is not None:
+        return err
+    return 200, {"ok": True, "loop": session_loop_snapshot(pilot)}
+
+
+def post_session_loop(body: dict, svc: SessionControlServices) -> tuple[int, JsonPayload]:
+    """POST /api/session/loop — start / stop. Distinct from /api/session/goal."""
+    pilot, err = _goal_pilot(svc)
+    if err is not None:
+        return err
+    action = str(body.get("action") or "start").strip().lower()
+    try:
+        if action == "stop":
+            loop = stop_session_loop(pilot)
+        elif action == "start":
+            interval = body.get("interval_seconds")
+            if interval in ("", None):
+                interval_seconds = None
+            else:
+                try:
+                    interval_seconds = float(interval)
+                except (TypeError, ValueError):
+                    return 400, {
+                        "ok": False,
+                        "error": "interval_seconds must be a number",
+                    }
+            raw_until = body.get("until")
+            if raw_until in ("", None):
+                until = None
+            else:
+                try:
+                    until = float(raw_until)
+                except (TypeError, ValueError):
+                    return 400, {
+                        "ok": False,
+                        "error": "until must be a unix timestamp",
+                    }
+            loop = start_session_loop(
+                pilot,
+                body.get("mode"),
+                (body.get("prompt") or body.get("text") or ""),
+                interval_seconds=interval_seconds,
+                until=until,
+            )
+        else:
+            return 400, {"ok": False, "error": "unknown action"}
+    except SessionLoopError as exc:
+        return 400, {"ok": False, "error": str(exc), "code": exc.code}
+    return 200, {"ok": True, "loop": loop.to_dict()}
+
+
 def post_session_todo(body: dict, svc: SessionControlServices) -> tuple[int, JsonPayload]:
     """POST /api/session/todo — local /todo slash (view/export/import/mutate)."""
     pilot, err = _goal_pilot(svc)
@@ -646,6 +714,42 @@ def post_session_rewind_restore(svc: SessionControlServices) -> tuple[int, JsonP
     return 200, result
 
 
+def _pilot_turn_busy(pilot: Any) -> bool:
+    try:
+        if hasattr(pilot, "is_turn_busy"):
+            return bool(pilot.is_turn_busy())
+    except Exception:
+        return False
+    return False
+
+
+def _optional_expected_turn_id(body: dict) -> Optional[str]:
+    raw = body.get("expected_turn_id")
+    if raw in (None, ""):
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def _pilot_action_store(pilot: Any) -> Optional[SessionActionStore]:
+    store = getattr(pilot, "_session_actions", None)
+    if isinstance(store, SessionActionStore):
+        return store
+    getter = getattr(pilot, "_action_store", None)
+    if callable(getter):
+        got = getter()
+        if isinstance(got, SessionActionStore):
+            return got
+    return None
+
+
+def _is_recover_turn(body: dict) -> bool:
+    if body.get("recover") is True:
+        return True
+    kind = str(body.get("kind") or "").strip().lower()
+    return kind == "recover"
+
+
 def post_session_steer(body: dict, svc: SessionControlServices) -> tuple[int, JsonPayload]:
     """POST /api/session/steer."""
     text = (body.get("text") or "").strip()
@@ -665,28 +769,97 @@ def post_session_steer(body: dict, svc: SessionControlServices) -> tuple[int, Js
     valid_imgs, err = _validate_upload_images(images, svc.upload_dir)
     if err is not None:
         return err
+
+    turn_input_mode = body.get("turn_input_mode")
+    normalized_turn_mode = None
+    if turn_input_mode not in (None, ""):
+        normalized_turn_mode = normalize_turn_input_mode(turn_input_mode)
+        if normalized_turn_mode is None:
+            return 400, {"ok": False, "error": "invalid turn_input_mode"}
+    expected_turn_id = _optional_expected_turn_id(body)
+    # RecoverTurn is admit(kind=recover) on this same endpoint — not a new UI.
+    if _is_recover_turn(body):
+        try:
+            if hasattr(pilot, "admit_session_action"):
+                action = pilot.admit_session_action(
+                    ActionKind.RECOVER,
+                    text,
+                    images=valid_imgs,
+                    expected_turn_id=expected_turn_id,
+                )
+            else:
+                store = _pilot_action_store(pilot)
+                if store is None:
+                    return 400, {
+                        "ok": False,
+                        "error": "session lacks action store",
+                        "code": "missing_action_store",
+                    }
+                action = store.admit(
+                    ActionKind.RECOVER,
+                    text,
+                    images=valid_imgs,
+                    expected_turn_id=expected_turn_id,
+                )
+        except SessionActionIllegalTransition as exc:
+            return 400, {"ok": False, "error": str(exc), "code": exc.code}
+        return 200, {
+            "ok": True,
+            "action": "recover",
+            "kind": action.kind.value,
+        }
     # Optional delivery_mode: when set, route via shared DeliveryMode resolver.
     delivery_mode = body.get("delivery_mode")
     if delivery_mode:
-        from ..delivery_mode import apply_delivery, normalize_delivery_mode
-
         if normalize_delivery_mode(delivery_mode) is None:
             return 400, {"ok": False, "error": "invalid delivery_mode"}
-        busy = False
-        try:
-            busy = bool(pilot.is_turn_busy()) if hasattr(pilot, "is_turn_busy") else False
-        except Exception:
-            busy = False
+        busy = _pilot_turn_busy(pilot)
         result = apply_delivery(
             pilot, text, session_busy=busy, requested=delivery_mode, images=valid_imgs,
         )
         code = 200 if result.get("ok") else 400
         return code, result
+    if normalized_turn_mode is not None:
+        busy = _pilot_turn_busy(pilot)
+        try:
+            store = _pilot_action_store(pilot)
+            if store is None:
+                return 400, {
+                    "ok": False,
+                    "error": "session lacks action store",
+                    "code": "missing_action_store",
+                }
+            action = store.admit_turn_input(
+                text,
+                normalized_turn_mode,
+                expected_turn_id=expected_turn_id,
+                idle=not busy,
+                images=valid_imgs,
+            )
+        except SessionActionIllegalTransition as exc:
+            return 400, {"ok": False, "error": str(exc), "code": exc.code}
+        result = {
+            "ok": True,
+            "action": action.kind.value,
+            "kind": action.kind.value,
+            "turn_input_mode": normalized_turn_mode,
+        }
+        if action.kind is ActionKind.START and hasattr(pilot, "enqueue_prompt"):
+            result["item"] = pilot.enqueue_prompt(text, images=valid_imgs)
+            if not busy:
+                result["deferred"] = True
+        return 200, result
     if valid_imgs and hasattr(pilot, "steer_with_images"):
-        from ..delivery_mode import realized_steer_action
-
         actual = realized_steer_action(pilot.steer_with_images(text, valid_imgs))
         return 200, {"ok": True, "action": actual}
+    if expected_turn_id is not None and hasattr(pilot, "enqueue_steer"):
+        try:
+            pilot.enqueue_steer(text, expected_turn_id=expected_turn_id)
+        except TypeError:
+            pilot.enqueue_steer(text)
+        except SessionActionIllegalTransition as exc:
+            return 400, {"ok": False, "error": str(exc), "code": exc.code}
+        return 200, {"ok": True, "action": "enqueue_steer"}
     pilot.enqueue_steer(text)
     return 200, {"ok": True, "action": "enqueue_steer"}
 
@@ -725,8 +898,6 @@ def post_session_queue(body: dict, svc: SessionControlServices) -> tuple[int, Js
         return err
     delivery_mode = body.get("delivery_mode")
     if delivery_mode:
-        from ..delivery_mode import apply_delivery, normalize_delivery_mode
-
         if normalize_delivery_mode(delivery_mode) is None:
             return 400, {"ok": False, "error": "invalid delivery_mode"}
         busy = False

--- a/harness/compaction_mixin.py
+++ b/harness/compaction_mixin.py
@@ -20,6 +20,7 @@ import os
 import re
 import threading
 import time
+import uuid
 from typing import Iterator, Optional
 
 from .context_budget import age_history_images
@@ -73,6 +74,22 @@ REASON_SUMMARY_REJECTED = "summary_rejected"
 REASON_THRASH_COOLDOWN = "thrash_cooldown"
 REASON_CACHE_DEFERRED = "cache_deferred"
 REASON_RESIDUAL_OFF = "residual_off"
+REASON_WATERMARK_FENCE = "watermark_fence"
+
+
+def _active_message_id(message, index: int) -> int:
+    """Index, or explicit integer ``id`` when a history row carries one."""
+    if isinstance(message, dict):
+        raw = message.get("id")
+        if raw is not None and str(raw).strip() != "":
+            try:
+                return int(raw)
+            except (TypeError, ValueError):
+                pass
+    try:
+        return int(index)
+    except (TypeError, ValueError):
+        return 0
 
 
 def neutralize_compaction_control_tokens(text: str) -> str:
@@ -375,6 +392,130 @@ class CompactionContextMixin:
             pass
         return savings_pct, int(getattr(self, "_compaction_ineffective_count", 0) or 0)
 
+    def get_active_message_watermark(self) -> int:
+        """MAX index/id of messages still on the live ``_history``.
+
+        Captured at compact start so a concurrent tail (messages that land
+        after this watermark) can stay on the live list while residual/vault
+        elide the middle.
+        """
+        history = getattr(self, "_history", None) or []
+        max_id = -1
+        for i, msg in enumerate(history):
+            candidate = _active_message_id(msg, i)
+            if candidate > max_id:
+                max_id = candidate
+        return max_id if max_id >= 0 else 0
+
+    def mark_commit_watermark_fenced(self, watermark: int) -> None:
+        """Hold compact-commit admission at this watermark.
+
+        A turn-hold can keep commit admission while compact clones the tail
+        (messages after ``watermark`` stay on the live list). A proposed
+        rewrite that would drop that tail is refused.
+        """
+        try:
+            self._commit_watermark_fence = int(watermark)
+        except (TypeError, ValueError):
+            self._commit_watermark_fence = 0
+
+    def _clone_concurrent_tail(self, watermark: int) -> list:
+        """Live messages whose index/id is after ``watermark``."""
+        history = getattr(self, "_history", None) or []
+        tail = []
+        try:
+            fence = int(watermark)
+        except (TypeError, ValueError):
+            fence = 0
+        for i, msg in enumerate(history):
+            if _active_message_id(msg, i) > fence:
+                tail.append(msg)
+        return tail
+
+    def _admit_compact_commit(self, proposed_history) -> bool:
+        """False when a watermark fence would drop the live concurrent tail."""
+        fence = getattr(self, "_commit_watermark_fence", None)
+        if fence is None:
+            return True
+        try:
+            wm = int(fence)
+        except (TypeError, ValueError):
+            return True
+        history = getattr(self, "_history", None) or []
+        proposed_ids = {id(m) for m in (proposed_history or [])}
+        for i, msg in enumerate(history):
+            if _active_message_id(msg, i) <= wm:
+                continue
+            if id(msg) not in proposed_ids:
+                return False
+        return True
+
+    def _plan_compacted_history(
+        self,
+        summary_msg: dict,
+        recent_block: list,
+        start_watermark: int,
+    ):
+        """Build the rewrite list (residual + live tail) or None if fenced."""
+        concurrent_tail = self._clone_concurrent_tail(start_watermark)
+        recent_ids = {id(m) for m in (recent_block or [])}
+        extra = [m for m in concurrent_tail if id(m) not in recent_ids]
+        history = getattr(self, "_history", None) or []
+        system = history[0] if history else {"role": "system", "content": ""}
+        proposed = [system, summary_msg] + list(recent_block or []) + extra
+        if not self._admit_compact_commit(proposed):
+            return None
+        return proposed
+
+    def _prompt_cache_prefix_name(self) -> str:
+        """Builder-declared stable prefix on the live system message, if any."""
+        try:
+            from harness.prompt_cache_scope import find_stable_prefix
+
+            history = getattr(self, "_history", None) or []
+            if not history:
+                return ""
+            first = history[0]
+            content = first.get("content") if isinstance(first, dict) else ""
+            name = find_stable_prefix(str(content or ""))
+            return name or ""
+        except Exception:
+            return ""
+
+    def _prompt_cache_conversation_key(self) -> str:
+        """Rotation-stable conversation identity. Never ``harness_session_id``."""
+        base = ""
+        for attr in ("conversation_key", "_conversation_key", "_compression_lineage_root"):
+            raw = getattr(self, attr, None)
+            if raw is not None and str(raw).strip():
+                base = str(raw).strip()
+                break
+        if not base:
+            minted = uuid.uuid4().hex
+            try:
+                self._compression_lineage_root = minted
+            except Exception:
+                pass
+            base = minted
+        prefix = self._prompt_cache_prefix_name()
+        if prefix:
+            return "%s|%s" % (base, prefix)
+        return base
+
+    def _attach_prompt_cache_scope(self, fields: dict) -> None:
+        """Add ``prompt_cache_scope`` to an existing usage/peek dict."""
+        try:
+            from harness.prompt_cache_scope import prompt_cache_scope
+
+            key = self._prompt_cache_conversation_key()
+            if key:
+                fields["prompt_cache_scope"] = prompt_cache_scope(key)
+            name = self._prompt_cache_prefix_name()
+            if name:
+                fields["prompt_cache_prefix"] = name
+        except Exception:
+            pass
+
     def _advertised_compaction_generation(self) -> int:
         """Generation peek_history will see after this compact is journaled."""
         try:
@@ -479,15 +620,17 @@ class CompactionContextMixin:
         try:
             from harness.history_compaction_journal import history_compaction_payload
 
-            return history_compaction_payload(
+            fields = history_compaction_payload(
                 self.state_dir,
                 self.harness_session_id or "default",
             )
         except Exception:
-            return {
+            fields = {
                 "history_compactions": 0,
                 "history_tokens_saved": 0,
             }
+        self._attach_prompt_cache_scope(fields)
+        return fields
 
     def _format_block_for_summary(self, messages: list[dict]) -> str:
         lines = []
@@ -1057,6 +1200,12 @@ class CompactionContextMixin:
         except Exception:
             pass
 
+        start_watermark = self.get_active_message_watermark()
+        try:
+            self._compaction_start_watermark = start_watermark
+        except Exception:
+            pass
+
         yield ConvEvent("compacting", {"message": "Summarizing chat context"})
 
         # Pre-prune the middle block (cheap, pre-LLM). Large middles get a
@@ -1380,6 +1529,30 @@ class CompactionContextMixin:
         chars_before = sum(len(str(m.get("content") or "")) for m in middle_block)
         chars_after = len(summary_msg["content"])
 
+        proposed = self._plan_compacted_history(
+            summary_msg, recent_block, start_watermark,
+        )
+        if proposed is None:
+            _pct, _strikes = self._note_compaction_effectiveness(
+                before_tokens=before_tokens,
+                after_tokens=before_tokens,
+            )
+            self._set_compaction_attempt(
+                REASON_WATERMARK_FENCE,
+                before_tokens=before_tokens,
+                start_watermark=start_watermark,
+                thrash_strikes=_strikes,
+            )
+            yield ConvEvent("compaction", {
+                "before_tokens": before_tokens,
+                "after_tokens": before_tokens,
+                "summarized_messages": 0,
+                "aborted": True,
+                "reason": REASON_WATERMARK_FENCE,
+                "thrash_strikes": _strikes,
+            })
+            return
+
         # Persist the elided middle before the rewrite so peek_history can
         # still address those rows after residual transcript persist. Fail
         # closed: archive I/O must not block or crash Compact Now.
@@ -1394,7 +1567,7 @@ class CompactionContextMixin:
         except Exception:
             pass
 
-        self._history[:] = [self._history[0], summary_msg] + recent_block
+        self._history[:] = proposed
         # Compaction replaces the middle with a summary; new length usually
         # differs but not guaranteed (a tiny middle replaced by a summary_msg
         # could land at the same length). Explicitly invalidate.

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -68,6 +68,8 @@ from .tool_dispatch import (
     is_safe_path,
 )
 from .prompt_queue import PromptQueueMixin
+from .session_actions import SessionActionStore, SteerQueueView
+from .session_loop import SessionLoop
 from .steer_mixin import SteerMixin
 from .adapter_resolve import AdapterResolveMixin
 from .compaction_mixin import CompactionContextMixin
@@ -779,8 +781,9 @@ class ConversationalSession(
         from .tool_discovery import ToolCatalog
         self._tool_catalog = ToolCatalog()
         self._checkpoints = CheckpointStore(config.repo)
-        import collections
-        self._steer_queue = collections.deque()
+        self._session_actions = SessionActionStore()
+        self._steer_queue = SteerQueueView(self._session_actions)
+        self._loop_state = SessionLoop()
         self._steer_lock = threading.Lock()
         self._steer_pending = False
         # Set by drop_queued_steers / interrupt; flushed as ConvEvent("notice")

--- a/harness/delivery_mode.py
+++ b/harness/delivery_mode.py
@@ -7,7 +7,15 @@ Actions: run_auto | enqueue_steer | enqueue_prompt | interrupt_then_queue
 """
 
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Sequence, Tuple
+
+from .session_actions import (
+    ActionKind,
+    DeliveryPolicy,
+    SessionActionIllegalTransition,
+    SessionActionStore,
+    WakePolicy,
+)
 
 
 class DeliveryMode(str, Enum):
@@ -52,6 +60,77 @@ def _try_interrupt_session(session: Any) -> bool:
                 pass
             return True
     return False
+
+
+def delivery_mode_action_kinds(requested: Optional[str]) -> Tuple[ActionKind, ...]:
+    """Map HTTP DeliveryMode onto SessionAction kinds (domain vocabulary)."""
+    mode = normalize_delivery_mode(requested)
+    if mode == DeliveryMode.STEER.value:
+        return (ActionKind.STEER,)
+    if mode == DeliveryMode.FOLLOW_UP.value:
+        return (ActionKind.MAILBOX,)
+    if mode == DeliveryMode.INTERRUPT.value:
+        return (ActionKind.REDIRECT, ActionKind.MAILBOX)
+    return ()
+
+
+def _session_action_store(session: Any) -> Optional[SessionActionStore]:
+    store = getattr(session, "_session_actions", None)
+    if isinstance(store, SessionActionStore):
+        return store
+    return None
+
+
+def _steer_text_already_admitted(session: Any, text: str) -> bool:
+    store = _session_action_store(session)
+    if store is None:
+        return False
+    cleaned = (text or "").strip()
+    for action in store:
+        if action.kind is ActionKind.STEER and action.text == cleaned:
+            return True
+    return False
+
+
+def _admit_delivery_kinds(
+    session: Any,
+    kinds: Sequence[ActionKind],
+    text: str,
+    images: Optional[list] = None,
+) -> None:
+    """Record domain actions. Never raises into the HTTP result path."""
+    if not kinds:
+        return
+    admit = getattr(session, "admit_session_action", None)
+    store = _session_action_store(session)
+    if not callable(admit) and store is None:
+        return
+    cleaned = (text or "").strip()
+    imgs = list(images or [])
+    for kind in kinds:
+        kwargs = {}
+        payload = cleaned
+        if kind is ActionKind.REDIRECT:
+            payload = ""
+            kwargs["delivery"] = DeliveryPolicy.NEXT_TURN_BOUNDARY
+            kwargs["wake"] = WakePolicy.ON_ADMIT
+        elif kind is ActionKind.MAILBOX:
+            kwargs["delivery"] = DeliveryPolicy.WHEN_RUN_IDLE
+            kwargs["wake"] = WakePolicy.ON_IDLE
+        elif kind is ActionKind.STEER:
+            kwargs["delivery"] = DeliveryPolicy.NEXT_TURN_BOUNDARY
+            kwargs["wake"] = WakePolicy.NONE
+        if imgs:
+            kwargs["images"] = imgs
+        try:
+            if callable(admit):
+                admit(kind, payload, **kwargs)
+            elif store is not None:
+                store.admit(kind, payload, **kwargs)
+        except SessionActionIllegalTransition:
+            return
+        except Exception:
+            return
 
 
 def realized_steer_action(result: Any) -> str:
@@ -110,6 +189,10 @@ def apply_delivery(
             session.enqueue_steer(cleaned)
         else:
             return {"ok": False, "error": "session lacks enqueue_steer", "action": action}
+        if not _steer_text_already_admitted(session, cleaned):
+            _admit_delivery_kinds(
+                session, delivery_mode_action_kinds(requested), cleaned, imgs,
+            )
         return {"ok": True, "action": action}
     if action == DeliveryAction.ENQUEUE_PROMPT.value:
         if not cleaned:
@@ -117,6 +200,9 @@ def apply_delivery(
         if not hasattr(session, "enqueue_prompt"):
             return {"ok": False, "error": "session lacks enqueue_prompt", "action": action}
         item = session.enqueue_prompt(cleaned, images=imgs)
+        _admit_delivery_kinds(
+            session, delivery_mode_action_kinds(requested), cleaned, imgs,
+        )
         return {"ok": True, "action": action, "item": item}
     if action == DeliveryAction.INTERRUPT_THEN_QUEUE.value:
         if not cleaned:
@@ -126,6 +212,11 @@ def apply_delivery(
             interrupted = _try_interrupt_session(session)
         if not hasattr(session, "enqueue_prompt"):
             return {"ok": False, "error": "session lacks enqueue_prompt", "action": action}
+        # Domain: redirect, then mailbox the text. HTTP still uses the existing
+        # interrupt hook + prompt playlist (no second interrupt path).
+        _admit_delivery_kinds(
+            session, delivery_mode_action_kinds(requested), cleaned, imgs,
+        )
         item = session.enqueue_prompt(cleaned, images=imgs)
         result: dict = {"ok": True, "action": action, "item": item}
         if interrupted:

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -290,6 +290,8 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
             services=svc.session_control_services),
         "/api/session/goal": post_json(
             _sc_api.post_session_goal, services=svc.session_control_services),
+        "/api/session/loop": post_json(
+            _sc_api.post_session_loop, services=svc.session_control_services),
         "/api/session/todo": post_json(
             _sc_api.post_session_todo, services=svc.session_control_services),
         "/api/refine": post_json(
@@ -691,6 +693,8 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         "/api/session/events": _get_session_events,
         "/api/session/goal": get_json(
             _sc_api.get_session_goal, services=svc.session_control_services),
+        "/api/session/loop": get_json(
+            _sc_api.get_session_loop, services=svc.session_control_services),
         "/api/refine/history": get_json(
             _skills_api.get_refine_history, services=svc.skills_services),
         "/api/session/context_at": _get_session_context_at,

--- a/harness/plugin_capabilities.py
+++ b/harness/plugin_capabilities.py
@@ -1,0 +1,63 @@
+"""Plugin capability ids and consent hashes (defaults OFF).
+
+Known ids are a tiny allowlist. Unknown ids fail closed — they are never
+implicitly granted and ``parse_requested_capabilities`` raises.
+The default requested set is empty (no capabilities) until a plugin
+declares them and the user consents.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, FrozenSet, Iterable, Mapping
+
+from .agent_plugins import AgentPluginError
+
+# Privilege-style ids only. Unknown ids fail closed (see parse).
+KNOWN_CAPABILITY_IDS = frozenset({"fs", "mcp", "browser", "shell"})
+
+
+def capability_set_hash(ids: Iterable[str]) -> str:
+    """Return sha256 hex of the sorted unique capability ids."""
+    unique = sorted(set(ids))
+    hasher = hashlib.sha256()
+    for item in unique:
+        hasher.update(item.encode("utf-8"))
+        hasher.update(b"\0")
+    return hasher.hexdigest()
+
+
+def parse_requested_capabilities(raw: Any) -> FrozenSet[str]:
+    """Parse a requested capability list. ``None`` / empty → OFF.
+
+    Raises :class:`AgentPluginError` on unknown ids or a non-list payload.
+    """
+    if raw is None:
+        return frozenset()
+    if isinstance(raw, str) or not isinstance(raw, (list, tuple, set, frozenset)):
+        raise AgentPluginError("requested capabilities must be a list of ids")
+    parsed = []
+    for item in raw:
+        if not isinstance(item, str) or not item.strip():
+            raise AgentPluginError("requested capabilities must be a list of ids")
+        cap = item.strip()
+        if cap not in KNOWN_CAPABILITY_IDS:
+            raise AgentPluginError(f"unknown capability id: {cap}")
+        parsed.append(cap)
+    return frozenset(parsed)
+
+
+def requested_capabilities_from_manifest(manifest: Mapping[str, Any]) -> FrozenSet[str]:
+    """Read requested ids from ``extensions.marionette.requested_capabilities``.
+
+    Missing or empty → default OFF. Unknown ids fail closed.
+    """
+    extensions = manifest.get("extensions")
+    if not isinstance(extensions, dict):
+        return frozenset()
+    marionette = extensions.get("marionette")
+    if not isinstance(marionette, dict):
+        return frozenset()
+    if "requested_capabilities" not in marionette:
+        return frozenset()
+    return parse_requested_capabilities(marionette.get("requested_capabilities"))

--- a/harness/plugin_registry.py
+++ b/harness/plugin_registry.py
@@ -17,7 +17,7 @@ import tempfile
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from .agent_plugins import (
     STAMP_FILENAME,
@@ -27,6 +27,11 @@ from .agent_plugins import (
     compute_package_sha256,
     load_agent_plugin,
     read_agent_plugin_manifest,
+)
+from .plugin_capabilities import (
+    capability_set_hash,
+    parse_requested_capabilities,
+    requested_capabilities_from_manifest,
 )
 from .plugin_source_urls import (
     ResolvedPluginSource,
@@ -38,6 +43,7 @@ from .secure_files import restrict_to_owner
 from .diag import note as _diag
 
 _ENABLED_FILENAME = "enabled.json"
+_CAPABILITIES_FILENAME = "capabilities.json"
 _INSTALL_ID_RE = re.compile(r"^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
 _lock = threading.RLock()
 
@@ -138,13 +144,127 @@ def _read_enabled() -> List[str]:
     return out
 
 
+def _capabilities_path() -> Path:
+    return plugins_dir() / _CAPABILITIES_FILENAME
+
+
+def _read_capability_records() -> Dict[str, Dict[str, Any]]:
+    path = _capabilities_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    raw = data.get("plugins", data)
+    if not isinstance(raw, dict):
+        return {}
+    out: Dict[str, Dict[str, Any]] = {}
+    for key, value in raw.items():
+        if isinstance(key, str) and key.strip() and isinstance(value, dict):
+            out[key.strip()] = value
+    return out
+
+
+def _write_capability_records(records: Dict[str, Dict[str, Any]]) -> None:
+    root = plugins_dir()
+    root.mkdir(parents=True, exist_ok=True)
+    path = _capabilities_path()
+    payload = {"plugins": dict(records)}
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(root), prefix="capabilities_")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+        os.replace(tmp_path, str(path))
+        if not restrict_to_owner(str(path)):
+            _diag("secure_files.restrict_failed", msg=str(path))
+    except Exception:
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+        raise
+
+
+def _stored_capability_set(entry: Mapping[str, Any], key: str) -> frozenset:
+    try:
+        return parse_requested_capabilities(entry.get(key))
+    except AgentPluginError:
+        return frozenset()
+
+
+def _capability_entry(
+    requested: frozenset, consented: frozenset
+) -> Dict[str, Any]:
+    return {
+        "requested": sorted(requested),
+        "requested_hash": capability_set_hash(requested),
+        "consented": sorted(consented),
+        "consented_hash": capability_set_hash(consented),
+    }
+
+
+def _upsert_capability_entry(
+    plugin_id: str,
+    *,
+    requested: frozenset,
+    consented: Optional[frozenset] = None,
+    reset_consent: bool = False,
+) -> Dict[str, Any]:
+    records = _read_capability_records()
+    current = records.get(plugin_id) or {}
+    if reset_consent:
+        consented_set: frozenset = frozenset()
+    elif consented is not None:
+        consented_set = consented
+    else:
+        consented_set = _stored_capability_set(current, "consented")
+    entry = _capability_entry(requested, consented_set)
+    records[plugin_id] = entry
+    _write_capability_records(records)
+    return entry
+
+
+def _require_capability_consent(plugin_id: str, requested: frozenset) -> None:
+    """Fail closed when any requested id is outside the consented set."""
+    if not requested:
+        return
+    current = _read_capability_records().get(plugin_id) or {}
+    consented = _stored_capability_set(current, "consented")
+    missing = requested - consented
+    if missing:
+        raise AgentPluginError(
+            "plugin capability consent required for: " + ", ".join(sorted(missing))
+        )
+
+
+def _capability_snapshot(
+    plugin_id: str,
+    manifest: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    stored = _read_capability_records().get(plugin_id) or {}
+    if manifest is not None:
+        requested = requested_capabilities_from_manifest(manifest)
+    else:
+        requested = _stored_capability_set(stored, "requested")
+    consented = _stored_capability_set(stored, "consented")
+    return {
+        "requested_capabilities": sorted(requested),
+        "capability_set_hash": capability_set_hash(requested),
+        "consented_capabilities": sorted(consented),
+        "consented_hash": capability_set_hash(consented),
+    }
+
+
 def _write_enabled(enabled: List[str]) -> None:
     root = plugins_dir()
     root.mkdir(parents=True, exist_ok=True)
     path = _enabled_path()
     payload = {"enabled": list(enabled)}
-    import tempfile
-
     tmp_fd, tmp_path = tempfile.mkstemp(dir=str(root), prefix="enabled_")
     try:
         with os.fdopen(tmp_fd, "w", encoding="utf-8", newline="\n") as handle:
@@ -199,6 +319,10 @@ class PluginRecord:
     content_sha256: str = ""
     sha256: str = ""
     stamp_ok: bool = False
+    requested_capabilities: List[str] = field(default_factory=list)
+    capability_set_hash: str = ""
+    consented_capabilities: List[str] = field(default_factory=list)
+    consented_hash: str = ""
     diagnostics: List[Dict[str, str]] = field(default_factory=list)
     error: str = ""
 
@@ -223,6 +347,7 @@ def _record_from_package(
     diagnostics = list(_diag_dicts(package.diagnostics))
     diagnostics.extend(_diag_dicts(extra_diagnostics))
     sha256 = digest or package.content_sha256
+    caps = _capability_snapshot(plugin_id, package.manifest)
     return PluginRecord(
         id=plugin_id,
         name=package.name,
@@ -237,6 +362,10 @@ def _record_from_package(
         content_sha256=sha256,
         sha256=sha256,
         stamp_ok=stamp_ok,
+        requested_capabilities=list(caps["requested_capabilities"]),
+        capability_set_hash=str(caps["capability_set_hash"]),
+        consented_capabilities=list(caps["consented_capabilities"]),
+        consented_hash=str(caps["consented_hash"]),
         diagnostics=diagnostics,
         error=error,
     )
@@ -379,6 +508,7 @@ def _materialize_source(source: object, *, clone_fn=None) -> Tuple[Path, Optiona
 def _install_materialized(src: Path, *, force: bool = False) -> PluginRecord:
     staging_ns = portable_skill_namespace("_install_probe")
     package = load_agent_plugin(src, plugin_data_root() / staging_ns)
+    requested = requested_capabilities_from_manifest(package.manifest)
     install_id = _sanitize_install_id(package.name)
     dest = plugins_dir() / install_id
     with _lock:
@@ -394,6 +524,9 @@ def _install_materialized(src: Path, *, force: bool = False) -> PluginRecord:
         digest = write_integrity_stamp(dest)
         enabled = [x for x in _read_enabled() if x != install_id]
         _write_enabled(enabled)
+        _upsert_capability_entry(
+            install_id, requested=requested, reset_consent=True
+        )
     namespace = portable_skill_namespace(install_id)
     loaded = load_agent_plugin(dest, plugin_data_root() / namespace)
     digest = verify_integrity_stamp(dest)
@@ -433,13 +566,45 @@ def enable_plugin(plugin_id: str) -> PluginRecord:
     namespace = portable_skill_namespace(plugin_id)
     package = load_agent_plugin(path, plugin_data_root() / namespace)
     digest = verify_integrity_stamp(path)
+    requested = requested_capabilities_from_manifest(package.manifest)
     with _lock:
+        _upsert_capability_entry(plugin_id, requested=requested)
+        _require_capability_consent(plugin_id, requested)
         enabled = _read_enabled()
         if plugin_id not in enabled:
             enabled.append(plugin_id)
             _write_enabled(enabled)
     return _record_from_package(
         plugin_id, package, enabled=True, digest=digest, stamp_ok=True
+    )
+
+
+def consent_plugin_capabilities(plugin_id: str, ids: object) -> PluginRecord:
+    """Store an explicit consented capability set (hash, not the integrity stamp)."""
+    plugin_id = (plugin_id or "").strip()
+    if not plugin_id:
+        raise AgentPluginError("plugin id is required")
+    path = plugins_dir() / plugin_id
+    if not path.is_dir():
+        raise AgentPluginError(f"plugin not found: {plugin_id}")
+    namespace = portable_skill_namespace(plugin_id)
+    package = load_agent_plugin(path, plugin_data_root() / namespace)
+    requested = requested_capabilities_from_manifest(package.manifest)
+    consented = parse_requested_capabilities(ids)
+    with _lock:
+        _upsert_capability_entry(
+            plugin_id, requested=requested, consented=consented
+        )
+    enabled = plugin_id in set(_read_enabled())
+    digest = read_integrity_stamp(path) or package.content_sha256
+    stamp_ok = False
+    try:
+        digest = verify_integrity_stamp(path)
+        stamp_ok = True
+    except AgentPluginError:
+        pass
+    return _record_from_package(
+        plugin_id, package, enabled=enabled, digest=digest, stamp_ok=stamp_ok
     )
 
 
@@ -500,6 +665,10 @@ def _load_enabled_packages() -> List[Tuple[str, str, AgentPluginPackage]]:
         try:
             package = load_agent_plugin(path, plugin_data_root() / namespace)
             verify_integrity_stamp(path)
+            _require_capability_consent(
+                plugin_id,
+                requested_capabilities_from_manifest(package.manifest),
+            )
         except Exception as exc:
             _diag("agent_plugins.load_enabled", msg=f"{plugin_id}: {exc}")
             continue
@@ -583,6 +752,10 @@ def plugin_record_to_dict(record: PluginRecord) -> Dict[str, Any]:
         "content_sha256": record.content_sha256,
         "sha256": record.sha256,
         "stamp_ok": record.stamp_ok,
+        "requested_capabilities": list(record.requested_capabilities),
+        "capability_set_hash": record.capability_set_hash,
+        "consented_capabilities": list(record.consented_capabilities),
+        "consented_hash": record.consented_hash,
         "diagnostics": list(record.diagnostics),
         "error": record.error,
     }

--- a/harness/prompt_cache_scope.py
+++ b/harness/prompt_cache_scope.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Builder-declared prompt-cache watermarks and rotation-stable cache scope.
+
+Stdlib-only. ``prompt_cache_scope`` hashes a conversation identity /
+compression-lineage ROOT — never the physical ``session_id`` string.
+"""
+
+import hashlib
+from typing import Dict, Optional
+
+# name -> prefix text. Process-local; builders register at startup.
+_STABLE_PREFIXES: Dict[str, str] = {}
+
+
+def register_stable_prefix(name: str, text: str) -> None:
+    """Register a builder-declared stable prefix watermark.
+
+    Re-registering the same name replaces the previous text. Empty names
+    are ignored so a blank register cannot shadow real watermarks.
+    """
+    key = (name or "").strip()
+    if not key:
+        return
+    _STABLE_PREFIXES[key] = text if text is not None else ""
+
+
+def find_stable_prefix(text: str) -> Optional[str]:
+    """Return the registered prefix name if ``text`` starts with that prefix.
+
+    Longest matching prefix wins when more than one is registered.
+    """
+    blob = text if isinstance(text, str) else ""
+    if not blob or not _STABLE_PREFIXES:
+        return None
+    best_name = None
+    best_len = -1
+    for name, prefix in _STABLE_PREFIXES.items():
+        if not prefix:
+            continue
+        if blob.startswith(prefix) and len(prefix) > best_len:
+            best_name = name
+            best_len = len(prefix)
+    return best_name
+
+
+def prompt_cache_scope(conversation_key: str) -> str:
+    """Return sha256 hex of a rotation-stable conversation identity.
+
+    ``conversation_key`` is a hashed conversation identity or compression-
+    lineage ROOT. The digest never embeds a physical session id: callers
+    must not pass ``harness_session_id`` / ``session_id`` as the key.
+    """
+    raw = conversation_key if isinstance(conversation_key, str) else ""
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def clear_stable_prefixes() -> None:
+    """Drop all registered prefixes. Tests only."""
+    _STABLE_PREFIXES.clear()

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -2254,6 +2254,45 @@ def drain_idle_turn(
             session._history.append({"role": "user", "content": content})
         session._steer_pending = False
         return ("continue", user_message)
+    mailbox_texts = []
+    drain_mailbox = getattr(session, "drain_mailbox", None)
+    if callable(drain_mailbox):
+        try:
+            mailbox_texts = [
+                str(text).strip()
+                for text in (drain_mailbox() or [])
+                if str(text or "").strip()
+            ]
+        except Exception:
+            mailbox_texts = []
+    leftover_queued = None
+    if mailbox_texts:
+        seen = set(mailbox_texts)
+        while True:
+            if session._next_queued_needs_driver_swap():
+                leftover_queued = None
+                break
+            queued = session._pop_next_prompt() or {}
+            q_text = str(queued.get("text") or "").strip()
+            if not q_text:
+                leftover_queued = None
+                break
+            if q_text in seen:
+                continue
+            leftover_queued = queued
+            break
+        format_steer = getattr(session, "_format_steer_user_content", None)
+        for text in mailbox_texts:
+            yield ConvEvent("queued_prompt", {"id": "", "text": text, "images": []})
+            content = format_steer(text) if callable(format_steer) else text
+            session._history.append({"role": "user", "content": content})
+        if leftover_queued and leftover_queued.get("text"):
+            queued = leftover_queued
+        else:
+            session._steer_pending = False
+            return ("continue", mailbox_texts[-1])
+    else:
+        queued = None
     # Steer took priority above; only if no steer was pending do we
     # look at the PROMPT QUEUE ("playlist"). A queued prompt runs as
     # a genuine next-turn user message — same first-class user shape as
@@ -2265,9 +2304,20 @@ def drain_idle_turn(
     # (Hermes-style mid-turn picker change), stop this turn instead
     # of draining it under the wrong driver -- idle drain + deferred
     # swap will pick it up next.
-    if session._next_queued_needs_driver_swap():
-        return ("break", user_message)
-    queued = session._pop_next_prompt()
+    if not (queued and queued.get("text")):
+        if session._next_queued_needs_driver_swap():
+            return ("break", user_message)
+        queued = session._pop_next_prompt()
+    if not (queued and queued.get("text")):
+        from .session_loop import note_session_loop_response, tick_session_loop
+
+        try:
+            if turn_prose:
+                note_session_loop_response(session, turn_prose[-1])
+            tick_session_loop(session, idle=True)
+        except Exception:
+            pass
+        queued = session._pop_next_prompt()
     if queued and queued.get("text"):
         q_text = queued.get("text", "")
         q_images = [p for p in (queued.get("images") or []) if p]

--- a/harness/session_actions.py
+++ b/harness/session_actions.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+"""SessionActionStore — typed admission machine for mid-session user input.
+
+Domain vocabulary (ranks 1+2+7). DeliveryMode stays the HTTP/composer
+vocabulary; this store is what steer/mailbox/redirect/recover admit into.
+Stdlib dataclasses only. Snapshot/restore is JSON-safe.
+"""
+
+import json
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+class ActionKind(str, Enum):
+    START = "start"
+    STEER = "steer"
+    REDIRECT = "redirect"
+    MAILBOX = "mailbox"
+    RECOVER = "recover"
+
+
+class DeliveryPolicy(str, Enum):
+    NEXT_TURN_BOUNDARY = "next_turn_boundary"
+    WHEN_RUN_IDLE = "when_run_idle"
+
+
+class WakePolicy(str, Enum):
+    NONE = "none"
+    ON_ADMIT = "on_admit"
+    ON_IDLE = "on_idle"
+
+
+class TurnInputMode(str, Enum):
+    START_OR_STEER = "start_or_steer"
+    START_IF_IDLE = "start_if_idle"
+    STEER = "steer"
+
+
+class SessionActionIllegalTransition(Exception):
+    """Named illegal-transition error for admit/restore guards."""
+
+    def __init__(self, code: str, message: str = "") -> None:
+        self.code = str(code or "illegal_transition")
+        super().__init__(message or self.code)
+
+
+_KIND_DEFAULTS: Dict[ActionKind, Tuple[DeliveryPolicy, WakePolicy]] = {
+    ActionKind.START: (DeliveryPolicy.NEXT_TURN_BOUNDARY, WakePolicy.ON_ADMIT),
+    ActionKind.STEER: (DeliveryPolicy.NEXT_TURN_BOUNDARY, WakePolicy.NONE),
+    ActionKind.REDIRECT: (DeliveryPolicy.NEXT_TURN_BOUNDARY, WakePolicy.ON_ADMIT),
+    ActionKind.MAILBOX: (DeliveryPolicy.WHEN_RUN_IDLE, WakePolicy.ON_IDLE),
+    ActionKind.RECOVER: (DeliveryPolicy.NEXT_TURN_BOUNDARY, WakePolicy.ON_ADMIT),
+}
+
+_INJECTABLE_KINDS = (ActionKind.STEER, ActionKind.MAILBOX)
+
+
+def normalize_turn_input_mode(requested: Optional[str]) -> Optional[str]:
+    """Return a canonical TurnInputMode value, or None when unset/invalid."""
+    if requested is None:
+        return None
+    mode = str(requested).strip().lower().replace("-", "_")
+    if not mode:
+        return None
+    for item in TurnInputMode:
+        if item.value == mode:
+            return item.value
+    return None
+
+
+def _coerce_enum(value: Any, enum_cls: Any, *, field_name: str) -> Any:
+    if isinstance(value, enum_cls):
+        return value
+    raw = str(value or "").strip().lower().replace("-", "_")
+    for item in enum_cls:
+        if item.value == raw:
+            return item
+    raise SessionActionIllegalTransition(
+        "unknown_%s" % field_name,
+        "unknown %s: %s" % (field_name, value),
+    )
+
+
+def _json_images(images: Optional[Iterable[Any]]) -> List[str]:
+    out: List[str] = []
+    for item in images or []:
+        if item is None:
+            continue
+        text = str(item).strip()
+        if text:
+            out.append(text)
+    return out
+
+
+def _optional_turn_id(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+@dataclass
+class SessionAction:
+    id: str
+    kind: ActionKind
+    text: str
+    images: List[str] = field(default_factory=list)
+    delivery: DeliveryPolicy = DeliveryPolicy.NEXT_TURN_BOUNDARY
+    wake: WakePolicy = WakePolicy.NONE
+    expected_turn_id: Optional[str] = None
+    created_at: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": str(self.id),
+            "kind": self.kind.value,
+            "text": str(self.text),
+            "images": list(self.images),
+            "delivery": self.delivery.value,
+            "wake": self.wake.value,
+            "expected_turn_id": self.expected_turn_id,
+            "created_at": float(self.created_at),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "SessionAction":
+        if not isinstance(data, dict):
+            raise SessionActionIllegalTransition(
+                "invalid_snapshot", "action snapshot must be an object"
+            )
+        kind = _coerce_enum(data.get("kind"), ActionKind, field_name="kind")
+        delivery = data.get("delivery")
+        wake = data.get("wake")
+        if delivery in (None, ""):
+            delivery = _KIND_DEFAULTS[kind][0]
+        if wake in (None, ""):
+            wake = _KIND_DEFAULTS[kind][1]
+        created = data.get("created_at") or 0.0
+        try:
+            created_at = float(created)
+        except (TypeError, ValueError):
+            created_at = 0.0
+        return cls(
+            id=str(data.get("id") or ""),
+            kind=kind,
+            text=str(data.get("text") or ""),
+            images=_json_images(data.get("images")),
+            delivery=_coerce_enum(delivery, DeliveryPolicy, field_name="delivery"),
+            wake=_coerce_enum(wake, WakePolicy, field_name="wake"),
+            expected_turn_id=_optional_turn_id(data.get("expected_turn_id")),
+            created_at=created_at,
+        )
+
+
+class SessionActionStore:
+    """In-memory admission queue. Callers that share a session hold ``_steer_lock``."""
+
+    def __init__(self) -> None:
+        self._actions: List[SessionAction] = []
+        self._closed: bool = False
+        self._current_turn_id: Optional[str] = None
+
+    def __iter__(self):
+        return iter(self._actions)
+
+    def __len__(self) -> int:
+        return len(self._actions)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def current_turn_id(self) -> Optional[str]:
+        return self._current_turn_id
+
+    def set_current_turn_id(self, turn_id: Optional[str]) -> None:
+        self._current_turn_id = _optional_turn_id(turn_id)
+
+    def close(self) -> None:
+        self._closed = True
+
+    def clear(self) -> List[SessionAction]:
+        dropped = list(self._actions)
+        self._actions = []
+        return dropped
+
+    def admit(
+        self,
+        kind: Any,
+        text: str = "",
+        *,
+        images: Optional[Iterable[Any]] = None,
+        delivery: Optional[Any] = None,
+        wake: Optional[Any] = None,
+        expected_turn_id: Optional[str] = None,
+    ) -> SessionAction:
+        if self._closed:
+            raise SessionActionIllegalTransition(
+                "store_closed", "admit after closed"
+            )
+        resolved = _coerce_enum(kind, ActionKind, field_name="kind")
+        expected = _optional_turn_id(expected_turn_id)
+        if resolved is ActionKind.RECOVER and not expected:
+            raise SessionActionIllegalTransition(
+                "recover_requires_expected_turn_id",
+                "recover requires expected_turn_id",
+            )
+        if resolved is ActionKind.STEER and expected is not None:
+            current = self._current_turn_id
+            if current != expected:
+                raise SessionActionIllegalTransition(
+                    "steer_turn_mismatch",
+                    "steer expected_turn_id does not match current",
+                )
+        defaults = _KIND_DEFAULTS[resolved]
+        delivery_policy = (
+            defaults[0]
+            if delivery in (None, "")
+            else _coerce_enum(delivery, DeliveryPolicy, field_name="delivery")
+        )
+        wake_policy = (
+            defaults[1]
+            if wake in (None, "")
+            else _coerce_enum(wake, WakePolicy, field_name="wake")
+        )
+        action = SessionAction(
+            id=uuid.uuid4().hex,
+            kind=resolved,
+            text=str(text or ""),
+            images=_json_images(images),
+            delivery=delivery_policy,
+            wake=wake_policy,
+            expected_turn_id=expected,
+            created_at=time.time(),
+        )
+        if resolved is ActionKind.START and not self._current_turn_id:
+            self._current_turn_id = expected or action.id
+        self._actions.append(action)
+        return action
+
+    def admit_turn_input(
+        self,
+        text: str,
+        mode: Any,
+        *,
+        expected_turn_id: Optional[str] = None,
+        idle: bool = True,
+        images: Optional[Iterable[Any]] = None,
+        delivery: Optional[Any] = None,
+        wake: Optional[Any] = None,
+    ) -> SessionAction:
+        if isinstance(mode, TurnInputMode):
+            resolved_mode = mode
+        else:
+            normalized = normalize_turn_input_mode(mode if isinstance(mode, str) else None)
+            if normalized is None:
+                raise SessionActionIllegalTransition(
+                    "unknown_turn_input_mode",
+                    "unknown turn_input_mode: %s" % (mode,),
+                )
+            resolved_mode = TurnInputMode(normalized)
+        if resolved_mode is TurnInputMode.START_IF_IDLE:
+            if not idle:
+                raise SessionActionIllegalTransition(
+                    "start_if_idle_busy",
+                    "start_if_idle refused because a run is active",
+                )
+            kind = ActionKind.START
+        elif resolved_mode is TurnInputMode.START_OR_STEER:
+            kind = ActionKind.START if idle else ActionKind.STEER
+        else:
+            kind = ActionKind.STEER
+        return self.admit(
+            kind,
+            text,
+            images=images,
+            delivery=delivery,
+            wake=wake,
+            expected_turn_id=expected_turn_id,
+        )
+
+    def drain_ready(
+        self,
+        policy: Any,
+        *,
+        kinds: Optional[Sequence[Any]] = None,
+    ) -> List[SessionAction]:
+        delivery = _coerce_enum(policy, DeliveryPolicy, field_name="delivery")
+        kind_set = None
+        if kinds is not None:
+            kind_set = set(
+                _coerce_enum(item, ActionKind, field_name="kind") for item in kinds
+            )
+        ready: List[SessionAction] = []
+        kept: List[SessionAction] = []
+        for action in self._actions:
+            match_kind = kind_set is None or action.kind in kind_set
+            if match_kind and action.delivery is delivery:
+                ready.append(action)
+            else:
+                kept.append(action)
+        self._actions = kept
+        return ready
+
+    def requeue_front(self, actions: Sequence[SessionAction]) -> None:
+        """Put previously drained actions back at the front (inject defer)."""
+        if not actions:
+            return
+        self._actions = list(actions) + self._actions
+
+    def admit_front(
+        self,
+        kind: Any,
+        text: str = "",
+        **kwargs: Any,
+    ) -> SessionAction:
+        """Admit, then move that action to the front of the queue."""
+        action = self.admit(kind, text, **kwargs)
+        if self._actions and self._actions[-1] is action:
+            self._actions = [action] + self._actions[:-1]
+        return action
+
+    def append_action(self, action: SessionAction) -> None:
+        """Append an already-built action (legacy queue view / restore helpers)."""
+        self._actions.append(action)
+
+    def snapshot(self) -> Dict[str, Any]:
+        payload = {
+            "closed": bool(self._closed),
+            "current_turn_id": self._current_turn_id,
+            "actions": [action.to_dict() for action in self._actions],
+        }
+        # Fail closed: snapshot must be committible as JSON.
+        json.dumps(payload)
+        return payload
+
+    def restore(self, data: Optional[Dict[str, Any]]) -> None:
+        if data is None:
+            self._actions = []
+            self._closed = False
+            self._current_turn_id = None
+            return
+        if not isinstance(data, dict):
+            raise SessionActionIllegalTransition(
+                "invalid_snapshot", "store snapshot must be an object"
+            )
+        raw_actions = data.get("actions") or []
+        if not isinstance(raw_actions, list):
+            raise SessionActionIllegalTransition(
+                "invalid_snapshot", "actions must be a list"
+            )
+        restored = [SessionAction.from_dict(row) for row in raw_actions]
+        self._actions = restored
+        self._closed = bool(data.get("closed"))
+        self._current_turn_id = _optional_turn_id(data.get("current_turn_id"))
+
+
+def injectable_kinds() -> Tuple[ActionKind, ActionKind]:
+    return _INJECTABLE_KINDS
+
+
+class SteerQueueView:
+    """Text-facing deque-compatible view over a SessionActionStore.
+
+    Existing tests and late-enqueue race sites treat ``_steer_queue`` as
+    strings. The store stays the single queue of SessionAction objects.
+    """
+
+    def __init__(self, store: SessionActionStore) -> None:
+        self._store = store
+
+    def __iter__(self):
+        return (action.text for action in self._store)
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def __bool__(self) -> bool:
+        return len(self._store) > 0
+
+    def append(self, item: Any) -> None:
+        if isinstance(item, SessionAction):
+            self._store.append_action(item)
+            return
+        text = str(item or "").strip()
+        if not text:
+            return
+        self._store.admit(
+            ActionKind.STEER,
+            text,
+            delivery=DeliveryPolicy.NEXT_TURN_BOUNDARY,
+        )
+
+    def appendleft(self, item: Any) -> None:
+        if isinstance(item, SessionAction):
+            self._store.requeue_front([item])
+            return
+        text = str(item or "").strip()
+        if not text:
+            return
+        self._store.admit_front(
+            ActionKind.STEER,
+            text,
+            delivery=DeliveryPolicy.NEXT_TURN_BOUNDARY,
+        )
+
+    def clear(self) -> None:
+        self._store.clear()

--- a/harness/session_loop.py
+++ b/harness/session_loop.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+"""In-session /loop — interval or self-paced mailbox wakes.
+
+Distinct from host cron (Schedule) and from SessionGoal / Goal Mode.
+Uses SessionActionStore WakePolicy.on_idle. No TUI chrome.
+"""
+
+import hashlib
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from .session_actions import (
+    ActionKind,
+    DeliveryPolicy,
+    SessionAction,
+    SessionActionStore,
+    WakePolicy,
+)
+
+
+class LoopMode(str, Enum):
+    INTERVAL = "interval"
+    SELF_PACED = "self_paced"
+
+
+class SessionLoopError(Exception):
+    """Named illegal-loop error for start/tick guards."""
+
+    def __init__(self, code: str, message: str = "") -> None:
+        self.code = str(code or "illegal_loop")
+        super().__init__(message or self.code)
+
+
+def response_digest(text: str) -> str:
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def normalize_loop_mode(requested: Optional[str]) -> Optional[str]:
+    if requested is None:
+        return None
+    mode = str(requested).strip().lower().replace("-", "_")
+    if not mode:
+        return None
+    for item in LoopMode:
+        if item.value == mode:
+            return item.value
+    return None
+
+
+@dataclass
+class SessionLoop:
+    enabled: bool = False
+    mode: Optional[LoopMode] = None
+    prompt: str = ""
+    interval_seconds: Optional[float] = None
+    until: Optional[float] = None
+    started_at: float = 0.0
+    last_fired_at: Optional[float] = None
+    last_idle: Optional[bool] = None
+    last_response_digest: Optional[str] = None
+
+    def start(
+        self,
+        mode: Any,
+        prompt: str,
+        *,
+        interval_seconds: Optional[float] = None,
+        until: Optional[float] = None,
+        now: Optional[float] = None,
+    ) -> "SessionLoop":
+        if isinstance(mode, LoopMode):
+            resolved = mode
+        else:
+            normalized = normalize_loop_mode(mode if isinstance(mode, str) else None)
+            if normalized is None:
+                raise SessionLoopError(
+                    "unknown_loop_mode",
+                    "unknown loop mode: %s" % (mode,),
+                )
+            resolved = LoopMode(normalized)
+        cleaned = (prompt or "").strip()
+        if not cleaned:
+            raise SessionLoopError("missing_prompt", "loop prompt is required")
+        interval = None
+        if resolved is LoopMode.INTERVAL:
+            try:
+                interval = float(interval_seconds)
+            except (TypeError, ValueError):
+                raise SessionLoopError(
+                    "interval_requires_seconds",
+                    "interval loop requires interval_seconds",
+                )
+            if interval <= 0:
+                raise SessionLoopError(
+                    "interval_requires_seconds",
+                    "interval_seconds must be > 0",
+                )
+        deadline = None
+        if until not in (None, ""):
+            try:
+                deadline = float(until)
+            except (TypeError, ValueError):
+                raise SessionLoopError(
+                    "invalid_until",
+                    "until must be a unix timestamp",
+                )
+        stamp = time.time() if now is None else float(now)
+        self.enabled = True
+        self.mode = resolved
+        self.prompt = cleaned
+        self.interval_seconds = interval
+        self.until = deadline
+        self.started_at = stamp
+        self.last_fired_at = None
+        self.last_idle = None
+        self.last_response_digest = None
+        return self
+
+    def stop(self) -> "SessionLoop":
+        self.enabled = False
+        return self
+
+    def note_response(self, text: str) -> bool:
+        """Record the last assistant digest. Same digest stops the loop."""
+        if not self.enabled:
+            return False
+        digest = response_digest(text)
+        if self.last_response_digest and self.last_response_digest == digest:
+            self.stop()
+            return False
+        self.last_response_digest = digest
+        return True
+
+    def due(self, *, idle: bool, now: float) -> bool:
+        if not self.enabled or self.mode is None:
+            return False
+        if self.until is not None and now >= self.until:
+            self.stop()
+            return False
+        if not idle:
+            return False
+        if self.mode is LoopMode.SELF_PACED:
+            return self.last_idle is False or self.last_idle is None
+        if self.interval_seconds is None:
+            return False
+        anchor = (
+            self.last_fired_at
+            if self.last_fired_at is not None
+            else self.started_at
+        )
+        return (now - anchor) >= float(self.interval_seconds)
+
+    def mark_fired(self, now: float) -> None:
+        self.last_fired_at = float(now)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": bool(self.enabled),
+            "mode": None if self.mode is None else self.mode.value,
+            "prompt": str(self.prompt),
+            "interval_seconds": self.interval_seconds,
+            "until": self.until,
+            "started_at": float(self.started_at),
+            "last_fired_at": self.last_fired_at,
+            "last_response_digest": self.last_response_digest,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "SessionLoop":
+        loop = cls()
+        if not isinstance(data, dict):
+            return loop
+        mode = normalize_loop_mode(data.get("mode"))
+        loop.enabled = bool(data.get("enabled"))
+        loop.mode = LoopMode(mode) if mode else None
+        loop.prompt = str(data.get("prompt") or "")
+        raw_interval = data.get("interval_seconds")
+        if raw_interval in (None, ""):
+            loop.interval_seconds = None
+        else:
+            try:
+                loop.interval_seconds = float(raw_interval)
+            except (TypeError, ValueError):
+                loop.interval_seconds = None
+        raw_until = data.get("until")
+        if raw_until in (None, ""):
+            loop.until = None
+        else:
+            try:
+                loop.until = float(raw_until)
+            except (TypeError, ValueError):
+                loop.until = None
+        digest = data.get("last_response_digest")
+        loop.last_response_digest = (
+            str(digest) if digest not in (None, "") else None
+        )
+        try:
+            loop.started_at = float(data.get("started_at") or 0.0)
+        except (TypeError, ValueError):
+            loop.started_at = 0.0
+        raw_fired = data.get("last_fired_at")
+        if raw_fired in (None, ""):
+            loop.last_fired_at = None
+        else:
+            try:
+                loop.last_fired_at = float(raw_fired)
+            except (TypeError, ValueError):
+                loop.last_fired_at = None
+        return loop
+
+
+def session_loop_of(session: Any) -> SessionLoop:
+    loop = getattr(session, "_loop_state", None)
+    if isinstance(loop, SessionLoop):
+        return loop
+    loop = SessionLoop()
+    try:
+        session._loop_state = loop
+    except Exception:
+        pass
+    return loop
+
+
+def _action_store_of(session: Any) -> Optional[SessionActionStore]:
+    store = getattr(session, "_session_actions", None)
+    if isinstance(store, SessionActionStore):
+        return store
+    getter = getattr(session, "_action_store", None)
+    if callable(getter):
+        got = getter()
+        if isinstance(got, SessionActionStore):
+            return got
+    return None
+
+
+def start_session_loop(
+    session: Any,
+    mode: Any,
+    prompt: str,
+    *,
+    interval_seconds: Optional[float] = None,
+    until: Optional[float] = None,
+    now: Optional[float] = None,
+) -> SessionLoop:
+    return session_loop_of(session).start(
+        mode,
+        prompt,
+        interval_seconds=interval_seconds,
+        until=until,
+        now=now,
+    )
+
+
+def note_session_loop_response(session: Any, text: str) -> bool:
+    loop = getattr(session, "_loop_state", None)
+    if not isinstance(loop, SessionLoop):
+        return True
+    return loop.note_response(text)
+
+
+def stop_session_loop(session: Any) -> SessionLoop:
+    return session_loop_of(session).stop()
+
+
+def session_loop_snapshot(session: Any) -> Dict[str, Any]:
+    return session_loop_of(session).to_dict()
+
+
+def fire_session_loop(
+    loop: SessionLoop,
+    store: SessionActionStore,
+    *,
+    idle: bool,
+    now: float,
+    enqueue_prompt: Any = None,
+) -> Optional[SessionAction]:
+    """Admit a mailbox wake when due. Playlist enqueue is optional."""
+    should_fire = loop.due(idle=idle, now=now)
+    loop.last_idle = bool(idle)
+    if not should_fire:
+        return None
+    action = store.admit(
+        ActionKind.MAILBOX,
+        loop.prompt,
+        delivery=DeliveryPolicy.WHEN_RUN_IDLE,
+        wake=WakePolicy.ON_IDLE,
+    )
+    if callable(enqueue_prompt) and loop.prompt:
+        try:
+            enqueue_prompt(loop.prompt)
+        except Exception:
+            pass
+    loop.mark_fired(now)
+    return action
+
+
+def tick_session_loop(
+    session: Any,
+    *,
+    idle: bool,
+    now: Optional[float] = None,
+) -> bool:
+    """Fire a due loop into the session store (and prompt playlist when present)."""
+    loop = getattr(session, "_loop_state", None)
+    if not isinstance(loop, SessionLoop) or not loop.enabled:
+        return False
+    store = _action_store_of(session)
+    if store is None:
+        return False
+    stamp = time.time() if now is None else float(now)
+    enqueue = getattr(session, "enqueue_prompt", None)
+    action = fire_session_loop(
+        loop, store, idle=idle, now=stamp, enqueue_prompt=enqueue
+    )
+    return action is not None

--- a/harness/steer_mixin.py
+++ b/harness/steer_mixin.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 Extracted mechanically from harness/conversation.py to continue decomposing the
 ConversationalSession god-object, matching ToolDispatchMixin / PromptQueueMixin
-contract: these methods operate through `self` (``_steer_queue``, ``_steer_lock``,
-``_steer_pending``, ``_history``) provided by the concrete class -- the mixin
-defines no state and no __init__.
+contract: these methods operate through `self` (``_session_actions`` /
+``_steer_queue``, ``_steer_lock``, ``_steer_pending``, ``_history``)
+provided by the concrete class -- the mixin defines no state and no __init__.
+Pending mid-turn input is stored as SessionAction objects under ``_steer_lock``.
 
 Prompt-queue playlist CRUD stays on PromptQueueMixin. Busy lifecycle lives
 on BusyControlMixin; ``_send_locked_inner`` control flow lives on
@@ -17,7 +18,16 @@ enqueue_steer / drain_steer / _check_and_inject_steer still resolve via
 inheritance.
 """
 
-from typing import Iterator, Optional
+from typing import Iterator, List, Optional
+
+from .session_actions import (
+    ActionKind,
+    DeliveryPolicy,
+    SessionAction,
+    SessionActionStore,
+    SteerQueueView,
+    injectable_kinds,
+)
 
 
 class SteerMixin:
@@ -47,6 +57,40 @@ class SteerMixin:
             pass
         return False
 
+    def _action_store(self) -> SessionActionStore:
+        """Return the session admission store, installing one on minimal hosts."""
+        store = getattr(self, "_session_actions", None)
+        if not isinstance(store, SessionActionStore):
+            view = getattr(self, "_steer_queue", None)
+            if isinstance(view, SteerQueueView):
+                store = view._store
+            elif isinstance(view, SessionActionStore):
+                store = view
+            else:
+                store = SessionActionStore()
+                if view is not None:
+                    for item in list(view):
+                        text = (
+                            item.text
+                            if isinstance(item, SessionAction)
+                            else str(item or "").strip()
+                        )
+                        if text:
+                            store.admit(
+                                ActionKind.STEER,
+                                text,
+                                delivery=DeliveryPolicy.NEXT_TURN_BOUNDARY,
+                            )
+            self._session_actions = store
+        if not isinstance(getattr(self, "_steer_queue", None), SteerQueueView):
+            self._steer_queue = SteerQueueView(store)
+        return store
+
+    def admit_session_action(self, kind, text: str = "", **kwargs) -> SessionAction:
+        """Locked admit into the session store (HTTP RecoverTurn / turn input)."""
+        with self._steer_lock:
+            return self._action_store().admit(kind, text, **kwargs)
+
     def drop_queued_steers(self) -> list[str]:
         """Atomically discard pending steers and clear the mid-spree pending flag.
 
@@ -54,13 +98,12 @@ class SteerMixin:
         an abandoned generator or contaminate a later unrelated user send.
         """
         with self._steer_lock:
-            items = list(self._steer_queue)
-            self._steer_queue.clear()
+            dropped = self._action_store().clear()
         try:
             self._steer_pending = False
         except Exception:
             pass
-        return [item for item in items if str(item or "").strip()]
+        return [action.text for action in dropped if str(action.text or "").strip()]
 
     @staticmethod
     def _steer_drop_notice_text(dropped: list[str]) -> str:
@@ -191,9 +234,10 @@ class SteerMixin:
             # Fail closed under Stop hold if the lock is unreadable.
             return True
 
-    def enqueue_steer(self, text: str) -> None:
+    def enqueue_steer(self, text: str, *, expected_turn_id: Optional[str] = None) -> None:
         """Append a pending mid-turn user steer.
 
+        Thin adapter: admits ``kind=steer`` with ``delivery=next_turn_boundary``.
         While an abandoned generator still holds ``_busy`` after Stop, refuse
         to queue: a steer has nowhere truthful to go. Ready/idle sessions keep
         standard enqueue/drain even if ``_stop_holds_idle`` is still sticky for
@@ -206,14 +250,33 @@ class SteerMixin:
             self._record_steer_drop_notice([cleaned])
             return
         with self._steer_lock:
-            self._steer_queue.append(cleaned)
+            self._action_store().admit(
+                ActionKind.STEER,
+                cleaned,
+                delivery=DeliveryPolicy.NEXT_TURN_BOUNDARY,
+                expected_turn_id=expected_turn_id,
+            )
+
+    def _drain_steer_actions(self) -> List[SessionAction]:
+        """Pop steer/mailbox actions ready at the next-turn boundary."""
+        with self._steer_lock:
+            return self._action_store().drain_ready(
+                DeliveryPolicy.NEXT_TURN_BOUNDARY,
+                kinds=injectable_kinds(),
+            )
 
     def drain_steer(self) -> list[str]:
-        """Atomically pop and return all pending steer messages (empty list if none)."""
+        """Atomically pop and return all pending steer/mailbox texts (empty if none)."""
+        return [action.text for action in self._drain_steer_actions()]
+
+    def drain_mailbox(self) -> list[str]:
+        """Pop mailbox actions due when the run is idle."""
         with self._steer_lock:
-            items = list(self._steer_queue)
-            self._steer_queue.clear()
-            return items
+            actions = self._action_store().drain_ready(
+                DeliveryPolicy.WHEN_RUN_IDLE,
+                kinds=(ActionKind.MAILBOX,),
+            )
+        return [action.text for action in actions if str(action.text or "").strip()]
 
     @staticmethod
     def _format_steer_user_content(text: str) -> str:
@@ -316,8 +379,8 @@ class SteerMixin:
             else:
                 yield from self._flush_steer_drop_notice()
             return
-        steers = self.drain_steer()
-        if not steers:
+        actions = self._drain_steer_actions()
+        if not actions:
             return
         if not self._steer_inject_boundary_is_safe():
             # Keep pending until pairs complete (or sanitize heals them). Signal
@@ -325,11 +388,11 @@ class SteerMixin:
             # inject at a safe boundary — do NOT insert a user row between
             # assistant tool_use and tool_result.
             with self._steer_lock:
-                for steer in reversed(steers):
-                    self._steer_queue.appendleft(steer)
+                self._action_store().requeue_front(actions)
             self._steer_pending = True
             return
-        for steer in steers:
+        for action in actions:
+            steer = action.text
             content = self._format_steer_user_content(steer)
             try:
                 from .task_transaction import context_block

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.401"
+version = "0.9.402"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_api_session_control_peel.py
+++ b/tests/test_api_session_control_peel.py
@@ -6,12 +6,14 @@ from types import SimpleNamespace
 from harness.api.session_control import (
     SessionControlServices,
     get_session_context_at,
+    get_session_loop,
     get_session_queue,
     get_session_state,
     get_session_swarm_results,
     post_chat_stash,
     post_session_compact,
     post_session_interrupt,
+    post_session_loop,
     post_session_persist,
     post_session_queue,
     post_session_queue_reorder,
@@ -20,6 +22,8 @@ from harness.api.session_control import (
     post_session_todo,
     prepare_session_restart,
 )
+from harness.session_actions import ActionKind, SessionActionStore
+from harness.session_loop import SessionLoop
 
 
 def _svc(pilot=None, runners=None, upload_dir="/uploads", sessions=None):
@@ -175,6 +179,117 @@ def test_steer_vision_images_reports_enqueue_prompt(tmp_path):
     assert payload["action"] == "enqueue_prompt"
     assert p.steers == []
     assert p.prompts[0]["text"] == "look"
+
+
+def test_steer_invalid_turn_input_mode_is_400():
+    class _P:
+        def enqueue_steer(self, text):
+            raise AssertionError("invalid mode must not enqueue")
+
+    svc = _svc(pilot=_P())
+    code, payload = post_session_steer(
+        {"text": "go", "turn_input_mode": "recover"}, svc,
+    )
+    assert code == 400
+    assert payload["ok"] is False
+    assert payload["error"] == "invalid turn_input_mode"
+
+
+def test_steer_recover_turn_admits_recover_and_requires_expected_turn_id():
+    class _P:
+        def __init__(self):
+            self._session_actions = SessionActionStore()
+
+        def enqueue_steer(self, text):
+            raise AssertionError("RecoverTurn must not enqueue_steer")
+
+    p = _P()
+    svc = _svc(pilot=p)
+    code, payload = post_session_steer(
+        {"text": "resume", "kind": "recover"}, svc,
+    )
+    assert code == 400
+    assert payload["ok"] is False
+    assert payload["code"] == "recover_requires_expected_turn_id"
+    assert list(p._session_actions) == []
+
+    code, payload = post_session_steer(
+        {"text": "resume", "kind": "recover", "expected_turn_id": "turn-7"}, svc,
+    )
+    assert code == 200
+    assert payload["ok"] is True
+    assert payload["action"] == "recover"
+    admitted = list(p._session_actions)
+    assert [a.kind for a in admitted] == [ActionKind.RECOVER]
+    assert admitted[0].expected_turn_id == "turn-7"
+
+
+def test_steer_turn_input_mode_start_if_idle():
+    class _P:
+        def __init__(self):
+            self._session_actions = SessionActionStore()
+            self._busy = False
+
+        def is_turn_busy(self):
+            return self._busy
+
+        def enqueue_steer(self, text):
+            raise AssertionError("start_if_idle must admit, not enqueue_steer")
+
+        def enqueue_prompt(self, text, images=None, model=None):
+            item = {"id": "s1", "text": text, "images": images or []}
+            self.prompts.append(item)
+            return item
+
+    p = _P()
+    p.prompts = []
+    svc = _svc(pilot=p)
+    code, payload = post_session_steer(
+        {"text": "begin", "turn_input_mode": "start_if_idle"}, svc,
+    )
+    assert code == 200
+    assert payload["action"] == "start"
+    assert payload["kind"] == "start"
+    assert list(p._session_actions)[0].kind is ActionKind.START
+    assert p.prompts[0]["text"] == "begin"
+    assert payload["item"]["text"] == "begin"
+    assert payload["deferred"] is True
+
+    p._busy = True
+    code, payload = post_session_steer(
+        {"text": "nope", "turn_input_mode": "start_if_idle"}, svc,
+    )
+    assert code == 400
+    assert payload["code"] == "start_if_idle_busy"
+
+
+def test_session_loop_start_stop_and_rejects_interval_without_seconds():
+    p = SimpleNamespace(_loop_state=SessionLoop())
+    svc = _svc(pilot=p)
+    code, payload = get_session_loop(svc)
+    assert code == 200
+    assert payload["loop"]["enabled"] is False
+
+    code, payload = post_session_loop(
+        {"action": "start", "mode": "interval", "prompt": "again"}, svc,
+    )
+    assert code == 400
+    assert payload["code"] == "interval_requires_seconds"
+
+    code, payload = post_session_loop(
+        {
+            "action": "start",
+            "mode": "self_paced",
+            "prompt": "next beat",
+        },
+        svc,
+    )
+    assert code == 200
+    assert payload["loop"]["enabled"] is True
+    assert payload["loop"]["mode"] == "self_paced"
+    code, payload = post_session_loop({"action": "stop"}, svc)
+    assert code == 200
+    assert payload["loop"]["enabled"] is False
 
 
 def test_rewind_requires_target():

--- a/tests/test_compaction_mixin.py
+++ b/tests/test_compaction_mixin.py
@@ -5,8 +5,13 @@ harness.conversation into harness.compaction_mixin. If the class-hierarchy
 wiring or the MRO ever regresses, these fail loudly.
 """
 
-from harness.compaction_mixin import CompactionContextMixin
+from harness.compaction_mixin import (
+    CompactionContextMixin,
+    REASON_WATERMARK_FENCE,
+)
+from harness.config import HarnessConfig
 from harness.conversation import ConversationalSession
+from harness.prompt_cache_scope import prompt_cache_scope
 
 
 MOVED_METHODS = (
@@ -84,3 +89,171 @@ def test_steer_and_prompt_queue_not_folded_in():
             name,
             attr.__qualname__,
         )
+
+
+NEW_WATERMARK_METHODS = (
+    "get_active_message_watermark",
+    "mark_commit_watermark_fenced",
+    "_clone_concurrent_tail",
+    "_admit_compact_commit",
+    "_plan_compacted_history",
+)
+
+
+def test_watermark_methods_resolve_to_mixin():
+    for name in NEW_WATERMARK_METHODS:
+        assert hasattr(ConversationalSession, name), name
+        attr = getattr(ConversationalSession, name)
+        assert attr.__qualname__ == f"CompactionContextMixin.{name}", (
+            name,
+            attr.__qualname__,
+        )
+
+
+class _WatermarkHost(CompactionContextMixin):
+    """Minimal host: mixin defines no __init__, so tests supply _history."""
+
+    def __init__(self):
+        self._history = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+        ]
+        self.state_dir = ""
+        self.harness_session_id = "sess-physical-must-not-leak"
+        self.conversation_key = "lineage-ROOT-1"
+
+
+def test_get_active_message_watermark_is_max_live_index_or_id():
+    host = _WatermarkHost()
+    assert host.get_active_message_watermark() == 3
+    host._history.append({"role": "user", "content": "four", "id": 12})
+    assert host.get_active_message_watermark() == 12
+
+
+def test_concurrent_tail_remains_after_planned_commit():
+    host = _WatermarkHost()
+    start_wm = host.get_active_message_watermark()
+    recent = [host._history[-1]]
+    tail = {"role": "user", "content": "concurrent-tail"}
+    host._history.append(tail)
+    summary = {
+        "role": "user",
+        "content": "residual",
+        "_compressed_summary": True,
+    }
+    proposed = host._plan_compacted_history(summary, recent, start_wm)
+    assert proposed is not None
+    assert proposed[-1] is tail
+    host._history[:] = proposed
+    assert host._history[-1]["content"] == "concurrent-tail"
+    assert host._history[1] is summary
+
+
+def test_fence_blocks_compact_commit_that_would_drop_the_tail():
+    host = _WatermarkHost()
+    wm = host.get_active_message_watermark()
+    host.mark_commit_watermark_fenced(wm)
+    tail = {"role": "user", "content": "concurrent-tail"}
+    host._history.append(tail)
+    dropping = [
+        host._history[0],
+        {"role": "user", "content": "residual", "_compressed_summary": True},
+    ]
+    assert host._admit_compact_commit(dropping) is False
+    planned = host._plan_compacted_history(dropping[1], [], wm)
+    # Plan clones the live tail, so admission succeeds when the clone is kept.
+    assert planned is not None
+    assert planned[-1] is tail
+    # A rewrite that omits the tail is still refused.
+    assert host._admit_compact_commit(dropping) is False
+    assert host._history[-1] is tail
+
+
+def test_history_compaction_fields_include_hashed_scope_not_session_id():
+    host = _WatermarkHost()
+    fields = host._history_compaction_fields()
+    scope = fields.get("prompt_cache_scope")
+    assert scope == prompt_cache_scope("lineage-ROOT-1")
+    assert host.harness_session_id not in scope
+    assert host._prompt_cache_conversation_key() != host.harness_session_id
+
+
+def test_history_compaction_fields_include_builder_prefix_name():
+    from harness.prompt_cache_scope import (
+        clear_stable_prefixes,
+        prompt_cache_scope,
+        register_stable_prefix,
+    )
+
+    host = _WatermarkHost()
+    host._history = [{"role": "system", "content": "You are Marionette.\n"}]
+    register_stable_prefix("system_v1", "You are Marionette.\n")
+    try:
+        fields = host._history_compaction_fields()
+        assert fields.get("prompt_cache_prefix") == "system_v1"
+        assert fields.get("prompt_cache_scope") == prompt_cache_scope(
+            "lineage-ROOT-1|system_v1"
+        )
+    finally:
+        clear_stable_prefixes()
+
+
+def _fat_catalog_session(monkeypatch):
+    monkeypatch.setattr("harness.compaction_mixin.MIN_COMPACTABLE_TOKENS", 0)
+    monkeypatch.delenv("HARNESS_COMPACTION_RESIDUAL", raising=False)
+    cfg = HarnessConfig(max_context_tokens=4000)
+    session = ConversationalSession(cfg)
+    session.harness_session_id = "sess-physical-must-not-leak"
+    session.conversation_key = "lineage-ROOT-compact"
+    session._history = [{"role": "system", "content": "sys"}]
+    for i in range(10):
+        session._history.append({
+            "role": "user",
+            "content": f"User message number {i}: " + ("A" * 150),
+        })
+        session._history.append({
+            "role": "assistant",
+            "content": f"Assistant response number {i}: " + ("B" * 150),
+        })
+    return session
+
+
+def test_compact_captures_start_watermark_and_keeps_concurrent_tail(monkeypatch):
+    session = _fat_catalog_session(monkeypatch)
+    before_wm = session.get_active_message_watermark()
+    orig = session._injected_residual_content
+
+    def _append_tail_then_inject(summary):
+        if session._history[-1].get("content") != "concurrent-tail":
+            session._history.append({"role": "user", "content": "concurrent-tail"})
+        return orig(summary)
+
+    session._injected_residual_content = _append_tail_then_inject
+    events = list(session._maybe_compact_history(force=True))
+    assert [e.kind for e in events] == ["compacting", "compaction"]
+    assert events[-1].data.get("aborted") is not True
+    assert session._compaction_start_watermark == before_wm
+    assert session._history[-1]["content"] == "concurrent-tail"
+
+
+def test_fence_blocks_maybe_compact_when_clone_would_drop_tail(monkeypatch):
+    session = _fat_catalog_session(monkeypatch)
+    orig = session._injected_residual_content
+    original_len = len(session._history)
+
+    def _append_tail_then_omit_clone(summary):
+        session.mark_commit_watermark_fenced(session._compaction_start_watermark)
+        if session._history[-1].get("content") != "concurrent-tail":
+            session._history.append({"role": "user", "content": "concurrent-tail"})
+        session._clone_concurrent_tail = lambda _watermark: []
+        return orig(summary)
+
+    session._injected_residual_content = _append_tail_then_omit_clone
+    events = list(session._maybe_compact_history(force=True))
+    assert events[-1].kind == "compaction"
+    assert events[-1].data.get("aborted") is True
+    assert events[-1].data.get("reason") == REASON_WATERMARK_FENCE
+    assert session._history[-1]["content"] == "concurrent-tail"
+    assert len(session._history) == original_len + 1

--- a/tests/test_delivery_mode.py
+++ b/tests/test_delivery_mode.py
@@ -6,12 +6,14 @@ from harness.delivery_mode import (
     DeliveryMode,
     apply_delivery,
     deliver_schedule_to_session,
+    delivery_mode_action_kinds,
     normalize_delivery_mode,
     realized_steer_action,
     resolve_delivery,
     schedule_should_inject,
 )
 from harness.schedule_core import Schedule
+from harness.session_actions import ActionKind, DeliveryPolicy, SessionActionStore
 
 
 class _FakeSession:
@@ -176,3 +178,57 @@ def test_delivery_mode_interrupt_when_idle():
     assert "interrupted" not in result
     assert session.prompts[0]["text"] == "just queue"
     assert normalize_delivery_mode("interrupt") == DeliveryMode.INTERRUPT.value
+
+
+def test_delivery_mode_maps_to_session_action_kinds():
+    assert delivery_mode_action_kinds("steer") == (ActionKind.STEER,)
+    assert delivery_mode_action_kinds("follow_up") == (ActionKind.MAILBOX,)
+    assert delivery_mode_action_kinds("interrupt") == (
+        ActionKind.REDIRECT,
+        ActionKind.MAILBOX,
+    )
+    assert delivery_mode_action_kinds("auto") == ()
+
+
+def test_delivery_mode_steer_admits_kind_steer():
+    session = _FakeSession()
+    session._session_actions = SessionActionStore()
+    session._busy = True
+    result = apply_delivery(session, "nudge left", session_busy=True, requested="steer")
+    assert result["ok"] is True
+    assert result["action"] == "enqueue_steer"
+    assert session.steers == ["nudge left"]
+    admitted = list(session._session_actions)
+    assert [a.kind for a in admitted] == [ActionKind.STEER]
+    assert admitted[0].delivery is DeliveryPolicy.NEXT_TURN_BOUNDARY
+
+
+def test_delivery_mode_follow_up_admits_mailbox_when_run_idle():
+    session = _FakeSession()
+    session._session_actions = SessionActionStore()
+    result = apply_delivery(
+        session, "next turn please", session_busy=True, requested="follow_up",
+    )
+    assert result["ok"] is True
+    assert result["action"] == "enqueue_prompt"
+    assert session.prompts[0]["text"] == "next turn please"
+    admitted = list(session._session_actions)
+    assert [a.kind for a in admitted] == [ActionKind.MAILBOX]
+    assert admitted[0].delivery is DeliveryPolicy.WHEN_RUN_IDLE
+
+
+def test_delivery_mode_interrupt_admits_redirect_then_mailbox():
+    session = _FakeSessionWithInterrupt()
+    session._session_actions = SessionActionStore()
+    session._busy = True
+    result = apply_delivery(
+        session, "stop and do this", session_busy=True, requested="interrupt",
+    )
+    assert result["ok"] is True
+    assert result["action"] == "interrupt_then_queue"
+    assert session.interrupts == [True]
+    assert session.prompts[0]["text"] == "stop and do this"
+    admitted = list(session._session_actions)
+    assert [a.kind for a in admitted] == [ActionKind.REDIRECT, ActionKind.MAILBOX]
+    assert admitted[1].text == "stop and do this"
+    assert admitted[1].delivery is DeliveryPolicy.WHEN_RUN_IDLE

--- a/tests/test_plugin_integrity.py
+++ b/tests/test_plugin_integrity.py
@@ -1,4 +1,4 @@
-"""Agent plugin integrity stamp + permission list (hermetic)."""
+"""Agent plugin integrity stamp + capability consent (hermetic)."""
 
 from __future__ import annotations
 
@@ -10,12 +10,25 @@ from pathlib import Path
 import pytest
 
 from harness.agent_plugins import AgentPluginError, PLUGIN_SCHEMA_V1, load_agent_plugin
+from harness.plugin_capabilities import (
+    capability_set_hash,
+    parse_requested_capabilities,
+)
 from harness.plugin_registry import (
+    consent_plugin_capabilities,
     enable_plugin,
     install_from_path,
     verify_integrity_stamp,
 )
 from tests.test_agent_plugins import _valid_package, _write_json
+
+
+def _package_requesting(root: Path, caps: list) -> Path:
+    source = _valid_package(root)
+    manifest = json.loads((source / "plugin.json").read_text(encoding="utf-8"))
+    manifest["extensions"] = {"marionette": {"requested_capabilities": caps}}
+    _write_json(source / "plugin.json", manifest)
+    return source
 
 
 def test_stamp_match_install_and_enable(plugins_home: Path, tmp_path: Path) -> None:
@@ -64,3 +77,88 @@ def test_rejects_unknown_permission(tmp_path: Path) -> None:
     )
     with pytest.raises(AgentPluginError, match="permissions"):
         load_agent_plugin(root, tmp_path / "data")
+
+
+def test_unknown_capability_id_rejected() -> None:
+    with pytest.raises(AgentPluginError, match="unknown"):
+        parse_requested_capabilities(["not-a-cap"])
+    with pytest.raises(AgentPluginError, match="unknown"):
+        parse_requested_capabilities(["fs", "camera"])
+
+
+def test_unknown_capability_id_rejected_on_install(
+    plugins_home: Path, tmp_path: Path
+) -> None:
+    source = _package_requesting(tmp_path / "src", ["camera"])
+    with pytest.raises(AgentPluginError, match="unknown"):
+        install_from_path(str(source))
+
+
+def test_requested_capabilities_default_empty(
+    plugins_home: Path, tmp_path: Path
+) -> None:
+    assert parse_requested_capabilities(None) == frozenset()
+    assert parse_requested_capabilities([]) == frozenset()
+    source = _valid_package(tmp_path / "src")
+    record = install_from_path(str(source))
+    assert record.requested_capabilities == []
+    assert record.capability_set_hash == capability_set_hash([])
+    enabled = enable_plugin(record.id)
+    assert enabled.enabled is True
+
+
+def test_capability_set_hash_changes_when_set_changes() -> None:
+    empty = capability_set_hash([])
+    fs_only = capability_set_hash(["fs"])
+    fs_shell = capability_set_hash(["shell", "fs"])
+    assert empty != fs_only
+    assert fs_only != fs_shell
+    assert fs_shell == capability_set_hash(["fs", "shell"])
+    assert fs_only == capability_set_hash(["fs", "fs"])
+
+
+def test_enable_without_consent_of_requested_caps_fails(
+    plugins_home: Path, tmp_path: Path
+) -> None:
+    source = _package_requesting(tmp_path / "src", ["fs", "shell"])
+    record = install_from_path(str(source))
+    assert record.requested_capabilities == ["fs", "shell"]
+    assert record.capability_set_hash == capability_set_hash(["fs", "shell"])
+    assert record.consented_capabilities == []
+    with pytest.raises(AgentPluginError, match="consent"):
+        enable_plugin(record.id)
+    consent_plugin_capabilities(record.id, ["fs"])
+    with pytest.raises(AgentPluginError, match="consent"):
+        enable_plugin(record.id)
+
+
+def test_enable_after_consent_succeeds(
+    plugins_home: Path, tmp_path: Path
+) -> None:
+    source = _package_requesting(tmp_path / "src", ["fs", "shell"])
+    record = install_from_path(str(source))
+    first = consent_plugin_capabilities(record.id, ["fs"])
+    second = consent_plugin_capabilities(record.id, ["fs", "shell"])
+    assert first.consented_hash != second.consented_hash
+    assert second.consented_hash == capability_set_hash(["fs", "shell"])
+    enabled = enable_plugin(record.id)
+    assert enabled.enabled is True
+    assert enabled.stamp_ok is True
+    assert enabled.consented_capabilities == ["fs", "shell"]
+
+
+def test_stamp_mismatch_rejected_independently_of_consent(
+    plugins_home: Path, tmp_path: Path
+) -> None:
+    source = _package_requesting(tmp_path / "src", ["fs"])
+    record = install_from_path(str(source))
+    consent_plugin_capabilities(record.id, ["fs"])
+    installed = Path(record.path)
+    (installed / "plugin.json").write_text(
+        (installed / "plugin.json").read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(AgentPluginError, match="mismatch"):
+        enable_plugin(record.id)
+    with pytest.raises(AgentPluginError, match="mismatch"):
+        verify_integrity_stamp(installed)

--- a/tests/test_prompt_cache_scope.py
+++ b/tests/test_prompt_cache_scope.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Builder-declared prompt-cache watermarks and rotation-stable scope."""
+
+import hashlib
+
+from harness.prompt_cache_scope import (
+    clear_stable_prefixes,
+    find_stable_prefix,
+    prompt_cache_scope,
+    register_stable_prefix,
+)
+
+
+def setup_function():
+    clear_stable_prefixes()
+
+
+def teardown_function():
+    clear_stable_prefixes()
+
+
+def test_prompt_cache_scope_is_stable_sha256():
+    key = "lineage-root-alpha"
+    first = prompt_cache_scope(key)
+    second = prompt_cache_scope(key)
+    assert first == second
+    assert first == hashlib.sha256(key.encode("utf-8")).hexdigest()
+    assert prompt_cache_scope("lineage-root-beta") != first
+
+
+def test_prompt_cache_scope_never_embeds_session_id():
+    session_id = "sess-physical-abc123-do-not-leak"
+    scope = prompt_cache_scope("compression-lineage-ROOT")
+    assert session_id not in scope
+    assert scope != session_id
+    hashed_if_misused = prompt_cache_scope(session_id)
+    assert hashed_if_misused != session_id
+    assert session_id not in hashed_if_misused
+
+
+def test_register_and_find_stable_prefix_longest_match():
+    register_stable_prefix("short", "You are")
+    register_stable_prefix("system_v1", "You are Marionette.\n")
+    register_stable_prefix("", "ignored-empty-name")
+    assert find_stable_prefix("You are Marionette.\nUser turn") == "system_v1"
+    assert find_stable_prefix("Hello") is None
+    assert find_stable_prefix("") is None

--- a/tests/test_send_loop_phases.py
+++ b/tests/test_send_loop_phases.py
@@ -1375,6 +1375,102 @@ def test_drain_idle_turn_finalizes_when_idle():
     assert submitted == [("ingest", ("hi", ["p"], ["f"]))]
 
 
+def test_drain_idle_turn_delivers_mailbox_and_skips_duplicate_playlist():
+    from harness.session_actions import ActionKind, DeliveryPolicy, SessionActionStore, WakePolicy
+    from harness.steer_mixin import SteerMixin
+
+    class Host(SteerMixin):
+        def __init__(self):
+            import threading
+            self._steer_lock = threading.Lock()
+            self._session_actions = SessionActionStore()
+            self._steer_queue = self._session_actions
+            self._steer_pending = False
+            self._history = []
+            self._prompts = [{"id": "p1", "text": "later please", "images": []}]
+
+        def _next_queued_needs_driver_swap(self):
+            return False
+
+        def _pop_next_prompt(self):
+            return self._prompts.pop(0) if self._prompts else {}
+
+    host = Host()
+    host._session_actions.admit(
+        ActionKind.MAILBOX,
+        "later please",
+        delivery=DeliveryPolicy.WHEN_RUN_IDLE,
+        wake=WakePolicy.ON_IDLE,
+    )
+    events = []
+    gen = drain_idle_turn(
+        host,
+        user_message="orig",
+        step=0,
+        swarms=0,
+        turn_prose=[],
+        turn_findings=[],
+    )
+    try:
+        while True:
+            events.append(next(gen))
+    except StopIteration as stop:
+        disposition, user_message = stop.value
+    assert disposition == "continue"
+    assert user_message == "later please"
+    assert [ev.kind for ev in events] == ["queued_prompt"]
+    assert host._history[-1]["content"] == "later please"
+    assert host._prompts == []
+
+
+def test_drain_idle_turn_fires_self_paced_loop_into_queue():
+    from harness.session_actions import SessionActionStore
+    from harness.session_loop import start_session_loop
+
+    prompts = []
+
+    def enqueue_prompt(text, images=None, model=None):
+        prompts.append({"id": "loop1", "text": text, "images": images or []})
+        return prompts[-1]
+
+    def pop_next():
+        return prompts.pop(0) if prompts else None
+
+    session = SimpleNamespace(
+        drain_steer=lambda: [],
+        _history=[],
+        _steer_pending=False,
+        _next_queued_needs_driver_swap=lambda: False,
+        _pop_next_prompt=pop_next,
+        enqueue_prompt=enqueue_prompt,
+        _session_actions=SessionActionStore(),
+        _loop_state=None,
+        _submit_housekeeping=MagicMock(),
+        _maybe_ingest=MagicMock(),
+    )
+    start_session_loop(session, "self_paced", "keep going", now=1.0)
+    events = []
+    gen = drain_idle_turn(
+        session,
+        user_message="orig",
+        step=0,
+        swarms=0,
+        turn_prose=[],
+        turn_findings=[],
+    )
+    try:
+        while True:
+            events.append(next(gen))
+    except StopIteration as stop:
+        disposition, user_message = stop.value
+    assert disposition == "continue"
+    assert user_message == "keep going"
+    assert events[0].kind == "queued_prompt"
+    assert events[0].data["text"] == "keep going"
+    assert session._history[-1]["content"] == "keep going"
+    session._submit_housekeeping.assert_not_called()
+
+
 def test_drain_idle_turn_blank_stop_cause_is_unspecified():
     session = SimpleNamespace(
         drain_steer=lambda: [],

--- a/tests/test_session_actions.py
+++ b/tests/test_session_actions.py
@@ -1,0 +1,117 @@
+"""SessionActionStore — illegal transitions, snapshot/restore, TurnInputMode."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from harness.session_actions import (
+    ActionKind,
+    DeliveryPolicy,
+    SessionActionIllegalTransition,
+    SessionActionStore,
+    TurnInputMode,
+    WakePolicy,
+    normalize_turn_input_mode,
+)
+
+
+def test_recover_requires_expected_turn_id():
+    store = SessionActionStore()
+    with pytest.raises(SessionActionIllegalTransition) as exc:
+        store.admit(ActionKind.RECOVER, "resume this turn")
+    assert exc.value.code == "recover_requires_expected_turn_id"
+    store.admit(ActionKind.RECOVER, "resume this turn", expected_turn_id="turn-1")
+    assert [a.kind for a in store] == [ActionKind.RECOVER]
+    assert store.drain_ready(DeliveryPolicy.NEXT_TURN_BOUNDARY)[0].expected_turn_id == "turn-1"
+
+
+def test_steer_expected_turn_id_must_match_current():
+    store = SessionActionStore()
+    store.set_current_turn_id("turn-a")
+    with pytest.raises(SessionActionIllegalTransition) as exc:
+        store.admit(ActionKind.STEER, "nudge", expected_turn_id="turn-b")
+    assert exc.value.code == "steer_turn_mismatch"
+    action = store.admit(ActionKind.STEER, "nudge", expected_turn_id="turn-a")
+    assert action.kind is ActionKind.STEER
+    assert action.delivery is DeliveryPolicy.NEXT_TURN_BOUNDARY
+
+
+def test_admit_after_closed_is_illegal():
+    store = SessionActionStore()
+    store.admit(ActionKind.STEER, "before close")
+    store.close()
+    with pytest.raises(SessionActionIllegalTransition) as exc:
+        store.admit(ActionKind.MAILBOX, "too late")
+    assert exc.value.code == "store_closed"
+
+
+def test_snapshot_restore_is_json_safe_and_committible():
+    store = SessionActionStore()
+    store.set_current_turn_id("turn-9")
+    store.admit(ActionKind.STEER, "keep going", images=["/tmp/a.png"])
+    store.admit(
+        ActionKind.MAILBOX,
+        "later",
+        delivery=DeliveryPolicy.WHEN_RUN_IDLE,
+        wake=WakePolicy.ON_IDLE,
+    )
+    snap = store.snapshot()
+    encoded = json.dumps(snap)
+    loaded = json.loads(encoded)
+    assert loaded["current_turn_id"] == "turn-9"
+    assert loaded["closed"] is False
+    assert [row["kind"] for row in loaded["actions"]] == ["steer", "mailbox"]
+    assert loaded["actions"][0]["images"] == ["/tmp/a.png"]
+
+    other = SessionActionStore()
+    other.restore(loaded)
+    assert other.current_turn_id == "turn-9"
+    assert [a.kind.value for a in other] == ["steer", "mailbox"]
+    assert other.drain_ready(DeliveryPolicy.WHEN_RUN_IDLE)[0].text == "later"
+    assert [a.text for a in other] == ["keep going"]
+
+
+def test_turn_input_mode_start_if_idle_vs_steer():
+    idle = SessionActionStore()
+    started = idle.admit_turn_input("begin", TurnInputMode.START_IF_IDLE, idle=True)
+    assert started.kind is ActionKind.START
+    assert idle.current_turn_id
+
+    busy = SessionActionStore()
+    busy.set_current_turn_id("live")
+    with pytest.raises(SessionActionIllegalTransition) as exc:
+        busy.admit_turn_input("nope", TurnInputMode.START_IF_IDLE, idle=False)
+    assert exc.value.code == "start_if_idle_busy"
+
+    steered = busy.admit_turn_input(
+        "course correct",
+        TurnInputMode.STEER,
+        expected_turn_id="live",
+        idle=False,
+    )
+    assert steered.kind is ActionKind.STEER
+
+    either = SessionActionStore()
+    assert either.admit_turn_input("go", TurnInputMode.START_OR_STEER, idle=True).kind is ActionKind.START
+    running = SessionActionStore()
+    running.set_current_turn_id("t2")
+    assert (
+        running.admit_turn_input("go", TurnInputMode.START_OR_STEER, idle=False).kind
+        is ActionKind.STEER
+    )
+
+
+def test_admit_front_moves_new_action_to_head():
+    store = SessionActionStore()
+    store.admit(ActionKind.STEER, "older")
+    store.admit_front(ActionKind.STEER, "newer")
+    assert [a.text for a in store] == ["newer", "older"]
+
+
+def test_normalize_turn_input_mode_rejects_unknown():
+    assert normalize_turn_input_mode("start-if-idle") == TurnInputMode.START_IF_IDLE.value
+    assert normalize_turn_input_mode("STEER") == TurnInputMode.STEER.value
+    assert normalize_turn_input_mode("recover") is None
+    assert normalize_turn_input_mode("nope") is None
+    assert normalize_turn_input_mode(None) is None

--- a/tests/test_session_loop.py
+++ b/tests/test_session_loop.py
@@ -1,0 +1,133 @@
+"""Session /loop — interval vs self_paced, distinct from cron and SessionGoal."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from harness.session_actions import ActionKind, DeliveryPolicy, SessionActionStore, WakePolicy
+from harness.session_loop import (
+    LoopMode,
+    SessionLoop,
+    SessionLoopError,
+    fire_session_loop,
+    start_session_loop,
+    stop_session_loop,
+    tick_session_loop,
+)
+
+
+def test_interval_requires_seconds():
+    loop = SessionLoop()
+    with pytest.raises(SessionLoopError) as exc:
+        loop.start("interval", "continue")
+    assert exc.value.code == "interval_requires_seconds"
+    with pytest.raises(SessionLoopError) as exc:
+        loop.start("interval", "continue", interval_seconds=0)
+    assert exc.value.code == "interval_requires_seconds"
+
+
+def test_unknown_mode_and_missing_prompt():
+    loop = SessionLoop()
+    with pytest.raises(SessionLoopError) as exc:
+        loop.start("ralph", "x")
+    assert exc.value.code == "unknown_loop_mode"
+    with pytest.raises(SessionLoopError) as exc:
+        loop.start("self_paced", "   ")
+    assert exc.value.code == "missing_prompt"
+
+
+def test_self_paced_fires_on_idle_edge_once():
+    loop = SessionLoop()
+    store = SessionActionStore()
+    loop.start("self_paced", "next beat", now=10.0)
+    assert fire_session_loop(loop, store, idle=False, now=10.5) is None
+    action = fire_session_loop(loop, store, idle=True, now=11.0)
+    assert action is not None
+    assert action.kind is ActionKind.MAILBOX
+    assert action.delivery is DeliveryPolicy.WHEN_RUN_IDLE
+    assert action.wake is WakePolicy.ON_IDLE
+    assert action.text == "next beat"
+    assert fire_session_loop(loop, store, idle=True, now=12.0) is None
+
+
+def test_self_paced_fires_immediately_when_started_idle():
+    loop = SessionLoop()
+    store = SessionActionStore()
+    loop.start(LoopMode.SELF_PACED, "go", now=1.0)
+    action = fire_session_loop(loop, store, idle=True, now=1.0)
+    assert action is not None
+    assert [a.kind for a in store] == [ActionKind.MAILBOX]
+
+
+def test_interval_waits_then_fires_when_idle():
+    loop = SessionLoop()
+    store = SessionActionStore()
+    loop.start("interval", "tick", interval_seconds=5, now=100.0)
+    assert fire_session_loop(loop, store, idle=True, now=103.0) is None
+    action = fire_session_loop(loop, store, idle=True, now=105.0)
+    assert action is not None
+    assert action.text == "tick"
+    assert fire_session_loop(loop, store, idle=True, now=106.0) is None
+    later = fire_session_loop(loop, store, idle=True, now=110.0)
+    assert later is not None
+
+
+def test_interval_does_not_fire_while_busy():
+    loop = SessionLoop()
+    store = SessionActionStore()
+    loop.start("interval", "tick", interval_seconds=1, now=0.0)
+    assert fire_session_loop(loop, store, idle=False, now=5.0) is None
+    assert list(store) == []
+
+
+def test_snapshot_restore_is_json_safe():
+    loop = SessionLoop()
+    loop.start("interval", "again", interval_seconds=2.5, until=99.0, now=9.0)
+    encoded = json.dumps(loop.to_dict())
+    other = SessionLoop.from_dict(json.loads(encoded))
+    assert other.enabled is True
+    assert other.mode is LoopMode.INTERVAL
+    assert other.prompt == "again"
+    assert other.interval_seconds == 2.5
+    assert other.until == 99.0
+    assert other.started_at == 9.0
+
+
+def test_until_deadline_stops_the_loop():
+    loop = SessionLoop()
+    store = SessionActionStore()
+    loop.start("interval", "tick", interval_seconds=1, until=104.0, now=100.0)
+    assert fire_session_loop(loop, store, idle=True, now=101.0) is not None
+    assert fire_session_loop(loop, store, idle=True, now=104.0) is None
+    assert loop.enabled is False
+
+
+def test_repeated_response_digest_stops_the_loop():
+    loop = SessionLoop()
+    store = SessionActionStore()
+    loop.start("self_paced", "next beat", now=1.0)
+    assert loop.note_response("same answer") is True
+    assert loop.note_response("same answer") is False
+    assert loop.enabled is False
+    assert fire_session_loop(loop, store, idle=True, now=2.0) is None
+
+
+def test_tick_session_loop_enqueues_prompt_and_stop_disables():
+    class Host:
+        def __init__(self) -> None:
+            self._loop_state = SessionLoop()
+            self._session_actions = SessionActionStore()
+            self.prompts = []
+
+        def enqueue_prompt(self, text, images=None, model=None):
+            self.prompts.append(text)
+            return {"text": text}
+
+    host = Host()
+    start_session_loop(host, "self_paced", "again", now=1.0)
+    assert tick_session_loop(host, idle=True, now=1.0) is True
+    assert host.prompts == ["again"]
+    stop_session_loop(host)
+    assert tick_session_loop(host, idle=True, now=2.0) is False
+    assert host.prompts == ["again"]

--- a/tests/test_steer.py
+++ b/tests/test_steer.py
@@ -23,6 +23,7 @@ def test_steer_queue_round_trip():
     
     assert s.drain_steer() == ["First steer message", "Second steer message"]
     assert s.drain_steer() == []
+    assert list(s._session_actions) == []
 
 
 def test_enqueue_steer_ignores_blank_and_stop_does_not_notice():
@@ -37,6 +38,7 @@ def test_enqueue_steer_ignores_blank_and_stop_does_not_notice():
     assert dropped == []
     assert s._record_steer_drop_notice(dropped) is None
     assert getattr(s, "_pending_steer_drop_notice", None) in (None, {})
+    assert list(s._session_actions) == []
 
 
 class _SteeringPilot:

--- a/tests/test_steer_concurrency.py
+++ b/tests/test_steer_concurrency.py
@@ -12,9 +12,9 @@ Production seam (harness/steer_mixin.py):
 """
 from __future__ import annotations
 
-import collections
 import threading
 
+from harness.session_actions import SessionActionStore, SteerQueueView
 from harness.steer_mixin import SteerMixin
 
 
@@ -23,7 +23,8 @@ class _SteerHost(SteerMixin):
 
     def __init__(self) -> None:
         self._steer_lock = threading.Lock()
-        self._steer_queue = collections.deque()
+        self._session_actions = SessionActionStore()
+        self._steer_queue = SteerQueueView(self._session_actions)
         self._steer_pending = False
         self._stop_holds_idle = False
         self._busy = threading.Lock()
@@ -208,3 +209,25 @@ def test_enqueue_steer_ignores_blank_and_whitespace():
 
     host.enqueue_steer("  keep me  ")
     assert host.drain_steer() == ["keep me"]
+    assert list(host._session_actions) == []
+
+
+def test_stop_abandon_drop_clears_session_action_store():
+    """Stop-abandon refuse + drop_queued_steers still empty the typed store."""
+    host = _SteerHost()
+    host.enqueue_steer("keep then drop")
+    assert len(host._session_actions) == 1
+    dropped = host.drop_queued_steers()
+    assert dropped == ["keep then drop"]
+    assert list(host._session_actions) == []
+    assert list(host._steer_queue) == []
+
+    host._stop_holds_idle = True
+    assert host._busy.acquire(blocking=False)
+    try:
+        host.enqueue_steer("late after stop")
+        assert list(host._session_actions) == []
+        assert host.drain_steer() == []
+        assert host._pending_steer_drop_notice["reason"] == "steer_dropped"
+    finally:
+        host._busy.release()

--- a/tests/test_steer_mixin.py
+++ b/tests/test_steer_mixin.py
@@ -12,7 +12,9 @@ from harness.steer_mixin import SteerMixin
 MOVED_METHODS = (
     "steer_with_images",
     "enqueue_steer",
+    "admit_session_action",
     "drain_steer",
+    "drain_mailbox",
     "drop_queued_steers",
     "_steer_boundary_blocks_inject",
     "_record_steer_drop_notice",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.401",
+  "version": "0.9.402",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.401",
+      "version": "0.9.402",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.401",
+  "version": "0.9.402",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -549,6 +549,19 @@ export type SessionGoal = {
 
 export type DeliveryMode = "auto" | "steer" | "follow_up" | "interrupt";
 
+export type TurnInputMode = "start_or_steer" | "start_if_idle" | "steer";
+
+export type SessionLoopMode = "interval" | "self_paced";
+
+export type SessionLoop = {
+  enabled: boolean;
+  mode?: SessionLoopMode | null;
+  prompt?: string;
+  interval_seconds?: number | null;
+  until?: number | null;
+  last_response_digest?: string | null;
+};
+
 export type SessionState = {
   state: "idle" | "thinking" | "awaiting_swarm";
   pending_swarms: boolean;
@@ -1501,6 +1514,26 @@ export const api = {
     postJSON<{ ok: boolean; goal: SessionGoal }>("/api/session/goal", { action: "complete" }),
   clearSessionGoal: () =>
     postJSON<{ ok: boolean; goal: SessionGoal }>("/api/session/goal", { action: "clear" }),
+  getSessionLoop: () =>
+    getJSON<{ ok: boolean; loop: SessionLoop }>(withToken("/api/session/loop")),
+  startSessionLoop: (
+    mode: SessionLoopMode,
+    prompt: string,
+    intervalSeconds?: number,
+    until?: number,
+  ) =>
+    postJSON<{ ok: boolean; loop: SessionLoop; error?: string; code?: string }>(
+      "/api/session/loop",
+      {
+        action: "start",
+        mode,
+        prompt,
+        ...(intervalSeconds != null ? { interval_seconds: intervalSeconds } : {}),
+        ...(until != null ? { until } : {}),
+      },
+    ),
+  stopSessionLoop: () =>
+    postJSON<{ ok: boolean; loop: SessionLoop }>("/api/session/loop", { action: "stop" }),
   sessionTodo: (body: { command: string }) =>
     postJSON<{
       ok: boolean;
@@ -1998,13 +2031,20 @@ export const api = {
       error?: string;
       reason?: string;
     }>("/api/session/compact", {}),
-  steerSession: (text: string, images?: string[], deliveryMode?: DeliveryMode) =>
-    postJSON<{ ok: boolean; action?: string }>(
+  steerSession: (
+    text: string,
+    images?: string[],
+    deliveryMode?: DeliveryMode,
+    opts?: { turnInputMode?: TurnInputMode; expectedTurnId?: string },
+  ) =>
+    postJSON<{ ok: boolean; action?: string; kind?: string; code?: string }>(
       "/api/session/steer",
       {
         text,
         images: images && images.length ? images : undefined,
         ...(deliveryMode ? { delivery_mode: deliveryMode } : {}),
+        ...(opts?.turnInputMode ? { turn_input_mode: opts.turnInputMode } : {}),
+        ...(opts?.expectedTurnId ? { expected_turn_id: opts.expectedTurnId } : {}),
       },
     ),
   // PROMPT QUEUE: a "playlist" of full user prompts that each run as their own


### PR DESCRIPTION
## Summary
- Admit session actions (start / steer / redirect / mailbox / recover) with idle `start_if_idle` returning `deferred: true`. Live `send()` stays on `/api/chat` SSE.
- Plugin capability consent (`fs|mcp|browser|shell`) before enable; session `/loop` (interval or self-paced, `until` + repeat-digest stop); mailbox idle drain with playlist dedupe.
- Compaction attaches hashed `prompt_cache_scope` (lineage root, plus registered `find_stable_prefix` name). Never hashes the physical session id.

## Test plan
- [x] Focused lift suite (`session_actions`, `session_loop`, peel, send_loop_phases, delivery, steer*, prompt_cache_scope, compaction_mixin, plugin_integrity, http_routes_table): 179 passed
- [x] Version files agree on 0.9.402
- [ ] CI `tests` matrix (3.9, 3.11, Windows, frontend-build) green on this PR
- [ ] Tag `v0.9.402` only after merge^{tree} matches this green tree