### PR TITLE
Release v0.9.403

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.402, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.403, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.402"
+__version__ = "0.9.403"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.402"
+version = "0.9.403"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.402",
+  "version": "0.9.403",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.402",
+      "version": "0.9.403",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.402",
+  "version": "0.9.403",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/EconomicsDurable.test.tsx
+++ b/webapp/src/__tests__/EconomicsDurable.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import EconomicsDurable from "../components/EconomicsDurable";
+
+function economicsData(models: unknown[]) {
+  return {
+    available: true,
+    recent_jobs: [{
+      job_id: "job-models",
+      status: "completed",
+      accounting_owned: true,
+      models,
+    }],
+  } as any;
+}
+
+describe("EconomicsDurable model ID rendering", () => {
+  it("renders valid provider:model IDs unchanged", () => {
+    render(<EconomicsDurable data={economicsData([
+      { model_id: "openai:gpt-5" },
+      { model_id: "anthropic:claude-sonnet-4" },
+    ])} />);
+
+    expect(screen.getByTitle("openai:gpt-5, anthropic:claude-sonnet-4")).toHaveTextContent(
+      "openai:gpt-5, anthropic:claude-sonnet-4",
+    );
+  });
+
+  it("ignores malformed and whitespace-only model IDs without crashing", () => {
+    render(<EconomicsDurable data={economicsData([
+      { model_id: null },
+      { model_id: [] },
+      { model_id: {} },
+      { model_id: 42 },
+      {},
+      { model_id: "   " },
+      { model_id: "google:gemini-2.5-pro" },
+    ])} />);
+
+    expect(screen.getByTitle("google:gemini-2.5-pro")).toHaveTextContent("google:gemini-2.5-pro");
+    expect(screen.queryByText("42")).not.toBeInTheDocument();
+  });
+});

--- a/webapp/src/__tests__/EconomicsDurable.test.tsx
+++ b/webapp/src/__tests__/EconomicsDurable.test.tsx
@@ -1,17 +1,18 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import type { EconomicsData, EconomicsJobRow } from "../lib/api";
 import EconomicsDurable from "../components/EconomicsDurable";
 
-function economicsData(models: unknown[]) {
+function economicsData(models: unknown): EconomicsData {
   return {
     available: true,
     recent_jobs: [{
       job_id: "job-models",
       status: "completed",
       accounting_owned: true,
-      models,
+      models: models as EconomicsJobRow["models"],
     }],
-  } as any;
+  };
 }
 
 describe("EconomicsDurable model ID rendering", () => {
@@ -39,5 +40,12 @@ describe("EconomicsDurable model ID rendering", () => {
 
     expect(screen.getByTitle("google:gemini-2.5-pro")).toHaveTextContent("google:gemini-2.5-pro");
     expect(screen.queryByText("42")).not.toBeInTheDocument();
+  });
+
+  it("ignores a non-array models field without crashing", () => {
+    render(<EconomicsDurable data={economicsData({ not: "an-array" })} />);
+
+    expect(screen.getByText("job-models")).toBeInTheDocument();
+    expect(screen.queryByTitle("an-array")).not.toBeInTheDocument();
   });
 });

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -193,7 +193,9 @@ export default function EconomicsDurable({
             <div className="py-2 text-[10px] text-faint">No job receipts in this scope.</div>
           ) : jobs.map((job) => {
             const owned = Boolean(job.accounting_owned);
-            const modelIds = (job.models || []).map((model) => model.model_id || "").filter(Boolean);
+            const modelIds = (Array.isArray(job.models) ? job.models : [])
+              .map((model) => model?.model_id)
+              .filter((modelId): modelId is string => typeof modelId === "string" && modelId.trim().length > 0);
             const measuredCost = isFiniteNumber(job.measured_cost_usd)
               && (job.measured_cost_usd > 0 || job.cost_basis === "measured")
               ? job.measured_cost_usd


### PR DESCRIPTION
## Why

Ship Benton's Economics model-id harden after the v0.9.402 cut.

## Scope

- Absorb #286 / PR #287: keep only non-empty string model IDs on job receipts; ignore a non-array `models` field.
- Version 0.9.402 → 0.9.403. Pin stays `puppetmaster-ai==1.22.43`.
- Issue #285 (spend/saved semantics) is not in this cut.

## Tradeoffs

Renderer boundary parse only. API `model_id` coerce deferred. Shared `/api/usage` snapshot between footer and pane deferred.

## Blast radius

`EconomicsDurable` job-receipt model line and its vitest file.

## Verification

- `npx vitest run src/__tests__/EconomicsDurable.test.tsx src/__tests__/EconomicsPane.test.tsx src/__tests__/CostBreakdown.test.tsx` — passed.
- `pytest tests/test_version_consistency.py -q` — 3 passed.
