### PR TITLE
Release v0.9.423: recover startup and fix narrow session layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.23.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.422, deliberately pre-1.0. Pins puppetmaster-ai==1.23.0. Saved inputs retain original text and attachments through interrupted delivery and archive restoration. Session changes and model swaps preserve input ownership. Job evidence distinguishes verified checks, uncertain effects, and measured, estimated, or unknown consumption. Forks, schedule editing, scoped reviews, and authenticated desktop image loading are integrated.
+> Status: v0.9.423, deliberately pre-1.0. Pins puppetmaster-ai==1.23.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows have a 900×600 minimum; smaller layouts use bounded Sessions and Panels drawers. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.422"
+__version__ = "0.9.423"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/prompt_queue.py
+++ b/harness/prompt_queue.py
@@ -164,6 +164,12 @@ class PromptQueueMixin:
                     continue
                 except OSError:
                     content = None
+                if kind == 'legacy' and content is not None:
+                    try:
+                        if json.loads(content) == {'queue': []}:
+                            continue
+                    except ValueError:
+                        pass
                 recovery.append({'kind': kind, 'path': path, 'content': content})
             return recovery
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.422"
+version = "0.9.423"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_prompt_queue_persistence.py
+++ b/tests/test_prompt_queue_persistence.py
@@ -94,3 +94,21 @@ def test_legacy_items_are_not_automatically_imported():
     s = _session(d)
     assert s.list_prompts() == []
     assert json.loads(s.prompt_queue_recovery()[0]["content"]) == payload
+
+
+def test_empty_legacy_queue_does_not_raise_recovery_notice(tmp_path):
+    legacy = tmp_path / "prompt_queue.json"
+    original = b'{ "queue": [] }\n'
+    legacy.write_bytes(original)
+    s = _session(str(tmp_path))
+    assert s.prompt_queue_recovery() == []
+    assert legacy.read_bytes() == original
+
+
+def test_unknown_legacy_fields_remain_recoverable(tmp_path):
+    legacy = tmp_path / "prompt_queue.json"
+    original = '{"queue": [], "draft": "keep this original"}'
+    legacy.write_text(original)
+    s = _session(str(tmp_path))
+    assert s.prompt_queue_recovery()[0]["content"] == original
+    assert legacy.read_text() == original

--- a/webapp/electron/bootstrap-revision.test.cjs
+++ b/webapp/electron/bootstrap-revision.test.cjs
@@ -7,7 +7,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 const { execFileSync } = require("node:child_process");
 const git = (dir, ...args) => execFileSync("git", ["-C", dir, ...args], { encoding: "utf8" }).trim();
-function fixture(t) {
+function fixture(t, packaged = false) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "bootstrap-revision-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   const origin = path.join(root, "origin"); fs.mkdirSync(origin);
@@ -29,7 +29,9 @@ function fixture(t) {
     npm: async (args, opts) => { calls.push(args.join(" ")); if (args[0] === "ci") fs.mkdirSync(path.join(opts.cwd, "node_modules"), { recursive: true }); else { if (failBuild) throw Error("interrupted build"); fs.mkdirSync(path.join(opts.cwd, "dist"), { recursive: true }); fs.writeFileSync(path.join(opts.cwd, "dist/index.html"), "built"); } },
   };
   vm.runInNewContext(fs.readFileSync(path.join(__dirname, "bootstrap.cjs"), "utf8") + '\nhydratePath = () => {}; ensurePortableGit = ensureUv = ensurePortableNode = async () => {}; provisionPython = provision; runNpmAsync = npm;', context);
-  return { origin, dest, revision, calls, packagedDir, api: context.module.exports, fail: () => { failBuild = true; }, recover: () => { failBuild = false; } };
+  if (packaged) vm.runInNewContext(`bootstrapTarget = () => (${JSON.stringify({ mode: "packaged", repo: origin, revision })});`, context);
+  return { origin, dest, revision, calls, packagedDir, api: context.module.exports,
+    retarget: sha => vm.runInNewContext(`bootstrapTarget = () => (${JSON.stringify({ mode: "packaged", repo: origin, revision: sha })});`, context), fail: () => { failBuild = true; }, recover: () => { failBuild = false; } };
 }
 test("bootstrap pins the requested commit even when main has advanced", async t => {
   const f = fixture(t); await f.api.runBootstrap(f.dest);
@@ -155,4 +157,76 @@ test("failed rebuild cannot reuse old dist or a previous success receipt", async
   f.recover(); await f.api.runBootstrap(f.dest);
   assert.equal(f.calls.filter(x => x === "ci").length, 3);
   assert.equal(f.api.isInstallComplete(f.dest), true);
+});
+
+for (const dirty of ['untracked', 'tracked', 'origin']) {
+  test(`production selection preserves legacy ${dirty} and reuses one pinned checkout`, async t => {
+    const f = fixture(t, true);
+    const home = path.dirname(f.dest);
+    const legacy = path.join(home, '.marionette', 'marionette');
+    await f.api.runBootstrap(legacy);
+    const userFile = path.join(legacy, dirty === 'tracked' ? 'pyproject.toml' : 'tests/test_stream_chat_framing_done.py');
+    fs.mkdirSync(path.dirname(userFile), { recursive: true });
+    fs.writeFileSync(userFile, 'user work\n\x00exact bytes');
+    if (dirty === 'origin') git(legacy, 'remote', 'set-url', 'origin', f.origin + '-unrelated');
+    const hash = file => require('node:crypto').createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+    const before = hash(userFile), head = git(legacy, 'rev-parse', 'HEAD');
+    const selected = f.api.selectPackagedCheckout({ home, env: {} });
+    assert.notEqual(selected, legacy);
+    f.fail(); await assert.rejects(f.api.runBootstrap(selected), /interrupted build/);
+    assert.equal(f.api.isInstallComplete(selected), false);
+    f.recover(); await f.api.runBootstrap(selected);
+    const calls = f.calls.length;
+    assert.equal(f.api.selectPackagedCheckout({ home, env: {} }), selected);
+    await f.api.runBootstrap(selected);
+    assert.equal(f.calls.length, calls);
+    assert.equal(git(selected, 'rev-parse', 'HEAD'), f.revision);
+    assert.equal(hash(userFile), before);
+    assert.equal(git(legacy, 'rev-parse', 'HEAD'), head);
+    assert.equal(fs.readdirSync(path.dirname(selected)).length, 2);
+  });
+}
+
+test('explicit development choices retain their checkout contract', () => {
+  const { selectPackagedCheckout } = require('./bootstrap.cjs');
+  const home = path.resolve(os.tmpdir(), 'selection-only');
+  for (const key of ['MARIONETTE_CHECKOUT', 'HARNESS_CHECKOUT']) {
+    assert.equal(selectPackagedCheckout({ home, env: { [key]: '/chosen' } }), '/chosen');
+  }
+  for (const env of [{ MARIONETTE_BRANCH: 'dev' }, { MARIONETTE_REVISION: 'a'.repeat(40) },
+    { MARIONETTE_REPO_URL: '/fork' }, { MARIONETTE_SELF_DEV: 'true' }, { PMHARNESS_DEV_SERVER: 'http://localhost:5273' }]) {
+    assert.equal(selectPackagedCheckout({ home, env }), path.join(home, '.marionette', 'marionette'));
+  }
+  assert.equal(selectPackagedCheckout({ home, env: { MARIONETTE_SELF_DEV: 'false' } }),
+    selectPackagedCheckout({ home, env: {} }));
+});
+
+
+test('persisted self-dev honors the legacy root and records the current root for later toggles', () => {
+  const { selectPackagedCheckout } = require('./bootstrap.cjs');
+  const home = path.resolve(os.tmpdir(), 'persisted-self-dev');
+  const release = selectPackagedCheckout({ home, env: {} });
+  assert.equal(selectPackagedCheckout({ home, env: {}, selfDev: true }), path.join(home, '.marionette', 'marionette'));
+  assert.equal(selectPackagedCheckout({ home, env: {}, selfDev: true, selfDevCheckout: release }), release);
+  assert.equal(selectPackagedCheckout({ home, env: { HARNESS_CHECKOUT: '/explicit' }, selfDev: true, selfDevCheckout: release }), '/explicit');
+});
+
+
+test('a replacement installer rebuilds the same production slot at its new pinned revision', async t => {
+  const f = fixture(t, true);
+  const selected = f.api.selectPackagedCheckout({ home: path.dirname(f.dest), env: {} });
+  await f.api.runBootstrap(selected);
+  const next = git(f.origin, 'rev-parse', 'HEAD');
+  f.retarget(next);
+  assert.equal(f.api.isInstallComplete(selected), false);
+  await f.api.runBootstrap(selected);
+  assert.equal(git(selected, 'rev-parse', 'HEAD'), next);
+  await f.api.runBootstrap(selected);
+  assert.equal(f.calls.filter(x => x === 'ci').length, 2);
+  assert.deepEqual(fs.readdirSync(path.dirname(selected)), ['release']);
+  fs.writeFileSync(path.join(selected, 'user-work.txt'), 'preserve even in release slot');
+  f.retarget(f.revision);
+  await assert.rejects(f.api.runBootstrap(selected), /Local changes/);
+  assert.equal(fs.readFileSync(path.join(selected, 'user-work.txt'), 'utf8'), 'preserve even in release slot');
+  assert.equal(git(selected, 'rev-parse', 'HEAD'), next);
 });

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -1,7 +1,7 @@
 // Bootstrap a Marionette source checkout for the packaged thin Electron shell.
 // When the app is installed from a release build (DMG/NSIS/AppImage), it does NOT
 // bundle Python or a frozen backend. On first launch it clones the repo into
-// ~/.marionette/marionette, provisions uv + node + git as needed, builds the venv
+// ~/.marionette/release, provisions uv + node + git as needed, builds the venv
 // and renderer, then hands off to main.cjs for normal source-run operation.
 //
 // Node stdlib + child_process only. Progress is streamed via onProgress(message, pct).
@@ -31,6 +31,20 @@ const VERSIONS = {
 const DEFAULT_REPO = "https://github.com/professorpalmer/marionette.git";
 const crypto = require("node:crypto");
 const RECEIPT = "marionette-bootstrap.json";
+
+function usesDevelopmentCheckout(env = process.env) {
+  return !!(env.MARIONETTE_CHECKOUT || env.HARNESS_CHECKOUT ||
+    env.MARIONETTE_REPO_URL || env.MARIONETTE_BRANCH || env.MARIONETTE_REVISION ||
+    env.PMHARNESS_DEV_SERVER || /^(1|true|yes)$/i.test(env.MARIONETTE_SELF_DEV || ""));
+}
+
+function selectPackagedCheckout({ env = process.env, home = os.homedir(), selfDev = false, selfDevCheckout = null } = {}) {
+  const explicit = env.MARIONETTE_CHECKOUT || env.HARNESS_CHECKOUT;
+  if (explicit) return explicit;
+  if (selfDev && selfDevCheckout) return selfDevCheckout;
+  // One reusable release checkout; never move, clean, or execute the legacy tree.
+  return path.join(home, ".marionette", (selfDev || usesDevelopmentCheckout(env)) ? "marionette" : "release");
+}
 
 function bootstrapTarget(env = process.env) {
   const override = env.MARIONETTE_REPO_URL || env.MARIONETTE_BRANCH || env.MARIONETTE_REVISION;
@@ -424,6 +438,8 @@ function reinjectPortableTools() {
 }
 
 module.exports = {
+  selectPackagedCheckout,
+  usesDevelopmentCheckout,
   bootstrapTarget,
   isInstallComplete,
   runBootstrap,

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -17,7 +17,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const crypto = require("node:crypto");
 const { readLiveUpdateMarker } = require("./update-marker.cjs");
-const { isInstallComplete, runBootstrap, reinjectPortableTools } = require("./bootstrap.cjs");
+const { isInstallComplete, runBootstrap, reinjectPortableTools, selectPackagedCheckout, usesDevelopmentCheckout } = require("./bootstrap.cjs");
 const { buildUpdaterEnv, windowsShellEnv } = require("./update-env.cjs");
 const {
   ensurePuppetmasterRuntime,
@@ -441,21 +441,14 @@ let respawnTimes = [];
 // UI. A single in-flight promise guarantees at most one backend launch at a time.
 let startInFlight = null;
 
-// The source checkout the app runs from. Marionette always runs from source
-// (Hermes model): the backend is `harness.cli` under this root, and the updater
-// pulls + rebuilds it in place. Optional MARIONETTE_CHECKOUT / legacy
-// HARNESS_CHECKOUT overrides the checkout path only -- do not use HARNESS_REPO
-// here (that env is the user's open project). Packaged thin shell: checkout at
-// ~/.marionette/marionette; dev: two levels up from webapp/electron/.
-function packagedRepoRoot() {
-  return path.join(os.homedir(), ".marionette", "marionette");
-}
-
+// Freeze the choice before bootstrap yields. Every runtime consumer uses this root.
+let selectedRepoRoot = null;
 function resolveRepoRoot() {
-  const checkout = process.env.MARIONETTE_CHECKOUT || process.env.HARNESS_CHECKOUT;
-  if (checkout) return checkout;
-  if (isPackaged) return packagedRepoRoot();
-  return path.resolve(__dirname, "..", "..");
+  if (selectedRepoRoot) return selectedRepoRoot;
+  selectedRepoRoot = isPackaged
+    ? selectPackagedCheckout({ selfDev: selfDevEnabled(), selfDevCheckout: selfDevCheckout() })
+    : (process.env.MARIONETTE_CHECKOUT || process.env.HARNESS_CHECKOUT || path.resolve(__dirname, "..", ".."));
+  return selectedRepoRoot;
 }
 
 function venvPython(repoRoot) {
@@ -473,6 +466,12 @@ function venvPython(repoRoot) {
 function selfDevConfigPath() {
   return path.join(os.homedir(), ".pmharness", "self-dev.json");
 }
+function selfDevCheckout() {
+  try {
+    const config = JSON.parse(fs.readFileSync(selfDevConfigPath(), "utf8"));
+    return typeof config.checkout === "string" && path.isAbsolute(config.checkout) ? config.checkout : null;
+  } catch { return null; }
+}
 function selfDevEnabled() {
   const env = String(process.env.MARIONETTE_SELF_DEV || "").toLowerCase();
   if (env === "1" || env === "true" || env === "yes") return true;
@@ -485,7 +484,7 @@ function selfDevEnabled() {
 function setSelfDevEnabled(enabled) {
   try {
     fs.mkdirSync(path.dirname(selfDevConfigPath()), { recursive: true });
-    fs.writeFileSync(selfDevConfigPath(), JSON.stringify({ enabled: !!enabled }, null, 2));
+    fs.writeFileSync(selfDevConfigPath(), JSON.stringify({ enabled: !!enabled, checkout: resolveRepoRoot() }, null, 2));
     return true;
   } catch { return false; }
 }
@@ -1293,6 +1292,7 @@ let packagedRuntimeParity = null;
 
 registerUpdateBridge(ipcMain, app, shell, {
   getRepoRoot: resolveRepoRoot,
+  allowSourceUpdates: !isPackaged || usesDevelopmentCheckout() || selfDevEnabled(),
   getRuntimeParity: () => packagedRuntimeParity,
   // A Finder/Dock launch gets a stripped launchd PATH, so npm/uv are not found
   // and the rebuild spawns with ENOENT ("spawn npm ENOENT") -- the source pulls
@@ -1384,9 +1384,7 @@ async function ensurePuppetmasterParity(repoRoot) {
 async function ensurePackagedCheckout() {
   if (!isPackaged) return resolveRepoRoot();
   const repoRoot = resolveRepoRoot();
-  // Do not set HARNESS_REPO to the Marionette checkout. resolveRepoRoot() already
-  // uses packagedRepoRoot() when HARNESS_REPO is unset; HARNESS_REPO is reserved
-  // for the user's open project (restored from workspace.json by the backend).
+  // HARNESS_REPO remains the user's open project, independent of this runtime root.
   if (isInstallComplete(repoRoot)) {
     await ensurePuppetmasterParity(repoRoot);
     return repoRoot;
@@ -1398,6 +1396,7 @@ async function ensurePackagedCheckout() {
   const send = (msg, pct) => sendBootstrapProgress(win, msg, pct);
   try {
     await runBootstrap(repoRoot, send);
+    await ensurePuppetmasterParity(repoRoot);
     return repoRoot;
   } finally {
     try { if (bootstrapWin) bootstrapWin.close(); } catch {}
@@ -1408,6 +1407,8 @@ async function ensurePackagedCheckout() {
 // --- window bounds persistence -------------------------------------------
 // Restore the main window's last size/position/maximized state across runs
 // (like every other desktop app). State lives beside other pmharness state.
+const MIN_WINDOW_WIDTH = 900;
+const MIN_WINDOW_HEIGHT = 600;
 function windowStatePath() {
   return path.join(os.homedir(), ".pmharness", "window-state.json");
 }
@@ -1419,8 +1420,8 @@ function loadWindowState() {
     const { x, y, width, height, maximized } = j;
     if (!Number.isFinite(width) || !Number.isFinite(height)) return null;
     const state = {
-      width: Math.max(640, Math.round(width)),
-      height: Math.max(480, Math.round(height)),
+      width: Math.max(MIN_WINDOW_WIDTH, Math.round(width)),
+      height: Math.max(MIN_WINDOW_HEIGHT, Math.round(height)),
       maximized: !!maximized,
     };
     // Only restore a position that is still (mostly) on a connected display —
@@ -1644,6 +1645,8 @@ function createWindow() {
   win = new BrowserWindow({
     width: saved ? saved.width : 1440,
     height: saved ? saved.height : 900,
+    minWidth: MIN_WINDOW_WIDTH,
+    minHeight: MIN_WINDOW_HEIGHT,
     ...(saved && Number.isFinite(saved.x) ? { x: saved.x, y: saved.y } : {}),
     ...translucency.surfaceOptions(),
     titleBarStyle: "hiddenInset",

--- a/webapp/electron/packaged-recovery.test.cjs
+++ b/webapp/electron/packaged-recovery.test.cjs
@@ -1,0 +1,114 @@
+"use strict";
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const vm = require('node:vm');
+const { EventEmitter } = require('node:events');
+const bootstrap = require('./bootstrap.cjs');
+
+test('startup awaits selected checkout before parity, backend spawn and renderer resolution', async t => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'packaged-startup-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const source = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8');
+  const region = (a, b) => source.slice(source.indexOf(a), source.indexOf(b, source.indexOf(a)));
+  const events = [];
+  const selected = bootstrap.selectPackagedCheckout({ home, env: {} });
+  const env = {};
+  const noop = () => {};
+  let ready;
+  const context = {
+    require, fs, path, os: { homedir: () => home }, __dirname, console,
+    process: { env, platform: process.platform, argv: [], stdout: { write: noop }, stderr: { write: noop } },
+    setImmediate, setTimeout, isPackaged: true, isDev: false, gotSingleInstanceLock: true,
+    selfDevEnabled: () => false, selfDevCheckout: () => null,
+    selectPackagedCheckout: () => bootstrap.selectPackagedCheckout({ home, env }),
+    isInstallComplete: () => false,
+    runBootstrap: async root => {
+      assert.equal(root, selected); events.push('build-start');
+      await new Promise(resolve => setImmediate(resolve));
+      // An event changing the environment cannot redirect later consumers.
+      env.MARIONETTE_CHECKOUT = path.join(home, 'other');
+      const dist = path.join(root, 'webapp/dist'); fs.mkdirSync(dist, { recursive: true });
+      fs.writeFileSync(path.join(dist, 'index.html'), 'selected renderer');
+      events.push('built');
+    },
+    ensurePuppetmasterParity: async root => { assert.equal(root, selected); events.push('parity'); },
+    createBootstrapWindow: () => ({ close: noop }), waitForBootstrapWindow: async () => {},
+    bootstrapWin: null, sendBootstrapProgress: noop,
+    loginShellEnv: () => ({}), registerMarionetteProtocol: noop, configureBrowserSession: noop,
+    setupRequestInterception: noop, flushWikiConnectQueue: noop,
+    app: { getVersion: () => '0.9.422', whenReady: () => ({ then: cb => { ready = cb(); } }) },
+    dialog: { showErrorBox: message => assert.fail(message) },
+    startInFlight: null, backend: null, backendOwned: false, backendPort: 0,
+    currentBackendIdentity: ({ repoRoot }) => { assert.equal(repoRoot, selected); return {}; },
+    readPmHarnessStateFile: () => null, decideBackendReuse: () => ({ action: 'spawn' }),
+    readLiveUpdateMarker: () => null, freePort: async () => 12345,
+    resolveHarnessStateDir: () => path.join(home, 'state'), buildPuppetmasterBackendEnv: x => x,
+    isInspectMode: () => false, harnessToken: 'fixture', harnessAppRunId: 'fixture',
+    secretVault: { injectEnv: noop }, waitForBackend: async () => {}, refreshAllowedLoopbackAliases: noop,
+    markerPath: () => path.join(home, 'marker'), buildBackendMarkerPayload: x => x,
+    _dbg2: noop,
+    spawn: (python, args, options) => {
+      assert.equal(options.cwd, selected);
+      assert.equal(python, bootstrap.venvPython(selected));
+      assert.equal(options.env.MARIONETTE_APP_ROOT, selected);
+      assert.deepEqual(events, ['build-start', 'built', 'parity']); events.push('spawn');
+      const child = new EventEmitter(); child.stdout = new EventEmitter(); child.stderr = new EventEmitter(); return child;
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(region('let selectedRepoRoot = null;', '// Live-UI mode:') +
+    region('function resolveDistIndex()', 'function freePort()') +
+    region('async function ensurePackagedCheckout()', '// --- window bounds') +
+    region('function startBackend()', '// ---- transport seam'), context);
+  context.createWindow = () => {
+    assert.equal(vm.runInContext('resolveDistIndex()', context), path.join(selected, 'webapp/dist/index.html'));
+    events.push('renderer');
+  };
+  vm.runInContext(region('app.whenReady().then(async () => {', '  // Re-open: ensure a healthy backend') + '\n});', context);
+  await ready;
+  assert.deepEqual(events, ['build-start', 'built', 'parity', 'spawn', 'renderer']);
+});
+
+test('managed production updates install the shell without source fetch, stash, pull or relaunch', async () => {
+  const handlers = {}, roots = [];
+  let installed = 0;
+  require('./update-bridge.cjs').registerUpdateBridge(
+    { handle: (name, handler) => { handlers[name] = handler; } },
+    { isPackaged: true, getVersion: () => '0.9.422' }, {}, {
+      allowSourceUpdates: false, getRepoRoot: () => '/selected/release',
+      readCheckoutVersion: root => { roots.push(root); return '0.9.422'; },
+      checkSourceUpdate: () => assert.fail('must not fetch a source branch'),
+      applySourceUpdate: () => assert.fail('must not mutate the pinned checkout'),
+      relaunch: () => assert.fail('must wait for installer'),
+      packagedUpdater: { enabled: true, isDownloaded: () => false,
+        check: async () => ({ available: true, latest: '0.9.423' }),
+        downloadAndInstall: async () => { installed++; return { ok: true }; } },
+    });
+  assert.equal((await handlers['updates:check']()).available, true);
+  const result = await handlers['updates:apply']({ sender: { isDestroyed: () => true } });
+  assert.equal(result.ok, true); assert.equal(result.packagedInstallPending, true);
+  assert.equal(installed, 1); assert.ok(roots.every(root => root === '/selected/release'));
+});
+
+test('self-dev toggle persists the actual root across a fresh process', t => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'self-dev-root-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const source = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8');
+  const resolver = source.slice(source.indexOf('let selectedRepoRoot = null;'), source.indexOf('// Live React needs'));
+  const launch = () => {
+    const context = vm.createContext({ fs, path, os: { homedir: () => home }, __dirname,
+      process: { env: {}, platform: process.platform }, isPackaged: true,
+      selectPackagedCheckout: options => bootstrap.selectPackagedCheckout({ ...options, home, env: {} }),
+    });
+    vm.runInContext(resolver, context); return code => vm.runInContext(code, context);
+  };
+  const first = launch(), root = first('resolveRepoRoot()');
+  assert.equal(first('setSelfDevEnabled(true)'), true);
+  assert.equal(launch()('resolveRepoRoot()'), root);
+  const settings = path.join(home, '.pmharness/self-dev.json');
+  fs.writeFileSync(settings, JSON.stringify({ enabled: true }));
+  assert.equal(launch()('resolveRepoRoot()'), path.join(home, '.marionette/marionette'));
+});

--- a/webapp/electron/update-bridge.cjs
+++ b/webapp/electron/update-bridge.cjs
@@ -810,7 +810,11 @@ function registerUpdateBridge(ipcMain, app, shell, opts = {}) {
   // to inherit process.env (dev/CLI runs already have a full env).
   const getEnv = opts.getEnv || (() => process.env);
   const packagedUpdater = opts.packagedUpdater || null;
-  const checkSourceUpdate = opts.checkSourceUpdate || checkForUpdate;
+  // A managed production checkout is pinned by its installer. Pulling a branch
+  // here would build code that the next launch immediately replaces.
+  const checkSourceUpdate = opts.allowSourceUpdates === false
+    ? async () => ({ available: false })
+    : (opts.checkSourceUpdate || checkForUpdate);
   const applySourceUpdate = opts.applySourceUpdate || applyUpdate;
   const readCheckoutVersion = opts.readCheckoutVersion || readCheckoutPackageVersion;
   // Startup Puppetmaster parity result (puppetmaster-runtime.cjs). A stale

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.422",
+  "version": "0.9.423",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.422",
+      "version": "0.9.423",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.422",
+  "version": "0.9.423",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -5,6 +5,7 @@ import { subscribeDocumentMotionPolicy } from "./lib/motionPolicy";
 import { malformedBackendDiagnostic, parseBackendDiagnostic } from "./lib/operationalDiagnostic";
 import { clearDiagnostic, publishDiagnostic } from "./lib/operationalDiagnosticBus";
 import { setCorrelationId } from "./lib/correlationId";
+import ShellSurface from "./components/ShellSurface";
 import LeftRail from "./components/LeftRail";
 import Conversation from "./components/Conversation";
 import RightPane from "./components/RightPane";
@@ -78,7 +79,7 @@ export default function App() {
 
   const [leftW, setLeftW] = useState(() => num(LS.left, 248));
   const {
-    width, compact, view, setView, desktopLeftOpen, desktopRightOpen,
+    width, compact, rightDrawer, view, setView, desktopLeftOpen, desktopRightOpen,
     leftOpen, rightOpen, setLeftOpen, setRightOpen,
   } = useResponsiveShell(bool(LS.leftOpen, true), bool(LS.rightOpen, false) && hasStoredRightPaneCards());
   const previousSessionId = useRef<string | null>(null);
@@ -130,11 +131,11 @@ export default function App() {
     setRightOpen(!rightOpen);
   }, [rightOpen, setRightOpen]);
   const requestRightMinWidth = useCallback((minPx: number) => {
-    if (!compact) setRightW(previous => Math.max(previous, minPx));
-  }, [compact]);
+    if (!rightDrawer) setRightW(previous => Math.max(previous, minPx));
+  }, [rightDrawer]);
   // Reserve 480px for content plus the 68px dock, beyond railLayout's 360px center.
   // Clamp presentation only; resizing the window must not rewrite saved widths.
-  const displayed = reclampRailWidths(leftW, rightW, leftOpen, rightOpen, width - SHELL_EXTRA_CENTER_W);
+  const displayed = reclampRailWidths(leftW, rightW, leftOpen && !compact, rightOpen && !rightDrawer, width - SHELL_EXTRA_CENTER_W);
 
   const [showWizard, setShowWizard] = useState(false);
   const [showOverlay, setShowOverlay] = useState(false);
@@ -368,27 +369,23 @@ export default function App() {
               "radial-gradient(120% 80% at 50% -10%, rgba(139,150,196,0.06), rgba(139,150,196,0) 60%)",
           }}
         >
-          {(leftOpen || compact || desktopLeftOpen) && (
-            <>
-              <div data-shell-hidden={!leftOpen} style={{ width: compact ? "100%" : displayed.leftW, display: leftOpen ? undefined : "none" }} className="shell-inset-panel shrink-0 h-full min-w-0">
-                <LeftRail jobsRefresh={jobsRefresh} onSessionChange={handleSessionChange} />
-              </div>
-              {!compact && leftOpen && <Resizer
-                side="left"
-                onResize={(dx) => {
-                  const next = reclampRailWidths(
-                    displayed.leftW + dx,
-                    rightWRef.current,
-                    true,
-                    rightOpen,
-                    width - SHELL_EXTRA_CENTER_W,
-                  );
-                  setLeftW(next.leftW);
-                }}
-              />}
-            </>
-          )}
-          <div className="relative flex-1 min-w-0 min-h-0 flex" style={{ display: compact && view !== "chat" ? "none" : undefined }} data-shell-hidden={compact && view !== "chat"}>
+          <ShellSurface visible={leftOpen} presentation={compact ? "left" : "inline"} label="Sessions" width={displayed.leftW} onClose={() => setLeftOpen(false)}>
+            <LeftRail jobsRefresh={jobsRefresh} onSessionChange={handleSessionChange} />
+          </ShellSurface>
+          {!compact && leftOpen && <Resizer
+            side="left"
+            onResize={(dx) => {
+              const next = reclampRailWidths(
+                displayed.leftW + dx,
+                rightWRef.current,
+                true,
+                rightOpen && !rightDrawer,
+                width - SHELL_EXTRA_CENTER_W,
+              );
+              setLeftW(next.leftW);
+            }}
+          />}
+          <div className="relative flex-1 min-w-0 min-h-0 flex" aria-hidden={(compact && view !== "chat") || (rightDrawer && rightOpen) || undefined} inert={(compact && view !== "chat") || (rightDrawer && rightOpen)}>
             <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
               <ErrorBoundary label="Chat">
                 <Conversation
@@ -399,14 +396,16 @@ export default function App() {
                 />
               </ErrorBoundary>
             </div>
-            <RightDock
-              panelsOpen={rightOpen}
-              onOpenTab={openRightTo}
-              onExpand={() => openRightTo(lastRightTab())}
-              onCollapse={() => setRightOpen(false)}
-            />
+            <div className="shell-dock-slot">
+              <RightDock
+                panelsOpen={rightOpen}
+                onOpenTab={openRightTo}
+                onExpand={() => openRightTo(lastRightTab())}
+                onCollapse={() => setRightOpen(false)}
+              />
+            </div>
           </div>
-          {rightOpen && !compact && (
+          {rightOpen && !rightDrawer && (
             <Resizer
               side="right"
               onResize={(dx) => {
@@ -421,11 +420,7 @@ export default function App() {
               }}
             />
           )}
-          <div
-            className={`shrink-0 h-full min-w-0 overflow-hidden ${rightOpen ? "" : "hidden"}`}
-            data-shell-hidden={!rightOpen}
-            style={{ width: compact ? "100%" : displayed.rightW }}
-          >
+          <ShellSurface visible={rightOpen} presentation={rightDrawer ? "right" : "inline"} label="Panels" width={displayed.rightW} onClose={() => setRightOpen(false)}>
             <ErrorBoundary label="Tool board">
               <RightPane
                 visible={rightOpen}
@@ -439,7 +434,7 @@ export default function App() {
                 onRequestMinWidth={requestRightMinWidth}
               />
             </ErrorBoundary>
-          </div>
+          </ShellSurface>
         </div>
       </div>
       <div className="shrink-0 px-px py-px">

--- a/webapp/src/__tests__/App.responsive.test.tsx
+++ b/webapp/src/__tests__/App.responsive.test.tsx
@@ -81,3 +81,36 @@ it("keeps desktop preferences and chat mounted through real window resize events
   expect(localStorage.getItem("pmharness.leftOpen")).toBe("1");
   expect(localStorage.getItem("pmharness.rightOpen")).toBe("1");
 });
+
+it("keeps Sessions inline at 900px and uses a bounded right drawer for Panels", async () => {
+  resize(900);
+  await act(async () => { render(<App />); });
+  expect(screen.getByRole("complementary", { name: "Sessions" })).toHaveAttribute("data-presentation", "inline");
+  const panels = screen.getByRole("dialog", { name: "Panels" });
+  expect(panels).toHaveAttribute("data-presentation", "right");
+  fireEvent.click(screen.getByRole("button", { name: "Close Panels" }));
+  expect(screen.getByRole("textbox", { name: "Chat editor" })).toBeVisible();
+  expect(screen.getByRole("button", { name: "Session item" })).toBeVisible();
+});
+
+it("closes phone drawers on native Escape cancellation and backdrop, restoring the trigger", async () => {
+  resize(390);
+  await act(async () => { render(<App />); });
+  const editor = screen.getByRole("textbox", { name: "Chat editor" });
+  fireEvent.change(editor, { target: { value: "phone draft" } });
+  const trigger = screen.getByRole("button", { name: "Sessions", exact: true });
+  trigger.focus();
+  fireEvent.click(trigger);
+  const drawer = screen.getByRole("dialog", { name: "Sessions" });
+  expect(drawer).toHaveAttribute("data-presentation", "left");
+  fireEvent(drawer, new Event("cancel", { cancelable: true }));
+  expect(trigger).toHaveFocus();
+  expect(editor).toBeVisible();
+  fireEvent.click(trigger);
+  fireEvent.click(drawer, { clientX: -1, clientY: -1 });
+  expect(trigger).toHaveFocus();
+  expect(editor).toHaveValue("phone draft");
+  resize(1280);
+  expect(screen.getByRole("button", { name: "Session item" })).toBeVisible();
+  expect(screen.getByRole("button", { name: "Panel item" })).toBeVisible();
+});

--- a/webapp/src/__tests__/LeftRail.fork.test.tsx
+++ b/webapp/src/__tests__/LeftRail.fork.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, expect, it, vi } from "vitest";
+import LeftRail from "../components/LeftRail";
+import { api, type Session } from "../lib/api";
+import { clearSWRCache } from "../lib/useStaleWhileRevalidate";
+
+vi.mock("../lib/usePolling", () => ({ usePolling: vi.fn() }));
+vi.mock("../lib/useOperationalDiagnostic", () => ({ useOperationalDiagnostic: () => null }));
+const sources: Session[] = [
+  { id: "active", title: "Active conversation", created: 1, active: true, repo: "/workspace" },
+  { id: "target", title: "Other conversation", created: 2, repo: "/workspace" },
+];
+vi.mock("../lib/api", () => ({ api: {
+  getWorkspace: vi.fn().mockResolvedValue({ repo: "/workspace", is_git: false, recents: [] }),
+  sessions: vi.fn(), sessionsBank: vi.fn(), jobs: vi.fn().mockResolvedValue([]),
+  previewSessionFork: vi.fn(), forkSession: vi.fn(), switchSession: vi.fn(),
+} }));
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  localStorage.setItem("pmharness.leftRail.tab", "sessions");
+  clearSWRCache();
+  vi.mocked(api.sessions).mockResolvedValue(sources);
+  vi.mocked(api.sessionsBank).mockResolvedValue(sources);
+  vi.mocked(api.previewSessionFork).mockResolvedValue({ revision: "source-revision", boundaries: [
+    { event_id: 1, role: "user", label: "Earlier" }, { event_id: 2, role: "assistant", label: "Later" },
+  ] });
+});
+
+it("forks the actual context target and retains its selection/error/identity across dismissal", async () => {
+  vi.mocked(api.forkSession).mockRejectedValue(new Error("Source changed. Refresh boundaries."));
+  const onSessionChange = vi.fn();
+  render(<LeftRail jobsRefresh={0} onSessionChange={onSessionChange} />);
+  const target = await screen.findByRole("button", { name: /Other conversation/ });
+  expect(screen.queryByRole("button", { name: "Fork session" })).toBeNull();
+  fireEvent.contextMenu(target, { clientX: 30, clientY: 50 });
+  fireEvent.click(screen.getByRole("button", { name: "Fork session" }));
+  const boundary = await screen.findByLabelText("Fork after saved message");
+  expect(api.previewSessionFork).toHaveBeenCalledWith("target");
+  expect(screen.getByRole("dialog", { name: "Fork Other conversation" })).toBeVisible();
+  fireEvent.change(boundary, { target: { value: "1" } });
+  fireEvent.click(screen.getByRole("button", { name: "Create fork" }));
+  await screen.findByRole("alert");
+  expect(api.forkSession).toHaveBeenCalledWith({ session_id: "target", event_id: 1,
+    revision: "source-revision", request_id: expect.any(String) });
+  fireEvent.click(screen.getByRole("button", { name: "Close Fork Other conversation" }));
+  expect(target).toHaveFocus();
+  fireEvent.contextMenu(target);
+  fireEvent.click(screen.getByRole("button", { name: "Fork session" }));
+  expect(screen.getByLabelText("Fork after saved message")).toHaveValue("1");
+  expect(screen.getByRole("alert")).toHaveTextContent("Source changed");
+  fireEvent.click(screen.getByRole("button", { name: "Create fork" }));
+  await waitFor(() => expect(api.forkSession).toHaveBeenCalledTimes(2));
+  expect(vi.mocked(api.forkSession).mock.calls[0]).toEqual(vi.mocked(api.forkSession).mock.calls[1]);
+  expect(api.previewSessionFork).toHaveBeenCalledTimes(1);
+  expect(api.switchSession).not.toHaveBeenCalled();
+});

--- a/webapp/src/__tests__/ShellSurface.test.tsx
+++ b/webapp/src/__tests__/ShellSurface.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import ShellSurface from "../components/ShellSurface";
+
+it("dismisses only the innermost dialog on Escape", () => {
+  const closeSessions = vi.fn();
+  const closeFork = vi.fn();
+  render(<ShellSurface visible presentation="left" label="Sessions" onClose={closeSessions}>
+    <ShellSurface visible presentation="modal" label="Fork session" onClose={closeFork}>
+      <button>Choose boundary</button>
+    </ShellSurface>
+  </ShellSurface>);
+  fireEvent(screen.getByRole("dialog", { name: "Fork session", exact: true }), new Event("cancel", { cancelable: true }));
+  expect(closeFork).toHaveBeenCalledOnce();
+  expect(closeSessions).not.toHaveBeenCalled();
+});

--- a/webapp/src/__tests__/setup.ts
+++ b/webapp/src/__tests__/setup.ts
@@ -6,3 +6,20 @@ import "../index.css";
 afterEach(() => {
   cleanup();
 });
+
+// jsdom has no dialog top layer. Browser focus containment/backdrops need E2E;
+// these shims expose open/close and focus restoration for component regressions.
+if (!HTMLDialogElement.prototype.showModal) {
+  const priorFocus = new WeakMap<HTMLDialogElement, Element | null>();
+  HTMLDialogElement.prototype.showModal = function () {
+    priorFocus.set(this, document.activeElement);
+    this.open = true;
+    this.querySelector<HTMLElement>("[autofocus], button, input, select, textarea")?.focus();
+  };
+  HTMLDialogElement.prototype.close = function () {
+    this.open = false;
+    const previous = priorFocus.get(this);
+    if (previous instanceof HTMLElement && previous.isConnected) previous.focus();
+    priorFocus.delete(this);
+  };
+}

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -84,11 +84,16 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
   jobsRefresh: number;
   onSessionChange?: (id: string | null, expectedPreviousId?: string) => void;
 }) {
+  const [forkTarget, setForkTarget] = useState<Pick<Session, "id" | "title" | "forked_from"> | null>(null);
+  const contextTrigger = useRef<HTMLElement | null>(null);
+  const [forkTrigger, setForkTrigger] = useState<HTMLElement | null>(null);
+  const [forkOpen, setForkOpen] = useState(false);
   const [swapping, setSwapping] = useState<string | null>(null);
   const operationalDiagnostic = useOperationalDiagnostic();
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
+    session: Pick<Session, "id" | "title" | "forked_from">;
     sessionId: string;
     title: string;
     settled: boolean;
@@ -1100,11 +1105,16 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     toast(ok ? `Copied transcript ID ${sid}` : "Could not copy transcript ID");
   };
 
-  const handleContextMenu = (e: React.MouseEvent, s: Session, allowSettle: boolean) => {
+  const handleContextMenu = (e: React.MouseEvent, s: Pick<Session, "id" | "title" | "forked_from" | "settled" | "archived">, allowSettle: boolean) => {
     e.preventDefault();
+    if (e.currentTarget instanceof HTMLElement) {
+      contextTrigger.current = e.currentTarget;
+      e.currentTarget.focus();
+    }
     setContextMenu({
-      x: e.clientX,
-      y: e.clientY,
+      session: s,
+      x: Math.max(8, Math.min(e.clientX, window.innerWidth - 208)),
+      y: Math.max(8, Math.min(e.clientY, window.innerHeight - 400)),
       sessionId: s.id,
       title: displaySessionListTitle(s.title),
       settled: !!s.settled,
@@ -1408,14 +1418,14 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
   };
 
   return (
-    <aside ref={railRef} className="bg-transparent flex flex-col h-full overflow-hidden text-[0.8125rem]">
+    <aside ref={railRef} className="session-rail bg-transparent flex flex-col h-full overflow-hidden text-[0.8125rem]">
       <div ref={topChromeRef}>
       {/* Keep the native traffic-light/titlebar area separate from the actions.
           The same draggable region also preserves window movement on other
           desktop platforms. */}
       <div
         aria-hidden="true"
-        className="h-12 shrink-0"
+        className="session-rail-drag h-12 shrink-0"
         style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
       />
 
@@ -1462,25 +1472,28 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
         data-slot="left-rail-upper-sections"
         className={`min-h-0 overflow-y-auto overflow-x-hidden min-w-0 ${panelOpacityClass(panelSwitching, sessionsStale || workspaceStale)}`}
       >
-      {sessions.filter((session) => session.active).map((session) => (
+      {forkTarget && (
         <SessionFork
-          key={session.id}
-          session={session}
+          key={forkTarget.id}
+          session={forkTarget}
+          open={forkOpen}
+          returnFocus={forkTrigger}
+          onClose={() => setForkOpen(false)}
           sessions={[...sessions, ...bankSessions.filter((row) => !sessions.some((current) => current.id === row.id))]}
-          onSelect={(id) => { void switchSession(id); }}
+          onSelect={(id) => { setForkOpen(false); void switchSession(id); }}
           onCreated={(child) => {
             const root = child.workspace_root || child.repo || "";
             const cached = readSWRCache<Session[]>(`sessions:${root}`) || [];
             writeSessionListCache(root, [...cached.filter((row) => row.id !== child.id), child]);
             if (repoPathsEqual(root, currentRepoRef.current)) {
-              mutateSessions([...sessions.filter((row) => row.id !== child.id), child]);
+              mutateSessions([...cached.filter((row) => row.id !== child.id), child]);
             }
             setSessionsCacheEpoch((epoch) => epoch + 1);
             void revalidateSessions();
             void refreshBankSessions();
           }}
         />
-      ))}
+      )}
       {/* Projects | Sessions toggle */}
       <div className="px-2.5 pt-2 flex items-center gap-0 border-b border-edge/35">
         <button
@@ -1545,6 +1558,11 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                 {sessionSearchRows.map((row) => (
                   <button
                     key={row.id}
+                    data-session-row="true"
+                    onContextMenu={(event) => {
+                      const source = [...sessions, ...bankSessions].find((session) => session.id === row.id);
+                      handleContextMenu(event, source || { id: row.id, title: row.title, settled: row.settled }, false);
+                    }}
                     type="button"
                     disabled={!!switchingSessionId || opening}
                     onClick={() => { if (!switchingSessionId) void switchSession(row.id); }}
@@ -1607,6 +1625,8 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                       type="button"
                       disabled={!!switchingSessionId || opening}
                       onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
+                      data-session-row="true"
+                      aria-current={s.active ? "true" : undefined}
                       onDoubleClick={() => beginSessionRename(s.id, displaySessionListTitle(s.title))}
                       onContextMenu={(e) => handleContextMenu(e, s, canSettleSessionsForProject(root, workspaceInfo?.repo))}
                       className={`w-full min-h-8 flex flex-col justify-center text-left px-2 rounded transition min-w-0 disabled:opacity-60 ${
@@ -1785,6 +1805,8 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                                 onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
                                 disabled={!!switchingSessionId || opening}
                                 title={s.preview ? `${displaySessionListTitle(s.title)}\n${s.preview}` : displaySessionListTitle(s.title)}
+                                data-session-row="true"
+                                aria-current={s.active ? "true" : undefined}
                                 onDoubleClick={() => beginSessionRename(s.id, displaySessionListTitle(s.title))}
                                 onContextMenu={(e) => handleContextMenu(e, s, isCurrentActive)}
                                 className={`flex-1 min-w-0 h-7 text-left rounded pl-2.5 pr-1.5 flex items-center gap-1.5 text-[12px] transition disabled:opacity-60
@@ -1888,6 +1910,8 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                                 <button
                                   onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
                                   disabled={!!switchingSessionId || opening}
+                                  data-session-row="true"
+                                  aria-current={s.active ? "true" : undefined}
                                   onDoubleClick={() => beginSessionRename(s.id, displaySessionListTitle(s.title))}
                                   onContextMenu={(e) => handleContextMenu(e, s, isCurrentActive)}
                                   className={`flex-1 min-w-0 h-6 text-left rounded px-1.5 flex items-center gap-1.5 text-[11px] motion-safe:transition opacity-45 hover:opacity-90 disabled:opacity-40
@@ -1964,6 +1988,8 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                       type="button"
                       onClick={() => { if (!switchingSessionId) void switchSession(s.id); }}
                       disabled={!!switchingSessionId || opening}
+                      data-session-row="true"
+                      aria-current={s.active ? "true" : undefined}
                       onDoubleClick={() => beginSessionRename(s.id, displaySessionListTitle(s.title))}
                       onContextMenu={(e) => handleContextMenu(e, s, true)}
                       className={`w-full h-7 text-left rounded px-2 flex items-center gap-1.5 text-[12.5px] transition opacity-60 hover:opacity-100 disabled:opacity-40
@@ -2266,10 +2292,17 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       {/* CONTEXT MENU */}
       {contextMenu && (
         <div
-          className="fixed z-50 bg-panel border border-edge rounded shadow-lg text-[12px] py-1 min-w-[150px]"
+          className="session-context-menu fixed z-50 bg-panel border border-edge rounded shadow-lg text-[12px] py-1 min-w-[150px]"
           style={{ top: contextMenu.y, left: contextMenu.x }}
           onClick={(e) => e.stopPropagation()}
         >
+          <button type="button" className="w-full text-left px-3 py-1.5 hover:bg-panel2 text-txt transition-colors"
+            onClick={() => {
+              setForkTrigger(contextTrigger.current);
+              setForkTarget(contextMenu.session);
+              setForkOpen(true);
+              setContextMenu(null);
+            }}>Fork session</button>
           {contextMenu.running && (
             <>
               <button

--- a/webapp/src/components/SessionFork.tsx
+++ b/webapp/src/components/SessionFork.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState } from "react";
+import ShellSurface from "./ShellSurface";
 import { api, type Session, type SessionForkPreview } from "../lib/api";
 
 type ForkState =
@@ -12,8 +13,11 @@ type ForkState =
 const buttonClass = "min-h-11 px-2 rounded text-sm text-txt hover:bg-panel2 focus-visible:outline focus-visible:outline-accent disabled:opacity-50";
 
 /** Mount keyed by session.id, outside any session-row button. */
-export function SessionFork({ session, sessions, onSelect, onCreated }: {
-  session: Session;
+export function SessionFork({ session, sessions, onSelect, onCreated, open, onClose, returnFocus }: {
+  returnFocus?: HTMLElement | null;
+  open?: boolean;
+  onClose?: () => void;
+  session: Pick<Session, "id" | "title" | "forked_from">;
   sessions: Session[];
   onSelect: (id: string) => void;
   onCreated: (child: Session) => void;
@@ -27,8 +31,11 @@ export function SessionFork({ session, sessions, onSelect, onCreated }: {
     return () => { mounted.current = false; };
   }, []);
   useEffect(() => {
-    if (state.kind === "created") anotherButton.current?.focus();
-  }, [state.kind]);
+    if (state.kind === "created" && open !== false) anotherButton.current?.focus();
+  }, [state.kind, open]);
+  useEffect(() => {
+    if (open && state.kind === "closed") void preview();
+  }, [open]);
   const selectId = useId();
   const origin = session.forked_from;
   const parent = origin && sessions.find((row) => row.id === origin.parent_id);
@@ -73,7 +80,7 @@ export function SessionFork({ session, sessions, onSelect, onCreated }: {
     }
   }
 
-  return <section aria-label={`Fork ${session.title}`} className="space-y-2 rounded border border-edge p-2">
+  const content = <section aria-label={`Fork ${session.title}`} className="space-y-2 rounded border border-edge p-2">
     {origin && <div className="text-sm text-muted">
       Forked from {parent
         ? <button type="button" className={buttonClass} onClick={() => onSelect(parent.id)}>{parent.title}</button>
@@ -104,7 +111,7 @@ export function SessionFork({ session, sessions, onSelect, onCreated }: {
         </button>
       </>}
       <button type="button" className={buttonClass} disabled={state.kind === "creating"} onClick={() => void preview()}>Refresh boundaries</button>
-      <button type="button" className={buttonClass} disabled={state.kind === "creating"} onClick={() => setState({ kind: "closed" })}>Cancel</button>
+      <button type="button" className={buttonClass} disabled={state.kind === "creating"} onClick={() => onClose ? onClose() : setState({ kind: "closed" })}>Cancel</button>
       {state.kind === "ready" && state.error && <p role="alert">{state.error}</p>}
       {state.kind === "creating" && <span role="status" className="text-sm text-muted">Saving child session...</span>}
     </>}
@@ -113,4 +120,6 @@ export function SessionFork({ session, sessions, onSelect, onCreated }: {
       <button ref={anotherButton} type="button" className={buttonClass} onClick={() => void preview()}>Create another fork</button>
     </>}
   </section>;
+  return open === undefined ? content : <ShellSurface visible={open} presentation="modal"
+    label={`Fork ${session.title}`} returnFocus={returnFocus} onClose={() => onClose?.()}>{content}</ShellSurface>;
 }

--- a/webapp/src/components/ShellSurface.tsx
+++ b/webapp/src/components/ShellSurface.tsx
@@ -37,7 +37,7 @@ export default function ShellSurface({ visible, presentation, label, width, onCl
   return <dialog ref={ref} role={presentation === "inline" ? "complementary" : "dialog"} aria-label={label} aria-modal={presentation === "inline" ? undefined : true}
     data-shell-hidden={!visible} data-presentation={presentation}
     className="shell-surface" style={presentation === "inline" ? { width } : undefined}
-    onCancel={(event) => { event.preventDefault(); onClose(); }}
+    onCancel={(event) => { event.preventDefault(); event.stopPropagation(); onClose(); }}
     onClick={(event) => { if (event.target === event.currentTarget && presentation !== "inline") {
       const rect = event.currentTarget.getBoundingClientRect();
       if (event.clientX < rect.left || event.clientX > rect.right || event.clientY < rect.top || event.clientY > rect.bottom) onClose();

--- a/webapp/src/components/ShellSurface.tsx
+++ b/webapp/src/components/ShellSurface.tsx
@@ -1,0 +1,51 @@
+import { useLayoutEffect, useRef, type ReactNode } from "react";
+
+type Presentation = "inline" | "left" | "right" | "modal";
+
+/** Native modal focus containment without reparenting or unmounting live panes. */
+export default function ShellSurface({ visible, presentation, label, width, onClose, returnFocus, children }: {
+  visible: boolean;
+  presentation: Presentation;
+  label: string;
+  width?: number;
+  onClose: () => void;
+  returnFocus?: HTMLElement | null;
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLDialogElement>(null);
+  const focusTarget = useRef(returnFocus);
+  focusTarget.current = returnFocus;
+  const opener = useRef<HTMLElement | null>(null);
+  useLayoutEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    if (dialog.open) dialog.close();
+    if (visible) {
+      if (presentation === "inline") dialog.open = true;
+      else {
+        const active = document.activeElement;
+        opener.current = focusTarget.current || (active instanceof HTMLElement ? active : null);
+        dialog.showModal();
+      }
+    } else if (opener.current?.isConnected) {
+      opener.current.focus();
+      opener.current = null;
+    }
+    return () => { if (dialog.open) dialog.close(); };
+  }, [visible, presentation]);
+
+  return <dialog ref={ref} role={presentation === "inline" ? "complementary" : "dialog"} aria-label={label} aria-modal={presentation === "inline" ? undefined : true}
+    data-shell-hidden={!visible} data-presentation={presentation}
+    className="shell-surface" style={presentation === "inline" ? { width } : undefined}
+    onCancel={(event) => { event.preventDefault(); onClose(); }}
+    onClick={(event) => { if (event.target === event.currentTarget && presentation !== "inline") {
+      const rect = event.currentTarget.getBoundingClientRect();
+      if (event.clientX < rect.left || event.clientX > rect.right || event.clientY < rect.top || event.clientY > rect.bottom) onClose();
+    } }}>
+    {presentation !== "inline" && <header className="shell-surface-header">
+      <h2>{label}</h2>
+      <button type="button" aria-label={`Close ${label}`} onClick={onClose}>Close</button>
+    </header>}
+    <div className="shell-surface-content">{children}</div>
+  </dialog>;
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -607,3 +607,101 @@ body.is-row-resizing iframe {
 .chat-column [data-testid="composer-chrome"] {
   user-select: none;
 }
+
+/* Live shell panes keep their DOM and subscriptions in both presentations. */
+:root {
+  --shell-drawer-gap: 16px;
+  --shell-drawer-left-width: 336px;
+  --shell-drawer-right-width: 520px;
+  --shell-dialog-width: 480px;
+  --shell-overlay-radius: 12px;
+  --shell-hit-size: 44px;
+}
+.shell-surface {
+  padding: 0;
+  color: inherit;
+  background: var(--shell-overlay);
+  border: 1px solid var(--shell-panel-border);
+  overflow: hidden;
+  min-width: 0;
+}
+.shell-surface:not([open]) { display: none; }
+.shell-surface[open] { display: flex; flex-direction: column; }
+.shell-surface[data-presentation="inline"] {
+  position: static;
+  margin: 0;
+  height: 100%;
+  max-height: none;
+  max-width: none;
+  flex-shrink: 0;
+  border: 0;
+  background: transparent;
+}
+.shell-surface::backdrop { background: rgb(0 0 0 / 48%); }
+.shell-surface[data-presentation="left"],
+.shell-surface[data-presentation="right"] {
+  position: fixed;
+  inset-block: var(--shell-drawer-gap);
+  height: calc(100dvh - 2 * var(--shell-drawer-gap));
+  max-height: calc(100dvh - 2 * var(--shell-drawer-gap));
+  max-width: calc(100vw - 2 * var(--shell-drawer-gap));
+  margin: 0;
+  border-radius: var(--shell-overlay-radius);
+  box-shadow: 0 16px 48px rgb(0 0 0 / 32%);
+}
+.shell-surface[data-presentation="left"] {
+  left: var(--shell-drawer-gap); right: auto;
+  width: var(--shell-drawer-left-width);
+}
+.shell-surface[data-presentation="right"] {
+  right: var(--shell-drawer-gap); left: auto;
+  width: var(--shell-drawer-right-width);
+}
+.shell-surface[data-presentation="modal"] {
+  width: var(--shell-dialog-width);
+  max-width: calc(100vw - 2 * var(--shell-drawer-gap));
+  max-height: calc(100dvh - 2 * var(--shell-drawer-gap));
+  margin: auto;
+  border-radius: var(--shell-overlay-radius);
+}
+.shell-surface-header {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 4px 16px;
+  border-bottom: 1px solid var(--shell-panel-border);
+  flex-shrink: 0;
+}
+.shell-surface-header h2 { font-size: 14px; font-weight: 600; overflow-wrap: anywhere; }
+.shell-surface-header button { min-height: var(--shell-hit-size); padding-inline: 8px; }
+.shell-surface-content { flex: 1; min-height: 0; min-width: 0; overflow: hidden; }
+.shell-surface[data-presentation="modal"] .shell-surface-content { overflow: auto; padding: 16px; }
+.shell-surface[data-presentation="modal"] section { border: 0; padding: 0; overflow-wrap: anywhere; }
+.shell-surface:not([data-presentation="inline"]) .session-rail-drag { display: none; }
+.session-rail [data-session-row] {
+  min-height: 36px;
+  border-radius: 6px;
+  color: theme('colors.txt');
+  transition-property: background-color, color;
+}
+.session-rail [data-session-row]:hover { background: theme('colors.panel2'); }
+.session-rail [data-session-row][aria-current="true"] { background: theme('colors.panel2'); box-shadow: inset 2px 0 theme('colors.accent'); }
+.session-rail [data-session-row] > .flex { width: 100%; }
+.session-rail [data-session-row] .text-faint { font-family: inherit; color: theme('colors.muted'); }
+.session-context-menu { max-width: calc(100vw - 16px); max-height: calc(100dvh - 16px); overflow-y: auto; }
+@media (max-width: 799px) {
+  html { font-size: 14px; }
+  .session-rail [data-session-row], .session-context-menu button { min-height: var(--shell-hit-size); }
+}
+.session-rail [data-session-row] > .flex .truncate { color: theme('colors.txt'); font-size: 13px; font-weight: 500; }
+.shell-surface[data-presentation="modal"] :is(button, select),
+nav[aria-label="Workspace views"] button { min-height: var(--shell-hit-size); }
+.shell-surface[data-presentation="inline"][aria-label="Sessions"] {
+  border-radius: var(--shell-panel-radius);
+  border: 1px solid var(--shell-panel-border);
+  background: var(--shell-panel);
+}
+.shell-dock-slot { display: contents; }
+@media (max-width: 479px) {
+  .shell-dock-slot { display: none; }
+}
+.shell-surface-header h2 { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.shell-surface-header button { flex-shrink: 0; }

--- a/webapp/src/lib/useResponsiveShell.ts
+++ b/webapp/src/lib/useResponsiveShell.ts
@@ -5,8 +5,9 @@ import { LEFT_MIN_W, MIN_CENTER_W, RAIL_GUTTER_W, RIGHT_MIN_W } from "./railLayo
 const CONTENT_MIN_W = 480;
 const DOCK_W = 68;
 const SHELL_FRAME_W = 4;
-export const COMPACT_SHELL_WIDTH = CONTENT_MIN_W + DOCK_W + LEFT_MIN_W + RIGHT_MIN_W
+export const DUAL_RAIL_SHELL_WIDTH = CONTENT_MIN_W + DOCK_W + LEFT_MIN_W + RIGHT_MIN_W
   + 2 * RAIL_GUTTER_W + SHELL_FRAME_W;
+export const COMPACT_SHELL_WIDTH = 800;
 // railLayout already budgets MIN_CENTER_W and two pixels of frame.
 export const SHELL_EXTRA_CENTER_W = CONTENT_MIN_W + DOCK_W - MIN_CENTER_W + SHELL_FRAME_W - 2;
 export type ShellView = "chat" | "left" | "right";
@@ -45,7 +46,7 @@ export function useResponsiveShell(initialLeft: boolean, initialRight: boolean) 
     });
   }, [compact]);
   return {
-    width, compact, view, setView, desktopLeftOpen, desktopRightOpen,
+    width, compact, rightDrawer: width < DUAL_RAIL_SHELL_WIDTH, view, setView, desktopLeftOpen, desktopRightOpen,
     leftOpen: compact ? view === "left" : desktopLeftOpen,
     rightOpen: compact ? view === "right" : desktopRightOpen,
     setLeftOpen, setRightOpen,


### PR DESCRIPTION
Installed releases could refuse to start when the older managed checkout contained local files, even after reinstalling. Production launches now use a dedicated checkout pinned to the installer revision, preserving the older tree and explicit development overrides. Packaged updates follow the installer path.

Desktop windows now enforce a 900×600 minimum, including restored bounds. Narrow layouts keep chat in place and open bounded Sessions/ Panels drawers with Escape, backdrop dismissal, and focus restoration. Session rows have clearer hierarchy; Fork moves from the permanent sidebar block into each session’s context menu and retains the clicked source and selected message boundary. Empty legacy queues no longer produce recovery notices; recoverable content remains untouched.

Validation: 7,105 backend tests passed on Python 3.9 with public Puppetmaster 1.23.0; 1,988 frontend tests; 308 Electron tests; production build and version consistency passed. Live browser checks covered 390px and 900px layouts, inactive-session fork creation, draft preservation, and opaque drawers with transparent-window mode. Native Electron verified restored and user-resized minimum bounds, bounded Panels, Escape, and draft/focus preservation. Cross-platform CI is required before merge/tag.
