### PR TITLE
fix: keep incomplete replies on their owning turns

### DIFF
--- a/webapp/src/__tests__/turnTerminal.wave3.test.ts
+++ b/webapp/src/__tests__/turnTerminal.wave3.test.ts
@@ -668,6 +668,37 @@ describe("Wave 3 last-mile: turn_terminal hydrate / merge", () => {
     expect(terminalChip(merged)?.id).toBe("term-local");
     expect(mergeLocalTurnTerminals(remote, local)).toHaveLength(3);
   });
+
+  it("keeps a client-only terminal chip on its owning turn after a later completed turn", () => {
+    const firstTerminal: Extract<Item, { kind: "turn_terminal" }> = {
+      kind: "turn_terminal",
+      id: "term-first",
+      cause: "incomplete",
+      state: "settled_incomplete",
+      text: "Reply incomplete.",
+    };
+    const local: Item[] = [
+      msg("user", "first"),
+      msg("assistant", "Halfway"),
+      firstTerminal,
+      msg("user", "continue"),
+      msg("assistant", "Done"),
+    ];
+    const remote: Item[] = [
+      msg("user", "first"),
+      msg("assistant", "Halfway"),
+      msg("user", "continue"),
+      msg("assistant", "Done"),
+    ];
+
+    expect(mergeTranscriptItems(local, remote)).toEqual([
+      remote[0],
+      remote[1],
+      firstTerminal,
+      remote[2],
+      remote[3],
+    ]);
+  });
 });
 
 describe("Wave 3 last-mile: unique keys and shelf identity", () => {

--- a/webapp/src/components/conversation/transcriptItems.ts
+++ b/webapp/src/components/conversation/transcriptItems.ts
@@ -706,15 +706,27 @@ function insertIndexForRemoteCard(
  * path, remote swarm_result / swarm_pending rows still reconcile by stable
  * identity (latest-explicit reuse merge + terminal pending merge).
  */
-/** Keep this session's terminal chip when disk/API hydrate omits client-only rows. */
+/** Restore client-only terminal chips at their owning user-turn boundary. */
 export function mergeLocalTurnTerminals(remote: Item[], local: Item[]): Item[] {
-  const remoteHas = remote.some((it) => it.kind === "turn_terminal");
-  if (remoteHas) return remote;
-  const localTerms = local.filter(
-    (it): it is Extract<Item, { kind: "turn_terminal" }> => it.kind === "turn_terminal",
-  );
-  if (localTerms.length === 0) return remote;
-  return [...remote, ...localTerms];
+  const merged = [...remote];
+  const remoteUserCount = remote.filter(
+    (it) => it.kind === "msg" && it.msg.role === "user",
+  ).length;
+  const occupiedTurns = new Set<number>();
+  remote.forEach((it, index) => {
+    if (it.kind === "turn_terminal") {
+      occupiedTurns.add(owningUserTurnOrdinal(remote, index));
+    }
+  });
+  local.forEach((it, index) => {
+    if (it.kind !== "turn_terminal") return;
+    const turnOrdinal = owningUserTurnOrdinal(local, index);
+    if (turnOrdinal < 0 || turnOrdinal >= remoteUserCount || occupiedTurns.has(turnOrdinal)) return;
+    const { end } = localTurnBounds(merged, turnOrdinal);
+    merged.splice(end, 0, it);
+    occupiedTurns.add(turnOrdinal);
+  });
+  return merged;
 }
 
 export function mergeTranscriptItems(local: Item[], remote: Item[]): Item[] {


### PR DESCRIPTION
If the pilot ever emitted `Reply incomplete.`, that emission would follow every output afterwards until...something(?)...cleared it

## Summary
- preserve client-only incomplete-turn warnings across transcript hydration
- restore each warning at its owning user-turn boundary instead of appending it to the latest reply
- keep durable terminal rows authoritative for their own turns and reject unmatched local terminals

## Semantics
`Reply incomplete` remains historical evidence that a provider turn lacked an authoritative natural finish. This change does not reinterpret or delete that evidence; it prevents an older warning from appearing to describe a later successful reply.

## Verification
- `NODE_ENV=test npm test -- --run src/__tests__/turnTerminal.wave3.test.ts` (39 passed)
- `NODE_ENV=test npm run build` (passed)
- `git diff --check` (passed)