### PR TITLE
Prevent malformed model IDs from crashing Economics

### DIFF
--- a/webapp/src/__tests__/EconomicsDurable.test.tsx
+++ b/webapp/src/__tests__/EconomicsDurable.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import EconomicsDurable from "../components/EconomicsDurable";
+
+function economicsData(models: unknown[]) {
+  return {
+    available: true,
+    recent_jobs: [{
+      job_id: "job-models",
+      status: "completed",
+      accounting_owned: true,
+      models,
+    }],
+  } as any;
+}
+
+describe("EconomicsDurable model ID rendering", () => {
+  it("renders valid provider:model IDs unchanged", () => {
+    render(<EconomicsDurable data={economicsData([
+      { model_id: "openai:gpt-5" },
+      { model_id: "anthropic:claude-sonnet-4" },
+    ])} />);
+
+    expect(screen.getByTitle("openai:gpt-5, anthropic:claude-sonnet-4")).toHaveTextContent(
+      "openai:gpt-5, anthropic:claude-sonnet-4",
+    );
+  });
+
+  it("ignores malformed and whitespace-only model IDs without crashing", () => {
+    render(<EconomicsDurable data={economicsData([
+      { model_id: null },
+      { model_id: [] },
+      { model_id: {} },
+      { model_id: 42 },
+      {},
+      { model_id: "   " },
+      { model_id: "google:gemini-2.5-pro" },
+    ])} />);
+
+    expect(screen.getByTitle("google:gemini-2.5-pro")).toHaveTextContent("google:gemini-2.5-pro");
+    expect(screen.queryByText("42")).not.toBeInTheDocument();
+  });
+});

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -193,7 +193,9 @@ export default function EconomicsDurable({
             <div className="py-2 text-[10px] text-faint">No job receipts in this scope.</div>
           ) : jobs.map((job) => {
             const owned = Boolean(job.accounting_owned);
-            const modelIds = (job.models || []).map((model) => model.model_id || "").filter(Boolean);
+            const modelIds = (Array.isArray(job.models) ? job.models : [])
+              .map((model) => model?.model_id)
+              .filter((modelId): modelId is string => typeof modelId === "string" && modelId.trim().length > 0);
             const measuredCost = isFiniteNumber(job.measured_cost_usd)
               && (job.measured_cost_usd > 0 || job.cost_basis === "measured")
               ? job.measured_cost_usd


### PR DESCRIPTION
## Summary

The Economics job-receipts UI could crash the Electron renderer when the API returned a non-string `model_id`. The UI eventually called string methods such as `.slice()` on that value.

This PR validates model IDs before displaying them:

- Valid non-empty strings continue to render normally.
- Null, missing, numeric, array, object, and whitespace-only values are ignored.
- The renderer remains usable when the API sends malformed runtime data.

## Scope

This is a crash-hardening change only. It does not change economics calculations, usage meters, backend behavior, pricing, or API types.

## Verification

- `npx vitest run src/__tests__/EconomicsDurable.test.tsx`
- `npm run build`