### PR TITLE
Release v0.9.425: compact full-width sidebar selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.23.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.424, deliberately pre-1.0. Session selection uses a neutral grey highlight and subtle shadow; sidebar titles and secondary labels are scaled below chat text. Pins puppetmaster-ai==1.23.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows have a 900×600 minimum; smaller layouts use bounded Sessions and Panels drawers. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
+> Status: v0.9.425, deliberately pre-1.0. Session selection uses one compact, full-width grey bar; session and Jobs titles share a smaller scale than chat text. Pins puppetmaster-ai==1.23.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows have a 900×600 minimum; smaller layouts use bounded Sessions and Panels drawers. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.424"
+__version__ = "0.9.425"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.424"
+version = "0.9.425"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.424",
+  "version": "0.9.425",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.424",
+      "version": "0.9.425",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.424",
+  "version": "0.9.425",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -1776,9 +1776,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                               className="w-full bg-bg border border-accent rounded px-2 py-1 text-[12px] text-txt focus:outline-none"
                             />
                           ) : (
-                            <div className={`group relative flex items-center gap-0.5 min-w-0 min-h-7 rounded-md px-0.5 focus-within:bg-panel2/50 ${
-                              s.active ? "bg-panel2/70" : "hover:bg-panel2/50"
-                            }`}>
+                            <div data-session-container="true" className="group relative flex items-center gap-0.5 min-w-0 min-h-7 rounded-md px-0.5">
                               <div
                                 className="w-3 shrink-0 flex items-center justify-center self-center"
                                 aria-hidden={!(unreadFinishedIds[s.id] && !s.active && runners[s.id] !== "running") && (!runners[s.id] || runners[s.id] === "missing")}
@@ -2117,7 +2115,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
           <div className="h-7 flex items-center justify-between px-1.5 gap-2 min-w-0">
             <button
               onClick={toggleSessionJobsCollapsed}
-              className="h-6 flex items-center gap-1 min-w-0 text-[11px] uppercase tracking-wider text-muted font-semibold hover:text-txt focus:outline-none"
+              className="h-6 flex items-center gap-1 min-w-0 rail-job-detail uppercase tracking-wider text-muted font-semibold hover:text-txt focus:outline-none"
             >
               {sessionJobsCollapsed ? <ChevronRight size={11} className="shrink-0" /> : <ChevronDown size={11} className="shrink-0" />}
               <span className="truncate">Jobs</span>
@@ -2164,7 +2162,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
             {visibleJobs.length === 0 ? (
               <div className="px-1 py-1">
                 {jobsValidating ? (
-                  <div className="text-[11px] text-faint italic px-1 py-1 flex items-center gap-1.5">
+                  <div className="rail-job-detail text-faint italic px-1 py-1 flex items-center gap-1.5">
                     <Loader2 size={10} className="animate-spin shrink-0" />
                     Loading jobs...
                   </div>
@@ -2204,7 +2202,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                       >
                         <JobStatusIcon status={st} />
                         <span
-                          className={`flex-1 min-w-0 truncate text-[12px] ${st === "completed" ? "text-muted" : st === "cancelled" ? "text-red-400/90" : "text-txt"}`}
+                          className={`flex-1 min-w-0 truncate rail-job-title ${st === "completed" ? "text-muted" : st === "cancelled" ? "text-red-400/90" : "text-txt"}`}
                           title={j.goal}
                         >
                           {j.goal}
@@ -2222,7 +2220,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                       </button>
                       {isOpen && (
                         <div className="px-1.5 pb-1.5 pt-1 border-t border-edge/35 space-y-1.5 min-w-0 max-h-48 overflow-y-auto overflow-x-hidden">
-                          <p className={`text-[12px] leading-snug break-words whitespace-normal ${st === "completed" ? "text-muted" : st === "cancelled" ? "text-red-400/90" : "text-txt"}`}>
+                          <p className={`rail-job-title leading-snug break-words whitespace-normal ${st === "completed" ? "text-muted" : st === "cancelled" ? "text-red-400/90" : "text-txt"}`}>
                             {j.goal}
                           </p>
                           {detail.length > 0 && (
@@ -2242,7 +2240,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                           {arts.length > 0 ? (
                             <div className="space-y-0.5">
                               {arts.map((a, i) => (
-                                <div key={a.id || i} className="text-[11px] text-txt/90 flex items-start gap-1.5 leading-snug min-w-0">
+                                <div key={a.id || i} className="rail-job-detail text-txt/90 flex items-start gap-1.5 leading-snug min-w-0">
                                   <span className="text-good mt-[3px] shrink-0">·</span>
                                   <span className="flex-1 min-w-0 break-words whitespace-normal">{a.headline}</span>
                                 </div>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -100,6 +100,7 @@ body {
   --shell-panel-radius: 12px;
   --shell-selection: #292c31;
   --shell-selection-shadow: 0 1px 3px rgb(0 0 0 / 24%);
+  --shell-rail-row-height: 28px;
   --shell-rail-title-size: 0.75rem;
   --shell-rail-detail-size: 0.6875rem;
   /* Floating menus over chat. Same fill as Tailwind `panel`. Glass must
@@ -681,16 +682,25 @@ body.is-row-resizing iframe {
 .shell-surface[data-presentation="modal"] section { border: 0; padding: 0; overflow-wrap: anywhere; }
 .shell-surface:not([data-presentation="inline"]) .session-rail-drag { display: none; }
 .session-rail [data-session-row] {
-  min-height: 36px;
+  min-height: var(--shell-rail-row-height);
   border-radius: 6px;
   color: theme('colors.txt');
   transition-property: background-color, color;
 }
-.session-rail [data-session-row]:hover { background: theme('colors.panel2'); }
-.session-rail [data-session-row][aria-current="true"] {
+.session-rail [data-session-row]:hover,
+.session-rail [data-session-container]:hover,
+.session-rail [data-session-container]:focus-within { background: theme('colors.panel2'); }
+.session-rail [data-session-row][aria-current="true"],
+.session-rail [data-session-container]:has([data-session-row][aria-current="true"]) {
   background: var(--shell-selection);
   box-shadow: var(--shell-selection-shadow);
 }
+.session-rail [data-session-container] [data-session-row] {
+  background: transparent;
+  box-shadow: none;
+}
+.session-rail .rail-job-title { font-size: var(--shell-rail-title-size); font-weight: 400; }
+.session-rail .rail-job-detail { font-size: var(--shell-rail-detail-size); }
 .session-rail [data-session-row][aria-current="true"] .text-accent { color: theme('colors.muted'); }
 .session-rail [data-session-row] > .flex { width: 100%; }
 .session-rail [data-session-row] .text-faint { font-family: inherit; font-size: var(--shell-rail-detail-size); color: theme('colors.muted'); }


### PR DESCRIPTION
Session selection now paints the whole row, including the status and action areas, so it no longer appears as two nested bars. Single-line session rows shrink from 36px to 28px. Jobs titles and expanded descriptions use the same smaller type scale as session titles.

Validation: 1,989 frontend tests, 308 Electron checks, production build and 3 version consistency tests passed. Live renderer checks measured 28px rows, transparent inner buttons, full-width grey row selection, and Jobs titles at 11.277px versus chat at 12.2168px. The full local Python 3.9 backend suite passed: 7,105 tests, 68 skipped. Required CI is pending.

Release v0.9.425 contains only this sidebar refinement and version metadata.
