### PR TITLE
Bound desktop metadata requests and JSON response handling

### DIFF
--- a/webapp/electron/backend-transport.test.cjs
+++ b/webapp/electron/backend-transport.test.cjs
@@ -9,6 +9,7 @@ const { EventEmitter } = require('node:events');
 function seam(port, client = http) {
   const source = fs.readFileSync(__dirname + '/main.cjs', 'utf8');
   const context = vm.createContext({ http: client, Buffer, setTimeout, backendPort: port,
+    ipcMain: { on() {}, handle() {} },
     harnessToken: '', startInFlight: null, tryRefreshBackendPortFromMarker() {},
     require: (name) => require(require('node:path').resolve(__dirname, name)),
   });
@@ -20,6 +21,7 @@ async function fixture(t, handler) {
     return seam(0, { request(options, callback) {
       const req = new EventEmitter();
       req.write = () => {};
+      req.destroy = () => {};
       req.end = () => queueMicrotask(() => {
         const res = new PassThrough();
         res.statusCode = 200;
@@ -86,6 +88,7 @@ for (const code of ['ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT']) {
     const ctx = seam(0, { request(_options, callback) {
       const req = new EventEmitter();
       req.write = () => {};
+      req.destroy = () => {};
       req.end = () => queueMicrotask(() => {
         attempts++;
         if (attempts === 1) req.emit('error', Object.assign(new Error(code), {code}));
@@ -111,6 +114,7 @@ test('response abort rejects instead of hanging or resolving partial data', asyn
   const ctx = seam(0, { request(_options, callback) {
     const req = new EventEmitter();
     req.write = () => {};
+    req.destroy = () => {};
     req.end = () => queueMicrotask(() => {
       const res = Object.assign(new PassThrough(), {statusCode:200, headers:{}});
       callback(res);

--- a/webapp/electron/endpoint-transport.test.cjs
+++ b/webapp/electron/endpoint-transport.test.cjs
@@ -40,11 +40,15 @@ test('actual preload/main IPC passes only identity headers for JSON, upload and 
   const identity={'X-Harness-Protocol':'1','X-Harness-Endpoint':'endpoint','X-Harness-Boot':'boot','X-Harness-Token':'forbidden','Other':'ignored'};
   const bridge=exposed.harnessIPC;
   assert.equal(bridge.endpointHeaders,true);
+  assert.throws(() => bridge.requestJSON('DELETE','/write',{},'correlation',identity), /Unsupported JSON request method/);
+  assert.equal(requests.length,0);
   await bridge.requestJSON('POST','/write',{},'correlation',identity);
   await bridge.uploadFile({name:'a.txt',type:'text/plain',bytes:Buffer.from('a')},identity);
   await new Promise((resolve,reject)=>bridge.stream('/stream',()=>{},resolve,reject,identity));
   assert.equal(requests.length,3);
   for(const request of requests){
+    assert.equal(request.host,'127.0.0.1');
+    assert.equal(request.port,1);
     assert.equal(request.headers['X-Harness-Endpoint'],'endpoint');
     assert.equal(request.headers['X-Harness-Boot'],'boot');
     assert.equal(request.headers['X-Harness-Protocol'],'1');

--- a/webapp/electron/job-metadata-policy.cjs
+++ b/webapp/electron/job-metadata-policy.cjs
@@ -1,0 +1,31 @@
+const {parse} = require('node:url');
+
+const policies = new Map([
+  ['GET /api/jobs/metadata', 64],
+  ['GET /api/jobs/metadata/detail', 96],
+  ['GET /api/jobs/metadata/local', 32],
+  ['GET /api/jobs/metadata/local/detail', 32],
+  ['GET /api/jobs/metadata/view', 16],
+  ['POST /api/jobs/metadata/pins', 64],
+  ['POST /api/jobs/metadata/view/refresh', 16],
+].map(([route, kib]) => [route, Object.freeze({
+  maxRequestBytes: 64 * 1024,
+  maxResponseBytes: kib * 1024,
+  timeoutMs: 30000,
+})]));
+
+function jobMetadataPolicy(method, apiPath) {
+  // Match Handler's urlparse(...).path: no dot resolution or escape decoding,
+  // and final-segment parameters are separate from the path. Python's HTTP
+  // handler also collapses leading slashes before routing. Invalid input is
+  // left to the request helper's sanitized transport errors.
+  if (typeof apiPath !== 'string') return undefined;
+  try {
+    const pathname = parse(apiPath.replace(/^\/{2,}/, '/')).pathname;
+    return policies.get(`${method} ${pathname?.replace(/;[^/]*$/, '')}`);
+  } catch {
+    return undefined;
+  }
+}
+
+module.exports = {jobMetadataPolicy};

--- a/webapp/electron/job-metadata.test.cjs
+++ b/webapp/electron/job-metadata.test.cjs
@@ -1,0 +1,347 @@
+const {test} = require('node:test');
+const assert = require('node:assert/strict');
+const {EventEmitter} = require('node:events');
+const {PassThrough} = require('node:stream');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+const {MAX_JSON_BYTES, JSON_TIMEOUT_MS} = require('./json-request.cjs');
+
+const routes = [
+  ['GET', '/api/jobs/metadata', 64 * 1024],
+  ['GET', '/api/jobs/metadata/detail', 96 * 1024],
+  ['GET', '/api/jobs/metadata/local', 32 * 1024],
+  ['GET', '/api/jobs/metadata/local/detail', 32 * 1024],
+  ['GET', '/api/jobs/metadata/view', 16 * 1024],
+  ['POST', '/api/jobs/metadata/pins', 64 * 1024],
+  ['POST', '/api/jobs/metadata/view/refresh', 16 * 1024],
+];
+function client(serve) {
+  const calls = [];
+  return {calls, request(options, callback) {
+    const req = new EventEmitter();
+    req.destroy = () => {req.destroyed = true;};
+    req.write = body => {req.body = body;};
+    req.end = () => queueMicrotask(() => serve(req, callback));
+    calls.push({req, options});
+    return req;
+  }};
+}
+function response(callback, headers = {}) {
+  const res = Object.assign(new PassThrough(), {statusCode:200, headers});
+  callback(res);
+  return res;
+}
+function seam(http, overrides) {
+  const handlers = new Map(), selected = [];
+  const source = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8');
+  const context = vm.createContext({http, Buffer, setTimeout, clearTimeout,
+    backendPort:32123, harnessToken:'main-owned', startInFlight:null,
+    tryRefreshBackendPortFromMarker() {throw new Error('metadata must not enter legacy retry wait');},
+    require(name) {
+      const mod = require(path.resolve(__dirname, name));
+      if (name !== './json-request.cjs') return mod;
+      return {...mod, requestJSONOnce(options, body, deps) {
+        selected.push({...deps});
+        return mod.requestJSONOnce(options, body, {...deps, ...overrides});
+      }};
+    },
+    ipcMain:{handle:(name, fn) => handlers.set(name, fn), on(){}},
+  });
+  vm.runInContext(source.slice(source.indexOf('function authToken()'), source.indexOf('ipcMain.handle("secrets:save"')), context);
+  return {context, selected, invoke(method, apiPath, body, options = {}) {
+    const fn = handlers.get(`harness:${method === 'GET' ? 'getJSON' : 'postJSON'}`);
+    return fn({}, apiPath, ...(method === 'GET' ? [{responseEnvelope:true, ...options}] : [body, {responseEnvelope:true, ...options}]));
+  }};
+}
+function jsonBytes(size) {return Buffer.from('"' + 'é'.repeat((size - 2) / 2) + '"');}
+
+for (const [method, apiPath, cap] of routes) {
+  for (const declared of [true, false]) {
+    test(`main rejects ${declared ? 'declared' : 'chunked'} overflow: ${method} ${apiPath}`, async () => {
+      let res;
+      const transport = client((req, cb) => {
+        res = response(cb, declared ? {'content-length':String(cap + 1)} : {});
+        if (!res.destroyed) res.end(Buffer.alloc(cap + 1, 32));
+      });
+      const result = await seam(transport).invoke(method, apiPath, {});
+      assert.equal(result.code, 'JSON_RESPONSE_TOO_LARGE');
+      assert.equal(transport.calls.length, 1);
+      assert.equal(transport.calls[0].req.destroyed, true);
+      assert.equal(res.destroyed, true);
+      if (declared) assert.equal(res.listenerCount('data'), 0, 'declared overflow refused before body collection');
+    });
+  }
+  test(`main accepts UTF-8 JSON exactly at cap: ${method} ${apiPath}`, async () => {
+    const bytes = jsonBytes(cap);
+    const transport = client((_req, cb) => {
+      const res = response(cb, {'content-length':String(bytes.length)});
+      res.write(bytes.subarray(0, 2)); // Split the first multibyte character.
+      res.end(bytes.subarray(2));
+    });
+    const actual = seam(transport);
+    const result = await actual.invoke(method, apiPath, {});
+    assert.equal(result.kind, 'response');
+    assert.equal(Buffer.byteLength(result.text), cap);
+    assert.equal(JSON.parse(result.text), 'é'.repeat((cap - 2) / 2));
+    assert.equal(actual.selected[0].maxResponseBytes, cap);
+    assert.equal(actual.selected[0].timeoutMs, 30000);
+  });
+}
+
+test('legacy transcript and bundle verification retain 64 MiB and 120 seconds', async () => {
+  for (const apiPath of ['/api/sessions/history', '/api/bundles/verify']) {
+    const bytes = jsonBytes(9 * 1024 * 1024);
+    const transport = client((_req, cb) => response(cb).end(bytes));
+    const actual = seam(transport);
+    assert.equal((await actual.invoke('POST', apiPath, {offer:'a'.repeat(5 * 1024 * 1024)})).kind, 'response');
+    assert.equal(actual.selected[0].maxResponseBytes ?? MAX_JSON_BYTES, 64 * 1024 * 1024);
+    assert.equal(actual.selected[0].timeoutMs ?? JSON_TIMEOUT_MS, 120000);
+  }
+});
+
+for (const [method, apiPath, cap] of routes) {
+  test(`query pathname selects main policy and preserves identity: ${apiPath}`, async () => {
+    const transport = client((_req, cb) => response(cb, {'x-correlation-id':'server-correlation'}).end('{}'));
+    const actual = seam(transport);
+    const queryPath = apiPath + '?scope=a%2Fb&next=/api/sessions/history';
+    const result = await actual.invoke(method, queryPath, {}, {
+      correlationId:'request-correlation',
+      identityHeaders:{'X-Harness-Protocol':'1', 'X-Harness-Endpoint':'endpoint', 'X-Harness-Boot':'boot',
+        'X-Harness-Token':'renderer-secret', 'Untrusted':'ignored'},
+      maxBytes:Infinity, maxResponseBytes:Infinity, maxRequestBytes:Infinity, timeoutMs:120000,
+      policy:{maxResponseBytes:Infinity, timeoutMs:120000},
+    });
+    assert.equal(result.correlationId, 'server-correlation');
+    assert.equal(actual.selected[0].maxResponseBytes, cap);
+    assert.equal(actual.selected[0].timeoutMs, 30000);
+    assert.equal(transport.calls[0].options.path, queryPath);
+    assert.deepEqual(transport.calls[0].options.headers, {
+      'X-Harness-Protocol':'1', 'X-Harness-Endpoint':'endpoint', 'X-Harness-Boot':'boot',
+      'Content-Type':'application/json', 'X-Harness-Token':'main-owned',
+      'X-Correlation-Id':'request-correlation', ...(method === 'POST' ? {'Content-Length':2} : {}),
+    });
+  });
+}
+
+test('renderer options cannot enlarge the enforced response cap', async () => {
+  const transport = client((_req, cb) => response(cb).end(Buffer.alloc(16 * 1024 + 1)));
+  const result = await seam(transport).invoke('GET', '/api/jobs/metadata/view?job_id=x', undefined, {
+    maxBytes:Infinity, maxResponseBytes:Infinity, timeoutMs:Infinity,
+    policy:{maxResponseBytes:Infinity},
+  });
+  assert.equal(result.code, 'JSON_RESPONSE_TOO_LARGE');
+});
+
+for (const apiPath of ['/api/jobs/metadata/pins', '/api/jobs/metadata/view/refresh']) {
+  test(`64 KiB UTF-8 request cap is independent of response cap: ${apiPath}`, async () => {
+    const transport = client((_req, cb) => response(cb).end('{}'));
+    const actual = seam(transport);
+    const body = 'é'.repeat((64 * 1024 - 2) / 2);
+    assert.equal((await actual.invoke('POST', apiPath, body)).kind, 'response');
+    assert.equal(transport.calls[0].options.headers['Content-Length'], 64 * 1024);
+    assert.equal(Buffer.byteLength(transport.calls[0].req.body), 64 * 1024);
+    assert.equal(actual.selected[0].maxRequestBytes, 64 * 1024);
+    const tooLarge = await actual.invoke('POST', apiPath, body + 'x', {maxRequestBytes:Infinity, maxBytes:Infinity});
+    assert.equal(tooLarge.code, 'JSON_REQUEST_TOO_LARGE');
+    assert.equal(transport.calls.length, 1, 'oversized request refused before socket creation');
+  });
+}
+
+test('refresh accepts a 64 KiB request but rejects a response above 16 KiB', async () => {
+  const transport = client((_req, cb) => response(cb).end(jsonBytes(16 * 1024 + 2)));
+  const result = await seam(transport).invoke('POST', '/api/jobs/metadata/view/refresh', 'x'.repeat(64 * 1024 - 2));
+  assert.equal(result.code, 'JSON_RESPONSE_TOO_LARGE');
+  assert.match(result.message, /write may have completed/);
+  assert.equal(transport.calls[0].options.headers['Content-Length'], 64 * 1024);
+});
+
+for (const apiPath of [
+  '/api/jobs/metadata-extra', '/api/jobs/metadata/', '/api/jobs/metadata/detail/extra',
+  '/api/jobs/%6detadata', '/api/other/../jobs/metadata', '/api/sessions/history?next=/api/jobs/metadata',
+]) {
+  test(`policy does not reinterpret the transmitted pathname: ${apiPath}`, async () => {
+    const actual = seam(client((_req, cb) => response(cb).end('{}')));
+    assert.equal((await actual.invoke('GET', apiPath)).kind, 'response');
+    assert.equal(actual.selected[0].maxResponseBytes, undefined);
+    assert.equal(actual.selected[0].timeoutMs, undefined);
+  });
+}
+
+test('method mismatch does not acquire a metadata policy', async () => {
+  for (const [method, apiPath] of [['POST', '/api/jobs/metadata'], ['GET', '/api/jobs/metadata/pins']]) {
+    const actual = seam(client((_req, cb) => response(cb).end('{}')));
+    assert.equal((await actual.invoke(method, apiPath, {})).kind, 'response');
+    assert.equal(actual.selected[0].maxResponseBytes, undefined);
+  }
+});
+
+test('invalid paths cannot leak URL parser or HTTP validation errors', async () => {
+  const http = require('node:http');
+  for (const apiPath of ['/api/jobs/metadata?secret=\u0000', 'http://[secret\u0100', {secret:'private'}]) {
+    const result = await seam(http).invoke('POST', apiPath, {});
+    assert.equal(result.kind, 'connection-error');
+    assert.equal(result.code, 'JSON_REQUEST_INVALID');
+    assert.doesNotMatch(result.message, /secret|private|http:|\[|\u0000/);
+  }
+});
+
+for (const method of ['GET', 'POST']) {
+  for (const stage of ['headers', 'body', 'endless chunks']) {
+    test(`metadata ${method} deadline covers ${stage} and ignores late callbacks`, async () => {
+      let res, callback, interval;
+      const transport = client((_req, cb) => {
+        callback = cb;
+        if (stage === 'headers') return;
+        res = response(cb);
+        res.write('{');
+        if (stage === 'endless chunks') interval = setInterval(() => res.write(' '), 2);
+      });
+      const actual = seam(transport, {timeoutMs:25});
+      actual.context.startInFlight = new Promise(() => {});
+      try {
+        const started = Date.now();
+        const result = await actual.invoke(method, method === 'GET' ? '/api/jobs/metadata' : '/api/jobs/metadata/view/refresh', {}, {retries:999, timeoutMs:Infinity});
+        assert.equal(result.code, 'JSON_REQUEST_TIMEOUT');
+        assert.equal(actual.selected[0].timeoutMs, 30000, 'actual main policy before test-only deadline injection');
+        assert.ok(Date.now() - started < 1000);
+        assert.equal(transport.calls.length, 1);
+        assert.equal(transport.calls[0].req.destroyed, true);
+        if (method === 'POST') assert.match(result.message, /write may have completed/);
+        if (!res) res = response(callback);
+        assert.equal(res.destroyed, true);
+        res.emit('error', new Error('late private response'));
+        res.emit('aborted');
+        res.emit('data', Buffer.alloc(100));
+        res.emit('end');
+        transport.calls[0].req.emit('error', new Error('late private request'));
+        await new Promise(resolve => setImmediate(resolve));
+        assert.equal(transport.calls.length, 1);
+      } finally {clearInterval(interval);}
+    });
+  }
+}
+
+for (const method of ['GET', 'POST']) {
+  test(`metadata ${method} transient failure does not wait for restart or replay`, async () => {
+    const transport = client(req => req.emit('error', Object.assign(new Error('private URL token'), {code:'ECONNRESET'})));
+    const actual = seam(transport);
+    actual.context.startInFlight = new Promise(() => {});
+    const result = await actual.invoke(method, method === 'GET' ? '/api/jobs/metadata/local' : '/api/jobs/metadata/view/refresh', {});
+    assert.equal(result.code, 'ECONNRESET');
+    assert.doesNotMatch(result.message, /private|URL|token/);
+    assert.equal(transport.calls.length, 1);
+  });
+}
+
+test('huge declared metadata body is refused without receiving data', async () => {
+  let res;
+  const transport = client((_req, cb) => {res = response(cb, {'content-length':String(2 ** 40)});});
+  const result = await seam(transport).invoke('GET', '/api/jobs/metadata');
+  assert.equal(result.code, 'JSON_RESPONSE_TOO_LARGE');
+  assert.equal(res.listenerCount('data'), 0);
+  assert.equal(res.destroyed, true);
+});
+
+
+test('malformed URL and non-string policy lookup never throws', () => {
+  const {jobMetadataPolicy} = require('./job-metadata-policy.cjs');
+  for (const apiPath of ['http://[secret', undefined, null, {}, 3]) {
+    assert.equal(jobMetadataPolicy('GET', apiPath), undefined);
+  }
+});
+
+test('real loopback metadata bounds through actual main IPC', {timeout:10000}, async t => {
+  const http = require('node:http');
+  const received = [], sockets = new Set();
+  const server = http.createServer((req, res) => {
+    const call = {url:req.url, method:req.method, headers:req.headers, bytes:0};
+    received.push(call);
+    req.on('data', chunk => {call.bytes += chunk.length;});
+    req.on('end', () => {
+      const mode = req.headers['x-correlation-id'];
+      const cap = Number(new URL(req.url, 'http://localhost').searchParams.get('cap'));
+      if (mode === 'headers') return;
+      if (mode === 'trickle') {
+        res.writeHead(200, {'Content-Type':'application/json'});
+        res.write('{');
+        const interval = setInterval(() => res.write(' '), 5);
+        res.on('close', () => clearInterval(interval));
+        return;
+      }
+      if (mode === 'declared') {
+        res.writeHead(200, {'Content-Length':String(cap + 1)});
+        res.flushHeaders();
+        return;
+      }
+      if (mode === 'chunked') {
+        res.writeHead(200, {'Transfer-Encoding':'chunked'});
+        res.write(Buffer.alloc(cap, 32));
+        res.end('x');
+        return;
+      }
+      const body = jsonBytes(cap);
+      res.writeHead(200, {'Content-Length':body.length, 'X-Correlation-Id':'loopback-correlation'});
+      res.write(body.subarray(0, 2));
+      res.end(body.subarray(2));
+    });
+  });
+  server.on('connection', socket => {sockets.add(socket); socket.on('close', () => sockets.delete(socket));});
+  t.after(() => {for (const socket of sockets) socket.destroy(); return new Promise(resolve => server.close(resolve));});
+  try {
+    await new Promise((resolve, reject) => {server.once('error', reject); server.listen(0, '127.0.0.1', resolve);});
+  } catch (error) {
+    if (['EPERM', 'EACCES'].includes(error.code) && process.env.REQUIRE_LOCAL_HTTP !== '1') {
+      t.skip(`Local HTTP bind unavailable (${error.code}); rerun REQUIRE_LOCAL_HTTP=1 node --test webapp/electron/job-metadata.test.cjs`);
+      return;
+    }
+    throw error;
+  }
+  const actual = seam(http);
+  actual.context.backendPort = server.address().port;
+  for (const [method, apiPath, cap] of routes) {
+    for (const mode of ['declared', 'chunked', 'exact']) {
+      const count = received.length;
+      const result = await actual.invoke(method, `${apiPath}?cap=${cap}`, method === 'POST' ? 'é'.repeat((64 * 1024 - 2) / 2) : undefined, {
+        correlationId:mode,
+        identityHeaders:{'X-Harness-Protocol':'1', 'X-Harness-Endpoint':'endpoint', 'X-Harness-Boot':'boot', 'X-Harness-Token':'forbidden'},
+      });
+      assert.equal(received.length, count + 1);
+      if (mode === 'exact') {
+        assert.equal(Buffer.byteLength(result.text), cap);
+        assert.equal(result.correlationId, 'loopback-correlation');
+        assert.equal(JSON.parse(result.text), 'é'.repeat((cap - 2) / 2));
+      } else assert.equal(result.code, 'JSON_RESPONSE_TOO_LARGE');
+      const call = received.at(-1);
+      assert.equal(call.headers['x-harness-token'], 'main-owned');
+      assert.equal(call.headers['x-harness-endpoint'], 'endpoint');
+      assert.equal(call.headers['x-harness-boot'], 'boot');
+      assert.equal(call.headers['x-harness-protocol'], '1');
+      assert.equal(call.bytes, method === 'POST' ? 64 * 1024 : 0);
+      assert.equal(actual.selected.at(-1).timeoutMs, 30000);
+    }
+  }
+  const short = seam(http, {timeoutMs:80});
+  short.context.backendPort = server.address().port;
+  for (const mode of ['headers', 'trickle']) {
+    const count = received.length;
+    const result = await short.invoke('POST', '/api/jobs/metadata/view/refresh', {}, {correlationId:mode, retries:20});
+    assert.equal(result.code, 'JSON_REQUEST_TIMEOUT');
+    assert.match(result.message, /write may have completed/);
+    assert.equal(short.selected.at(-1).timeoutMs, 30000);
+    assert.equal(received.length, count + 1, 'refresh executed once');
+  }
+  const count = received.length;
+  assert.equal((await actual.invoke('POST', '/api/jobs/metadata/view/refresh', 'é'.repeat(32 * 1024))).code, 'JSON_REQUEST_TOO_LARGE');
+  assert.equal(received.length, count, 'oversized request never reaches loopback');
+});
+
+for (const [method, apiPath, cap] of routes) {
+  for (const routedPath of [apiPath + ';ignored?scope=all', '/' + apiPath]) {
+    test(`backend pathname aliases retain metadata bounds: ${method} ${routedPath}`, async () => {
+      const transport = client((_req, cb) => response(cb).end(Buffer.alloc(cap + 1)));
+      const result = await seam(transport).invoke(method, routedPath, {});
+      assert.equal(result.code, 'JSON_RESPONSE_TOO_LARGE');
+    });
+  }
+}

--- a/webapp/electron/json-request.cjs
+++ b/webapp/electron/json-request.cjs
@@ -1,0 +1,120 @@
+const http = require('node:http');
+const {performance} = require('node:perf_hooks');
+
+// General JSON includes unpaginated transcripts, not just 5 MiB bundle Offers.
+// Keep headroom above the backend's configurable 8 MiB request default.
+const MAX_JSON_BYTES = 64 * 1024 * 1024;
+const JSON_TIMEOUT_MS = 120000;
+const SLAB_BYTES = 64 * 1024;
+const messages = {
+  JSON_REQUEST_CANCELLED: 'JSON read was cancelled.',
+  JSON_REQUEST_TOO_LARGE: 'JSON request exceeds the desktop byte limit. Reduce the payload or use a file/CLI transfer.',
+  JSON_RESPONSE_TOO_LARGE: 'JSON response exceeds the desktop byte limit. Use a smaller query or file/CLI export.',
+  JSON_REQUEST_INVALID: 'Unable to serialize or send the JSON request. Check the request input.',
+  JSON_REQUEST_TIMEOUT: 'Backend JSON request exceeded its deadline. Check backend health.',
+  JSON_RESPONSE_LENGTH: 'Backend JSON response length is inconsistent. Check backend health.',
+};
+function failure(code, method) {
+  let message = messages[code] || 'Backend JSON connection failed. Check backend health.';
+  if (method !== 'GET' && method !== 'HEAD' && !['JSON_REQUEST_TOO_LARGE', 'JSON_REQUEST_INVALID'].includes(code)) {
+    message += ' The write may have completed; check its status before trying again.';
+  }
+  return Object.assign(new Error(message), {code});
+}
+function connectionCode(error) {
+  return ['ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT'].includes(error?.code)
+    ? error.code : 'JSON_CONNECTION_ERROR';
+}
+
+/** One request, no replay. Policy is main-owned and never accepted over IPC. */
+function requestJSONOnce(options, body, {
+  request = http.request, maxBytes = MAX_JSON_BYTES, timeoutMs = JSON_TIMEOUT_MS,
+  maxRequestBytes = maxBytes, maxResponseBytes = maxBytes, signal,
+} = {}) {
+  const deadline = performance.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    let req, res, timer, settled = false, size = 0, used = 0;
+    let slabs = [], slab;
+    const finish = (error, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', abort);
+      slabs = [];
+      slab = undefined;
+      if (error) {
+        reject(error);
+        res?.destroy();
+        req?.destroy();
+      } else resolve(value);
+    };
+    const fail = code => finish(failure(code, options.method));
+    const abort = () => fail('JSON_REQUEST_CANCELLED');
+    const expired = () => {
+      if (performance.now() < deadline) return false;
+      fail('JSON_REQUEST_TIMEOUT');
+      return true;
+    };
+    try {
+      if (signal?.aborted) { abort(); return; }
+      signal?.addEventListener('abort', abort, {once: true});
+      const data = body === undefined ? undefined : JSON.stringify(body);
+      const bytes = data === undefined ? 0 : Buffer.byteLength(data);
+      if (bytes > maxRequestBytes) { fail('JSON_REQUEST_TOO_LARGE'); return; }
+      if (expired()) return;
+      timer = setTimeout(() => fail('JSON_REQUEST_TIMEOUT'), Math.max(1, deadline - performance.now()));
+      req = request({...options, headers:{...options.headers,
+        ...(data !== undefined ? {'Content-Length':bytes} : {}),
+      }}, response => {
+        res = response;
+        res.on('error', error => fail(connectionCode(error)));
+        res.on('aborted', () => fail('ECONNRESET'));
+        if (settled) { res.destroy(); return; }
+        if (expired()) return;
+        // HEAD/204/304 may describe a representation without sending its body.
+        const hasBody = options.method !== 'HEAD' && ![204, 304].includes(res.statusCode);
+        const declared = hasBody ? res.headers['content-length'] : undefined;
+        if (declared !== undefined && (!/^\d+$/.test(String(declared)) || !Number.isSafeInteger(Number(declared)))) {
+          fail('JSON_RESPONSE_LENGTH'); return;
+        }
+        if (declared !== undefined && Number(declared) > maxResponseBytes) {
+          fail('JSON_RESPONSE_TOO_LARGE'); return;
+        }
+        res.on('data', chunk => {
+          if (settled || expired()) return;
+          size += chunk.length;
+          if (size > maxResponseBytes) { fail('JSON_RESPONSE_TOO_LARGE'); return; }
+          // Slabs also bound bookkeeping when the backend sends tiny chunks.
+          let offset = 0;
+          while (offset < chunk.length) {
+            if (!slab || used === slab.length) {
+              slab = Buffer.allocUnsafe(Math.min(SLAB_BYTES, maxResponseBytes));
+              slabs.push(slab);
+              used = 0;
+            }
+            const take = Math.min(slab.length - used, chunk.length - offset);
+            chunk.copy(slab, used, offset, offset + take);
+            used += take;
+            offset += take;
+          }
+        });
+        res.on('end', () => {
+          if (settled || expired()) return;
+          if (declared !== undefined && Number(declared) !== size) { fail('JSON_RESPONSE_LENGTH'); return; }
+          if (slabs.length) slabs[slabs.length - 1] = slab.subarray(0, used);
+          const text = Buffer.concat(slabs, size).toString('utf8');
+          if (expired()) return;
+          finish(null, {kind:'response', status:res.statusCode, text,
+            correlationId:String(res.headers['x-correlation-id'] || ''),
+          });
+        });
+      });
+      req.on('error', error => fail(connectionCode(error)));
+      if (data !== undefined) req.write(data);
+      req.end();
+    } catch {
+      fail(req ? 'JSON_CONNECTION_ERROR' : 'JSON_REQUEST_INVALID');
+    }
+  });
+}
+module.exports = {requestJSONOnce, MAX_JSON_BYTES, JSON_TIMEOUT_MS};

--- a/webapp/electron/json-request.test.cjs
+++ b/webapp/electron/json-request.test.cjs
@@ -1,0 +1,261 @@
+const {test} = require('node:test');
+const assert = require('node:assert/strict');
+const {EventEmitter} = require('node:events');
+const {PassThrough} = require('node:stream');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+
+function client(serve) {
+  const calls = [];
+  return {calls, request(options, callback) {
+    const req = new EventEmitter();
+    req.destroyed = false;
+    req.destroy = () => { req.destroyed = true; };
+    req.write = data => { req.body = data; };
+    req.end = () => queueMicrotask(() => serve(req, callback));
+    calls.push({options, req});
+    return req;
+  }};
+}
+function response(callback, headers = {}, status = 200) {
+  const res = Object.assign(new PassThrough(), {statusCode:status, headers});
+  callback(res);
+  return res;
+}
+function mainSeam(http, policy) {
+  const source = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8');
+  const handlers = new Map();
+  const context = vm.createContext({http, Buffer, setTimeout, clearTimeout,
+    backendPort:32123, harnessToken:'owner-secret', startInFlight:null,
+    tryRefreshBackendPortFromMarker() { throw new Error('unexpected retry'); },
+    require(name) {
+      const mod = require(path.resolve(__dirname, name));
+      return name === './json-request.cjs' && policy
+        ? {...mod, requestJSONOnce:(options, body, deps) => mod.requestJSONOnce(options, body, {...deps, ...policy})}
+        : mod;
+    },
+    ipcMain:{handle:(name, fn) => handlers.set(name, fn), on(){}},
+  });
+  vm.runInContext(source.slice(source.indexOf('function authToken()'), source.indexOf('ipcMain.handle("secrets:save"')), context);
+  return {invoke:(method, body, options = {}) => handlers.get(`harness:${method === 'GET' ? 'getJSON' : 'postJSON'}`)({}, '/api/test', ...(method === 'GET' ? [options] : [body, options])), context};
+}
+
+test('actual main IPC bounds chunked JSON with production defaults', async () => {
+  let res;
+  const transport = client((req, cb) => {
+    res = response(cb);
+    const chunk = Buffer.alloc(1024 * 1024, 32);
+    for (let i=0; i<65 && !req.destroyed; i++) res.write(chunk);
+    if (!req.destroyed) res.end('{}');
+  });
+  const result = await mainSeam(transport).invoke('POST', {}, {responseEnvelope:true});
+  assert.equal(result.kind, 'connection-error');
+  assert.equal(result.code, 'JSON_RESPONSE_TOO_LARGE');
+  assert.equal(transport.calls.length, 1);
+  assert.equal(transport.calls[0].req.destroyed, true);
+  assert.equal(res.destroyed, true);
+});
+
+
+const {requestJSONOnce, MAX_JSON_BYTES} = require('./json-request.cjs');
+const options = {host:'127.0.0.1', port:1, path:'/api/private?secret=value', method:'POST', headers:{'X-Harness-Token':'secret'}};
+function run(transport, body, policy = {}) {
+  return requestJSONOnce(options, body, {request:transport.request, maxBytes:16, timeoutMs:1000, ...policy});
+}
+for (const delta of [0, 1]) {
+  test(`UTF-8 request boundary ${delta ? 'plus one' : 'exact'} is measured before socket creation`, async () => {
+    const transport = client((_req, cb) => response(cb).end('{}'));
+    const body = 'é'.repeat(7) + (delta ? 'x' : ''); // JSON quotes count too.
+    if (delta) {
+      await assert.rejects(run(transport, body), {code:'JSON_REQUEST_TOO_LARGE'});
+      assert.equal(transport.calls.length, 0);
+    } else {
+      assert.equal((await run(transport, body)).text, '{}');
+      assert.equal(transport.calls[0].options.headers['Content-Length'], 16);
+      assert.equal(Buffer.byteLength(transport.calls[0].req.body), 16);
+    }
+  });
+  test(`UTF-8 response boundary ${delta ? 'plus one' : 'exact'} across codepoint splits`, async () => {
+    const transport = client((_req, cb) => {
+      const res = response(cb);
+      const bytes = Buffer.from('"' + 'é'.repeat(7) + (delta ? 'x' : '') + '"');
+      for (const byte of bytes) res.write(Buffer.from([byte]));
+      res.end();
+    });
+    if (delta) await assert.rejects(run(transport), {code:'JSON_RESPONSE_TOO_LARGE'});
+    else assert.equal(JSON.parse((await run(transport)).text), 'é'.repeat(7));
+  });
+}
+for (const [length, text, code] of [
+  ['17', '', 'JSON_RESPONSE_TOO_LARGE'],
+  ['1', ' '.repeat(17), 'JSON_RESPONSE_TOO_LARGE'],
+  ['4', '{}', 'JSON_RESPONSE_LENGTH'],
+  ['1', '{}', 'JSON_RESPONSE_LENGTH'],
+  ['garbage', '', 'JSON_RESPONSE_LENGTH'],
+]) {
+  test(`declared length ${length} with ${text.length} actual bytes is refused`, async () => {
+    let res;
+    const transport = client((_req, cb) => {
+      res = response(cb, {'content-length':length});
+      if (!res.destroyed) res.end(text);
+    });
+    await assert.rejects(run(transport), {code});
+    assert.equal(transport.calls[0].req.destroyed, true);
+    assert.equal(res.destroyed, true);
+  });
+}
+test('5 MiB Offer and 9 MiB transcript remain usable through actual main', async () => {
+  const body = {offer:'a'.repeat(5 * 1024 * 1024)};
+  const text = JSON.stringify({history:['a'.repeat(9 * 1024 * 1024)], display:[]});
+  const transport = client((_req, cb) => response(cb).end(text));
+  const result = await mainSeam(transport).invoke('POST', body, {responseEnvelope:true});
+  assert.equal(result.kind, 'response');
+  assert.equal(result.text.length, text.length);
+  assert.ok(MAX_JSON_BYTES > text.length);
+});
+for (const stage of ['headers', 'body', 'trickle']) {
+  test(`absolute deadline stops stalled ${stage}, destroys ownership and never replays POST`, async () => {
+    let res, interval;
+    const transport = client((_req, cb) => {
+      if (stage === 'headers') return;
+      res = response(cb);
+      res.write('{');
+      if (stage === 'trickle') interval = setInterval(() => res.write(' '), 2);
+    });
+    try {
+      const start = Date.now();
+      const result = await mainSeam(transport, {timeoutMs:35}).invoke('POST', {}, {responseEnvelope:true, retries:5});
+      assert.equal(result.kind, 'connection-error');
+      assert.equal(result.code, 'JSON_REQUEST_TIMEOUT');
+      assert.match(result.message, /write may have completed/);
+      assert.ok(Date.now() - start < 1000);
+      assert.equal(transport.calls.length, 1);
+      assert.equal(transport.calls[0].req.destroyed, true);
+      if (res) assert.equal(res.destroyed, true);
+    } finally { clearInterval(interval); }
+  });
+}
+test('GET deadline is not retried by legacy recovery', async () => {
+  const transport = client(() => {});
+  const result = await mainSeam(transport, {timeoutMs:10}).invoke('GET', undefined, {responseEnvelope:true});
+  assert.equal(result.code, 'JSON_REQUEST_TIMEOUT');
+  assert.equal(transport.calls.length, 1);
+});
+test('serialization failure and synchronous request failure never leak input', async () => {
+  const circular = {secret:'credential'}; circular.self = circular;
+  const transport = client(() => { throw new Error('not reached'); });
+  await assert.rejects(run(transport, circular), e => e.code === 'JSON_REQUEST_INVALID' && !/credential|secret|private/.test(e.message));
+  assert.equal(transport.calls.length, 0);
+  await assert.rejects(requestJSONOnce(options, {}, {request() { throw new Error('secret private credential'); }}),
+    e => e.code === 'JSON_REQUEST_INVALID' && !/credential|secret|private/.test(e.message));
+});
+test('deadline includes synchronous serialization time and opens no socket afterward', async () => {
+  const transport = client(() => {});
+  const body = {toJSON() { const until = Date.now() + 20; while (Date.now() < until) {} return {}; }};
+  await assert.rejects(run(transport, body, {timeoutMs:5}), {code:'JSON_REQUEST_TIMEOUT'});
+  assert.equal(transport.calls.length, 0);
+});
+test('transport error text is sanitized and stays distinct from HTTP errors', async () => {
+  const transport = client(req => req.emit('error', Object.assign(new Error('secret URL response body'), {code:'ECONNREFUSED'})));
+  const result = await mainSeam(transport).invoke('POST', {}, {responseEnvelope:true});
+  assert.equal(result.kind, 'connection-error');
+  assert.equal(result.code, 'ECONNREFUSED');
+  assert.equal(result.status, undefined);
+  assert.doesNotMatch(result.message, /secret|URL|response body/);
+});
+test('HTTP 4xx shared contract and malformed JSON stay with the existing parser', async () => {
+  const transport = client((_req, cb) => response(cb, {'x-correlation-id':'corr'}, 409).end('{"ok":false,"code":"outcome_unknown"}'));
+  const seam = mainSeam(transport);
+  const result = await seam.invoke('POST', {}, {responseEnvelope:true});
+  assert.equal(result.kind, 'response');
+  assert.equal(result.status, 409);
+  assert.equal(result.correlationId, 'corr');
+  await assert.rejects(seam.invoke('POST', {}), e => e.status === 409 && e.code === 'outcome_unknown');
+  const malformed = mainSeam(client((_req, cb) => response(cb).end('broken')));
+  await assert.rejects(malformed.invoke('GET'), {code:'INVALID_JSON_RESPONSE', status:200});
+});
+test('normal completion clears the deadline and ignores late errors', async () => {
+  let res;
+  const transport = client((_req, cb) => {res = response(cb, {'content-length':'2'}); res.end('{}');});
+  assert.equal((await run(transport, undefined, {timeoutMs:15})).text, '{}');
+  await new Promise(resolve => setTimeout(resolve, 30));
+  assert.equal(transport.calls[0].req.destroyed, false);
+  res.emit('error', new Error('late secret'));
+  transport.calls[0].req.emit('error', new Error('late secret'));
+});
+
+test('real loopback HTTP through main IPC: boundaries, stalls, no write replay', {timeout:10000}, async t => {
+  const http = require('node:http');
+  const writes = new Map();
+  const sockets = new Set();
+  const server = http.createServer((req, res) => {
+    const mode = req.headers['x-correlation-id'];
+    writes.set(mode, (writes.get(mode) || 0) + 1);
+    req.resume();
+    if (mode === 'headers') return;
+    if (mode === 'body' || mode === 'trickle') {
+      res.writeHead(200, {'Content-Type':'application/json'});
+      res.write('{');
+      if (mode === 'trickle') {
+        const interval = setInterval(() => res.write(' '), 20);
+        res.once('close', () => clearInterval(interval));
+      }
+      return;
+    }
+    if (mode === 'declared-large') { res.writeHead(200, {'Content-Length':'17'}); res.flushHeaders(); return; }
+    if (mode === 'declared-short-body') { res.writeHead(200, {'Content-Length':'10'}); res.end('{}'); return; }
+    if (mode === 'over') { res.write(' '.repeat(16)); res.end('x'); return; }
+    if (mode === 'exact') { res.end('"' + 'x'.repeat(14) + '"'); return; }
+    if (mode === 'bad') { res.end('not JSON'); return; }
+    if (mode === 'http-error') { res.writeHead(409, {'X-Correlation-Id':'server-corr'}); res.end('{"ok":false,"code":"outcome_unknown"}'); return; }
+    res.end('{"ok":true}');
+  });
+  server.on('connection', socket => {sockets.add(socket); socket.once('close', () => sockets.delete(socket));});
+  t.after(() => {for (const socket of sockets) socket.destroy(); return new Promise(resolve => server.close(resolve));});
+  try {
+    await new Promise((resolve, reject) => {server.once('error', reject); server.listen(0, '127.0.0.1', resolve);});
+  } catch (error) {
+    if (['EPERM', 'EACCES'].includes(error.code) && process.env.REQUIRE_LOCAL_HTTP !== '1') {
+      t.skip(`Local HTTP bind unavailable (${error.code}); rerun REQUIRE_LOCAL_HTTP=1 node --test electron/json-request.test.cjs`);
+      return;
+    }
+    throw error;
+  }
+  const seam = mainSeam(http, {maxBytes:16, timeoutMs:120});
+  seam.context.backendPort = server.address().port;
+  const invoke = mode => seam.invoke('POST', {}, {responseEnvelope:true, correlationId:mode, retries:5});
+  for (const mode of ['headers', 'body', 'trickle', 'declared-short-body']) {
+    const result = await invoke(mode);
+    assert.equal(result.kind, 'connection-error', mode);
+    assert.ok(['JSON_REQUEST_TIMEOUT', 'ECONNRESET'].includes(result.code), mode);
+    assert.equal(writes.get(mode), 1);
+  }
+  for (const mode of ['declared-large', 'over']) assert.equal((await invoke(mode)).code, 'JSON_RESPONSE_TOO_LARGE');
+  assert.equal((await invoke('exact')).text.length, 16);
+  assert.equal(JSON.parse((await invoke('ok')).text).ok, true);
+  await assert.rejects(seam.invoke('POST', {}, {correlationId:'bad'}), {code:'INVALID_JSON_RESPONSE'});
+  const larger = mainSeam(http, {maxBytes:64, timeoutMs:120});
+  larger.context.backendPort = server.address().port;
+  const result = await larger.invoke('POST', {}, {responseEnvelope:true, correlationId:'http-error'});
+  assert.equal(result.status, 409);
+  assert.equal(result.correlationId, 'server-corr');
+  assert.deepEqual(JSON.parse(result.text), {ok:false, code:'outcome_unknown'});
+});
+
+test('late headers after timeout are destroyed without a second settlement', async () => {
+  let callback;
+  const transport = client((_req, cb) => {callback = cb;});
+  await assert.rejects(run(transport, {}, {timeoutMs:5}), {code:'JSON_REQUEST_TIMEOUT'});
+  const res = response(callback);
+  assert.equal(res.destroyed, true);
+  assert.equal(transport.calls[0].req.destroyed, true);
+});
+test('synchronous write failure destroys the request and warns about the outcome', async () => {
+  const req = new EventEmitter();
+  req.destroy = () => {req.destroyed = true;};
+  req.write = () => {throw new Error('private body');};
+  await assert.rejects(run({request:() => req}, {}), e =>
+    e.code === 'JSON_CONNECTION_ERROR' && /write may have completed/.test(e.message) && !/private/.test(e.message));
+  assert.equal(req.destroyed, true);
+});

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -964,27 +964,11 @@ function endpointRequestHeaders(value) {
   return headers;
 }
 
-function _backendRequestOnce(method, apiPath, body, correlationId = "", identityHeaders) {
-  return new Promise((resolve, reject) => {
-    const data = body === undefined ? null : JSON.stringify(body);
-    const req = http.request({
-      host: "127.0.0.1", port: backendPort, path: apiPath, method,
-      headers: { ...endpointRequestHeaders(identityHeaders), "Content-Type": "application/json", "X-Harness-Token": authToken(), ...(correlationId ? { "X-Correlation-Id": correlationId } : {}), ...(data ? { "Content-Length": Buffer.byteLength(data) } : {}) },
-    }, (res) => {
-      let buf = "";
-      res.setEncoding("utf8");
-      res.on("data", (c) => (buf += c));
-      res.on("error", reject);
-      res.on("aborted", () => reject(Object.assign(new Error("Backend response aborted"), { code: "ECONNRESET" })));
-      res.on("end", () => resolve({
-        kind: "response", status: res.statusCode, text: buf,
-        correlationId: String(res.headers["x-correlation-id"] || ""),
-      }));
-    });
-    req.on("error", reject);
-    if (data) req.write(data);
-    req.end();
-  });
+function _backendRequestOnce(method, apiPath, body, correlationId = "", identityHeaders, policy) {
+  return require("./json-request.cjs").requestJSONOnce({
+    host: "127.0.0.1", port: backendPort, path: apiPath, method,
+    headers: { ...endpointRequestHeaders(identityHeaders), "Content-Type": "application/json", "X-Harness-Token": authToken(), ...(correlationId ? { "X-Correlation-Id": correlationId } : {}) },
+  }, body, { request: http.request, ...policy });
 }
 
 function _isTransientBackendConnError(err) {
@@ -1002,14 +986,18 @@ function _isTransientBackendConnError(err) {
 // this the renderer paints a raw "harness:getJSON ECONNREFUSED" that clears on
 // the next manual refresh. A few short retries cover the usual gap.
 async function backendRequest(method, apiPath, body, { retries = 5, delayMs = 200, responseEnvelope = false, correlationId = "", identityHeaders } = {}) {
+  const policy = require("./job-metadata-policy.cjs").jobMetadataPolicy(method, apiPath);
+  // Metadata must settle within one absolute deadline, including during a
+  // backend restart. Legacy read recovery may wait on startInFlight indefinitely.
+  const maxRetries = policy ? 0 : retries;
   let lastErr;
-  for (let attempt = 0; attempt <= retries; attempt++) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      const response = await _backendRequestOnce(method, apiPath, body, correlationId, identityHeaders);
+      const response = await _backendRequestOnce(method, apiPath, body, correlationId, identityHeaders, policy);
       return responseEnvelope ? response : require("./json-response.mjs").parseJSONResponse(response, apiPath);
     } catch (err) {
       lastErr = err;
-      if ((method !== "GET" && method !== "HEAD") || err.status || !_isTransientBackendConnError(err) || attempt === retries) break;
+      if ((method !== "GET" && method !== "HEAD") || err.status || !_isTransientBackendConnError(err) || attempt === maxRetries) break;
       // Marker may already list a new port (respawn / other window) while our
       // in-memory backendPort is still the dead one -- adopt before retrying.
       tryRefreshBackendPortFromMarker();


### PR DESCRIPTION
Desktop JSON reads previously accumulated response bodies without a byte cap or absolute deadline. Metadata reads could also wait indefinitely for backend restart recovery.

This adds a finite JSON transport and main-owned policies for the seven metadata routes: 16–96 KiB response limits, a 64 KiB request limit, and a 30-second deadline without automatic replay. General JSON requests use a 64 MiB limit and a 120-second deadline. Ambiguous write failures retain an explicit outcome warning.

Review `json-request.cjs` for streaming limits and cleanup, `job-metadata-policy.cjs` for route budgets, and the small `main.cjs` change for runtime wiring. This is the transport prerequisite for the upcoming Marionette consumer integration; package pins remain unchanged.

Validation: 100 transport tests passed, zero failures or skips, including real loopback HTTP through the main IPC seam, byte boundaries, stalled responses, identity headers, and no write replay. `git diff --check` passed.
