### PR TITLE
Release v0.9.424: refined session selection and typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.23.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.423, deliberately pre-1.0. Pins puppetmaster-ai==1.23.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows have a 900×600 minimum; smaller layouts use bounded Sessions and Panels drawers. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
+> Status: v0.9.424, deliberately pre-1.0. Session selection uses a neutral grey highlight and subtle shadow; sidebar titles and secondary labels are scaled below chat text. Pins puppetmaster-ai==1.23.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows have a 900×600 minimum; smaller layouts use bounded Sessions and Panels drawers. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.423"
+__version__ = "0.9.424"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.423"
+version = "0.9.424"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.423",
+  "version": "0.9.424",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.423",
+      "version": "0.9.424",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.423",
+  "version": "0.9.424",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -1567,7 +1567,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                     disabled={!!switchingSessionId || opening}
                     onClick={() => { if (!switchingSessionId) void switchSession(row.id); }}
                     className={`w-full min-h-8 flex flex-col justify-center text-left px-2 rounded transition min-w-0 disabled:opacity-60 ${
-                      switchingSessionId === row.id ? "bg-panel2/60 border-l-2 border-accent" : "hover:bg-panel2/30"
+                      switchingSessionId === row.id ? "bg-panel2/60" : "hover:bg-panel2/30"
                     }`}
                     title={row.snippet ? `${displaySessionListTitle(row.title)}\n${row.snippet}` : displaySessionListTitle(row.title)}
                   >
@@ -1630,7 +1630,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                       onDoubleClick={() => beginSessionRename(s.id, displaySessionListTitle(s.title))}
                       onContextMenu={(e) => handleContextMenu(e, s, canSettleSessionsForProject(root, workspaceInfo?.repo))}
                       className={`w-full min-h-8 flex flex-col justify-center text-left px-2 rounded transition min-w-0 disabled:opacity-60 ${
-                        isActive ? "bg-panel2/60 border-l-2 border-accent" : "hover:bg-panel2/30"
+                        isActive ? "bg-panel2/60" : "hover:bg-panel2/30"
                       }`}
                       title={`${displaySessionListTitle(s.title)}${s.preview ? `\n${s.preview}` : ""}\n${root}`}
                     >

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -98,6 +98,10 @@ body {
   --shell-panel: #13161a;
   --shell-panel-border: rgba(255, 255, 255, 0.05);
   --shell-panel-radius: 12px;
+  --shell-selection: #292c31;
+  --shell-selection-shadow: 0 1px 3px rgb(0 0 0 / 24%);
+  --shell-rail-title-size: 0.75rem;
+  --shell-rail-detail-size: 0.6875rem;
   /* Floating menus over chat. Same fill as Tailwind `panel`. Glass must
      not mix this token — labels have to stay readable at any tint. */
   --shell-overlay: #181a1d;
@@ -683,15 +687,21 @@ body.is-row-resizing iframe {
   transition-property: background-color, color;
 }
 .session-rail [data-session-row]:hover { background: theme('colors.panel2'); }
-.session-rail [data-session-row][aria-current="true"] { background: theme('colors.panel2'); box-shadow: inset 2px 0 theme('colors.accent'); }
+.session-rail [data-session-row][aria-current="true"] {
+  background: var(--shell-selection);
+  box-shadow: var(--shell-selection-shadow);
+}
+.session-rail [data-session-row][aria-current="true"] .text-accent { color: theme('colors.muted'); }
 .session-rail [data-session-row] > .flex { width: 100%; }
-.session-rail [data-session-row] .text-faint { font-family: inherit; color: theme('colors.muted'); }
+.session-rail [data-session-row] .text-faint { font-family: inherit; font-size: var(--shell-rail-detail-size); color: theme('colors.muted'); }
 .session-context-menu { max-width: calc(100vw - 16px); max-height: calc(100dvh - 16px); overflow-y: auto; }
 @media (max-width: 799px) {
   html { font-size: 14px; }
   .session-rail [data-session-row], .session-context-menu button { min-height: var(--shell-hit-size); }
 }
-.session-rail [data-session-row] > .flex .truncate { color: theme('colors.txt'); font-size: 13px; font-weight: 500; }
+.session-rail [data-session-row],
+.session-rail [data-session-row] > .flex .truncate { font-size: var(--shell-rail-title-size); font-weight: 400; }
+.session-rail [data-session-row] > .flex .truncate { color: theme('colors.txt'); }
 .shell-surface[data-presentation="modal"] :is(button, select),
 nav[aria-label="Workspace views"] button { min-height: var(--shell-hit-size); }
 .shell-surface[data-presentation="inline"][aria-label="Sessions"] {


### PR DESCRIPTION
Selected sessions now use a neutral grey surface with a subtle drop shadow. Removes the amber curved edge from project rows and Recent sessions, and scales sidebar titles and secondary labels below chat body text.

Validation: 1,989 frontend tests passed; production build and version consistency passed. Live desktop and narrow-layout checks confirmed the selection has no left border and sidebar titles are smaller than chat text. Local Python 3.9 backend: 7,105 passed, 68 skipped. Electron: 308 passed. Merge and tagging remain gated on CI.

Release v0.9.424 contains this styling patch and the version bump.
