### PR TITLE
Release v0.9.412

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.22.46` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.411, deliberately pre-1.0. Rides puppetmaster-ai==1.22.46. `scripts/dev.sh` stays the replace launcher; `scripts/inspect.sh` is the supported side-by-side fixture (isolated state/userData, no credential fold, no production backend marker). Worker patches land in the validated target repo, including `run_parallel`. Package scripts pin `NODE_ENV` so a production parent shell cannot empty the dev renderer or trip React `act`. 1.22.46 names selected-model usage cost instead of actual spend.
+> Status: v0.9.412, deliberately pre-1.0. Rides puppetmaster-ai==1.22.46. Electron backend spawn pins the Marionette catalog and drops inherited Puppetmaster adapter/provider policy; a normal launch does not relocate the job store into harness state. `scripts/dev.sh` stays the replace launcher; `scripts/inspect.sh` is the supported side-by-side fixture (isolated state/userData, no credential fold, no production backend marker). Worker patches land in the validated target repo, including `run_parallel`. Package scripts pin `NODE_ENV` so a production parent shell cannot empty the dev renderer or trip React `act`. 1.22.46 names selected-model usage cost instead of actual spend.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.411"
+__version__ = "0.9.412"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.411"
+version = "0.9.412"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/electron/inspect-isolation.cjs
+++ b/webapp/electron/inspect-isolation.cjs
@@ -35,6 +35,16 @@ function resolveInspectUserDataDir(env = process.env) {
   return "";
 }
 
+function buildPuppetmasterBackendEnv(env, { stateDir, modelsPath }) {
+  const out = {
+    ...env,
+    PUPPETMASTER_STATE_DIR: stateDir,
+    PUPPETMASTER_MODELS_PATH: modelsPath,
+  };
+  delete out.PUPPETMASTER_ONLY_ADAPTERS;
+  return out;
+}
+
 function stateFileSearchDirs(env = process.env) {
   const explicit = resolveHarnessStateDir(env);
   if (isInspectMode(env)) {
@@ -48,6 +58,7 @@ function stateFileSearchDirs(env = process.env) {
 }
 
 module.exports = {
+  buildPuppetmasterBackendEnv,
   isInspectMode,
   pmharnessHome,
   resolveHarnessStateDir,

--- a/webapp/electron/inspect-isolation.cjs
+++ b/webapp/electron/inspect-isolation.cjs
@@ -35,13 +35,18 @@ function resolveInspectUserDataDir(env = process.env) {
   return "";
 }
 
-function buildPuppetmasterBackendEnv(env, { stateDir, modelsPath }) {
+function buildPuppetmasterBackendEnv(env, options = {}) {
   const out = {
     ...env,
-    PUPPETMASTER_STATE_DIR: stateDir,
-    PUPPETMASTER_MODELS_PATH: modelsPath,
+    PUPPETMASTER_MODELS_PATH: options.modelsPath,
   };
   delete out.PUPPETMASTER_ONLY_ADAPTERS;
+  delete out.PUPPETMASTER_DISABLED_PROVIDERS;
+  if (options.stateDir) {
+    out.PUPPETMASTER_STATE_DIR = options.stateDir;
+  } else {
+    delete out.PUPPETMASTER_STATE_DIR;
+  }
   return out;
 }
 

--- a/webapp/electron/inspect-isolation.test.cjs
+++ b/webapp/electron/inspect-isolation.test.cjs
@@ -6,6 +6,7 @@ const path = require("node:path");
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const {
+  buildPuppetmasterBackendEnv,
   isInspectMode,
   resolveHarnessStateDir,
   resolveInspectUserDataDir,
@@ -17,6 +18,26 @@ test("preload inspect flag stays env-only and never requires inspect-isolation",
   assert.match(preload, /__HARNESS_INSPECT__/);
   assert.doesNotMatch(preload, /inspect-isolation/);
   assert.doesNotMatch(preload, /node:fs/);
+});
+
+test("backend Puppetmaster env replaces inherited standalone policy", () => {
+  const env = buildPuppetmasterBackendEnv(
+    {
+      PATH: "/usr/bin",
+      PUPPETMASTER_STATE_DIR: "/global/state",
+      PUPPETMASTER_MODELS_PATH: "/global/models.json",
+      PUPPETMASTER_ONLY_ADAPTERS: "codex",
+    },
+    {
+      stateDir: "/mari/state",
+      modelsPath: "/mari/marionette-models.json",
+    },
+  );
+
+  assert.equal(env.PATH, "/usr/bin");
+  assert.equal(env.PUPPETMASTER_STATE_DIR, "/mari/state");
+  assert.equal(env.PUPPETMASTER_MODELS_PATH, "/mari/marionette-models.json");
+  assert.equal("PUPPETMASTER_ONLY_ADAPTERS" in env, false);
 });
 
 test("isInspectMode accepts 1/true/yes only", () => {

--- a/webapp/electron/inspect-isolation.test.cjs
+++ b/webapp/electron/inspect-isolation.test.cjs
@@ -20,6 +20,12 @@ test("preload inspect flag stays env-only and never requires inspect-isolation",
   assert.doesNotMatch(preload, /node:fs/);
 });
 
+test("normal backend spawn relocates Puppetmaster state only in inspect", () => {
+  const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  assert.match(main, /buildPuppetmasterBackendEnv/);
+  assert.match(main, /isInspectMode\(process\.env\) \? \{ stateDir: harnessStateDir \}/);
+});
+
 test("backend Puppetmaster env replaces inherited standalone policy", () => {
   const env = buildPuppetmasterBackendEnv(
     {
@@ -27,15 +33,34 @@ test("backend Puppetmaster env replaces inherited standalone policy", () => {
       PUPPETMASTER_STATE_DIR: "/global/state",
       PUPPETMASTER_MODELS_PATH: "/global/models.json",
       PUPPETMASTER_ONLY_ADAPTERS: "codex",
+      PUPPETMASTER_DISABLED_PROVIDERS: "agentic,openrouter",
     },
     {
-      stateDir: "/mari/state",
       modelsPath: "/mari/marionette-models.json",
     },
   );
 
   assert.equal(env.PATH, "/usr/bin");
-  assert.equal(env.PUPPETMASTER_STATE_DIR, "/mari/state");
+  assert.equal("PUPPETMASTER_STATE_DIR" in env, false);
+  assert.equal(env.PUPPETMASTER_MODELS_PATH, "/mari/marionette-models.json");
+  assert.equal("PUPPETMASTER_ONLY_ADAPTERS" in env, false);
+  assert.equal("PUPPETMASTER_DISABLED_PROVIDERS" in env, false);
+});
+
+test("inspect backend Puppetmaster env pins isolated state dir", () => {
+  const env = buildPuppetmasterBackendEnv(
+    {
+      HARNESS_INSPECT: "1",
+      PUPPETMASTER_STATE_DIR: "/global/state",
+      PUPPETMASTER_ONLY_ADAPTERS: "codex",
+    },
+    {
+      stateDir: "/inspect/state",
+      modelsPath: "/mari/marionette-models.json",
+    },
+  );
+
+  assert.equal(env.PUPPETMASTER_STATE_DIR, "/inspect/state");
   assert.equal(env.PUPPETMASTER_MODELS_PATH, "/mari/marionette-models.json");
   assert.equal("PUPPETMASTER_ONLY_ADAPTERS" in env, false);
 });

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -844,8 +844,8 @@ async function _startBackendOnce() {
     // from boot restore + PROJECTS recents so Marionette never auto-opens itself.
     MARIONETTE_APP_ROOT: repoRoot,
   }, {
-    stateDir: harnessStateDir,
     modelsPath: marionetteModels,
+    ...(isInspectMode(process.env) ? { stateDir: harnessStateDir } : {}),
   });
   try {
     const { safeStorage } = require("electron");

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -42,6 +42,7 @@ const {
 const { createTranslucencyController } = require("./translucency.cjs");
 const secretVault = require("./secret-vault.cjs");
 const {
+  buildPuppetmasterBackendEnv,
   isInspectMode,
   pmharnessHome,
   resolveHarnessStateDir,
@@ -831,20 +832,21 @@ async function _startBackendOnce() {
     ".pmharness",
     "marionette-models.json",
   );
-  const customEnv = {
+  const harnessStateDir = process.env.HARNESS_STATE_DIR || resolveHarnessStateDir();
+  const customEnv = buildPuppetmasterBackendEnv({
     ..._shellEnv,
     ...process.env,
     PYTHONUNBUFFERED: "1",
     HARNESS_TOKEN: harnessToken,
     HARNESS_APP_RUN_ID: harnessAppRunId,
-    HARNESS_STATE_DIR: process.env.HARNESS_STATE_DIR || resolveHarnessStateDir(),
+    HARNESS_STATE_DIR: harnessStateDir,
     // App source root (not the user's project). Backend excludes this path
     // from boot restore + PROJECTS recents so Marionette never auto-opens itself.
     MARIONETTE_APP_ROOT: repoRoot,
-    // Prefer an explicit shell override; otherwise pin the isolated catalog.
-    PUPPETMASTER_MODELS_PATH:
-      process.env.PUPPETMASTER_MODELS_PATH || marionetteModels,
-  };
+  }, {
+    stateDir: harnessStateDir,
+    modelsPath: marionetteModels,
+  });
   try {
     const { safeStorage } = require("electron");
     secretVault.injectEnv({

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.411",
+  "version": "0.9.412",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.411",
+      "version": "0.9.412",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.411",
+  "version": "0.9.412",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Absorb Benton #307: Electron backend spawn pins the Marionette catalog and drops inherited Puppetmaster adapter/provider policy (`PUPPETMASTER_ONLY_ADAPTERS`, `PUPPETMASTER_DISABLED_PROVIDERS`).
- Do not relocate `PUPPETMASTER_STATE_DIR` into harness state on a normal launch (that would collapse per-project stores). Inspect still pins isolated state.
- Version 0.9.412. Pin stays `puppetmaster-ai==1.22.46`.

## Test plan
- [ ] `tests` matrix green on this dest-into-main PR (3.9, 3.11, Windows shards, frontend-build)
- [ ] Electron inspect-isolation tests cover inherited Codex-only env
- [ ] Tag `v0.9.412` only when `merge^{tree}` matches this PR tree
- [ ] `release.yml` reuses dest-PR installers; no pytest rerun; one notarization; dmg + universal zip

Credit: @kbentonferguson