### PR TITLE
Add bounded metadata service with runtime capability gating

### DIFF
--- a/docs/puppetmaster-consumer-development.md
+++ b/docs/puppetmaster-consumer-development.md
@@ -1,0 +1,25 @@
+# Testing the Puppetmaster consumer integration
+
+The consumer changes use the bounded metadata contracts in Puppetmaster development commit `057a786b0e53302ceff0a271b8af73d86864c664`. Release dependency pins are separate from this development setup. Publish a 1.25.0 pin only after that version is available on PyPI.
+
+Use an isolated environment in the Marionette checkout:
+
+```sh
+python3 -m venv .venv
+.venv/bin/python -m pip install -e ".[dev]"
+.venv/bin/python -m pip install --no-deps -e ../Puppetmaster
+```
+
+Select the intended Puppetmaster development revision before the second install. To check which source Python actually imports:
+
+```sh
+env -u PYTHONPATH .venv/bin/python -c 'import puppetmaster, importlib.metadata; print(puppetmaster.__file__); print(importlib.metadata.version("puppetmaster-ai"))'
+```
+
+Clear inherited `PYTHONPATH` for these checks. A worker host can otherwise prepend its installed Puppetmaster and hide the package in the isolated environment.
+
+The desktop bootstrap already accepts `MARIONETTE_PUPPETMASTER_SPEC`. For development bootstrap, set it to an absolute local Puppetmaster checkout path. This changes the local installation receipt without editing the release pin.
+
+The supported inspector shows bounded task and artifact references, captured attempt/run/process history, publication receipts, and selected terminal economics. Captured models are historical; selected receipt totals do not represent all attempts or live session spend. The current bounded API does not expose current PM routing assignments, routing policies and rejected alternatives, artifact verification diagnoses, PM job timestamps, or live aggregate economics.
+
+The transport, service, native observation/control, and shared UI changes must be reviewed together for deployment. The service can report unsupported-runtime unavailability on older installations; enabling the new UI with full metadata requires the compatible local development runtime or the later published dependency update.

--- a/harness/api/attach.py
+++ b/harness/api/attach.py
@@ -64,6 +64,7 @@ def attach_view(
     factory=None,
     load_transcript_on_create: bool = True,
     defer_cold_build: Optional[bool] = None,
+    view_repo: Optional[str] = None,
 ) -> Any:
     """Point the UI at ``session_id`` via the runner registry.
 
@@ -84,6 +85,8 @@ def attach_view(
     if not session_id:
         raise ValueError("session_id required to attach view")
 
+    view_repo = (svc.cfg.repo or "") if view_repo is None else view_repo
+
     # --- Warm fast path: never rebuild; never interrupt other runners. ---
     existing = svc.runners.get(session_id)
     if existing is not None:
@@ -99,7 +102,7 @@ def attach_view(
             with svc.pilot_swap_lock:
                 if isinstance(existing, ConversationalSession):
                     existing.bind_prompt_queue(svc.sessions_state_dir(), session_id)
-                svc.runners.set_active_view(session_id)
+                svc.runners.set_active_view(session_id, repo=view_repo)
                 svc.set_pilot(existing)
                 try:
                     svc.get_session().state_dir = svc.get_pilot().state_dir
@@ -139,7 +142,9 @@ def attach_view(
     transcript_payload = normalize_transcript_payload(history)
 
     if want_defer:
-        config = _fork_runner_config(session_id, svc, svc.runner_config_snapshot())
+        config = svc.runner_config_snapshot()
+        config.repo = view_repo
+        config = _fork_runner_config(session_id, svc, config)
         placeholder = DeferredPilotPlaceholder(
             session_id=session_id,
             state_dir=config.state_dir,
@@ -152,7 +157,7 @@ def attach_view(
 
         runner = svc.runners.get_or_create(session_id, _factory)
         with svc.pilot_swap_lock:
-            svc.runners.set_active_view(session_id)
+            svc.runners.set_active_view(session_id, repo=view_repo)
             svc.set_pilot(runner)
             try:
                 svc.get_session().state_dir = svc.get_pilot().state_dir
@@ -235,15 +240,17 @@ def attach_view(
             runner = factory()
         else:
             # New runners start at zero meters -- boot pill sums carry + live.
+            config = svc.runner_config_snapshot()
+            config.repo = view_repo
             runner = svc.build_conversational_pilot(
-                config=_fork_runner_config(session_id, svc, svc.runner_config_snapshot()))
+                config=_fork_runner_config(session_id, svc, config))
         if isinstance(runner, ConversationalSession):
             runner.bind_prompt_queue(svc.sessions_state_dir(), session_id)
         return runner
 
     runner = svc.runners.get_or_create(session_id, _factory)
     with svc.pilot_swap_lock:
-        svc.runners.set_active_view(session_id)
+        svc.runners.set_active_view(session_id, repo=view_repo)
         svc.set_pilot(runner)
         # Keep tracker/jobs pointed at the store this runner writes to.
         try:

--- a/harness/api/job_readmodel.py
+++ b/harness/api/job_readmodel.py
@@ -1,0 +1,181 @@
+"""Strict HTTP boundary for the separate bounded metadata lane.
+
+Authentication and request-body byte limits remain the host Handler's responsibility.
+Pass parse_qs(..., keep_blank_values=True) so blank duplicate selectors are rejected.
+"""
+from __future__ import annotations
+
+import re
+
+from puppetmaster.models import JobRef
+
+from ..job_readmodel import (
+    InvalidReadRequest, MetadataReader, PMSelection, ReadContext, PM_STATUSES, StoreSelection, ViewChanged,
+)
+from ..paths import same_workspace_path
+
+CONTEXT = {'session_id', 'repo', 'scope', 'view_generation'}
+STORE = {'source', 'state_id'}
+ID = re.compile(r'[a-zA-Z0-9_-]{1,256}\Z')
+JOB = re.compile(r'job_[a-zA-Z0-9_-]{1,128}\Z')
+
+
+def _text(value, maximum=256):
+    if not isinstance(value, str) or not value or value != value.strip() or any(ord(c) < 32 for c in value):
+        raise InvalidReadRequest()
+    try:
+        if len(value.encode('utf-8')) > maximum:
+            raise InvalidReadRequest()
+    except UnicodeError as exc:
+        raise InvalidReadRequest() from exc
+    return value
+
+
+def _query(qs, required, optional=()):
+    if not isinstance(qs, dict) or not required <= qs.keys() or qs.keys() - required - set(optional):
+        raise InvalidReadRequest()
+    result = {}
+    for key, values in qs.items():
+        if not isinstance(values, list) or len(values) != 1:
+            raise InvalidReadRequest()
+        maximum = 8192 if key.endswith('cursor') else 1024 if key == 'repo' else 256
+        result[key] = _text(values[0], maximum)
+    return result
+
+
+def _context(values):
+    if values['scope'] not in ('session', 'repo', 'all'):
+        raise InvalidReadRequest()
+    session = _text(values['session_id'])
+    generation = _text(values['view_generation'], 128)
+    repo = _text(values['repo'], 1024)
+    if not ID.fullmatch(session) or not ID.fullmatch(generation):
+        raise InvalidReadRequest()
+    # Repository is only a captured context match, never a store locator.
+    return ReadContext(session, repo, generation, values['scope'])
+
+
+def _store(values):
+    if values['source'] not in ('harness', 'cli'):
+        raise InvalidReadRequest()
+    identity = _text(values['state_id'])
+    if not ID.fullmatch(identity):
+        raise InvalidReadRequest()
+    return StoreSelection(values['source'], identity)
+
+
+def _selection(ctx, values):
+    jid = _text(values['job_id'])
+    if not JOB.fullmatch(jid):
+        raise InvalidReadRequest()
+    store = _store(values)
+    version = values.get('version', '1')
+    if version not in ('1', '2') or (version == '1' and values.get('incarnation') is not None):
+        raise InvalidReadRequest()
+    try:
+        ref = JobRef(jid, store.state_id, version=int(version), incarnation=values.get('incarnation'))
+    except ValueError as exc:
+        raise InvalidReadRequest() from exc
+    return PMSelection(ctx, store, ref)
+
+
+def _respond(call):
+    try:
+        return 200, call()
+    except ViewChanged:
+        return 409, dict(code='view_changed')
+    except InvalidReadRequest:
+        return 400, dict(code='invalid_read_request')
+    except ValueError as exc:
+        # Public PM CursorCodec uses these two errors. Malformed stored JSON or
+        # invalid stored bindings are corruption, not malformed client input.
+        if str(exc) in ('invalid cursor', 'cursor does not match query'):
+            return 400, dict(code='invalid_read_request')
+        return 503, dict(code='store_unavailable')
+    except Exception:
+        return 503, dict(code='store_unavailable')
+
+
+def get_job_metadata(qs: dict, reader: MetadataReader):
+    def read():
+        values = _query(qs, CONTEXT | STORE | {'mode'}, {'cursor', 'after_revision', 'status'})
+        ctx = _context(values)
+        if values['mode'] not in ('snapshot', 'changes'):
+            raise InvalidReadRequest()
+        if 'status' in values and values['status'] not in PM_STATUSES:
+            raise InvalidReadRequest()
+        after = values.get('after_revision', '0')
+        if not re.fullmatch(r'0|[1-9][0-9]{0,18}', after) or int(after) > 2**63 - 1:
+            raise InvalidReadRequest()
+        if values['mode'] == 'snapshot' and 'after_revision' in values:
+            raise InvalidReadRequest()
+        return reader.read_job_page(ctx, _store(values), mode=values['mode'],
+                                    cursor=values.get('cursor'), after_revision=int(after), status=values.get('status'))
+    return _respond(read)
+
+
+def get_job_metadata_detail(qs: dict, reader: MetadataReader):
+    def read():
+        values = _query(qs, CONTEXT | STORE | {'job_id'}, {'task_cursor', 'artifact_cursor', 'version', 'incarnation',
+                  'attempt_cursor', 'run_cursor', 'process_outcome_cursor', 'observation_cursor'})
+        return reader.read_selected_metadata(_selection(_context(values), values),
+                                             **{name: values.get(name) for name in ('task_cursor', 'artifact_cursor',
+                                                'attempt_cursor', 'run_cursor', 'process_outcome_cursor', 'observation_cursor')})
+    return _respond(read)
+
+
+def post_job_metadata_pins(body: dict, reader: MetadataReader):
+    def read():
+        if not isinstance(body, dict) or body.keys() != CONTEXT | {'selections'}:
+            raise InvalidReadRequest()
+        ctx = _context(body)
+        raw = body['selections']
+        if not isinstance(raw, list) or len(raw) > 8:
+            raise InvalidReadRequest()
+        selections = []
+        for item in raw:
+            if not isinstance(item, dict) or item.keys() != {'job_ref', 'source', 'session_id', 'repo'}:
+                raise InvalidReadRequest()
+            ref = item['job_ref']
+            if (not isinstance(ref, dict) or not {'job_id', 'state_id'} <= ref.keys()
+                    or ref.keys() - {'job_id', 'state_id', 'version', 'incarnation'}
+                    or ('version' in ref and (type(ref['version']) is not int or ref['version'] not in (1, 2)))):
+                raise InvalidReadRequest()
+            if (_text(item['session_id']) != ctx.session_id
+                    or not same_workspace_path(_text(item['repo'], 1024), ctx.repo)):
+                raise ViewChanged()
+            selections.append(_selection(ctx, dict(ref, source=item['source'], version=str(ref.get('version', 1)))))
+        if len(set(selections)) != len(selections):
+            raise InvalidReadRequest()
+        return reader.read_pins(ctx, selections)
+    return _respond(read)
+
+
+def get_local_metadata(qs: dict, reader: MetadataReader):
+    def read():
+        values = _query(qs, CONTEXT, {'mode', 'cursor', 'after_revision', 'lane'})
+        lane = values.get('lane', 'history')
+        if lane not in ('history', 'active'):
+            raise InvalidReadRequest()
+        mode = values.get('mode', 'snapshot')
+        after = values.get('after_revision', '0')
+        if (mode not in ('snapshot', 'changes') or not re.fullmatch(r'0|[1-9][0-9]{0,18}', after)
+                or int(after) > 2**63 - 1 or (mode == 'snapshot' and 'after_revision' in values)):
+            raise InvalidReadRequest()
+        return reader.read_local(_context(values), mode=mode, cursor=values.get('cursor'),
+                                 after_revision=int(after), lane=lane)
+    return _respond(read)
+
+
+def get_local_metadata_detail(qs: dict, reader: MetadataReader):
+    def read():
+        values = _query(qs, CONTEXT | {'job_id', 'incarnation', 'lane'}, {'cursor', 'include_context'})
+        if (('include_context' in values and values['include_context'] != 'true')
+                or not ID.fullmatch(values['job_id']) or not ID.fullmatch(values['incarnation'])
+                or values['lane'] not in ('actions', 'output', 'children', 'tasks', 'routing')):
+            raise InvalidReadRequest()
+        return reader.read_local_selected(_context(values),
+                    dict(job_id=values['job_id'], incarnation=values['incarnation']),
+                    lane=values['lane'], cursor=values.get('cursor'),
+                    include_context=values.get('include_context') == 'true')
+    return _respond(read)

--- a/harness/api/sessions.py
+++ b/harness/api/sessions.py
@@ -205,6 +205,7 @@ def handle_session_relocate(body: dict, svc: SessionServices) -> tuple[int, dict
         pass
 
     with svc.pilot_swap_lock or nullcontext():
+        metadata_transition = svc.runners.metadata_view.invalidate()
         relocated = svc.sessions.relocate(
             sid,
             target_repo,
@@ -214,6 +215,7 @@ def handle_session_relocate(body: dict, svc: SessionServices) -> tuple[int, dict
             make_active=True,
         )
     if not relocated:
+        svc.runners.metadata_view.restore(metadata_transition)
         return 404, {"ok": False, "error": "unknown session"}
 
     svc.cfg.repo = target_repo
@@ -242,7 +244,7 @@ def handle_session_relocate(body: dict, svc: SessionServices) -> tuple[int, dict
             svc.set_codegraph_status("unsupported")
 
     try:
-        svc.attach_view(sid)
+        svc.attach_view(sid, view_repo=target_repo)
     except LeaseExhaustedError as e:
         if prev_active:
             try:
@@ -256,6 +258,7 @@ def handle_session_relocate(body: dict, svc: SessionServices) -> tuple[int, dict
                 os.environ.pop("HARNESS_REPO", None)
             else:
                 os.environ["HARNESS_REPO"] = prev_env_repo
+        svc.runners.metadata_view.restore(metadata_transition)
         return 409, svc.lease_exhausted_body(e)
 
     return 200, {
@@ -301,6 +304,7 @@ def post_sessions_create(body: dict, svc: SessionServices) -> tuple[int, dict]:
         except Exception:
             pass
     with svc.pilot_swap_lock or nullcontext():
+        metadata_transition = svc.runners.metadata_view.invalidate()
         res = svc.sessions.create(title, repo=repo, branch=branch, workspace_root=repo)
     sid = res.get("id", "")
     if sid:
@@ -311,6 +315,7 @@ def post_sessions_create(body: dict, svc: SessionServices) -> tuple[int, dict]:
                 sid,
                 load_transcript_on_create=False,
                 defer_cold_build=True,
+                view_repo=repo,
             )
             svc.get_pilot().load_history([])
         except LeaseExhaustedError as e:
@@ -325,6 +330,7 @@ def post_sessions_create(body: dict, svc: SessionServices) -> tuple[int, dict]:
                         svc.sessions.switch(prev_active)
                 except Exception as roll_e:
                     svc.diag("server.session_create_lease_rollback", roll_e)
+            svc.runners.metadata_view.restore(metadata_transition)
             return 409, svc.lease_exhausted_body(e)
 
     from ..hooks import run_hooks
@@ -344,6 +350,7 @@ def post_sessions_switch(body: dict, svc: SessionServices) -> tuple[int, dict]:
     prev_repo = svc.cfg.repo
     prev_env_repo = os.environ.get("HARNESS_REPO")
     with svc.pilot_swap_lock or nullcontext():
+        metadata_transition = svc.runners.metadata_view.invalidate()
         res = svc.sessions.switch(target_id)
     if res.get("ok") and svc.sessions.active:
         target_sess = None
@@ -357,6 +364,10 @@ def post_sessions_switch(body: dict, svc: SessionServices) -> tuple[int, dict]:
                 session_stored_root(target_sess)
                 or (target_sess.get("repo") or "").strip()
             )
+
+        view_repo = prev_repo or ""
+        if target_repo and os.path.isdir(target_repo) and not svc.is_app_install_root(target_repo):
+            view_repo = target_repo
 
         # Never let a stale app-checkout session yank the live workspace
         # back to ~/.marionette/marionette (or the running source tree).
@@ -401,7 +412,7 @@ def post_sessions_switch(body: dict, svc: SessionServices) -> tuple[int, dict]:
                     svc.set_codegraph_status("unsupported")
 
         try:
-            svc.attach_view(svc.sessions.active, defer_cold_build=True)
+            svc.attach_view(target_id, defer_cold_build=True, view_repo=view_repo)
         except LeaseExhaustedError as e:
             if prev_active:
                 try:
@@ -415,6 +426,7 @@ def post_sessions_switch(body: dict, svc: SessionServices) -> tuple[int, dict]:
                     os.environ.pop("HARNESS_REPO", None)
                 else:
                     os.environ["HARNESS_REPO"] = prev_env_repo
+            svc.runners.metadata_view.restore(metadata_transition)
             return 409, svc.lease_exhausted_body(e)
 
         res["repo"] = svc.cfg.repo
@@ -430,6 +442,8 @@ def post_sessions_switch(body: dict, svc: SessionServices) -> tuple[int, dict]:
             svc.get_pilot(), active_id
         )
 
+    if not res.get("ok"):
+        svc.runners.metadata_view.restore(metadata_transition)
     return 200, res
 
 
@@ -788,14 +802,18 @@ def post_sessions_attach(body: dict, svc: SessionServices) -> tuple[int, dict]:
     target_id = (body.get("id") or body.get("session_id") or "").strip()
     if not target_id:
         return 400, {"ok": False, "error": "session id required"}
+    target = next((row for row in svc.sessions.rows() if row.get("id") == target_id), {})
+    view_repo = session_stored_root(target) or svc.cfg.repo or ""
     svc.save_active_transcript()
     previous_active = svc.sessions.active
     with svc.pilot_swap_lock or nullcontext():
+        metadata_transition = svc.runners.metadata_view.invalidate()
         res = svc.sessions.switch(target_id)
     if not res.get("ok"):
+        svc.runners.metadata_view.restore(metadata_transition)
         return 404, res
     try:
-        svc.attach_view(svc.sessions.active, defer_cold_build=True)
+        svc.attach_view(target_id, defer_cold_build=True, view_repo=view_repo)
     except LeaseExhaustedError as exc:
         if previous_active:
             with svc.pilot_swap_lock or nullcontext():
@@ -804,6 +822,7 @@ def post_sessions_attach(body: dict, svc: SessionServices) -> tuple[int, dict]:
             with svc.pilot_swap_lock or nullcontext(), svc.sessions._lock:
                 svc.sessions._active = None
                 svc.sessions._save(immediate=True)
+        svc.runners.metadata_view.restore(metadata_transition)
         return 409, svc.lease_exhausted_body(exc)
     transcript = svc.attach_view_transcript_payload(svc.get_pilot(), target_id)
     return 200, {

--- a/harness/api/workspace.py
+++ b/harness/api/workspace.py
@@ -215,6 +215,9 @@ class WorkspaceServices:
     is_app_install_root: Callable[[str], bool]
     diag: Callable[..., Any]
     # POST /api/workspace/open
+    invalidate_metadata_view: Optional[Callable[[], Any]] = None
+    restore_metadata_view: Optional[Callable[[Any], None]] = None
+    invalidate_metadata_sources: Optional[Callable[[], None]] = None
     sessions: Any = None
     save_active_transcript: Optional[Callable[[], None]] = None
     note_boot_repo: Optional[Callable[[str], None]] = None
@@ -274,6 +277,7 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
     prev_env_repo = os.environ.get("HARNESS_REPO")
 
     old_repo = (prev_repo or "").strip()
+    metadata_transition = svc.invalidate_metadata_view() if svc.invalidate_metadata_view else None
     svc.cfg.repo = target_repo
     os.environ["HARNESS_REPO"] = target_repo
     if old_repo != target_repo:
@@ -323,15 +327,17 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
         ]
         if target_sessions:
             newest_session = max(target_sessions, key=lambda s: s.get("created", 0))
-            svc.sessions.switch(newest_session["id"])
+            target_session_id = newest_session["id"]
+            svc.sessions.switch(target_session_id)
         else:
             basename = os.path.basename(os.path.abspath(target_repo)) or "Workspace"
-            svc.sessions.create(title=basename, repo=target_repo, branch=branch)
+            created = svc.sessions.create(title=basename, repo=target_repo, branch=branch)
+            target_session_id = created["id"]
             created_session = True
 
-        if svc.sessions.active and svc.attach_view is not None:
+        if target_session_id and svc.attach_view is not None:
             try:
-                svc.attach_view(svc.sessions.active, defer_cold_build=True)
+                svc.attach_view(target_session_id, defer_cold_build=True, view_repo=target_repo)
             except Exception as e:
                 lease_cls = svc.lease_exhausted_error
                 if lease_cls is not None and isinstance(e, lease_cls):
@@ -353,6 +359,8 @@ def post_workspace_open(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPa
                         if svc.lease_exhausted_body is not None
                         else {"error": "lease exhausted"}
                     )
+                    if metadata_transition is not None and svc.restore_metadata_view is not None:
+                        svc.restore_metadata_view(metadata_transition)
                     return 409, body_payload
                 raise
 
@@ -397,6 +405,8 @@ def post_workspace_forget(body: dict, svc: WorkspaceServices) -> tuple[int, Json
         # Clear live process state when forgetting the open workspace so
         # the rail does not keep re-appending currentRepo after forget.
         if repo and svc.paths_same_workspace(repo, target_repo):
+            if svc.invalidate_metadata_view is not None:
+                svc.invalidate_metadata_view()
             svc.cfg.repo = ""
             os.environ.pop("HARNESS_REPO", None)
             cleared_active = True
@@ -415,11 +425,17 @@ def post_workspace_forget(body: dict, svc: WorkspaceServices) -> tuple[int, Json
 def post_workspaces_switch(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPayload]:
     """POST /api/workspaces/switch."""
     name = body.get("name", "")
-    result = svc.ws.switch_workspace(
-        svc.cfg.repo,
-        name,
-        allow_dirty=svc.parse_bool(body.get("allow_dirty")),
-    )
+    if svc.invalidate_metadata_sources is not None:
+        svc.invalidate_metadata_sources()
+    try:
+        result = svc.ws.switch_workspace(
+            svc.cfg.repo,
+            name,
+            allow_dirty=svc.parse_bool(body.get("allow_dirty")),
+        )
+    finally:
+        if svc.invalidate_metadata_sources is not None:
+            svc.invalidate_metadata_sources()
     if isinstance(result, dict) and result.get("ok") is not False:
         try:
             from ..context_switch_guard import note_switch
@@ -447,11 +463,17 @@ def post_workspaces_confirm(body: dict, svc: WorkspaceServices) -> tuple[int, Js
 
 def post_workspaces_create(body: dict, svc: WorkspaceServices) -> tuple[int, JsonPayload]:
     """POST /api/workspaces/create."""
-    return 200, svc.ws.create_workspace(
-        svc.cfg.repo,
-        body.get("name", ""),
-        body.get("branch") or None,
-    )
+    if svc.invalidate_metadata_sources is not None:
+        svc.invalidate_metadata_sources()
+    try:
+        return 200, svc.ws.create_workspace(
+            svc.cfg.repo,
+            body.get("name", ""),
+            body.get("branch") or None,
+        )
+    finally:
+        if svc.invalidate_metadata_sources is not None:
+            svc.invalidate_metadata_sources()
 
 
 def get_workspaces(svc: WorkspaceServices) -> tuple[int, JsonPayload]:

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -54,13 +54,14 @@ def get_json(
     qs_args: Optional[tuple[str, ...]] = None,
     empty_as_none: bool = False,
     pass_qs: bool = False,
+    keep_blank_values: bool = False,
 ) -> GetHandler:
     """Wrap an api.* GET that returns ``(status, payload)``."""
 
     def handle(handler: Any, u: Any, qs: dict) -> Any:
         args: list[Any] = []
         if pass_qs:
-            args.append(qs)
+            args.append(parse_qs(u.query, keep_blank_values=True) if keep_blank_values else qs)
         elif qs_args:
             for key in qs_args:
                 val = qs.get(key, [""])[0]
@@ -95,6 +96,8 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
     from .api import git as _git_api
     from .api import hooks as _hooks_api
     from .api import jobs as _jobs_api
+    from .job_metadata_capability import metadata_handler
+    from . import job_metadata_view as _metadata_view
     from .api import mcp as _mcp_api
     from .api import platform as _plat_api
     from .api import plugins as _plugins_api
@@ -117,6 +120,10 @@ def build_post_json_routes(svc: Any) -> dict[str, PostHandler]:
     from .api import local_models as _local_models_api
 
     routes: dict[str, PostHandler] = {
+        "/api/jobs/metadata/pins": post_json(
+            metadata_handler("post_job_metadata_pins"), services=lambda: svc.metadata_view()),
+        "/api/jobs/metadata/view/refresh": post_json(
+            _metadata_view.refresh_view, services=lambda: svc.metadata_view()),
         "/api/browser/relay": post_json(_browser_api.post_browser_relay),
         "/api/collab/presence/heartbeat": post_json(
             _collab_presence_api.post_presence_heartbeat),
@@ -511,6 +518,8 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
     from .api import hooks as _hooks_api
     from .api import job_evidence as _job_evidence_api
     from .api import jobs as _jobs_api
+    from .job_metadata_capability import metadata_handler
+    from . import job_metadata_view as _metadata_view
     from .api import mcp as _mcp_api
     from .api import platform as _plat_api
     from .api import plugins as _plugins_api
@@ -739,6 +748,21 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
             handler, qs, svc.session_services())
 
     return {
+        "/api/jobs/metadata": get_json(
+            metadata_handler("get_job_metadata"), services=lambda: svc.metadata_view(),
+            pass_qs=True, keep_blank_values=True),
+        "/api/jobs/metadata/detail": get_json(
+            metadata_handler("get_job_metadata_detail"), services=lambda: svc.metadata_view(),
+            pass_qs=True, keep_blank_values=True),
+        "/api/jobs/metadata/local/detail": get_json(
+            metadata_handler("get_local_metadata_detail"), services=lambda: svc.metadata_view(),
+            pass_qs=True, keep_blank_values=True),
+        "/api/jobs/metadata/local": get_json(
+            metadata_handler("get_local_metadata"), services=lambda: svc.metadata_view(),
+            pass_qs=True, keep_blank_values=True),
+        "/api/jobs/metadata/view": get_json(
+            _metadata_view.get_view, services=lambda: svc.metadata_view(),
+            pass_qs=True, keep_blank_values=True),
         "/api/git/status": get_json(
             _git_api.get_git_status, services=svc.git_services, qs_arg="repo"),
         "/api/git/branches": get_json(

--- a/harness/job_metadata_capability.py
+++ b/harness/job_metadata_capability.py
@@ -1,0 +1,64 @@
+"""Optional bounded metadata API; legacy runtime startup must not depend on it."""
+from dataclasses import dataclass
+from importlib import import_module
+from importlib.util import find_spec
+from inspect import signature
+
+
+@dataclass(frozen=True)
+class ActiveContext:
+    session_id: str
+    repo: str
+    generation: str
+
+
+class ViewChanged(RuntimeError):
+    pass
+
+
+UNAVAILABLE_REASON = "bounded_metadata_unsupported"
+STORE_METHODS = (
+    "list_job_summaries", "list_task_refs", "list_artifact_refs",
+    "get_selected_economics", "historical_evidence_counts", "list_attempt_refs",
+    "list_run_refs", "list_process_outcome_refs", "list_usage_observation_refs",
+    "get_completion_receipt",
+)
+
+
+def bounded_metadata_available():
+    """Check public contracts without opening stores or masking import failures."""
+    modules = ("identity", "models", "state", "store_factory", "store", "sqlite_store")
+    if any(find_spec("puppetmaster." + name) is None for name in modules):
+        return False
+    identity, models, state, factory, file_store, sqlite_store = (
+        import_module("puppetmaster." + name) for name in modules
+    )
+    ref = getattr(models, "JobRef", None)
+    create = getattr(factory, "create_store", None)
+    if (not hasattr(identity, "StoreIdentityError") or not callable(ref)
+            or not callable(getattr(state, "state_identity", None)) or not callable(create)):
+        return False
+    if (not {"version", "incarnation"} <= signature(ref).parameters.keys()
+            or "mode" not in signature(create).parameters):
+        return False
+    return all(callable(getattr(store, method, None))
+               for store in (getattr(file_store, "SwarmStore", None),
+                             getattr(sqlite_store, "SQLiteSwarmStore", None))
+               for method in STORE_METHODS)
+
+
+def create_metadata_reader(capture, sources=None, local_handle=None):
+    """Only import the new reader after the host has established capability."""
+    from .job_readmodel import KnownSources, MetadataReader
+    return MetadataReader(capture, sources if sources is not None else KnownSources(()), local_handle)
+
+
+def metadata_handler(name):
+    """Adapt an optional metadata endpoint to the registry-owned view."""
+    def handle(request, view):
+        if not view.supported:
+            return 503, dict(code="metadata_unavailable", availability="unavailable",
+                             missing=[UNAVAILABLE_REASON])
+        from .api import job_readmodel
+        return getattr(job_readmodel, name)(request, view.reader())
+    return handle

--- a/harness/job_metadata_view.py
+++ b/harness/job_metadata_view.py
@@ -1,0 +1,161 @@
+"""Registry-owned metadata view. Polls read a capture, never live server globals."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import secrets
+import threading
+
+from .job_metadata_capability import (
+    ActiveContext, ViewChanged, UNAVAILABLE_REASON,
+    bounded_metadata_available, create_metadata_reader,
+)
+
+
+def discover_sources(state_dir, repo):
+    from .job_readmodel import discover_sources as discover
+    return discover(state_dir, repo)
+
+
+@dataclass(frozen=True)
+class ViewTarget:
+    session_id: str = ''
+    repo: str = ''
+    state_dir: str = ''
+
+
+class MetadataView:
+    """Short publication lock, persistent reader, explicitly refreshed sources.
+
+    Registry mutations acquire lock after the pilot/replacement gates. The
+    reader callback acquires only this lock. Never call reader methods, factories,
+    discovery, or external cleanup while holding it.
+    """
+
+    def __init__(self):
+        self.supported = bounded_metadata_available()
+        self.lock = threading.RLock()
+        self._target = ViewTarget()
+        self._context = ActiveContext('', '', secrets.token_hex(16))
+        self._local_handle = None
+        self._sources = None
+        self._reason = 'view_unavailable' if self.supported else UNAVAILABLE_REASON
+        self._discovery = None
+        self._reader = create_metadata_reader(self.capture) if self.supported else None
+
+    def capture(self):
+        with self.lock:
+            return self._context
+
+    def reader(self):
+        with self.lock:
+            return self._reader
+
+    def select(self, session_id='', repo='', state_dir='', *, force=False, local_handle=None):
+        target = ViewTarget(session_id, repo, state_dir)
+        with self.lock:
+            if force or target != self._target or local_handle is not self._local_handle:
+                self._target = target
+                self._local_handle = local_handle
+                self._rotate('sources_not_refreshed' if session_id and repo and state_dir else 'view_unavailable')
+
+    def invalidate(self):
+        # An in-progress configuration transition has no authoritative context.
+        with self.lock:
+            previous = self._target
+            previous_handle = self._local_handle
+            self.select(force=True)
+            return self._context.generation, previous, previous_handle
+
+    def restore(self, transition):
+        """Restore a rejected transition only if no newer publisher intervened."""
+        generation, previous, local_handle = transition
+        with self.lock:
+            if self._context.generation == generation:
+                self.select(previous.session_id, previous.repo, previous.state_dir, force=True, local_handle=local_handle)
+
+    def invalidate_sources(self):
+        with self.lock:
+            self._rotate("sources_not_refreshed")
+
+    def replace_root(self, state_dir, *, local_handle=None):
+        with self.lock:
+            target = self._target
+            self.select(target.session_id, target.repo, state_dir, force=True, local_handle=local_handle)
+
+    def _rotate(self, reason, sources=None):
+        target = self._target
+        self._context = ActiveContext(target.session_id, target.repo, secrets.token_hex(16))
+        self._sources = sources
+        self._reason = reason if self.supported else UNAVAILABLE_REASON
+        self._reader = (create_metadata_reader(self.capture, sources, self._local_handle)
+                        if self.supported else None)
+
+    def describe(self):
+        with self.lock:
+            ctx = self._context
+            result = dict(version=1, context=dict(session_id=ctx.session_id, repo=ctx.repo,
+                          view_generation=ctx.generation), availability='unavailable', sources=[],
+                          local=(self._local_handle.describe() if self.supported and self._local_handle is not None
+                                 else dict(available=False, incarnation=None)),
+                          missing=[self._reason], refreshing=self._discovery == ctx.generation)
+            if self._sources is not None:
+                result.update(availability='known', missing=[], sources=[
+                    dict(source=s.selection.source, state_id=s.selection.state_id,
+                         cross_project=s.cross_project, available=s.handle is not None)
+                    for s in self._sources.stores])
+            if len(json.dumps(result).encode()) > 16384:
+                return dict(version=1, availability='unavailable', sources=[], missing=['response_budget'])
+            return result
+
+    def refresh(self, generation):
+        with self.lock:
+            if generation != self._context.generation:
+                raise ViewChanged()
+            if not self.supported:
+                return 200, self.describe()
+            if self._discovery is not None:
+                return 409, dict(code='refresh_in_progress')
+            target = self._target
+            if not (target.session_id and target.repo and target.state_dir):
+                return 200, self.describe()
+            self._rotate('source_discovery_unavailable')
+            ticket = self._context.generation
+            self._discovery = ticket
+        try:
+            try:
+                sources = discover_sources(target.state_dir, target.repo)
+            except Exception:
+                sources = None
+            with self.lock:
+                if self._context.generation != ticket:
+                    raise ViewChanged()
+                if sources is not None and sources.stores:
+                    # Publication changes the source set: it gets its own epoch
+                    # and exactly one reader, just like the pending view.
+                    self._rotate('', sources)
+                elif sources is not None:
+                    self._reason = 'no_known_sources'
+                self._discovery = None
+                return 200, self.describe()
+        finally:
+            with self.lock:
+                if self._discovery == ticket:
+                    self._discovery = None
+
+
+def get_view(qs, view):
+    if qs:
+        return 400, dict(code='invalid_read_request')
+    return 200, view.describe()
+
+
+def refresh_view(body, view):
+    if (not isinstance(body, dict) or body.keys() != {'view_generation'}
+            or not isinstance(body['view_generation'], str)
+            or not 1 <= len(body['view_generation']) <= 128):
+        return 400, dict(code='invalid_read_request')
+    try:
+        return view.refresh(body['view_generation'])
+    except ViewChanged:
+        return 409, dict(code='view_changed')

--- a/harness/job_readmodel.py
+++ b/harness/job_readmodel.py
@@ -1,0 +1,496 @@
+"""Bounded public PM metadata reads; no body hydration or cancellation authority."""
+from __future__ import annotations
+
+import base64
+import hmac
+import json
+import secrets
+import threading
+from collections import OrderedDict
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Callable, Literal
+
+from puppetmaster.identity import StoreIdentityError
+from puppetmaster.models import JobRef
+from puppetmaster.state import state_identity
+from puppetmaster.store_factory import create_store
+
+from .cli_job_merge import (
+    _foreign_state_dir_candidates,
+    cross_project_scan_enabled,
+    is_marionette_host_scratch_dir,
+    resolve_cli_state_dir,
+)
+from .job_scoping import job_owned_by_marionette
+from .paths import same_workspace_path
+from .job_metadata_capability import ActiveContext, ViewChanged
+
+PAGE_BUDGET = dict(limit=50, max_scan=51, max_bytes=32768)
+EXACT_BUDGET = dict(limit=1, max_scan=2, max_bytes=8192)
+HISTORY_BUDGET = dict(limit=20, max_scan=21, max_bytes=8192)
+HISTORY_LANES = {
+    'attempts': 'list_attempt_refs', 'runs': 'list_run_refs',
+    'process_outcomes': 'list_process_outcome_refs',
+    'observations': 'list_usage_observation_refs',
+}
+RUNNING = frozenset(('queued', 'running', 'stitching', 'in_progress', 'pending', 'started'))
+PM_STATUSES = RUNNING | frozenset(('complete', 'failed', 'stalled', 'cancelled'))
+ATTENTION = frozenset(('failed', 'stalled'))
+MEMBERSHIP_IDS = 200
+
+
+class InvalidReadRequest(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ReadContext:
+    session_id: str
+    repo: str
+    view_generation: str
+    scope: Literal['session', 'repo', 'all']
+
+
+@dataclass(frozen=True)
+class StoreSelection:
+    source: Literal['harness', 'cli']
+    state_id: str
+
+
+@dataclass(frozen=True)
+class PMSelection:
+    context: ReadContext
+    store: StoreSelection
+    job_ref: JobRef
+
+    def wire(self):
+        return dict(job_ref=self.job_ref.as_dict(), source=self.store.source,
+                    session_id=self.context.session_id, repo=self.context.repo)
+
+
+@dataclass(frozen=True)
+class KnownStore:
+    selection: StoreSelection
+    root: Path
+    backend: Literal['sqlite', 'file']
+    cross_project: bool = False
+    handle: object = field(default=None, repr=False, compare=False)
+
+
+@dataclass(frozen=True)
+class KnownSources:
+    stores: tuple[KnownStore, ...]
+
+    @classmethod
+    def from_roots(cls, roots):
+        """Trusted host roots only; bounded and deduplicated before serving reads."""
+        entries = list(roots)
+        if len(entries) > 34:
+            raise ValueError('at most two primary and 32 sibling roots')
+        result = {}
+        for source, root, backend, cross_project in sorted(entries, key=lambda x: x[0] != 'harness'):
+            if source not in ('harness', 'cli') or backend not in ('sqlite', 'file'):
+                raise ValueError('invalid host source')
+            path = Path(root).resolve()
+            if is_marionette_host_scratch_dir(path):
+                continue
+            identity = state_identity(path)
+            if identity not in result:
+                database = path / ('state.sqlite3' if backend == 'sqlite' else 'metadata.sqlite3')
+                # Store handles are captured at view creation, not in the HTTP
+                # hot path. A disappearing root can never be recreated by a poll.
+                handle = create_store(backend, path, mode='deferred') if path.is_dir() and database.is_file() else None
+                result[identity] = KnownStore(StoreSelection(source, identity), path, backend, cross_project, handle)
+        return cls(tuple(result.values()))
+
+    def resolve(self, selection):
+        return next((s for s in self.stores if s.selection == selection), None)
+
+
+def discover_sources(harness_root, workspace, *, harness_backend='sqlite'):
+    """Run at host view creation, never inside a metadata request."""
+    primary = resolve_cli_state_dir(workspace)
+    roots = [('harness', harness_root, harness_backend, False)]
+    if primary:
+        roots.append(('cli', primary, 'sqlite', False))
+    if cross_project_scan_enabled():
+        roots.extend(('cli', root, 'sqlite', True) for root in
+                     _foreign_state_dir_candidates(str(Path(primary).resolve()) if primary else '', max_opens=32))
+    return KnownSources.from_roots(roots)
+
+
+def _attach(known):
+    # Public attach() sets journal_mode=WAL even on rejected old stores.
+    # Deferred construction plus public metadata reads never invokes init/ensure.
+    # Reuse the startup handle: constructors can create roots and chmod them.
+    database = known.root / ('state.sqlite3' if known.backend == 'sqlite' else 'metadata.sqlite3')
+    if not known.root.is_dir() or not database.is_file():
+        return None
+    return known.handle
+
+
+def _page(outcome='unavailable', revision=0, cursor=None, scanned=0, checkpoint=0):
+    return dict(outcome=outcome, revision=revision, next_cursor=cursor,
+                scanned=scanned, checkpoint=checkpoint)
+
+
+def _size(value):
+    # Exactly the encoding used by http_routes.send_json, including ASCII escaping.
+    return len(json.dumps(value).encode('utf-8'))
+
+
+class MetadataReader:
+    """One host view lifetime; immutable sources and a bounded authorization window.
+
+    active_context must atomically capture session, repo and an ABA-safe generation.
+    No callback may discover roots, instantiate DurableState or load job bodies.
+    """
+
+    def __init__(self, active_context: Callable[[], ActiveContext], sources: KnownSources, local_handle=None):
+        self.active_context = active_context
+        self.sources = sources
+        self.local_handle = local_handle
+        self._secret = secrets.token_bytes(32)
+        if len(sources.stores) > 34:
+            raise ValueError('at most 34 known sources')
+        # The captured view fixes sources/context; only scopes and status lanes vary.
+        self.membership_stream_limit = sum(
+            len(RUNNING) * 2 if s.cross_project else (len(PM_STATUSES) + 1) * 3
+            for s in sources.stores)
+        self._seen = OrderedDict()
+        self._lock = threading.Lock()
+
+    def check(self, ctx):
+        if ctx.scope not in ('session', 'repo', 'all'):
+            raise InvalidReadRequest()
+        active = self.active_context()
+        if (active.session_id != ctx.session_id or active.generation != ctx.view_generation
+                or not same_workspace_path(active.repo, ctx.repo)):
+            raise ViewChanged()
+        return active
+
+    def _binding(self, ctx, selection, lane, after, status, job_id):
+        return [asdict(ctx), asdict(selection), lane, after, status, job_id]
+
+    def _cursor(self, token, binding):
+        if token is None:
+            return None
+        try:
+            raw = base64.b64decode(token, altchars=b'-_', validate=True)
+            signature, data = raw[:32], raw[32:]
+            if not hmac.compare_digest(signature, hmac.digest(self._secret, data, 'sha256')):
+                raise ValueError()
+            value = json.loads(data)
+            if value['binding'] != binding or not isinstance(value['cursor'], str):
+                raise ValueError()
+            return value['cursor']
+        except (ValueError, KeyError, TypeError, UnicodeError) as exc:
+            raise InvalidReadRequest() from exc
+
+    def _wrap(self, cursor, binding):
+        if cursor is None:
+            return None
+        data = json.dumps(dict(binding=binding, cursor=cursor), separators=(',', ':')).encode()
+        return base64.urlsafe_b64encode(hmac.digest(self._secret, data, 'sha256') + data).decode()
+
+    def _wire_page(self, page, binding, after):
+        result = _page(page.outcome, page.revision, self._wrap(page.next_cursor, binding),
+                       page.scanned, page.revision if page.outcome == 'complete' else after)
+        if page.reason is not None:
+            result['reason'] = page.reason
+        if page.retry_after_ms is not None:
+            result['retry_after_ms'] = page.retry_after_ms
+        return result
+
+    def _known(self, ctx, selection):
+        known = self.sources.resolve(selection)
+        if known and (not known.cross_project or (ctx.scope != 'repo' and cross_project_scan_enabled())):
+            return known
+        return None
+
+    def _owned(self, row, known, ctx, *, pin=False):
+        if not row.session_id or not job_owned_by_marionette(
+            session_id=row.session_id, origin=row.origin or '', source=known.selection.source,
+            allow_registered_heal=False,
+        ):
+            return False
+        if known.cross_project and row.status not in RUNNING:
+            return False
+        return (ctx.scope != 'session' or row.session_id == ctx.session_id
+                or (pin and not known.cross_project))
+
+    def _previous_owned(self, row, known, ctx, status):
+        if row.previous_membership != 'present':
+            return False
+        previous = replace(row, status=row.previous_status, origin=row.previous_origin,
+                           project_id=row.previous_project_id, session_id=row.previous_session_id)
+        return self._owned(previous, known, ctx) and (status is None or previous.status == status)
+
+    @staticmethod
+    def _display(row):
+        return dict(kind='available' if row.goal_preview is not None else 'unavailable',
+                    goal_preview=row.goal_preview, goal_preview_truncated=row.goal_preview_truncated,
+                    delivery=row.delivery, quality=row.quality,
+                    **({} if row.goal_preview is not None else {'reason': 'goal_preview_unavailable'}))
+
+    def _summary(self, row, ctx, selection, *, removed=False):
+        result = dict(selection=PMSelection(ctx, selection, row.job_ref).wire(),
+                      revision=row.revision, deleted=removed)
+        if not removed:
+            result.update(lifecycle=row.status,
+                          activity=('active' if row.status in RUNNING else 'attention' if row.status in ATTENTION
+                                    else 'terminal' if row.status in PM_STATUSES else 'unknown'),
+                          ownership=dict(origin=row.origin, session_id=row.session_id, project_id=row.project_id),
+                          task_count=row.task_count, artifact_count=row.artifact_count, stamp=row.stamp,
+                          display=self._display(row), economics=dict(kind='unavailable', reason='selected_only'))
+        return result
+
+    def read_job_page(self, ctx, selection, *, mode='snapshot', cursor=None, after_revision=0, status=None):
+        if (mode not in ('snapshot', 'changes') or type(after_revision) is not int or after_revision < 0
+                or (status is not None and status not in PM_STATUSES)):
+            raise InvalidReadRequest()
+        active = self.check(ctx)
+        binding = self._binding(ctx, selection, mode, after_revision, status, None)
+        pm_cursor = self._cursor(cursor, binding)
+        result = dict(version=1, context=asdict(ctx), store=asdict(selection), mode=mode,
+                      page=_page(checkpoint=after_revision), rows=[],
+                      coverage=dict(membership='known_metadata', legacy='unavailable', ordering='id', store_set='known_sources'),
+                      missing=['legacy_ownership', 'economics'])
+        known = self._known(ctx, selection)
+        if known is None:
+            result['missing'].append('store_unavailable')
+            self.check(ctx)
+            return result
+        result['lanes'] = dict(statuses=sorted(RUNNING if known.cross_project else PM_STATUSES),
+                               active_statuses=sorted(RUNNING),
+                               attention_statuses=[] if known.cross_project else sorted(ATTENTION))
+        if known.cross_project and status not in RUNNING:
+            raise InvalidReadRequest()
+        store = _attach(known)
+        if store is None:
+            result['missing'].append('store_unavailable')
+            self.check(ctx)
+            return result
+        filters = dict(session_id=ctx.session_id if ctx.scope == 'session' else None,
+                       origin='marionette' if selection.source == 'cli' else None, status=status)
+        method = store.list_job_summaries if mode == 'snapshot' else store.read_job_summary_changes
+        try:
+            page = method(cursor=pm_cursor, after_revision=after_revision, **filters, **PAGE_BUDGET)
+        except StoreIdentityError:
+            result['missing'].append('selection_changed')
+            self.check(ctx)
+            return result
+        result['page'] = self._wire_page(page, binding, after_revision)
+        if page.reason:
+            result['missing'].append(page.reason)
+        key = (active, ctx.scope, selection, status)
+        with self._lock:
+            seen = self._seen.get(key, {})
+            updates = []
+            uncertain = False
+            for row in page.items:
+                owned = not row.deleted and self._owned(row, known, ctx)
+                previous_owned = self._previous_owned(row, known, ctx, status)
+                if owned:
+                    result['rows'].append(self._summary(row, ctx, selection))
+                    updates.append((row.job_ref, row.revision))
+                elif row.job_ref in seen or previous_owned:
+                    if row.revision >= seen.get(row.job_ref, 0):
+                        result['rows'].append(self._summary(row, ctx, selection, removed=True))
+                elif mode == 'changes' and row.previous_membership == 'unavailable':
+                    uncertain = True
+            if uncertain:
+                result.update(page=_page(checkpoint=after_revision), rows=[])
+                result['missing'].append('previous_membership_unavailable')
+            if _size(result) > 65536:
+                result.update(page=_page(checkpoint=after_revision), rows=[])
+                result['missing'].append('response_budget')
+            self.check(ctx)
+            if result['page']['outcome'] in ('complete', 'partial'):
+                window = self._seen.setdefault(key, OrderedDict())
+                for jid, revision in updates:
+                    window[jid] = max(revision, window.get(jid, 0))
+                    window.move_to_end(jid)
+                while len(window) > MEMBERSHIP_IDS:
+                    window.popitem(last=False)
+                self._seen.move_to_end(key)
+                while len(self._seen) > self.membership_stream_limit:
+                    self._seen.popitem(last=False)
+        return result
+
+    def _selected(self, selection, *, pin=False):
+        ctx = selection.context
+        known = self._known(ctx, selection.store)
+        if known is None:
+            return None, None, 'store_unavailable'
+        store = _attach(known)
+        if store is None:
+            return None, None, 'store_unavailable'
+        try:
+            page = store.list_job_summaries(job_ref=selection.job_ref, **EXACT_BUDGET)
+        except StoreIdentityError:
+            return None, None, 'selection_changed'
+        if page.outcome != 'complete':
+            return None, None, page.reason or page.outcome
+        if len(page.items) != 1 or page.items[0].deleted:
+            return None, None, 'missing'
+        row = page.items[0]
+        if row.job_ref != selection.job_ref or not self._owned(row, known, ctx, pin=pin):
+            return None, None, 'ownership_unknown'
+        return store, row, None
+
+    def read_pins(self, ctx, selections):
+        if len(selections) > 8 or any(s.context != ctx or s.job_ref.state_id != s.store.state_id for s in selections):
+            raise InvalidReadRequest()
+        self.check(ctx)
+        results = []
+        for selection in selections:
+            self.check(ctx)
+            _, row, reason = self._selected(selection, pin=True)
+            result = dict(kind='unavailable', reason=reason) if reason else dict(
+                kind='present', row=self._summary(row, ctx, selection.store))
+            results.append(dict(selection=selection.wire(), result=result))
+        response = dict(version=1, context=asdict(ctx), results=results)
+        if _size(response) > 65536:
+            response['results'] = [dict(selection=s.wire(), result=dict(kind='unavailable', reason='response_budget'))
+                                   for s in selections]
+        self.check(ctx)
+        return response
+
+    def read_selected_metadata(self, selection, *, task_cursor=None, artifact_cursor=None,
+                               attempt_cursor=None, run_cursor=None, process_outcome_cursor=None,
+                               observation_cursor=None):
+        if selection.job_ref.state_id != selection.store.state_id:
+            raise InvalidReadRequest()
+        ctx = selection.context
+        self.check(ctx)
+        bindings = {lane: self._binding(ctx, selection.store, lane, 0, None, selection.job_ref.as_dict())
+                    for lane in ('tasks', 'artifacts', *HISTORY_LANES)}
+        cursors = dict(tasks=self._cursor(task_cursor, bindings['tasks']),
+                       artifacts=self._cursor(artifact_cursor, bindings['artifacts']))
+        history_cursors = dict(attempts=attempt_cursor, runs=run_cursor,
+                               process_outcomes=process_outcome_cursor, observations=observation_cursor)
+        history_cursors = {lane: self._cursor(token, bindings[lane]) for lane, token in history_cursors.items()}
+        unavailable_reason = 'legacy_ref' if selection.job_ref.version == 1 else 'selection_unavailable'
+        result = dict(version=1, selection=selection.wire(), context=asdict(ctx), lifecycle=None,
+                      tasks=dict(page=_page(), rows=[]), artifacts=dict(page=_page(), rows=[]),
+                      display=dict(kind='unavailable', reason='selection_unavailable'),
+                      task_count=None, artifact_count=None,
+                      history=dict(kind='unavailable', reason=unavailable_reason),
+                      cost=dict(kind='unavailable', reason=unavailable_reason),
+                      cancellation_authority=False, missing=['history', 'cost'])
+        store, row, reason = self._selected(selection)
+        if reason:
+            result.update(display=dict(kind='unavailable', reason=reason),
+                          history=dict(kind='unavailable', reason=reason),
+                          cost=dict(kind='unavailable', reason=reason))
+            result['missing'].append(reason)
+            self.check(ctx)
+            return result
+        result.update(lifecycle=row.status, display=self._display(row),
+                      task_count=row.task_count, artifact_count=row.artifact_count)
+        for lane, method in (('tasks', store.list_task_refs), ('artifacts', store.list_artifact_refs)):
+            self.check(ctx)
+            page = method(selection.job_ref, cursor=cursors[lane], **PAGE_BUDGET)
+            rows = []
+            for item in page.items:
+                if item.job_ref != selection.job_ref:
+                    raise RuntimeError('public metadata escaped selected ref')
+                projected = dict(id=item.id, status=item.status, stamp=item.stamp, revision=item.revision)
+                if lane == 'tasks':
+                    projected['binding'] = asdict(item.binding) if item.binding else None
+                else:
+                    projected.update(task_id=item.task_id, type=item.artifact_type, sha256=item.sha256,
+                                     presence='recorded', check_result='unavailable')
+                rows.append(projected)
+            result[lane] = dict(page=self._wire_page(page, bindings[lane], 0), rows=rows)
+        if selection.job_ref.version == 2:
+            self.check(ctx)
+            economics = store.get_selected_economics(selection.job_ref, expected_summary_revision=row.revision)
+            if economics.job_ref != selection.job_ref:
+                raise RuntimeError('public economics escaped selected ref')
+            result['cost'] = dict(kind=economics.outcome, **asdict(economics))
+            if economics.outcome == 'available':
+                result['missing'].remove('cost')
+            result['history'] = self._history(store, selection, bindings, history_cursors)
+            if result['history']['kind'] == 'available':
+                result['missing'].remove('history')
+        # Separate bounded reads are not a transaction. Never return lanes from a
+        # selection that lost ownership or changed while they were being read.
+        _, current, reason = self._selected(selection)
+        if reason or current.revision != row.revision:
+            result.update(lifecycle=None, display=dict(kind='unavailable', reason='selection_changed'),
+                          task_count=None, artifact_count=None,
+                          tasks=dict(page=_page(), rows=[]), artifacts=dict(page=_page(), rows=[]),
+                          history=dict(kind='unavailable', reason='selection_changed'),
+                          cost=dict(kind='unavailable', reason='selection_changed'),
+                          missing=['selection_changed', 'history', 'cost'])
+        if _size(result) > 98304:
+            result.update(tasks=dict(page=_page(), rows=[]), artifacts=dict(page=_page(), rows=[]),
+                          history=dict(kind='unavailable', reason='response_budget'),
+                          cost=dict(kind='unavailable', reason='response_budget'))
+            result['missing'] = list(dict.fromkeys(result['missing'] + ['response_budget', 'history', 'cost']))
+        self.check(ctx)
+        return result
+
+    def _history(self, store, selection, bindings, cursors):
+        counts = store.historical_evidence_counts(selection.job_ref)
+        result = dict(kind='available' if counts.outcome == 'available' else 'unavailable',
+                      counts=asdict(counts), missing=[] if counts.outcome == 'available' else ['counts'])
+        for lane, method in HISTORY_LANES.items():
+            self.check(selection.context)
+            page = getattr(store, method)(selection.job_ref, cursor=cursors[lane], **HISTORY_BUDGET)
+            rows = []
+            for item in page.items:
+                if item.job_ref != selection.job_ref:
+                    raise RuntimeError('public history escaped selected ref')
+                projected = asdict(item)
+                if lane == 'runs':
+                    receipt = store.get_completion_receipt(selection.job_ref, item.facts['id'])
+                    if receipt.job_ref != selection.job_ref or receipt.run_id != item.facts['id']:
+                        raise RuntimeError('public completion escaped selected run')
+                    projected['completion'] = asdict(receipt)
+                rows.append(projected)
+            result[lane] = dict(page=dict(outcome=page.outcome,
+                next_cursor=self._wrap(page.next_cursor, bindings[lane]), scanned=page.scanned,
+                captured_count=page.captured_count, coverage=page.coverage,
+                complete_invocation_history=page.complete_invocation_history), rows=rows)
+            if page.outcome not in ('complete', 'partial'):
+                result['kind'] = 'unavailable'
+                result['missing'].append(lane)
+        return result
+
+    def read_local(self, ctx, *, mode='snapshot', cursor=None, after_revision=0, lane='history'):
+        if lane not in ('active', 'history'):
+            raise InvalidReadRequest()
+        self.check(ctx)
+        context = dict(session_id=ctx.session_id, repo=ctx.repo,
+                       view_generation=ctx.view_generation, scope=ctx.scope)
+        if self.local_handle is None:
+            result = dict(version=1, page=_page(checkpoint=after_revision), rows=[],
+                          missing=['local_index_unavailable'])
+        else:
+            result = self.local_handle.read_page(context, mode=mode, cursor=cursor,
+                                                 after_revision=after_revision, lane=lane)
+        result['context'] = context
+        if _size(result) > 32768:
+            result = dict(version=1, context=context, page=_page(checkpoint=after_revision),
+                          rows=[], missing=['response_budget'])
+        result['lane'] = lane
+        self.check(ctx)
+        return result
+
+    def read_local_selected(self, ctx, local_ref, *, lane='actions', cursor=None, include_context=False):
+        self.check(ctx)
+        context = dict(session_id=ctx.session_id, repo=ctx.repo,
+                       view_generation=ctx.view_generation, scope=ctx.scope)
+        if self.local_handle is None:
+            result = dict(version=1, page=_page(), rows=[], missing=['local_index_unavailable'])
+        else:
+            result = self.local_handle.read_selected(context, local_ref, lane=lane, cursor=cursor, include_context=include_context)
+        result['context'] = context
+        if _size(result) > 32768:
+            result = dict(version=1, context=context, page=_page(), rows=[], missing=['response_budget'])
+        self.check(ctx)
+        return result

--- a/harness/server.py
+++ b/harness/server.py
@@ -164,6 +164,7 @@ def _clear_active_pilot() -> None:
         if active_id:
             _runners.detach_view(active_id)
         _pilot = None
+        _runners.metadata_view.invalidate()
 
 
 def _sync_pilot_session_id() -> None:
@@ -1386,6 +1387,7 @@ def _attach_view(
     factory=None,
     load_transcript_on_create: bool = True,
     defer_cold_build: Optional[bool] = None,
+    view_repo: Optional[str] = None,
 ) -> Any:
     """Point the UI at ``session_id`` via the runner registry.
 
@@ -1399,6 +1401,7 @@ def _attach_view(
         factory=factory,
         load_transcript_on_create=load_transcript_on_create,
         defer_cold_build=defer_cold_build,
+        view_repo=view_repo,
     )
 
 
@@ -1826,6 +1829,9 @@ def _workspace_services():
 
     return WorkspaceServices(
         cfg=_cfg,
+        invalidate_metadata_view=_runners.metadata_view.invalidate,
+        restore_metadata_view=_runners.metadata_view.restore,
+        invalidate_metadata_sources=_runners.metadata_view.invalidate_sources,
         parse_bool=_parse_bool,
         ws=_ws,
         paths_same_workspace=_paths_same_workspace,
@@ -2283,7 +2289,7 @@ _migrate_orphan_sessions_to_home()
 if _sessions.active:
     _startup_history = load_transcript(_cfg.state_dir or _tf.gettempdir(), _sessions.active)
     _runners.get_or_create(_sessions.active, lambda: _pilot)
-    _runners.set_active_view(_sessions.active)
+    _runners.set_active_view(_sessions.active, repo=_cfg.repo or "")
     # Session ownership before hydrate so pending DANGER approval restore
     # validates display rows against the owning session.
     _sync_pilot_session_id()
@@ -2561,6 +2567,7 @@ def _route_services():
         endpoint_identity=lambda: _endpoint_identity(),
         review_services=_review_services,
         job_services=_job_services,
+        metadata_view=lambda: _runners.metadata_view,
         session_control_services=_session_control_services,
         checkpoint_services=_checkpoint_services,
         codegraph_services=_codegraph_services,
@@ -2798,19 +2805,24 @@ class Handler(BaseHTTPRequestHandler):
                     return
         return self._send(404, json.dumps({"error": "not found"}))
 
-    def _read_json(self) -> dict:
+    def _read_json(self, *, max_bytes=None) -> dict:
         """Parse the request JSON body, rejecting oversized Content-Length first.
 
         Cap mirrors the upload DoS gate style: refuse before ``rfile.read`` so a
         huge POST cannot exhaust memory on the thread-per-request server.
         """
+        if max_bytes is not None:
+            lengths = self.headers.get_all('Content-Length', [])
+            if (len(lengths) != 1 or not lengths[0].isascii() or not lengths[0].isdigit()
+                    or self.headers.get('Transfer-Encoding')):
+                raise json.JSONDecodeError('invalid request framing', doc='', pos=0)
         try:
             n = int(self.headers.get("Content-Length", 0) or 0)
         except (TypeError, ValueError):
             n = 0
         if not n:
             return {}
-        limit = _json_body_max_bytes()
+        limit = min(_json_body_max_bytes(), max_bytes) if max_bytes is not None else _json_body_max_bytes()
         if n > limit:
             raise _JsonBodyTooLarge(n, limit)
         data = self.rfile.read(n)
@@ -2822,7 +2834,12 @@ class Handler(BaseHTTPRequestHandler):
 
     def _handle_post_json(self, path):
         try:
-            body = self._read_json()
+            if path in ('/api/jobs/metadata/pins', '/api/jobs/metadata/view/refresh'):
+                if urlparse(self.path).query:
+                    return self._send(400, json.dumps({'code': 'invalid_read_request'}))
+                body = self._read_json(max_bytes=65536)
+            else:
+                body = self._read_json()
         except _JsonBodyTooLarge as exc:
             return self._send(
                 413,

--- a/harness/session_runners.py
+++ b/harness/session_runners.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 from typing import Any, Callable, Optional
 from .pilot_replacement import replacement_gate
+from .job_metadata_view import MetadataView
 
 DEFAULT_MAX_CONCURRENT_SESSIONS = 3
 
@@ -153,6 +154,7 @@ class SessionRunnerRegistry:
         self._runners: dict[str, Any] = {}
         self._order: list[str] = []
         self._active_view_id: Optional[str] = None
+        self.metadata_view = MetadataView()
         # Optional hook (e.g. fold boot cost meters) when a runner leaves the
         # registry via drop/evict. Rebuild/swap pass notify=False to skip it.
         self._on_drop = on_drop
@@ -163,7 +165,8 @@ class SessionRunnerRegistry:
 
     @property
     def active_view_id(self) -> Optional[str]:
-        return self._active_view_id
+        with self.metadata_view.lock:
+            return self._active_view_id
 
     def get(self, session_id: str) -> Optional[Any]:
         return self._runners.get(session_id)
@@ -192,8 +195,12 @@ class SessionRunnerRegistry:
             )
 
         runner = factory()
-        self._runners[session_id] = runner
-        self._order.append(session_id)
+        with self.metadata_view.lock:
+            self._runners[session_id] = runner
+            self._order.append(session_id)
+            if self._active_view_id == session_id:
+                self.metadata_view.replace_root(getattr(runner, 'state_dir', '') or '',
+                                                local_handle=getattr(runner, '_local_metadata', None))
         return runner
 
     def drop(self, session_id: str, *, notify: bool = True) -> Optional[Any]:
@@ -211,13 +218,15 @@ class SessionRunnerRegistry:
             if getattr(runner, '_input_admissions', 0):
                 raise RuntimeError('input admission in progress -- retry removing the session')
             runner._replacement_retired = True
-            self._runners.pop(session_id, None)
+            with self.metadata_view.lock:
+                self._runners.pop(session_id, None)
+                if self._active_view_id == session_id:
+                    self._active_view_id = None
+                    self.metadata_view.invalidate()
         try:
             self._order.remove(session_id)
         except ValueError:
             pass
-        if self._active_view_id == session_id:
-            self._active_view_id = None
         # S3: session-switch / eviction owns this runner — close warm ACP so
         # Windows cannot retain orphan agent acp children after drop.
         try:
@@ -255,14 +264,22 @@ class SessionRunnerRegistry:
                 raise LeaseExhaustedError(
                     "session runner lease exhausted: all concurrent sessions are busy"
                 )
-            self._runners[session_id] = runner
-            self._order.append(session_id)
+            with self.metadata_view.lock:
+                self._runners[session_id] = runner
+                self._order.append(session_id)
+                if self._active_view_id == session_id:
+                    self.metadata_view.replace_root(getattr(runner, 'state_dir', '') or '',
+                                                local_handle=getattr(runner, '_local_metadata', None))
             return None
         with replacement_gate(old):
             if getattr(old, '_input_admissions', 0):
                 raise RuntimeError('input admission in progress -- retry replacing the runner')
             old._replacement_retired = True
-            self._runners[session_id] = runner
+            with self.metadata_view.lock:
+                self._runners[session_id] = runner
+                if self._active_view_id == session_id:
+                    self.metadata_view.replace_root(getattr(runner, 'state_dir', '') or '',
+                                                    local_handle=getattr(runner, '_local_metadata', None))
         if notify and self._on_drop is not None:
             try:
                 self._on_drop(session_id, old)
@@ -270,15 +287,25 @@ class SessionRunnerRegistry:
                 pass
         return old
 
-    def set_active_view(self, session_id: str) -> None:
-        self._active_view_id = session_id
+    def set_active_view(self, session_id: str, *, repo: Optional[str] = None) -> None:
+        with self.metadata_view.lock:
+            runner = self._runners.get(session_id)
+            if repo is None:
+                repo = getattr(getattr(runner, 'config', None), 'repo', '') or ''
+            root = getattr(runner, 'state_dir', '') or ''
+            changed = self._active_view_id != session_id
+            self._active_view_id = session_id
+            self.metadata_view.select(session_id, repo, root, force=changed,
+                                      local_handle=getattr(runner, '_local_metadata', None))
 
     def detach_view(self, session_id: str) -> bool:
         """Clear active view when the UI detaches; runner keeps executing."""
-        if self._active_view_id == session_id:
-            self._active_view_id = None
-            return True
-        return False
+        with self.metadata_view.lock:
+            if self._active_view_id == session_id:
+                self._active_view_id = None
+                self.metadata_view.invalidate()
+                return True
+            return False
 
     def status(self, session_id: str) -> str:
         runner = self._runners.get(session_id)

--- a/tests/test_api_workspace_peel.py
+++ b/tests/test_api_workspace_peel.py
@@ -203,7 +203,7 @@ def _bind_workspace_open(svc, sessions, tmp_path):
     svc.record_recent_workspace = lambda r, as_active=True: []
     svc.sessions_state_dir = lambda: str(tmp_path)
     svc.session_visible_for_workspace = lambda s, r, d: True
-    svc.attach_view = lambda sid, defer_cold_build=False: attached.__setitem__(
+    svc.attach_view = lambda sid, defer_cold_build=False, view_repo=None: attached.__setitem__(
         "n", attached["n"] + 1
     )
     svc.puppetmaster_available = lambda: False
@@ -350,7 +350,7 @@ def test_workspace_open_existing_sessions_does_not_create(tmp_path):
     svc.record_recent_workspace = lambda r, as_active=True: []
     svc.sessions_state_dir = lambda: str(tmp_path)
     svc.session_visible_for_workspace = lambda s, r, d: True
-    svc.attach_view = lambda sid, defer_cold_build=False: None
+    svc.attach_view = lambda sid, defer_cold_build=False, view_repo=None: None
     svc.puppetmaster_available = lambda: False
     svc.set_codegraph_status = lambda status, reason=None: None
     svc.index_codegraph_bg = lambda r: None
@@ -400,7 +400,7 @@ def test_workspace_open_lease_exhausted_rolls_back(tmp_path):
     svc.record_recent_workspace = lambda r, as_active=True: []
     svc.sessions_state_dir = lambda: str(tmp_path)
     svc.session_visible_for_workspace = lambda s, r, d: True
-    svc.attach_view = lambda sid, defer_cold_build=False: (_ for _ in ()).throw(
+    svc.attach_view = lambda sid, defer_cold_build=False, view_repo=None: (_ for _ in ()).throw(
         _LeaseErr("full")
     )
     svc.lease_exhausted_error = _LeaseErr

--- a/tests/test_job_metadata_capability.py
+++ b/tests/test_job_metadata_capability.py
@@ -1,0 +1,133 @@
+"""Public-runtime startup and bounded metadata capability boundary."""
+import http.client
+import json
+import os
+import sys
+import threading
+from http.server import ThreadingHTTPServer
+from types import SimpleNamespace
+
+import pytest
+
+from harness.job_metadata_capability import bounded_metadata_available, UNAVAILABLE_REASON
+
+
+@pytest.mark.parametrize("force_missing", [False, True])
+def test_server_startup_and_registry(tmp_path, monkeypatch, force_missing):
+    import harness.server as server
+    from harness.session_runners import SessionRunnerRegistry
+
+    import harness.job_metadata_view as view_module
+
+    actual = bounded_metadata_available()
+    expected = os.environ.get("PM_METADATA_EXPECT_SUPPORTED")
+    if expected is not None:
+        assert actual == (expected == "1")
+    if force_missing:
+        monkeypatch.setattr(view_module, "bounded_metadata_available", lambda: False)
+    supported = actual and not force_missing
+    if not supported:
+        def forbidden(*args, **kwargs):
+            pytest.fail("unsupported metadata invoked reader, discovery, or native observer")
+        monkeypatch.setattr(view_module, "create_metadata_reader", forbidden)
+        monkeypatch.setattr(view_module, "discover_sources", forbidden)
+
+    reg = SessionRunnerRegistry()
+    assert reg.metadata_view.supported is supported
+    assert (reg.metadata_view.reader() is not None) is supported
+    runner = SimpleNamespace(config=SimpleNamespace(repo=str(tmp_path)),
+                             state_dir=str(tmp_path / "store"))
+    if not supported:
+        runner._local_metadata = SimpleNamespace(describe=forbidden)
+    assert reg.get_or_create("A", lambda: runner) is runner
+    reg.set_active_view("A")
+    assert reg.get("A") is runner
+    assert reg.active_view_id == "A"
+    assert reg.status("A") == "idle"
+    monkeypatch.setattr(server, "_runners", reg)
+    monkeypatch.setattr(server, "_GET_ROUTES", None)
+    monkeypatch.setattr(server, "_POST_JSON_ROUTES", None)
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    def request(method, path, body=None, token=True):
+        conn = http.client.HTTPConnection("127.0.0.1", httpd.server_port, timeout=5)
+        headers = {"X-Harness-Token": server._TOKEN} if token else {}
+        conn.request(method, path, body=json.dumps(body) if body is not None else None, headers=headers)
+        response = conn.getresponse()
+        result = response.status, json.loads(response.read())
+        conn.close()
+        return result
+
+    try:
+        status, payload = request("GET", "/api/jobs/metadata/view")
+        assert status == 200
+        assert payload["context"]["session_id"] == "A"
+        assert payload["availability"] == "unavailable"
+        assert payload["missing"] == (["sources_not_refreshed"] if supported else [UNAVAILABLE_REASON])
+        generation = payload["context"]["view_generation"]
+        assert request("GET", "/api/sessions/runners")[0] == 200
+        assert request("GET", "/api/jobs/metadata/view?unknown=")[0] == 400
+        assert request("POST", "/api/jobs/metadata/view/refresh", {})[0] == 400
+        assert request("POST", "/api/jobs/metadata/view/refresh", {"view_generation": "stale"})[0] == 409
+        endpoints = [("GET", "", None), ("GET", "/detail", None),
+                     ("GET", "/local", None), ("GET", "/local/detail", None),
+                     ("POST", "/pins", {})]
+        for method, suffix, body in endpoints + [("GET", "/view", None),
+                ("POST", "/view/refresh", {"view_generation": generation})]:
+            assert request(method, "/api/jobs/metadata" + suffix, body, token=False)[0] == 403
+        for method, suffix, body in endpoints:
+            status, result = request(method, "/api/jobs/metadata" + suffix, body)
+            if supported:
+                assert status == 400
+                assert result["code"] == "invalid_read_request"
+            else:
+                assert status == 503
+                assert result == dict(code="metadata_unavailable", availability="unavailable",
+                                      missing=[UNAVAILABLE_REASON])
+        if not supported:
+            assert request("POST", "/api/jobs/metadata/view/refresh",
+                           {"view_generation": generation}) == (200, payload)
+            transition = reg.metadata_view.invalidate()
+            reg.metadata_view.restore(transition)
+            reg.metadata_view.invalidate_sources()
+            reg.metadata_view.replace_root(str(tmp_path / "another"))
+            assert reg.metadata_view.describe()["missing"] == [UNAVAILABLE_REASON]
+            assert reg.metadata_view.capture().session_id == "A"
+            assert reg.metadata_view.capture().generation != generation
+        if not actual:
+            assert "harness.job_readmodel" not in sys.modules
+            assert "harness.api.job_readmodel" not in sys.modules
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(5)
+    assert reg.detach_view("A")
+    assert reg.get("A") is runner
+
+
+def test_capability_does_not_mask_broken_imports(monkeypatch):
+    import harness.job_metadata_capability as capability
+
+    monkeypatch.setattr(capability, "find_spec", lambda name: object())
+    def broken(name):
+        raise RuntimeError("broken PM installation")
+    monkeypatch.setattr(capability, "import_module", broken)
+    with pytest.raises(RuntimeError, match="broken PM installation"):
+        capability.bounded_metadata_available()
+
+
+def test_capability_requires_both_store_contracts(monkeypatch):
+    import harness.job_metadata_capability as capability
+
+    if not bounded_metadata_available():
+        # Public 1.23 has no identity module; no new API may be imported.
+        assert capability.find_spec("puppetmaster.identity") is None
+        return
+    from puppetmaster.sqlite_store import SQLiteSwarmStore
+    from puppetmaster.store import SwarmStore
+    for store in (SQLiteSwarmStore, SwarmStore):
+        with monkeypatch.context() as patch:
+            patch.setattr(store, "list_job_summaries", None)
+            assert not capability.bounded_metadata_available()
+    assert capability.bounded_metadata_available()

--- a/tests/test_job_metadata_contract.py
+++ b/tests/test_job_metadata_contract.py
@@ -1,0 +1,256 @@
+"""Selected history and economics through public Puppetmaster contracts."""
+from dataclasses import asdict, replace
+
+
+from uuid import uuid4
+
+
+import json
+
+
+import re
+
+
+import pytest
+
+from harness.job_metadata_capability import bounded_metadata_available
+
+if not bounded_metadata_available():
+    pytest.skip("public PM lacks bounded metadata APIs", allow_module_level=True)
+
+
+from puppetmaster.attempts import ExecutionAttempt, UsageObservation
+
+
+from puppetmaster.models import AgentRun, Artifact, ArtifactType, JobRef, JobStatus, Task
+
+
+from puppetmaster.store_factory import create_store
+
+
+from puppetmaster.usage import token_usage
+
+
+from harness.api.job_readmodel import get_job_metadata, get_job_metadata_detail, post_job_metadata_pins
+
+
+from harness.job_readmodel import ActiveContext, KnownSources, MetadataReader, PMSelection, ReadContext
+
+
+@pytest.fixture(params=['sqlite', 'file'])
+def case(tmp_path, request):
+    store = create_store(request.param, tmp_path / 'store')
+    job = store.create_job('expert goal', origin='marionette', session_id='session-a')
+    ctx = ReadContext('session-a', str(tmp_path / 'repo'), 'view-a', 'session')
+    sources = KnownSources.from_roots([('harness', store.root, request.param, False)])
+    reader = MetadataReader(lambda: ActiveContext(ctx.session_id, ctx.repo, ctx.view_generation), sources)
+    selection = PMSelection(ctx, sources.stores[0].selection, store.job_ref(job.id))
+    return store, job, reader, selection
+
+
+def query(selection, **extra):
+    return {k: [str(v)] for k, v in dict(asdict(selection.context), source=selection.store.source,
+                                      **selection.job_ref.as_dict(), **extra).items()}
+
+
+def detail(case, **extra):
+    return get_job_metadata_detail(query(case[3], **extra), case[2])
+
+
+def test_v2_pins_display_and_explicit_legacy(case):
+    store, job, reader, selection = case
+    code, selected = detail(case)
+    assert code == 200 and selected['selection']['job_ref'] == store.job_ref(job.id).as_dict()
+    assert selected['display'] == dict(kind='available', goal_preview='expert goal',
+        goal_preview_truncated=False, delivery='pending', quality='unverified')
+    assert selected['cost']['kind'] == 'unavailable' and selected['cost']['reason'] == 'no_terminal_receipt'
+    assert selected['history']['counts']['captured_attempts'] == 0
+    assert selected['history']['counts']['complete_invocation_history'] is False
+    legacy = replace(selection, job_ref=JobRef(job.id, selection.store.state_id))
+    code, old = get_job_metadata_detail(query(legacy), reader)
+    assert code == 200 and old['selection']['job_ref'] == legacy.job_ref.as_dict()
+    assert old['cost']['reason'] == old['history']['reason'] == 'legacy_ref'
+    code, pinned = post_job_metadata_pins(dict(asdict(selection.context), selections=[selection.wire(), legacy.wire()]), reader)
+    assert code == 200
+    assert [row['result']['row']['selection']['job_ref'] for row in pinned['results']] == [selection.job_ref.as_dict(), legacy.job_ref.as_dict()]
+
+
+@pytest.mark.parametrize('fields', [dict(version='2'), dict(version='1', incarnation=str(uuid4())),
+                                    dict(version='true'), dict(version='2', incarnation='bad')])
+def test_invalid_nested_ref_is_rejected(case, fields):
+    qs = query(case[3])
+    qs.pop('version'); qs.pop('incarnation')
+    qs.update({k: [v] for k, v in fields.items()})
+    assert get_job_metadata_detail(qs, case[2])[0] == 400
+    ref = {**case[3].job_ref.as_dict(), **fields}
+    assert post_job_metadata_pins(dict(asdict(case[3].context), selections=[dict(case[3].wire(), job_ref=ref)]), case[2])[0] == 400
+
+
+def populate_history(store, job, count):
+    for n in range(count):
+        run = AgentRun(job.id, f'task_{n}', 'worker', 'worker-a', id=f'run_{n}')
+        store.save_run(run)
+        store.record_attempt(ExecutionAttempt(job.id, run.task_id, run.id, f'attempt_{n}', 'now', 'codex', 'model-a', 'provider-a'))
+        store.record_usage_observation(UsageObservation(job.id, f'attempt_{n}', f'observation_{n}', 'sdk', 'now',
+            usage_state='measured', tokens_in=10, tokens_out=0, cost_state='measured', cost_usd=0,
+            cost_basis='api', returncode=0, timed_out=False))
+
+
+def test_captured_history_pagination_and_full_ref_cursor_binding(case):
+    store, job, reader, selection = case
+    populate_history(store, job, 35)
+    code, first = detail(case)
+    assert code == 200
+    history = first['history']
+    assert history['kind'] == 'available'
+    assert history['counts'] == dict(captured_attempts=35, captured_runs=35, captured_process_outcomes=35,
+        captured_observations=35, outcome='available', coverage='captured', complete_invocation_history=False)
+    params = dict(attempts='attempt_cursor', runs='run_cursor', process_outcomes='process_outcome_cursor', observations='observation_cursor')
+    for lane, parameter in params.items():
+        token = history[lane]['page']['next_cursor']
+        assert token and history[lane]['page']['outcome'] == 'partial'
+        assert 0 < len(history[lane]['rows']) <= 20
+        assert history[lane]['page']['scanned'] <= 21
+        assert history[lane]['page']['complete_invocation_history'] is False
+        ids = {row['sequence'] for row in history[lane]['rows']}
+        while token:
+            code, next_page = detail(case, **{parameter: token})
+            assert code == 200
+            rows = next_page['history'][lane]['rows']
+            assert not ids.intersection(row['sequence'] for row in rows)
+            ids.update(row['sequence'] for row in rows)
+            token = next_page['history'][lane]['page']['next_cursor']
+        assert len(ids) == 35
+    observation = history['observations']['rows'][0]['facts']
+    assert observation['tokens_out'] == observation['cost_usd'] == 0
+    assert observation['identity_state'] == 'available' and observation['run_id'] and observation['task_id']
+    assert history['runs']['rows'][0]['completion']['outcome'] == 'legacy_unknown'
+    assert first['cost']['kind'] == 'unavailable'  # captured usage is not selected/live cost
+    token = history['attempts']['page']['next_cursor']
+    stale = replace(selection, job_ref=replace(selection.job_ref, incarnation=str(uuid4())))
+    assert get_job_metadata_detail(query(stale, attempt_cursor=token), reader)[0] == 400
+    assert detail(case, run_cursor=token)[0] == 400
+    legacy = replace(selection, job_ref=JobRef(job.id, selection.store.state_id))
+    assert get_job_metadata_detail(query(legacy, attempt_cursor=token), reader)[0] == 400
+    assert len(json.dumps(first).encode()) < 98304
+
+
+def test_selected_receipt_economics_preserves_metric_states(case):
+    store, job, _, _ = case
+    payload = dict(check='test', result='passed', model='model-a', real_cost_usd=0)
+    payload.update(token_usage(sdk_usage={'inputTokens': 12, 'outputTokens': 0}))
+    store.save_artifact(Artifact(job.id, 'task-a', ArtifactType.VERIFICATION, 'worker', payload, 1, ['test']))
+    store.update_job_status(job.id, JobStatus.COMPLETE)
+    code, selected = detail(case)
+    expected = store.get_selected_economics(case[3].job_ref)
+    assert expected.outcome == 'available'
+    assert code == 200 and selected['cost'] == dict(kind=expected.outcome, **asdict(expected))
+    assert selected['cost']['source'] == 'terminal_receipt'
+    assert selected['cost']['totals']['tokens_out']['total'] == 0
+    assert selected['cost']['totals']['tokens_out']['state'] == 'measured'
+    assert selected['cost']['totals']['cache_read_tokens']['total'] is None
+    assert selected['display']['delivery'] == selected['display']['quality'] == 'unverified'
+    assert selected['artifact_count'] == 1
+    assert selected['artifacts']['rows'][0]['check_result'] == 'unavailable'
+
+
+def test_published_completion_receipt_from_bounded_run_page(case):
+    store, job, _, selection = case
+    store.save_task(Task(job.id, 'worker', 'work'))
+    task = store.claim_next_task(job.id, 'worker-a')
+    run = AgentRun(job.id, task.id, task.role, 'worker-a')
+    expected = store.submit_completion(task, run, [], {}, job_ref=selection.job_ref)
+    assert expected.outcome == 'published'
+    code, selected = detail(case)
+    assert code == 200
+    assert selected['history']['runs']['rows'][0]['completion'] == asdict(expected)
+    assert selected['task_count'] == 1
+    assert selected['cancellation_authority'] is False
+
+
+def test_selected_reads_never_hydrate_source_bodies_or_write(case, monkeypatch):
+    store, job, reader, selection = case
+    populate_history(store, job, 2)
+    from puppetmaster.store import SwarmStore
+    for name in ('get_job', 'list_jobs', 'list_tasks', 'list_artifacts', 'get_task_by_id', 'ensure_schema', 'init'):
+        monkeypatch.setattr(SwarmStore, name, lambda *a, **kw: pytest.fail('body read or schema mutation'), raising=False)
+    from puppetmaster.readonly import ReadConnection
+    execute = ReadConnection.execute
+    reads = []
+    def checked(connection, sql, parameters=()):
+        reads.append(sql)
+        assert not re.search(r'\b(?:FROM|JOIN)\s+(?:jobs|tasks|artifacts|runs|execution_attempts|usage_observations|completions)\b', sql, re.I)
+        assert not re.search(r'\b(?:INSERT|UPDATE|DELETE|CREATE|ALTER|DROP)\b', sql, re.I)
+        return execute(connection, sql, parameters)
+    monkeypatch.setattr(ReadConnection, 'execute', checked)
+    for _ in range(3):
+        code, selected = detail(case)
+        assert code == 200 and selected['history']['kind'] == 'available'
+    assert any('historical_refs' in sql for sql in reads)
+    assert any('selected_economics_current' in sql for sql in reads)
+
+
+def test_ownership_change_during_selected_read_discards_all_lanes(case, monkeypatch):
+    store, job, reader, _ = case
+    handle = reader.sources.stores[0].handle
+    original = handle.list_run_refs
+    def changed(*a, **kw):
+        result = original(*a, **kw)
+        store.save_job(replace(job, session_id='foreign'))
+        return result
+    monkeypatch.setattr(handle, 'list_run_refs', changed)
+    code, selected = detail(case)
+    assert code == 200 and selected['missing'][0] == 'selection_changed'
+    assert selected['lifecycle'] is None and selected['tasks']['rows'] == selected['artifacts']['rows'] == []
+    assert selected['history']['kind'] == selected['cost']['kind'] == 'unavailable'
+    assert 'foreign' not in json.dumps(selected)
+
+
+def test_previous_membership_uses_same_policy_and_no_foreign_tombstones(case):
+    store, job, reader, selection = case
+    ctx = replace(selection.context, scope='all')
+    filters = {k: [str(v)] for k, v in dict(asdict(ctx), **asdict(selection.store), mode='snapshot').items()}
+    code, before = get_job_metadata(filters, reader)
+    assert code == 200
+    store.save_job(replace(job, session_id=None, origin=None))
+    store.create_job('foreign', session_id=None, origin='other')
+    fresh = MetadataReader(reader.active_context, reader.sources)
+    filters.update(mode=['changes'], after_revision=[str(before['page']['checkpoint'])])
+    code, changed = get_job_metadata(filters, fresh)
+    assert code == 200 and changed['page']['outcome'] == 'complete'
+    assert len(changed['rows']) == 1 and changed['rows'][0]['deleted'] is True
+    assert changed['rows'][0].keys() == {'selection', 'revision', 'deleted'}
+    assert 'foreign' not in json.dumps(changed)
+
+
+def test_task_and_artifact_cursors_cannot_cross_incarnations_or_lanes(case):
+    store, job, reader, selection = case
+    for n in range(60):
+        task = Task(job.id, 'worker', 'work', id=f'task_{n:04d}')
+        store.save_task(task)
+        store.save_artifact(Artifact(job.id, task.id, ArtifactType.FINDING, 'worker', {'claim': 'recorded'}, 1, ['test']))
+    code, selected = detail(case)
+    assert code == 200
+    tokens = {lane: selected[lane]['page']['next_cursor'] for lane in ('tasks', 'artifacts')}
+    assert all(tokens.values())
+    stale = replace(selection, job_ref=replace(selection.job_ref, incarnation=str(uuid4())))
+    for lane, parameter in (('tasks', 'task_cursor'), ('artifacts', 'artifact_cursor')):
+        assert get_job_metadata_detail(query(stale, **{parameter: tokens[lane]}), reader)[0] == 400
+    assert detail(case, artifact_cursor=tokens['tasks'])[0] == 400
+    assert detail(case, task_cursor=tokens['artifacts'])[0] == 400
+    assert selected['cancellation_authority'] is False
+
+
+def test_cli_previous_membership_never_promotes_foreign_origin(case):
+    store, job, _, selection = case
+    store.save_job(replace(job, origin='foreign'))
+    ctx = replace(selection.context, scope='all')
+    sources = KnownSources.from_roots([('cli', store.root, store.backend_name, False)])
+    reader = MetadataReader(lambda: ActiveContext(ctx.session_id, ctx.repo, ctx.view_generation), sources)
+    checkpoint = store.list_job_summaries().revision
+    # This prior session stamp is insufficient for CLI ownership.
+    store.save_job(replace(job, origin=None, session_id=None))
+    query_values = dict(asdict(ctx), **asdict(sources.stores[0].selection), mode='changes', after_revision=checkpoint)
+    code, changed = get_job_metadata({k: [str(v)] for k, v in query_values.items()}, reader)
+    assert code == 200 and changed['rows'] == []
+    assert changed['page']['outcome'] == 'complete'

--- a/tests/test_job_metadata_handler.py
+++ b/tests/test_job_metadata_handler.py
@@ -1,0 +1,284 @@
+"""Actual authenticated Handler dispatch, with optional real loopback transport.
+
+PM_METADATA_REQUIRE_HTTP=1 requires sockets (parent replay); default executes the
+same raw HTTP bytes through BaseHTTPRequestHandler with an in-memory socket.
+"""
+import http.client
+import io
+import json
+import os
+import threading
+from http.server import ThreadingHTTPServer
+from types import SimpleNamespace
+from urllib.parse import urlencode
+
+import pytest
+
+from harness.job_metadata_capability import bounded_metadata_available
+
+if not bounded_metadata_available():
+    pytest.skip("public PM lacks bounded metadata APIs", allow_module_level=True)
+
+from harness.config import HarnessConfig
+from harness.session import Session
+from harness.session_runners import SessionRunnerRegistry
+from puppetmaster.models import Task, Artifact, ArtifactType
+from test_job_readmodel import assert_bounded_page, hashes, trace_metadata
+
+
+class MemorySocket:
+    def __init__(self, request):
+        self.input = io.BytesIO(request)
+        self.output = bytearray()
+
+    def makefile(self, *args):
+        return self.input
+
+    def sendall(self, data):
+        self.output.extend(data)
+
+
+@pytest.fixture
+def host(tmp_path, monkeypatch):
+    import harness.server as server
+    monkeypatch.setenv('PUPPETMASTER_STATE_DIR', str(tmp_path / 'absent-cli'))
+    monkeypatch.setenv('HARNESS_CLI_CROSS_PROJECT', '0')
+    reg = SessionRunnerRegistry()
+    session = Session(HarnessConfig(driver='stub-oracle-v2', repo=str(tmp_path),
+                                   state_dir=str(tmp_path / 'store'), swarm_adapter='demo'))
+    store = session.state().store
+    jobs = [store.create_job('fixture', origin='marionette', session_id='A') for _ in range(55)]
+    expected = dict(tasks=set(), artifacts=set())
+    for i in range(55):
+        task = Task(jobs[0].id, 'fixture', 'body')
+        store.save_task(task)
+        artifact = Artifact(jobs[0].id, task.id, ArtifactType.FINDING, 'fixture', {'claim': 'body'}, 1.0, ['fixture'])
+        store.save_artifact(artifact)
+        expected['tasks'].add(task.id)
+        expected['artifacts'].add(artifact.id)
+    reg.get_or_create('A', lambda: session)
+    reg.set_active_view('A')
+    monkeypatch.setattr(server, '_runners', reg)
+    monkeypatch.setattr(server, '_session', session)
+    monkeypatch.setattr(server, '_GET_ROUTES', None)
+    monkeypatch.setattr(server, '_POST_JSON_ROUTES', None)
+    httpd = None
+    if os.environ.get('PM_METADATA_REQUIRE_HTTP') == '1':
+        # conftest permits loopback sockets. Binding can still be sandbox-denied.
+        httpd = ThreadingHTTPServer(('127.0.0.1', 0), server.Handler)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+
+    def request(method, path, body=None, *, token=True, host='127.0.0.1', headers=None):
+        encoded = b'' if body is None else body if isinstance(body, bytes) else json.dumps(body).encode()
+        fields = [('Host', host), ('Content-Length', str(len(encoded)))]
+        if token:
+            fields.append(('X-Harness-Token', server._TOKEN))
+        fields.extend(headers or [])
+        if httpd:
+            conn = http.client.HTTPConnection('127.0.0.1', httpd.server_port, timeout=5)
+            conn.putrequest(method, path, skip_host=True)
+            for key, value in fields:
+                conn.putheader(key, value)
+            conn.endheaders(encoded)
+            response = conn.getresponse()
+            status, data = response.status, response.read()
+            conn.close()
+        else:
+            raw = f'{method} {path} HTTP/1.0\r\n' + ''.join(f'{k}: {v}\r\n' for k, v in fields) + '\r\n'
+            sock = MemorySocket(raw.encode() + encoded)
+            server.Handler(sock, ('127.0.0.1', 12345), SimpleNamespace(server_name='localhost', server_port=80))
+            head, data = bytes(sock.output).split(b'\r\n\r\n', 1)
+            status = int(head.split(b' ')[1])
+        return status, json.loads(data), len(data)
+
+    yield SimpleNamespace(server=server, reg=reg, session=session, store=store, jobs=jobs, expected=expected, request=request)
+    if httpd:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(5)
+
+
+def context(host):
+    status, payload, _ = host.request('GET', '/api/jobs/metadata/view')
+    assert status == 200
+    status, payload, _ = host.request('POST', '/api/jobs/metadata/view/refresh',
+                                    {'view_generation': payload['context']['view_generation']})
+    assert status == 200
+    selection = next(s for s in payload['sources'] if s['source'] == 'harness')
+    return dict(payload['context'], scope='session', source=selection['source'], state_id=selection['state_id'])
+
+
+def path(ctx, suffix='', **kw):
+    return '/api/jobs/metadata' + suffix + '?' + urlencode(dict(ctx, **kw))
+
+
+def test_actual_auth_host_parser_body_limits(host):
+    request = host.request
+    for method, url, body in [('GET', '/api/jobs/metadata/view', None),
+                              ('GET', '/api/jobs/metadata', None),
+                              ('GET', '/api/jobs/metadata/detail', None),
+                              ('GET', '/api/jobs/metadata/local', None),
+                              ('POST', '/api/jobs/metadata/pins', {}),
+                              ('POST', '/api/jobs/metadata/view/refresh', {})]:
+        assert request(method, url, body, token=False)[0] == 403
+        assert request(method, url, body, host='rebound.invalid')[0] == 403
+    assert request('GET', '/api/jobs/metadata/view', token=False, headers=[('X-Harness-Token', 'wrong')])[0] == 403
+    assert request('GET', '/api/jobs/metadata/view?unknown=')[0] == 400
+    assert request('GET', '/api/jobs/metadata/view', headers=[('Origin', 'https://evil.invalid')])[0] == 403
+    ctx = context(host)
+    good = path(ctx, mode='snapshot')
+    for suffix in ('&scope=', '&scope=repo', '&scope=session', '&unknown=', '&cursor=', '&limit=99'):
+        assert request('GET', good + suffix)[0] == 400
+    assert request('GET', path(dict(ctx, scope='wrong'), mode='snapshot'))[0] == 400
+    assert request('POST', '/api/jobs/metadata/pins', b' ' * 65537)[0] == 413
+    assert request('POST', '/api/jobs/metadata/pins', b'{')[0] == 400
+    assert request('POST', '/api/jobs/metadata/pins?scope=', {})[0] == 400
+    assert request('POST', '/api/jobs/metadata/pins', {}, headers=[('Content-Length', '-1')])[0] == 400
+    assert request('POST', '/api/jobs/metadata/pins', {}, headers=[('Transfer-Encoding', 'chunked')])[0] == 400
+
+
+def test_actual_snapshot_continuation_detail_pins_and_aba(host):
+    ctx = context(host)
+    request = host.request
+    status, first, size = request('GET', path(ctx, mode='snapshot'))
+    assert status == 200 and size <= 65536
+    assert first['page']['outcome'] == 'partial'
+    cursor = first['page']['next_cursor']
+    current = first
+    ids = []
+    tokens = set()
+    while True:
+        assert_bounded_page(current)
+        assert current['page']['revision'] == first['page']['revision']
+        ids.extend(r['selection']['job_ref']['job_id'] for r in current['rows'])
+        assert len(ids) == len(set(ids))
+        token = current['page']['next_cursor']
+        if token is None:
+            break
+        assert token not in tokens
+        tokens.add(token)
+        status, current, size = request('GET', path(ctx, mode='snapshot', cursor=token))
+        assert status == 200 and size <= 65536
+    assert set(ids) == {j.id for j in host.jobs}
+    selected = host.store.job_ref(host.jobs[0].id).as_dict()
+    status, detail, size = request('GET', path(ctx, '/detail', **selected))
+    assert status == 200 and size <= 98304
+    assert detail['cancellation_authority'] is False
+    for lane, parameter in (('tasks', 'task_cursor'), ('artifacts', 'artifact_cursor')):
+        current = detail
+        ids = []
+        tokens = set()
+        assert current[lane]['page']['outcome'] == 'partial'
+        while True:
+            chunk = current[lane]
+            assert len(chunk['rows']) <= 50 and chunk['page']['scanned'] <= 51
+            ids.extend(r['id'] for r in chunk['rows'])
+            assert len(ids) == len(set(ids))
+            token = chunk['page']['next_cursor']
+            if token is None:
+                assert chunk['page']['outcome'] == 'complete'
+                break
+            assert chunk['page']['outcome'] == 'partial' and token not in tokens
+            tokens.add(token)
+            status, current, size = request('GET', path(ctx, '/detail', **selected, **{parameter: token}))
+            assert status == 200 and size <= 98304 and current['cancellation_authority'] is False
+        assert set(ids) == host.expected[lane]
+    pin_context = {k: ctx[k] for k in ('session_id', 'repo', 'view_generation', 'scope')}
+    status, pins, size = request('POST', '/api/jobs/metadata/pins', dict(pin_context, selections=[first['rows'][0]['selection']]))
+    assert status == 200 and size <= 65536 and pins['results'][0]['result']['kind'] == 'present'
+    assert request('GET', path(pin_context, '/local'))[1]['page']['outcome'] == 'unavailable'
+    host.reg.set_active_view('B', repo=ctx['repo'])
+    host.reg.set_active_view('A')
+    assert request('GET', path(ctx, mode='snapshot', cursor=cursor))[0] == 409
+    assert request('GET', path(ctx, '/detail', job_id=host.jobs[0].id))[0] == 409
+    assert request('POST', '/api/jobs/metadata/view/refresh', {'view_generation': ctx['view_generation']})[0] == 409
+
+
+def test_actual_sustained_polls_no_body_constructor_discovery(host, monkeypatch):
+    ctx = context(host)
+    reader = host.reg.metadata_view.reader()
+    store = reader.sources.stores[0].handle
+    original = store.list_job_summaries
+    calls = []
+    def summary(**kw):
+        calls.append(kw)
+        return original(**kw)
+    monkeypatch.setattr(store, 'list_job_summaries', summary)
+    def forbidden(*a, **kw):
+        pytest.fail('metadata poll exceeded its lane')
+    monkeypatch.setattr(Session, 'state', forbidden)
+    monkeypatch.setattr('harness.session.DurableState', forbidden)
+    monkeypatch.setattr('harness.job_readmodel.create_store', forbidden)
+    monkeypatch.setattr('harness.job_metadata_view.discover_sources', forbidden)
+    from puppetmaster.store import SwarmStore
+    for method in ('get_job', 'list_jobs', 'list_tasks', 'list_artifacts'):
+        monkeypatch.setattr(SwarmStore, method, forbidden)
+    before = hashes(host.store.root)
+    selections = [dict(job_ref=host.store.job_ref(j.id).as_dict(), source='harness',
+                       session_id='A', repo=ctx['repo']) for j in host.jobs[:8]]
+    metrics = trace_metadata(monkeypatch)
+    pin_context = {k: ctx[k] for k in ('session_id', 'repo', 'view_generation', 'scope')}
+    for _ in range(30):
+        assert host.request('GET', '/api/jobs/metadata/view')[0] == 200
+        assert host.request('GET', path(ctx, mode='snapshot'))[0] == 200
+        status, pinned, size = host.request('POST', '/api/jobs/metadata/pins', dict(pin_context, selections=selections))
+        assert status == 200 and size <= 65536
+        assert [r['result']['row']['selection'] for r in pinned['results']] == selections
+        assert host.reg.metadata_view.reader() is reader
+    assert len(calls) == 30 * 9
+    assert sum(kw['limit'] == 50 and kw['max_scan'] == 51 and kw['max_bytes'] == 32768 for kw in calls) == 30
+    assert sum(kw['limit'] == 1 and kw['max_scan'] == 2 and kw['max_bytes'] == 8192 for kw in calls) == 240
+    assert hashes(host.store.root) == before
+    assert metrics['reads'] and any(table == 'projection_versions' for table, _ in metrics['reads'])
+
+
+def test_actual_held_read_and_discovery_cross_switch(host, monkeypatch):
+    ctx = context(host)
+    store = host.reg.metadata_view.reader().sources.stores[0].handle
+    original = store.list_job_summaries
+    entered, release = threading.Event(), threading.Event()
+    def held(**kw):
+        entered.set()
+        assert release.wait(5)
+        return original(**kw)
+    monkeypatch.setattr(store, 'list_job_summaries', held)
+    result = []
+    t = threading.Thread(target=lambda: result.append(host.request('GET', path(ctx, mode='snapshot'))))
+    t.start()
+    assert entered.wait(5)
+    host.reg.set_active_view('B', repo=ctx['repo'])
+    host.reg.set_active_view('A')
+    release.set()
+    t.join(5)
+    assert not t.is_alive() and result[0][0] == 409
+    from harness.job_metadata_view import discover_sources
+    entered.clear(); release.clear(); result.clear()
+    def discover(*a):
+        entered.set()
+        assert release.wait(5)
+        return discover_sources(*a)
+    monkeypatch.setattr('harness.job_metadata_view.discover_sources', discover)
+    generation = host.reg.metadata_view.capture().generation
+    t = threading.Thread(target=lambda: result.append(host.request('POST', '/api/jobs/metadata/view/refresh',
+                                                                  {'view_generation': generation})))
+    t.start()
+    assert entered.wait(5)
+    host.reg.detach_view('A')
+    release.set()
+    t.join(5)
+    assert not t.is_alive() and result[0][0] == 409
+    current = host.request('GET', '/api/jobs/metadata/view')[1]
+    assert current['availability'] == 'unavailable' and current['sources'] == []
+
+
+def test_authoritative_view_generation_retires_after_session_round_trip(host):
+    request = host.request
+    original = request('GET', '/api/jobs/metadata/view')[1]['context']['view_generation']
+    host.reg.set_active_view('B', repo=host.session.config.repo)
+    intermediate = request('GET', '/api/jobs/metadata/view')[1]['context']['view_generation']
+    host.reg.set_active_view('A')
+    returned = request('GET', '/api/jobs/metadata/view')[1]['context']['view_generation']
+    assert len({original, intermediate, returned}) == 3
+    assert request('POST', '/api/jobs/metadata/view/refresh', {'view_generation': original})[0] == 409
+    assert request('GET', '/api/jobs/metadata/view')[1]['context']['view_generation'] == returned

--- a/tests/test_job_metadata_view.py
+++ b/tests/test_job_metadata_view.py
@@ -1,0 +1,315 @@
+"""Real registry/Session lifetimes and public PM stores; no provider work."""
+import threading
+
+import pytest
+
+from harness.job_metadata_capability import bounded_metadata_available
+
+if not bounded_metadata_available():
+    pytest.skip("public PM lacks bounded metadata APIs", allow_module_level=True)
+
+from harness.config import HarnessConfig
+from harness.session import Session
+from harness.session_runners import SessionRunnerRegistry
+from harness.job_readmodel import ReadContext, ViewChanged
+from harness.job_metadata_view import refresh_view
+from harness.api.job_readmodel import get_job_metadata
+
+
+@pytest.fixture(autouse=True)
+def isolate_discovery(tmp_path, monkeypatch):
+    monkeypatch.setenv('PUPPETMASTER_STATE_DIR', str(tmp_path / 'absent-cli'))
+    monkeypatch.setenv('HARNESS_CLI_CROSS_PROJECT', '0')
+
+
+def runner(tmp_path, sid='A'):
+    root = tmp_path / sid
+    root.mkdir(exist_ok=True)
+    return Session(HarnessConfig(driver='stub-oracle-v2', repo=str(tmp_path),
+                                 state_dir=str(root), swarm_adapter='demo'))
+
+
+def seeded(tmp_path):
+    reg = SessionRunnerRegistry()
+    a = runner(tmp_path)
+    # Session.state() really constructs a new DurableState on each invocation.
+    state = a.state()
+    assert state is not a.state()
+    job = state.store.create_job('owned', origin='marionette', session_id='A')
+    reg.get_or_create('A', lambda: a)
+    reg.set_active_view('A')
+    view = reg.metadata_view
+    assert view.describe()['availability'] == 'unavailable'
+    assert refresh_view({'view_generation': view.capture().generation}, view)[0] == 200
+    ctx = view.capture()
+    read = ReadContext(ctx.session_id, ctx.repo, ctx.generation, 'session')
+    selection = next(s.selection for s in view.reader().sources.stores if s.selection.source == 'harness')
+    return reg, a, read, selection, job
+
+
+def test_session_state_not_stable_and_polls_never_construct(tmp_path, monkeypatch):
+    reg, a, ctx, selection, _ = seeded(tmp_path)
+    reader = reg.metadata_view.reader()
+    def forbidden(*a, **kw):
+        pytest.fail('poll performed construction/discovery/body work')
+    monkeypatch.setattr(Session, 'state', forbidden)
+    monkeypatch.setattr('harness.job_metadata_view.discover_sources', forbidden)
+    monkeypatch.setattr('harness.job_readmodel.create_store', forbidden)
+    monkeypatch.setattr('harness.session.DurableState', forbidden)
+    from puppetmaster.store import SwarmStore
+    for name in ('get_job', 'list_jobs', 'list_tasks', 'list_artifacts'):
+        monkeypatch.setattr(SwarmStore, name, forbidden)
+    for _ in range(30):
+        assert reg.metadata_view.reader() is reader
+        page = reader.read_job_page(ctx, selection)
+        assert len(page['rows']) == 1
+        assert page['page']['outcome'] == 'complete'
+
+
+def test_registry_aba_detach_drop_replace_invalidate(tmp_path):
+    reg, a, ctx, selection, _ = seeded(tmp_path)
+    view = reg.metadata_view
+    first = view.reader()
+    b = runner(tmp_path, 'B')
+    reg.get_or_create('B', lambda: b)
+    reg.set_active_view('B')
+    reg.set_active_view('A')
+    with pytest.raises(ViewChanged):
+        first.read_job_page(ctx, selection)
+    epoch = view.capture().generation
+    reg.set_active_view('A')
+    assert view.capture().generation == epoch
+    assert not reg.detach_view('B')
+    assert view.capture().generation == epoch
+    reg.replace('A', runner(tmp_path))
+    assert view.capture().generation != epoch
+    epoch = view.capture().generation
+    reg.detach_view('A')
+    assert view.capture().session_id == ''
+    assert view.capture().generation != epoch
+    reg.set_active_view('A')
+    epoch = view.capture().generation
+    reg.drop('A')
+    assert view.capture().session_id == ''
+    assert view.capture().generation != epoch
+
+
+def test_input_admission_gates_still_precede_epoch_change(tmp_path):
+    reg, a, _, _, _ = seeded(tmp_path)
+    epoch = reg.metadata_view.capture()
+    a._input_admissions = 1
+    with pytest.raises(RuntimeError):
+        reg.drop('A')
+    with pytest.raises(RuntimeError):
+        reg.replace('A', runner(tmp_path, 'replacement'))
+    assert reg.metadata_view.capture() == epoch
+    assert reg.get('A') is a
+
+
+def test_held_discovery_cannot_publish_after_switch(tmp_path, monkeypatch):
+    reg, a, _, _, _ = seeded(tmp_path)
+    view = reg.metadata_view
+    entered, release = threading.Event(), threading.Event()
+    from harness.job_metadata_view import discover_sources
+    def held(*args):
+        entered.set()
+        assert release.wait(5)
+        return discover_sources(*args)
+    monkeypatch.setattr('harness.job_metadata_view.discover_sources', held)
+    result = []
+    t = threading.Thread(target=lambda: result.append(refresh_view(
+        {'view_generation': view.capture().generation}, view)))
+    t.start()
+    assert entered.wait(5)
+    reg.set_active_view('B', repo=str(tmp_path / 'B'))
+    new = view.capture()
+    assert view.refresh(new.generation)[0] == 409
+    release.set()
+    t.join(5)
+    assert not t.is_alive()
+    assert result == [(409, {'code': 'view_changed'})]
+    assert view.capture() == new
+    assert view.describe()['availability'] == 'unavailable'
+    assert view._discovery is None
+
+
+def test_held_query_rejects_aba_without_blocking_transition(tmp_path, monkeypatch):
+    reg, _, ctx, selection, _ = seeded(tmp_path)
+    reader = reg.metadata_view.reader()
+    store = reader.sources.resolve(selection).handle
+    original = store.list_job_summaries
+    entered, release = threading.Event(), threading.Event()
+    def held(**kwargs):
+        entered.set()
+        assert release.wait(5)
+        return original(**kwargs)
+    monkeypatch.setattr(store, 'list_job_summaries', held)
+    result = []
+    qs = dict(session_id=['A'], repo=[ctx.repo], view_generation=[ctx.view_generation],
+              scope=['session'], source=[selection.source], state_id=[selection.state_id], mode=['snapshot'])
+    t = threading.Thread(target=lambda: result.append(get_job_metadata(qs, reader)))
+    t.start()
+    assert entered.wait(5)
+    reg.set_active_view('B', repo=ctx.repo)
+    reg.set_active_view('A')
+    release.set()
+    t.join(5)
+    assert not t.is_alive()
+    assert result == [(409, {'code': 'view_changed'})]
+
+
+def test_refresh_failure_and_missing_roots_are_unavailable(tmp_path, monkeypatch):
+    reg = SessionRunnerRegistry()
+    reg.get_or_create('A', lambda: runner(tmp_path))
+    reg.set_active_view('A')
+    view = reg.metadata_view
+    missing_root = tmp_path / 'A'
+    assert list(missing_root.iterdir()) == []
+    assert view.refresh(view.capture().generation)[0] == 200
+    assert list(missing_root.iterdir()) == []
+    assert all(not item['available'] for item in view.describe()['sources'])
+    def fail(*a):
+        raise OSError('fixture')
+    monkeypatch.setattr('harness.job_metadata_view.discover_sources', fail)
+    assert view.refresh(view.capture().generation)[0] == 200
+    assert view.describe()['availability'] == 'unavailable'
+    assert view.describe()['missing'] == ['source_discovery_unavailable']
+
+
+def test_real_host_attach_rebuild_swap_relocate_workspace_and_clear(owned_server, tmp_path, monkeypatch):
+    from harness.api.sessions import handle_session_relocate, post_sessions_clear, post_sessions_switch
+    from harness.api.workspace import post_workspace_forget, post_workspace_open
+    srv = owned_server
+    monkeypatch.setenv('HARNESS_DEFER_COLD_ATTACH', '0')
+    monkeypatch.setattr(srv, '_puppetmaster_available', lambda: False)
+    monkeypatch.setattr(srv, '_index_codegraph_bg', lambda *a: None)
+    monkeypatch.setattr(srv, '_maybe_refresh_codegraph', lambda *a: None)
+    a, b = tmp_path / 'repo-a', tmp_path / 'repo-b'
+    a.mkdir(); b.mkdir()
+    srv._cfg.repo = str(a)
+    sid = srv._sessions.active
+    srv._sessions.relocate(sid, str(a), repo=str(a), make_active=True)
+    srv._attach_view(sid)
+    view = srv._runners.metadata_view
+    assert view.capture().session_id == sid and view.capture().repo == str(a)
+    original = view.capture()
+    srv._rebuild_pilot_and_session()
+    assert view.capture().generation != original.generation
+    original = view.capture()
+    srv._perform_pilot_swap(srv._cfg.driver)
+    assert view.capture().generation != original.generation
+    original = view.capture()
+    assert handle_session_relocate({'session_id': sid, 'path': str(b)}, srv._session_services())[0] == 200
+    assert view.capture().repo == str(b) and view.capture().session_id == sid
+    assert view.capture().generation != original.generation
+    original = view.capture()
+    assert post_workspace_open({'path': str(a)}, srv._workspace_services())[0] == 200
+    assert view.capture().repo == str(a) and view.capture().generation != original.generation
+    original = view.capture()
+    assert post_sessions_switch({'id': sid}, srv._session_services())[0] == 200
+    assert view.capture().repo == str(b) and view.capture().session_id == sid
+    assert view.capture().generation != original.generation
+    original = view.capture()
+    assert post_workspace_forget({'path': str(b)}, srv._workspace_services())[0] == 200
+    assert view.capture().session_id == '' and view.capture().generation != original.generation
+    srv._cfg.repo = str(b)
+    srv._attach_view(sid)
+    original = view.capture()
+    assert post_sessions_clear(srv._session_services())[0] == 200
+    assert view.capture().generation != original.generation
+    assert view.capture().session_id != sid
+
+
+def test_deferred_real_host_publication_rotates_epoch(owned_server, monkeypatch):
+    srv = owned_server
+    pending = []
+    monkeypatch.setenv('HARNESS_DEFER_COLD_ATTACH', '1')
+    monkeypatch.setattr('harness.api.attach.schedule_deferred_build', lambda fn, **kw: pending.append((fn, kw)))
+    row = srv._sessions.create('deferred', repo=srv._cfg.repo)
+    srv._attach_view(row['id'], defer_cold_build=True)
+    view = srv._runners.metadata_view
+    before = view.capture()
+    build, callbacks = pending.pop()
+    callbacks['on_done'](build())
+    assert view.capture().session_id == row['id']
+    assert view.capture().generation != before.generation
+    assert srv._pilot is srv._runners.get(row['id'])
+
+
+def test_rejected_transition_restores_context_but_never_old_epoch(tmp_path):
+    reg, _, ctx, _, _ = seeded(tmp_path)
+    view = reg.metadata_view
+    ticket = view.invalidate()
+    view.restore(ticket)
+    assert view.capture().session_id == ctx.session_id
+    assert view.capture().repo == ctx.repo
+    assert view.capture().generation != ctx.view_generation
+    stale = view.invalidate()
+    reg.set_active_view('B', repo='B')
+    current = view.capture()
+    view.restore(stale)
+    assert view.capture() == current
+
+
+def test_rejected_host_switch_and_lease_restore_refreshable_view(owned_server, tmp_path):
+    from harness.api.sessions import post_sessions_switch
+    srv = owned_server
+    srv._cfg.repo = str(tmp_path)
+    srv._attach_view(srv._sessions.active)
+    view = srv._runners.metadata_view
+    before = view.capture()
+    status, result = post_sessions_switch({'id': 'not-found'}, srv._session_services())
+    assert result['ok'] is False
+    assert view.capture().session_id == before.session_id and view.capture().repo == before.repo
+    assert view.capture().generation != before.generation
+    # A lease failure occurs after SessionStore switches, before view attach.
+    srv._runners._max = 1
+    srv._pilot._busy.acquire()
+    other = srv._sessions.create('other', repo=str(tmp_path))
+    srv._sessions.switch(before.session_id)
+    try:
+        status, _ = post_sessions_switch({'id': other['id']}, srv._session_services())
+    finally:
+        srv._pilot._busy.release()
+    assert status == 409
+    assert view.capture().session_id == before.session_id and view.capture().repo == before.repo
+
+
+def test_empty_discovery_is_unavailable_not_complete_empty(tmp_path, monkeypatch):
+    from harness.job_readmodel import KnownSources
+    reg = SessionRunnerRegistry()
+    reg.get_or_create('A', lambda: runner(tmp_path))
+    reg.set_active_view('A')
+    monkeypatch.setattr('harness.job_metadata_view.discover_sources', lambda *a: KnownSources(()))
+    view = reg.metadata_view
+    assert view.refresh(view.capture().generation)[0] == 200
+    assert view.describe()['availability'] == 'unavailable'
+    assert view.describe()['missing'] == ['no_known_sources']
+
+
+def test_source_refresh_replaces_reader_and_revokes_old_cursor(tmp_path):
+    reg, _, ctx, selection, _ = seeded(tmp_path)
+    view = reg.metadata_view
+    old = view.reader()
+    generation = view.capture().generation
+    assert view.refresh(generation)[0] == 200
+    assert view.reader() is not old
+    assert view.capture().generation != generation
+    with pytest.raises(ViewChanged):
+        old.read_job_page(ctx, selection)
+
+
+def test_attach_captures_repo_before_factory_work(owned_server, tmp_path):
+    srv = owned_server
+    a, b = str(tmp_path / 'A'), str(tmp_path / 'B')
+    row = srv._sessions.create('capture', repo=a)
+    srv._cfg.repo = a
+    def build():
+        pilot = srv._build_conversational_pilot()
+        # A second workspace request changed global config during this build.
+        srv._cfg.repo = b
+        return pilot
+    srv._attach_view(row['id'], factory=build, load_transcript_on_create=False)
+    capture = srv._runners.metadata_view.capture()
+    assert capture.session_id == row['id'] and capture.repo == a
+    assert srv._cfg.repo == b

--- a/tests/test_job_readmodel.py
+++ b/tests/test_job_readmodel.py
@@ -1,0 +1,651 @@
+"""Real public PM stores, fixed metadata budgets, and strict HTTP boundary regressions."""
+from contextlib import closing
+from dataclasses import asdict, replace
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import sqlite3
+
+import pytest
+
+from harness.job_metadata_capability import bounded_metadata_available
+
+if not bounded_metadata_available():
+    pytest.skip("public PM lacks bounded metadata APIs", allow_module_level=True)
+from puppetmaster.models import Artifact, ArtifactType, Job, JobRef, JobStatus, Task
+from puppetmaster.state import state_identity
+from puppetmaster.store_factory import create_store
+
+from harness.job_readmodel import ActiveContext, KnownSources, MetadataReader, PMSelection, ReadContext
+from harness.api.job_readmodel import (
+    get_job_metadata, get_job_metadata_detail, get_local_metadata, post_job_metadata_pins,
+)
+
+
+@pytest.fixture(params=['sqlite', 'file'])
+def env(tmp_path, request):
+    backend = request.param
+    root = tmp_path / 'store'
+    store = create_store(backend, root, mode='ensure')
+    store.init()
+    sources = KnownSources.from_roots([('harness', root, backend, False)])
+    ctx = ReadContext('session-A', str(tmp_path), 'generation-1', 'session')
+    active = [ActiveContext(ctx.session_id, ctx.repo, ctx.view_generation)]
+    reader = MetadataReader(lambda: active[0], sources)
+    return store, reader, ctx, sources.stores[0].selection, active
+
+
+def job(store, n=0, **kw):
+    value = store.create_job(f'goal-{n}', origin='marionette', session_id='session-A', **kw)
+    return value
+
+
+def query(ctx, selection=None, **kw):
+    values = asdict(ctx)
+    if selection:
+        values.update(asdict(selection))
+    values.update(kw)
+    return {k: [str(v)] for k, v in values.items()}
+
+
+def page(env, **kw):
+    _, reader, ctx, selection, _ = env
+    return get_job_metadata(query(ctx, selection, mode='snapshot', **kw), reader)
+
+
+def hashes(root):
+    return {str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in root.rglob('*') if p.is_file() and not p.name.endswith(('-shm', '-wal'))}
+
+
+def trace_metadata(monkeypatch, *, measure=False):
+    """Observe the real isolated reader through its forwarded SQLite callbacks."""
+    from puppetmaster.readonly import ReadConnection
+    metrics = dict(reads=[], queries=[], operations=0)
+    initialize, execute = ReadConnection.__init__, ReadConnection.execute
+    def instrument(connection, *args, **kwargs):
+        initialize(connection, *args, **kwargs)
+        def authorize(action, table, column, *_):
+            if action == sqlite3.SQLITE_READ:
+                metrics['reads'].append((table, column))
+                assert table not in ('jobs', 'tasks', 'artifacts', 'runs',
+                                     'execution_attempts', 'usage_observations', 'completions')
+            assert action not in (sqlite3.SQLITE_INSERT, sqlite3.SQLITE_UPDATE, sqlite3.SQLITE_DELETE,
+                                  sqlite3.SQLITE_CREATE_TABLE, sqlite3.SQLITE_ALTER_TABLE, sqlite3.SQLITE_DROP_TABLE)
+            return sqlite3.SQLITE_OK
+        connection.set_authorizer(authorize)
+        if measure:
+            def progress():
+                metrics['operations'] += 100
+                return 0
+            connection.set_progress_handler(progress, 100)
+    def checked(connection, sql, parameters=()):
+        metrics['queries'].append((sql, parameters))
+        return execute(connection, sql, parameters)
+    monkeypatch.setattr(ReadConnection, '__init__', instrument)
+    monkeypatch.setattr(ReadConnection, 'execute', checked)
+    return metrics
+
+
+def assert_bounded_page(result, *, checkpoint=0):
+    assert result['page']['outcome'] in ('partial', 'complete')
+    assert len(result['rows']) <= 50 and result['page']['scanned'] <= 51
+    assert len(json.dumps(result).encode()) <= 65536
+    assert result['page']['checkpoint'] == (result['page']['revision']
+        if result['page']['outcome'] == 'complete' else checkpoint)
+    assert bool(result['page']['next_cursor']) == (result['page']['outcome'] == 'partial')
+
+
+def test_fixed_page_and_no_body_or_writes(env, monkeypatch):
+    store, reader, ctx, selection, _ = env
+    expected = set()
+    for i in range(70):
+        j = job(store, i)
+        expected.add(j.id)
+        t = Task(j.id, 'test', 'x' * 16384, payload={'blob': 'x' * 16384})
+        store.save_task(t)
+        store.save_artifact(Artifact(j.id, t.id, ArtifactType.FINDING, 'test', {'claim': 'x' * 16384}, 1.0, ['fixture']))
+    before = hashes(store.root)
+    metrics = trace_metadata(monkeypatch)
+    calls = []
+    from puppetmaster.store import SwarmStore
+    original_list = SwarmStore.list_job_summaries
+    def summary(self, *args, **kwargs):
+        calls.append(kwargs)
+        return original_list(self, *args, **kwargs)
+    monkeypatch.setattr(SwarmStore, 'list_job_summaries', summary)
+    for name in ('get_job', 'list_jobs', 'list_tasks', 'list_artifacts', 'get_completion_receipt'):
+        monkeypatch.setattr(SwarmStore, name, lambda *a, **k: pytest.fail('body read'))
+    code, result = page(env)
+    assert code == 200
+    assert result['page']['outcome'] == 'partial'
+    assert_bounded_page(result)
+    assert 0 < len(result['rows']) < 50
+    assert result['page']['checkpoint'] == 0
+    assert len(calls) == 1
+    assert {k: calls[0][k] for k in ('limit', 'max_scan', 'max_bytes')} == dict(limit=50, max_scan=51, max_bytes=32768)
+    ids = [r['selection']['job_ref']['job_id'] for r in result['rows']]
+    while result['page']['next_cursor']:
+        before_calls = len(calls)
+        code, result = page(env, cursor=result['page']['next_cursor'])
+        assert code == 200 and len(calls) == before_calls + 1
+        assert_bounded_page(result)
+        ids.extend(r['selection']['job_ref']['job_id'] for r in result['rows'])
+        assert len(ids) == len(set(ids))
+    assert set(ids) == expected
+    assert all({k: call[k] for k in ('limit', 'max_scan', 'max_bytes')}
+               == dict(limit=50, max_scan=51, max_bytes=32768) for call in calls)
+    assert hashes(store.root) == before
+    assert metrics['reads'] and any(table == 'projection_versions' for table, _ in metrics['reads'])
+
+
+def test_partial_empty_is_not_complete(env):
+    store, _, _, _, _ = env
+    for i in range(70):
+        store.create_job('foreign', origin='marionette', session_id='other')
+    code, result = page(env)
+    assert code == 200 and result['rows'] == []
+    assert result['page']['outcome'] == 'partial' and result['page']['next_cursor']
+
+
+def test_session_removal_does_not_expose_foreign_ownership(env):
+    store, reader, ctx, selection, _ = env
+    j = job(store)
+    _, first = page(env)
+    store.save_job(replace(j, session_id='foreign-secret', project_id='foreign-project'))
+    code, changed = get_job_metadata(query(ctx, selection, mode='changes', after_revision=first['page']['checkpoint']), reader)
+    assert code == 200 and len(changed['rows']) == 1
+    row = changed['rows'][0]
+    assert row.keys() == {'selection', 'revision', 'deleted'} and row['deleted'] is True
+    assert row['selection']['session_id'] == ctx.session_id
+    assert 'foreign-secret' not in json.dumps(changed) and 'foreign-project' not in json.dumps(changed)
+
+
+@pytest.mark.parametrize('scope', ['repo', 'all'])
+def test_null_ownership_removal_is_source_proven_without_host_cache(env, scope):
+    store, reader, original, selection, _ = env
+    ctx = replace(original, scope=scope)
+    j = job(store)
+    _, first = get_job_metadata(query(ctx, selection, mode='snapshot'), reader)
+    store.save_job(replace(j, session_id=None, origin=None))
+    code, result = get_job_metadata(query(ctx, selection, mode='changes', after_revision=first['page']['checkpoint']), reader)
+    assert code == 200 and result['page']['outcome'] == 'complete'
+    assert result['rows'][0]['deleted'] and len(result['rows'][0]) == 3
+    fresh = MetadataReader(reader.active_context, reader.sources)
+    _, uncertain = get_job_metadata(query(ctx, selection, mode='changes', after_revision=first['page']['checkpoint']), fresh)
+    assert uncertain == result
+    assert uncertain['rows'][0]['selection']['job_ref'] == store.job_ref(j.id).as_dict()
+    assert uncertain['page']['checkpoint'] > first['page']['checkpoint']
+    foreign = store.create_job('foreign-secret', origin='other', session_id=None)
+    store.save_job(replace(foreign, origin=None))
+    _, isolated = get_job_metadata(query(ctx, selection, mode='changes',
+        after_revision=result['page']['checkpoint']), fresh)
+    assert isolated['page']['outcome'] == 'complete' and isolated['rows'] == []
+    assert 'foreign-secret' not in json.dumps(isolated)
+
+
+def test_unknown_legacy_is_never_hydrated(env):
+    store, _, _, _, _ = env
+    store.create_job('legacy', label=json.dumps({'origin': 'marionette', 'session_id': 'session-A'}))
+    _, result = page(env)
+    assert not result['rows'] and 'legacy_ownership' in result['missing']
+    assert result['coverage']['legacy'] == 'unavailable'
+
+
+def test_cursor_tamper_binding_and_captured_snapshot(env):
+    store, reader, ctx, selection, active = env
+    jobs = [job(store, i) for i in range(70)]
+    _, first = page(env)
+    cursor = first['page']['next_cursor']
+    assert page(env, cursor='!' + cursor)[0] == 400
+    assert get_job_metadata(query(replace(ctx, scope='all'), selection, mode='snapshot', cursor=cursor), reader)[0] == 400
+    active[0] = replace(active[0], session_id='session-B', generation='generation-2')
+    assert page(env, cursor=cursor)[0] == 409
+    new_ctx = replace(ctx, session_id='session-B', view_generation='generation-2')
+    assert get_job_metadata(query(new_ctx, selection, mode='snapshot', cursor=cursor), reader)[0] == 400
+    active[0] = ActiveContext(ctx.session_id, ctx.repo, ctx.view_generation)
+    later = job(store, 100)
+    unseen = next(j for j in jobs if j.id not in {r['selection']['job_ref']['job_id'] for r in first['rows']})
+    removed = next(j for j in jobs if j != unseen and j.id not in {
+        r['selection']['job_ref']['job_id'] for r in first['rows']})
+    store.save_job(replace(unseen, goal='mutated-preview', status=JobStatus.COMPLETE))
+    store.delete_job(removed.id)
+    rows = list(first['rows'])
+    while cursor:
+        code, continued = page(env, cursor=cursor)
+        assert code == 200
+        assert_bounded_page(continued)
+        assert continued['page']['revision'] == first['page']['revision']
+        rows.extend(continued['rows'])
+        cursor = continued['page']['next_cursor']
+    ids = [r['selection']['job_ref']['job_id'] for r in rows]
+    assert len(ids) == len(set(ids)) == 70 and set(ids) == {j.id for j in jobs}
+    assert later.id not in ids
+    old = next(r for r in rows if r['selection']['job_ref']['job_id'] == unseen.id)
+    assert old['display']['goal_preview'] == unseen.goal and old['lifecycle'] == 'queued'
+    code, delta = get_job_metadata(query(ctx, selection, mode='changes',
+        after_revision=continued['page']['checkpoint']), reader)
+    assert code == 200 and delta['page']['outcome'] == 'complete'
+    assert {r['selection']['job_ref']['job_id'] for r in delta['rows']} == {later.id, unseen.id, removed.id}
+    assert next(r for r in delta['rows'] if r['selection']['job_ref']['job_id'] == unseen.id)['lifecycle'] == 'complete'
+    assert next(r for r in delta['rows'] if r['selection']['job_ref']['job_id'] == removed.id)['deleted'] is True
+
+
+def test_frozen_change_continuation(env):
+    store, reader, ctx, selection, _ = env
+    for i in range(70):
+        job(store, i)
+    _, first = get_job_metadata(query(ctx, selection, mode='changes', after_revision=0), reader)
+    assert first['page']['outcome'] == 'partial'
+    upper = first['page']['revision']
+    later = job(store, 100)
+    _, second = get_job_metadata(query(ctx, selection, mode='changes', after_revision=0, cursor=first['page']['next_cursor']), reader)
+    assert second['page']['outcome'] == 'complete'
+    assert second['page']['checkpoint'] == upper
+    assert all(r['selection']['job_ref']['job_id'] != later.id for r in second['rows'])
+    assert get_job_metadata(query(ctx, selection, mode='changes', after_revision=upper, cursor=first['page']['next_cursor']), reader)[0] == 400
+
+
+def test_detail_exact_scope_and_budget(env):
+    store, reader, ctx, selection, _ = env
+    j = job(store)
+    expected = dict(tasks=set(), artifacts=set())
+    for i in range(206):
+        t = Task(j.id, 'test', 'body', id=f'task_{i:04d}')
+        a = Artifact(j.id, t.id, ArtifactType.FINDING, 'test', {'claim': 'recorded', 'passed': True}, 1.0, ['fixture'])
+        store.save_task(t)
+        store.save_artifact(a)
+        expected['tasks'].add(t.id)
+        expected['artifacts'].add(a.id)
+    qs = query(ctx, selection, **store.job_ref(j.id).as_dict())
+    code, result = get_job_metadata_detail(qs, reader)
+    assert code == 200
+    assert result['cancellation_authority'] is False
+    assert result['cost']['kind'] == 'unavailable' and result['cost']['reason'] == 'no_terminal_receipt'
+    assert result['history']['kind'] == 'available'
+    assert result['history']['counts']['captured_runs'] == 0
+    assert result['artifacts']['rows'][0]['check_result'] == 'unavailable'
+    # The task and artifact byte budgets can exhaust at different row counts.
+    for lane, parameter in (('tasks', 'task_cursor'), ('artifacts', 'artifact_cursor')):
+        current = result
+        ids = []
+        tokens = set()
+        assert current[lane]['page']['outcome'] == 'partial'
+        while True:
+            assert len(json.dumps(current).encode()) <= 98304
+            assert current['cancellation_authority'] is False
+            chunk = current[lane]
+            assert len(chunk['rows']) <= 50 and chunk['page']['scanned'] <= 51
+            ids.extend(r['id'] for r in chunk['rows'])
+            assert len(ids) == len(set(ids))
+            token = chunk['page']['next_cursor']
+            if token is None:
+                assert chunk['page']['outcome'] == 'complete'
+                break
+            assert chunk['page']['outcome'] == 'partial' and token not in tokens
+            tokens.add(token)
+            code, current = get_job_metadata_detail(dict(qs, **{parameter: [token]}), reader)
+            assert code == 200
+        assert set(ids) == expected[lane]
+    store.save_job(replace(j, session_id='other'))
+    _, denied = get_job_metadata_detail(qs, reader)
+    assert denied['tasks']['rows'] == denied['artifacts']['rows'] == []
+    assert denied['lifecycle'] is None
+
+
+def test_missing_old_store_no_creation(tmp_path):
+    for name in ('missing', 'old'):
+        root = tmp_path / name
+        if name == 'old':
+            root.mkdir()
+            with closing(sqlite3.connect(root / 'state.sqlite3')) as c, c:
+                c.execute('CREATE TABLE metadata (key TEXT, value TEXT)')
+                c.execute("INSERT INTO metadata VALUES ('schema_version','1')")
+        sources = KnownSources.from_roots([('harness', root, 'sqlite', False)])
+        ctx = ReadContext('session-A', str(tmp_path), 'g', 'session')
+        reader = MetadataReader(lambda: ActiveContext(ctx.session_id, ctx.repo, 'g'), sources)
+        before = hashes(tmp_path)
+        code, result = get_job_metadata(query(ctx, sources.stores[0].selection, mode='snapshot'), reader)
+        assert code == 200
+        assert result['page']['outcome'] == 'unavailable' and result['rows'] == []
+        assert hashes(tmp_path) == before
+        assert root.exists() == (name == 'old')
+
+
+def test_large_binding_unavailable_without_truncation(env):
+    store, reader, ctx, selection, _ = env
+    j = job(store)
+    store.save_task(Task(j.id, 'test', 'body', lease_owner='x' * 300000))
+    _, result = get_job_metadata_detail(query(ctx, selection, job_id=j.id), reader)
+    assert result['tasks']['page']['outcome'] == 'unavailable'
+    assert result['tasks']['rows'] == [] and result['cancellation_authority'] is False
+
+
+def test_stale_context_during_public_read(env, monkeypatch):
+    store, reader, ctx, selection, active = env
+    job(store)
+    from puppetmaster.store import SwarmStore
+    original = SwarmStore.list_job_summaries
+    def read(self, *a, **kw):
+        result = original(self, *a, **kw)
+        active[0] = replace(active[0], generation='changed')
+        return result
+    monkeypatch.setattr(SwarmStore, 'list_job_summaries', read)
+    code, result = page(env)
+    assert code == 409 and result == {'code': 'view_changed'}
+
+
+def test_strict_boundary_and_pins(env):
+    store, reader, ctx, selection, _ = env
+    refs = [PMSelection(ctx, selection, JobRef(job(store, i).id, selection.state_id)) for i in range(9)]
+    body = dict(asdict(ctx), selections=[s.wire() for s in refs[:8]])
+    code, result = post_job_metadata_pins(body, reader)
+    assert code == 200 and len(result['results']) == 8
+    assert all(r['result']['kind'] == 'present' for r in result['results'])
+    assert post_job_metadata_pins(dict(body, selections=[s.wire() for s in refs]), reader)[0] == 400
+    for extra in ({'limit': ['1']}, {'repo': ['', ctx.repo]}, {'source': ['cli', 'harness']}, {'mode': ['']}, {'cursor': [True]}):
+        qs = query(ctx, selection, mode='snapshot')
+        qs.update(extra)
+        assert get_job_metadata(qs, reader)[0] == 400
+    assert get_local_metadata(query(ctx), reader)[1]['page']['outcome'] == 'unavailable'
+
+
+def test_cross_store_collision_and_alias_preference(env, tmp_path, monkeypatch):
+    store, _, ctx, selection, active = env
+    j = job(store)
+    foreign = create_store('sqlite', tmp_path / 'foreign', mode='ensure')
+    monkeypatch.setattr('puppetmaster.models.new_id', lambda prefix: j.id if prefix == 'job' else prefix + '_fixture')
+    foreign.create_job('foreign', origin='foreign', session_id='session-A')
+    sources = KnownSources.from_roots([('cli', store.root, store.backend_name, False),
+                                     ('harness', store.root, store.backend_name, False),
+                                     ('cli', foreign.root, 'sqlite', False)])
+    assert len(sources.stores) == 2 and sources.stores[0].selection.source == 'harness'
+    reader = MetadataReader(lambda: active[0], sources)
+    selected = PMSelection(ctx, sources.stores[1].selection, JobRef(j.id, state_identity(foreign.root)))
+    _, pins = post_job_metadata_pins(dict(asdict(ctx), selections=[selected.wire()]), reader)
+    assert pins['results'][0]['result']['kind'] == 'unavailable'
+    assert get_job_metadata_detail(query(ctx, selected.store, job_id=j.id), reader)[1]['tasks']['rows'] == []
+
+
+def test_same_path_replacement_requires_explicit_source_refresh(env, tmp_path, monkeypatch):
+    store, reader, ctx, selection, _ = env
+    j = job(store)
+    old_ref = store.job_ref(j.id)
+    assert page(env)[0] == 200
+    replacement = create_store(store.backend_name, tmp_path / 'replacement', mode='ensure')
+    replacement.init()
+    monkeypatch.setattr('puppetmaster.models.new_id', lambda prefix: j.id if prefix == 'job' else prefix + '_fixture')
+    replacement.create_job('replacement body', origin='marionette', session_id='session-A')
+    old_id = state_identity(store.root)
+    shutil.rmtree(store.root)
+    shutil.move(str(replacement.root), str(store.root))
+    assert state_identity(store.root) == old_id
+    code, result = page(env)
+    assert code == 200 and result['page']['outcome'] == 'unavailable'
+    assert result['rows'] == [] and 'selection_changed' in result['missing']
+    assert 'replacement body' not in json.dumps(result)
+    fresh_sources = KnownSources.from_roots([('harness', store.root, store.backend_name, False)])
+    fresh = MetadataReader(reader.active_context, fresh_sources)
+    code, refreshed = get_job_metadata(query(ctx, selection, mode='snapshot'), fresh)
+    assert code == 200 and refreshed['page']['outcome'] == 'complete'
+    ref = refreshed['rows'][0]['selection']['job_ref']
+    assert ref['job_id'] == j.id and ref['state_id'] == old_id
+    assert ref['version'] == 2 and ref['incarnation'] != old_ref.incarnation
+
+
+def test_repo_visibility_and_sibling_status_removal(env, tmp_path, monkeypatch):
+    store, _, ctx, _, active = env
+    monkeypatch.setenv('HARNESS_CLI_CROSS_PROJECT', '1')
+    sibling = create_store('sqlite', tmp_path / 'sibling', mode='ensure')
+    j = sibling.create_job('sibling', origin='marionette', session_id=ctx.session_id, project_id='unrelated-project')
+    sibling.save_job(replace(j, status=JobStatus.RUNNING))
+    sources = KnownSources.from_roots([('harness', store.root, store.backend_name, False),
+                                     ('cli', sibling.root, 'sqlite', True)])
+    reader = MetadataReader(lambda: active[0], sources)
+    selection = sources.stores[1].selection
+    _, denied = get_job_metadata(query(replace(ctx, scope='repo'), selection, mode='snapshot', status='running'), reader)
+    assert denied['page']['outcome'] == 'unavailable'
+    assert get_job_metadata(query(ctx, selection, mode='snapshot'), reader)[0] == 400
+    _, first = get_job_metadata(query(ctx, selection, mode='snapshot', status='running'), reader)
+    assert len(first['rows']) == 1
+    sibling.save_job(replace(j, status=JobStatus.COMPLETE, session_id='foreign'))
+    _, change = get_job_metadata(query(ctx, selection, mode='changes', status='running', after_revision=first['page']['checkpoint']), reader)
+    assert change['rows'][0]['deleted'] and len(change['rows'][0]) == 3
+    assert 'foreign' not in json.dumps(change)
+    monkeypatch.setenv('HARNESS_CLI_CROSS_PROJECT', '0')
+    assert get_job_metadata(query(ctx, selection, mode='snapshot', status='running'), reader)[1]['page']['outcome'] == 'unavailable'
+
+
+def test_repo_ignores_project_identity_and_pin_retains_owned_other_session(env):
+    store, reader, ctx, selection, _ = env
+    j = store.create_job('owned', session_id='other', origin='marionette', project_id='unrelated')
+    _, result = get_job_metadata(query(replace(ctx, scope='repo'), selection, mode='snapshot'), reader)
+    assert len(result['rows']) == 1
+    ref = PMSelection(ctx, selection, JobRef(j.id, selection.state_id))
+    _, pins = post_job_metadata_pins(dict(asdict(ctx), selections=[ref.wire()]), reader)
+    assert pins['results'][0]['result']['kind'] == 'present'
+    assert get_job_metadata_detail(query(ctx, selection, job_id=j.id), reader)[1]['tasks']['page']['outcome'] == 'unavailable'
+
+
+def test_wrapper_overflow_keeps_checkpoint_and_no_rows(env):
+    store, reader, original, selection, active = env
+    # Long ASCII repo repeated in each exact selection exceeds the host wrapper
+    # budget although the public PM page still fits. It is never row-clipped.
+    ctx = replace(original, repo='/' + 'r' * 1000)
+    active[0] = ActiveContext(ctx.session_id, ctx.repo, ctx.view_generation)
+    for i in range(70):
+        job(store, i)
+    _, result = get_job_metadata(query(ctx, selection, mode='changes', after_revision=0), reader)
+    assert result['page']['outcome'] == 'unavailable'
+    assert result['page']['checkpoint'] == 0 and result['page']['next_cursor'] is None
+    assert result['rows'] == [] and 'response_budget' in result['missing']
+    assert len(json.dumps(result).encode()) <= 65536
+
+
+def test_sustained_writes_do_not_trigger_refill(env, monkeypatch):
+    store, reader, ctx, selection, _ = env
+    expected = {job(store, i).id for i in range(70)}
+    handle = reader.sources.stores[0].handle
+    original = handle.list_job_summaries
+    calls = []
+    def counted(**kwargs):
+        calls.append(kwargs)
+        return original(**kwargs)
+    monkeypatch.setattr(handle, 'list_job_summaries', counted)
+    for i in range(5):
+        code, current = page(env)
+        assert code == 200 and current['page']['outcome'] == 'partial'
+        revision = current['page']['revision']
+        captured = set(expected)
+        ids = [r['selection']['job_ref']['job_id'] for r in current['rows']]
+        while current['page']['next_cursor']:
+            expected.add(job(store, 100 + len(expected)).id)
+            before = len(calls)
+            code, current = page(env, cursor=current['page']['next_cursor'])
+            assert code == 200 and len(calls) == before + 1
+            assert_bounded_page(current)
+            assert current['page']['revision'] == revision
+            ids.extend(r['selection']['job_ref']['job_id'] for r in current['rows'])
+            assert len(ids) == len(set(ids))
+        assert set(ids) == captured
+        assert current['page']['checkpoint'] == revision
+    assert all({k: call[k] for k in ('limit', 'max_scan', 'max_bytes')}
+               == dict(limit=50, max_scan=51, max_bytes=32768) for call in calls)
+
+
+def test_projection_epoch_and_pending(env):
+    store, reader, ctx, selection, _ = env
+    for i in range(60):
+        job(store, i)
+    _, first = page(env)
+    database = store.root / ('state.sqlite3' if store.backend_name == 'sqlite' else 'metadata.sqlite3')
+    # Fixture corruption/epoch rotation only: production never accesses tables.
+    with closing(sqlite3.connect(database)) as c, c:
+        c.execute("UPDATE projection_meta SET value=CAST(value AS INTEGER)+1 WHERE key='epoch'")
+    assert page(env, cursor=first['page']['next_cursor'])[1]['page']['outcome'] == 'cursor_expired'
+    with closing(sqlite3.connect(database)) as c, c:
+        fields = c.execute('PRAGMA table_info(projection_pending)').fetchall()
+        assert fields
+        c.execute("INSERT INTO projection_pending VALUES ('fixture')")
+    assert page(env)[1]['page']['outcome'] == 'unavailable'
+
+
+def test_unknown_source_does_not_attach_arbitrary_path(env, monkeypatch):
+    _, reader, ctx, selection, _ = env
+    monkeypatch.setattr('harness.job_readmodel.create_store', lambda *a, **kw: pytest.fail('unknown store opened'))
+    _, result = get_job_metadata(query(ctx, replace(selection, state_id='unknown'), mode='snapshot'), reader)
+    assert result['page']['outcome'] == 'unavailable'
+    assert get_job_metadata(query(ctx, selection, mode='snapshot', state_dir='/tmp/arbitrary'), reader)[0] == 400
+
+
+def test_corrupt_store_is_503(env):
+    store, reader, ctx, selection, _ = env
+    database = store.root / ('state.sqlite3' if store.backend_name == 'sqlite' else 'metadata.sqlite3')
+    database.write_bytes(b'not a database')
+    assert page(env)[0] == 503
+
+
+def test_poll_never_constructs_store_or_recreates_deleted_root(env, monkeypatch):
+    store, reader, ctx, selection, _ = env
+    job(store)
+    monkeypatch.setattr('harness.job_readmodel.create_store', lambda *a, **kw: pytest.fail('constructor in poll'))
+    assert page(env)[0] == 200
+    shutil.rmtree(store.root)
+    assert page(env)[1]['page']['outcome'] == 'unavailable'
+    assert not store.root.exists()
+
+
+def test_invalid_scalar_and_corrupt_metadata_classification(env):
+    store, reader, ctx, selection, _ = env
+    assert get_job_metadata(query(ctx, selection, mode='snapshot', status='invalid'), reader)[0] == 400
+    qs = query(ctx, selection, mode='snapshot')
+    qs['repo'] = ['\ud800']
+    assert get_job_metadata(qs, reader)[0] == 400
+    job(store)
+    database = store.root / ('state.sqlite3' if store.backend_name == 'sqlite' else 'metadata.sqlite3')
+    with closing(sqlite3.connect(database)) as c, c:
+        c.execute("UPDATE projection_current SET scope='not-json'")
+    code, corrupt = page(env)
+    assert code == 200 and corrupt['page']['outcome'] == 'unavailable'
+    assert corrupt['page']['reason'] == 'membership_invalid' and corrupt['rows'] == []
+    assert corrupt['page']['checkpoint'] == 0
+
+
+def test_null_counts_and_independent_detail_cursors(env):
+    store, reader, ctx, selection, _ = env
+    j = job(store)
+    for i in range(60):
+        store.save_task(Task(j.id, 'test', 'body', id=f'task_{i:04d}'))
+    database = store.root / ('state.sqlite3' if store.backend_name == 'sqlite' else 'metadata.sqlite3')
+    with closing(sqlite3.connect(database)) as c, c:
+        c.execute("UPDATE projection_current SET task_count=NULL, artifact_count=NULL WHERE kind='job'")
+    _, listed = page(env)
+    assert listed['rows'][0]['task_count'] is listed['rows'][0]['artifact_count'] is None
+    _, detail = get_job_metadata_detail(query(ctx, selection, job_id=j.id), reader)
+    cursor = detail['tasks']['page']['next_cursor']
+    assert cursor
+    assert get_job_metadata_detail(query(ctx, selection, job_id=j.id, artifact_cursor=cursor), reader)[0] == 400
+    other = job(store, 100)
+    assert get_job_metadata_detail(query(ctx, selection, job_id=other.id, task_cursor=cursor), reader)[0] == 400
+
+
+def test_source_discovery_is_once_bounded_and_scratch_excluded(tmp_path, monkeypatch):
+    from harness.job_readmodel import discover_sources
+    primary = tmp_path / 'primary'
+    create_store('sqlite', primary, mode='ensure')
+    called = []
+    monkeypatch.setattr('harness.job_readmodel.resolve_cli_state_dir', lambda workspace: str(primary))
+    monkeypatch.setattr('harness.job_readmodel.cross_project_scan_enabled', lambda: True)
+    def candidates(primary_resolved, *, max_opens):
+        called.append((primary_resolved, max_opens))
+        return [str(tmp_path / 'pmh-edit-scratch'), str(tmp_path / 'sibling')]
+    monkeypatch.setattr('harness.job_readmodel._foreign_state_dir_candidates', candidates)
+    sources = discover_sources(primary, tmp_path)
+    assert len(called) == 1 and called[0][1] == 32
+    assert len(sources.stores) == 2
+    assert sources.stores[0].selection.source == 'harness'
+    assert all(s.root.name != 'pmh-edit-scratch' for s in sources.stores)
+
+
+def test_old_file_store_without_projection_stays_unavailable(tmp_path, monkeypatch):
+    root = tmp_path / 'old-file'
+    root.mkdir()
+    (root / 'legacy-job.json').write_text('{"body":"never read"}')
+    before = hashes(root)
+    sources = KnownSources.from_roots([('harness', root, 'file', False)])
+    ctx = ReadContext('session-A', str(tmp_path), 'g', 'session')
+    reader = MetadataReader(lambda: ActiveContext(ctx.session_id, ctx.repo, 'g'), sources)
+    monkeypatch.setattr('harness.job_readmodel.create_store', lambda *a, **k: pytest.fail('constructor in poll'))
+    _, result = get_job_metadata(query(ctx, sources.stores[0].selection, mode='snapshot'), reader)
+    assert result['page']['outcome'] == 'unavailable' and result['rows'] == []
+    assert hashes(root) == before and not (root / 'metadata.sqlite3').exists()
+
+
+def test_current_owner_retained_while_prior_owner_receives_tombstone(env):
+    store, reader, ctx, selection, _ = env
+    j = job(store)
+    ref = store.job_ref(j.id)
+    _, first = page(env)
+    moved = replace(j, session_id='session-B', goal='new-owner-preview')
+    store.save_job(moved)
+    after = first['page']['checkpoint']
+    code, departed = get_job_metadata(query(ctx, selection, mode='changes', after_revision=after), reader)
+    assert code == 200 and departed['page']['outcome'] == 'complete'
+    assert len(departed['rows']) == 1 and departed['rows'][0]['deleted']
+    assert set(departed['rows'][0]) == {'selection', 'revision', 'deleted'}
+    assert 'session-B' not in json.dumps(departed) and 'new-owner-preview' not in json.dumps(departed)
+    current_ctx = replace(ctx, session_id='session-B')
+    current_reader = MetadataReader(lambda: ActiveContext('session-B', ctx.repo, ctx.view_generation), reader.sources)
+    for owner_ctx, owner_reader in ((current_ctx, current_reader), (replace(ctx, scope='repo'), reader),
+                                    (replace(ctx, scope='all'), reader)):
+        code, retained = get_job_metadata(query(owner_ctx, selection, mode='changes', after_revision=after), owner_reader)
+        assert code == 200 and retained['page']['outcome'] == 'complete'
+        assert len(retained['rows']) == 1 and not retained['rows'][0]['deleted']
+        assert retained['rows'][0]['selection']['job_ref'] == ref.as_dict()
+        assert retained['rows'][0]['ownership']['session_id'] == 'session-B'
+        assert retained['rows'][0]['display']['goal_preview'] == 'new-owner-preview'
+    store.save_job(replace(moved, session_id=ctx.session_id))
+    code, returned = get_job_metadata(query(ctx, selection, mode='changes',
+        after_revision=departed['page']['checkpoint']), reader)
+    assert code == 200 and returned['page']['outcome'] == 'complete'
+    assert len(returned['rows']) == 1 and not returned['rows'][0]['deleted']
+    assert returned['rows'][0]['revision'] > departed['rows'][0]['revision']
+
+
+def test_missing_source_membership_witness_does_not_advance_checkpoint(env):
+    store, reader, ctx, selection, _ = env
+    j = job(store)
+    _, first = page(env)
+    store.save_job(replace(j, session_id=None, origin=None))
+    database = store.root / ('state.sqlite3' if store.backend_name == 'sqlite' else 'metadata.sqlite3')
+    with closing(sqlite3.connect(database)) as connection, connection:
+        changed = connection.execute("UPDATE projection_changes SET previous_membership=NULL "
+                                     "WHERE kind='job' AND revision>?", (first['page']['checkpoint'],))
+        assert changed.rowcount > 0
+    code, result = get_job_metadata(query(ctx, selection, mode='changes',
+        after_revision=first['page']['checkpoint']), reader)
+    assert code == 200 and result['page']['outcome'] == 'unavailable'
+    assert result['rows'] == [] and result['page']['checkpoint'] == first['page']['checkpoint']
+    assert 'previous_membership_unavailable' in result['missing']
+
+
+def test_reader_safety_instrumentation_rejects_source_reads_and_writes(env, monkeypatch):
+    from puppetmaster.projections import connection
+    store, reader, _, _, _ = env
+    job(store)
+    before = hashes(store.root)
+    metrics = trace_metadata(monkeypatch)
+    assert page(env)[0] == 200 and metrics['reads']
+    if store.backend_name == 'sqlite':
+        with pytest.raises(AssertionError):
+            with connection(reader.sources.stores[0].handle, metadata_only=True) as c:
+                c.execute('SELECT id FROM jobs')
+    else:
+        with pytest.raises(sqlite3.OperationalError, match='no such table: jobs'):
+            with connection(reader.sources.stores[0].handle, metadata_only=True) as c:
+                c.execute('SELECT id FROM jobs')
+    with pytest.raises(AssertionError):
+        with connection(reader.sources.stores[0].handle, metadata_only=True) as c:
+            c.execute('CREATE TABLE forbidden_write (id INTEGER)')
+    assert hashes(store.root) == before


### PR DESCRIPTION
Expose seven authenticated job metadata routes backed by captured source handles and bounded Puppetmaster reads. Lists, exact selections, task/artifact references, history, publication receipts, and terminal economics preserve session/repository context, source identity, job incarnation, revision, and cursor boundaries. Session and workspace transitions retire stale views.

The service opens no stores during polls and grants no cancellation authority. Native routes report unavailable until the companion observation producer is present. Older public runtimes retain normal server/registry startup and receive explicit metadata unavailability; supported development runtimes activate the new reader without a release pin change.

Review `job_metadata_capability.py` and `job_metadata_view.py` for activation/publication, `job_readmodel.py` for bounded public reads, and `api/job_readmodel.py` for request validation. Existing server/session edits only wire lifecycle and authenticated routes. `docs/puppetmaster-consumer-development.md` documents the isolated local checkout install and existing desktop bootstrap override.

Companion changes: transport #332 and shared UI #333, plus native observations and exact cancellation #335. Runtime validation used local Puppetmaster development commit `057a786b0e53302ceff0a271b8af73d86864c664`; public package/version pins are unchanged.

Validation: 145 extraction checks passed against the local 1.25 development install. After adding the capability boundary, 22 supported-runtime checks passed, including real authenticated loopback HTTP. Actual public 1.23 startup, registry, framing, and unavailable-route checks passed: 48 tests, with four new optional metadata integration modules skipped because their required APIs are absent. Existing tests were not skipped; all candidate-specific positive tests remain collected on 1.25. `git diff --check` passed. No full-suite, live GUI, or public 1.25 release claim.
