### PR TITLE
Release v0.9.404

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.43` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.403, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.404, deliberately pre-1.0. Rides puppetmaster-ai==1.22.43. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.403"
+__version__ = "0.9.404"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.403"
+version = "0.9.404"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.403",
+  "version": "0.9.404",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.403",
+      "version": "0.9.404",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.403",
+  "version": "0.9.404",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CostBreakdown.test.tsx
+++ b/webapp/src/__tests__/CostBreakdown.test.tsx
@@ -27,13 +27,13 @@ describe("CostBreakdown receipt", () => {
 
     expect(screen.getByText("Spend")).toBeTruthy();
     expect(screen.getByText("~$0.12")).toBeTruthy();
-    expect(screen.getByText("Without savings")).toBeTruthy();
+    expect(screen.getByText("At list price")).toBeTruthy();
     expect(screen.getByText("~$0.18")).toBeTruthy();
-    expect(screen.getByText("Estimated savings")).toBeTruthy();
+    expect(screen.getByText("List-price value (est.)")).toBeTruthy();
     expect(screen.getByText("~$0.06")).toBeTruthy();
-    expect(screen.getByText("Less spent")).toBeTruthy();
+    expect(screen.getByText("Less than list price")).toBeTruthy();
     expect(screen.getByText("33.3%")).toBeTruthy();
-    expect(screen.getByText("Why you saved")).toBeTruthy();
+    expect(screen.getByText("Why list-price is lower")).toBeTruthy();
     expect(screen.getByText("Prompt-cache value")).toBeTruthy();
     expect(screen.getByText("Compact tool outputs")).toBeTruthy();
   });
@@ -50,9 +50,9 @@ describe("CostBreakdown receipt", () => {
     render(<CostBreakdown data={baseData} hero={false} />);
 
     expect(screen.queryByText("Spend")).toBeNull();
-    expect(screen.queryByText("Without savings")).toBeNull();
-    expect(screen.queryByText("Less spent")).toBeNull();
-    expect(screen.getByText("Why you saved")).toBeTruthy();
+    expect(screen.queryByText("At list price")).toBeNull();
+    expect(screen.queryByText("Less than list price")).toBeNull();
+    expect(screen.getByText("Why list-price is lower")).toBeTruthy();
     expect(screen.getByText("Prompt-cache value")).toBeTruthy();
     expect(screen.getByText("Compact tool outputs")).toBeTruthy();
     expect(screen.getByText(/since you opened Marionette/)).toBeTruthy();
@@ -71,10 +71,10 @@ describe("CostBreakdown receipt", () => {
     render(<CostBreakdown data={{ tokens_used: 0, est_cost_usd: 0 }} />);
 
     expect(screen.getByText("Spend").parentElement?.textContent).toContain("~$0.00");
-    expect(screen.getByText("Without savings").parentElement?.textContent).toContain("~$0.00");
-    expect(screen.getByText("Estimated savings").parentElement?.textContent).toContain("~$0.00");
-    expect(screen.getByText("Less spent").parentElement?.textContent).toContain("—");
-    expect(screen.queryByText("Why you saved")).toBeNull();
+    expect(screen.getByText("At list price").parentElement?.textContent).toContain("~$0.00");
+    expect(screen.getByText("List-price value").parentElement?.textContent).toContain("~$0.00");
+    expect(screen.getByText("Less than list price").parentElement?.textContent).toContain("—");
+    expect(screen.queryByText("Why list-price is lower")).toBeNull();
   });
 });
 

--- a/webapp/src/__tests__/EconomicsPane.test.tsx
+++ b/webapp/src/__tests__/EconomicsPane.test.tsx
@@ -1,7 +1,8 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import EconomicsPane from "../components/EconomicsPane";
 import { api } from "../lib/api";
+import { _resetProcessUsageForTests } from "../lib/processUsage";
 import { openAgentSwarmJob } from "../lib/agentLinks";
 import { clearSWRCache } from "../lib/useStaleWhileRevalidate";
 import { dispatchProjectSelected } from "../lib/panelTransition";
@@ -68,6 +69,7 @@ async function chooseScope(value: "conversation" | "repo" | "all_projects") {
 describe("EconomicsPane", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetProcessUsageForTests();
     clearSWRCache();
     dispatchProjectSelected("/repo-a");
     mockGetUsage.mockResolvedValue(emptyUsage);
@@ -76,6 +78,10 @@ describe("EconomicsPane", () => {
       scope,
       all_projects: scope === "all_projects",
     }));
+  });
+
+  afterEach(() => {
+    _resetProcessUsageForTests();
   });
 
   it("removes the previous repo receipt immediately while the selected repo loads", async () => {
@@ -164,7 +170,7 @@ describe("EconomicsPane", () => {
     expect(screen.getByRole("option", { name: "This session" })).toBeTruthy();
     expect(screen.queryByRole("option", { name: "This conversation" })).toBeNull();
     expect(container.querySelectorAll(".overflow-y-auto")).toHaveLength(1);
-    expect(screen.queryByText("Why you saved")).toBeNull();
+    expect(screen.queryByText("Why list-price is lower")).toBeNull();
     expect(screen.queryByText("Additional estimates")).toBeNull();
     expect(screen.queryByText("This repo · all time")).toBeNull();
     expect((await screen.findByText("Job receipts")).closest("details")).toBeNull();
@@ -180,6 +186,7 @@ describe("EconomicsPane", () => {
     render(<EconomicsPane />);
 
     expect(await screen.findByText("Measured usage cost")).toBeTruthy();
+    expect(screen.getByText("Job receipts for the selected scope and period. Not this-open process spend.")).toBeTruthy();
     expect(screen.getByText("$0.32")).toBeTruthy();
     expect(screen.getByText("Estimated frontier cost")).toBeTruthy();
     expect(screen.getByText("~$4.24")).toBeTruthy();
@@ -508,8 +515,8 @@ describe("EconomicsPane", () => {
 
     expect(await screen.findByText(/job reports do not agree/)).toBeTruthy();
     expect(screen.queryByText("Spend")).toBeNull();
-    expect(screen.queryByText("Without savings")).toBeNull();
-    expect(screen.getByText("Why you saved")).toBeTruthy();
+    expect(screen.queryByText("At list price")).toBeNull();
+    expect(screen.getByText("Why list-price is lower")).toBeTruthy();
     expect(screen.getByText("Prompt-cache value")).toBeTruthy();
   });
 
@@ -540,9 +547,9 @@ describe("EconomicsPane", () => {
     expect(await screen.findByText("Measured usage cost")).toBeTruthy();
     expect(screen.getByText("$0.32")).toBeTruthy();
     expect(screen.getByText("Estimated frontier cost")).toBeTruthy();
-    expect(screen.queryByText("Without savings")).toBeNull();
-    expect(screen.queryByText("Less spent")).toBeNull();
-    expect(screen.getByText("Why you saved")).toBeTruthy();
+    expect(screen.queryByText("At list price")).toBeNull();
+    expect(screen.queryByText("Less than list price")).toBeNull();
+    expect(screen.getByText("Why list-price is lower")).toBeTruthy();
     expect(screen.getByText("Prompt-cache value")).toBeTruthy();
     expect(screen.getByText("Compact tool outputs")).toBeTruthy();
     expect(screen.getByText(/since you opened Marionette/)).toBeTruthy();
@@ -583,8 +590,8 @@ describe("EconomicsPane", () => {
     expect(await screen.findByText("Prompt-cache value")).toBeTruthy();
     expect(screen.getByText("Compact tool outputs")).toBeTruthy();
     expect(screen.getByText("Spend")).toBeTruthy();
-    expect(screen.getByText("Without savings")).toBeTruthy();
-    expect(screen.getByText("No owned jobs for this session.")).toBeTruthy();
+    expect(screen.getByText("At list price")).toBeTruthy();
+    expect(await screen.findByText("No owned jobs for this session.")).toBeTruthy();
   });
 
   it("keeps conversation scope honest when no full comparison exists", async () => {

--- a/webapp/src/__tests__/StatusBar.test.tsx
+++ b/webapp/src/__tests__/StatusBar.test.tsx
@@ -9,6 +9,7 @@ import StatusBar, {
 import EconomicsPane from "../components/EconomicsPane";
 import UpdateBanner, { type UpdateAvailability } from "../components/UpdateBanner";
 import { api } from "../lib/api";
+import { _resetProcessUsageForTests } from "../lib/processUsage";
 import { publishTaskProfile } from "../lib/taskProfileChrome";
 
 vi.mock("../lib/api", () => ({
@@ -59,12 +60,17 @@ const mockCompleteSessionGoal = vi.mocked(api.completeSessionGoal);
 const mockClearSessionGoal = vi.mocked(api.clearSessionGoal);
 
 beforeEach(() => {
+  _resetProcessUsageForTests();
   mockGetUsage.mockResolvedValue(processUsage);
   mockGetEconomics.mockResolvedValue({
     available: true,
     scope: "conversation",
     counterfactual: null,
   });
+});
+
+afterEach(() => {
+  _resetProcessUsageForTests();
 });
 
 const statusBarProps = {
@@ -229,6 +235,36 @@ describe("StatusBar usage pills", () => {
 
     expect(await screen.findByLabelText("Economics ownership")).toHaveValue("conversation");
     expect(screen.getByLabelText("Economics period")).toHaveValue("all");
+  });
+
+  it("footer and pane spend the same process-usage snapshot", async () => {
+    (window as unknown as { __pmPendingEconomicsSelection?: { scope: string; period: string } })
+      .__pmPendingEconomicsSelection = { scope: "conversation", period: "all" };
+
+    render(
+      <>
+        <StatusBar {...statusBarProps} />
+        <EconomicsPane />
+      </>,
+    );
+
+    expect(await screen.findByRole("button", { name: "$0.55" })).toBeTruthy();
+    expect(await screen.findByText("Spend")).toBeTruthy();
+    expect(screen.getAllByText("$0.55").length).toBeGreaterThan(1);
+    expect(screen.getByText("this open")).toBeTruthy();
+    expect(screen.getByText("~$6.67 list-price")).toBeTruthy();
+
+    mockGetUsage.mockResolvedValue({
+      ...processUsage,
+      session: { ...processUsage.session, est_cost_usd: 0.99 },
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event("harness-usage-refresh"));
+    });
+
+    expect(await screen.findByRole("button", { name: "$0.99" })).toBeTruthy();
+    expect(screen.getAllByText("$0.99").length).toBeGreaterThan(1);
+    expect(screen.queryByRole("button", { name: "$0.55" })).toBeNull();
   });
 });
 

--- a/webapp/src/__tests__/processUsage.test.ts
+++ b/webapp/src/__tests__/processUsage.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../lib/api";
+import {
+  _resetProcessUsageForTests,
+  getProcessUsage,
+  refreshProcessUsage,
+  subscribeProcessUsage,
+  type ProcessUsageSnapshot,
+} from "../lib/processUsage";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    getUsage: vi.fn(),
+  },
+}));
+
+const mockGetUsage = vi.mocked(api.getUsage);
+
+function session(estCostUsd: number, tokensUsed = 100) {
+  return {
+    session: {
+      tokens_used: tokensUsed,
+      est_cost_usd: estCostUsd,
+      driver: "test",
+      price_in: 1,
+      price_out: 1,
+    },
+    jobs: [],
+    session_total: { session_id: "s", est_cost_usd: estCostUsd, input_tokens: 1, output_tokens: 1 },
+  };
+}
+
+describe("processUsage store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetProcessUsageForTests();
+    mockGetUsage.mockResolvedValue(session(0.55));
+  });
+
+  afterEach(() => {
+    _resetProcessUsageForTests();
+  });
+
+  it("gives two subscribers the same generation and session", async () => {
+    const first: ProcessUsageSnapshot[] = [];
+    const second: ProcessUsageSnapshot[] = [];
+    const offA = subscribeProcessUsage((snap) => first.push(snap));
+    const offB = subscribeProcessUsage((snap) => second.push(snap));
+    await refreshProcessUsage();
+    const latestA = first.at(-1);
+    const latestB = second.at(-1);
+    expect(latestA?.session?.est_cost_usd).toBe(0.55);
+    expect(latestB?.session?.est_cost_usd).toBe(0.55);
+    expect(latestA?.generation).toBe(latestB?.generation);
+    expect(latestA?.generation).toBeGreaterThan(0);
+    offA();
+    offB();
+  });
+
+  it("does not start a second getUsage while one is in flight", async () => {
+    let resolveFirst!: (value: ReturnType<typeof session>) => void;
+    mockGetUsage.mockImplementation(
+      () => new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+    const first = refreshProcessUsage();
+    const second = refreshProcessUsage();
+    expect(first).toBe(second);
+    expect(mockGetUsage).toHaveBeenCalledTimes(1);
+    resolveFirst(session(0.12));
+    await first;
+    expect(getProcessUsage().session?.est_cost_usd).toBe(0.12);
+  });
+
+  it("keeps the previous spend snapshot when a zero poll arrives", async () => {
+    subscribeProcessUsage(() => {});
+    await refreshProcessUsage();
+    expect(getProcessUsage().session?.est_cost_usd).toBe(0.55);
+    mockGetUsage.mockResolvedValue(session(0, 0));
+    await refreshProcessUsage();
+    expect(getProcessUsage().session?.est_cost_usd).toBe(0.55);
+  });
+
+  it("accepts a zero snapshot after a session-change event", async () => {
+    subscribeProcessUsage(() => {});
+    await refreshProcessUsage();
+    mockGetUsage.mockResolvedValue(session(0, 0));
+    window.dispatchEvent(new Event("harness-session-changed"));
+    await refreshProcessUsage();
+    expect(getProcessUsage().session?.est_cost_usd).toBe(0);
+    expect(getProcessUsage().session?.tokens_used).toBe(0);
+  });
+});

--- a/webapp/src/components/CostBreakdown.tsx
+++ b/webapp/src/components/CostBreakdown.tsx
@@ -462,7 +462,7 @@ export default function CostBreakdown({
   return (
     <div className="w-full min-h-0 px-3 py-3 text-[11px] text-txt">
       <p className="text-[10px] text-muted mb-2 leading-snug">
-        Spend and savings since you opened Marionette.
+        Spend and list-price value since you opened Marionette.
       </p>
       {hero ? (
       <div className="mb-3 rounded-md border border-edge/50 bg-panel2/20 px-2.5 py-2.5">
@@ -472,15 +472,15 @@ export default function CostBreakdown({
             <div className="mt-0.5 text-[15px] font-medium tabular-nums text-txt">{spendPrefix}{fmtCost(est)}</div>
           </div>
           <div className="min-w-0">
-            <div className="text-[10px] text-muted">Without savings</div>
+            <div className="text-[10px] text-muted">At list price</div>
             <div className="mt-0.5 text-[15px] font-medium tabular-nums text-txt">~{fmtCost(withoutSavings)}</div>
           </div>
           <div className="min-w-0">
-            <div className="text-[10px] text-muted">Estimated savings</div>
+            <div className="text-[10px] text-muted">{listPriceValueHeading(listPriceValueWeakestBasis(data))}</div>
             <div className="mt-0.5 text-[15px] font-medium tabular-nums text-good/65">~{fmtCost(valueTotal)}</div>
           </div>
           <div className="min-w-0">
-            <div className="text-[10px] text-muted">Less spent</div>
+            <div className="text-[10px] text-muted">Less than list price</div>
             <div className="mt-0.5 text-[15px] font-medium tabular-nums text-good/65">
               {savingsPercent === null ? "—" : `${savingsPercent.toFixed(1)}%`}
             </div>
@@ -491,9 +491,9 @@ export default function CostBreakdown({
 
       {showWhySaved ? (
       <div className={hero ? "mt-2 pt-2 border-t border-edge/50" : undefined}>
-      <div className="text-[10px] text-faint mb-1">Why you saved</div>
+      <div className="text-[10px] text-faint mb-1">Why list-price is lower</div>
       <p className="text-[10px] text-muted mb-1.5 leading-snug">
-        Each saving is shown once, so the total stays honest.
+        Each line is shown once, so the total stays honest.
       </p>
       {promptCacheSaved > 0 ? (
         <div

--- a/webapp/src/components/EconomicsDurable.tsx
+++ b/webapp/src/components/EconomicsDurable.tsx
@@ -94,6 +94,9 @@ export default function EconomicsDurable({
 
       {durableReceiptHeroAvailable(data) ? (
         <section className="mx-3 mb-3 rounded-md border border-edge/50 bg-panel2/20 px-3 py-2.5">
+          <p className="text-[10px] text-muted mb-2 leading-snug">
+            Job receipts for the selected scope and period. Not this-open process spend.
+          </p>
           <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">
             <div className="min-w-0">
               <div className="text-[10px] text-muted">{spendHeading}</div>

--- a/webapp/src/components/EconomicsPane.tsx
+++ b/webapp/src/components/EconomicsPane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Coins } from "lucide-react";
-import { api, type EconomicsData, type EconomicsScope, type UsageData } from "../lib/api";
+import { api, type EconomicsData, type EconomicsScope } from "../lib/api";
+import { useProcessUsage } from "../lib/processUsage";
 import { usePolling } from "../lib/usePolling";
 import { readSWRCache, writeSWRCache } from "../lib/useStaleWhileRevalidate";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
@@ -53,16 +54,8 @@ export default function EconomicsPane() {
       ),
     ) ?? null,
   );
-  const [usage, setUsage] = useState<UsageData | null>(null);
   const economicsRequest = useRef(0);
-
-  const loadUsage = () => {
-    return Promise.resolve(api.getUsage())
-      .then((data) => {
-        if (data && data.session) setUsage(data);
-      })
-      .catch(() => {});
-  };
+  const processUsage = useProcessUsage();
 
   const loadEconomics = (
     requestedScope = scope,
@@ -96,11 +89,9 @@ export default function EconomicsPane() {
   };
 
   usePolling(loadEconomics, 10000, { enabled: Boolean(projectRoot) });
-  usePolling(loadUsage, 10000);
 
   useEffect(() => {
     const onUsageRefresh = () => {
-      void loadUsage();
       void loadEconomics();
     };
     const onSessionChanged = () => {
@@ -155,8 +146,8 @@ export default function EconomicsPane() {
     && (periodDays === 30 ? economics.window_days === 30 : !economics.window_days),
   );
   const projectLabel = projectRoot.split(/[\\/]/).filter(Boolean).at(-1) || "this repo";
-  const processMeters = usage?.session
-    ? usageToCostBreakdownData(usage.session)
+  const processMeters = processUsage.session
+    ? usageToCostBreakdownData(processUsage.session)
     : null;
   const showProcessMeters = Boolean(
     processMeters

--- a/webapp/src/components/StatusBar.tsx
+++ b/webapp/src/components/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Circle,
   GitBranch,
@@ -15,7 +15,8 @@ import {
   Check,
   X,
 } from "lucide-react";
-import { api, type Config, type SessionGoal, type SessionState, type UsageData } from "../lib/api";
+import { api, type Config, type SessionGoal, type SessionState } from "../lib/api";
+import { useProcessUsage } from "../lib/processUsage";
 import {
   subscribeTaskProfile,
   taskProfileTitle,
@@ -88,7 +89,6 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
   onOpenEconomics: () => void;
 }) {
   const [branch, setBranch] = useState("");
-  const [usage, setUsage] = useState<UsageData["session"] | null>(null);
   const [apply, setApply] = useState<{ stage: string; message: string; percent: number | null } | null>(null);
   const [toast, setToast] = useState<{
     message: string;
@@ -194,33 +194,6 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
     };
   }, []);
 
-  const usageInFlight = useRef(false);
-  const acceptZeroUsageRef = useRef(false);
-  const fetchUsage = () => {
-    if (usageInFlight.current) return;
-    usageInFlight.current = true;
-    api.getUsage()
-      .then((data) => {
-        if (data && data.session) {
-          setUsage((prev) => {
-            const next = data.session;
-            const nextZero =
-              (next.tokens_used ?? 0) === 0 && (next.est_cost_usd ?? 0) === 0;
-            const prevHadSpend =
-              !!prev && ((prev.tokens_used ?? 0) > 0 || (prev.est_cost_usd ?? 0) > 0);
-            if (acceptZeroUsageRef.current) {
-              acceptZeroUsageRef.current = false;
-              return next;
-            }
-            if (nextZero && prevHadSpend) return prev;
-            return next;
-          });
-        }
-      })
-      .catch((err) => console.error("Failed to load usage in StatusBar", err))
-      .finally(() => { usageInFlight.current = false; });
-  };
-
   useEffect(() => {
     api.workspaces().then((ws) => {
       const active = ws.find((w) => w.active);
@@ -236,34 +209,22 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
   const runtimeReady = runtimeStatus === "ready";
   const sessionGoal = sessionGoalForChip(sessionState?.goal);
   const usageBusy = runtimeStatus === "busy" || runtimeStatus === "thinking";
+  const usage = useProcessUsage({ busy: usageBusy }).session;
 
   useEffect(() => {
-    fetchUsage();
-    const interval = setInterval(fetchUsage, usageBusy ? 2000 : 10000);
-    const onRefresh = () => fetchUsage();
     const onSessionChanged = () => {
-      acceptZeroUsageRef.current = true;
-      setUsage(null);
       setTaskProfile(null);
-      fetchUsage();
       // Session/view swaps carry a different sticky GOAL — refresh immediately
       // rather than waiting for the next 4s poll tick.
       void refreshSessionState();
     };
-    window.addEventListener("harness-config-changed", onRefresh);
-    window.addEventListener("harness-project-selected", onRefresh);
     window.addEventListener("harness-new-session", onSessionChanged);
-    window.addEventListener("harness-usage-refresh", onRefresh);
     window.addEventListener("harness-session-changed", onSessionChanged);
     return () => {
-      clearInterval(interval);
-      window.removeEventListener("harness-config-changed", onRefresh);
-      window.removeEventListener("harness-project-selected", onRefresh);
       window.removeEventListener("harness-new-session", onSessionChanged);
-      window.removeEventListener("harness-usage-refresh", onRefresh);
       window.removeEventListener("harness-session-changed", onSessionChanged);
     };
-  }, [usageBusy]);
+  }, []);
 
   const formatTokens = (num: number) => {
     if (num >= 1000000) {
@@ -457,7 +418,7 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
                   {hit.percent != null && savedUsd > 0 ? (
                     <span className="text-good/50" aria-hidden="true">·</span>
                   ) : null}
-                  {savedUsd > 0 ? `~${formatCost(savedUsd)} saved` : null}
+                  {savedUsd > 0 ? `~${formatCost(savedUsd)} list-price` : null}
                 </button>
               );
             })()}
@@ -474,7 +435,7 @@ export default function StatusBar({ config, update, leftOpen, rightOpen, onToggl
               {spendIsEstimated(usage) ? "~" : ""}
               {formatCost(usage.est_cost_usd)}
             </button>
-            <span className="text-faint/70 normal-case font-sans tracking-normal status-bar-optional-lg">process</span>
+            <span className="text-faint/70 normal-case font-sans tracking-normal">this open</span>
           </span>
         </>
       )}

--- a/webapp/src/lib/processUsage.ts
+++ b/webapp/src/lib/processUsage.ts
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+import { api, type UsageData } from "./api";
+
+export type ProcessUsageSession = UsageData["session"];
+
+export type ProcessUsageSnapshot = {
+  session: ProcessUsageSession | null;
+  fetchedAt: number;
+  generation: number;
+};
+
+type Listener = (snapshot: ProcessUsageSnapshot) => void;
+
+const listeners = new Set<Listener>();
+
+let snapshot: ProcessUsageSnapshot = emptySnapshot();
+let inFlight: Promise<void> | null = null;
+let acceptZero = false;
+let pollTimer: number | undefined;
+let subscriberCount = 0;
+let busyCount = 0;
+let bridgesInstalled = false;
+
+function emptySnapshot(): ProcessUsageSnapshot {
+  return { session: null, fetchedAt: 0, generation: 0 };
+}
+
+function sessionIsZero(session: ProcessUsageSession): boolean {
+  return (session.tokens_used ?? 0) === 0 && (session.est_cost_usd ?? 0) === 0;
+}
+
+function sessionHasSpend(session: ProcessUsageSession | null): boolean {
+  return Boolean(
+    session && ((session.tokens_used ?? 0) > 0 || (session.est_cost_usd ?? 0) > 0),
+  );
+}
+
+function emit(next: ProcessUsageSnapshot): void {
+  snapshot = next;
+  listeners.forEach((listener) => listener(snapshot));
+}
+
+function acceptSession(session: ProcessUsageSession): void {
+  if (acceptZero) {
+    acceptZero = false;
+  } else if (sessionIsZero(session) && sessionHasSpend(snapshot.session)) {
+    return;
+  }
+  emit({
+    session,
+    fetchedAt: Date.now(),
+    generation: snapshot.generation + 1,
+  });
+}
+
+export function getProcessUsage(): ProcessUsageSnapshot {
+  return snapshot;
+}
+
+export function refreshProcessUsage(): Promise<void> {
+  if (inFlight) return inFlight;
+  const run = (async () => {
+    try {
+      const data = await api.getUsage();
+      if (data?.session) acceptSession(data.session);
+    } catch (err) {
+      console.error("Failed to load process usage", err);
+    } finally {
+      inFlight = null;
+    }
+  })();
+  inFlight = run;
+  return run;
+}
+
+function resetForSessionChange(): void {
+  acceptZero = true;
+  emit({
+    session: null,
+    fetchedAt: Date.now(),
+    generation: snapshot.generation + 1,
+  });
+  void refreshProcessUsage();
+}
+
+function pollIntervalMs(): number {
+  return busyCount > 0 ? 2000 : 10000;
+}
+
+function stopPolling(): void {
+  if (typeof window === "undefined" || pollTimer === undefined) return;
+  window.clearTimeout(pollTimer);
+  pollTimer = undefined;
+}
+
+function schedulePoll(): void {
+  if (typeof window === "undefined") return;
+  stopPolling();
+  if (subscriberCount <= 0) return;
+  pollTimer = window.setTimeout(() => {
+    if (typeof document !== "undefined" && document.hidden) {
+      schedulePoll();
+      return;
+    }
+    void refreshProcessUsage().finally(() => {
+      schedulePoll();
+    });
+  }, pollIntervalMs());
+}
+
+function installBridges(): void {
+  if (bridgesInstalled || typeof window === "undefined") return;
+  bridgesInstalled = true;
+  const refresh = () => {
+    void refreshProcessUsage();
+  };
+  window.addEventListener("harness-usage-refresh", refresh);
+  window.addEventListener("harness-config-changed", refresh);
+  window.addEventListener("harness-project-selected", refresh);
+  window.addEventListener("harness-new-session", resetForSessionChange);
+  window.addEventListener("harness-session-changed", resetForSessionChange);
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) refresh();
+  });
+}
+
+export function subscribeProcessUsage(listener: Listener): () => void {
+  installBridges();
+  listeners.add(listener);
+  subscriberCount += 1;
+  if (subscriberCount === 1) {
+    void refreshProcessUsage();
+    schedulePoll();
+  }
+  listener(snapshot);
+  return () => {
+    listeners.delete(listener);
+    subscriberCount = Math.max(0, subscriberCount - 1);
+    if (subscriberCount === 0) stopPolling();
+  };
+}
+
+export function useProcessUsage(opts?: { busy?: boolean }): ProcessUsageSnapshot {
+  const [current, setCurrent] = useState(getProcessUsage);
+  useEffect(() => subscribeProcessUsage(setCurrent), []);
+  useEffect(() => {
+    if (!opts?.busy) return undefined;
+    busyCount += 1;
+    schedulePoll();
+    return () => {
+      busyCount = Math.max(0, busyCount - 1);
+      schedulePoll();
+    };
+  }, [opts?.busy]);
+  return current;
+}
+
+export function _resetProcessUsageForTests(): void {
+  stopPolling();
+  listeners.clear();
+  subscriberCount = 0;
+  busyCount = 0;
+  inFlight = null;
+  acceptZero = false;
+  snapshot = emptySnapshot();
+}


### PR DESCRIPTION
## Why

Ship the #285 absorb: one process-usage snapshot for footer and Economics pane, plus glance labels that name list-price and this-open spend.

## Scope

- PR #289 on dest: `processUsage` store, StatusBar/EconomicsPane subscribe, CostBreakdown/EconomicsDurable copy.
- Version 0.9.404. Pin stays puppetmaster-ai==1.22.43.

## Verification

Focused vitest 63 passed (processUsage, StatusBar, EconomicsPane, CostBreakdown, EconomicsDurable). Dest-into-main `tests` matrix is the ship gate.