### PR TITLE
absorb #307: isolate Marionette Puppetmaster env without relocating the job store

### DIFF
--- a/webapp/electron/inspect-isolation.cjs
+++ b/webapp/electron/inspect-isolation.cjs
@@ -35,6 +35,16 @@ function resolveInspectUserDataDir(env = process.env) {
   return "";
 }
 
+function buildPuppetmasterBackendEnv(env, { stateDir, modelsPath }) {
+  const out = {
+    ...env,
+    PUPPETMASTER_STATE_DIR: stateDir,
+    PUPPETMASTER_MODELS_PATH: modelsPath,
+  };
+  delete out.PUPPETMASTER_ONLY_ADAPTERS;
+  return out;
+}
+
 function stateFileSearchDirs(env = process.env) {
   const explicit = resolveHarnessStateDir(env);
   if (isInspectMode(env)) {
@@ -48,6 +58,7 @@ function stateFileSearchDirs(env = process.env) {
 }
 
 module.exports = {
+  buildPuppetmasterBackendEnv,
   isInspectMode,
   pmharnessHome,
   resolveHarnessStateDir,

--- a/webapp/electron/inspect-isolation.cjs
+++ b/webapp/electron/inspect-isolation.cjs
@@ -35,13 +35,18 @@ function resolveInspectUserDataDir(env = process.env) {
   return "";
 }
 
-function buildPuppetmasterBackendEnv(env, { stateDir, modelsPath }) {
+function buildPuppetmasterBackendEnv(env, options = {}) {
   const out = {
     ...env,
-    PUPPETMASTER_STATE_DIR: stateDir,
-    PUPPETMASTER_MODELS_PATH: modelsPath,
+    PUPPETMASTER_MODELS_PATH: options.modelsPath,
   };
   delete out.PUPPETMASTER_ONLY_ADAPTERS;
+  delete out.PUPPETMASTER_DISABLED_PROVIDERS;
+  if (options.stateDir) {
+    out.PUPPETMASTER_STATE_DIR = options.stateDir;
+  } else {
+    delete out.PUPPETMASTER_STATE_DIR;
+  }
   return out;
 }
 

--- a/webapp/electron/inspect-isolation.test.cjs
+++ b/webapp/electron/inspect-isolation.test.cjs
@@ -6,6 +6,7 @@ const path = require("node:path");
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const {
+  buildPuppetmasterBackendEnv,
   isInspectMode,
   resolveHarnessStateDir,
   resolveInspectUserDataDir,
@@ -17,6 +18,26 @@ test("preload inspect flag stays env-only and never requires inspect-isolation",
   assert.match(preload, /__HARNESS_INSPECT__/);
   assert.doesNotMatch(preload, /inspect-isolation/);
   assert.doesNotMatch(preload, /node:fs/);
+});
+
+test("backend Puppetmaster env replaces inherited standalone policy", () => {
+  const env = buildPuppetmasterBackendEnv(
+    {
+      PATH: "/usr/bin",
+      PUPPETMASTER_STATE_DIR: "/global/state",
+      PUPPETMASTER_MODELS_PATH: "/global/models.json",
+      PUPPETMASTER_ONLY_ADAPTERS: "codex",
+    },
+    {
+      stateDir: "/mari/state",
+      modelsPath: "/mari/marionette-models.json",
+    },
+  );
+
+  assert.equal(env.PATH, "/usr/bin");
+  assert.equal(env.PUPPETMASTER_STATE_DIR, "/mari/state");
+  assert.equal(env.PUPPETMASTER_MODELS_PATH, "/mari/marionette-models.json");
+  assert.equal("PUPPETMASTER_ONLY_ADAPTERS" in env, false);
 });
 
 test("isInspectMode accepts 1/true/yes only", () => {

--- a/webapp/electron/inspect-isolation.test.cjs
+++ b/webapp/electron/inspect-isolation.test.cjs
@@ -20,6 +20,12 @@ test("preload inspect flag stays env-only and never requires inspect-isolation",
   assert.doesNotMatch(preload, /node:fs/);
 });
 
+test("normal backend spawn relocates Puppetmaster state only in inspect", () => {
+  const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  assert.match(main, /buildPuppetmasterBackendEnv/);
+  assert.match(main, /isInspectMode\(process\.env\) \? \{ stateDir: harnessStateDir \}/);
+});
+
 test("backend Puppetmaster env replaces inherited standalone policy", () => {
   const env = buildPuppetmasterBackendEnv(
     {
@@ -27,15 +33,34 @@ test("backend Puppetmaster env replaces inherited standalone policy", () => {
       PUPPETMASTER_STATE_DIR: "/global/state",
       PUPPETMASTER_MODELS_PATH: "/global/models.json",
       PUPPETMASTER_ONLY_ADAPTERS: "codex",
+      PUPPETMASTER_DISABLED_PROVIDERS: "agentic,openrouter",
     },
     {
-      stateDir: "/mari/state",
       modelsPath: "/mari/marionette-models.json",
     },
   );
 
   assert.equal(env.PATH, "/usr/bin");
-  assert.equal(env.PUPPETMASTER_STATE_DIR, "/mari/state");
+  assert.equal("PUPPETMASTER_STATE_DIR" in env, false);
+  assert.equal(env.PUPPETMASTER_MODELS_PATH, "/mari/marionette-models.json");
+  assert.equal("PUPPETMASTER_ONLY_ADAPTERS" in env, false);
+  assert.equal("PUPPETMASTER_DISABLED_PROVIDERS" in env, false);
+});
+
+test("inspect backend Puppetmaster env pins isolated state dir", () => {
+  const env = buildPuppetmasterBackendEnv(
+    {
+      HARNESS_INSPECT: "1",
+      PUPPETMASTER_STATE_DIR: "/global/state",
+      PUPPETMASTER_ONLY_ADAPTERS: "codex",
+    },
+    {
+      stateDir: "/inspect/state",
+      modelsPath: "/mari/marionette-models.json",
+    },
+  );
+
+  assert.equal(env.PUPPETMASTER_STATE_DIR, "/inspect/state");
   assert.equal(env.PUPPETMASTER_MODELS_PATH, "/mari/marionette-models.json");
   assert.equal("PUPPETMASTER_ONLY_ADAPTERS" in env, false);
 });

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -844,8 +844,8 @@ async function _startBackendOnce() {
     // from boot restore + PROJECTS recents so Marionette never auto-opens itself.
     MARIONETTE_APP_ROOT: repoRoot,
   }, {
-    stateDir: harnessStateDir,
     modelsPath: marionetteModels,
+    ...(isInspectMode(process.env) ? { stateDir: harnessStateDir } : {}),
   });
   try {
     const { safeStorage } = require("electron");

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -42,6 +42,7 @@ const {
 const { createTranslucencyController } = require("./translucency.cjs");
 const secretVault = require("./secret-vault.cjs");
 const {
+  buildPuppetmasterBackendEnv,
   isInspectMode,
   pmharnessHome,
   resolveHarnessStateDir,
@@ -831,20 +832,21 @@ async function _startBackendOnce() {
     ".pmharness",
     "marionette-models.json",
   );
-  const customEnv = {
+  const harnessStateDir = process.env.HARNESS_STATE_DIR || resolveHarnessStateDir();
+  const customEnv = buildPuppetmasterBackendEnv({
     ..._shellEnv,
     ...process.env,
     PYTHONUNBUFFERED: "1",
     HARNESS_TOKEN: harnessToken,
     HARNESS_APP_RUN_ID: harnessAppRunId,
-    HARNESS_STATE_DIR: process.env.HARNESS_STATE_DIR || resolveHarnessStateDir(),
+    HARNESS_STATE_DIR: harnessStateDir,
     // App source root (not the user's project). Backend excludes this path
     // from boot restore + PROJECTS recents so Marionette never auto-opens itself.
     MARIONETTE_APP_ROOT: repoRoot,
-    // Prefer an explicit shell override; otherwise pin the isolated catalog.
-    PUPPETMASTER_MODELS_PATH:
-      process.env.PUPPETMASTER_MODELS_PATH || marionetteModels,
-  };
+  }, {
+    stateDir: harnessStateDir,
+    modelsPath: marionetteModels,
+  });
   try {
     const { safeStorage } = require("electron");
     secretVault.injectEnv({


### PR DESCRIPTION
## Why
Benton filed #307 after launching Marionette from a Codex-only standalone Puppetmaster shell. Dest spawn merged parent `PUPPETMASTER_MODELS_PATH`, `PUPPETMASTER_ONLY_ADAPTERS`, and `PUPPETMASTER_STATE_DIR`, so workers followed the standalone catalog, adapter lock, and store.

## Scope
- Cherry-pick #307 (`buildPuppetmasterBackendEnv` at Electron backend spawn).
- Always pin `PUPPETMASTER_MODELS_PATH` to the Marionette catalog.
- Delete inherited `PUPPETMASTER_ONLY_ADAPTERS` and `PUPPETMASTER_DISABLED_PROVIDERS`.
- Do not overwrite `PUPPETMASTER_STATE_DIR` with `HARNESS_STATE_DIR` on a normal launch. That would collapse every workspace onto one harness store (`resolve_state_dir` honors the env). Drop the inherited store instead so per-project resolution stays. Inspect still pins isolated state.

## Tradeoffs
Allowlist-copying the whole spawn env was rejected. `PUPPETMASTER_HOME` is left alone (no repro).

## Blast radius
Electron backend spawn only. Preload stays env-only and must not require `inspect-isolation.cjs`.

## Verification
- dest merge repro: inherited Codex-only env leaked models, `ONLY_ADAPTERS`, and state (exit 2).
- `node --test webapp/electron/inspect-isolation.test.cjs` — 8 passed (failing then passing on store/policy delete).
- `npm run test:electron` — 220 passed.

Credit: @kbentonferguson