### PR TITLE
Fix active swarm visibility during tracker bootstrap

### DIFF
--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -2124,6 +2124,60 @@ describe("SwarmPane worker outcome hierarchy", () => {
   });
 });
 
+describe("SwarmPane session scope before a project event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem("marionette.jobScope.v1", "session");
+    sessionStorage.clear();
+    clearSWRCache();
+    dispatchProjectSelected("");
+    mockArtifacts.mockResolvedValue([]);
+  });
+
+  it("resolves the backend active session and keeps its running swarm visible", async () => {
+    vi.mocked(api.sessions).mockResolvedValue([
+      { id: "sess-test", title: "Active chat", active: true, created: 1 },
+    ]);
+    mockSwarmLive.mockResolvedValue(liveJob({ goal: "Running before project event" }));
+
+    render(<SwarmPane />);
+
+    expect(await screen.findByText("Running before project event")).toBeInTheDocument();
+    expect(api.sessions).toHaveBeenCalledWith(undefined);
+  });
+
+  it("ignores the bootstrap response after a project selection", async () => {
+    const repo = "/repo-selected";
+    let resolveBootstrap: ((rows: Awaited<ReturnType<typeof api.sessions>>) => void) | undefined;
+    vi.mocked(api.sessions).mockImplementation((root?: string) => {
+      if (!root) {
+        return new Promise((resolve) => { resolveBootstrap = resolve; });
+      }
+      return Promise.resolve([
+        { id: "sess-selected", title: "Selected chat", active: true, created: 2 },
+      ]);
+    });
+    mockSwarmLive.mockResolvedValue(liveJob({
+      session_id: "sess-selected",
+      goal: "Selected project running swarm",
+    }));
+
+    render(<SwarmPane />);
+    await waitFor(() => expect(api.sessions).toHaveBeenCalledWith(undefined));
+    dispatchProjectSelected(repo);
+    expect(await screen.findByText("Selected project running swarm")).toBeInTheDocument();
+
+    resolveBootstrap?.([
+      { id: "sess-stale", title: "Stale chat", active: true, created: 1 },
+    ]);
+    await Promise.resolve();
+
+    expect(screen.getByText("Selected project running swarm")).toBeInTheDocument();
+    expect(api.sessions).toHaveBeenCalledWith(repo);
+  });
+});
+
 describe("SwarmPane tracker header", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/webapp/src/components/SwarmPane.tsx
+++ b/webapp/src/components/SwarmPane.tsx
@@ -1151,10 +1151,6 @@ export default function SwarmPane() {
   const [nowTick, setNowTick] = useState(() => Date.now());
 
   useEffect(() => {
-    if (!scopedRepo) {
-      setActiveSessionId("");
-      return;
-    }
     let cancelled = false;
     api.sessions(scopedRepo).then((rows) => {
       if (cancelled) return;


### PR DESCRIPTION
## Summary

Fixes a Swarm Tracker bootstrap race where a real running swarm was present in `/api/swarm/live` and visible in chat, but the default Session scope showed no active swarms.

When the pane mounted before `harness-project-selected`, it left `activeSessionId` empty and fail-closed the Session view. Opening the swarm from chat temporarily pinned the row through the existing deep-link path, so it flashed into the tracker and disappeared again when that pin cleared.

The tracker now resolves the active session through the existing unscoped sessions API during that bootstrap window. Once a project is selected, the existing repo-scoped request and stale-response cancellation remain unchanged.

## Test plan

- Added a mounted component regression for a running swarm before any project-selection event.
- Added a race regression proving a late bootstrap response cannot overwrite the selected project's active session.
- `npm test -- src/__tests__/SwarmPane.test.tsx` — 111 passed.
- `npm test` — 1,629 passed across 148 files.
- `npm run build` — passed.
- `git diff --check` — passed.

## Scope

Production change deletes four lines. No new store, event, endpoint, polling loop, or status abstraction.
