### PR TITLE
fix: Settings model enable writes the isolated worker catalog

### DIFF
--- a/harness/api/providers.py
+++ b/harness/api/providers.py
@@ -42,12 +42,19 @@ class ProviderServices:
 # Models (visibility / catalog)
 # ---------------------------------------------------------------------------
 
+def _sync_worker_catalog_after_picker_change() -> None:
+    """Settings enable is the worker allowlist. Refresh the isolated catalog now."""
+    from ..auto_registry import sync_agentic_registry_safe
+    sync_agentic_registry_safe()
+
+
 def post_models_toggle(body: dict, svc: ProviderServices) -> tuple[int, dict]:
     """POST /api/models/toggle — enable/disable one provider:model spec."""
     from .. import model_visibility as _mv
     spec = body.get("spec", "")
     on = svc.parse_bool(body.get("enabled", True))
     enabled = _mv.toggle(spec, on)
+    _sync_worker_catalog_after_picker_change()
     sync = svc.resync_driver_after_model_curation()
     return 200, {
         "ok": True,
@@ -61,6 +68,7 @@ def post_models_set(body: dict, svc: ProviderServices) -> tuple[int, dict]:
     """POST /api/models/set — replace the enabled model set."""
     from .. import model_visibility as _mv
     enabled = _mv.set_enabled(body.get("enabled") or [])
+    _sync_worker_catalog_after_picker_change()
     sync = svc.resync_driver_after_model_curation()
     return 200, {
         "ok": True,

--- a/harness/auto_registry.py
+++ b/harness/auto_registry.py
@@ -497,15 +497,12 @@ def _get_provider_models_from_discovery(
                     return f"openai-codex/{name}"
                 return name
 
+            # Settings toggles are the worker allowlist. Keep every enabled
+            # id even when this live fetch omitted it; do not add extras.
             selected = [(m, _tier_of_known(m), _slug_for(m)) for m in enabled]
             live_models = fetch_models(provider, provider_key, force=force)
-            if live_models:
-                if provider_name == "openrouter":
-                    selected = _promote_openrouter_snapshots(selected, live_models)
-                selected = [
-                    item for item in selected
-                    if _in_live_catalog(item[0], item[2], live_models)
-                ]
+            if live_models and provider_name == "openrouter":
+                selected = _promote_openrouter_snapshots(selected, live_models)
             return selected
 
         # Per-provider only: another provider's Models toggles must not empty

--- a/harness/swarm_model_pin.py
+++ b/harness/swarm_model_pin.py
@@ -17,6 +17,15 @@ from .diag import note as _diag
 
 # Prefer agentic (API-billed) remaps before platform cursor when both match.
 _PIN_ADAPTER_ORDER = ("agentic", "cursor", "openai")
+_GENERIC_MODEL_TOKENS = frozenset({
+    "pro", "mini", "nano", "fast", "high", "low", "max", "latest",
+    "free", "exp", "preview", "flash", "plus", "chat", "code",
+})
+_PIN_PROVIDER_ALIASES = {
+    "codex": "openai-codex",
+    "chatgpt-codex": "openai-codex",
+    "codex-plan": "openai-codex",
+}
 
 
 @dataclass(frozen=True)
@@ -44,21 +53,119 @@ class AgenticModelPin:
         }
 
 
-def _direct_agentic_provider_model(pin: str) -> Optional[AgenticModelPin]:
-    """Resolve ``provider/model`` when a keyed live model is not in the registry."""
+def _model_family_token(model_id: str) -> str:
+    """Distinctive last token (``astra``, ``luna``), or empty for generic tails."""
+    bare = (model_id or "").rsplit("/", 1)[-1].strip().lower()
+    parts = [p for p in re.split(r"[-_.]+", bare) if p]
+    if not parts:
+        return ""
+    token = parts[-1]
+    if token.isdigit() or token in _GENERIC_MODEL_TOKENS or len(token) < 3:
+        return ""
+    return token
 
-    requested = (pin or "").strip()
-    body = requested
+
+def _normalize_pin_provider(provider: str) -> str:
+    raw = (provider or "").strip().lower()
+    return _PIN_PROVIDER_ALIASES.get(raw, raw)
+
+
+def _parse_pin_provider_model(pin: str) -> tuple[str, str]:
+    """Best-effort ``(provider, model)`` from a pilot-supplied pin."""
+    body = (pin or "").strip()
     if body.lower().startswith("agentic/"):
         body = body.split("/", 1)[1].strip()
     if ":" in body:
         provider, model = body.split(":", 1)
-    elif "/" in body:
-        provider, model = body.split("/", 1)
+        return _normalize_pin_provider(provider), model.strip()
+    known = {
+        "cursor",
+        "cursor-cli",
+        "codex",
+        "openai",
+        "openai-codex",
+        "opencode-go",
+        "opencode-zen",
+        "openrouter",
+        "native",
+    }
+    if "/" in body:
+        head, rest = body.split("/", 1)
+        if head.lower() in known:
+            return _normalize_pin_provider(head), rest.strip()
+    return "", body
+
+
+def settings_enabled_pin_specs(
+    pin: str,
+    *,
+    enabled: Optional[list[str]] = None,
+) -> list[str]:
+    """Settings specs for the same enabled model — never a different sibling.
+
+    ``gpt-5.6-astra`` maps to enabled ``openai-codex:gpt-6-astra``. It does
+    not map to Sol or Luna. Generic tails (``pro``, ``mini``) match exact ids
+    only.
+    """
+    requested = (pin or "").strip()
+    if not requested:
+        return []
+    if enabled is None:
+        try:
+            from .model_visibility import get_enabled
+            enabled = get_enabled()
+        except Exception as exc:
+            _diag("swarm_model_pin.enabled_specs", exc)
+            enabled = []
+    pin_provider, pin_model = _parse_pin_provider_model(requested)
+    pin_model_l = (pin_model or "").strip().lower()
+    pin_token = _model_family_token(pin_model or requested)
+    out: list[str] = []
+    seen: set[str] = set()
+    for spec in enabled or []:
+        raw = str(spec or "").strip()
+        if ":" not in raw:
+            continue
+        prov, mid = raw.split(":", 1)
+        prov = _normalize_pin_provider(prov)
+        mid = mid.strip()
+        if not prov or not mid:
+            continue
+        if pin_provider and prov != pin_provider:
+            continue
+        exact = bool(pin_model_l) and mid.lower() == pin_model_l
+        token = bool(pin_token) and _model_family_token(mid) == pin_token
+        if not (exact or token):
+            continue
+        key = raw.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(raw)
+    return out
+
+
+def _direct_agentic_provider_model(pin: str) -> Optional[AgenticModelPin]:
+    """Resolve ``provider/model`` when a keyed live model is not in the registry."""
+
+    requested = (pin or "").strip()
+    matches = settings_enabled_pin_specs(requested)
+    if len(matches) == 1:
+        provider, model = matches[0].split(":", 1)
+        provider = _normalize_pin_provider(provider)
+        model = model.strip()
     else:
-        return None
-    provider = provider.strip().lower()
-    model = model.strip()
+        body = requested
+        if body.lower().startswith("agentic/"):
+            body = body.split("/", 1)[1].strip()
+        if ":" in body:
+            provider, model = body.split(":", 1)
+        elif "/" in body:
+            provider, model = body.split("/", 1)
+        else:
+            return None
+        provider = _normalize_pin_provider(provider)
+        model = model.strip()
     if not provider or not model:
         return None
     try:
@@ -348,7 +455,16 @@ def resolve_swarm_model_pin(
         _diag("swarm_model_pin.health", e)
 
     adapters = _allowed_pin_adapters(allowed_adapters)
-    for candidate in pin_candidates(requested):
+    candidates = list(pin_candidates(requested))
+    seen_cands = {c.lower() for c in candidates}
+    for spec in settings_enabled_pin_specs(requested):
+        for extra in pin_candidates(spec):
+            key = extra.lower()
+            if key in seen_cands:
+                continue
+            seen_cands.add(key)
+            candidates.append(extra)
+    for candidate in candidates:
         for adapter in adapters:
             stamped = _try_apply_pin(candidate, adapter=adapter)
             if not stamped:

--- a/tests/test_api_models_toggle.py
+++ b/tests/test_api_models_toggle.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Settings model toggle/set must refresh the isolated worker catalog."""
+
+from types import SimpleNamespace
+
+from harness.api.providers import ProviderServices, post_models_set, post_models_toggle
+
+
+def _svc():
+    return ProviderServices(
+        cfg=SimpleNamespace(driver="openai-codex:gpt-5.6-sol"),
+        diag=lambda *_a, **_k: None,
+        parse_bool=lambda v: bool(v) if not isinstance(v, str) else v.lower() in (
+            "1", "true", "yes", "on",
+        ),
+        resync_driver_after_model_curation=lambda: {
+            "driver": "openai-codex:gpt-5.6-sol",
+            "changed": False,
+        },
+        driver_provider_available=lambda _n: True,
+        resolve_available_driver=lambda: None,
+        rebuild_pilot_and_session=lambda: None,
+    )
+
+
+def test_models_toggle_syncs_agentic_worker_registry(monkeypatch):
+    syncs = []
+    monkeypatch.setattr(
+        "harness.model_visibility.toggle",
+        lambda spec, on: ["openai-codex:gpt-6-astra"] if on else [],
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.sync_agentic_registry_safe",
+        lambda force=False: syncs.append({"force": force}),
+    )
+
+    code, body = post_models_toggle(
+        {"spec": "openai-codex:gpt-6-astra", "enabled": True},
+        _svc(),
+    )
+    assert code == 200
+    assert body["ok"] is True
+    assert syncs, "Settings enable must sync the isolated worker catalog"
+
+
+def test_models_set_syncs_agentic_worker_registry(monkeypatch):
+    syncs = []
+    monkeypatch.setattr(
+        "harness.model_visibility.set_enabled",
+        lambda specs: list(specs or []),
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.sync_agentic_registry_safe",
+        lambda force=False: syncs.append({"force": force}),
+    )
+
+    code, body = post_models_set(
+        {"enabled": ["openai-codex:gpt-6-astra", "openai-codex:gpt-5.6-sol"]},
+        _svc(),
+    )
+    assert code == 200
+    assert body["ok"] is True
+    assert syncs, "Settings set must sync the isolated worker catalog"

--- a/tests/test_auto_registry.py
+++ b/tests/test_auto_registry.py
@@ -1282,3 +1282,33 @@ def test_zen_explicit_enabled_set_does_not_auto_enable_ox(monkeypatch, tmp_path)
     assert ids == {"agentic/big-pickle"}
     assert "agentic/x-preview-f-free" not in ids
     assert "agentic/gpt-5.5" not in ids
+
+
+def test_enabled_codex_astra_stays_when_live_listing_omits_it(monkeypatch, tmp_path):
+    """Settings enable is the worker allowlist. A stale Codex listing must not
+    drop an explicitly enabled model (gpt-6-astra) that the picker already showed."""
+    models_path = tmp_path / "models.json"
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+
+    def mock_get_provider_key(provider):
+        return "fake-codex" if provider.name == "openai-codex" else None
+
+    live = ["gpt-5.6-sol", "gpt-5.6-luna"]
+    with patch("harness.registry_wizard.get_provider_key", mock_get_provider_key), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda *_a, **_k: list(live)), \
+         patch(
+             "harness.auto_registry._enabled_picker_models",
+             lambda name: (
+                 ["gpt-6-astra", "gpt-5.6-sol"] if name == "openai-codex" else []
+             ),
+         ):
+        from harness.auto_registry import sync_agentic_registry
+        result = sync_agentic_registry()
+
+    assert result["synced"] is True
+    ids = {m["id"] for m in json.loads(models_path.read_text())["models"]}
+    assert "agentic/openai-codex/gpt-6-astra" in ids
+    assert "agentic/openai-codex/gpt-5.6-sol" in ids
+    assert "agentic/openai-codex/gpt-5.6-luna" not in ids

--- a/tests/test_swarm_model_pin.py
+++ b/tests/test_swarm_model_pin.py
@@ -348,6 +348,122 @@ def test_resolve_cursor_pin_across_adapter_union(monkeypatch, tmp_path):
     assert out["resolved"] == "cursor/grok-4-5"
 
 
+def test_settings_enabled_pin_specs_maps_astra_generation_not_sol():
+    from harness.swarm_model_pin import settings_enabled_pin_specs
+
+    enabled = [
+        "openai-codex:gpt-5.6-sol",
+        "openai-codex:gpt-5.6-luna",
+        "openai-codex:gpt-6-astra",
+    ]
+    assert settings_enabled_pin_specs(
+        "agentic/openai-codex/gpt-5.6-astra", enabled=enabled,
+    ) == ["openai-codex:gpt-6-astra"]
+    assert settings_enabled_pin_specs(
+        "openai-codex:gpt-6-astra", enabled=enabled,
+    ) == ["openai-codex:gpt-6-astra"]
+    assert settings_enabled_pin_specs(
+        "agentic/openai-codex/gpt-5.6-sol", enabled=enabled,
+    ) == ["openai-codex:gpt-5.6-sol"]
+    assert settings_enabled_pin_specs("agentic/openai-codex/gpt-5.6-astra", enabled=[
+        "openai-codex:gpt-5.6-sol",
+        "openai-codex:gpt-5.6-luna",
+    ]) == []
+
+
+def test_resolve_gpt56_astra_pin_to_enabled_gpt6_astra(monkeypatch, tmp_path):
+    """Pilot 'GPT 5.6 Astra' pins must resolve to the Settings-enabled wire id."""
+    models_path = tmp_path / "models.json"
+    models_path.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "id": "agentic/openai-codex/gpt-5.6-sol",
+                        "adapter": "agentic",
+                        "adapter_model_name": "gpt-5.6-sol",
+                        "payload_defaults": {"provider": "openai-codex"},
+                    },
+                    {
+                        "id": "agentic/openai-codex/gpt-6-astra",
+                        "adapter": "agentic",
+                        "adapter_model_name": "gpt-6-astra",
+                        "payload_defaults": {"provider": "openai-codex"},
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setattr(
+        "harness.auto_registry.ensure_keyed_provider_registry_health",
+        lambda: {"ready": True},
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: {"openai-codex"},
+    )
+    monkeypatch.setattr(
+        "harness.model_visibility.get_enabled",
+        lambda: [
+            "openai-codex:gpt-5.6-sol",
+            "openai-codex:gpt-6-astra",
+        ],
+    )
+
+    def _fake_pin(payload, model, *, adapter, registry=None):
+        if adapter != "agentic":
+            return {**(payload or {}), "model": model}
+        if model in (
+            "gpt-6-astra",
+            "openai-codex/gpt-6-astra",
+            "agentic/openai-codex/gpt-6-astra",
+        ):
+            return {
+                **(payload or {}),
+                "model": "gpt-6-astra",
+                "provider": "openai-codex",
+                "pinned_model": "agentic/openai-codex/gpt-6-astra",
+                "pinned_adapter_model_name": "gpt-6-astra",
+            }
+        if model in (
+            "gpt-5.6-sol",
+            "openai-codex/gpt-5.6-sol",
+            "agentic/openai-codex/gpt-5.6-sol",
+        ):
+            return {
+                **(payload or {}),
+                "model": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "pinned_model": "agentic/openai-codex/gpt-5.6-sol",
+                "pinned_adapter_model_name": "gpt-5.6-sol",
+            }
+        return {**(payload or {}), "model": model}
+
+    monkeypatch.setattr("puppetmaster.model_registry.apply_model_pin", _fake_pin)
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist.resolve_swarm_worker_allowlist",
+        lambda **_k: {
+            "allowed_adapters": ["agentic"],
+            "prefer_plan_billed": False,
+            "primary_adapter": "agentic",
+        },
+    )
+
+    from harness.swarm_model_pin import resolve_agentic_model_pin, resolve_swarm_model_pin
+
+    out = resolve_swarm_model_pin("agentic/openai-codex/gpt-5.6-astra")
+    assert out["demoted"] is False
+    assert out["resolved"] == "agentic/openai-codex/gpt-6-astra"
+    assert out["pin_fields"].get("provider") == "openai-codex"
+    pin, error = resolve_agentic_model_pin("agentic/openai-codex/gpt-5.6-astra")
+    assert error == ""
+    assert pin is not None
+    assert pin.model == "gpt-6-astra"
+    assert pin.router_model_id == "agentic/openai-codex/gpt-6-astra"
+
+
 def test_opencode_go_curated_bound_into_auto_registry():
     from harness.auto_registry import _CURATED_MODELS
     from harness.opencode_go import CURATED_MODELS


### PR DESCRIPTION
## Summary
- Enabling a model in Marionette Settings now syncs the isolated worker catalog (`marionette-models.json`) so swarm/implement pins are routable without `puppetmaster models discover --write`.
- Explicitly enabled picker models stay in that catalog even when a stale live listing omits them (Astra vs Sol/Luna).
- Pins such as `gpt-5.6-astra` resolve to the Settings-enabled `gpt-6-astra` row. They do not fail closed as missing, and they do not silently substitute Sol.

## Test plan
- [x] `pytest -q tests/test_api_models_toggle.py tests/test_auto_registry.py tests/test_swarm_model_pin.py` (failing before, passing after)
- [x] Nearby visibility / swarm-routing suites green
- [ ] CI `tests` matrix on this dest-into-main PR