### PR TITLE
absorb #286: harden Economics model ID rendering

### DIFF
--- a/webapp/src/__tests__/EconomicsDurable.test.tsx
+++ b/webapp/src/__tests__/EconomicsDurable.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import EconomicsDurable from "../components/EconomicsDurable";
+
+function economicsData(models: unknown[]) {
+  return {
+    available: true,
+    recent_jobs: [{
+      job_id: "job-models",
+      status: "completed",
+      accounting_owned: true,
+      models,
+    }],
+  } as any;
+}
+
+describe("EconomicsDurable model ID rendering", () => {
+  it("renders valid provider:model IDs unchanged", () => {
+    render(<EconomicsDurable data={economicsData([
+      { model_id: "openai:gpt-5" },
+      { model_id: "anthropic:claude-sonnet-4" },
+    ])} />);
+
+    expect(screen.getByTitle("openai:gpt-5, anthropic:claude-sonnet-4")).toHaveTextContent(
+      "openai:gpt-5, anthropic:claude-sonnet-4",
+    );
+  });
+
+  it("ignores malformed and whitespace-only model IDs without crashing", () => {
+    render(<EconomicsDurable data={economicsData([
+      { model_id: null },
+      { model_id: [] },
+      { model_id: {} },
+      { model_id: 42 },
+      {},
+      { model_id: "   " },
+      { model_id: "google:gemini-2.5-pro" },
+    ])} />);
+
+    expect(screen.getByTitle("google:gemini-2.5-pro")).toHaveTextContent("google:gemini-2.5-pro");
+    expect(screen.queryByText("42")).not.toBeInTheDocument();
+  });
+});

--- a/webapp/src/__tests__/EconomicsDurable.test.tsx
+++ b/webapp/src/__tests__/EconomicsDurable.test.tsx
@@ -1,17 +1,18 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import type { EconomicsData, EconomicsJobRow } from "../lib/api";
 import EconomicsDurable from "../components/EconomicsDurable";
 
-function economicsData(models: unknown[]) {
+function economicsData(models: unknown): EconomicsData {
   return {
     available: true,
     recent_jobs: [{
       job_id: "job-models",
       status: "completed",
       accounting_owned: true,
-      models,
+      models: models as EconomicsJobRow["models"],
     }],
-  } as any;
+  };
 }
 
 describe("EconomicsDurable model ID rendering", () => {
@@ -39,5 +40,12 @@ describe("EconomicsDurable model ID rendering", () => {
 
     expect(screen.getByTitle("google:gemini-2.5-pro")).toHaveTextContent("google:gemini-2.5-pro");
     expect(screen.queryByText("42")).not.toBeInTheDocument();
+  });
+
+  it("ignores a non-array models field without crashing", () => {
+    render(<EconomicsDurable data={economicsData({ not: "an-array" })} />);
+
+    expect(screen.getByText("job-models")).toBeInTheDocument();
+    expect(screen.queryByTitle("an-array")).not.toBeInTheDocument();
   });
 });

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -193,7 +193,9 @@ export default function EconomicsDurable({
             <div className="py-2 text-[10px] text-faint">No job receipts in this scope.</div>
           ) : jobs.map((job) => {
             const owned = Boolean(job.accounting_owned);
-            const modelIds = (job.models || []).map((model) => model.model_id || "").filter(Boolean);
+            const modelIds = (Array.isArray(job.models) ? job.models : [])
+              .map((model) => model?.model_id)
+              .filter((modelId): modelId is string => typeof modelId === "string" && modelId.trim().length > 0);
             const measuredCost = isFiniteNumber(job.measured_cost_usd)
               && (job.measured_cost_usd > 0 || job.cost_basis === "measured")
               ? job.measured_cost_usd


### PR DESCRIPTION
## Why

Fork PR #286 reported that Economics job receipts can crash the renderer when `model_id` is not a string. `model.model_id || ""` keeps numbers and objects; a non-array `models` field throws on `.map`.

## Scope

- Cherry-pick Benton (`7d8f26e3`) onto dest: keep only non-empty string model IDs.
- Follow-up: type the fixture as `EconomicsData` and cover a non-array `models` field.
- No economics math, pricing, or API type changes.

## Tradeoffs

UI-only boundary parse. `GET /api/economics` already emits `by_model` keys as strings. Coercing the API is deferred; the renderer must not throw on malformed runtime JSON.

## Blast radius

`EconomicsDurable` job-receipt model line only. StatusBar and CostBreakdown do not read `job.models`.

## Verification

- `npx vitest run src/__tests__/EconomicsDurable.test.tsx src/__tests__/EconomicsPane.test.tsx src/__tests__/CostBreakdown.test.tsx` — 32 passed, then 22 after the follow-up (pane + durable).
- Cherry-pick applied cleanly onto `origin/dest` (`a8ebcc54`).

Credit: @kbentonferguson. Closing the fork PR after this lands; do not merge #286 into dest.
