### PR TITLE
fix: distinguish todo focus from running work

### DIFF
--- a/webapp/src/__tests__/ComposerTodoPanel.test.tsx
+++ b/webapp/src/__tests__/ComposerTodoPanel.test.tsx
@@ -52,4 +52,17 @@ describe("ComposerTodoPanel", () => {
     expect(screen.queryByText("TODO 0/1")).not.toBeInTheDocument();
     expect(screen.queryByText("arena leftover")).not.toBeInTheDocument();
   });
+
+  it("does not present durable in-progress plan state as a running job", () => {
+    publishSessionTodos({
+      phases: [
+        { name: "Implement", tasks: [{ content: "rewrite the DAG", status: "in_progress" }] },
+      ],
+    }, "sess-plan");
+
+    render(<ComposerTodoPanel sessionId="sess-plan" />);
+
+    const taskRow = screen.getByText("rewrite the DAG").parentElement;
+    expect(taskRow?.querySelector("svg")?.classList.contains("animate-spin")).toBe(false);
+  });
 });

--- a/webapp/src/components/conversation/ComposerTodoPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTodoPanel.tsx
@@ -27,7 +27,8 @@ function TaskMark({
   if (status === "completed") return <CheckCircle2 size={11} className="shrink-0 text-good" />;
   if (status === "abandoned") return <MinusCircle size={11} className="shrink-0 text-faint" />;
   if (status === "blocked") return <Ban size={11} className="shrink-0 text-warn" />;
-  if (status === "in_progress" || lit) return <Loader2 size={11} className="shrink-0 animate-spin text-accent" />;
+  if (lit) return <Loader2 size={11} className="shrink-0 animate-spin text-accent" />;
+  if (status === "in_progress") return <Circle size={11} className="shrink-0 text-accent" />;
   return <Circle size={11} className="shrink-0 text-faint" />;
 }
 


### PR DESCRIPTION
TODO looks like task is running when nothing is actually running:
<img width="925" height="944" alt="Screenshot 2026-09-03 at 9 31 04 AM" src="https://github.com/user-attachments/assets/c8b3a828-4256-445f-b7ec-a8a6d15f0ed9" />


## Summary
- keep durable `in_progress` TODO state visible without implying a worker is running
- animate the TODO marker only when a live job correlates to that task
- add a focused regression for an in-progress plan with no live jobs

## Verification
- `NODE_ENV=test npm test -- --run src/__tests__/ComposerTodoPanel.test.tsx` (3 passed)
- `NODE_ENV=test npm run build` (passed)