### PR TITLE
Release v0.9.407

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.45` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.406, deliberately pre-1.0. Rides puppetmaster-ai==1.22.45. Skill catalog stays in the frozen prefix (bodies retrieve per turn); git spawns neutralize repo hooks; tools[] freeze across sends with a `/reload-mcp` hatch; cron keeps a continuity digest and can suppress failure notices; compaction fail-until persists and idle ungrown transcripts skip auto-compact; vault retrieve is fail-closed; analysis/QA roles cannot write. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.407, deliberately pre-1.0. Rides puppetmaster-ai==1.22.45. TODO markers spin only when a live job correlates; incomplete-reply chips stay on their owning turn after hydrate. Skill catalog stays in the frozen prefix (bodies retrieve per turn); git spawns neutralize repo hooks; tools[] freeze across sends with a `/reload-mcp` hatch; cron keeps a continuity digest and can suppress failure notices; compaction fail-until persists and idle ungrown transcripts skip auto-compact; vault retrieve is fail-closed; analysis/QA roles cannot write. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.406"
+__version__ = "0.9.407"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.406"
+version = "0.9.407"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.406",
+  "version": "0.9.407",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.406",
+      "version": "0.9.407",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.406",
+  "version": "0.9.407",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/ComposerTodoPanel.test.tsx
+++ b/webapp/src/__tests__/ComposerTodoPanel.test.tsx
@@ -52,4 +52,17 @@ describe("ComposerTodoPanel", () => {
     expect(screen.queryByText("TODO 0/1")).not.toBeInTheDocument();
     expect(screen.queryByText("arena leftover")).not.toBeInTheDocument();
   });
+
+  it("does not present durable in-progress plan state as a running job", () => {
+    publishSessionTodos({
+      phases: [
+        { name: "Implement", tasks: [{ content: "rewrite the DAG", status: "in_progress" }] },
+      ],
+    }, "sess-plan");
+
+    render(<ComposerTodoPanel sessionId="sess-plan" />);
+
+    const taskRow = screen.getByText("rewrite the DAG").parentElement;
+    expect(taskRow?.querySelector("svg")?.classList.contains("animate-spin")).toBe(false);
+  });
 });

--- a/webapp/src/__tests__/ComposerTodoPanel.test.tsx
+++ b/webapp/src/__tests__/ComposerTodoPanel.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import ComposerTodoPanel from "../components/conversation/ComposerTodoPanel";
+import type { Job } from "../lib/api";
 import { clearSessionTodos, publishSessionTodos } from "../lib/sessionTodos";
 
 vi.mock("../lib/api", () => ({
@@ -64,5 +65,25 @@ describe("ComposerTodoPanel", () => {
 
     const taskRow = screen.getByText("rewrite the DAG").parentElement;
     expect(taskRow?.querySelector("svg")?.classList.contains("animate-spin")).toBe(false);
+  });
+
+  it("animates an in-progress todo only when a live job correlates", () => {
+    publishSessionTodos({
+      phases: [
+        { name: "Implement", tasks: [{ content: "rewrite the DAG", status: "in_progress" }] },
+      ],
+    }, "sess-plan");
+    const job = {
+      id: "j-live",
+      goal: "rewrite the DAG worker",
+      status: "running",
+      session_id: "sess-plan",
+      tasks: [{ id: "t1", role: "implement", instruction: "rewrite the DAG", status: "running" }],
+    } as Job;
+
+    render(<ComposerTodoPanel sessionId="sess-plan" jobs={[job]} />);
+
+    const taskRow = screen.getByText("rewrite the DAG").parentElement;
+    expect(taskRow?.querySelector("svg")?.classList.contains("animate-spin")).toBe(true);
   });
 });

--- a/webapp/src/__tests__/composerTodos.test.ts
+++ b/webapp/src/__tests__/composerTodos.test.ts
@@ -89,6 +89,27 @@ describe("composerTodos", () => {
     expect([...litTodoContents(snapshot, liveJobTodoLabels(jobs, "sess-1"))]).toEqual(["hosted pari"]);
   });
 
+  it("lights a matching in_progress todo when a live job correlates", () => {
+    const jobs = [
+      {
+        id: "j1",
+        goal: "nested todo lighting",
+        status: "running",
+        session_id: "sess-1",
+        tasks: [{ id: "t1", role: "explore", instruction: "hosted pari service", status: "running" }],
+      },
+    ] as Job[];
+    const snapshot: SessionTodoSnapshot = {
+      phases: [
+        {
+          name: "WP-02",
+          tasks: [task("hosted pari", "in_progress"), task("unrelated cutover", "pending")],
+        },
+      ],
+    };
+    expect([...litTodoContents(snapshot, liveJobTodoLabels(jobs, "sess-1"))]).toEqual(["hosted pari"]);
+  });
+
   it("keeps lit pending todos in the folded viewport", () => {
     const tasks = [
       task("old-1", "completed"),

--- a/webapp/src/__tests__/turnTerminal.wave3.test.ts
+++ b/webapp/src/__tests__/turnTerminal.wave3.test.ts
@@ -668,6 +668,37 @@ describe("Wave 3 last-mile: turn_terminal hydrate / merge", () => {
     expect(terminalChip(merged)?.id).toBe("term-local");
     expect(mergeLocalTurnTerminals(remote, local)).toHaveLength(3);
   });
+
+  it("keeps a client-only terminal chip on its owning turn after a later completed turn", () => {
+    const firstTerminal: Extract<Item, { kind: "turn_terminal" }> = {
+      kind: "turn_terminal",
+      id: "term-first",
+      cause: "incomplete",
+      state: "settled_incomplete",
+      text: "Reply incomplete.",
+    };
+    const local: Item[] = [
+      msg("user", "first"),
+      msg("assistant", "Halfway"),
+      firstTerminal,
+      msg("user", "continue"),
+      msg("assistant", "Done"),
+    ];
+    const remote: Item[] = [
+      msg("user", "first"),
+      msg("assistant", "Halfway"),
+      msg("user", "continue"),
+      msg("assistant", "Done"),
+    ];
+
+    expect(mergeTranscriptItems(local, remote)).toEqual([
+      remote[0],
+      remote[1],
+      firstTerminal,
+      remote[2],
+      remote[3],
+    ]);
+  });
 });
 
 describe("Wave 3 last-mile: unique keys and shelf identity", () => {

--- a/webapp/src/__tests__/turnTerminal.wave3.test.ts
+++ b/webapp/src/__tests__/turnTerminal.wave3.test.ts
@@ -699,6 +699,68 @@ describe("Wave 3 last-mile: turn_terminal hydrate / merge", () => {
       remote[3],
     ]);
   });
+
+  it("keeps an earlier local chip when remote already has a later-turn terminal", () => {
+    const firstTerminal: Extract<Item, { kind: "turn_terminal" }> = {
+      kind: "turn_terminal",
+      id: "term-first",
+      cause: "incomplete",
+      state: "settled_incomplete",
+      text: "Reply incomplete.",
+    };
+    const laterTerminal: Extract<Item, { kind: "turn_terminal" }> = {
+      kind: "turn_terminal",
+      id: "term-later",
+      cause: "incomplete",
+      state: "settled_incomplete",
+      text: "Reply incomplete.",
+    };
+    const local: Item[] = [
+      msg("user", "first"),
+      msg("assistant", "Halfway"),
+      firstTerminal,
+      msg("user", "continue"),
+      msg("assistant", "Done"),
+    ];
+    const remote: Item[] = [
+      msg("user", "first"),
+      msg("assistant", "Halfway"),
+      msg("user", "continue"),
+      msg("assistant", "Done"),
+      laterTerminal,
+    ];
+
+    expect(mergeLocalTurnTerminals(remote, local)).toEqual([
+      remote[0],
+      remote[1],
+      firstTerminal,
+      remote[2],
+      remote[3],
+      laterTerminal,
+    ]);
+  });
+
+  it("rejects a local chip whose owning turn is missing from remote", () => {
+    const orphan: Extract<Item, { kind: "turn_terminal" }> = {
+      kind: "turn_terminal",
+      id: "term-orphan",
+      cause: "incomplete",
+      state: "settled_incomplete",
+      text: "Reply incomplete.",
+    };
+    const remote: Item[] = [
+      msg("user", "first"),
+      msg("assistant", "Halfway"),
+    ];
+    const local: Item[] = [
+      ...remote,
+      msg("user", "only local"),
+      msg("assistant", "ghost"),
+      orphan,
+    ];
+
+    expect(mergeLocalTurnTerminals(remote, local)).toEqual(remote);
+  });
 });
 
 describe("Wave 3 last-mile: unique keys and shelf identity", () => {

--- a/webapp/src/components/conversation/ComposerTodoPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTodoPanel.tsx
@@ -27,7 +27,8 @@ function TaskMark({
   if (status === "completed") return <CheckCircle2 size={11} className="shrink-0 text-good" />;
   if (status === "abandoned") return <MinusCircle size={11} className="shrink-0 text-faint" />;
   if (status === "blocked") return <Ban size={11} className="shrink-0 text-warn" />;
-  if (status === "in_progress" || lit) return <Loader2 size={11} className="shrink-0 animate-spin text-accent" />;
+  if (lit) return <Loader2 size={11} className="shrink-0 animate-spin text-accent" />;
+  if (status === "in_progress") return <Circle size={11} className="shrink-0 text-accent" />;
   return <Circle size={11} className="shrink-0 text-faint" />;
 }
 

--- a/webapp/src/components/conversation/transcriptItems.ts
+++ b/webapp/src/components/conversation/transcriptItems.ts
@@ -706,15 +706,27 @@ function insertIndexForRemoteCard(
  * path, remote swarm_result / swarm_pending rows still reconcile by stable
  * identity (latest-explicit reuse merge + terminal pending merge).
  */
-/** Keep this session's terminal chip when disk/API hydrate omits client-only rows. */
+/** Restore client-only terminal chips at their owning user-turn boundary. */
 export function mergeLocalTurnTerminals(remote: Item[], local: Item[]): Item[] {
-  const remoteHas = remote.some((it) => it.kind === "turn_terminal");
-  if (remoteHas) return remote;
-  const localTerms = local.filter(
-    (it): it is Extract<Item, { kind: "turn_terminal" }> => it.kind === "turn_terminal",
-  );
-  if (localTerms.length === 0) return remote;
-  return [...remote, ...localTerms];
+  const merged = [...remote];
+  const remoteUserCount = remote.filter(
+    (it) => it.kind === "msg" && it.msg.role === "user",
+  ).length;
+  const occupiedTurns = new Set<number>();
+  remote.forEach((it, index) => {
+    if (it.kind === "turn_terminal") {
+      occupiedTurns.add(owningUserTurnOrdinal(remote, index));
+    }
+  });
+  local.forEach((it, index) => {
+    if (it.kind !== "turn_terminal") return;
+    const turnOrdinal = owningUserTurnOrdinal(local, index);
+    if (turnOrdinal < 0 || turnOrdinal >= remoteUserCount || occupiedTurns.has(turnOrdinal)) return;
+    const { end } = localTurnBounds(merged, turnOrdinal);
+    merged.splice(end, 0, it);
+    occupiedTurns.add(turnOrdinal);
+  });
+  return merged;
 }
 
 export function mergeTranscriptItems(local: Item[], remote: Item[]): Item[] {

--- a/webapp/src/components/conversation/transcriptItems.ts
+++ b/webapp/src/components/conversation/transcriptItems.ts
@@ -699,13 +699,6 @@ function insertIndexForRemoteCard(
   return insertAt;
 }
 
-/**
- * Merge a disk/API transcript into the live feed without dropping in-flight
- * cards. Prefer remote message text when ids match; keep local-only cards
- * and still-pending command approval cards. When local cards win the prefer
- * path, remote swarm_result / swarm_pending rows still reconcile by stable
- * identity (latest-explicit reuse merge + terminal pending merge).
- */
 /** Restore client-only terminal chips at their owning user-turn boundary. */
 export function mergeLocalTurnTerminals(remote: Item[], local: Item[]): Item[] {
   const merged = [...remote];
@@ -729,6 +722,13 @@ export function mergeLocalTurnTerminals(remote: Item[], local: Item[]): Item[] {
   return merged;
 }
 
+/**
+ * Merge a disk/API transcript into the live feed without dropping in-flight
+ * cards. Prefer remote message text when ids match; keep local-only cards
+ * and still-pending command approval cards. When local cards win the prefer
+ * path, remote swarm_result / swarm_pending rows still reconcile by stable
+ * identity (latest-explicit reuse merge + terminal pending merge).
+ */
 export function mergeTranscriptItems(local: Item[], remote: Item[]): Item[] {
   if (!shouldPreferLocalTranscript(local, remote)) {
     // Equal card counts take remote, but never drop a still-pending approval

--- a/webapp/src/lib/composerTodos.ts
+++ b/webapp/src/lib/composerTodos.ts
@@ -99,7 +99,7 @@ export function litTodoContents(
   const lit = new Set<string>();
   for (const phase of snapshot?.phases || []) {
     for (const task of phase.tasks) {
-      if (task.status !== "pending") continue;
+      if (task.status !== "pending" && task.status !== "in_progress") continue;
       if (todoMatchesAnyDescription(task.content, descriptions)) {
         lit.add(task.content);
       }


### PR DESCRIPTION
## Why
Ship Benton's dest absorb (#293 TODO focus vs live work, #294 incomplete replies on owning turns) plus the stack lighting gate as v0.9.407.

## Scope
- Absorb #295 already on dest: TaskMark spins only when lit; litTodoContents lights pending and in_progress; mergeLocalTurnTerminals restores chips at the owning user-turn.
- Version stamps 0.9.407 (pyproject, harness.__init__, webapp package + lock). README status line.

## Blast radius
Composer TODO markers and client-only turn_terminal hydrate. No Python harness behavior change. Puppetmaster pin stays 1.22.45.

## Verification
- Focused vitest (ComposerTodoPanel, composerTodos, composerFamilyChrome, turnTerminal.wave3): 61 passed
- npm run build: passed
- tests/test_version_consistency.py: 3 passed
