### PR TITLE
Release v0.9.408

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.45` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.407, deliberately pre-1.0. Rides puppetmaster-ai==1.22.45. TODO markers spin only when a live job correlates; incomplete-reply chips stay on their owning turn after hydrate. Skill catalog stays in the frozen prefix (bodies retrieve per turn); git spawns neutralize repo hooks; tools[] freeze across sends with a `/reload-mcp` hatch; cron keeps a continuity digest and can suppress failure notices; compaction fail-until persists and idle ungrown transcripts skip auto-compact; vault retrieve is fail-closed; analysis/QA roles cannot write. Pi TUI/pilot package (not a worker adapter).
+> Status: v0.9.408, deliberately pre-1.0. Rides puppetmaster-ai==1.22.45. Source-update npm ci rehydrates Electron 44 before relaunch; TODO markers spin only when a live job correlates; incomplete-reply chips stay on their owning turn after hydrate. Skill catalog stays in the frozen prefix (bodies retrieve per turn); git spawns neutralize repo hooks; tools[] freeze across sends with a `/reload-mcp` hatch; cron keeps a continuity digest and can suppress failure notices; compaction fail-until persists and idle ungrown transcripts skip auto-compact; vault retrieve is fail-closed; analysis/QA roles cannot write. Pi TUI/pilot package (not a worker adapter).
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.407"
+__version__ = "0.9.408"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.407"
+version = "0.9.408"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -395,6 +395,26 @@ function runNpmStreamed(args, opts, onLine) {
     : runStreamed("npm", args, opts, onLine);
 }
 
+const ELECTRON_RUNTIME_RESTORE_ARGS = ["-e", "require('electron')"];
+
+/**
+ * npm ci deletes the Electron platform binary that is currently executing
+ * Marionette. Electron 44 restores it lazily when required from plain Node.
+ */
+async function refreshWebappNodeModules({
+  webappDir,
+  env,
+  onLine,
+  runNpm = runNpmStreamed,
+  runNode = (args, opts, line) => runStreamed("node", args, opts, line),
+} = {}) {
+  const npmci = await runNpm(["ci"], { cwd: webappDir, env }, onLine);
+  if (npmci.code !== 0) return { ok: false, error: npmci.tail || "npm ci failed" };
+  const electron = await runNode(ELECTRON_RUNTIME_RESTORE_ARGS, { cwd: webappDir, env }, onLine);
+  if (electron.code !== 0) return { ok: false, error: electron.tail || "Electron runtime install failed" };
+  return { ok: true };
+}
+
 function runStreamed(cmd, args, opts, onLine) {
   return new Promise((resolve) => {
     let tail = "";
@@ -680,14 +700,12 @@ async function applyUpdate({ repoRoot, branch = DEFAULT_BRANCH, strategy = "ff",
     }
     if (nodeChanged) {
       progress("deps", "Updating node dependencies", 0.7);
-      const webappDir = path.join(repoRoot, "webapp");
-      const onNodeLine = (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating node dependencies", 0.8); };
-      const npmci = await runNpmStreamed(["ci"], { cwd: webappDir, env: childEnv }, onNodeLine);
-      if (npmci.code !== 0) return { ok: false, error: npmci.tail || "npm ci failed" };
-      // npm ci removes the Electron.app executing Marionette; Electron 44
-      // restores its platform runtime lazily when required from plain Node.
-      const electron = await runStreamed("node", ["-e", "require('electron')"], { cwd: webappDir, env: childEnv }, onNodeLine);
-      if (electron.code !== 0) return { ok: false, error: electron.tail || "Electron runtime install failed" };
+      const refreshed = await refreshWebappNodeModules({
+        webappDir: path.join(repoRoot, "webapp"),
+        env: childEnv,
+        onLine: (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating node dependencies", 0.8); },
+      });
+      if (!refreshed.ok) return refreshed;
     }
 
     // Puppetmaster -- the one integral runtime dep -- ships independently of this
@@ -1035,6 +1053,8 @@ module.exports = {
   registerUpdateBridge,
   checkForUpdate,
   applyUpdate,
+  refreshWebappNodeModules,
+  ELECTRON_RUNTIME_RESTORE_ARGS,
   isTrackedSelfEditLine,
   statusPath,
   isUnmergedStatusLine,

--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -680,9 +680,14 @@ async function applyUpdate({ repoRoot, branch = DEFAULT_BRANCH, strategy = "ff",
     }
     if (nodeChanged) {
       progress("deps", "Updating node dependencies", 0.7);
-      const npmci = await runNpmStreamed(["ci"], { cwd: path.join(repoRoot, "webapp"), env: childEnv },
-        (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating node dependencies", 0.8); });
+      const webappDir = path.join(repoRoot, "webapp");
+      const onNodeLine = (l) => { appendUpdateLog(`[deps] ${l}`); progress("deps", "Updating node dependencies", 0.8); };
+      const npmci = await runNpmStreamed(["ci"], { cwd: webappDir, env: childEnv }, onNodeLine);
       if (npmci.code !== 0) return { ok: false, error: npmci.tail || "npm ci failed" };
+      // npm ci removes the Electron.app executing Marionette; Electron 44
+      // restores its platform runtime lazily when required from plain Node.
+      const electron = await runStreamed("node", ["-e", "require('electron')"], { cwd: webappDir, env: childEnv }, onNodeLine);
+      if (electron.code !== 0) return { ok: false, error: electron.tail || "Electron runtime install failed" };
     }
 
     // Puppetmaster -- the one integral runtime dep -- ships independently of this

--- a/webapp/electron/update.test.cjs
+++ b/webapp/electron/update.test.cjs
@@ -709,6 +709,55 @@ test("describeMainProcessUpdate: no shell change means nothing extra to require"
   assert.equal(verdict.note, undefined);
 });
 
+test("refreshWebappNodeModules: npm ci failure does not restore Electron", async () => {
+  const calls = [];
+  const result = await bridge.refreshWebappNodeModules({
+    webappDir: "/tmp/webapp",
+    env: { PATH: "/bin" },
+    runNpm: async (args, opts) => {
+      calls.push({ kind: "npm", args, cwd: opts.cwd });
+      return { code: 1, tail: "npm ERR! peer" };
+    },
+    runNode: async (args, opts) => {
+      calls.push({ kind: "node", args, cwd: opts.cwd });
+      return { code: 0, tail: "" };
+    },
+  });
+  assert.deepEqual(result, { ok: false, error: "npm ERR! peer" });
+  assert.deepEqual(calls, [{ kind: "npm", args: ["ci"], cwd: "/tmp/webapp" }]);
+});
+
+test("refreshWebappNodeModules: Electron restore failure blocks relaunch", async () => {
+  const calls = [];
+  const result = await bridge.refreshWebappNodeModules({
+    webappDir: "/tmp/webapp",
+    env: { PATH: "/bin" },
+    runNpm: async (args, opts) => {
+      calls.push({ kind: "npm", args, cwd: opts.cwd });
+      return { code: 0, tail: "" };
+    },
+    runNode: async (args, opts) => {
+      calls.push({ kind: "node", args, cwd: opts.cwd });
+      return { code: 1, tail: "Cannot find module 'electron'" };
+    },
+  });
+  assert.deepEqual(result, { ok: false, error: "Cannot find module 'electron'" });
+  assert.deepEqual(calls, [
+    { kind: "npm", args: ["ci"], cwd: "/tmp/webapp" },
+    { kind: "node", args: bridge.ELECTRON_RUNTIME_RESTORE_ARGS, cwd: "/tmp/webapp" },
+  ]);
+  assert.deepEqual(bridge.ELECTRON_RUNTIME_RESTORE_ARGS, ["-e", "require('electron')"]);
+});
+
+test("refreshWebappNodeModules: successful ci then restore is ok", async () => {
+  const result = await bridge.refreshWebappNodeModules({
+    webappDir: "/tmp/webapp",
+    runNpm: async () => ({ code: 0, tail: "" }),
+    runNode: async () => ({ code: 0, tail: "" }),
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
 test("emptyApplyPlanResult: authoritative no-update is a no_update code", () => {
   const result = bridge.emptyApplyPlanResult({
     gitResult: { available: false, behind: 0 },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.407",
+  "version": "0.9.408",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.407",
+      "version": "0.9.408",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.407",
+  "version": "0.9.408",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Why
Ship the dest absorb of Benton #297: source-update npm ci rehydrates Electron 44 before relaunch, fail-closed if restore fails.

## Scope
- dest already contains main (merged 2b1d6682).
- refreshWebappNodeModules after lockfile npm ci.
- Version stamps 0.9.408. Puppetmaster pin stays 1.22.45.

## Blast radius
Source-checkout applyUpdate only when webapp package manifests change. Packaged installer path unchanged.

## Verification
- node --test electron/update.test.cjs — 54 passed
- tests/test_version_consistency.py — 3 passed
