### PR TITLE
fix: isolate Marionette Puppetmaster environment

### DIFF
--- a/webapp/electron/inspect-isolation.cjs
+++ b/webapp/electron/inspect-isolation.cjs
@@ -35,6 +35,16 @@ function resolveInspectUserDataDir(env = process.env) {
   return "";
 }
 
+function buildPuppetmasterBackendEnv(env, { stateDir, modelsPath }) {
+  const out = {
+    ...env,
+    PUPPETMASTER_STATE_DIR: stateDir,
+    PUPPETMASTER_MODELS_PATH: modelsPath,
+  };
+  delete out.PUPPETMASTER_ONLY_ADAPTERS;
+  return out;
+}
+
 function stateFileSearchDirs(env = process.env) {
   const explicit = resolveHarnessStateDir(env);
   if (isInspectMode(env)) {
@@ -48,6 +58,7 @@ function stateFileSearchDirs(env = process.env) {
 }
 
 module.exports = {
+  buildPuppetmasterBackendEnv,
   isInspectMode,
   pmharnessHome,
   resolveHarnessStateDir,

--- a/webapp/electron/inspect-isolation.test.cjs
+++ b/webapp/electron/inspect-isolation.test.cjs
@@ -6,6 +6,7 @@ const path = require("node:path");
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const {
+  buildPuppetmasterBackendEnv,
   isInspectMode,
   resolveHarnessStateDir,
   resolveInspectUserDataDir,
@@ -17,6 +18,26 @@ test("preload inspect flag stays env-only and never requires inspect-isolation",
   assert.match(preload, /__HARNESS_INSPECT__/);
   assert.doesNotMatch(preload, /inspect-isolation/);
   assert.doesNotMatch(preload, /node:fs/);
+});
+
+test("backend Puppetmaster env replaces inherited standalone policy", () => {
+  const env = buildPuppetmasterBackendEnv(
+    {
+      PATH: "/usr/bin",
+      PUPPETMASTER_STATE_DIR: "/global/state",
+      PUPPETMASTER_MODELS_PATH: "/global/models.json",
+      PUPPETMASTER_ONLY_ADAPTERS: "codex",
+    },
+    {
+      stateDir: "/mari/state",
+      modelsPath: "/mari/marionette-models.json",
+    },
+  );
+
+  assert.equal(env.PATH, "/usr/bin");
+  assert.equal(env.PUPPETMASTER_STATE_DIR, "/mari/state");
+  assert.equal(env.PUPPETMASTER_MODELS_PATH, "/mari/marionette-models.json");
+  assert.equal("PUPPETMASTER_ONLY_ADAPTERS" in env, false);
 });
 
 test("isInspectMode accepts 1/true/yes only", () => {

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -42,6 +42,7 @@ const {
 const { createTranslucencyController } = require("./translucency.cjs");
 const secretVault = require("./secret-vault.cjs");
 const {
+  buildPuppetmasterBackendEnv,
   isInspectMode,
   pmharnessHome,
   resolveHarnessStateDir,
@@ -831,20 +832,21 @@ async function _startBackendOnce() {
     ".pmharness",
     "marionette-models.json",
   );
-  const customEnv = {
+  const harnessStateDir = process.env.HARNESS_STATE_DIR || resolveHarnessStateDir();
+  const customEnv = buildPuppetmasterBackendEnv({
     ..._shellEnv,
     ...process.env,
     PYTHONUNBUFFERED: "1",
     HARNESS_TOKEN: harnessToken,
     HARNESS_APP_RUN_ID: harnessAppRunId,
-    HARNESS_STATE_DIR: process.env.HARNESS_STATE_DIR || resolveHarnessStateDir(),
+    HARNESS_STATE_DIR: harnessStateDir,
     // App source root (not the user's project). Backend excludes this path
     // from boot restore + PROJECTS recents so Marionette never auto-opens itself.
     MARIONETTE_APP_ROOT: repoRoot,
-    // Prefer an explicit shell override; otherwise pin the isolated catalog.
-    PUPPETMASTER_MODELS_PATH:
-      process.env.PUPPETMASTER_MODELS_PATH || marionetteModels,
-  };
+  }, {
+    stateDir: harnessStateDir,
+    modelsPath: marionetteModels,
+  });
   try {
     const { safeStorage } = require("electron");
     secretVault.injectEnv({


### PR DESCRIPTION
## Summary
- Replace inherited standalone Puppetmaster state and model paths at the Electron backend spawn boundary.
- Remove inherited `PUPPETMASTER_ONLY_ADAPTERS` so Marionette uses its own platform configuration.
- Preserve unrelated parent-shell variables and add a focused regression test.

## Behavior
Launching Marionette from a shell configured for standalone Codex-only Puppetmaster no longer redirects Marionette workers into the standalone state, registry, or adapter policy. The parent shell configuration remains unchanged.

## Verification
- `npm run test:electron` — 218 passed
- `.venv/bin/python -m pytest -q tests/test_swarm_worker_allowlist.py tests/test_swarm_model_pin.py tests/test_run_implement_provider.py tests/test_run_implement_repo_param.py` — 36 passed
- `npm run build` — passed
- Live Marionette smoke: `run_swarm` job `job_c02fdd37eb91` completed through adapter `agentic` with four readable artifacts, including a decision-bearing finding.