### PR TITLE
fix: spin only the live wave on composer TODOs

### DIFF
--- a/webapp/src/__tests__/ComposerTodoPanel.test.tsx
+++ b/webapp/src/__tests__/ComposerTodoPanel.test.tsx
@@ -86,4 +86,48 @@ describe("ComposerTodoPanel", () => {
     const taskRow = screen.getByText("rewrite the DAG").parentElement;
     expect(taskRow?.querySelector("svg")?.classList.contains("animate-spin")).toBe(true);
   });
+
+  it("spins only the todo that matches the live wave job", () => {
+    publishSessionTodos({
+      phases: [
+        {
+          name: "Wave 1 — Station & Stadium Operations",
+          tasks: [
+            { content: "Ship station inventory read path", status: "completed" },
+            { content: "Implement station management server actions", status: "in_progress" },
+            { content: "Validate station ops", status: "pending" },
+          ],
+        },
+        {
+          name: "Wave 2 — Live Spectator",
+          tasks: [
+            { content: "Implement dedicated live spectator TV", status: "pending" },
+            { content: "Validate spectator display", status: "pending" },
+          ],
+        },
+        {
+          name: "Tasks",
+          tasks: [{ content: "implement (agentic) WAVE 1B (Part 1 - Actions only):", status: "pending" }],
+        },
+      ],
+    }, "sess-wave");
+    const job = {
+      id: "j-wave-1b",
+      goal: "WAVE 1B (Part 1 - Actions only)",
+      status: "running",
+      session_id: "sess-wave",
+      role: "implement",
+      tasks: [
+        { id: "t1", role: "implement", instruction: "Implement station management server actions", status: "running" },
+        { id: "t2", role: "implement", instruction: "Implement dedicated live spectator TV", status: "pending" },
+      ],
+    } as Job;
+
+    render(<ComposerTodoPanel sessionId="sess-wave" jobs={[job]} />);
+
+    const lit = document.querySelectorAll("[data-todo-lit='1']");
+    expect(lit).toHaveLength(1);
+    expect(lit[0]?.textContent).toContain("Implement station management server actions");
+    expect(document.querySelectorAll(".animate-spin")).toHaveLength(1);
+  });
 });

--- a/webapp/src/__tests__/composerTodos.test.ts
+++ b/webapp/src/__tests__/composerTodos.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   collapseTodoTasks,
   litTodoContents,
+  litTodoContentsFromGroups,
+  liveJobTodoLabelGroups,
   liveJobTodoLabels,
   todoHasWork,
   todoMatchesAnyDescription,
@@ -76,7 +78,6 @@ describe("composerTodos", () => {
     expect(liveJobTodoLabels(jobs, "sess-1")).toEqual([
       "nested todo lighting",
       "hosted pari service",
-      "explore",
     ]);
     const snapshot: SessionTodoSnapshot = {
       phases: [
@@ -108,6 +109,130 @@ describe("composerTodos", () => {
       ],
     };
     expect([...litTodoContents(snapshot, liveJobTodoLabels(jobs, "sess-1"))]).toEqual(["hosted pari"]);
+  });
+
+  it("does not treat a generic implement role as a match", () => {
+    expect(todoMatchesAnyDescription("Implement station management server actions", ["implement"])).toBe(false);
+    expect(todoMatchesAnyDescription("Implement dedicated live spectator TV", ["implement", "agentic"])).toBe(false);
+    expect(todoMatchesAnyDescription("implement (agentic) WAVE 1B (Part 1 - Actions only):", ["WAVE 1B"])).toBe(true);
+  });
+
+  it("lights only the running wave when one implement job is live", () => {
+    const jobs = [
+      {
+        id: "j-wave-1b",
+        goal: "WAVE 1B (Part 1 - Actions only)",
+        status: "running",
+        session_id: "sess-1",
+        role: "implement",
+        tasks: [
+          { id: "t1", role: "implement", instruction: "Implement station management server actions", status: "running" },
+          { id: "t2", role: "implement", instruction: "Implement dedicated live spectator TV", status: "pending" },
+          { id: "t3", role: "implement", instruction: "Implement versioned ruleset validator", status: "pending" },
+        ],
+      },
+    ] as Job[];
+    const snapshot: SessionTodoSnapshot = {
+      phases: [
+        {
+          name: "Wave 1 — Station & Stadium Operations",
+          tasks: [
+            task("Ship station inventory read path", "completed"),
+            task("Implement station management server actions", "in_progress"),
+            task("Validate station ops", "pending"),
+          ],
+        },
+        {
+          name: "Wave 2 — Live Spectator",
+          tasks: [
+            task("Implement dedicated live spectator TV", "pending"),
+            task("Validate spectator display", "pending"),
+          ],
+        },
+        {
+          name: "Wave 3 — Ruleset",
+          tasks: [task("Implement versioned ruleset validator", "pending")],
+        },
+        {
+          name: "Tasks",
+          tasks: [task("implement (agentic) WAVE 1B (Part 1 - Actions only):", "pending")],
+        },
+      ],
+    };
+    expect(liveJobTodoLabels(jobs, "sess-1")).toEqual([
+      "WAVE 1B (Part 1 - Actions only)",
+      "Implement station management server actions",
+    ]);
+    expect([...litTodoContents(snapshot, liveJobTodoLabels(jobs, "sess-1"))]).toEqual([
+      "Implement station management server actions",
+    ]);
+  });
+
+  it("lights one todo per actually-running job", () => {
+    const jobs = [
+      {
+        id: "j1",
+        goal: "pari cutover",
+        status: "running",
+        session_id: "sess-1",
+        tasks: [{ id: "t1", instruction: "hosted pari service", status: "running" }],
+      },
+      {
+        id: "j2",
+        goal: "station board",
+        status: "running",
+        session_id: "sess-1",
+        tasks: [{ id: "t2", instruction: "station board ui", status: "running" }],
+      },
+    ] as Job[];
+    const snapshot: SessionTodoSnapshot = {
+      phases: [
+        {
+          name: "Work",
+          tasks: [task("hosted pari", "pending"), task("station board", "pending")],
+        },
+      ],
+    };
+    expect([...litTodoContentsFromGroups(snapshot, liveJobTodoLabelGroups(jobs, "sess-1"))].sort()).toEqual([
+      "hosted pari",
+      "station board",
+    ]);
+  });
+
+  it("lights the wave handle from a running parent before child statuses arrive", () => {
+    const jobs = [
+      {
+        id: "j-wave-1b",
+        goal: "WAVE 1B (Part 1 - Actions only)",
+        status: "running",
+        session_id: "sess-1",
+        role: "implement",
+        tasks: [
+          { id: "t1", role: "implement", instruction: "Implement station management server actions", status: "pending" },
+          { id: "t2", role: "implement", instruction: "Implement dedicated live spectator TV", status: "pending" },
+        ],
+      },
+    ] as Job[];
+    const snapshot: SessionTodoSnapshot = {
+      phases: [
+        {
+          name: "Wave 1",
+          tasks: [task("Implement station management server actions", "in_progress")],
+        },
+        {
+          name: "Wave 2",
+          tasks: [task("Implement dedicated live spectator TV", "pending")],
+        },
+        {
+          name: "Tasks",
+          tasks: [task("implement (agentic) WAVE 1B (Part 1 - Actions only):", "pending")],
+        },
+      ],
+    };
+    expect(liveJobTodoLabels(jobs, "sess-1")).toEqual(["WAVE 1B (Part 1 - Actions only)"]);
+    expect([...litTodoContents(snapshot, liveJobTodoLabels(jobs, "sess-1"))]).toEqual([
+      "implement (agentic) WAVE 1B (Part 1 - Actions only):",
+    ]);
   });
 
   it("keeps lit pending todos in the folded viewport", () => {

--- a/webapp/src/components/conversation/ComposerTodoPanel.tsx
+++ b/webapp/src/components/conversation/ComposerTodoPanel.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { Ban, CheckCircle2, ChevronDown, ChevronRight, Circle, ListTree, Loader2, MinusCircle } from "lucide-react";
 import { api, type Job, type SessionTodoItem, type SessionTodoSnapshot } from "../../lib/api";
 import {
-  litTodoContents,
-  liveJobTodoLabels,
+  litTodoContentsFromGroups,
+  liveJobTodoLabelGroups,
   todoHasWork,
   todoPhaseProgress,
   todoSnapshotProgress,
@@ -62,7 +62,7 @@ export default function ComposerTodoPanel({
   const [open, setOpen] = useState(true);
   const [collapsedPhaseKeys, setCollapsedPhaseKeys] = useState<Set<string>>(() => new Set());
   const lit = useMemo(
-    () => litTodoContents(snapshot, liveJobTodoLabels(jobs, sessionId)),
+    () => litTodoContentsFromGroups(snapshot, liveJobTodoLabelGroups(jobs, sessionId)),
     [jobs, sessionId, snapshot],
   );
 

--- a/webapp/src/lib/composerTodos.ts
+++ b/webapp/src/lib/composerTodos.ts
@@ -47,6 +47,24 @@ export function collapseTodoTasks(
   return { items, hidden: Math.max(0, tasks.length - items.length) };
 }
 
+export const TODO_DESCRIPTION_MIN_OVERLAP = 6;
+
+const GENERIC_TODO_LABEL_TOKENS = new Set([
+  "implement",
+  "explore",
+  "audit",
+  "review",
+  "architect",
+  "worker",
+  "swarm",
+  "plan",
+  "agentic",
+  "analysis",
+  "parallel",
+  "wave",
+  "coder",
+]);
+
 export function normalizeForTodoMatch(value: string): string {
   return (value || "")
     .toLowerCase()
@@ -54,56 +72,114 @@ export function normalizeForTodoMatch(value: string): string {
     .trim();
 }
 
+export function isGenericTodoLabel(value: string): boolean {
+  const tokens = normalizeForTodoMatch(value).split(/\s+/).filter(Boolean);
+  const substantive = tokens.filter((token) => token.length >= 3 || /\d/.test(token));
+  if (!substantive.length) return true;
+  return substantive.every((token) => GENERIC_TODO_LABEL_TOKENS.has(token));
+}
+
+function usableTodoLabel(value: string): boolean {
+  const normalized = normalizeForTodoMatch(value);
+  return normalized.length >= TODO_DESCRIPTION_MIN_OVERLAP && !isGenericTodoLabel(value);
+}
+
+function todoMatchScore(content: string, descriptions: readonly string[]): number {
+  const target = normalizeForTodoMatch(content);
+  if (!target) return 0;
+  let best = 0;
+  for (const desc of descriptions) {
+    if (!usableTodoLabel(desc)) continue;
+    const candidate = normalizeForTodoMatch(desc);
+    if (target === candidate) return Math.max(best, target.length + 1_000);
+    if (target.length >= TODO_DESCRIPTION_MIN_OVERLAP && candidate.includes(target)) {
+      best = Math.max(best, target.length);
+    }
+    if (candidate.length >= TODO_DESCRIPTION_MIN_OVERLAP && target.includes(candidate)) {
+      best = Math.max(best, candidate.length);
+    }
+  }
+  return best;
+}
+
 export function todoMatchesAnyDescription(
   content: string,
   descriptions: readonly string[],
 ): boolean {
-  const target = normalizeForTodoMatch(content);
-  if (!target) return false;
-  for (const desc of descriptions) {
-    const candidate = normalizeForTodoMatch(desc);
-    if (!candidate) continue;
-    if (target === candidate) return true;
-    if (target.length >= TODO_DESCRIPTION_MIN_OVERLAP && candidate.includes(target)) return true;
-    if (candidate.length >= TODO_DESCRIPTION_MIN_OVERLAP && target.includes(candidate)) return true;
-  }
-  return false;
+  return todoMatchScore(content, descriptions) > 0;
 }
 
-export const TODO_DESCRIPTION_MIN_OVERLAP = 6;
-
-export function liveJobTodoLabels(jobs: readonly Job[], sessionId: string): string[] {
-  const labels: string[] = [];
-  for (const job of jobs) {
-    if (!jobInActiveSession(job, sessionId)) continue;
-    const jobLive = taskState(job.status) === "in_progress" || taskState(job.status) === "pending";
-    const liveTasks = (job.tasks || []).filter((task) => {
-      const state = taskState(task.status);
-      return state === "in_progress" || state === "pending";
-    });
-    if (!jobLive && !liveTasks.length) continue;
-    if (job.goal) labels.push(job.goal);
-    if (job.role) labels.push(job.role);
-    for (const task of liveTasks) {
-      if (task.instruction) labels.push(String(task.instruction));
-      if (task.role) labels.push(String(task.role));
+function openTodoItems(snapshot: SessionTodoSnapshot | null | undefined): SessionTodoItem[] {
+  const open: SessionTodoItem[] = [];
+  for (const phase of snapshot?.phases || []) {
+    for (const task of phase.tasks) {
+      if (task.status === "pending" || task.status === "in_progress") open.push(task);
     }
   }
-  return labels;
+  return open;
+}
+
+function bestMatchingOpenTodo(
+  snapshot: SessionTodoSnapshot | null | undefined,
+  descriptions: readonly string[],
+): string | null {
+  let winner: SessionTodoItem | null = null;
+  let bestScore = 0;
+  for (const task of openTodoItems(snapshot)) {
+    const score = todoMatchScore(task.content, descriptions);
+    if (score <= 0) continue;
+    if (
+      score > bestScore
+      || (score === bestScore && task.status === "in_progress" && winner?.status !== "in_progress")
+    ) {
+      winner = task;
+      bestScore = score;
+    }
+  }
+  return winner?.content ?? null;
+}
+
+export function liveJobTodoLabelGroups(jobs: readonly Job[], sessionId: string): string[][] {
+  const groups: string[][] = [];
+  for (const job of jobs) {
+    if (!jobInActiveSession(job, sessionId)) continue;
+    const jobLive = taskState(job.status) === "in_progress";
+    const runningTasks = (job.tasks || []).filter((task) => taskState(task.status) === "in_progress");
+    if (!jobLive && !runningTasks.length) continue;
+    if (runningTasks.length) {
+      for (const task of runningTasks) {
+        const labels: string[] = [];
+        if (job.goal && usableTodoLabel(job.goal)) labels.push(job.goal);
+        const instruction = String(task.instruction || "");
+        if (usableTodoLabel(instruction)) labels.push(instruction);
+        if (labels.length) groups.push(labels);
+      }
+      continue;
+    }
+    if (job.goal && usableTodoLabel(job.goal)) groups.push([job.goal]);
+  }
+  return groups;
+}
+
+export function liveJobTodoLabels(jobs: readonly Job[], sessionId: string): string[] {
+  return liveJobTodoLabelGroups(jobs, sessionId).flat();
 }
 
 export function litTodoContents(
   snapshot: SessionTodoSnapshot | null | undefined,
   descriptions: readonly string[],
 ): Set<string> {
+  return litTodoContentsFromGroups(snapshot, descriptions.length ? [descriptions] : []);
+}
+
+export function litTodoContentsFromGroups(
+  snapshot: SessionTodoSnapshot | null | undefined,
+  groups: readonly (readonly string[])[],
+): Set<string> {
   const lit = new Set<string>();
-  for (const phase of snapshot?.phases || []) {
-    for (const task of phase.tasks) {
-      if (task.status !== "pending" && task.status !== "in_progress") continue;
-      if (todoMatchesAnyDescription(task.content, descriptions)) {
-        lit.add(task.content);
-      }
-    }
+  for (const group of groups) {
+    const winner = bestMatchingOpenTodo(snapshot, group);
+    if (winner) lit.add(winner);
   }
   return lit;
 }


### PR DESCRIPTION
## Why

Composer TODO wave circles spun for every `Implement …` row while Swarm Tracker showed one live WAVE 1B job. The lighting path treated generic roles (`implement`) and pending sibling briefs as live labels, then substring-matched them onto the whole plan.

## Scope

- `webapp/src/lib/composerTodos.ts`: drop generic roles, use only running-job goals and in-progress child instructions, pick one best match per live job.
- `webapp/src/components/conversation/ComposerTodoPanel.tsx`: light from those per-job groups.
- Regression coverage for the WAVE 1B fixture, parallel live jobs, and parent-goal lighting before child statuses arrive.

## Tradeoffs

Queued wave todos stay hollow until their job is actually running. Two real parallel jobs can still light two rows.

## Blast radius

Composer TODO spinners only. Swarm Tracker, session todo persistence, and `normalize_in_progress` are unchanged.

## Verification

- Failing-then-passing: `npm test -- src/__tests__/composerTodos.test.ts src/__tests__/ComposerTodoPanel.test.tsx` (WAVE 1B fixture went from 3 lit rows to 1).
- CodeGraph-affected composer suite: 10 files, 45 passed.

Did not drive the live Electron session that produced the original screenshots.