### PR TITLE
fix: land worker patches in target repository

### DIFF
--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -3535,10 +3535,13 @@ class ConversationalSession(
             self._accumulate_session_meters(cache_read_tokens=sum_cached)
         return (sum_in, sum_out, sum_cached)
 
-    def _apply_worker_patch(self, artifacts: list, job_id: str = "") -> tuple[bool, list[str], str]:
+    def _apply_worker_patch(
+        self, artifacts: list, job_id: str = "", repo: str = "",
+    ) -> tuple[bool, list[str], str]:
         """Finds the patch artifact (type=="patch"), extracts its unified_diff,
         and applies it cleanly/idempotently via git apply to the effective git
-        checkout for ``self.config.repo`` (Home parent → single git child).
+        checkout for the worker repo, falling back to ``self.config.repo``
+        (Home parent → single git child).
         Returns (applied_bool, files_changed, message). Checkpoint id (if any) is stashed on self._last_checkpoint_id.
 
         Resolution is per-operation only — never mutates ``config.repo``.
@@ -3572,13 +3575,14 @@ class ConversationalSession(
                 self._last_checkpoint_id = None
                 return False, [], "analysis/QA role cannot write"
 
-        if not self.config.repo or not os.path.exists(self.config.repo):
+        target_repo = repo or self.config.repo
+        if not target_repo or not os.path.exists(target_repo):
             self._last_checkpoint_id = None
             return False, [], "no workspace directory (config.repo) is open"
 
         # Home / workspace root may not be a git checkout; workers already
         # dispatch into the resolved child — apply must use the same target.
-        repo_root = resolve_effective_repo(self.config.repo)
+        repo_root = resolve_effective_repo(target_repo)
         if not repo_root or not os.path.exists(repo_root):
             self._last_checkpoint_id = None
             return False, [], "no workspace directory (config.repo) is open"
@@ -3884,12 +3888,18 @@ class ConversationalSession(
         except Exception:
             pass
 
-    def _run_swarm_background(self, job_id: str, objective: str, state_dir: Optional[str] = None) -> None:
+    def _run_swarm_background(
+        self, job_id: str, objective: str, state_dir: Optional[str] = None,
+        target_repo: str = "",
+    ) -> None:
         try:
             # CORRECTNESS: Do NOT touch self._history here to maintain single-writer invariant.
             # Background threads are strictly read-only or local-variable-only with respect to transcript memory,
             # ensuring that the self._history shared list is never corrupted by concurrent modifications.
-            res_dict = self._await_and_apply_job(job_id, state_dir=state_dir, objective=objective)
+            res_dict = self._await_and_apply_job(
+                job_id, state_dir=state_dir, objective=objective,
+                target_repo=target_repo,
+            )
             
             # Put result in queue
             self._swarm_results.put({

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -532,17 +532,17 @@ class ConversationJobsMixin:
             pass
         return None
 
-    def _await_and_apply_job(self, job_id: str, state_dir: Optional[str] = None, objective: str = "") -> dict:
+    def _await_and_apply_job(
+        self, job_id: str, state_dir: Optional[str] = None,
+        objective: str = "", target_repo: str = "",
+    ) -> dict:
         import json
         import subprocess
         from .repo_resolve import resolve_effective_repo
 
         # Per-operation only — do not persist the resolved child onto config.repo.
-        effective_repo = (
-            resolve_effective_repo(self.config.repo or "")
-            if (self.config.repo or "").strip()
-            else (self.config.repo or "")
-        )
+        repo = target_repo or self.config.repo or ""
+        effective_repo = resolve_effective_repo(repo) if repo.strip() else repo
 
         # 1. Await job
         if state_dir:
@@ -650,6 +650,7 @@ class ConversationJobsMixin:
             pending_review = {
                 "id": review_id,
                 "job_id": job_id,
+                "target_repo": effective_repo,
                 "objective": objective or "Implement edits",
                 "files": parsed_files,
                 "created_at": time.time()
@@ -677,7 +678,7 @@ class ConversationJobsMixin:
             else:
                 with self._apply_lock:
                     applied, applied_files, apply_msg = self._apply_worker_patch(
-                        artifacts, job_id,
+                        artifacts, job_id, repo=effective_repo,
                     )
                     cp_id = getattr(self, "_last_checkpoint_id", None)
 
@@ -1232,6 +1233,7 @@ class ConversationJobsMixin:
                     pending_review = {
                         "id": review_id,
                         "job_id": job_id,
+                        "target_repo": target_repo,
                         "objective": objective or "Implement edits",
                         "files": parsed_files,
                         "created_at": time.time()
@@ -1258,7 +1260,9 @@ class ConversationJobsMixin:
                     else:
                         with self._apply_lock:
                             applied, applied_files, apply_msg = (
-                                self._apply_worker_patch(artifacts, job_id)
+                                self._apply_worker_patch(
+                                    artifacts, job_id, repo=target_repo,
+                                )
                             )
                             cp_id = getattr(self, "_last_checkpoint_id", None)
 

--- a/harness/review_memory.py
+++ b/harness/review_memory.py
@@ -89,7 +89,11 @@ class ReviewMemoryMixin:
         ]
 
         with self._apply_lock:
-            applied, files_changed, apply_msg = self._apply_worker_patch(mock_artifacts, review.get("job_id", ""))
+            applied, files_changed, apply_msg = self._apply_worker_patch(
+                mock_artifacts,
+                review.get("job_id", ""),
+                repo=review.get("target_repo", ""),
+            )
             cp_id = getattr(self, "_last_checkpoint_id", None)
 
         if applied:

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -1380,7 +1380,13 @@ Yields the same ConvEvent stream. Generator return value is ``None``
                     pass
             if job_id:
                 session._session_job_ids.append(job_id)
-                if not session._submit_swarm(session._run_swarm_background, job_id, act.goal, None):
+                if not session._submit_swarm(
+                    session._run_swarm_background,
+                    job_id,
+                    act.goal,
+                    None,
+                    effective_repo,
+                ):
                     cap_msg = session._swarm_submit_reject_message()
                     session._release_objective(act.goal)
                     yield ConvEvent('action_result', {'id': aid, 'error': cap_msg})

--- a/tests/test_conversation_jobs_mixin.py
+++ b/tests/test_conversation_jobs_mixin.py
@@ -65,8 +65,7 @@ def test_local_jobs_not_folded_into_conversation_jobs():
         assert name not in ConversationJobsMixin.__dict__
 
 
-def test_await_and_apply_job_still_on_session_surface(tmp_path):
-    """Public surface unchanged: session._await_and_apply_job still applies patches."""
+def test_background_job_applies_patch_to_worker_repo(tmp_path):
     subprocess.run(["git", "init"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
@@ -76,8 +75,10 @@ def test_await_and_apply_job_still_on_session_surface(tmp_path):
     subprocess.run(["git", "add", "hello.txt"], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-m", "initial commit"], cwd=tmp_path, check=True)
 
+    active_repo = tmp_path / "active"
+    subprocess.run(["git", "init", str(active_repo)], check=True)
     cfg = HarnessConfig()
-    cfg.repo = str(tmp_path)
+    cfg.repo = str(active_repo)
     session = ConversationalSession(cfg)
     assert session._tokens_used == 0
 
@@ -114,7 +115,10 @@ def test_await_and_apply_job_still_on_session_surface(tmp_path):
         return original_run(cmd, *args, **kwargs)
 
     with patch("subprocess.run", side_effect=mock_subprocess_run):
-        res = session._await_and_apply_job("job_mixin_char_001")
+        session._run_swarm_background(
+            "job_mixin_char_001", "cross-repo edit", target_repo=str(tmp_path),
+        )
+        res = session._swarm_results.get_nowait()["result"]
 
     assert res["job_id"] == "job_mixin_char_001"
     assert res["applied"] is True
@@ -125,8 +129,7 @@ def test_await_and_apply_job_still_on_session_surface(tmp_path):
     assert res["error"] is None
     assert session._tokens_used == 150
     assert file_path.read_text() == "Hello World\nHello New World\n"
-
-
+    assert not (active_repo / "hello.txt").exists()
 def test_drain_swarm_results_characterization():
     """Drain still yields swarm_result + pilot_resume and appends history."""
     cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())

--- a/tests/test_diff_review.py
+++ b/tests/test_diff_review.py
@@ -190,9 +190,11 @@ def test_legacy_plain_id_decisions_still_resolve():
     assert decision_for_hunk({}, hunk, "f.py") == "reject"
 
 
-def test_apply_review(temp_git_repo):
+def test_apply_review(temp_git_repo, tmp_path):
+    active_repo = tmp_path / "active"
+    subprocess.run(["git", "init", str(active_repo)], check=True)
     cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
-    cfg.repo = temp_git_repo
+    cfg.repo = str(active_repo)
     session = ConversationalSession(cfg)
     session._review_edits_before_apply = True
     
@@ -241,7 +243,10 @@ def test_apply_review(temp_git_repo):
 
     with patch("subprocess.run", side_effect=mock_run):
         # Process job which triggers review hold since review_edits_before_apply is True
-        res = session._await_and_apply_job("job-123", state_dir=None, objective="Test edits")
+        res = session._await_and_apply_job(
+            "job-123", state_dir=None, objective="Test edits",
+            target_repo=temp_git_repo,
+        )
         assert res["held_for_review"] is True
         assert res["applied"] is False
         
@@ -276,6 +281,7 @@ def test_apply_review(temp_git_repo):
         with open(os.path.join(temp_git_repo, "file2.txt")) as f:
             content2 = f.read()
         assert "Delta" not in content2
+        assert not (active_repo / "file1.txt").exists()
         
         # Verify the pending review was cleared
         assert review_id not in session._pending_reviews

--- a/tests/test_send_loop_dispatch.py
+++ b/tests/test_send_loop_dispatch.py
@@ -284,6 +284,57 @@ def test_dispatch_implement_requires_workspace():
     session._append_action_result.assert_called_once()
 
 
+def test_dispatch_implement_keeps_target_repo_for_patch_landing(tmp_path, monkeypatch):
+    import subprocess
+    import harness.send_loop_dispatch as dispatch
+
+    target = tmp_path / "terraform"
+    subprocess.run(["git", "init", str(target)], check=True, capture_output=True)
+    act = PilotAction(
+        kind="run_implement", goal="edit terraform", repo=str(target),
+        adapter="codex",
+    )
+    submit = MagicMock(return_value=True)
+    background = MagicMock()
+    session = SimpleNamespace(
+        config=SimpleNamespace(repo=str(tmp_path), driver="test"),
+        _session_job_ids=[],
+        _append_action_result=MagicMock(),
+        _validate_target_repo=MagicMock(return_value=(str(target), "")),
+        _resolve_requested_implement_adapter=MagicMock(return_value=("codex", "")),
+        _external_adapter_available=MagicMock(return_value=True),
+        _claim_objective=MagicMock(return_value=True),
+        _release_objective=MagicMock(),
+        _submit_swarm=submit,
+        _run_swarm_background=background,
+        _job_dispatch_label_args=MagicMock(return_value=[]),
+        _answer_remaining_tool_calls=MagicMock(return_value=iter(())),
+    )
+    proc = SimpleNamespace(
+        stdout=iter(["started job_abcdef123456\n"]),
+        wait=MagicMock(return_value=0),
+    )
+    monkeypatch.setattr(dispatch, "_puppetmaster_available", lambda: True)
+    monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda _repo: None)
+    monkeypatch.setattr(dispatch.subprocess, "Popen", MagicMock(return_value=proc))
+    monkeypatch.setattr(
+        "harness.implement_guards.check_implement_workspace", lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "harness.implement_guards.check_oversized_single_file_rewrite",
+        lambda *_a, **_k: None,
+    )
+
+    list(dispatch_implement_action(
+        session, act, "a-cross", True, turn_actions=[act], action_idx=0,
+        action_seq=1, step=0, swarms=0,
+    ))
+
+    submit.assert_called_once_with(
+        background, "job_abcdef123456", "edit terraform", None, str(target),
+    )
+
+
 def test_dispatch_parallel_requires_goals():
     act = PilotAction(kind="run_parallel", goals=[])
     session = SimpleNamespace(


### PR DESCRIPTION
## Summary
- preserve the validated `run_implement` target repository through background job delivery
- apply and checkpoint worker patches in their owning repository instead of the active session repository
- retain target ownership when edits are held for review

## Behavioral proof
- a background patch changes the worker repository while the active repository remains untouched
- external implementation dispatch carries the validated target repository into patch delivery
- accepted review hunks land in the worker repository while rejected files and the active repository remain unchanged

## Tests
- `.venv/bin/python -m pytest -q tests/test_conversation_jobs_mixin.py tests/test_send_loop_dispatch.py tests/test_diff_review.py`
- 45 passed
