### PR TITLE
absorb #297: restore Electron after source-update npm ci

### DIFF
--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -395,6 +395,26 @@ function runNpmStreamed(args, opts, onLine) {
     : runStreamed("npm", args, opts, onLine);
 }
 
+const ELECTRON_RUNTIME_RESTORE_ARGS = ["-e", "require('electron')"];
+
+/**
+ * npm ci deletes the Electron platform binary that is currently executing
+ * Marionette. Electron 44 restores it lazily when required from plain Node.
+ */
+async function refreshWebappNodeModules({
+  webappDir,
+  env,
+  onLine,
+  runNpm = runNpmStreamed,
+  runNode = (args, opts, line) => runStreamed("node", args, opts, line),
+} = {}) {
+  const npmci = await runNpm(["ci"], { cwd: webappDir, env }, onLine);
+  if (npmci.code !== 0) return { ok: false, error: npmci.tail || "npm ci failed" };
+  const electron = await runNode(ELECTRON_RUNTIME_RESTORE_ARGS, { cwd: webappDir, env }, onLine);
+  if (electron.code !== 0) return { ok: false, error: electron.tail || "Electron runtime install failed" };
+  return { ok: true };
+}
+
 function runStreamed(cmd, args, opts, onLine) {
   return new Promise((resolve) => {
     let tail = "";
@@ -680,14 +700,12 @@ async function applyUpdate({ repoRoot, branch = DEFAULT_BRANCH, strategy = "ff",
     }
     if (nodeChanged) {
       progress("deps", "Updating node dependencies", 0.7);
-      const webappDir = path.join(repoRoot, "webapp");
-      const onNodeLine = (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating node dependencies", 0.8); };
-      const npmci = await runNpmStreamed(["ci"], { cwd: webappDir, env: childEnv }, onNodeLine);
-      if (npmci.code !== 0) return { ok: false, error: npmci.tail || "npm ci failed" };
-      // npm ci removes the Electron.app executing Marionette; Electron 44
-      // restores its platform runtime lazily when required from plain Node.
-      const electron = await runStreamed("node", ["-e", "require('electron')"], { cwd: webappDir, env: childEnv }, onNodeLine);
-      if (electron.code !== 0) return { ok: false, error: electron.tail || "Electron runtime install failed" };
+      const refreshed = await refreshWebappNodeModules({
+        webappDir: path.join(repoRoot, "webapp"),
+        env: childEnv,
+        onLine: (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating node dependencies", 0.8); },
+      });
+      if (!refreshed.ok) return refreshed;
     }
 
     // Puppetmaster -- the one integral runtime dep -- ships independently of this
@@ -1035,6 +1053,8 @@ module.exports = {
   registerUpdateBridge,
   checkForUpdate,
   applyUpdate,
+  refreshWebappNodeModules,
+  ELECTRON_RUNTIME_RESTORE_ARGS,
   isTrackedSelfEditLine,
   statusPath,
   isUnmergedStatusLine,

--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -680,9 +680,14 @@ async function applyUpdate({ repoRoot, branch = DEFAULT_BRANCH, strategy = "ff",
     }
     if (nodeChanged) {
       progress("deps", "Updating node dependencies", 0.7);
-      const npmci = await runNpmStreamed(["ci"], { cwd: path.join(repoRoot, "webapp"), env: childEnv },
-        (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating node dependencies", 0.8); });
+      const webappDir = path.join(repoRoot, "webapp");
+      const onNodeLine = (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating node dependencies", 0.8); };
+      const npmci = await runNpmStreamed(["ci"], { cwd: webappDir, env: childEnv }, onNodeLine);
       if (npmci.code !== 0) return { ok: false, error: npmci.tail || "npm ci failed" };
+      // npm ci removes the Electron.app executing Marionette; Electron 44
+      // restores its platform runtime lazily when required from plain Node.
+      const electron = await runStreamed("node", ["-e", "require('electron')"], { cwd: webappDir, env: childEnv }, onNodeLine);
+      if (electron.code !== 0) return { ok: false, error: electron.tail || "Electron runtime install failed" };
     }
 
     // Puppetmaster -- the one integral runtime dep -- ships independently of this

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -709,6 +709,55 @@ test("describeMainProcessUpdate: no shell change means nothing extra to require"
   assert.equal(verdict.note, undefined);
 });
 
+test("refreshWebappNodeModules: npm ci failure does not restore Electron", async () => {
+  const calls = [];
+  const result = await bridge.refreshWebappNodeModules({
+    webappDir: "/tmp/webapp",
+    env: { PATH: "/bin" },
+    runNpm: async (args, opts) => {
+      calls.push({ kind: "npm", args, cwd: opts.cwd });
+      return { code: 1, tail: "npm ERR! peer" };
+    },
+    runNode: async (args, opts) => {
+      calls.push({ kind: "node", args, cwd: opts.cwd });
+      return { code: 0, tail: "" };
+    },
+  });
+  assert.deepEqual(result, { ok: false, error: "npm ERR! peer" });
+  assert.deepEqual(calls, [{ kind: "npm", args: ["ci"], cwd: "/tmp/webapp" }]);
+});
+
+test("refreshWebappNodeModules: Electron restore failure blocks relaunch", async () => {
+  const calls = [];
+  const result = await bridge.refreshWebappNodeModules({
+    webappDir: "/tmp/webapp",
+    env: { PATH: "/bin" },
+    runNpm: async (args, opts) => {
+      calls.push({ kind: "npm", args, cwd: opts.cwd });
+      return { code: 0, tail: "" };
+    },
+    runNode: async (args, opts) => {
+      calls.push({ kind: "node", args, cwd: opts.cwd });
+      return { code: 1, tail: "Cannot find module 'electron'" };
+    },
+  });
+  assert.deepEqual(result, { ok: false, error: "Cannot find module 'electron'" });
+  assert.deepEqual(calls, [
+    { kind: "npm", args: ["ci"], cwd: "/tmp/webapp" },
+    { kind: "node", args: bridge.ELECTRON_RUNTIME_RESTORE_ARGS, cwd: "/tmp/webapp" },
+  ]);
+  assert.deepEqual(bridge.ELECTRON_RUNTIME_RESTORE_ARGS, ["-e", "require('electron')"]);
+});
+
+test("refreshWebappNodeModules: successful ci then restore is ok", async () => {
+  const result = await bridge.refreshWebappNodeModules({
+    webappDir: "/tmp/webapp",
+    runNpm: async () => ({ code: 0, tail: "" }),
+    runNode: async () => ({ code: 0, tail: "" }),
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
 test("emptyApplyPlanResult: authoritative no-update is a no_update code", () => {
   const result = bridge.emptyApplyPlanResult({
     gitResult: { available: false, behind: 0 },


### PR DESCRIPTION
## Why
Benton filed main-targeted #297: source updates run npm ci, Electron 44 deletes the running Electron.app, then app.relaunch() exits toward a missing binary. Absorb onto dest with a fail-closed, testable restore step.

## Scope
- Cherry-pick #297 (original authorship).
- Extract refreshWebappNodeModules: npm ci, then node -e require('electron'). Skip restore if npm ci fails. Block apply if restore fails.
- Tests in electron/update.test.cjs. Packaged installer path unchanged.

## Blast radius
Source-checkout applyUpdate only, and only when webapp/package.json or package-lock.json changed. Windows node spawn uses existing runStreamed windowsHide (not npm.cmd shell).

## Verification
- node --test electron/update.test.cjs — 54 passed
- node -e require('electron') from webapp/ resolves Electron.app

Credit: @kbentonferguson (Benton / bferguson_jepp).
