### PR TITLE
Fix Electron self-update relaunch

### DIFF
--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -680,9 +680,14 @@ async function applyUpdate({ repoRoot, branch = DEFAULT_BRANCH, strategy = "ff",
     }
     if (nodeChanged) {
       progress("deps", "Updating node dependencies", 0.7);
-      const npmci = await runNpmStreamed(["ci"], { cwd: path.join(repoRoot, "webapp"), env: childEnv },
-        (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating node dependencies", 0.8); });
+      const webappDir = path.join(repoRoot, "webapp");
+      const onNodeLine = (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating node dependencies", 0.8); };
+      const npmci = await runNpmStreamed(["ci"], { cwd: webappDir, env: childEnv }, onNodeLine);
       if (npmci.code !== 0) return { ok: false, error: npmci.tail || "npm ci failed" };
+      // npm ci removes the Electron.app executing Marionette; Electron 44
+      // restores its platform runtime lazily when required from plain Node.
+      const electron = await runStreamed("node", ["-e", "require('electron')"], { cwd: webappDir, env: childEnv }, onNodeLine);
+      if (electron.code !== 0) return { ok: false, error: electron.tail || "Electron runtime install failed" };
     }
 
     // Puppetmaster -- the one integral runtime dep -- ships independently of this


### PR DESCRIPTION
My Marionette instance fails to restart on update (clicking the update banner)

## Summary

- Rehydrate Electron's platform runtime immediately after `npm ci` when a source update changes the Node manifests.
- Keep the existing fetch → dependency refresh → build → relaunch ownership and sequencing unchanged.
- Fail before relaunch if Electron restoration fails, rather than exiting toward a deleted executable.

## Why

Electron 44 lazily installs its platform runtime when required from plain Node. During an in-app source update, `npm ci` removes the `Electron.app` currently executing Marionette but does not restore it. The renderer build succeeds, then `app.relaunch()` targets the deleted executable and Marionette exits without restarting.

This patch completes the existing Node dependency-refresh step; it does not change update detection, Git behavior, backend teardown, build behavior, packaged/source ownership, or relaunch ownership.

## Verification

- `node --test electron/update.test.cjs` — 51 passed
- `git diff --check origin/main...HEAD`
- Confirmed `node -e "require('electron')"` restores the missing Electron 44 runtime

A full behind-by-one update through final `app.relaunch()` has not been exercised on this branch.
