### PR TITLE
Release v0.9.426: desktop panels and compact drawer controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.23.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.425, deliberately pre-1.0. Session selection uses one compact, full-width grey bar; session and Jobs titles share a smaller scale than chat text. Pins puppetmaster-ai==1.23.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows have a 900×600 minimum; smaller layouts use bounded Sessions and Panels drawers. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
+> Status: v0.9.426, deliberately pre-1.0. Session selection uses one compact, full-width grey bar; session and Jobs titles share a smaller scale than chat text. Pins puppetmaster-ai==1.23.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.425"
+__version__ = "0.9.426"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.425"
+version = "0.9.426"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.425",
+  "version": "0.9.426",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.425",
+      "version": "0.9.426",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.425",
+  "version": "0.9.426",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
 import { flushSync } from "react-dom";
+import { isSettingsOverlayOpen, setSettingsOverlayOpen, subscribeSettingsOverlay } from "./lib/settingsOverlay";
 import { api, type Config } from "./lib/api";
 import { subscribeDocumentMotionPolicy } from "./lib/motionPolicy";
 import { malformedBackendDiagnostic, parseBackendDiagnostic } from "./lib/operationalDiagnostic";
@@ -9,6 +10,7 @@ import ShellSurface from "./components/ShellSurface";
 import LeftRail from "./components/LeftRail";
 import Conversation from "./components/Conversation";
 import RightPane from "./components/RightPane";
+import PanelChooser from "./components/PanelChooser";
 import RightDock from "./components/RightDock";
 import StatusBar from "./components/StatusBar";
 import UpdateBanner, { type UpdateAvailability } from "./components/UpdateBanner";
@@ -82,6 +84,7 @@ export default function App() {
     width, compact, rightDrawer, view, setView, desktopLeftOpen, desktopRightOpen,
     leftOpen, rightOpen, setLeftOpen, setRightOpen,
   } = useResponsiveShell(bool(LS.leftOpen, true), bool(LS.rightOpen, false) && hasStoredRightPaneCards());
+  const settingsOpen = useSyncExternalStore(subscribeSettingsOverlay, isSettingsOverlayOpen, isSettingsOverlayOpen);
   const previousSessionId = useRef<string | null>(null);
   useEffect(() => {
     if (compact && previousSessionId.current && previousSessionId.current !== activeSessionId) setView("chat");
@@ -118,6 +121,11 @@ export default function App() {
 
   const openRightTo = (tab: string) => {
     const target = tab || "state";
+    if (target === "settings") {
+      pendingRightTab.current = null;
+      setSettingsOverlayOpen(true);
+      return;
+    }
     pendingRightTab.current = target;
     if (rightOpen) {
       pendingRightTab.current = null;
@@ -133,7 +141,7 @@ export default function App() {
   const requestRightMinWidth = useCallback((minPx: number) => {
     if (!rightDrawer) setRightW(previous => Math.max(previous, minPx));
   }, [rightDrawer]);
-  // Reserve 480px for content plus the 68px dock, beyond railLayout's 360px center.
+  // Reserve the dock separately from railLayout's adaptive chat/rail budget.
   // Clamp presentation only; resizing the window must not rewrite saved widths.
   const displayed = reclampRailWidths(leftW, rightW, leftOpen && !compact, rightOpen && !rightDrawer, width - SHELL_EXTRA_CENTER_W);
 
@@ -369,7 +377,7 @@ export default function App() {
               "radial-gradient(120% 80% at 50% -10%, rgba(139,150,196,0.06), rgba(139,150,196,0) 60%)",
           }}
         >
-          <ShellSurface visible={leftOpen} presentation={compact ? "left" : "inline"} label="Sessions" width={displayed.leftW} onClose={() => setLeftOpen(false)}>
+          <ShellSurface visible={leftOpen} suspended={compact && settingsOpen} presentation={compact ? "left" : "inline"} label="Sessions" width={displayed.leftW} onClose={() => setLeftOpen(false)}>
             <LeftRail jobsRefresh={jobsRefresh} onSessionChange={handleSessionChange} />
           </ShellSurface>
           {!compact && leftOpen && <Resizer
@@ -420,20 +428,25 @@ export default function App() {
               }}
             />
           )}
-          <ShellSurface visible={rightOpen} presentation={rightDrawer ? "right" : "inline"} label="Panels" width={displayed.rightW} onClose={() => setRightOpen(false)}>
-            <ErrorBoundary label="Tool board">
-              <RightPane
-                visible={rightOpen}
-                artifacts={artifacts}
-                onOpenWizard={() => {
-                  setManual(true);
-                  setShowWizard(true);
-                }}
-                initialTab={pendingRightTab.current}
-                onEmpty={closeEmptyRightPane}
-                onRequestMinWidth={requestRightMinWidth}
-              />
-            </ErrorBoundary>
+          <ShellSurface visible={rightOpen} suspended={rightDrawer && settingsOpen} presentation={rightDrawer ? "right" : "inline"} label="Panels" width={displayed.rightW} onClose={() => setRightOpen(false)}>
+            <div className="flex h-full min-h-0 flex-col">
+              {rightDrawer && <PanelChooser drawer onOpenTab={openRightTo} />}
+              <div className="flex-1 min-h-0 min-w-0">
+                <ErrorBoundary label="Tool board">
+                  <RightPane
+                    visible={rightOpen}
+                    artifacts={artifacts}
+                    onOpenWizard={() => {
+                      setManual(true);
+                      setShowWizard(true);
+                    }}
+                    initialTab={pendingRightTab.current}
+                    onEmpty={closeEmptyRightPane}
+                    onRequestMinWidth={requestRightMinWidth}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
           </ShellSurface>
         </div>
       </div>

--- a/webapp/src/__tests__/App.panels.test.tsx
+++ b/webapp/src/__tests__/App.panels.test.tsx
@@ -1,0 +1,111 @@
+import { act, cleanup, fireEvent, render, screen, within, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import App from "../App";
+import { createPortal } from "react-dom";
+import { resetSettingsOverlay } from "../lib/settingsOverlay";
+const sessionSelection = vi.hoisted(() => ({ current: (_id: string) => {} }));
+
+vi.mock("../lib/api", () => ({ api: {
+  config: () => Promise.resolve({}), diagnostics: () => Promise.resolve({}), providers: () => Promise.resolve([{ has_key: true }]), getReviews: () => Promise.resolve([]), swarmLive: () => Promise.resolve({jobs: []}),
+} }));
+vi.mock("../components/LeftRail", () => ({ default: ({ onSessionChange }: { onSessionChange: (id: string) => void }) => {
+  sessionSelection.current = onSessionChange;
+  return <button>Session item</button>;
+} }));
+vi.mock("../components/Conversation", () => ({ default: () => <textarea aria-label="Chat editor" /> }));
+vi.mock("../components/RightDock", () => ({ default: ({ onOpenTab }: { onOpenTab: (tab: string) => void }) => <button onClick={() => onOpenTab("review")}>Review shortcut</button> }));
+vi.mock("../components/StatusBar", () => ({ default: () => null }));
+vi.mock("../components/UpdateBanner", () => ({ default: () => null }));
+vi.mock("../components/ProviderKeyBanner", () => ({ default: () => null }));
+vi.mock("../components/KeyBootstrapBanner", () => ({ default: () => null }));
+vi.mock("../components/RegistryWizard", () => ({ default: () => null }));
+vi.mock("../components/OnboardingOverlay", () => ({ default: () => null }));
+vi.mock("../components/CommandPalette", () => ({ default: () => null }));
+vi.mock("../components/SettingsShell", () => ({ focusSettingsPage: vi.fn(), default: ({ onClose }: { onClose: () => void }) => createPortal(<button onClick={onClose}>Close settings</button>, document.body) }));
+vi.mock("../components/StatePane", () => ({ default: () => <div /> }));
+vi.mock("../components/BrowserPane", () => ({ default: () => <div /> }));
+vi.mock("../components/FileTree", () => ({ default: () => <div /> }));
+vi.mock("../components/SourceControl", () => ({ default: () => <div /> }));
+vi.mock("../components/WorktreesPane", () => ({ default: () => <div /> }));
+vi.mock("../components/TerminalPane", () => ({ default: () => <div /> }));
+vi.mock("../components/CheckpointsPane", () => ({ default: () => <div /> }));
+vi.mock("../components/DiffReviewPane", () => ({ default: () => <div /> }));
+vi.mock("../components/SwarmPane", () => ({ default: () => <div /> }));
+vi.mock("../components/EconomicsPane", () => ({ default: () => <div /> }));
+function resize(width: number) {
+  act(() => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+    window.dispatchEvent(new Event("resize"));
+  });
+}
+beforeEach(() => {
+  resetSettingsOverlay();
+  localStorage.clear();
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.setItem("pmharness.leftW", "248");
+  localStorage.setItem("pmharness.rightW", "520");
+  localStorage.setItem("pmharness.leftOpen", "1");
+  localStorage.setItem("pmharness.rightOpen", "1");
+  localStorage.setItem("pmharness.board.openCards", '["state"]');
+});
+afterEach(cleanup);
+
+it.each([400, 639])("manages cards inside the %ipx drawer and retains state through resizing", async width => {
+  resize(1019);
+  await act(async () => { render(<App />); });
+  const editor = screen.getByRole("textbox", { name: "Chat editor" });
+  fireEvent.change(editor, { target: { value: "unsent desktop draft" } });
+  const stateCard = screen.getByRole("region", { name: "State panel" });
+  resize(width);
+  const trigger = screen.getByRole("button", { name: "Panels", exact: true });
+  trigger.focus();
+  fireEvent.click(trigger);
+  const drawer = screen.getByRole("dialog", { name: "Panels" });
+  const inside = within(drawer);
+  expect(editor.closest("[inert]")).not.toBeNull();
+  expect(inside.getByRole("region", { name: "State panel" })).toBe(stateCard);
+  const add = (name: string) => {
+    fireEvent.click(inside.getByRole("button", { name: "Add panel" }));
+    fireEvent.click(within(inside.getByRole("group", { name: "Add panel" })).getByRole("button", { name, exact: true }));
+  };
+  add("Files");
+  add("Economics");
+  expect(inside.getAllByRole("region")).toHaveLength(3);
+  const closeFiles = inside.getByRole("button", { name: "Close Files panel" });
+  closeFiles.focus();
+  fireEvent.click(closeFiles);
+  await waitFor(() => expect(stateCard).toHaveFocus());
+  expect(inside.queryByRole("region", { name: "Files panel" })).toBeNull();
+  expect(drawer).toHaveAttribute("open");
+  add("Files");
+  expect(inside.getByRole("region", { name: "Files panel" })).toBeVisible();
+  add("Settings");
+  expect(drawer).not.toHaveAttribute("open");
+  fireEvent.click(screen.getByRole("button", { name: "Close settings" }));
+  expect(drawer).toHaveAttribute("open");
+  const storedCards = localStorage.getItem("pmharness.board.openCards");
+  fireEvent(drawer, new Event("cancel", { cancelable: true }));
+  expect(trigger).toHaveFocus();
+  resize(640);
+  expect(screen.getByRole("complementary", { name: "Panels" })).not.toHaveAttribute("aria-modal");
+  resize(800);
+  expect(editor.closest("[inert]")).toBeNull();
+  resize(1280);
+  expect(screen.getByRole("textbox")).toBe(editor);
+  expect(editor).toHaveValue("unsent desktop draft");
+  expect(screen.getByRole("region", { name: "State panel" })).toBe(stateCard);
+  expect(localStorage.getItem("pmharness.board.openCards")).toBe(storedCards);
+  expect(localStorage.getItem("pmharness.leftW")).toBe("248");
+  expect(localStorage.getItem("pmharness.rightW")).toBe("520");
+  expect(localStorage.getItem("pmharness.leftOpen")).toBe("1");
+  expect(localStorage.getItem("pmharness.rightOpen")).toBe("1");
+});
+
+it("exposes Add panel inside an open narrow drawer", async () => {
+  resize(400);
+  await act(async () => { render(<App />); });
+  fireEvent.click(screen.getByRole("button", { name: "Panels", exact: true }));
+  const drawer = screen.getByRole("dialog", { name: "Panels" });
+  fireEvent.click(within(drawer).getByRole("button", { name: "Add panel" }));
+  expect(within(drawer).getByRole("button", { name: "Economics", exact: true })).toBeVisible();
+});

--- a/webapp/src/__tests__/App.responsive.test.tsx
+++ b/webapp/src/__tests__/App.responsive.test.tsx
@@ -43,7 +43,7 @@ it("keeps desktop preferences and chat mounted through real window resize events
   const editor = screen.getByRole("textbox", { name: "Chat editor" });
   fireEvent.change(editor, { target: { value: "unsent draft" } });
   screen.getByRole("button", { name: "Panel item" }).focus();
-  resize(697);
+  resize(600);
   expect(screen.getByRole("button", { name: "Chat", exact: true })).toHaveFocus();
   expect(screen.queryByRole("button", { name: "Panel item" })).toBeNull();
   expect(screen.queryByRole("button", { name: "Session item" })).toBeNull();
@@ -82,15 +82,16 @@ it("keeps desktop preferences and chat mounted through real window resize events
   expect(localStorage.getItem("pmharness.rightOpen")).toBe("1");
 });
 
-it("keeps Sessions inline at 900px and uses a bounded right drawer for Panels", async () => {
-  resize(900);
+it.each([800, 900, 1019, 1280])("keeps Panels inline and chat accessible at %ipx", async (width) => {
+  resize(width);
   await act(async () => { render(<App />); });
-  expect(screen.getByRole("complementary", { name: "Sessions" })).toHaveAttribute("data-presentation", "inline");
-  const panels = screen.getByRole("dialog", { name: "Panels" });
-  expect(panels).toHaveAttribute("data-presentation", "right");
-  fireEvent.click(screen.getByRole("button", { name: "Close Panels" }));
-  expect(screen.getByRole("textbox", { name: "Chat editor" })).toBeVisible();
-  expect(screen.getByRole("button", { name: "Session item" })).toBeVisible();
+  const panels = screen.getByRole("complementary", { name: "Panels" });
+  expect(panels).toHaveAttribute("data-presentation", "inline");
+  expect(panels).not.toHaveAttribute("aria-modal");
+  const editor = screen.getByRole("textbox", { name: "Chat editor" });
+  expect(editor.closest("[inert]")).toBeNull();
+  expect(screen.queryByRole("dialog")).toBeNull();
+  expect(screen.getByRole("button", { name: "Review shortcut" })).toBeVisible();
 });
 
 it("closes phone drawers on native Escape cancellation and backdrop, restoring the trigger", async () => {

--- a/webapp/src/__tests__/RightPane.activity.test.tsx
+++ b/webapp/src/__tests__/RightPane.activity.test.tsx
@@ -1,0 +1,66 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useEffect, useState } from "react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import RightPane from "../components/RightPane";
+import { resetSettingsOverlay } from "../lib/settingsOverlay";
+
+const activity = vi.hoisted(() => ({ poll: vi.fn() }));
+
+vi.mock("../lib/api", () => ({ api: {
+  getReviews: vi.fn().mockResolvedValue([]),
+  swarmLive: vi.fn().mockResolvedValue({ jobs: [] }),
+} }));
+vi.mock("../components/StatePane", () => ({ default: () => null }));
+vi.mock("../components/BrowserPane", () => ({ default: () => null }));
+vi.mock("../components/FileTree", () => ({ default: () => null }));
+vi.mock("../components/SourceControl", () => ({ default: () => null }));
+vi.mock("../components/WorktreesPane", () => ({ default: () => null }));
+vi.mock("../components/SettingsShell", () => ({ default: () => null }));
+vi.mock("../components/TerminalPane", () => ({ default: () => null }));
+vi.mock("../components/CheckpointsPane", () => ({ default: () => null }));
+vi.mock("../components/DiffReviewPane", () => ({ default: () => null }));
+vi.mock("../components/SwarmPane", () => ({ default: () => null }));
+vi.mock("../components/EconomicsPane", () => ({
+  default: function EconomicsProbe() {
+    const [scope, setScope] = useState("repo");
+    useEffect(() => {
+      const timer = setInterval(activity.poll, 1000);
+      return () => clearInterval(timer);
+    }, []);
+    return <input aria-label="Economics scope draft" value={scope}
+      onChange={event => setScope(event.target.value)} />;
+  },
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  localStorage.clear();
+  resetSettingsOverlay();
+  localStorage.setItem("pmharness.board.openCards", JSON.stringify(["economics"]));
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+it("pauses retained card effects while hidden and resumes without losing its draft", async () => {
+  const props = { artifacts: [], onOpenWizard: vi.fn() };
+  const view = render(<RightPane {...props} visible />);
+  const input = screen.getByRole("textbox", { name: "Economics scope draft" });
+  fireEvent.change(input, { target: { value: "session" } });
+  await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+  expect(activity.poll).toHaveBeenCalledTimes(1);
+
+  view.rerender(<RightPane {...props} visible={false} />);
+  await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+  expect(activity.poll).toHaveBeenCalledTimes(1);
+
+  view.rerender(<RightPane {...props} visible />);
+  expect(screen.getByRole("textbox", { name: "Economics scope draft" })).toBe(input);
+  expect(input).toHaveValue("session");
+  await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+  expect(activity.poll).toHaveBeenCalledTimes(2);
+});

--- a/webapp/src/__tests__/RightPane.collapse.test.tsx
+++ b/webapp/src/__tests__/RightPane.collapse.test.tsx
@@ -881,3 +881,51 @@ describe("RightPane and RightDock polling ownership", () => {
     }
   }
 });
+
+
+it("preserves saved column preferences and mounted cards across board resize", () => {
+  localStorage.clear();
+  seedBoardTabOrder(["state", "economics"]);
+  localStorage.setItem("pmharness.board.columns.v1", '[["state"],["economics"]]');
+  const layouts = '{"state":{"columnSpan":7,"customized":true},"economics":{"columnSpan":5,"customized":true}}';
+  localStorage.setItem("pmharness.board.cardLayouts.v1", layouts);
+  let notifyResize = () => {};
+  const rectSpy = vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue(new DOMRect(0, 0, 700, 600));
+  vi.stubGlobal("ResizeObserver", class {
+    constructor(callback: () => void) { notifyResize = callback; }
+    observe() {}
+    disconnect() {}
+  });
+  try {
+    const view = render(<RightPane {...baseProps} />);
+    const card = screen.getByRole("region", { name: "Economics panel" });
+    fireEvent.change(screen.getByRole("combobox", { name: "Economics ownership" }), { target: { value: "conversation" } });
+    card.scrollTop = 37;
+    rectSpy.mockReturnValue(new DOMRect(0, 0, 220, 600));
+    act(() => notifyResize());
+    expect(localStorage.getItem("pmharness.board.cardLayouts.v1")).toBe(layouts);
+    view.rerender(<RightPane {...baseProps} visible={false} />);
+    view.rerender(<RightPane {...baseProps} visible />);
+    expect(screen.getByRole("region", { name: "Economics panel" })).toBe(card);
+    expect(card.scrollTop).toBe(37);
+    expect(screen.getByRole("combobox", { name: "Economics ownership" })).toHaveValue("conversation");
+    rectSpy.mockReturnValue(new DOMRect(0, 0, 700, 600));
+    act(() => notifyResize());
+    expect(localStorage.getItem("pmharness.board.cardLayouts.v1")).toBe(layouts);
+  } finally {
+    rectSpy.mockRestore();
+    vi.unstubAllGlobals();
+  }
+});
+
+it("defers saved card contents until Panels has first been shown", () => {
+  localStorage.clear();
+  seedBoardTabOrder(["state", "economics"]);
+  const view = render(<RightPane {...baseProps} visible={false} />);
+  expect(view.container.querySelector('[aria-label="State panel"]')).toBeNull();
+  view.rerender(<RightPane {...baseProps} visible />);
+  const card = screen.getByRole("region", { name: "State panel" });
+  view.rerender(<RightPane {...baseProps} visible={false} />);
+  view.rerender(<RightPane {...baseProps} visible />);
+  expect(screen.getByRole("region", { name: "State panel" })).toBe(card);
+});

--- a/webapp/src/__tests__/RightPane.collapse.test.tsx
+++ b/webapp/src/__tests__/RightPane.collapse.test.tsx
@@ -929,3 +929,124 @@ it("defers saved card contents until Panels has first been shown", () => {
   view.rerender(<RightPane {...baseProps} visible />);
   expect(screen.getByRole("region", { name: "State panel" })).toBe(card);
 });
+
+describe("compact drawer sizing", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    seedBoardTabOrder(["economics", "browser"]);
+    localStorage.setItem("pmharness.board.columns.v1", '[["economics"],["browser"]]');
+    localStorage.setItem("pmharness.board.cardLayouts.v1", '{"economics":{"columnSpan":8},"browser":{"columnSpan":4}}');
+    localStorage.setItem("pmharness.board.stackFractions.v2", '{"economics|browser":[0.3,0.7]}');
+  });
+
+  it("provides visible compact height controls even for singleton columns", () => {
+    render(<RightPane {...baseProps} />);
+    expect(screen.getByLabelText("Resize Economics panel height")).toBeTruthy();
+    expect(css).toContain("height: var(--compact-card-height, 50dvh)");
+    expect(css).toMatch(/\.right-pane-compact-controls\s*\{[^}]*display: flex/);
+  });
+
+  it("changes compact height with buttons and keyboard without writing desktop geometry", () => {
+    render(<RightPane {...baseProps} />);
+    const card = screen.getByRole("region", { name: "Economics panel" });
+    vi.spyOn(card, "getBoundingClientRect").mockReturnValue(new DOMRect(0, 0, 360, 400));
+    const saved = ["pmharness.board.columns.v1", "pmharness.board.cardLayouts.v1", "pmharness.board.stackFractions.v2"].map(key => localStorage.getItem(key));
+    fireEvent.click(screen.getByLabelText("Taller Economics panel"));
+    expect(card.style.getPropertyValue("--compact-card-height")).toBe("448px");
+    fireEvent.keyDown(screen.getByLabelText("Resize Economics panel height"), { key: "ArrowDown" });
+    expect(card.style.getPropertyValue("--compact-card-height")).toBe("496px");
+    fireEvent.click(screen.getByLabelText("Shorter Economics panel"));
+    expect(card.style.getPropertyValue("--compact-card-height")).toBe("448px");
+    expect(["pmharness.board.columns.v1", "pmharness.board.cardLayouts.v1", "pmharness.board.stackFractions.v2"].map(key => localStorage.getItem(key))).toEqual(saved);
+  });
+});
+
+it("resizes compact cards by pointer and cleans up a cancelled drag", () => {
+  vi.stubGlobal("PointerEvent", class extends MouseEvent {
+    pointerId: number;
+    constructor(type: string, init: PointerEventInit) { super(type, init); this.pointerId = init.pointerId ?? 0; }
+  });
+  localStorage.clear();
+  seedBoardTabOrder(["economics"]);
+  render(<RightPane {...baseProps} />);
+  const card = screen.getByRole("region", { name: "Economics panel" });
+  vi.spyOn(card, "getBoundingClientRect").mockReturnValue(new DOMRect(0, 0, 360, 400));
+  const handle = screen.getByLabelText("Resize Economics panel height");
+  handle.setPointerCapture = vi.fn();
+  handle.hasPointerCapture = vi.fn(() => true);
+  handle.releasePointerCapture = vi.fn();
+  fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientY: 400 });
+  fireEvent.pointerMove(handle, { pointerId: 1, clientY: 520 });
+  expect(card.style.getPropertyValue("--compact-card-height")).toBe("520px");
+  fireEvent.pointerCancel(handle, { pointerId: 1 });
+  expect(document.body.classList.contains("is-row-resizing")).toBe(false);
+  fireEvent.pointerMove(handle, { pointerId: 1, clientY: 600 });
+  expect(card.style.getPropertyValue("--compact-card-height")).toBe("520px");
+  vi.unstubAllGlobals();
+});
+
+it("keeps panel state and focus through measured wide/narrow/wide widths", () => {
+  localStorage.clear();
+  seedBoardTabOrder(["economics", "browser"]);
+  let width = 900;
+  let notify = () => {};
+  vi.stubGlobal("ResizeObserver", class {
+    constructor(callback: () => void) { notify = callback; }
+    observe() {}
+    disconnect() {}
+  });
+  const rect = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(() => new DOMRect(0, 0, width, 400));
+  const view = render(<RightPane {...baseProps} />);
+  const input = screen.getByRole("combobox", { name: "Economics ownership" });
+  fireEvent.change(input, { target: { value: "conversation" } });
+  input.focus();
+  const card = screen.getByRole("region", { name: "Economics panel" });
+  for (const next of [480, 360, 640, 900]) {
+    width = next;
+    act(() => notify());
+    expect(screen.getByRole("region", { name: "Economics panel" })).toBe(card);
+    expect(screen.getByRole("combobox", { name: "Economics ownership" })).toBe(input);
+    expect(input).toHaveValue("conversation");
+    expect(document.activeElement).toBe(input);
+  }
+  view.unmount();
+  rect.mockRestore();
+  vi.unstubAllGlobals();
+});
+
+it("moves panels within a stack using a touch/keyboard select without losing body state", () => {
+  localStorage.clear();
+  seedBoardTabOrder(["economics", "browser"]);
+  render(<RightPane {...baseProps} />);
+  const input = screen.getByRole("combobox", { name: "Economics ownership" });
+  fireEvent.change(input, { target: { value: "conversation" } });
+  fireEvent.change(screen.getByLabelText("Move Browser panel"), { target: { value: "economics" } });
+  expectCardGridPlacement("Browser", "1", "1");
+  expectCardGridPlacement("Economics", "1", "2");
+  expect(screen.getByRole("combobox", { name: "Economics ownership" })).toBe(input);
+  expect(input).toHaveValue("conversation");
+});
+
+it("stacks a singleton column before another card without remounting its body", () => {
+  localStorage.clear();
+  seedBoardTabOrder(["economics", "browser"]);
+  localStorage.setItem("pmharness.board.columns.v1", '[["economics"],["browser"]]');
+  render(<RightPane {...baseProps} />);
+  const input = screen.getByRole("combobox", { name: "Economics ownership" });
+  fireEvent.change(input, { target: { value: "conversation" } });
+  fireEvent.change(screen.getByLabelText("Move Economics panel"), { target: { value: "browser" } });
+  expect(JSON.parse(localStorage.getItem("pmharness.board.columns.v1") || "[]")).toEqual([["economics", "browser"]]);
+  expect(screen.getByRole("combobox", { name: "Economics ownership" })).toBe(input);
+  expect(input).toHaveValue("conversation");
+});
+
+it("accepts a reorder drop on the portaled panel body", () => {
+  localStorage.clear();
+  seedBoardTabOrder(["economics", "browser"]);
+  render(<RightPane {...baseProps} />);
+  const dataTransfer = { effectAllowed: "", setData: vi.fn(), getData: vi.fn(() => "browser") };
+  fireEvent.dragStart(screen.getByRole("button", { name: "Drag Browser panel" }), { dataTransfer });
+  fireEvent.drop(screen.getByRole("combobox", { name: "Economics ownership" }), { dataTransfer });
+  expectCardGridPlacement("Browser", "1", "1");
+  expectCardGridPlacement("Economics", "1", "2");
+});

--- a/webapp/src/__tests__/railLayout.test.ts
+++ b/webapp/src/__tests__/railLayout.test.ts
@@ -1,3 +1,4 @@
+import { DUAL_RAIL_SHELL_WIDTH, SHELL_EXTRA_CENTER_W } from "../lib/useResponsiveShell";
 import { describe, expect, it } from "vitest";
 import {
   LEFT_MIN_W,
@@ -33,4 +34,13 @@ describe("reclampRailWidths", () => {
     expect(next.rightW).toBeGreaterThanOrEqual(RIGHT_COMPACT_MIN_W);
     expect(next.rightW).toBeLessThanOrEqual(RIGHT_MIN_W);
   });
+});
+
+it.each([640, 800, 844, 1019, 1280])("fits actual shell chrome and inline rails at %ipx", width => {
+  const leftOpen = width >= DUAL_RAIL_SHELL_WIDTH;
+  const result = reclampRailWidths(248, 520, leftOpen, true, width - SHELL_EXTRA_CENTER_W);
+  const chat = width - SHELL_EXTRA_CENTER_W - layoutChrome(leftOpen, true) - (leftOpen ? result.leftW : 0) - result.rightW;
+  expect(chat).toBeGreaterThanOrEqual(Math.min(MIN_CENTER_W, width - SHELL_EXTRA_CENTER_W - layoutChrome(leftOpen, true) - RIGHT_COMPACT_MIN_W));
+  expect(result.rightW).toBeGreaterThanOrEqual(RIGHT_COMPACT_MIN_W);
+  if (leftOpen) expect(result.leftW).toBeGreaterThanOrEqual(LEFT_MIN_W);
 });

--- a/webapp/src/__tests__/useResponsiveShell.test.tsx
+++ b/webapp/src/__tests__/useResponsiveShell.test.tsx
@@ -12,7 +12,7 @@ afterEach(cleanup);
 
 describe("responsive shell transitions", () => {
   it("starts narrow with chat even when both desktop panels were saved open", () => {
-    resize(697);
+    resize(600);
     const { result } = renderHook(() => useResponsiveShell(true, true));
     expect(result.current).toMatchObject({ compact: true, leftOpen: false, rightOpen: false, view: "chat" });
     act(() => result.current.setLeftOpen(true));
@@ -33,11 +33,27 @@ describe("responsive shell transitions", () => {
     resize(COMPACT_SHELL_WIDTH - 1);
     expect(result.current.view).toBe("chat");
     act(() => result.current.setLeftOpen(true));
-    resize(697);
+    resize(600);
     expect(result.current.view).toBe("left");
     resize(COMPACT_SHELL_WIDTH);
     expect(result.current).toMatchObject({ leftOpen: false, rightOpen: true });
-    resize(697);
+    resize(600);
     expect(result.current).toMatchObject({ view: "chat", leftOpen: false, rightOpen: false });
   });
+});
+
+it("temporarily selects one inline rail without rewriting desktop choices", () => {
+  resize(1019);
+  const { result } = renderHook(() => useResponsiveShell(true, true));
+  resize(800);
+  expect(result.current).toMatchObject({ compact: false, rightDrawer: false, leftOpen: false, rightOpen: true });
+  act(() => result.current.setLeftOpen(v => !v));
+  expect(result.current).toMatchObject({ leftOpen: true, rightOpen: false, desktopLeftOpen: true, desktopRightOpen: true });
+  act(() => result.current.setRightOpen(true));
+  resize(640);
+  expect(result.current).toMatchObject({ compact: false, rightDrawer: false, rightOpen: true });
+  resize(639);
+  expect(result.current).toMatchObject({ compact: true, rightDrawer: true, view: "chat" });
+  resize(1019);
+  expect(result.current).toMatchObject({ leftOpen: true, rightOpen: true });
 });

--- a/webapp/src/components/PanelChooser.tsx
+++ b/webapp/src/components/PanelChooser.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { Database, FolderTree, GitBranch, GitFork, GitPullRequest, Globe, History, Coins, Network, Plus, Settings, SquareTerminal } from "lucide-react";
+
+const PANEL_OPTIONS = [
+  { tab: "state", label: "State", icon: <Database size={12} /> },
+  { tab: "swarm", label: "Swarm", icon: <Network size={12} /> },
+  { tab: "economics", label: "Economics", icon: <Coins size={12} /> },
+  { tab: "files", label: "Files", icon: <FolderTree size={12} /> },
+  { tab: "git", label: "Git", icon: <GitBranch size={12} /> },
+  { tab: "worktrees", label: "Worktrees", icon: <GitFork size={12} /> },
+  { tab: "terminal", label: "Terminal", icon: <SquareTerminal size={12} /> },
+  { tab: "review", label: "Review", icon: <GitPullRequest size={12} /> },
+  { tab: "checkpoints", label: "History", icon: <History size={12} /> },
+  { tab: "browser", label: "Browser", icon: <Globe size={12} /> },
+];
+
+function readStoredList(key: string): string[] {
+  try {
+    const value = JSON.parse(localStorage.getItem(key) || "[]");
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Shared panel catalog and selection flow; no activity polling. */
+export default function PanelChooser({ onOpenTab, drawer = false }: {
+  onOpenTab: (tab: string) => void;
+  drawer?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const root = useRef<HTMLDivElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const id = useId();
+  useEffect(() => {
+    if (!open || drawer) return;
+    const outside = (event: MouseEvent) => {
+      if (event.target instanceof Node && !root.current?.contains(event.target)) setOpen(false);
+    };
+    const escape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") { setOpen(false); trigger.current?.focus(); }
+    };
+    document.addEventListener("mousedown", outside);
+    document.addEventListener("keydown", escape);
+    return () => {
+      document.removeEventListener("mousedown", outside);
+      document.removeEventListener("keydown", escape);
+    };
+  }, [open, drawer]);
+  const stored = readStoredList("pmharness.tabOrder");
+  const order = [...new Set([...stored, ...PANEL_OPTIONS.map(option => option.tab)])];
+  const openCards = readStoredList("pmharness.board.openCards");
+  const choose = (tab: string) => {
+    setOpen(false);
+    trigger.current?.focus();
+    onOpenTab(tab);
+  };
+  return <div ref={root} className={drawer ? "panel-chooser-drawer" : "relative"}>
+    <button ref={trigger} type="button" aria-label="Add panel" title="Add panel"
+      aria-expanded={open} aria-controls={id} aria-haspopup={drawer ? undefined : "menu"}
+      onClick={() => setOpen(value => !value)}
+      className={drawer ? "px-3 flex items-center gap-2 focus-visible:outline" : "flex h-7 w-7 items-center justify-center rounded-xl text-faint hover:text-muted hover:bg-panel2/50 transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"}>
+      <Plus size={15} strokeWidth={1.75} />{drawer && <span>Add panel</span>}
+    </button>
+    {open && <div id={id} role={drawer ? "group" : "menu"} aria-label="Add panel"
+      className={drawer ? "panel-chooser-options" : "right-pane-add-menu right-[calc(100%+8px)] left-auto top-0"}>
+      {order.map(tab => {
+        const option = PANEL_OPTIONS.find(item => item.tab === tab);
+        if (!option || openCards.includes(tab)) return null;
+        return <button key={tab} type="button" role={drawer ? undefined : "menuitem"}
+          aria-label={option.label} onClick={() => choose(tab)} className="right-pane-add-item">
+          {option.icon}<span>{option.label}</span>
+        </button>;
+      })}
+      <button type="button" role={drawer ? undefined : "menuitem"} onClick={() => choose("settings")} className="right-pane-add-item">
+        <Settings size={12} /><span>Settings</span>
+      </button>
+    </div>}
+  </div>;
+}

--- a/webapp/src/components/RightDock.tsx
+++ b/webapp/src/components/RightDock.tsx
@@ -1,17 +1,13 @@
+import PanelChooser from "./PanelChooser";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   Database,
-  FolderTree,
-  GitBranch,
-  GitFork,
   GitPullRequest,
   Globe,
-  History,
   Coins,
   Network,
   PanelRight,
   PanelRightClose,
-  Plus,
   Settings,
   SquareTerminal,
 } from "lucide-react";
@@ -62,28 +58,6 @@ const DOCK_LINKS: { id: string; tab: string; icon: ReactNode; title: string }[] 
   },
 ];
 
-const PANEL_OPTIONS = [
-  { tab: "state", label: "State", icon: <Database size={12} /> },
-  { tab: "swarm", label: "Swarm", icon: <Network size={12} /> },
-  { tab: "economics", label: "Economics", icon: <Coins size={12} /> },
-  { tab: "files", label: "Files", icon: <FolderTree size={12} /> },
-  { tab: "git", label: "Git", icon: <GitBranch size={12} /> },
-  { tab: "worktrees", label: "Worktrees", icon: <GitFork size={12} /> },
-  { tab: "terminal", label: "Terminal", icon: <SquareTerminal size={12} /> },
-  { tab: "review", label: "Review", icon: <GitPullRequest size={12} /> },
-  { tab: "checkpoints", label: "History", icon: <History size={12} /> },
-  { tab: "browser", label: "Browser", icon: <Globe size={12} /> },
-];
-
-function readStoredList(key: string): string[] {
-  try {
-    const value = JSON.parse(localStorage.getItem(key) || "[]");
-    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
-  } catch {
-    return [];
-  }
-}
-
 export default function RightDock({
   onOpenTab,
   onExpand,
@@ -102,9 +76,6 @@ export default function RightDock({
   const [swarmRepo, setSwarmRepo] = useState<string | undefined>(
     () => lastSelectedProjectRoot() || undefined,
   );
-  const [addMenuOpen, setAddMenuOpen] = useState(false);
-  const [menuVersion, setMenuVersion] = useState(0);
-  const addMenuRef = useRef<HTMLDivElement | null>(null);
   const [activitySessionId, setActivitySessionId] = useState("");
   const [scopeEpoch, setScopeEpoch] = useState(0);
   const activityEpoch = useRef(0);
@@ -127,23 +98,6 @@ export default function RightDock({
       window.removeEventListener(JOB_SCOPE_CHANGED_EVENT, onScope);
     };
   }, []);
-
-  useEffect(() => {
-    if (!addMenuOpen) return;
-    const closeOnOutsideClick = (event: MouseEvent) => {
-      if (addMenuRef.current?.contains(event.target as Node)) return;
-      setAddMenuOpen(false);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setAddMenuOpen(false);
-    };
-    document.addEventListener("mousedown", closeOnOutsideClick);
-    document.addEventListener("keydown", closeOnEscape);
-    return () => {
-      document.removeEventListener("mousedown", closeOnOutsideClick);
-      document.removeEventListener("keydown", closeOnEscape);
-    };
-  }, [addMenuOpen]);
 
   useEffect(() => {
     const onProject = (e: Event) => {
@@ -225,60 +179,7 @@ export default function RightDock({
 
         <span className="my-0.5 h-px w-4 bg-edge/50" aria-hidden />
 
-        <div ref={addMenuRef} className="relative">
-          <button
-            type="button"
-            onClick={() => { setAddMenuOpen(open => !open); setMenuVersion(version => version + 1); }}
-            aria-expanded={addMenuOpen}
-            aria-haspopup="menu"
-            aria-label="Add panel"
-            title="Add panel"
-            className="flex h-7 w-7 items-center justify-center rounded-xl text-faint hover:text-muted hover:bg-panel2/50 transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
-          >
-            <Plus size={15} strokeWidth={1.75} />
-          </button>
-          {addMenuOpen && (
-            <div key={menuVersion} role="menu" aria-label="Add panel" className="right-pane-add-menu right-[calc(100%+8px)] left-auto top-0">
-              <div className="px-2 py-1 text-[9px] uppercase tracking-wider text-faint">Add panel</div>
-              {(() => {
-                const stored = readStoredList("pmharness.tabOrder");
-                const fallback = PANEL_OPTIONS.map(option => option.tab);
-                return stored.length > 0
-                  ? [...stored, ...fallback.filter(tab => !stored.includes(tab))]
-                  : fallback;
-              })().filter(tab => tab !== "settings").map(tab => {
-                const option = PANEL_OPTIONS.find(item => item.tab === tab);
-                if (!option || readStoredList("pmharness.board.openCards").includes(tab)) return null;
-                return (
-                  <button
-                    role="menuitem"
-                    key={tab}
-                    type="button"
-                    aria-label={option.label}
-                    onClick={() => {
-                      onOpenTab(tab);
-                      setAddMenuOpen(false);
-                    }}
-                    className="right-pane-add-item"
-                  >
-                    {option.icon}<span>{option.label}</span>
-                  </button>
-                );
-              })}
-              <button
-                role="menuitem"
-                type="button"
-                onClick={() => {
-                  onOpenTab("settings");
-                  setAddMenuOpen(false);
-                }}
-                className="right-pane-add-item"
-              >
-                <Settings size={12} /><span>Settings</span>
-              </button>
-            </div>
-          )}
-        </div>
+        <PanelChooser onOpenTab={onOpenTab} />
 
         {DOCK_LINKS.map((link) => (
           <button

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useLayoutEffect, useRef } from "react";
+import { useCallback, useState, useEffect, useLayoutEffect, useRef, useSyncExternalStore } from "react";
 import { X, GripVertical } from "lucide-react";
 import StatePane from "./StatePane";
 import BrowserPane from "./BrowserPane";
@@ -20,6 +20,7 @@ import { filterJobsByScope, JOB_SCOPE_CHANGED_EVENT, loadJobScope } from "../lib
 import {
   isSettingsOverlayOpen,
   setSettingsOverlayOpen,
+  subscribeSettingsOverlay,
 } from "../lib/settingsOverlay";
 import {
   loadRightPaneTabVisibility,
@@ -48,7 +49,6 @@ import {
   columnSpanFromPointerDelta,
   columnTrackTemplate,
   groupGridColumn,
-  absorbShellResize,
   normalizeGroupWidths,
   showColumnResizeHandle,
 } from "../lib/boardColumnWidths";
@@ -265,10 +265,11 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
   stackFractionsRef.current = stackFractions;
   const boardRef = useRef<HTMLDivElement | null>(null);
   const [boardWidth, setBoardWidth] = useState(0);
-  const prevBoardWidthRef = useRef(0);
+  const [hasBeenVisible, setHasBeenVisible] = useState(visible);
+  useEffect(() => { if (visible) setHasBeenVisible(true); }, [visible]);
   const preferredResizeGroupRef = useRef(-1);
   const [draggedTab, setDraggedTab] = useState<Tab | null>(null);
-  const [settingsOpen, setSettingsOpen] = useState(isSettingsOverlayOpen);
+  const settingsOpen = useSyncExternalStore(subscribeSettingsOverlay, isSettingsOverlayOpen, isSettingsOverlayOpen);
   const handledInitialTab = useRef<string | null>(null);
   const [tabOrder, setTabOrder] = useState<Tab[]>(() => {
     const validTabs = CANONICAL_ORDER.filter(tab => tab !== PINNED_LAST);
@@ -309,12 +310,10 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
 
   const openSettings = useCallback(() => {
     setSettingsOverlayOpen(true);
-    setSettingsOpen(true);
   }, []);
 
   const closeSettings = useCallback(() => {
     setSettingsOverlayOpen(false);
-    setSettingsOpen(false);
     if (openCards.length === 0) onEmpty?.();
   }, [onEmpty, openCards.length]);
 
@@ -334,7 +333,11 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
 
   const removeCard = (tabName: Tab) => {
     const nextOpenCards = openCards.filter(card => card !== tabName);
+    const hadFocus = document.getElementById(`right-pane-card-${tabName}`)?.contains(document.activeElement);
     persistBoard(tabOrder, nextOpenCards);
+    if (hadFocus && nextOpenCards.length > 0) {
+      requestAnimationFrame(() => document.getElementById(`right-pane-card-${nextOpenCards[0]}`)?.focus());
+    }
   };
 
   useEffect(() => {
@@ -360,36 +363,19 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
   useLayoutEffect(() => {
     const el = boardRef.current;
     if (!el) {
-      prevBoardWidthRef.current = 0;
       setBoardWidth(0);
       return;
     }
     const applyWidth = () => {
       const nextWidth = el.getBoundingClientRect().width;
-      const prevWidth = prevBoardWidthRef.current;
-      prevBoardWidthRef.current = nextWidth;
       setBoardWidth(nextWidth);
-      if (!(prevWidth > 0 && nextWidth > 0) || Math.abs(prevWidth - nextWidth) < 0.5) return;
-      const groups = columnsRef.current.filter(group => group.length > 0);
-      if (groups.length <= 1) return;
-      const current = groups.map(group => Math.max(
-        ...group.map(tab => cardColumnSpan(tab, cardLayoutsRef.current, groups.length)),
-      ));
-      const absorbed = absorbShellResize(current, prevWidth, nextWidth);
-      const nextLayouts: CardLayouts = { ...cardLayoutsRef.current };
-      groups.forEach((group, index) => {
-        for (const tab of group) {
-          nextLayouts[tab] = { columnSpan: absorbed[index], customized: true };
-        }
-      });
-      persistCardLayouts(nextLayouts);
     };
     applyWidth();
     if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(applyWidth);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [visible, openCards.length, persistCardLayouts]);
+  }, [visible, openCards.length]);
 
   const persistStackFractions = useCallback((nextFractions: Record<string, number[]>) => {
     stackFractionsRef.current = nextFractions;
@@ -698,7 +684,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
       case "checkpoints":
         return <CheckpointsPane />;
       case "swarm":
-        return <SwarmPane />;
+        return <SwarmPane enabled={visible} />;
       case "economics":
         return <EconomicsPane />;
       case "review":
@@ -726,8 +712,8 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
 
   return (
     <>
-      {visible && openCards.length > 0 && (
-        <div ref={boardRef} className="right-pane-board h-full w-full overflow-y-auto">
+      {(visible || hasBeenVisible) && openCards.length > 0 && (
+        <div ref={boardRef} hidden={!visible} className="right-pane-board h-full w-full overflow-y-auto">
             {showNewColumnDrop && (
               <div
                 role="region"

--- a/webapp/src/components/RightPane.tsx
+++ b/webapp/src/components/RightPane.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState, useEffect, useLayoutEffect, useRef, useSyncExternalStore } from "react";
+import { Activity, useCallback, useState, useEffect, useLayoutEffect, useRef, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
 import { X, GripVertical } from "lucide-react";
 import StatePane from "./StatePane";
 import BrowserPane from "./BrowserPane";
@@ -265,6 +266,55 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
   stackFractionsRef.current = stackFractions;
   const boardRef = useRef<HTMLDivElement | null>(null);
   const [boardWidth, setBoardWidth] = useState(0);
+  // Stable portal hosts retain pane state when a card moves between stacks.
+  const [cardHosts] = useState(() => new Map(CANONICAL_ORDER.map(tab => {
+    const host = document.createElement("div");
+    host.className = "h-full";
+    return [tab, host] as const;
+  })));
+  // Compact sizing is presentation-only; desktop widths and stack ratios survive it.
+  const [compactHeights, setCompactHeights] = useState<Partial<Record<Tab, number>>>({});
+  const compactDragCleanup = useRef<(() => void) | null>(null);
+  useEffect(() => () => compactDragCleanup.current?.(), []);
+
+  const setCompactHeight = (tab: Tab, height: number) => {
+    const card = document.getElementById(`right-pane-card-${tab}`);
+    const minimum = card ? parseFloat(getComputedStyle(card).minHeight) || 256 : 256;
+    setCompactHeights(current => ({ ...current, [tab]: Math.max(minimum, height) }));
+  };
+  const stepCompactHeight = (tab: Tab, delta: number) => {
+    const height = compactHeights[tab] ?? document.getElementById(`right-pane-card-${tab}`)?.getBoundingClientRect().height ?? 256;
+    setCompactHeight(tab, height + delta);
+  };
+  const resizeCompactFromPointer = (event: React.PointerEvent<HTMLSpanElement>, tab: Tab) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    compactDragCleanup.current?.();
+    const handle = event.currentTarget;
+    const startHeight = document.getElementById(`right-pane-card-${tab}`)?.getBoundingClientRect().height ?? 256;
+    const startY = event.clientY;
+    const pointerId = event.pointerId;
+    handle.setPointerCapture(pointerId);
+    beginRowResize();
+    const move = (next: PointerEvent) => {
+      if (next.pointerId === pointerId) setCompactHeight(tab, startHeight + next.clientY - startY);
+    };
+    const finish = () => {
+      handle.removeEventListener("pointermove", move);
+      handle.removeEventListener("pointerup", finish);
+      handle.removeEventListener("pointercancel", finish);
+      handle.removeEventListener("lostpointercapture", finish);
+      if (handle.hasPointerCapture(pointerId)) handle.releasePointerCapture(pointerId);
+      endRowResize();
+      compactDragCleanup.current = null;
+    };
+    compactDragCleanup.current = finish;
+    handle.addEventListener("pointermove", move);
+    handle.addEventListener("pointerup", finish);
+    handle.addEventListener("pointercancel", finish);
+    handle.addEventListener("lostpointercapture", finish);
+  };
   const [hasBeenVisible, setHasBeenVisible] = useState(visible);
   useEffect(() => { if (visible) setHasBeenVisible(true); }, [visible]);
   const preferredResizeGroupRef = useRef(-1);
@@ -742,7 +792,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
                 );
                 return (
             <div
-              key={stackTabs[0]}
+              key={stackPlacement.groupIndex}
               className={`right-pane-card-stack${stackPlacement.groupIndex > 0 ? " right-pane-card-stack-join-end" : ""}`}
               style={{
                 gridColumn: stackPlacement.gridColumn,
@@ -767,6 +817,7 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
               style={{
                 gridColumn: "1",
                 gridRow: placement.gridRow,
+                ...{ "--compact-card-height": compactHeights[tabName] === undefined ? undefined : `${compactHeights[tabName]}px` },
               }}
               onDragOver={event => event.preventDefault()}
               onDrop={event => handleDrop(event, tabName)}
@@ -816,6 +867,27 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
               <header
                 className="right-pane-card-header"
               >
+                <select
+                  className="right-pane-compact-move"
+                  aria-label={`Move ${config.label} panel`}
+                  value=""
+                  onChange={event => {
+                    const target = openCards.find(tab => tab === event.target.value);
+                    if (!target) return;
+                    const stripped = columnsRef.current.map(col => col.filter(tab => tab !== tabName)).filter(col => col.length > 0);
+                    const destCol = columnIndexOf(stripped, target);
+                    const destIndex = stripped[destCol].indexOf(target);
+                    const nextCols = moveCardIntoColumn(stripped, tabName, destCol, destIndex);
+                    persistBoard(tabOrder, flattenColumns(nextCols), nextCols);
+                    requestAnimationFrame(() => document.getElementById(`right-pane-card-${tabName}`)
+                      ?.querySelector<HTMLSelectElement>(".right-pane-compact-move")?.focus());
+                  }}
+                >
+                  <option value="">Move panel</option>
+                  {openCards.filter(tab => tab !== tabName).map(tab => (
+                    <option key={tab} value={tab}>Before {TAB_CONFIG[tab].label}</option>
+                  ))}
+                </select>
                 <div className="flex items-center gap-0.5 shrink-0 ml-auto">
                   {tabName === "review" && reviews.length > 0 && <span className="right-pane-badge">{reviews.length}</span>}
                   {tabName === "swarm" && swarmRunning > 0 && <span className="right-pane-live" title={`${swarmRunning} swarm jobs running`} />}
@@ -851,7 +923,32 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
                   <button type="button" aria-label={`Close ${config.label} panel`} title={`Close ${config.label}`} onClick={() => removeCard(tabName)} onMouseDown={event => event.stopPropagation()} className="right-pane-icon-btn"><X size={12} /></button>
                 </div>
               </header>
-              <div className="right-pane-card-body">{renderCardBody(tabName)}</div>
+              <div className="right-pane-card-body" ref={element => {
+                const host = cardHosts.get(tabName);
+                if (element && host && host.parentElement !== element) {
+                  const focused = host.contains(document.activeElement) ? document.activeElement : null;
+                  element.appendChild(host);
+                  if (focused instanceof HTMLElement) focused.focus({ preventScroll: true });
+                }
+              }} />
+              <div className="right-pane-compact-controls">
+                <button type="button" aria-label={`Shorter ${config.label} panel`} onClick={() => stepCompactHeight(tabName, -48)}>Shorter</button>
+                <span
+                  role="separator"
+                  aria-orientation="horizontal"
+                  aria-label={`Resize ${config.label} panel height`}
+                  aria-valuetext={compactHeights[tabName] === undefined ? "Default height" : `${compactHeights[tabName]} pixels`}
+                  tabIndex={0}
+                  title="Drag to resize; use Up/Down arrows"
+                  onPointerDown={event => resizeCompactFromPointer(event, tabName)}
+                  onKeyDown={event => {
+                    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+                    event.preventDefault();
+                    stepCompactHeight(tabName, event.key === "ArrowDown" ? 48 : -48);
+                  }}
+                >Resize height</span>
+                <button type="button" aria-label={`Taller ${config.label} panel`} onClick={() => stepCompactHeight(tabName, 48)}>Taller</button>
+              </div>
             </section>
                 );
               })}
@@ -861,6 +958,14 @@ export default function RightPane({ visible, artifacts, onOpenWizard, initialTab
             </div>
         </div>
       )}
+      {(visible || hasBeenVisible) && openCards.map(tab => {
+        const host = cardHosts.get(tab);
+        return host ? createPortal(
+          <div className="h-full" onDragOver={event => event.preventDefault()} onDrop={event => handleDrop(event, tab)}>
+            <Activity mode={visible ? "visible" : "hidden"}>{renderCardBody(tab)}</Activity>
+          </div>, host, tab,
+        ) : null;
+      })}
       {/* Keep the expensive interactive panes alive when users close their cards. */}
       <div className="hidden" aria-hidden>
         {!openCards.includes("state") && (

--- a/webapp/src/components/ShellSurface.tsx
+++ b/webapp/src/components/ShellSurface.tsx
@@ -3,8 +3,9 @@ import { useLayoutEffect, useRef, type ReactNode } from "react";
 type Presentation = "inline" | "left" | "right" | "modal";
 
 /** Native modal focus containment without reparenting or unmounting live panes. */
-export default function ShellSurface({ visible, presentation, label, width, onClose, returnFocus, children }: {
+export default function ShellSurface({ visible, suspended = false, presentation, label, width, onClose, returnFocus, children }: {
   visible: boolean;
+  suspended?: boolean;
   presentation: Presentation;
   label: string;
   width?: number;
@@ -20,22 +21,24 @@ export default function ShellSurface({ visible, presentation, label, width, onCl
     const dialog = ref.current;
     if (!dialog) return;
     if (dialog.open) dialog.close();
-    if (visible) {
+    if (visible && !suspended) {
       if (presentation === "inline") dialog.open = true;
       else {
         const active = document.activeElement;
-        opener.current = focusTarget.current || (active instanceof HTMLElement ? active : null);
+        if (!opener.current?.isConnected) {
+          opener.current = focusTarget.current || (active instanceof HTMLElement ? active : null);
+        }
         dialog.showModal();
       }
-    } else if (opener.current?.isConnected) {
+    } else if (!visible && opener.current?.isConnected) {
       opener.current.focus();
       opener.current = null;
     }
     return () => { if (dialog.open) dialog.close(); };
-  }, [visible, presentation]);
+  }, [visible, suspended, presentation]);
 
   return <dialog ref={ref} role={presentation === "inline" ? "complementary" : "dialog"} aria-label={label} aria-modal={presentation === "inline" ? undefined : true}
-    data-shell-hidden={!visible} data-presentation={presentation}
+    data-shell-hidden={!visible || suspended} data-presentation={presentation}
     className="shell-surface" style={presentation === "inline" ? { width } : undefined}
     onCancel={(event) => { event.preventDefault(); event.stopPropagation(); onClose(); }}
     onClick={(event) => { if (event.target === event.currentTarget && presentation !== "inline") {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -734,11 +734,48 @@ nav[aria-label="Workspace views"] button { min-height: var(--shell-hit-size); }
 .shell-surface[data-presentation="right"] .right-pane-icon-btn,
 .shell-surface[data-presentation="right"] .right-pane-drag-handle { min-width: var(--shell-hit-size); min-height: var(--shell-hit-size); }
 
+.right-pane-compact-controls, .right-pane-compact-move { display: none; }
+
 /* Stack narrow boards without changing saved columns or moving mounted cards. */
 @container (max-width: 480px) {
   .right-pane-board-grid, .right-pane-card-stack { display: flex; flex-direction: column; height: auto; }
   .right-pane-card-stack { flex-shrink: 0; }
   .right-pane-icon-btn, .right-pane-drag-handle { min-width: var(--shell-hit-size); min-height: var(--shell-hit-size); }
-  .right-pane-card { min-height: 16rem; height: 50dvh; flex-shrink: 0; }
+  .right-pane-card { min-height: 16rem; height: var(--compact-card-height, 50dvh); flex-shrink: 0; }
   .right-pane-card-resize-handle, .right-pane-card-row-resize-handle { display: none; }
+}
+
+@container (max-width: 480px) {
+  .right-pane-compact-controls {
+    display: flex;
+    flex-shrink: 0;
+    align-items: stretch;
+    border-top: 1px solid var(--shell-panel-border);
+    font-size: var(--font-size-xs, 12px);
+  }
+  .right-pane-compact-controls button,
+  .right-pane-compact-controls [role="separator"] {
+    min-height: var(--shell-hit-size);
+    min-width: var(--shell-hit-size);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+  }
+  .right-pane-compact-controls [role="separator"] { cursor: row-resize; touch-action: none; }
+  .right-pane-compact-controls :focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .right-pane-compact-controls button:hover,
+  .right-pane-compact-controls [role="separator"]:hover { background: var(--shell-panel); }
+}
+
+@container (max-width: 480px) {
+  .right-pane-compact-move {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+    min-height: var(--shell-hit-size);
+    background: var(--shell-panel);
+    color: inherit;
+  }
+  .right-pane-compact-move:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -705,7 +705,7 @@ body.is-row-resizing iframe {
 .session-rail [data-session-row] > .flex { width: 100%; }
 .session-rail [data-session-row] .text-faint { font-family: inherit; font-size: var(--shell-rail-detail-size); color: theme('colors.muted'); }
 .session-context-menu { max-width: calc(100vw - 16px); max-height: calc(100dvh - 16px); overflow-y: auto; }
-@media (max-width: 799px) {
+@media (max-width: 639px) {
   html { font-size: 14px; }
   .session-rail [data-session-row], .session-context-menu button { min-height: var(--shell-hit-size); }
 }
@@ -725,3 +725,20 @@ nav[aria-label="Workspace views"] button { min-height: var(--shell-hit-size); }
 }
 .shell-surface-header h2 { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .shell-surface-header button { flex-shrink: 0; }
+
+.panel-chooser-drawer { flex-shrink: 0; border-bottom: 1px solid var(--shell-panel-border); }
+.panel-chooser-drawer > button { min-height: var(--shell-hit-size); }
+.panel-chooser-options { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); max-height: 35dvh; overflow-y: auto; padding: 4px; }
+.panel-chooser-options button { min-height: var(--shell-hit-size); }
+.panel-chooser-options button:focus-visible { outline: 1px solid currentColor; outline-offset: -2px; }
+.shell-surface[data-presentation="right"] .right-pane-icon-btn,
+.shell-surface[data-presentation="right"] .right-pane-drag-handle { min-width: var(--shell-hit-size); min-height: var(--shell-hit-size); }
+
+/* Stack narrow boards without changing saved columns or moving mounted cards. */
+@container (max-width: 480px) {
+  .right-pane-board-grid, .right-pane-card-stack { display: flex; flex-direction: column; height: auto; }
+  .right-pane-card-stack { flex-shrink: 0; }
+  .right-pane-icon-btn, .right-pane-drag-handle { min-width: var(--shell-hit-size); min-height: var(--shell-hit-size); }
+  .right-pane-card { min-height: 16rem; height: 50dvh; flex-shrink: 0; }
+  .right-pane-card-resize-handle, .right-pane-card-row-resize-handle { display: none; }
+}

--- a/webapp/src/lib/railLayout.ts
+++ b/webapp/src/lib/railLayout.ts
@@ -35,7 +35,7 @@ export function reclampRailWidths(
   const availableWidth = Math.max(0, innerWidth - chrome);
   const preferredLeft = leftOpen ? clamp(leftW, LEFT_MIN_W, LEFT_MAX_W) : 0;
   const preferredRight = rightOpen ? Math.max(RIGHT_MIN_W, rightW) : 0;
-  const requiredRails = (leftOpen ? LEFT_MIN_W : 0) + (rightOpen ? RIGHT_MIN_W : 0);
+  const requiredRails = (leftOpen ? LEFT_MIN_W : 0) + (rightOpen ? RIGHT_COMPACT_MIN_W : 0);
   const centerWidth = Math.min(MIN_CENTER_W, Math.max(0, availableWidth - requiredRails));
   const railBudget = Math.max(0, availableWidth - centerWidth);
 
@@ -62,7 +62,7 @@ export function reclampRailWidths(
     };
   }
 
-  const rightMin = Math.min(RIGHT_MIN_W, railBudget);
+  const rightMin = Math.min(RIGHT_COMPACT_MIN_W, railBudget);
   return {
     leftW,
     rightW: clamp(preferredRight, rightMin, railBudget),

--- a/webapp/src/lib/settingsOverlay.ts
+++ b/webapp/src/lib/settingsOverlay.ts
@@ -1,15 +1,23 @@
 /** Latch so Settings survives RightPane remounts and right-rail collapse. */
 
 let settingsOverlayOpen = false;
+const listeners = new Set<() => void>();
+
+export function subscribeSettingsOverlay(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
 
 export function isSettingsOverlayOpen(): boolean {
   return settingsOverlayOpen;
 }
 
 export function setSettingsOverlayOpen(open: boolean): void {
+  if (settingsOverlayOpen === open) return;
   settingsOverlayOpen = open;
+  listeners.forEach(listener => listener());
 }
 
 export function resetSettingsOverlay(): void {
-  settingsOverlayOpen = false;
+  setSettingsOverlayOpen(false);
 }

--- a/webapp/src/lib/useResponsiveShell.ts
+++ b/webapp/src/lib/useResponsiveShell.ts
@@ -1,15 +1,14 @@
 import { useCallback, useEffect, useRef, useState, type SetStateAction } from "react";
 
-import { LEFT_MIN_W, MIN_CENTER_W, RAIL_GUTTER_W, RIGHT_MIN_W } from "./railLayout";
+import { LEFT_MIN_W, MIN_CENTER_W, RAIL_GUTTER_W, RIGHT_COMPACT_MIN_W } from "./railLayout";
 
-const CONTENT_MIN_W = 480;
 const DOCK_W = 68;
 const SHELL_FRAME_W = 4;
-export const DUAL_RAIL_SHELL_WIDTH = CONTENT_MIN_W + DOCK_W + LEFT_MIN_W + RIGHT_MIN_W
+export const DUAL_RAIL_SHELL_WIDTH = MIN_CENTER_W + DOCK_W + LEFT_MIN_W + RIGHT_COMPACT_MIN_W
   + 2 * RAIL_GUTTER_W + SHELL_FRAME_W;
-export const COMPACT_SHELL_WIDTH = 800;
-// railLayout already budgets MIN_CENTER_W and two pixels of frame.
-export const SHELL_EXTRA_CENTER_W = CONTENT_MIN_W + DOCK_W - MIN_CENTER_W + SHELL_FRAME_W - 2;
+export const COMPACT_SHELL_WIDTH = 640;
+// railLayout budgets the chat column and two pixels of frame already.
+export const SHELL_EXTRA_CENTER_W = DOCK_W + SHELL_FRAME_W - 2;
 export type ShellView = "chat" | "left" | "right";
 
 export function useResponsiveShell(initialLeft: boolean, initialRight: boolean) {
@@ -19,6 +18,9 @@ export function useResponsiveShell(initialLeft: boolean, initialRight: boolean) 
   const [desktopRightOpen, setDesktopRightOpen] = useState(initialRight);
   const [view, setView] = useState<ShellView>("chat");
   const compact = width < COMPACT_SHELL_WIDTH;
+  const singleRail = width < DUAL_RAIL_SHELL_WIDTH;
+  const leftOpen = compact ? view === "left" : desktopLeftOpen && (!singleRail || !desktopRightOpen || view === "left");
+  const rightOpen = compact ? view === "right" : desktopRightOpen && (!singleRail || !desktopLeftOpen || view !== "left");
   useEffect(() => {
     const resize = () => {
       const next = window.innerWidth;
@@ -32,23 +34,32 @@ export function useResponsiveShell(initialLeft: boolean, initialRight: boolean) 
     return () => window.removeEventListener("resize", resize);
   }, []);
   const setLeftOpen = useCallback((action: SetStateAction<boolean>) => {
-    if (!compact) { setDesktopLeftOpen(action); return; }
+    if (!compact) {
+      const open = typeof action === "function" ? action(leftOpen) : action;
+      setDesktopLeftOpen(open);
+      if (open) setView("left");
+      return;
+    }
     setView(previous => {
       const open = typeof action === "function" ? action(previous === "left") : action;
       return open ? "left" : previous === "left" ? "chat" : previous;
     });
-  }, [compact]);
+  }, [compact, leftOpen]);
   const setRightOpen = useCallback((action: SetStateAction<boolean>) => {
-    if (!compact) { setDesktopRightOpen(action); return; }
+    if (!compact) {
+      const open = typeof action === "function" ? action(rightOpen) : action;
+      setDesktopRightOpen(open);
+      if (open) setView("right");
+      return;
+    }
     setView(previous => {
       const open = typeof action === "function" ? action(previous === "right") : action;
       return open ? "right" : previous === "right" ? "chat" : previous;
     });
-  }, [compact]);
+  }, [compact, rightOpen]);
   return {
-    width, compact, rightDrawer: width < DUAL_RAIL_SHELL_WIDTH, view, setView, desktopLeftOpen, desktopRightOpen,
-    leftOpen: compact ? view === "left" : desktopLeftOpen,
-    rightOpen: compact ? view === "right" : desktopRightOpen,
+    width, compact, rightDrawer: compact, view, setView, desktopLeftOpen, desktopRightOpen,
+    leftOpen, rightOpen,
     setLeftOpen, setRightOpen,
   };
 }


### PR DESCRIPTION
Opening Panels in a half-screen desktop window made chat and the outside dock inert, so adding Browser beside Swarm required closing the drawer first. Panels now stay inline at widths of 640px and above, and narrower drawers include their own Add panel chooser.

Narrow cards have height controls for dragging, arrow keys, and Shorter/Taller buttons, plus a Move panel selector. Resizing preserves desktop column proportions; moving cards retains their React state. Hidden card effects pause while their state is retained. Settings suspends the drawer and restores it on close. The Puppetmaster pin remains 1.23.0.

Validation: 7105 backend, 2011 frontend, 308 Electron, version consistency, and production build pass. Live checks cover Swarm-to-Browser addition without closing, physical height changes with buttons/keyboard/drag, moving and removing cards, Settings handoff, polling pause, and state retention at 360/400/639/640/800/1019/1280px. Final commit 5fd3f2a0 requires fresh green CI before release tagging.
