### PR TITLE
Add bounded native observations and exact job cancellation

### DIFF
--- a/harness/api/jobs.py
+++ b/harness/api/jobs.py
@@ -278,56 +278,48 @@ def _artifacts_from_durable(durable: Any, job_id: str, svc: JobServices, state_o
     return []
 
 
-def _legacy_cancel_selection(job_id: str, svc: JobServices) -> dict | None:
-    """Resolve an id only when exactly one known local/primary store contains it."""
-    from puppetmaster.state import state_identity
-    from ..cli_job_merge import resolve_cli_state_dir
-    from puppetmaster.store_factory import create_store
-
-    repo = svc.cfg.repo or ""
-    sid = getattr(svc.sessions, "active", None)
-    if not repo or not sid:
-        return None
-    candidates = []
-    pilot = svc.get_pilot()
-    getter = getattr(pilot, "get_local_job", None)
-    if callable(getter) and getter(job_id) is not None:
-        candidates.append({"source": "local", "job_ref": {"job_id": job_id, "state_id": None}})
-    primary = svc.get_session().state()
-    cli_root = resolve_cli_state_dir(repo)
-    cli_store = create_store("sqlite", cli_root, mode="attach") if cli_root else None
-    seen = set()
-    for source, store in (("harness", primary.store), ("cli", cli_store)):
-        if store is None:
-            continue
-        state_id = state_identity(store.root)
-        if state_id in seen:
-            continue
-        seen.add(state_id)
-        attach = getattr(store, "attach", None)
-        if callable(attach):
-            attach()
-        try:
-            job = store.get_job(job_id)
-        except (KeyError, FileNotFoundError):
-            continue
-        if job is not None:
-            candidates.append({"source": source, "job_ref": {"job_id": job_id, "state_id": state_id}})
-    if len(candidates) != 1:
-        return None
-    return {"version": 1, "repo": repo, "session_id": sid, **candidates[0]}
+def get_cancellation_receipt(qs: dict, svc: JobServices) -> tuple[int, dict]:
+    """Read an existing receipt; never create or retry cancellation."""
+    fields = ("job_id", "state_id", "source", "repo", "session_id", "request_id")
+    if not isinstance(qs, dict):
+        return 400, {"ok": False, "code": "invalid_cancellation_query"}
+    if any(not isinstance(qs.get(k), list) or len(qs[k]) != 1 for k in fields):
+        return 400, {"ok": False, "code": "invalid_cancellation_query",
+                     "error": "Invalid receipt query."}
+    if (set(qs) - set(fields) - {'version', 'incarnation'}
+            or any(not isinstance(qs[k], list) or len(qs[k]) != 1 for k in ('version', 'incarnation') if k in qs)):
+        return 400, {"ok": False, "code": "invalid_cancellation_query"}
+    values = {k: qs[k][0] for k in fields}
+    ref_fields = {}
+    if 'version' in qs:
+        if qs['version'][0] not in ('1', '2'):
+            return 400, {"ok": False, "code": "invalid_cancellation_query"}
+        ref_fields['version'] = int(qs['version'][0])
+    if 'incarnation' in qs:
+        ref_fields['incarnation'] = qs['incarnation'][0]
+    selection = {"version": 2, "job_ref": {"job_id": values.pop("job_id"),
+                 "state_id": values.pop("state_id"), **ref_fields},
+                 **{k: values[k] for k in ("source", "repo", "session_id")}}
+    return _scoped_cancel({"selection": selection, "request_id": values["request_id"]}, svc,
+                          read_only=True)
 
 
 def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
+    return _scoped_cancel(body, svc, read_only=False)
+
+
+def _scoped_cancel(body: dict, svc: JobServices, *, read_only: bool) -> tuple[int, dict]:
     """Cancel one versioned selection without using PM's global job-id flag.
 
-    PM 1.23.0 request_cancel has no state identity. Running durable jobs
-    require a scoped kernel cancellation API and must remain unchanged.
-    Local workers have a pilot-owned per-job event.
+    Durable requests carry the rendered generations into PM's atomic comparison.
+    Local workers retain their pilot-owned per-job event.
     """
+    from dataclasses import asdict
+    from .scoped_cancellation import parse_bindings, parse_job_ref, task_page, runtime_available
+    identity_errors = ()
     from puppetmaster.state import state_identity
     from ..cli_job_merge import resolve_cli_state_dir
-    from ..job_scoping import job_owned_by_marionette, parse_job_session_id
+    from ..job_scoping import job_owned_by_marionette
     from ..paths import same_workspace_path
     from puppetmaster.store_factory import create_store
 
@@ -338,16 +330,10 @@ def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
     if "selection" not in body and not body.get("job_id"):
         return 400, {"ok": False, "error": "missing job_id"}
     selection = body.get("selection")
-    if "selection" not in body and isinstance(body.get("job_id"), str) and body["job_id"].strip():
-        try:
-            selection = _legacy_cancel_selection(body["job_id"], svc)
-        except Exception as exc:
-            svc.diag("server.swarm_cancel_resolve", exc)
-            return 503, {"ok": False, "error": "Job selection could not be resolved."}
-    if not isinstance(selection, dict) or type(selection.get("version")) is not int or selection["version"] != 1:
+    if not isinstance(selection, dict) or type(selection.get("version")) is not int or selection["version"] not in (1, 2):
         return refused
     ref = selection.get("job_ref")
-    if not isinstance(ref, dict) or "state_id" not in ref:
+    if not isinstance(ref, dict) or not {"job_id", "state_id"} <= ref.keys():
         return refused
     jid, state_id = ref.get("job_id"), ref.get("state_id")
     sid, repo, source = (selection.get(k) for k in ("session_id", "repo", "source"))
@@ -355,6 +341,32 @@ def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
             or source not in ("harness", "cli", "local")
             or ("job_id" in body and body["job_id"] != jid)):
         return refused
+    local_incarnation = selection.get("local_incarnation")
+    if "local_incarnation" in selection and (
+            source != "local" or not isinstance(local_incarnation, str)
+            or not 1 <= len(local_incarnation) <= 128):
+        return refused
+    if source == "local":
+        if not local_incarnation:
+            return refused
+        if set(ref) != {"job_id", "state_id"}:
+            return refused
+        job_ref = None
+    else:
+        if ref.get('version') != 2:
+            return 409, {"ok": False, "code": "scoped_kernel_cancellation_required",
+                         "error": "Refresh the task view: an incarnation-bound job reference is required."}
+        if not runtime_available():
+            return 503, {"ok": False, "code": "scoped_cancellation_unsupported"}
+        from puppetmaster.identity import StoreIdentityError
+        identity_errors = (StoreIdentityError,)
+        try:
+            job_ref = parse_job_ref(ref)
+        except (ValueError, TypeError):
+            return refused
+        if not read_only and job_ref.version != 2:
+            return 409, {"ok": False, "code": "scoped_kernel_cancellation_required",
+                         "error": "Refresh the task view: cancellation requires an incarnation-bound job reference."}
     captured_repo = svc.cfg.repo or ""
     captured_sid = getattr(svc.sessions, "active", None)
     if sid != captured_sid or not same_workspace_path(repo, captured_repo):
@@ -363,12 +375,28 @@ def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
         pilot = svc.get_pilot()
 
         def context_matches() -> bool:
-            return (getattr(svc.sessions, "active", None) == captured_sid
-                    and same_workspace_path(svc.cfg.repo or "", captured_repo)
-                    and (source != "local" or svc.get_pilot() is pilot))
+            if (getattr(svc.sessions, "active", None) != captured_sid
+                    or not same_workspace_path(svc.cfg.repo or "", captured_repo)
+                    or (source == "local" and svc.get_pilot() is not pilot)):
+                return False
+            if source == "local" and local_incarnation is not None:
+                index = getattr(pilot, "_local_metadata", None)
+                if getattr(index, "incarnation", None) != local_incarnation:
+                    return False
+            if source == "harness":
+                session = svc.get_session()
+                root = getattr(session, "state_dir", None)
+                if root is None:
+                    root = getattr(session.state().store, "root", None)
+                return bool(root) and state_identity(root) == state_id
+            return True
 
         if source == "local":
+            if read_only or selection["version"] != 1:
+                return refused
             if state_id is not None or not jid.startswith("local-"):
+                return refused
+            if not context_matches():
                 return refused
             job = pilot.get_local_job(jid)
             if (not isinstance(job, dict) or job.get("id") != jid
@@ -377,8 +405,8 @@ def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
                     or getattr(pilot, "harness_session_id", None) != sid
                     or not context_matches()):
                 return refused
-            accepted = pilot.cancel_local_job(jid)
-            if not accepted:
+            accepted = pilot.cancel_local_job(jid, incarnation=local_incarnation)
+            if not accepted or not context_matches():
                 return refused
             return 200, {"ok": True, "job_id": jid, "selection": selection,
                          "cancellation": "local_event"}
@@ -394,34 +422,80 @@ def post_swarm_cancel(body: dict, svc: JobServices) -> tuple[int, dict]:
             if state_identity(root) != state_id:
                 return refused
             store = create_store("sqlite", root, mode="attach")
+        if not runtime_available(store):
+            return 503, {"ok": False, "code": "scoped_cancellation_unsupported"}
         if state_identity(store.root) != state_id:
             return refused
         attach = getattr(store, "attach", None)
         if callable(attach):
             attach()
+        def owned_summary():
+            page = store.list_job_summaries(job_ref=job_ref, limit=1, max_scan=2, max_bytes=8192)
+            if page.outcome != 'complete' or len(page.items) != 1:
+                return None
+            row = page.items[0]
+            if (row.deleted or row.job_ref != job_ref or row.session_id != sid
+                    or not job_owned_by_marionette(session_id=row.session_id, origin=row.origin or '',
+                                                   source=source, allow_registered_heal=False)):
+                return None
+            return row
+
+        job = owned_summary()
+        if job is None:
+            return refused
+        if selection["version"] != 2:
+            return 409, {"ok": False, "code": "scoped_kernel_cancellation_required",
+                         "error": "Refresh the task view: durable cancellation requires bound v2 selections."}
+        request_id = body.get("request_id")
+        if not isinstance(request_id, str) or not request_id.strip() or len(request_id) > 256:
+            return refused
+        receipt = store.get_cancellation_receipt(job_ref, request_id)
+        if read_only and receipt is None:
+            if not context_matches():
+                return refused
+            return 404, {"ok": False, "code": "cancellation_receipt_missing",
+                         "error": "No receipt found. Stop is unconfirmed; an explicit retry must reuse the original request."}
         try:
-            job = store.get_job(jid)
-        except (KeyError, FileNotFoundError):
+            bindings = parse_bindings([asdict(b) for b in receipt.bindings] if read_only else selection.get("bindings"))
+        except (TypeError, ValueError):
             return refused
-        if (job is None or parse_job_session_id(job.label, []) != sid
-                or not job_owned_by_marionette(label=job.label, job_id=jid,
-                    source=source, registered_job_ids=[])):
-            return refused
-        tasks = store.list_tasks(jid)
-        if not tasks or any(
-            task.payload.get("session_id") != sid or not task.payload.get("cwd")
-            or not same_workspace_path(task.payload["cwd"], repo) for task in tasks
-        ):
-            return refused
-        if (not context_matches()
-                or (source == "harness" and svc.get_session().state().store is not store)):
-            return refused
-        if str(job.status) in ("completed", "complete", "failed", "cancelled"):
-            return 200, {"ok": True, "job_id": jid, "selection": selection,
-                         "durable": True, "marked": False, "cancellation": "already_terminal"}
-        return 409, {"ok": False, "code": "scoped_kernel_cancellation_required",
-                     "error": "Cancel is unavailable: the worker was not stopped. "
-                              "Scoped kernel cancellation is required; the job remains running."}
+        selection = {**selection, "bindings": [asdict(b) for b in bindings]}
+
+        def authority_matches(*, require_complete_view: bool):
+            if (not context_matches() or state_identity(store.root) != state_id
+                    or (source == "cli" and state_identity(resolve_cli_state_dir(captured_repo)) != state_id)):
+                return False
+            current_job = owned_summary()
+            if current_job is None or any(getattr(current_job, field) != getattr(job, field)
+                                         for field in ("origin", "project_id", "session_id")):
+                return False
+            if require_complete_view:
+                page = task_page(store, job_ref)
+                if page.outcome != "complete" or {t.id for t in page.items} != {b.task_id for b in bindings}:
+                    return False
+            for binding in bindings:
+                task = store.get_task_by_id(binding.task_id)
+                if (task.job_id != jid or task.payload.get("session_id") != sid
+                        or not task.payload.get("cwd")
+                        or not same_workspace_path(task.payload["cwd"], repo)):
+                    return False
+            return (context_matches()
+                    and (source != "cli" or state_identity(resolve_cli_state_dir(captured_repo)) == state_id))
+
+        if not authority_matches(require_complete_view=not read_only and receipt is None):
+            return 409, {"ok": False, "code": "cancellation_view_unavailable",
+                         "error": "Task scope changed or is incomplete (maximum 200). Refresh the view; no new stop request was sent."}
+        if not read_only:
+            receipt = store.request_cancellation(job_ref, request_id, bindings)
+        if (not authority_matches(require_complete_view=False) or receipt.job_ref != job_ref or receipt.request_id != request_id
+                or (receipt.outcome != "conflict" and receipt.bindings != bindings)):
+            return 409, {"ok": False, "code": "cancellation_context_changed",
+                         "error": "Cancellation acknowledgement is unavailable for this context. Reconcile the original request."}
+        return 200, {"ok": True, "job_id": jid, "selection": selection,
+                     "request_id": request_id, "receipt": {**asdict(receipt), "job_ref": receipt.job_ref.as_dict()}}
+
+    except identity_errors:
+        return refused
     except Exception as exc:
         svc.diag("server.swarm_cancel_scoped", exc)
         return 503, {"ok": False, "error": "Job cancellation could not be completed."}
@@ -497,7 +571,7 @@ def get_scoped_artifacts(qs: dict, svc: JobServices) -> tuple[int, Any]:
     from puppetmaster.models import JobRef
     from puppetmaster.state import state_identity
     from ..cli_job_merge import resolve_cli_state_dir
-    from ..job_scoping import job_owned_by_marionette, parse_job_session_id
+    from ..job_scoping import job_owned_by_marionette
     from ..paths import same_workspace_path
     from ..state import DurableState
 

--- a/harness/api/scoped_cancellation.py
+++ b/harness/api/scoped_cancellation.py
@@ -1,0 +1,77 @@
+"""Bounded cancellation views and strict public PM contract boundaries."""
+from dataclasses import asdict
+
+from importlib import import_module
+from inspect import signature
+
+
+def runtime_available(store=None):
+    """No store discovery or body reads when the pinned PM lacks exact controls."""
+    try:
+        contracts = import_module('puppetmaster.contracts')
+        identity = import_module('puppetmaster.identity')
+        if not hasattr(identity, 'StoreIdentityError'):
+            return False
+        if not {'version', 'incarnation'} <= signature(contracts.JobRef).parameters.keys():
+            return False
+        if not {'task_id', 'generation', 'lease_id', 'owner'} <= signature(contracts.TaskBinding).parameters.keys():
+            return False
+    except (ImportError, AttributeError, TypeError, ValueError):
+        return False
+    return store is None or all(callable(getattr(store, name, None)) for name in (
+        'list_job_summaries', 'list_task_refs', 'get_task_by_id',
+        'get_cancellation_receipt', 'request_cancellation'))
+
+MAX_BINDINGS = 200
+
+
+def parse_job_ref(value):
+    from puppetmaster.contracts import JobRef
+    if (not isinstance(value, dict) or not {'job_id', 'state_id'} <= value.keys()
+            or value.keys() - {'job_id', 'state_id', 'version', 'incarnation'}):
+        raise ValueError('invalid job reference')
+    return JobRef(**value)
+
+
+def parse_bindings(value):
+    from puppetmaster.contracts import TaskBinding
+    if not isinstance(value, list) or not 1 <= len(value) <= MAX_BINDINGS:
+        raise ValueError('provide 1..200 task bindings')
+    bindings = []
+    for item in value:
+        if not isinstance(item, dict) or set(item) != {'task_id', 'generation', 'lease_id', 'owner'}:
+            raise ValueError('invalid task binding')
+        if any(v is not None and (not isinstance(v, str) or not v or len(v) > 256)
+               for v in (item['lease_id'], item['owner'])):
+            raise ValueError('invalid lease identity')
+        if not isinstance(item['task_id'], str) or not 1 <= len(item['task_id']) <= 256:
+            raise ValueError('invalid task identity')
+        bindings.append(TaskBinding(**item))
+    if len({b.task_id for b in bindings}) != len(bindings):
+        raise ValueError('duplicate task binding')
+    return tuple(sorted(bindings, key=lambda b: b.task_id))
+
+
+def task_page(store, ref):
+    return store.list_task_refs(ref, limit=MAX_BINDINGS, max_bytes=262144, max_scan=201)
+
+
+def cancellation_view(store, ref, rendered_tasks):
+    """Never pair authority for a successor with a previously rendered worker."""
+    if not runtime_available(store):
+        return {'status': 'unavailable', 'limit': MAX_BINDINGS, 'reason': 'scoped_cancellation_unsupported'}
+    if ref.version != 2:
+        return {'status': 'unavailable', 'limit': MAX_BINDINGS, 'reason': 'legacy_ref'}
+    try:
+        page = task_page(store, ref)
+        if page.outcome != 'complete':
+            return {'status': page.outcome, 'limit': MAX_BINDINGS}
+        bindings = [asdict(item.binding) for item in page.items if item.binding is not None]
+        parse_bindings(bindings)
+        rendered = {t['id']: t.get('binding') for t in rendered_tasks}
+        if (not bindings or len(bindings) != len(page.items) or len(rendered) != len(bindings)
+                or any(rendered.get(b['task_id']) != b for b in bindings)):
+            return {'status': 'unavailable', 'limit': MAX_BINDINGS}
+        return {'status': 'complete', 'limit': MAX_BINDINGS, 'bindings': bindings}
+    except (AttributeError, OSError, TypeError, ValueError):
+        return {'status': 'unavailable', 'limit': MAX_BINDINGS}

--- a/harness/http_routes.py
+++ b/harness/http_routes.py
@@ -54,13 +54,14 @@ def get_json(
     qs_args: Optional[tuple[str, ...]] = None,
     empty_as_none: bool = False,
     pass_qs: bool = False,
+    keep_blank_values: bool = False,
 ) -> GetHandler:
     """Wrap an api.* GET that returns ``(status, payload)``."""
 
     def handle(handler: Any, u: Any, qs: dict) -> Any:
         args: list[Any] = []
         if pass_qs:
-            args.append(qs)
+            args.append(parse_qs(u.query, keep_blank_values=True) if keep_blank_values else qs)
         elif qs_args:
             for key in qs_args:
                 val = qs.get(key, [""])[0]
@@ -868,6 +869,8 @@ def build_get_routes(svc: Any) -> dict[str, GetHandler]:
         "/api/artifacts": get_json(
             _jobs_api.get_artifacts, services=svc.job_services, qs_arg="job_id",
             empty_as_none=True),
+        "/api/swarm/cancellation-receipt": get_json(
+            _jobs_api.get_cancellation_receipt, services=svc.job_services, pass_qs=True, keep_blank_values=True),
         "/api/swarm/live": _get_swarm_live,
         "/api/providers": get_json(_prov_api.get_providers),
         "/api/secrets/presence": get_json(

--- a/harness/local_job_metadata.py
+++ b/harness/local_job_metadata.py
@@ -1,0 +1,598 @@
+"""Discardable local observation index; execution rows remain the authority.
+
+Writer order: execution lock -> index lock. Polls take only the index lock.
+No index lock spans filesystem work. Sorted-key maintenance costs O(N) on
+insert/delete; the finite revision ring costs O(1). Provider writers compare
+selected task/route projections; readers never construct these snapshots.
+"""
+from __future__ import annotations
+
+import base64
+import bisect
+import hashlib
+import hmac
+import json
+import math
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+
+LIMIT = 50
+MAX_SCAN = 51
+MAX_BYTES = 32768
+JOURNAL_SIZE = 2048
+CURSOR_SECONDS = 120
+LIFECYCLES = frozenset(('registered', 'queued', 'pending', 'running', 'in_progress',
+                        'started', 'completed', 'complete', 'done', 'failed', 'cancelled',
+                        'timeout', 'timed_out', 'truncated', 'partial', 'unknown', 'stitching', 'stalled'))
+ACTIVE = frozenset(('registered', 'queued', 'pending', 'running', 'in_progress', 'started', 'stitching'))
+ATTENTION = frozenset(('stalled', 'failed', 'timeout', 'timed_out', 'truncated', 'partial', 'unknown'))
+
+
+@dataclass(frozen=True)
+class LocalRef:
+    job_id: str
+    incarnation: str
+
+    def wire(self):
+        return dict(job_id=self.job_id, incarnation=self.incarnation)
+
+
+def text(value, limit):
+    # Slice before encoding, stripping, conversion or copying.
+    return value[:limit] if isinstance(value, str) else ''
+
+
+def identity(value):
+    return isinstance(value, str) and 0 < len(value) <= 256 and value.isascii() and all(
+        c.isalnum() or c in '_-' for c in value)
+
+
+def number(value):
+    return value if type(value) in (int, float) and abs(value) < 1e18 and math.isfinite(value) else None
+
+
+def count(value):
+    return len(value) if isinstance(value, (list, tuple)) else None
+
+
+def envelope(outcome='unavailable', *, revision=0, checkpoint=0, scanned=0):
+    return dict(version=1, page=dict(outcome=outcome, revision=revision,
+                checkpoint=checkpoint, scanned=scanned, next_cursor=None), rows=[],
+                coverage=dict(membership='retained_local_history', ordering='id',
+                              historical='unavailable'), missing=['unretained_history'])
+
+
+def encoded(value):
+    return json.dumps(value).encode('utf-8')
+
+
+def selected_context(row, kind):
+    """Only exact owner scalars; never materialize tasks or provider payloads."""
+    def bounded(value, limit):
+        if not isinstance(value, str):
+            return None
+        prefix = value[:limit]
+        raw = prefix.encode('utf-8', errors='replace')
+        clipped = raw[:limit].decode('utf-8', errors='ignore')
+        return dict(text=clipped, truncated=len(value) > len(prefix) or len(raw) > limit)
+
+    command = kind in ('run_command', 'run_command_batch')
+    source = 'command_preview' if command else 'goal'
+    request = bounded(row.get(source), 2048)
+    return dict(source=source, request=request, cwd=bounded(row.get('cwd'), 512),
+                omission='request_unavailable' if request is None else
+                         'raw_command_not_retained' if command else 'none')
+
+
+def capped_fields(source, caps):
+    result = {key: text(source.get(key), cap) for key, cap in caps.items()}
+    result['truncated'] = any(isinstance(source.get(key), str) and len(source[key]) > cap
+                              for key, cap in caps.items())
+    return result
+
+
+def selected_task(source):
+    if not isinstance(source, dict):
+        return dict(unavailable=True)
+    result = capped_fields(source, dict(role=160, instruction=1024, status=40, adapter=40, model=160))
+    result['task_id'] = source.get('id') if identity(source.get('id')) else None
+    result['model_kind'] = 'assigned' if result['model'] else 'unavailable'
+    return result
+
+
+def selected_route(source, row, ordinal):
+    if not isinstance(source, dict) or source.get('type') != 'ROUTING':
+        return None
+    result = capped_fields(source, dict(model=160, role=160, policy=40, adapter=40,
+                                        created_by=40, detail=512))
+    result.update(ordinal=ordinal, task_id=None, association='unavailable',
+                  model_kind='realized' if source.get('model_kind') == 'realized' else 'forecast',
+                  est_cost_usd=number(source.get('est_cost_usd')))
+    tasks = row.get('tasks')
+    if not isinstance(tasks, list) or len(tasks) != 1 or not isinstance(tasks[0], dict):
+        return result
+    task = tasks[0]
+    tid = task.get('id')
+    if not identity(tid) or tid != row.get('id', '') + '-w0':
+        return result
+    if source.get('task_id') == tid:
+        result.update(task_id=tid, association='explicit')
+    elif 'task_id' not in source:
+        # Legacy ownership is attested by the local producer's retained label,
+        # exact sole task and adapter, never by a route creator string alone.
+        label = row.get('label')
+        if not isinstance(label, str) or len(label) > 2048:
+            return result
+        try:
+            label = json.loads(label)
+        except (ValueError, TypeError):
+            return result
+        if (isinstance(label, dict) and label.get('origin') == 'marionette'
+                and label.get('session_id') == row.get('session_id')
+                and row.get('adapter') in ('native', 'agentic')
+                and task.get('adapter') == row.get('adapter')
+                and row.get('job_kind') not in ('run_command', 'run_command_batch', 'parallel_wave')
+                and row.get('role') not in ('command', 'command_batch', 'parallel_wave')):
+            result.update(task_id=tid, association='legacy_owner_single_task')
+    return result
+
+def operator_facts(jid, row, kind):
+    """Copy only writer-owned scalars; receipt construction is never a read path."""
+    if not any(key in row for key in ('model', 'adapter', 'tokens', 'financial_receipt',
+                                      'accounting_owned', 'accounting_scope')):
+        return dict(economics=dict(kind='unavailable'))
+    caps = dict(model=160, adapter=40)
+    display = {key: text(row.get(key), cap) for key, cap in caps.items()}
+    if kind != 'provider':
+        display['model'] = ''
+    display['label'] = {'provider': 'Provider worker', 'run_command': 'Command',
+                        'run_command_batch': 'Command batch',
+                        'parallel_wave': 'Parallel wave'}[kind]
+    display['truncated'] = any(isinstance(row.get(key), str) and len(row[key]) > cap
+                               for key, cap in caps.items())
+    excluded = (row.get('accounting_owned') is False
+                or row.get('accounting_scope') == 'visibility_only')
+    accounting = dict(kind='excluded' if excluded else
+                      'declared' if row.get('accounting_owned') is True else 'unresolved',
+                      aggregation_authority=False)
+    usage = dict(kind='unknown')
+    economics = dict(kind='unavailable')
+    if excluded:
+        return dict(display=display, usage=usage, economics=economics, accounting=accounting)
+    tokens = row.get('tokens')
+    worker = row.get('worker_provenance')
+    usage_known = worker.get('usage_known') if isinstance(worker, dict) else None
+    if (type(tokens) is int and 0 <= tokens < 10**18 and usage_known is not False
+            and (tokens > 0 or usage_known is True)):
+        usage = dict(kind='reported', tokens=tokens, source='local_job_tokens')
+    receipt = row.get('financial_receipt')
+    if (isinstance(receipt, dict) and receipt.get('job_id') == jid
+            and receipt.get('owner') == 'local'):
+        basis = receipt.get('spend_basis')
+        amount = number(receipt.get('spend_usd'))
+        provenance = receipt.get('cost_provenance')
+        estimated = receipt.get('estimated')
+        valid_basis = (
+            (basis == 'provider' and provenance == 'provider' and estimated is False)
+            or (basis == 'measured' and provenance in ('live', 'static') and estimated is False)
+            or (basis == 'estimated' and provenance in ('provider', 'live', 'static', 'default', 'unknown')
+                and estimated is True))
+        if valid_basis and amount is not None and amount >= 0:
+            economics.update(kind=basis, spend_usd=amount, estimated=estimated,
+                             cost_provenance=provenance, source='financial_receipt')
+        for key in ('route_forecast_usd', 'estimated_savings_usd'):
+            value = number(receipt.get(key))
+            if value is not None and value >= 0:
+                economics[key] = value
+    return dict(display=display, usage=usage, economics=economics, accounting=accounting)
+
+
+class LocalMetadataIndex:
+    def __init__(self, owner):
+        self.version = 1
+        self.owner = owner
+        self.incarnation = secrets.token_hex(16)
+        self.lock = threading.RLock()
+        self.secret = secrets.token_bytes(32)
+        self.revision = 0
+        self.rows = {}
+        self._selected_facts = {}
+        self.keys = []
+        self.journal = [None] * JOURNAL_SIZE
+        self.active_keys = []
+        self.active_revision = 0
+        self.active_epoch = 0
+        self.active_journal = [None] * JOURNAL_SIZE
+        self.invalid = set()
+        self.available = True
+
+    def describe(self):
+        with self.lock:
+            return dict(available=self.version == 1 and self.available and not self.invalid,
+                        incarnation=self.incarnation, version=self.version, lanes=['active', 'history'],
+                        active_statuses=sorted(ACTIVE), attention_statuses=sorted(ATTENTION))
+
+    def ref(self, jid):
+        return LocalRef(jid, self.incarnation).wire()
+
+    def project(self, jid, row):
+        if not identity(jid) or not isinstance(row, dict) or row.get('id') != jid:
+            raise ValueError('invalid local identity')
+        sid = row.get('session_id')
+        if not identity(sid):
+            raise ValueError('unknown session ownership')
+        kind = row.get('job_kind')
+        if kind not in ('run_command', 'run_command_batch', 'parallel_wave'):
+            role = row.get('role')
+            kind = {'command': 'run_command', 'command_batch': 'run_command_batch',
+                    'parallel_wave': 'parallel_wave'}.get(role, 'provider')
+        parent = row.get('parent_wave_id') or row.get('batch_id')
+        status = row.get('status')
+        lifecycle = status if isinstance(status, str) and len(status) <= 40 and status in LIFECYCLES else 'unknown'
+        return dict(local_ref=self.ref(jid), lifecycle=lifecycle,
+                    activity='active' if lifecycle in ACTIVE else 'attention' if lifecycle in ATTENTION else 'terminal',
+                    kind=kind, session_id=sid,
+                    parent_ref=self.ref(parent) if identity(parent) else None,
+                    task_count=count(row.get('tasks')), action_count=count(row.get('actions')),
+                    artifact_count=count(row.get('artifacts')), child_count=count(row.get('child_job_ids')),
+                    created_at=number(row.get('created_at')), updated_at=number(row.get('updated_at')),
+                    receipts=dict(terminal=isinstance(row.get('terminal_receipt'), dict),
+                                  launch=isinstance(row.get('launch_checkpoint'), dict),
+                                  recovery=isinstance(row.get('recovery_receipt'), dict),
+                                  child=isinstance(row.get('child_launch_receipt'), dict)),
+                    **operator_facts(jid, row, kind), deleted=False)
+
+    def publish(self, jid, row, *, force=False):
+        try:
+            projected = self.project(jid, row) if row is not None else None
+        except (ValueError, TypeError):
+            with self.lock:
+                self.invalid.add(jid)
+            return
+        with self.lock:
+            self.invalid.discard(jid)
+            previous = self.rows.get(jid)
+            # Writer-only snapshots of the selected wire fields. Never traverse
+            # arbitrary artifact bodies, and never put these facts in list rows.
+            if projected is not None and projected['kind'] == 'provider':
+                tasks, artifacts = row.get('tasks'), row.get('artifacts')
+                facts = (
+                    [selected_task(task) for task in tasks] if isinstance(tasks, list) else None,
+                    [selected_route(art, row, i) for i, art in enumerate(artifacts)]
+                    if isinstance(artifacts, list) else None,
+                )
+                force = force or self._selected_facts.get(jid) != facts
+                self._selected_facts[jid] = facts
+            else:
+                self._selected_facts.pop(jid, None)
+            if projected is None and previous is None:
+                return
+            if projected is not None and previous is not None and not force:
+                if all(previous.get(k) == v for k, v in projected.items()):
+                    return
+            self.revision += 1
+            if projected is None:
+                del self.rows[jid]
+                self.keys.pop(bisect.bisect_left(self.keys, jid))
+                projected = dict(local_ref=self.ref(jid), session_id=previous['session_id'], deleted=True)
+            else:
+                if previous is None:
+                    bisect.insort(self.keys, jid)
+                self.rows[jid] = projected
+            projected['revision'] = self.revision
+            was_active = previous is not None and previous.get('lifecycle') in ACTIVE
+            is_active = projected.get('lifecycle') in ACTIVE
+            if was_active != is_active:
+                if is_active:
+                    bisect.insort(self.active_keys, jid)
+                else:
+                    self.active_keys.pop(bisect.bisect_left(self.active_keys, jid))
+            if (was_active != is_active or (was_active and is_active
+                    and previous['session_id'] != projected['session_id'])):
+                self.active_epoch += 1
+            if was_active or is_active:
+                self.active_revision += 1
+                self.active_journal[self.active_revision % JOURNAL_SIZE] = (
+                    self.active_revision, projected, previous)
+            # Previous membership permits exact scope-loss removals.
+            self.journal[self.revision % JOURNAL_SIZE] = (self.revision, projected, previous)
+
+    def _binding(self, context, mode, after, selection=None, lane=None):
+        return hashlib.sha256(encoded([context, self.incarnation, mode, after, selection, lane])).hexdigest()
+
+    def _token(self, binding, revision, offset, deadline, epoch=None):
+        data = encoded([binding, revision, offset, deadline, epoch])
+        return base64.urlsafe_b64encode(hmac.digest(self.secret, data, 'sha256') + data).decode()
+
+    def _decode(self, token, binding):
+        from .job_readmodel import InvalidReadRequest
+        try:
+            if not isinstance(token, str) or len(token) > 4096:
+                raise ValueError()
+            raw = base64.b64decode(token, altchars=b'-_', validate=True)
+            signature, data = raw[:32], raw[32:]
+            if not hmac.compare_digest(signature, hmac.digest(self.secret, data, 'sha256')):
+                raise ValueError()
+            bound, revision, offset, deadline, epoch = json.loads(data)
+            if bound != binding or type(revision) is not int or type(offset) is not int or offset < 0:
+                raise ValueError()
+            return revision, offset, deadline, epoch
+        except (ValueError, TypeError, UnicodeError) as exc:
+            raise InvalidReadRequest() from exc
+
+    @staticmethod
+    def _owned(row, context):
+        return row is not None and (context['scope'] != 'session' or row['session_id'] == context['session_id'])
+
+    def read_page(self, context, *, mode='snapshot', cursor=None, after_revision=0, lane='history'):
+        from .job_readmodel import InvalidReadRequest
+        if (lane not in ('history', 'active') or mode not in ('snapshot', 'changes')
+                or type(after_revision) is not int or after_revision < 0):
+            raise InvalidReadRequest()
+        binding = self._binding(context, mode, after_revision, lane=lane)
+        decoded = self._decode(cursor, binding) if cursor is not None else None
+        with self.lock:
+            result = envelope(checkpoint=after_revision)
+            result['incarnation'] = self.incarnation
+            result['lane'] = lane
+            if lane == 'active':
+                result['coverage'].update(membership='retained_local_active', metadata='live_during_traversal')
+            if self.version != 1 or not self.available or self.invalid:
+                result['missing'].append('local_index_unavailable')
+                return result
+            revision = self.active_revision if lane == 'active' else self.revision
+            keys = self.active_keys if lane == 'active' else self.keys
+            journal = self.active_journal if lane == 'active' else self.journal
+            epoch = self.active_epoch if lane == 'active' else self.revision
+            upper, offset, deadline, captured_epoch = decoded or (
+                revision, 0 if mode == 'snapshot' else after_revision,
+                int(time.monotonic()) + CURSOR_SECONDS, epoch)
+            if (deadline < time.monotonic() or upper > revision or after_revision > upper
+                    or (mode == 'snapshot' and captured_epoch != epoch)
+                    or (mode == 'changes' and offset < revision - JOURNAL_SIZE)):
+                result['page']['outcome'] = 'expired'
+                return result
+            end = len(keys) if mode == 'snapshot' else upper
+            scanned = 0
+            budget = 22000  # Reserve envelope/context/cursor and ASCII escaping.
+            while offset < end and scanned < MAX_SCAN and len(result['rows']) < LIMIT:
+                if mode == 'snapshot':
+                    row, previous = self.rows[keys[offset]], None
+                else:
+                    event = journal[(offset + 1) % JOURNAL_SIZE]
+                    if event is None or event[0] != offset + 1:
+                        result['page']['outcome'] = 'unavailable'
+                        result['rows'] = []
+                        result['missing'].append('journal_corrupt')
+                        return result
+                    _, row, previous = event
+                scanned += 1
+                item = None
+                current_member = self._owned(row, context) and (lane == 'history' or row.get('lifecycle') in ACTIVE)
+                previous_member = self._owned(previous, context) and (lane == 'history' or previous.get('lifecycle') in ACTIVE)
+                if current_member:
+                    item = row
+                elif mode == 'changes' and previous_member:
+                    item = dict(local_ref=row['local_ref'], session_id=previous['session_id'],
+                                deleted=True, revision=row['revision'])
+                if item is not None:
+                    size = len(encoded(item))
+                    if size > budget:
+                        break
+                    # Only small projected fields are serialized/copied, never execution bodies.
+                    result['rows'].append(json.loads(encoded(item)))
+                    budget -= size + 2
+                offset += 1
+            complete = offset == end
+            result['page'].update(outcome='complete' if complete else 'partial', revision=upper,
+                                  checkpoint=upper if complete else after_revision, scanned=scanned,
+                                  next_cursor=None if complete else self._token(binding, upper, offset, deadline, captured_epoch))
+            return result
+
+    def read_selected(self, context, local_ref, *, lane='actions', cursor=None, include_context=False):
+        from .job_readmodel import InvalidReadRequest
+        if (not isinstance(local_ref, dict) or set(local_ref) != {'job_id', 'incarnation'}
+                or type(include_context) is not bool
+                or not identity(local_ref.get('job_id')) or lane not in ('actions', 'output', 'children', 'tasks', 'routing')):
+            raise InvalidReadRequest()
+        binding = self._binding(context, 'selected', 0, local_ref, [lane, include_context])
+        decoded = self._decode(cursor, binding) if cursor is not None else None
+        result = envelope()
+        result.update(local_ref=local_ref, lane=lane, cancellation_authority=False)
+        if local_ref['incarnation'] != self.incarnation:
+            result['page']['outcome'] = 'expired'
+            return result
+        # Selected reads alone may touch the exact execution row. No I/O occurs here.
+        with self.owner._local_jobs_lock:
+            with self.lock:
+                if self.version != 1 or not self.available or self.invalid:
+                    result['missing'].append('local_index_unavailable')
+                    return result
+                summary = self.rows.get(local_ref['job_id'])
+                if not self._owned(summary, context):
+                    result['missing'].append('selected_membership_unavailable')
+                    return result
+                revision = summary['revision']
+                upper, offset, deadline, _ = decoded or (revision, 0, int(time.monotonic()) + CURSOR_SECONDS, None)
+                if upper != revision or deadline < time.monotonic():
+                    result['page']['outcome'] = 'expired'
+                    return result
+                result['summary'] = json.loads(encoded(summary))
+                result['page']['revision'] = revision
+                row = self.owner._local_jobs.get(local_ref['job_id'])
+                if (not isinstance(row, dict) or row.get('id') != local_ref['job_id']
+                        or row.get('session_id') != summary['session_id']):
+                    result.pop('summary', None)
+                    return result
+                if include_context:
+                    result['selected_context'] = selected_context(row, summary['kind'])
+                value = row.get({'actions': 'actions', 'children': 'child_job_ids', 'output': 'output', 'tasks': 'tasks', 'routing': 'artifacts'}[lane])
+                expected = str if lane == 'output' else list
+                if not isinstance(value, expected):
+                    result['missing'].append('selected_lane_unavailable')
+                    return result
+                result['total'] = len(value)
+                scanned = 0
+                budget = 22000 - len(encoded(summary)) - len(encoded(result.get('selected_context')))
+                if lane == 'output':
+                    result['output'] = dict(coverage='in_memory_only',
+                        source_chars=number(row.get('output_chars')),
+                        spilled=row.get('output_spilled') is True or bool(row.get('spill_uri')))
+                    chunk = value[offset:offset + min(2048, max(1, budget // 12))]
+                    result['rows'] = [dict(offset=offset, text=chunk)] if chunk else []
+                    offset += len(chunk)
+                    scanned = 1 if chunk else 0
+                else:
+                    while offset < len(value) and scanned < MAX_SCAN and len(result['rows']) < LIMIT:
+                        source = value[offset]
+                        scanned += 1
+                        if lane == 'tasks':
+                            item = selected_task(source)
+                        elif lane == 'routing':
+                            item = selected_route(source, row, offset)
+                            if item is None:
+                                offset += 1
+                                continue
+                        elif lane == 'children':
+                            item = dict(local_ref=self.ref(source)) if identity(source) else dict(unavailable=True)
+                        elif isinstance(source, dict):
+                            caps = dict(action_id=128, kind=64, goal=240, status=40, error=240, worker_id=256)
+                            item = {key: text(source.get(key), cap) for key, cap in caps.items()}
+                            item['duration_ms'] = number(source.get('duration_ms'))
+                            item['truncated'] = any(isinstance(source.get(key), str) and len(source[key]) > cap
+                                                    for key, cap in caps.items())
+                        else:
+                            item = dict(unavailable=True)
+                        size = len(encoded(item))
+                        if size > budget:
+                            if not result['rows'] and lane in ('tasks', 'routing'):
+                                result['missing'].append('selected_row_budget')
+                                result['page']['scanned'] = scanned
+                                return result
+                            break
+                        budget -= size + 2
+                        result['rows'].append(item)
+                        offset += 1
+                complete = offset == len(value)
+                result['page'].update(outcome='complete' if complete else 'partial', revision=upper,
+                                      checkpoint=upper if complete else 0, scanned=scanned,
+                                      next_cursor=None if complete else self._token(binding, upper, offset, deadline))
+        return result
+
+
+class ObservedRow(dict):
+    """Observe native top-level mutations, including writes that do not persist.
+
+    Nested actions are replaced by the native action writers. Persistence also
+    republishes counts, covering legacy nested list changes at that seam.
+    """
+    def __init__(self, value, index, jid):
+        super().__init__(value)
+        self._index, self._jid = index, jid
+
+    def __copy__(self):
+        return dict(self)
+
+    def __deepcopy__(self, memo):
+        import copy
+        return copy.deepcopy(dict(self), memo)
+
+    def _publish(self):
+        if self._index.owner._local_jobs.get(self._jid) is self:
+            self._index.publish(self._jid, self, force=True)
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        self._publish()
+
+    def __delitem__(self, key):
+        super().__delitem__(key)
+        self._publish()
+
+    def update(self, *args, **kwargs):
+        super().update(*args, **kwargs)
+        self._publish()
+
+    def pop(self, key, *default):
+        value = super().pop(key, *default)
+        self._publish()
+        return value
+
+    def clear(self):
+        super().clear()
+        self._publish()
+
+    def popitem(self):
+        value = super().popitem()
+        self._publish()
+        return value
+
+    def __ior__(self, other):
+        self.update(other)
+        return self
+
+    def setdefault(self, key, default=None):
+        if key not in self:
+            self[key] = default
+        return self[key]
+
+
+class ObservedJobs(dict):
+    def __copy__(self):
+        return dict(self)
+
+    def __deepcopy__(self, memo):
+        import copy
+        return copy.deepcopy(dict(self), memo)
+
+    def __init__(self, values, index):
+        super().__init__()
+        self.index = index
+        for jid, row in values.items():
+            self[jid] = row
+
+    def __setitem__(self, jid, row):
+        if isinstance(row, ObservedRow) and row._index is self.index and row._jid == jid:
+            wrapped = row
+        else:
+            wrapped = ObservedRow(row, self.index, jid) if isinstance(row, dict) else row
+        super().__setitem__(jid, wrapped)
+        self.index.publish(jid, wrapped)
+
+    def __delitem__(self, jid):
+        super().__delitem__(jid)
+        self.index.publish(jid, None)
+
+    def pop(self, jid, *default):
+        if jid in self:
+            value = self[jid]
+            del self[jid]
+            return value
+        if default:
+            return default[0]
+        raise KeyError(jid)
+
+    def clear(self):
+        for jid in list(self):
+            del self[jid]
+
+    def update(self, *args, **kwargs):
+        for jid, row in dict(*args, **kwargs).items():
+            self[jid] = row
+
+    def setdefault(self, jid, default=None):
+        if jid not in self:
+            self[jid] = default
+        return self[jid]
+
+    def popitem(self):
+        if not self:
+            raise KeyError('popitem(): dictionary is empty')
+        jid = next(reversed(self))
+        return jid, self.pop(jid)
+
+    def __ior__(self, other):
+        self.update(other)
+        return self

--- a/harness/local_jobs.py
+++ b/harness/local_jobs.py
@@ -213,6 +213,24 @@ class LocalJobsMixin:
     instance state of its own.
     """
 
+    def local_metadata_handle(self):
+        """Capture only; initialization belongs to boot/load and writer seams."""
+        return getattr(self, '_local_metadata', None)
+
+
+    def _initialize_local_metadata_locked(self):
+        from .local_job_metadata import LocalMetadataIndex, ObservedJobs
+        if not hasattr(self, '_local_metadata'):
+            self._local_metadata = LocalMetadataIndex(self)
+            self._local_jobs = ObservedJobs(self._local_jobs, self._local_metadata)
+
+
+    def _publish_local_metadata_locked(self):
+        self._initialize_local_metadata_locked()
+        for jid, row in self._local_jobs.items():
+            self._local_metadata.publish(jid, row)
+
+
     def _register_command_job(
         self,
         job_id: str,
@@ -635,6 +653,7 @@ class LocalJobsMixin:
                 "review_required": False,
             }
             self._local_jobs[wave_id] = row
+            row = self._local_jobs[wave_id]
             for cid in ids:
                 child = self._local_jobs.get(cid)
                 if isinstance(child, dict):
@@ -1289,7 +1308,8 @@ class LocalJobsMixin:
 
                 # Explicit id at creation: artifact://local-*/<id> must survive
                 # the headline/model rewrite _finish_local_job performs later.
-                routing_arts.append({**art, "id": routing_artifact_id(job_id)})
+                routing_arts.append({**art, "id": routing_artifact_id(job_id),
+                                     "task_id": f"{job_id}-w0", "model_kind": "forecast"})
         # Never stamp bare agentic/native as job.model — that reads as a chosen
         # model in the Swarm Tracker. Leave empty until a real id is known.
         if model_id and not is_engine_only_model_id(model_id):
@@ -1311,6 +1331,8 @@ class LocalJobsMixin:
         if display_model:
             task_row["model"] = display_model
         with self._local_jobs_lock:
+            if job_id in self._local_jobs:
+                raise ValueError("Local job identity conflict")
             self._local_job_cancels[job_id] = threading.Event()
             now = time.time()
             row = {
@@ -1655,6 +1677,7 @@ class LocalJobsMixin:
                     updated["id"] = routing_artifact_id(job_id)
                     if model_id:
                         updated = _reconcile_routing_artifact(updated, model_id)
+                        updated["model_kind"] = "realized"
                     # Preserve attested policy; default balanced for router stamps.
                     if not (updated.get("policy") or "").strip():
                         if updated.get("created_by") == "router":
@@ -1960,6 +1983,7 @@ class LocalJobsMixin:
         crash mid-write never leaves a half-written (corrupt) file. Command
         barriers require success; provider bookkeeping remains best-effort."""
         import json
+        self._publish_local_metadata_locked()
         try:
             items = list(self._local_jobs.values())
             # Both unresolved checkpoints and settled receipts prevent replay.
@@ -2001,23 +2025,29 @@ class LocalJobsMixin:
         facts into unknown outcomes; only unlaunched work is cancelled.
         """
         import json
+        with self._local_jobs_lock:
+            self._initialize_local_metadata_locked()
         try:
             with open(self._local_jobs_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
         except FileNotFoundError:
             return
         except Exception:
-            # Corrupt/unreadable file: start empty rather than crash on restart.
+            # Execution recovery remains tolerant; observation cannot claim empty.
+            self._local_metadata.available = False
             return
         jobs = data.get("jobs") if isinstance(data, dict) else None
         if not isinstance(jobs, list):
+            self._local_metadata.available = False
             return
         with self._local_jobs_lock:
             for job in jobs:
                 if not isinstance(job, dict):
+                    self._local_metadata.available = False
                     continue
                 jid = job.get("id")
-                if not jid:
+                if not isinstance(jid, str) or not jid:
+                    self._local_metadata.available = False
                     continue
                 is_command_job = (
                     job.get("job_kind") == "run_command"
@@ -2171,7 +2201,7 @@ class LocalJobsMixin:
         # Rewrite so the healed statuses are the new on-disk baseline.
         self._persist_local_jobs()
 
-    def cancel_local_job(self, job_id: str) -> bool:
+    def cancel_local_job(self, job_id: str, *, incarnation: Optional[str] = None) -> bool:
         """Cooperatively cancel a running local (provider-worker) job.
 
         Sets the per-job cancel Event (best-effort: a Python thread cannot be
@@ -2184,6 +2214,8 @@ class LocalJobsMixin:
         Returns True if the job existed and was not already terminal.
         """
         with self._local_jobs_lock:
+            if incarnation is not None and getattr(self.local_metadata_handle(), 'incarnation', None) != incarnation:
+                return False
             job = self._local_jobs.get(job_id)
             if job is None:
                 return False

--- a/tests/test_cancellation_capabilities.py
+++ b/tests/test_cancellation_capabilities.py
@@ -1,0 +1,85 @@
+"""Compatibility refusal and exact native selection at the public boundary."""
+from dataclasses import dataclass
+from types import SimpleNamespace
+from urllib.parse import urlencode, urlparse
+
+import pytest
+from harness.api import jobs, scoped_cancellation
+
+
+def test_old_public_job_ref_refuses_without_store_reads(monkeypatch):
+    @dataclass
+    class OldRef:
+        job_id: str
+        state_id: str
+    real = scoped_cancellation.import_module
+    monkeypatch.setattr(scoped_cancellation, 'import_module', lambda name:
+        SimpleNamespace(JobRef=OldRef) if name == 'puppetmaster.contracts' else real(name))
+    assert not scoped_cancellation.runtime_available()
+    svc = SimpleNamespace(get_session=lambda: pytest.fail('opened unsupported store'))
+    body = {'selection': {'version': 2, 'source': 'harness', 'session_id': 'A', 'repo': '/repo',
+        'job_ref': {'job_id': 'job_a', 'state_id': 'state_a', 'version': 2, 'incarnation': 'a'}}}
+    assert jobs.post_swarm_cancel(body, svc) == (503, {'ok': False, 'code': 'scoped_cancellation_unsupported'})
+
+
+def test_missing_candidate_module_is_explicitly_unavailable(monkeypatch):
+    def missing(_):
+        raise ModuleNotFoundError('unsupported contracts')
+    monkeypatch.setattr(scoped_cancellation, 'import_module', missing)
+    assert not scoped_cancellation.runtime_available()
+    assert scoped_cancellation.cancellation_view(None, None, [])['reason'] == 'scoped_cancellation_unsupported'
+
+
+def test_id_only_cancel_never_discovers_or_reads_a_store():
+    assert jobs.post_swarm_cancel({'job_id': 'job_unselected'}, object())[0] == 409
+    assert jobs.post_swarm_cancel({'job_id': 'local-unselected'}, object())[0] == 409
+
+
+def test_receipt_route_preserves_blank_duplicates():
+    import json
+    from harness.http_routes import build_get_routes
+    class Services:
+        def __getattr__(self, _):
+            return lambda: None
+    sent = []
+    handler = SimpleNamespace(_send=lambda status, body: sent.append((status, json.loads(body))))
+    values = dict(job_id='job_a', state_id='state_a', source='harness', repo='/repo',
+                  session_id='A', request_id='r', version='2', incarnation='a')
+    raw = '/api/swarm/cancellation-receipt?' + urlencode(values) + '&job_id='
+    build_get_routes(Services())['/api/swarm/cancellation-receipt'](
+        handler, urlparse(raw), {k: [v] for k, v in values.items()})
+    assert sent[-1][0] == 400
+
+
+def test_local_incarnation_required_and_checked_at_effect_boundary(tmp_path):
+    import threading
+    from harness.local_jobs import LocalJobsMixin
+    pilot = LocalJobsMixin()
+    pilot.harness_session_id = 'A'
+    pilot.config = SimpleNamespace(repo=str(tmp_path), driver='stub')
+    pilot._local_jobs = {}
+    pilot._local_job_cancels = {}
+    pilot._local_jobs_lock = threading.Lock()
+    pilot._local_jobs_path = str(tmp_path / 'jobs.json')
+    pilot._load_local_jobs()
+    pilot._register_local_job('local-one', 'work', skip_routing_preview=True)
+    svc = jobs.make_job_services(cfg=pilot.config, sessions=SimpleNamespace(active='A'),
+                                get_pilot=lambda: pilot)
+    selection = dict(version=1, source='local', session_id='A', repo=str(tmp_path),
+                     job_ref=dict(job_id='local-one', state_id=None))
+    assert jobs.post_swarm_cancel({'selection': selection}, svc)[0] == 409
+    selection['local_incarnation'] = 'stale'
+    assert jobs.post_swarm_cancel({'selection': selection}, svc)[0] == 409
+    assert not pilot._local_job_cancels['local-one'].is_set()
+    selection['local_incarnation'] = pilot.local_metadata_handle().incarnation
+    original = pilot.cancel_local_job
+    def replaced(jid, *, incarnation):
+        pilot._local_metadata.incarnation = 'replacement'
+        return original(jid, incarnation=incarnation)
+    pilot.cancel_local_job = replaced
+    assert jobs.post_swarm_cancel({'selection': selection}, svc)[0] == 409
+    assert not pilot._local_job_cancels['local-one'].is_set()
+    pilot.cancel_local_job = original
+    selection['local_incarnation'] = 'replacement'
+    assert jobs.post_swarm_cancel({'selection': selection}, svc)[0] == 200
+    assert pilot._local_job_cancels['local-one'].is_set()

--- a/tests/test_local_job_metadata.py
+++ b/tests/test_local_job_metadata.py
@@ -1,0 +1,338 @@
+"""Native writer and bounded observation regressions (no model/network calls)."""
+import copy
+import json
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip('harness.job_readmodel', reason='requires companion PR2 metadata reader')
+
+from harness.local_jobs import LocalJobsMixin
+from harness.local_job_metadata import JOURNAL_SIZE, LocalMetadataIndex
+from harness.job_readmodel import ActiveContext, InvalidReadRequest, KnownSources, MetadataReader, ReadContext
+
+
+class Runner(LocalJobsMixin):
+    def __init__(self, path):
+        self.config = SimpleNamespace(repo=str(path), driver='stub')
+        self.state_dir = str(path)
+        self.harness_session_id = 'A'
+        self._local_jobs = {}
+        self._local_jobs_lock = threading.Lock()
+        self._local_job_cancels = {}
+        self._local_jobs_path = str(path / 'swarm_local_jobs.json')
+        self._display_transcript = []
+        self._load_local_jobs()
+
+
+def row(jid, session='A'):
+    return dict(id=jid, session_id=session, role='command', job_kind='run_command',
+                status='completed', created_at=1, updated_at=1,
+                terminal_receipt={'status': 'completed', 'exit_code': 0},
+                tasks=[], artifacts=[], actions=[], output='')
+
+
+def seed(runner, n=1100):
+    # Real native storage and metadata publication, no fake readmodel/store.
+    with runner._local_jobs_lock:
+        for i in range(n):
+            runner._local_jobs[f'local-{i:04d}'] = row(f'local-{i:04d}')
+
+
+def ctx():
+    return dict(session_id='A', repo='/repo', view_generation='generation', scope='session')
+
+
+def forbidden(*args, **kwargs):
+    pytest.fail('unbounded/body operation reached metadata poll')
+
+
+def test_large_retained_native_page_never_reads_bodies(tmp_path, monkeypatch):
+    runner = Runner(tmp_path)
+    seed(runner)
+    with runner._local_jobs_lock:
+        for job in runner._local_jobs.values():
+            job['output'] = 'private-body' * 10000
+            job['actions'] = [dict(action_id=str(i), goal='private-action' * 1000) for i in range(80)]
+    baseline = runner.live_local_jobs()
+    assert len(baseline) == 1100 and len(baseline[-1]['actions']) == 80
+    index = runner.local_metadata_handle()
+    monkeypatch.setattr(copy, 'deepcopy', forbidden)
+    monkeypatch.setattr(runner, 'live_local_jobs', forbidden)
+    monkeypatch.setattr(runner, 'get_local_job', forbidden)
+    monkeypatch.setattr('builtins.open', forbidden)
+    class NoScan(dict):
+        values = items = __iter__ = forbidden
+    runner._local_jobs = NoScan(runner._local_jobs)
+    first = index.read_page(ctx())
+    for _ in range(30):
+        page = index.read_page(ctx())
+        assert page['rows'] == first['rows']
+        assert page['page']['scanned'] <= 51
+        assert 0 < len(page['rows']) <= 50
+        assert len(json.dumps(page).encode()) <= 32768
+        assert 'private-' not in json.dumps(page)
+    cursor = None
+    ids = []
+    while True:
+        page = index.read_page(ctx(), cursor=cursor)
+        ids.extend(r['local_ref']['job_id'] for r in page['rows'])
+        cursor = page['page']['next_cursor']
+        if cursor is None:
+            break
+    assert len(ids) == len(set(ids)) == 1100
+
+
+def test_changes_frozen_revision_removals_scope_and_journal(tmp_path):
+    runner = Runner(tmp_path)
+    seed(runner, 100)
+    index = runner.local_metadata_handle()
+    before = index.revision
+    runner._local_jobs['local-0001']['status'] = 'failed'
+    runner._local_jobs['local-0002']['session_id'] = 'B'
+    del runner._local_jobs['local-0003']
+    changes = index.read_page(ctx(), mode='changes', after_revision=before)
+    assert changes['page']['outcome'] == 'complete'
+    byid = {r['local_ref']['job_id']: r for r in changes['rows']}
+    assert byid['local-0001']['lifecycle'] == 'failed'
+    assert byid['local-0002']['deleted'] and byid['local-0003']['deleted']
+    assert all(r['local_ref']['incarnation'] == index.incarnation for r in byid.values())
+    first = index.read_page(ctx(), mode='changes', after_revision=0)
+    upper = first['page']['revision']
+    assert first['page']['checkpoint'] == 0
+    runner._local_jobs['local-0000']['updated_at'] = 2
+    cursor = first['page']['next_cursor']
+    while cursor:
+        page = index.read_page(ctx(), mode='changes', after_revision=0, cursor=cursor)
+        assert page['page']['revision'] == upper
+        cursor = page['page']['next_cursor']
+    assert page['page']['checkpoint'] == upper < index.revision
+    for i in range(JOURNAL_SIZE + 1):
+        runner._local_jobs['local-0000']['updated_at'] = i
+    assert index.read_page(ctx(), mode='changes', after_revision=0)['page']['outcome'] == 'expired'
+    assert index.read_page(ctx(), mode='changes', after_revision=0, cursor=first['page']['next_cursor'])['page']['outcome'] == 'expired'
+
+
+def test_cursor_context_selection_incarnation_and_expiry(tmp_path, monkeypatch):
+    runner = Runner(tmp_path)
+    seed(runner, 100)
+    index = runner.local_metadata_handle()
+    first = index.read_page(ctx())
+    cursor = first['page']['next_cursor']
+    for change in ({'scope': 'repo'}, {'view_generation': 'other'}, {'session_id': 'B'}, {'repo': '/other'}):
+        with pytest.raises(InvalidReadRequest):
+            index.read_page(dict(ctx(), **change), cursor=cursor)
+    with pytest.raises(InvalidReadRequest):
+        index.read_page(ctx(), mode='changes', cursor=cursor)
+    with pytest.raises(InvalidReadRequest):
+        LocalMetadataIndex(runner).read_page(ctx(), cursor=cursor)
+    monkeypatch.setattr('harness.local_job_metadata.time.monotonic', lambda: 1e15)
+    expired = index.read_page(ctx(), cursor=cursor)
+    assert expired['page']['outcome'] == 'expired' and expired['rows'] == []
+
+
+def test_continuous_writes_and_empty_incomplete_are_honest(tmp_path):
+    runner = Runner(tmp_path)
+    seed(runner, 100)
+    index = runner.local_metadata_handle()
+    for _ in range(5):
+        page = index.read_page(ctx())
+        runner._local_jobs['local-0000']['status'] = 'running'
+        held = index.read_page(ctx(), cursor=page['page']['next_cursor'])
+        assert held['page']['outcome'] == 'expired' and held['page']['checkpoint'] == 0
+    empty = index.read_page(dict(ctx(), session_id='B'))
+    assert empty['rows'] == [] and empty['page']['outcome'] == 'partial'
+    assert empty['page']['scanned'] == 51 and empty['page']['checkpoint'] == 0
+    assert 'unretained_history' in empty['missing']
+
+
+def test_selected_actions_output_children_bound_before_copy(tmp_path, monkeypatch):
+    runner = Runner(tmp_path)
+    seed(runner, 2)
+    job = runner._local_jobs['local-0000']
+    job['actions'] = [dict(action_id=str(i), kind='edit', goal='x' * 100000,
+                           error='e' * 100000, status='running') for i in range(100)]
+    job['output'] = '\U0001f600' * 100000
+    job['child_job_ids'] = [f'local-{i:04d}' for i in range(100)]
+    index = runner.local_metadata_handle()
+    ref = index.ref('local-0000')
+    monkeypatch.setattr(copy, 'deepcopy', forbidden)
+    monkeypatch.setattr('builtins.open', forbidden)
+    for lane in ('actions', 'output', 'children'):
+        first = index.read_selected(ctx(), ref, lane=lane)
+        assert first['page']['outcome'] == 'partial'
+        assert first['page']['scanned'] <= 51 and len(first['rows']) <= 50
+        assert len(json.dumps(first).encode()) <= 32768
+        assert first['cancellation_authority'] is False
+        with pytest.raises(InvalidReadRequest):
+            index.read_selected(ctx(), index.ref('local-0001'), lane=lane, cursor=first['page']['next_cursor'])
+        with pytest.raises(InvalidReadRequest):
+            index.read_selected(ctx(), ref, lane='output' if lane != 'output' else 'actions', cursor=first['page']['next_cursor'])
+        second = index.read_selected(ctx(), ref, lane=lane, cursor=first['page']['next_cursor'])
+        assert second['rows'] != first['rows'] or lane == 'output'
+    assert index.read_selected(ctx(), dict(ref, incarnation='other'))['page']['outcome'] == 'expired'
+    page = index.read_selected(ctx(), ref)
+    job['actions'] = [dict(action_id='new', kind='read', status='complete')]
+    assert index.read_selected(ctx(), ref, cursor=page['page']['next_cursor'])['page']['outcome'] == 'expired'
+    assert index.read_selected(ctx(), ref)['rows'][0]['action_id'] == 'new'
+
+
+def test_native_action_writer_unpersisted_changes_and_deepcopy(tmp_path, monkeypatch):
+    runner = Runner(tmp_path)
+    seed(runner, 1)
+    runner._local_jobs['local-0000']['status'] = 'running'
+    index = runner.local_metadata_handle()
+    before = index.revision
+    # Native event path still publishes when persistence is disabled by caller/tests.
+    monkeypatch.setattr(runner, '_persist_local_jobs_locked', lambda **kw: None)
+    runner._upsert_local_job_action('local-0000', {'kind': 'action_start',
+        'data': {'id': 'a', 'kind': 'edit', 'goal': 'file'}})
+    changed = index.read_page(ctx(), mode='changes', after_revision=before)
+    assert changed['rows'][-1]['action_count'] == 1
+    copied = runner.get_local_job('local-0000')
+    copied['status'] = 'failed'
+    assert index.read_page(ctx())['rows'][0]['lifecycle'] == 'running'
+
+
+def test_cold_restart_unknown_receipts_and_corrupt_load(tmp_path):
+    runner = Runner(tmp_path)
+    runner._register_command_job('local-command', command='echo safe', action_id='action')
+    runner._checkpoint_command_job_launch('local-command')
+    restarted = Runner(tmp_path)
+    result = restarted.local_metadata_handle().read_page(ctx())['rows'][0]
+    assert result['kind'] == 'run_command' and result['lifecycle'] == 'unknown'
+    assert result['receipts'] == dict(terminal=False, launch=True, recovery=True, child=False)
+    assert restarted.local_metadata_handle().incarnation != runner.local_metadata_handle().incarnation
+    (tmp_path / 'swarm_local_jobs.json').write_text('{broken')
+    corrupt = Runner(tmp_path)
+    assert corrupt.local_metadata_handle().read_page(ctx())['page']['outcome'] == 'unavailable'
+
+
+def test_retained_history_and_classifications(tmp_path):
+    runner = Runner(tmp_path)
+    seed(runner, 1001)
+    for i in range(205):
+        runner._local_jobs[f'provider-{i:04d}'] = dict(row(f'provider-{i:04d}'), job_kind='', role='implement')
+    runner._local_jobs['wave'] = dict(row('wave'), job_kind='parallel_wave', role='parallel_wave')
+    runner._local_jobs['batch'] = dict(row('batch'), job_kind='run_command_batch', role='command_batch')
+    runner._persist_local_jobs()
+    assert len(runner._local_jobs) == 1208  # existing live history is not silently pruned
+    stored = json.loads((tmp_path / 'swarm_local_jobs.json').read_text())['jobs']
+    assert len(stored) == 1202  # all 1002 command receipts + 200 provider/wave history
+    restarted = Runner(tmp_path)
+    assert len(restarted._local_jobs) == 1202
+    kinds = set()
+    cursor = None
+    while True:
+        page = runner.local_metadata_handle().read_page(ctx(), cursor=cursor)
+        kinds.update(r['kind'] for r in page['rows'])
+        cursor = page['page']['next_cursor']
+        if cursor is None:
+            break
+    assert kinds == {'run_command', 'run_command_batch', 'parallel_wave', 'provider'}
+
+
+def test_invalid_and_missing_index_not_empty(tmp_path):
+    runner = Runner(tmp_path)
+    index = runner.local_metadata_handle()
+    runner._local_jobs['bad'] = dict(row('bad'), session_id='')
+    assert index.read_page(ctx())['page']['outcome'] == 'unavailable'
+    del runner._local_jobs['bad']
+    assert index.read_page(ctx())['page']['outcome'] == 'complete'
+    active = ActiveContext('A', '/repo', 'generation')
+    reader = MetadataReader(lambda: active, KnownSources(()))
+    assert reader.read_local(ReadContext(**ctx()))['page']['outcome'] == 'unavailable'
+
+
+def test_unsupported_index_and_selected_output_coverage(tmp_path):
+    runner = Runner(tmp_path)
+    seed(runner, 1)
+    index = runner.local_metadata_handle()
+    runner._local_jobs['local-0000'].update(output='retained', output_spilled=True, output_chars=100000)
+    detail = index.read_selected(ctx(), index.ref('local-0000'), lane='output')
+    assert detail['page']['outcome'] == 'complete'
+    assert detail['output'] == dict(coverage='in_memory_only', source_chars=100000, spilled=True)
+    index.version = 2
+    assert not index.describe()['available']
+    assert index.read_page(ctx())['page']['outcome'] == 'unavailable'
+    assert index.read_selected(ctx(), index.ref('local-0000'))['page']['outcome'] == 'unavailable'
+
+
+def test_snapshot_scope_transition_never_hides_missing_coverage(tmp_path):
+    runner = Runner(tmp_path)
+    seed(runner, 60)
+    index = runner.local_metadata_handle()
+    session = index.read_page(ctx())
+    broad = index.read_page(dict(ctx(), scope='all'))
+    assert session['missing'] == broad['missing'] == ['unretained_history']
+    before = index.revision
+    runner._local_jobs['local-0000']['session_id'] = 'B'
+    a = index.read_page(ctx(), mode='changes', after_revision=before)
+    b = index.read_page(dict(ctx(), session_id='B'), mode='changes', after_revision=before)
+    assert a['rows'][0]['deleted'] is True
+    assert b['rows'][0]['deleted'] is False
+    assert a['rows'][0]['local_ref'] == b['rows'][0]['local_ref']
+    assert a['missing'] == b['missing'] == ['unretained_history']
+
+
+def test_removed_or_replaced_row_callback_cannot_resurrect(tmp_path):
+    runner = Runner(tmp_path)
+    seed(runner, 1)
+    index = runner.local_metadata_handle()
+    stale = runner._local_jobs['local-0000']
+    del runner._local_jobs['local-0000']
+    revision = index.revision
+    stale['status'] = 'running'
+    assert index.revision == revision and index.read_page(ctx())['rows'] == []
+    runner._local_jobs['local-0000'] = row('local-0000')
+    stale['status'] = 'failed'
+    assert index.read_page(ctx())['rows'][0]['lifecycle'] == 'completed'
+
+
+def test_failed_command_receipt_remains_unknown_in_projection(tmp_path, monkeypatch):
+    runner = Runner(tmp_path)
+    runner._register_command_job('local-command', command='echo safe', action_id='action')
+    runner._checkpoint_command_job_launch('local-command')
+    def fail(*args):
+        raise OSError('disk failure')
+    monkeypatch.setattr('harness.local_jobs.os.replace', fail)
+    assert runner._finish_command_job('local-command', status='completed', summary='done', exit_code=0, output='done') is False
+    row = runner.local_metadata_handle().read_page(ctx())['rows'][0]
+    assert row['lifecycle'] == 'unknown' and row['receipts']['terminal'] is False
+    assert row['receipts']['recovery'] is True
+
+
+@pytest.mark.parametrize('contents', ['{"jobs":[null]}', '{"jobs":[{"id":""}]}', '{"jobs":{}}'])
+def test_malformed_cold_history_never_claims_complete_empty(tmp_path, contents):
+    (tmp_path / 'swarm_local_jobs.json').write_text(contents)
+    runner = Runner(tmp_path)
+    page = runner.local_metadata_handle().read_page(ctx())
+    assert page['page']['outcome'] == 'unavailable'
+    assert page['rows'] == []
+
+
+
+def test_copy_observation_containers_never_copies_index_or_changes_authority(tmp_path):
+    runner = Runner(tmp_path)
+    seed(runner, 1)
+    index = runner.local_metadata_handle()
+    copied = copy.deepcopy(runner._local_jobs)
+    assert type(copied) is dict and type(copied['local-0000']) is dict
+    copied['local-0000']['status'] = 'failed'
+    shallow = copy.copy(runner._local_jobs['local-0000'])
+    shallow['status'] = 'cancelled'
+    assert index.read_page(ctx())['rows'][0]['lifecycle'] == 'completed'
+
+
+def test_provider_registration_cannot_replace_observed_cancellation_identity(tmp_path):
+    runner = Runner(tmp_path)
+    runner._register_local_job('local-once', 'first', skip_routing_preview=True)
+    first = runner._local_jobs['local-once']
+    event = runner._local_job_cancels['local-once']
+    ref = runner.local_metadata_handle().ref('local-once')
+    with pytest.raises(ValueError, match='identity conflict'):
+        runner._register_local_job('local-once', 'replacement', skip_routing_preview=True)
+    assert runner._local_jobs['local-once'] is first
+    assert runner._local_job_cancels['local-once'] is event
+    assert runner.local_metadata_handle().ref('local-once') == ref

--- a/tests/test_native_active_lanes.py
+++ b/tests/test_native_active_lanes.py
@@ -190,4 +190,3 @@ def test_native_active_changes_freeze_upper_and_preserve_revision_order(tmp_path
     assert later['rows'][0]['revision'] > max(revisions)
     # Later payload revisions never move the earlier coverage checkpoint forward.
     assert later['page']['checkpoint'] == index.active_revision
-

--- a/tests/test_native_active_lanes.py
+++ b/tests/test_native_active_lanes.py
@@ -1,0 +1,193 @@
+"""Native foreground lane regressions extracted from the combined suite."""
+import copy
+import json
+import pytest
+
+pytest.importorskip('harness.job_readmodel', reason='requires companion PR2 metadata reader')
+from pathlib import Path
+from dataclasses import asdict
+from harness.api.job_readmodel import get_local_metadata
+from harness.job_readmodel import InvalidReadRequest, ActiveContext, KnownSources, MetadataReader, ReadContext
+from harness.local_job_metadata import ACTIVE, JOURNAL_SIZE, LIFECYCLES
+from test_local_job_metadata import Runner, ctx, forbidden, row, seed
+
+def query(context, **kwargs):
+    return {k: [str(v)] for k, v in dict(asdict(context), **kwargs).items()}
+
+
+def native_fixture(path, terminal_count=3200, active_count=1):
+    """Callable integration fixture: real LocalJobsMixin; foreground IDs sort last."""
+    runner = Runner(path)
+    seed(runner, terminal_count)
+    with runner._local_jobs_lock:
+        for i in range(active_count):
+            jid = f'zz-active-{i:04d}'
+            runner._local_jobs[jid] = dict(row(jid), status='running', terminal_receipt=None)
+    return runner
+
+
+def test_native_first_foreground_and_hotpath_guards(tmp_path, monkeypatch):
+    runner = native_fixture(tmp_path)
+    index = runner.local_metadata_handle()
+    assert index.read_page(ctx())['rows'][0]['local_ref']['job_id'] == 'local-0000'
+    monkeypatch.setattr(copy, 'deepcopy', forbidden)
+    monkeypatch.setattr(runner, 'live_local_jobs', forbidden)
+    monkeypatch.setattr(runner, 'get_local_job', forbidden)
+    monkeypatch.setattr(runner, '_publish_local_metadata_locked', forbidden)
+    monkeypatch.setattr(runner, '_load_local_jobs', forbidden)
+    monkeypatch.setattr('builtins.open', forbidden)
+    monkeypatch.setattr(Path, 'read_bytes', forbidden)
+    monkeypatch.setattr(Path, 'read_text', forbidden)
+    class NoScan(dict):
+        values = items = __iter__ = forbidden
+    class NoWalk(list):
+        __iter__ = __reversed__ = forbidden
+        def __getitem__(self, key):
+            assert not isinstance(key, slice)
+            return super().__getitem__(key)
+    runner._local_jobs = NoScan(runner._local_jobs)
+    index.rows = NoScan(index.rows)
+    index.keys = NoWalk(index.keys)
+    index.active_keys = NoWalk(index.active_keys)
+    for _ in range(30):
+        page = index.read_page(ctx(), lane='active')
+        assert page['page']['outcome'] == 'complete'
+        assert page['page']['scanned'] == 1
+        assert page['rows'][0]['local_ref']['job_id'] == 'zz-active-0000'
+        assert page['rows'][0]['activity'] == 'active'
+        assert len(json.dumps(page).encode()) <= 32768
+
+
+def test_native_active_continuation_survives_busy_and_terminal_writes(tmp_path):
+    runner = native_fixture(tmp_path, active_count=121)
+    index = runner.local_metadata_handle()
+    first = index.read_page(ctx(), lane='active')
+    checkpoint = first['page']['revision']
+    assert first['page']['checkpoint'] == 0
+    ids = [r['local_ref']['job_id'] for r in first['rows']]
+    cursor = first['page']['next_cursor']
+    while cursor:
+        # Saturating HISTORY's journal must not erase the active journal.
+        for i in range(JOURNAL_SIZE + 1):
+            runner._local_jobs['local-0000']['updated_at'] = i
+        runner._local_jobs['zz-active-0120']['updated_at'] += 1
+        page = index.read_page(ctx(), lane='active', cursor=cursor)
+        assert page['page']['outcome'] in ('partial', 'complete')
+        assert page['page']['revision'] == checkpoint
+        assert page['page']['scanned'] <= 51 and len(page['rows']) <= 50
+        assert len(json.dumps(page).encode()) <= 32768
+        ids.extend(r['local_ref']['job_id'] for r in page['rows'])
+        cursor = page['page']['next_cursor']
+    assert len(ids) == len(set(ids)) == 121
+    assert page['page']['checkpoint'] == checkpoint
+    changes = index.read_page(ctx(), lane='active', mode='changes', after_revision=checkpoint)
+    assert changes['page']['outcome'] == 'complete'
+    assert changes['page']['checkpoint'] == index.active_revision
+    assert {r['local_ref']['job_id'] for r in changes['rows']} == {'zz-active-0120'}
+    assert index.read_page(ctx(), mode='changes', after_revision=0)['page']['outcome'] == 'expired'
+
+
+@pytest.mark.parametrize('status', sorted(LIFECYCLES))
+def test_every_native_lifecycle_moves_and_exact_removals(tmp_path, status):
+    runner = native_fixture(tmp_path, terminal_count=0)
+    index = runner.local_metadata_handle()
+    jid = 'zz-active-0000'
+    start = index.active_revision
+    runner._local_jobs[jid]['status'] = status
+    active = index.read_page(ctx(), lane='active', mode='changes', after_revision=start)
+    assert active['page']['outcome'] == 'complete'
+    changed = active['rows'][0]
+    assert changed['local_ref'] == index.ref(jid)
+    assert changed['revision'] == index.revision
+    if status in ACTIVE:
+        assert changed['activity'] == 'active' and not changed['deleted']
+    else:
+        assert changed.keys() == {'local_ref', 'session_id', 'revision', 'deleted'}
+        assert changed['deleted']
+    history = index.read_page(ctx())['rows'][0]
+    assert not history['deleted'] and history['lifecycle'] == status
+    if status == 'stalled':
+        assert history['activity'] == 'attention'
+    assert bool(index.active_keys) == (status in ACTIVE)
+    before = index.active_revision
+    runner._local_jobs[jid]['status'] = 'queued'
+    admitted = index.read_page(ctx(), lane='active', mode='changes', after_revision=before)
+    assert admitted['rows'][0]['activity'] == 'active'
+    before = index.active_revision
+    runner._local_jobs[jid]['session_id'] = 'B'
+    lost = index.read_page(ctx(), lane='active', mode='changes', after_revision=before)
+    gained = index.read_page(dict(ctx(), session_id='B'), lane='active', mode='changes', after_revision=before)
+    assert lost['rows'][0]['deleted'] and not gained['rows'][0]['deleted']
+    assert 'B' not in json.dumps(lost)
+    before = index.active_revision
+    del runner._local_jobs[jid]
+    deleted = index.read_page(dict(ctx(), session_id='B'), lane='active', mode='changes', after_revision=before)
+    assert deleted['rows'][0]['deleted'] and not index.active_keys
+
+
+@pytest.mark.parametrize('mutation', ['admit', 'depart', 'session'])
+def test_native_active_membership_change_expires_snapshot(tmp_path, mutation):
+    runner = native_fixture(tmp_path, terminal_count=1, active_count=80)
+    index = runner.local_metadata_handle()
+    first = index.read_page(ctx(), lane='active')
+    if mutation == 'admit':
+        runner._local_jobs['local-0000']['status'] = 'queued'
+    elif mutation == 'depart':
+        runner._local_jobs['zz-active-0000']['status'] = 'complete'
+    else:
+        runner._local_jobs['zz-active-0000']['session_id'] = 'B'
+    page = index.read_page(ctx(), lane='active', cursor=first['page']['next_cursor'])
+    assert page['page']['outcome'] == 'expired' and page['page']['checkpoint'] == 0
+    assert page['rows'] == []
+
+
+def test_native_active_query_binding_and_separate_overflow(tmp_path):
+    runner = native_fixture(tmp_path, active_count=80)
+    index = runner.local_metadata_handle()
+    first = index.read_page(ctx(), lane='active')
+    cursor = first['page']['next_cursor']
+    with pytest.raises(InvalidReadRequest):
+        index.read_page(ctx(), lane='history', cursor=cursor)
+    context = ReadContext(**ctx())
+    reader = MetadataReader(lambda: ActiveContext('A', '/repo', 'generation'), KnownSources(()), index)
+    assert get_local_metadata(query(context, lane='active'), reader)[0] == 200
+    assert get_local_metadata(query(context, lane='history'), reader)[0] == 200
+    for value in ('', 'actions', 'ACTIVE'):
+        assert get_local_metadata(query(context, lane=value), reader)[0] == 400
+    qs = query(context, lane='active')
+    qs['lane'].append('history')
+    assert get_local_metadata(qs, reader)[0] == 400
+    first_changes = index.read_page(ctx(), lane='active', mode='changes')
+    assert first_changes['page']['outcome'] == 'partial'
+    for i in range(JOURNAL_SIZE + 1):
+        runner._local_jobs['zz-active-0000']['updated_at'] = i
+    for continuation in (None, first_changes['page']['next_cursor']):
+        page = index.read_page(ctx(), lane='active', mode='changes', cursor=continuation)
+        assert page['page']['outcome'] == 'expired' and page['page']['checkpoint'] == 0
+    # Payload-only updates do not invalidate membership traversal, even if changes expired.
+    assert index.read_page(ctx(), lane='active', cursor=cursor)['page']['outcome'] == 'complete'
+    assert len(index.active_journal) == len(index.journal) == JOURNAL_SIZE
+
+
+def test_native_active_changes_freeze_upper_and_preserve_revision_order(tmp_path):
+    runner = native_fixture(tmp_path, terminal_count=10, active_count=100)
+    index = runner.local_metadata_handle()
+    first = index.read_page(ctx(), lane='active', mode='changes')
+    upper = first['page']['revision']
+    cursor = first['page']['next_cursor']
+    assert cursor and first['page']['checkpoint'] == 0
+    runner._local_jobs['zz-active-0000']['updated_at'] = 20
+    revisions = [r['revision'] for r in first['rows']]
+    while cursor:
+        page = index.read_page(ctx(), lane='active', mode='changes', cursor=cursor)
+        assert page['page']['revision'] == upper
+        revisions.extend(r['revision'] for r in page['rows'])
+        cursor = page['page']['next_cursor']
+    assert revisions == sorted(revisions) and len(revisions) == 100
+    assert page['page']['checkpoint'] == upper < index.active_revision
+    later = index.read_page(ctx(), lane='active', mode='changes', after_revision=upper)
+    assert later['page']['outcome'] == 'complete'
+    assert later['rows'][0]['revision'] > max(revisions)
+    # Later payload revisions never move the earlier coverage checkpoint forward.
+    assert later['page']['checkpoint'] == index.active_revision
+

--- a/tests/test_native_controls_startup.py
+++ b/tests/test_native_controls_startup.py
@@ -1,0 +1,32 @@
+"""The optional observation producer must not require candidate PM imports at boot."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_native_producer_boots_without_metadata_reader_or_new_pm_contracts(tmp_path):
+    code = '''
+import builtins
+import threading
+from types import SimpleNamespace
+original = builtins.__import__
+def guarded(name, *args, **kwargs):
+    if name in ('puppetmaster.identity', 'puppetmaster.contracts', 'harness.job_readmodel'):
+        raise ModuleNotFoundError(name)
+    return original(name, *args, **kwargs)
+builtins.__import__ = guarded
+from harness.local_jobs import LocalJobsMixin
+class Runner(LocalJobsMixin):
+    pass
+runner = Runner()
+runner._local_jobs = {}
+runner._local_jobs_lock = threading.Lock()
+runner._local_jobs_path = PATH
+runner._load_local_jobs()
+assert runner.local_metadata_handle().describe()['available']
+assert runner.local_metadata_handle().rows == {}
+'''.replace('PATH', repr(str(tmp_path / 'jobs.json')))
+    result = subprocess.run([sys.executable, '-c', code], cwd=Path(__file__).resolve().parents[1],
+                            env=os.environ.copy(), capture_output=True, text=True, timeout=20)
+    assert result.returncode == 0, result.stderr

--- a/tests/test_native_operator_metadata.py
+++ b/tests/test_native_operator_metadata.py
@@ -1,0 +1,328 @@
+"""Bounded operator facts through real native writers, without provider calls."""
+import copy
+import json
+
+import pytest
+
+pytest.importorskip('harness.job_readmodel', reason='requires companion PR2 metadata reader')
+
+from harness.financial_receipt import apply_local_receipt, build_local_financial_receipt
+from test_local_job_metadata import Runner, ctx, forbidden
+
+
+def register(runner, jid='local-native'):
+    runner._register_local_job(jid, 'PRIVATE FULL PROMPT', role='implement',
+                               engine='native', model='test-model')
+    return runner._local_jobs[jid]
+
+
+def projected(runner, jid='local-native'):
+    return runner.local_metadata_handle().rows[jid]
+
+
+def test_real_finish_preserves_provider_spend_and_identity(tmp_path):
+    runner = Runner(tmp_path)
+    register(runner)
+    runner._finish_local_job('local-native', ok=False, summary='PRIVATE OUTPUT',
+                             tokens=123, est_cost_usd=0.125, model='test-model')
+    result = projected(runner)
+    assert result['economics']['kind'] == 'provider'
+    assert result['economics']['spend_usd'] == 0.125
+    assert result['economics']['estimated'] is False
+    assert result['usage'] == dict(kind='reported', tokens=123, source='local_job_tokens')
+    assert result['display'] == dict(label='Provider worker', model='native/test-model',
+                                     adapter='native', truncated=False)
+    assert 'PRIVATE' not in json.dumps(result)
+    assert result['lifecycle'] == 'failed'  # Spend does not imply success.
+
+
+def test_initial_and_finished_unknown_zero_are_not_observed_usage(tmp_path):
+    runner = Runner(tmp_path)
+    register(runner)
+    assert projected(runner)['usage'] == {'kind': 'unknown'}
+    assert projected(runner)['economics'] == {'kind': 'unavailable'}
+    runner._finish_local_job('local-native', ok=True)
+    assert projected(runner)['usage'] == {'kind': 'unknown'}
+    assert projected(runner)['economics']['kind'] == 'unavailable'
+
+
+def test_selected_existing_lane_has_bounded_header(tmp_path):
+    runner = Runner(tmp_path)
+    register(runner)
+    index = runner.local_metadata_handle()
+    result = index.read_selected(ctx(), index.ref('local-native'), lane='output')
+    assert result['summary']['display']['model'] == 'native/test-model'
+    assert result['summary']['local_ref'] == index.ref('local-native')
+    assert result['page']['outcome'] == 'unavailable'
+    assert result['cancellation_authority'] is False
+    result['summary']['display']['model'] = 'mutated'
+    assert projected(runner)['display']['model'] == 'native/test-model'
+
+
+def test_real_finish_estimate_keeps_usage_distinct_from_pricing(tmp_path, monkeypatch):
+    runner = Runner(tmp_path)
+    register(runner)
+    monkeypatch.setattr('pmharness.registry.resolve_price_with_source',
+                        lambda model: (1.0, 2.0, 'static'))
+    runner._finish_local_job('local-native', ok=True, tokens=1000)
+    receipt = runner._local_jobs['local-native']['financial_receipt']
+    result = projected(runner)
+    assert receipt['spend_basis'] == result['economics']['kind'] == 'estimated'
+    assert result['economics']['spend_usd'] == receipt['spend_usd']
+    assert result['economics']['estimated'] is True
+    assert result['usage']['tokens'] == 1000
+
+
+@pytest.mark.parametrize('basis,provenance,estimated,spend,tokens', [
+    ('provider', 'provider', False, 0.0, 10),
+    ('provider', 'provider', False, 0.25, 10),
+    ('measured', 'static', False, 0.25, 10),
+    ('measured', 'live', False, 0.25, 10),
+    ('estimated', 'static', True, 0.25, 10),
+    ('unavailable', 'unknown', True, 0.0, 0),
+])
+def test_canonical_receipt_scalar_contract(tmp_path, basis, provenance, estimated, spend, tokens):
+    runner = Runner(tmp_path)
+    job = register(runner)
+    # Exercise the canonical apply seam on an observed native row. In particular,
+    # only a receipt with positive usage and explicit provider provenance can
+    # represent provider zero; the ordinary finish signature cannot express it.
+    receipt = build_local_financial_receipt('local-native', spend_usd=spend,
+        estimated=estimated, cost_provenance=provenance, tokens=tokens,
+        artifacts=[{'type': 'ROUTING', 'est_cost_usd': 0.8}], routing_saved_usd=0.1)
+    assert receipt['spend_basis'] == basis
+    job['tokens'] = tokens
+    apply_local_receipt(job, receipt)
+    result = projected(runner)['economics']
+    assert result['kind'] == basis
+    assert result['route_forecast_usd'] == 0.8
+    assert result['estimated_savings_usd'] == 0.1
+    if basis != 'unavailable':
+        assert result['spend_usd'] == spend
+    else:
+        assert 'spend_usd' not in result
+
+
+def test_real_finish_explicit_zero_gap_is_not_fabricated(tmp_path, monkeypatch):
+    runner = Runner(tmp_path)
+    register(runner)
+    monkeypatch.setattr('pmharness.registry.resolve_price_with_source',
+                        lambda model: (None, None, 'unknown'))
+    runner._finish_local_job('local-native', ok=True, tokens=10, est_cost_usd=0.0)
+    assert projected(runner)['economics']['kind'] == 'unavailable'
+    assert projected(runner)['usage']['tokens'] == 10
+
+
+def test_cancelled_result_and_restart_preserve_facts(tmp_path):
+    runner = Runner(tmp_path)
+    register(runner)
+    runner._local_jobs['local-native']['status'] = 'cancelled'
+    runner._update_cancelled_local_job_provenance('local-native', tokens=17, est_cost_usd=0.5)
+    before = projected(runner)
+    assert before['lifecycle'] == 'cancelled'
+    assert before['economics']['kind'] == 'provider'
+    restarted = Runner(tmp_path)
+    after = projected(restarted)
+    assert after['economics'] == before['economics']
+    assert after['usage'] == before['usage']
+    assert after['local_ref']['incarnation'] != before['local_ref']['incarnation']
+
+
+@pytest.mark.parametrize('exclusion', [dict(accounting_owned=False),
+                                      dict(accounting_scope='visibility_only')])
+def test_accounting_exclusion_suppresses_receipt_and_usage(tmp_path, exclusion):
+    from harness.job_scoping import annotate_job_accounting
+    runner = Runner(tmp_path)
+    job = register(runner)
+    runner._finish_local_job('local-native', ok=True, tokens=10, est_cost_usd=0.25)
+    # Use production accounting resolution to establish a visibility-only row.
+    excluded = annotate_job_accounting(dict(job), active_session_id='another-session')
+    assert excluded['accounting_owned'] is False
+    job.update({key: excluded[key] for key in exclusion})
+    result = projected(runner)
+    assert result['accounting'] == dict(kind='excluded', aggregation_authority=False)
+    assert result['economics'] == dict(kind='unavailable')
+    assert result['usage'] == dict(kind='unknown')
+
+
+def test_command_supplied_preview_and_provider_goal_never_become_labels(tmp_path):
+    runner = Runner(tmp_path)
+    runner._register_command_job('local-command', command='echo PRIVATE_SECRET',
+                                 command_preview='PRIVATE_SECRET', action_id='a')
+    register(runner)
+    index = runner.local_metadata_handle()
+    page = index.read_page(ctx())
+    assert 'PRIVATE' not in json.dumps(page)
+    assert projected(runner, 'local-command')['display']['label'] == 'Command'
+    for lane in ('actions', 'children', 'output'):
+        detail = index.read_selected(ctx(), index.ref('local-command'), lane=lane)
+        assert 'PRIVATE' not in json.dumps(detail.get('summary'))
+    runner._refresh_local_job_routed_model('local-native', 'selected-new', engine='agentic')
+    assert projected(runner)['display']['model'] == 'agentic/selected-new'
+
+
+class NoTraversal(dict):
+    def __iter__(self):
+        forbidden()
+    items = values = keys = __iter__
+    def __deepcopy__(self, memo):
+        forbidden()
+
+
+class SliceFirst(str):
+    def encode(self, *args, **kwargs):
+        forbidden()
+    def strip(self, *args, **kwargs):
+        forbidden()
+    def __str__(self):
+        forbidden()
+    def __getitem__(self, key):
+        assert isinstance(key, slice) and key.stop <= 160
+        return super().__getitem__(key)
+
+
+def test_writer_bounds_before_copy_and_poll_never_reads_history(tmp_path, monkeypatch):
+    runner = Runner(tmp_path)
+    register(runner)
+    runner._finish_local_job('local-native', ok=True, tokens=10, est_cost_usd=0.25)
+    original = dict(runner._local_jobs['local-native'])
+    original.update(model=SliceFirst('\U0001f600' * 100000),
+                    adapter=SliceFirst('a' * 100000),
+                    goal=NoTraversal(secret='PRIVATE'),
+                    output='PRIVATE' * 100000,
+                    artifacts=[NoTraversal(secret='PRIVATE')],
+                    worker_provenance=NoTraversal(secret='PRIVATE'))
+    receipt_values = dict(original['financial_receipt'])
+    receipt = NoTraversal(receipt_values)
+    receipt['nested'] = NoTraversal(secret='PRIVATE')
+    original['financial_receipt'] = receipt
+    monkeypatch.setattr(copy, 'deepcopy', forbidden)
+    for i in range(1100):
+        jid = f'local-{i:04d}'
+        data = dict(original, id=jid, status='running' if i % 2 else 'completed',
+                    financial_receipt=NoTraversal(receipt_values, job_id=jid, nested=receipt['nested']))
+        runner._local_jobs[jid] = data
+    index = runner.local_metadata_handle()
+    assert projected(runner, 'local-0000')['display']['truncated'] is True
+    assert len(projected(runner, 'local-0000')['display']['model']) == 160
+    monkeypatch.setattr(runner, 'live_local_jobs', forbidden)
+    monkeypatch.setattr(runner, 'get_local_job', forbidden)
+    monkeypatch.setattr('builtins.open', forbidden)
+    monkeypatch.setattr('harness.financial_receipt.build_local_financial_receipt', forbidden)
+    monkeypatch.setattr('harness.financial_receipt.apply_local_receipt', forbidden)
+    class NoBody(NoTraversal):
+        get = __getitem__ = lambda *args: forbidden()
+    runner._local_jobs = NoBody(runner._local_jobs)
+    ids = []
+    for lane in ('active', 'history'):
+        cursor = None
+        while True:
+            page = index.read_page(ctx(), cursor=cursor, lane=lane)
+            assert page['page']['scanned'] <= 51 and len(page['rows']) <= 50
+            assert len(json.dumps(page).encode()) <= 32768
+            assert 'PRIVATE' not in json.dumps(page)
+            if lane == 'history':
+                ids.extend(row['local_ref']['job_id'] for row in page['rows'])
+            cursor = page['page']['next_cursor']
+            if not cursor:
+                break
+    assert len(ids) == len(set(ids)) == 1101
+
+
+def test_malformed_receipt_never_becomes_known_cost(tmp_path):
+    runner = Runner(tmp_path)
+    job = register(runner)
+    receipt = build_local_financial_receipt('local-native', spend_usd=0.25,
+                                            provider_cost_usd=0.25)
+    for change in (dict(job_id='other'), dict(owner='pm'), dict(spend_usd=float('nan')),
+                   dict(spend_usd=True), dict(spend_usd=-1), dict(spend_usd=10**1000),
+                   dict(spend_basis={'nested': 'provider'}), dict(estimated=True),
+                   dict(cost_provenance='provider' + 'x' * 100000)):
+        job['financial_receipt'] = dict(receipt, **change)
+        assert projected(runner)['economics']['kind'] == 'unavailable'
+
+
+def test_enriched_selected_detail_maximum_unicode_payload_stays_bounded(tmp_path):
+    runner = Runner(tmp_path)
+    job = register(runner)
+    job.update(model='\U0001f600' * 1000, adapter='\U0001f600' * 1000,
+               output='\U0001f600' * 100000,
+               actions=[dict(action_id=str(i), kind='edit', goal='\U0001f600' * 10000,
+                             error='\U0001f600' * 10000) for i in range(100)],
+               child_job_ids=['local-' + 'x' * 240] * 100)
+    index = runner.local_metadata_handle()
+    for lane in ('output', 'actions', 'children'):
+        result = index.read_selected(ctx(), index.ref('local-native'), lane=lane)
+        assert result['page']['outcome'] == 'partial'
+        assert len(json.dumps(result).encode()) <= 32768
+        assert result['page']['scanned'] <= 51
+        assert len(result['rows']) <= 50
+        assert result['summary']['display']['truncated'] is True
+
+
+def test_recorded_native_events_keep_active_revision_and_unknown_economics(tmp_path):
+    runner = Runner(tmp_path)
+    register(runner)
+    index = runner.local_metadata_handle()
+    before = index.active_revision
+    runner._ingest_local_job_events('local-native', [
+        {'kind': 'action_start', 'data': {'id': 'read-1', 'kind': 'read', 'goal': 'inspect file'}},
+        {'kind': 'action_end', 'data': {'id': 'read-1', 'kind': 'read', 'status': 'completed'}},
+    ])
+    changes = index.read_page(ctx(), lane='active', mode='changes', after_revision=before)
+    assert changes['page']['outcome'] == 'complete'
+    assert changes['rows'][-1]['action_count'] == 1
+    assert changes['rows'][-1]['economics']['kind'] == 'unavailable'
+    assert changes['rows'][-1]['usage']['kind'] == 'unknown'
+    ref = index.ref('local-native')
+    detail = index.read_selected(ctx(), ref, lane='actions')
+    assert detail['summary']['local_ref'] == ref
+    assert detail['rows'][0]['action_id'] == 'read-1'
+    hidden = index.read_selected(dict(ctx(), session_id='B'), ref, lane='actions')
+    assert 'summary' not in hidden
+    expired = index.read_selected(ctx(), dict(ref, incarnation='other'), lane='actions')
+    assert 'summary' not in expired
+
+
+@pytest.mark.parametrize('known,tokens,expected', [(True, 0, 'reported'), (False, 10, 'unknown'),
+                                                 (None, 0, 'unknown'), (True, 10, 'reported')])
+def test_native_finish_persisted_usage_known_flag(tmp_path, monkeypatch, known, tokens, expected):
+    runner = Runner(tmp_path)
+    register(runner)
+    monkeypatch.setattr('pmharness.registry.resolve_price_with_source',
+                        lambda model: (None, None, 'unknown'))
+    runner._finish_local_job('local-native', ok=False, tokens=tokens,
+                             worker_provenance={'usage_known': known})
+    assert runner._local_jobs['local-native']['worker_provenance']['usage_known'] is known
+    result = projected(runner)
+    assert result['usage']['kind'] == expected
+    if expected == 'reported':
+        assert result['usage']['tokens'] == tokens
+    else:
+        assert 'tokens' not in result['usage']
+    assert result['economics']['kind'] == 'unavailable'
+    restarted = Runner(tmp_path)
+    assert projected(restarted)['usage'] == result['usage']
+
+
+def test_enriched_fields_reach_existing_api_without_parser_changes(tmp_path):
+    from harness.api.job_readmodel import get_local_metadata, get_local_metadata_detail
+    from harness.job_readmodel import ActiveContext, KnownSources, MetadataReader, ReadContext
+    from dataclasses import asdict
+    def query(context, **kwargs):
+        return {k: [str(v)] for k, v in dict(asdict(context), **kwargs).items()}
+    runner = Runner(tmp_path)
+    register(runner)
+    runner._finish_local_job('local-native', ok=True, tokens=12, est_cost_usd=0.3)
+    index = runner.local_metadata_handle()
+    context = ReadContext(**ctx())
+    reader = MetadataReader(lambda: ActiveContext('A', '/repo', 'generation'), KnownSources(()), index)
+    status, page = get_local_metadata(query(context, lane='history'), reader)
+    assert status == 200 and page['rows'][0]['economics']['spend_usd'] == 0.3
+    for lane in ('actions', 'children', 'output'):
+        status, detail = get_local_metadata_detail(query(context, job_id='local-native',
+            incarnation=index.incarnation, lane=lane), reader)
+        assert status == 200
+        assert detail['summary']['display']['model'] == 'native/test-model'
+        assert detail['summary']['economics']['kind'] == 'provider'
+        assert len(json.dumps(detail).encode()) <= 32768

--- a/tests/test_native_selected_context.py
+++ b/tests/test_native_selected_context.py
@@ -1,0 +1,141 @@
+"""Explicit owned request projection through native registration and API."""
+import json
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip('harness.job_readmodel', reason='requires companion PR2 metadata reader')
+
+from harness.api.job_readmodel import get_local_metadata_detail
+from harness.command_jobs import _register_standalone_command
+from harness.job_readmodel import ActiveContext, KnownSources, MetadataReader, ReadContext
+from test_local_job_metadata import Runner, ctx, forbidden
+from test_native_operator_metadata import NoTraversal
+
+
+def selected(runner, jid, **kwargs):
+    index = runner.local_metadata_handle()
+    return index.read_selected(ctx(), index.ref(jid), lane='children', **kwargs)
+
+
+def test_real_dispatch_command_preview_and_no_model(tmp_path):
+    runner = Runner(tmp_path)
+    row = _register_standalone_command(runner, SimpleNamespace(command='printf selected-context'), 'selected-command')
+    result = selected(runner, row['id'], include_context=True)
+    assert result['selected_context']['request'] == {'text': 'printf selected-context', 'truncated': False}
+    assert result['selected_context']['source'] == 'command_preview'
+    assert result['selected_context']['omission'] == 'raw_command_not_retained'
+    assert result['selected_context']['cwd']['text'] == str(tmp_path)
+    assert result['summary']['display']['model'] == ''
+    assert result['page']['outcome'] == 'unavailable'
+    assert result['summary']['revision'] > 0
+
+
+def test_owned_provider_request_api_and_background_privacy(tmp_path):
+    runner = Runner(tmp_path)
+    runner._register_local_job('local-request', 'Explain selected code', model='actual-model', engine='native', skip_routing_preview=True)
+    index = runner.local_metadata_handle()
+    reader = MetadataReader(lambda: ActiveContext('A', '/repo', 'generation'), KnownSources(()), index)
+    query = {k: [v] for k, v in dict(ctx(), job_id='local-request', incarnation=index.incarnation, lane='children', include_context='true').items()}
+    status, result = get_local_metadata_detail(query, reader)
+    assert status == 200
+    assert result['selected_context']['request']['text'] == 'Explain selected code'
+    assert result['summary']['display']['model'] == 'native/actual-model'
+    for lane in ('active', 'history'):
+        assert 'Explain selected code' not in json.dumps(index.read_page(ctx(), lane=lane))
+    assert 'selected_context' not in selected(runner, 'local-request')
+    for value in ('false', '1', '', 'TRUE'):
+        assert get_local_metadata_detail(dict(query, include_context=[value]), reader)[0] == 400
+
+
+def test_bounds_before_encoding_nested_access_and_body_budget(tmp_path, monkeypatch):
+    runner = Runner(tmp_path)
+    runner._register_local_job('local-request', 'initial', skip_routing_preview=True)
+    class SliceFirst(str):
+        def encode(self, *args, **kwargs):
+            forbidden()
+        def __getitem__(self, key):
+            assert isinstance(key, slice) and key.stop <= 2048
+            return super().__getitem__(key)
+    row = runner._local_jobs['local-request']
+    deep = NoTraversal(secret='not selected')
+    for _ in range(2000):
+        deep = NoTraversal(nested=deep)
+    row.update(goal=SliceFirst('\U0001f642' * 1000000), cwd=SliceFirst('\U0001f642' * 100000), tasks=[deep], artifacts=[deep],
+               output='\U0001f642' * 10000, actions=[dict(goal='\U0001f642' * 10000)] * 100)
+    monkeypatch.setattr(runner, 'get_local_job', forbidden)
+    monkeypatch.setattr(runner, 'live_local_jobs', forbidden)
+    index = runner.local_metadata_handle()
+    for lane in ('output', 'actions', 'children'):
+        result = index.read_selected(ctx(), index.ref('local-request'), lane=lane, include_context=True)
+        context = result['selected_context']
+        assert len(context['request']['text'].encode()) == 2048
+        assert len(context['cwd']['text'].encode()) == 512
+        assert context['request']['truncated'] and context['cwd']['truncated']
+        assert len(json.dumps(result).encode()) <= 32768
+        assert result['page']['scanned'] <= 51
+    row['goal'] = deep
+    result = selected(runner, 'local-request', include_context=True)
+    assert result['selected_context']['request'] is None
+    assert result['selected_context']['omission'] == 'request_unavailable'
+    assert 'selected_context' not in index.read_selected(dict(ctx(), session_id='B'), index.ref('local-request'), include_context=True)
+    assert 'selected_context' not in index.read_selected(ctx(), dict(index.ref('local-request'), incarnation='old'), include_context=True)
+
+
+def test_actual_foreground_dispatch_projects_owned_registered_request(tmp_path):
+    from harness.pilot import PilotAction
+    from harness.send_loop_phases import dispatch_local_action
+    from test_command_jobs import _Session
+    session = _Session(str(tmp_path), str(tmp_path), session_id='A')
+    calls = []
+    def execute(act, **kwargs):
+        calls.append(act.command)
+        return True, 'success', {'output': 'selected-context\n', 'exit_code': 0, 'status': 'ok'}
+    session._do_run_command = execute
+    events = list(dispatch_local_action(session, PilotAction(kind='run_command', command='printf selected-context'), 'selected-dispatch', True, []))
+    jid = events[0].data['job_id']
+    assert calls == ['printf selected-context']
+    result = selected(session, jid, include_context=True)
+    assert result['summary']['lifecycle'] == 'completed'
+    assert result['summary']['display']['model'] == ''
+    assert result['selected_context']['request']['text'] == 'printf selected-context'
+    assert result['selected_context']['cwd']['text'] == str(tmp_path)
+
+
+def test_explicit_context_cursor_scope_and_incarnation_fences(tmp_path):
+    from harness.job_readmodel import InvalidReadRequest, ViewChanged
+    runner = Runner(tmp_path)
+    runner._register_local_job('local-request', 'owned instruction', skip_routing_preview=True)
+    runner._local_jobs['local-request']['output'] = 'x' * 10000
+    index = runner.local_metadata_handle()
+    ref = index.ref('local-request')
+    first = index.read_selected(ctx(), ref, lane='output', include_context=True)
+    cursor = first['page']['next_cursor']
+    assert cursor
+    with pytest.raises(InvalidReadRequest):
+        index.read_selected(ctx(), ref, lane='output', cursor=cursor)
+    runner._local_jobs['local-request']['status'] = 'cancelled'
+    expired = index.read_selected(ctx(), ref, lane='output', cursor=cursor, include_context=True)
+    assert expired['page']['outcome'] == 'expired'
+    assert 'summary' not in expired and 'selected_context' not in expired
+    calls = 0
+    def changed_context():
+        nonlocal calls
+        calls += 1
+        return ActiveContext('A', '/repo', 'generation' if calls == 1 else 'replaced')
+    reader = MetadataReader(changed_context, KnownSources(()), index)
+    with pytest.raises(ViewChanged):
+        reader.read_local_selected(ReadContext(**ctx()), ref, include_context=True)
+
+
+def test_selected_command_retains_writer_redaction_and_never_reads_payloads(tmp_path):
+    runner = Runner(tmp_path)
+    command = 'printf ok # token=' + 'synthetic-fixture-value'
+    row = _register_standalone_command(runner, SimpleNamespace(command=command), 'selected-redacted')
+    result = selected(runner, row['id'], include_context=True)
+    assert 'synthetic-fixture-value' not in result['selected_context']['request']['text']
+    assert 'REDACTED' in result['selected_context']['request']['text']
+    runner._local_jobs[row['id']]['provider_payload'] = NoTraversal(secret='hidden')
+    assert selected(runner, row['id'], include_context=True)['selected_context'] == result['selected_context']
+
+

--- a/tests/test_native_selected_context.py
+++ b/tests/test_native_selected_context.py
@@ -137,5 +137,3 @@ def test_selected_command_retains_writer_redaction_and_never_reads_payloads(tmp_
     assert 'REDACTED' in result['selected_context']['request']['text']
     runner._local_jobs[row['id']]['provider_payload'] = NoTraversal(secret='hidden')
     assert selected(runner, row['id'], include_context=True)['selected_context'] == result['selected_context']
-
-

--- a/tests/test_native_selected_metadata.py
+++ b/tests/test_native_selected_metadata.py
@@ -1,0 +1,227 @@
+"""Real native producers through the selected API and authenticated HTTP boundary."""
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip('harness.job_readmodel', reason='requires companion PR2 metadata reader')
+
+from harness.api.job_readmodel import get_local_metadata_detail
+from harness.job_readmodel import ActiveContext, KnownSources, MetadataReader
+from harness.local_job_routing import _routing_artifact
+from test_local_job_metadata import Runner, forbidden
+
+
+def producer(tmp_path, monkeypatch):
+    runner = Runner(tmp_path)
+    route = _routing_artifact('cheap-model', 0.01, role='implement', reason='Policy chose forecast',
+                              rejected=[], policy='balanced')
+    monkeypatch.setattr('harness.local_job_routing.preview_agentic_route',
+                        lambda *a, **kw: {'artifact': route})
+    runner._register_local_job('local-native', 'Keyboard disclosure', role='implement', engine='agentic')
+    return runner
+
+
+def endpoint(runner):
+    index = runner.local_metadata_handle()
+    ctx = dict(session_id='A', repo=runner.config.repo, view_generation='generation', scope='session')
+    reader = MetadataReader(lambda: ActiveContext('A', runner.config.repo, 'generation'),
+                            KnownSources(()), local_handle=index)
+    def read(lane, **kwargs):
+        values = dict(ctx, job_id='local-native', incarnation=index.incarnation, lane=lane)
+        values.update(kwargs)
+        return get_local_metadata_detail({k: [v] for k, v in values.items()}, reader)
+    return read
+
+
+def test_producer_instruction_forecast_fallback_and_realized(tmp_path, monkeypatch):
+    runner = producer(tmp_path, monkeypatch)
+    read = endpoint(runner)
+    status, tasks = read('tasks')
+    assert status == 200
+    assert tasks['rows'] == [dict(task_id='local-native-w0', role='implement (agentic)',
+        instruction='Keyboard disclosure', status='running', adapter='agentic', model='',
+        model_kind='unavailable', truncated=False)]
+    route = read('routing')[1]['rows'][0]
+    assert (route['task_id'], route['association'], route['model_kind'], route['model'],
+            route['policy'], route['created_by']) == (
+                'local-native-w0', 'explicit', 'forecast', 'cheap-model', 'balanced', 'router')
+    job = runner._local_jobs['local-native']
+    # Retained fallback data is distinct from the initial router producer.
+    job['artifacts'].append(dict(job['artifacts'][0], model='fallback-model',
+        created_by='router-fallback', detail='Recorded fallback'))
+    runner._persist_local_jobs()
+    routes = read('routing')[1]['rows']
+    assert [r['ordinal'] for r in routes] == [0, 1]
+    assert routes[-1]['created_by'] == 'router-fallback'
+    assert routes[-1]['detail'] == 'Recorded fallback'
+    assert job['model'] == read('tasks')[1]['rows'][0]['model'] == ''
+    runner._refresh_local_job_routed_model('local-native', 'actual-model', engine='agentic')
+    assert read('tasks')[1]['rows'][0]['model'] == 'agentic/actual-model'
+    assert read('routing')[1]['rows'][-1]['model_kind'] == 'forecast'
+    runner._finish_local_job('local-native', ok=True, model='actual-model', engine='agentic')
+    routes = read('routing')[1]['rows']
+    assert all(r['model_kind'] == 'realized' and r['model'] == 'actual-model' for r in routes)
+    assert routes[-1]['created_by'] == 'router-fallback'
+
+
+@pytest.mark.parametrize('damage', ['none', 'label', 'session', 'adapter', 'multiple', 'foreign_id'])
+def test_legacy_association_requires_owner_proof(tmp_path, monkeypatch, damage):
+    runner = producer(tmp_path, monkeypatch)
+    job = runner._local_jobs['local-native']
+    art = job['artifacts'][0]
+    del art['task_id']
+    if damage == 'label':
+        job['label'] = json.dumps(dict(origin='external', session_id='A'))
+    elif damage == 'session':
+        job['label'] = json.dumps(dict(origin='marionette', session_id='B'))
+    elif damage == 'adapter':
+        job['tasks'][0]['adapter'] = 'foreign'
+    elif damage == 'multiple':
+        job['tasks'].append(dict(job['tasks'][0], id='another'))
+    elif damage == 'foreign_id':
+        art['task_id'] = 'foreign-w0'
+    runner._persist_local_jobs()
+    route = endpoint(runner)('routing')[1]['rows'][0]
+    assert route['association'] == ('legacy_owner_single_task' if damage == 'none' else 'unavailable')
+    assert route['task_id'] == ('local-native-w0' if damage == 'none' else None)
+    assert route['created_by'] == 'router'
+
+
+@pytest.mark.parametrize('fact', ['instruction', 'policy'])
+def test_nested_revision_only_invalidates_cursor(tmp_path, monkeypatch, fact):
+    runner = producer(tmp_path, monkeypatch)
+    job = runner._local_jobs['local-native']
+    job['artifacts'] = [dict(job['artifacts'][0]) for _ in range(80)]
+    read = endpoint(runner)
+    before = read('routing')[1]
+    cursor = before['page']['next_cursor']
+    assert cursor
+    updated_at = job['updated_at']
+    if fact == 'instruction':
+        job['tasks'][0]['instruction'] = 'changed only instruction'
+    else:
+        job['artifacts'][-1]['policy'] = 'changed only policy'
+    runner._persist_local_jobs()
+    assert job['updated_at'] == updated_at
+    assert read('routing', cursor=cursor)[1]['page']['outcome'] == 'expired'
+    assert read('tasks')[1]['page']['revision'] > before['page']['revision']
+
+
+def test_caps_scan_budget_refusal_and_no_read_writes(tmp_path, monkeypatch):
+    runner = producer(tmp_path, monkeypatch)
+    job = runner._local_jobs['local-native']
+    job['goal'] = 'g' * 10000
+    job['tasks'][0].update(instruction='\U0001f600' * 10000, role='r' * 1000)
+    job['tasks'] = [dict(job['tasks'][0], id=f'task-{i}') for i in range(90)]
+    job['artifacts'] = [{'type': 'FINDING', 'body': object()} for _ in range(60)] + [
+        dict(type='ROUTING', model='m' * 10000, detail='d' * 10000)]
+    read = endpoint(runner)
+    index = runner.local_metadata_handle()
+    revision = index.revision
+    monkeypatch.setattr(runner, '_persist_local_jobs_locked', forbidden)
+    monkeypatch.setattr(runner, '_publish_local_metadata_locked', forbidden)
+    monkeypatch.setattr(copy, 'deepcopy', forbidden)
+    monkeypatch.setattr('builtins.open', forbidden)
+    for lane in ('tasks', 'routing'):
+        status, first = read(lane)
+        assert status == 200 and first['page']['outcome'] == 'partial'
+        assert first['page']['scanned'] <= 51 and len(first['rows']) <= 50
+        assert len(json.dumps(first).encode()) <= 32768
+        cursor = first['page']['next_cursor']
+        assert read(lane, job_id='foreign', cursor=cursor)[0] == 400
+        assert read('routing' if lane == 'tasks' else 'tasks', cursor=cursor)[0] == 400
+        assert read(lane, incarnation='stale')[1]['page']['outcome'] == 'expired'
+        assert read(lane, incarnation='stale', cursor=cursor)[0] == 400
+        assert read(lane, job_id='foreign')[1]['rows'] == []
+        assert read(lane, session_id='B')[0] == 409
+        assert read(lane, cursor=cursor)[0] == 200
+    task = read('tasks')[1]['rows'][0]
+    assert len(task['instruction']) == 1024 and len(task['role']) == 160 and task['truncated']
+    assert read('routing')[1]['rows'] == []
+    summary = index.read_page(dict(session_id='A', repo=runner.config.repo,
+                                  view_generation='generation', scope='session'))['rows'][0]
+    assert 'goal_preview' not in summary and 'g' * 240 not in json.dumps(summary)
+    assert 'instruction' not in json.dumps(summary) and 'body' not in json.dumps(summary)
+    assert index.revision == revision
+
+
+
+
+def test_selected_oversize_row_refuses_without_nonprogress_cursor(tmp_path, monkeypatch):
+    runner = producer(tmp_path, monkeypatch)
+    job = runner._local_jobs['local-native']
+    job.update(goal='\U0001f600' * 10000, model='\U0001f600' * 1000, cwd='\U0001f600' * 1000)
+    job['tasks'][0].update(**{key: '\U0001f600' * 10000
+                             for key in ('instruction', 'role', 'model', 'adapter', 'status')})
+    runner._persist_local_jobs()
+    status, body = endpoint(runner)('tasks', include_context='true')
+    assert status == 200 and len(json.dumps(body).encode()) <= 32768
+    assert body['page']['outcome'] == 'unavailable'
+    assert body['page']['next_cursor'] is None
+    assert 'selected_row_budget' in body['missing']
+
+
+def test_foreign_membership_and_restart_incarnation(tmp_path, monkeypatch):
+    runner = producer(tmp_path, monkeypatch)
+    read = endpoint(runner)
+    old = runner.local_metadata_handle().incarnation
+    restarted = Runner(tmp_path)
+    assert endpoint(restarted)('tasks', incarnation=old)[1]['page']['outcome'] == 'expired'
+    assert endpoint(restarted)('routing')[1]['rows'][0]['association'] == 'explicit'
+    runner._local_jobs['local-native']['session_id'] = 'B'
+    for lane in ('tasks', 'routing'):
+        status, body = read(lane)
+        assert status == 200 and body['rows'] == [] and 'summary' not in body
+        assert 'selected_membership_unavailable' in body['missing']
+
+
+@pytest.mark.parametrize('fact', ['instruction', 'policy'])
+def test_persistence_preserves_unchanged_provider_cursors(tmp_path, fact):
+    runner = Runner(tmp_path)
+    for name in ('a', 'b'):
+        jid = 'local-' + name
+        runner._register_local_job(jid, 'instruction-' + name, engine='native', model='model-' + name)
+        runner._local_jobs[jid]['artifacts'] = [
+            dict(type='ROUTING', task_id=jid + '-w0', policy='original') for _ in range(80)]
+    index = runner.local_metadata_handle()
+    context = dict(session_id='A', repo=runner.config.repo, view_generation='generation', scope='session')
+    pages = {jid: index.read_selected(context, index.ref(jid), lane='routing') for jid in index.rows}
+    revisions = {jid: row['revision'] for jid, row in index.rows.items()}
+    active_revision = index.active_revision
+    runner._persist_local_jobs()
+    assert {jid: row['revision'] for jid, row in index.rows.items()} == revisions
+    assert index.active_revision == active_revision
+    for jid, page in pages.items():
+        assert page['page']['next_cursor']
+        assert index.read_selected(context, index.ref(jid), lane='routing',
+            cursor=page['page']['next_cursor'])['page']['outcome'] == 'complete'
+    job = runner._local_jobs['local-a']
+    timestamp = job['updated_at']
+    if fact == 'instruction':
+        job['tasks'][0]['instruction'] = 'nested change'
+    else:
+        job['artifacts'][-1]['policy'] = 'nested change'
+    runner._persist_local_jobs()
+    assert job['updated_at'] == timestamp
+    assert index.rows['local-a']['revision'] > revisions['local-a']
+    assert index.rows['local-b']['revision'] == revisions['local-b']
+    for jid, outcome in [('local-a', 'expired'), ('local-b', 'complete')]:
+        assert index.read_selected(context, index.ref(jid), lane='routing',
+            cursor=pages[jid]['page']['next_cursor'])['page']['outcome'] == outcome
+    changes = index.read_page(context, lane='active', mode='changes', after_revision=active_revision)
+    assert [r['local_ref']['job_id'] for r in changes['rows']] == ['local-a']
+    revision = index.revision
+    runner._persist_local_jobs()
+    assert index.revision == revision
+
+
+@pytest.mark.parametrize('model', [None, 'explicit-model'])
+def test_configured_task_model_is_assigned_before_execution(tmp_path, model):
+    runner = Runner(tmp_path)
+    runner.config.driver = 'configured-model'
+    runner._register_local_job('local-native', 'pending work', engine='native', model=model)
+    task = endpoint(runner)('tasks')[1]['rows'][0]
+    assert task['model'] == 'native/' + (model or 'configured-model')
+    assert task['model_kind'] == 'assigned'

--- a/tests/test_pm124_scoped_cancellation.py
+++ b/tests/test_pm124_scoped_cancellation.py
@@ -1,0 +1,379 @@
+"""Candidate PM stores are the cancellation oracle; no mocked receipts."""
+from dataclasses import asdict, replace
+from types import SimpleNamespace
+
+import pytest
+from harness.api.scoped_cancellation import runtime_available
+if not runtime_available():
+    pytest.skip("requires exact PM cancellation contracts", allow_module_level=True)
+from puppetmaster.contracts import JobRef
+from puppetmaster.models import Task, TaskStatus
+from puppetmaster.state import state_identity
+from puppetmaster.store_contracts import task_binding
+from puppetmaster.store_factory import create_store
+
+from harness.api.jobs import make_job_services, post_swarm_cancel, get_cancellation_receipt
+from harness.api.scoped_cancellation import cancellation_view
+from harness.job_scoping import job_label_for_session, stamp_task_payload
+
+
+@pytest.fixture
+def case(tmp_path):
+    store = create_store('sqlite', tmp_path / 'primary')
+    job = store.create_job('cancel test', label=job_label_for_session('session-a'),
+                           origin='marionette', session_id='session-a')
+    repo = str(tmp_path / 'repo')
+    store.save_task(Task(job_id=job.id, role='worker', instruction='test',
+                        payload=stamp_task_payload({}, session_id='session-a', cwd=repo)))
+    task = store.claim_next_task(job.id, 'owner-a')
+    assert task is not None
+    state = SimpleNamespace(store=store)
+    svc = make_job_services(cfg=SimpleNamespace(repo=repo), sessions=SimpleNamespace(active='session-a'),
+                            get_session=lambda: SimpleNamespace(state=lambda: state),
+                            get_pilot=lambda: None)
+    selection = {'version': 2, 'source': 'harness', 'session_id': 'session-a', 'repo': repo,
+                 'job_ref': store.job_ref(job.id).as_dict(),
+                 'bindings': [asdict(task_binding(task))]}
+    return store, task, svc, {'selection': selection, 'request_id': 'request-a'}
+
+
+def query(body):
+    s = body['selection']
+    return {k: [str(v)] for k, v in {**s['job_ref'], 'source': s['source'], 'repo': s['repo'],
+                                'session_id': s['session_id'], 'request_id': body['request_id']}.items()}
+
+
+def receipt(store, body):
+    return store.get_cancellation_receipt(JobRef(**body['selection']['job_ref']), body['request_id'])
+
+
+def test_request_is_pending_exact_replay_and_read_do_not_claim_stop(case):
+    store, task, svc, body = case
+    before = store.get_task_by_id(task.id)
+    code, result = post_swarm_cancel(body, svc)
+    assert code == 200 and result['receipt']['outcome'] == 'requested'
+    assert result['receipt']['cleanup'] == 'unknown'
+    assert store.get_task_by_id(task.id) == before
+    assert post_swarm_cancel(body, svc) == (code, result)
+    assert get_cancellation_receipt(query(body), svc) == (code, result)
+    assert receipt(store, body).revision == 1
+    assert store.cancellation_pending(JobRef(**body['selection']['job_ref']), task_binding(task))
+
+
+def test_duplicate_request_different_body_conflicts(case):
+    store, task, svc, body = case
+    assert post_swarm_cancel(body, svc)[0] == 200
+    changed = {**body, 'selection': {**body['selection'], 'bindings': [asdict(replace(task_binding(task), generation=99))]}}
+    code, result = post_swarm_cancel(changed, svc)
+    assert code == 200 and result['receipt']['outcome'] == 'conflict'
+    assert receipt(store, body).bindings == (task_binding(task),)
+    assert receipt(store, body).revision == 1
+
+
+@pytest.mark.parametrize('change', [{'generation': 99}, {'lease_id': 'other'}, {'lease_owner': 'other'}])
+def test_changed_generation_or_lease_never_cancels_successor(case, change):
+    store, task, svc, body = case
+    successor = replace(task, **change)
+    store.save_task(successor)
+    code, result = post_swarm_cancel(body, svc)
+    assert code == 200 and result['receipt']['outcome'] == 'stale_binding'
+    ref = JobRef(**body['selection']['job_ref'])
+    assert not store.cancellation_pending(ref, task_binding(successor))
+    assert not store.cancellation_pending(ref, task_binding(task))
+
+
+def test_same_job_id_other_store_unchanged(case, tmp_path, monkeypatch):
+    store, task, svc, body = case
+    other = create_store('sqlite', tmp_path / 'other')
+    monkeypatch.setattr('puppetmaster.models.new_id', lambda _: task.job_id)
+    other.create_job('collision', label=job_label_for_session('session-a'))
+    other.save_task(task)
+    assert post_swarm_cancel(body, svc)[0] == 200
+    other_ref = other.job_ref(task.job_id)
+    assert other.get_cancellation_receipt(other_ref, body['request_id']) is None
+    assert not other.cancellation_pending(other_ref, task_binding(task))
+    wrong = {**body, 'selection': {**body['selection'], 'job_ref': other_ref.as_dict()}}
+    assert post_swarm_cancel(wrong, svc)[0] == 409
+
+
+@pytest.mark.parametrize('field', ['session', 'repo', 'store'])
+def test_context_changes_before_write_have_no_receipt(case, field, tmp_path):
+    store, _, svc, body = case
+    original = store.list_task_refs
+    def switch(*args, **kwargs):
+        page = original(*args, **kwargs)
+        if field == 'session': svc.sessions.active = 'other'
+        elif field == 'repo': svc.cfg.repo = str(tmp_path / 'other')
+        else: svc.get_session = lambda: SimpleNamespace(state=lambda: SimpleNamespace(store=None))
+        return page
+    store.list_task_refs = switch
+    assert post_swarm_cancel(body, svc)[0] == 409
+    assert receipt(store, body) is None
+
+
+@pytest.mark.parametrize('field', ['session', 'repo'])
+def test_context_changes_inside_request_reject_acknowledgement(case, field):
+    store, _, svc, body = case
+    original = store.request_cancellation
+    def switch(*args):
+        result = original(*args)
+        if field == 'session': svc.sessions.active = 'other'
+        else: svc.cfg.repo = '/other'
+        return result
+    store.request_cancellation = switch
+    code, result = post_swarm_cancel(body, svc)
+    assert code == 409 and result['code'] == 'cancellation_context_changed'
+    assert receipt(store, body).outcome == 'requested'
+
+
+@pytest.mark.parametrize('count', [200, 201])
+def test_capacity_never_silently_selects_first_200(case, count):
+    store, task, svc, body = case
+    tasks = [task]
+    for i in range(count - 1):
+        new = replace(task, id=f'extra-{i}', status=TaskStatus.COMPLETE)
+        store.save_task(new)
+        tasks.append(new)
+    body['selection']['bindings'] = [asdict(task_binding(t)) for t in tasks[:200]]
+    code, result = post_swarm_cancel(body, svc)
+    if count == 200:
+        assert code == 200 and result['receipt']['outcome'] == 'requested'
+    else:
+        assert code == 409 and receipt(store, body) is None
+    rendered = [{'id': t.id, 'binding': asdict(task_binding(t))} for t in tasks]
+    view = cancellation_view(store, JobRef(**body['selection']['job_ref']), rendered)
+    assert view['status'] == ('complete' if count == 200 else 'partial')
+
+
+def test_mixed_terminal_workers_need_only_live_worker_observation(case):
+    store, task, svc, body = case
+    finished = replace(task, id='finished', status=TaskStatus.COMPLETE)
+    store.save_task(finished)
+    body['selection']['bindings'].append(asdict(task_binding(finished)))
+    assert post_swarm_cancel(body, svc)[1]['receipt']['outcome'] == 'requested'
+    # This checks the store transition, not proof of a process exit.
+    ref = JobRef(**body['selection']['job_ref'])
+    store.observe_cancellation(ref, task_binding(task), cleanup='partial')
+    code, result = get_cancellation_receipt(query(body), svc)
+    assert code == 200 and result['receipt']['outcome'] == 'observed_stop'
+    assert result['receipt']['cleanup'] == 'partial'
+
+
+def test_terminal_receipt_and_missing_receipt_are_honest(case):
+    store, task, svc, body = case
+    assert get_cancellation_receipt(query(body), svc)[0] == 404
+    store.save_task(replace(task, status=TaskStatus.COMPLETE))
+    assert post_swarm_cancel(body, svc)[1]['receipt']['outcome'] == 'already_terminal'
+
+
+@pytest.mark.parametrize('field,value', [('session_id', 'foreign'), ('cwd', '/foreign')])
+def test_task_ownership_before_request_and_receipt(case, field, value):
+    store, task, svc, body = case
+    store.save_task(replace(task, payload={**task.payload, field: value}))
+    assert post_swarm_cancel(body, svc)[0] == 409
+    assert receipt(store, body) is None
+
+
+def test_bounded_metadata_no_list_tasks_and_mismatched_render_rejected(case):
+    store, task, svc, body = case
+    store.list_tasks = lambda *_: pytest.fail('unbounded cancellation task read')
+    assert post_swarm_cancel(body, svc)[0] == 200
+    rendered = [{'id': task.id, 'binding': asdict(replace(task_binding(task), generation=200))}]
+    assert cancellation_view(store, JobRef(**body['selection']['job_ref']), rendered)['status'] == 'unavailable'
+
+
+def test_real_supervised_command_stops(case, tmp_path, monkeypatch):
+    """PM supervises a real subprocess; its cancellation scope records observation."""
+    import os
+    import sys
+    import threading
+    import time
+    from puppetmaster.cancellation import cancellation_scope, JobCancelled
+    from puppetmaster.adapters._streaming import run_streamed_subprocess
+    store, task, svc, body = case
+    monkeypatch.setenv('PUPPETMASTER_STATE_DIR', str(store.root))
+    pid_file = tmp_path / 'command.pid'
+    command = [sys.executable, '-c',
+               'import os,time,pathlib; pathlib.Path(' + repr(str(pid_file)) + ').write_text(str(os.getpid())); time.sleep(30)']
+    errors = []
+    stopped = []
+    def worker():
+        try:
+            with cancellation_scope(store, task):
+                run_streamed_subprocess(command=command, env=None, task=task,
+                                        sidecar_name='cancel-proof', timeout_seconds=15,
+                                        cwd=str(tmp_path), start_new_session=True)
+        except JobCancelled:
+            stopped.append(True)
+        except BaseException as exc:
+            errors.append(exc)
+    thread = threading.Thread(target=worker)
+    thread.start()
+    try:
+        deadline = time.monotonic() + 5
+        while not pid_file.exists() and thread.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert pid_file.exists(), errors
+        pid = int(pid_file.read_text())
+        os.kill(pid, 0)
+        assert post_swarm_cancel(body, svc)[0] == 200
+        thread.join(8)
+        assert not thread.is_alive() and not errors and stopped
+        with pytest.raises(ProcessLookupError):
+            os.kill(pid, 0)
+        code, result = get_cancellation_receipt(query(body), svc)
+        assert code == 200 and result['receipt']['outcome'] == 'observed_stop'
+        assert result['receipt']['cleanup'] == 'unknown'
+    finally:
+        thread.join(20)
+
+
+def test_reconcile_original_receipt_after_new_tasks_appear(case):
+    store, task, svc, body = case
+    assert post_swarm_cancel(body, svc)[0] == 200
+    extra = replace(task, id='new-task', generation=20)
+    store.save_task(extra)
+    assert get_cancellation_receipt(query(body), svc)[0] == 200
+    assert post_swarm_cancel(body, svc)[0] == 200
+    assert not store.cancellation_pending(JobRef(**body['selection']['job_ref']), task_binding(extra))
+
+
+def test_receipt_read_revalidates_owner_and_store_at_response(case):
+    store, task, svc, body = case
+    assert post_swarm_cancel(body, svc)[0] == 200
+    original = store.get_cancellation_receipt
+    def switch(*args):
+        result = original(*args)
+        svc.sessions.active = 'other'
+        return result
+    store.get_cancellation_receipt = switch
+    assert get_cancellation_receipt(query(body), svc)[0] == 409
+
+
+@pytest.mark.parametrize('generation', [True, -1, '1'])
+def test_invalid_generation_is_not_coerced(case, generation):
+    store, _, svc, body = case
+    body['selection']['bindings'][0]['generation'] = generation
+    assert post_swarm_cancel(body, svc)[0] == 409
+    assert receipt(store, body) is None
+
+
+def test_changed_job_ownership_during_request_rejects_response(case):
+    store, task, svc, body = case
+    original = store.request_cancellation
+    def mutate(*args):
+        value = original(*args)
+        store.save_job(replace(store.get_job(task.job_id), project_id='changed-project'))
+        return value
+    store.request_cancellation = mutate
+    assert post_swarm_cancel(body, svc)[0] == 409
+
+
+def test_cli_binding_uses_only_explicit_cli_store(case, monkeypatch):
+    store, _, svc, body = case
+    body['selection']['source'] = 'cli'
+    monkeypatch.setattr('harness.cli_job_merge.resolve_cli_state_dir', lambda _: str(store.root))
+    svc.get_session = lambda: pytest.fail('CLI cancellation must not fall back to harness')
+    assert post_swarm_cancel(body, svc)[0] == 200
+    assert get_cancellation_receipt(query(body), svc)[0] == 200
+
+
+@pytest.mark.parametrize('case_fixture', ['case', 'real_session_case'])
+def test_http_route_wiring_for_request_and_receipt(request, case_fixture):
+    import json
+    from harness.http_routes import build_get_routes, build_post_json_routes
+    _, _, svc, body = request.getfixturevalue(case_fixture)
+    class Services:
+        def __getattr__(self, _):
+            return lambda: svc
+    sent = []
+    handler = SimpleNamespace(_send=lambda code, value: sent.append((code, json.loads(value))))
+    build_post_json_routes(Services())['/api/swarm/cancel'](handler, body)
+    assert sent[-1][0] == 200 and sent[-1][1]['receipt']['outcome'] == 'requested'
+    build_get_routes(Services())['/api/swarm/cancellation-receipt'](handler, None, query(body))
+    assert sent[-1] == sent[-2]
+
+
+@pytest.fixture
+def real_session_case(case):
+    from harness.session import Session
+    from harness.state import DurableState
+    store, task, svc, body = case
+    session = Session.__new__(Session)
+    session.state_dir = str(store.root)
+    first, second = session.state(), session.state()
+    assert isinstance(first, DurableState) and isinstance(second, DurableState)
+    assert first.store is not second.store
+    assert state_identity(first.store.root) == state_identity(second.store.root)
+    svc.get_session = lambda: session
+    return store, task, svc, body
+
+
+@pytest.mark.parametrize('field', ['state_dir', 'session', 'repo'])
+@pytest.mark.parametrize('phase', ['before_write', 'inside_request', 'receipt_read'])
+def test_real_session_context_changes_refuse(real_session_case, tmp_path, monkeypatch, field, phase):
+    store, _, svc, body = real_session_case
+    if phase == 'receipt_read':
+        assert post_swarm_cancel(body, svc)[0] == 200
+    method = {'before_write': 'list_task_refs', 'inside_request': 'request_cancellation',
+              'receipt_read': 'get_cancellation_receipt'}[phase]
+    original = getattr(type(store), method)
+    def switch(current_store, *args, **kwargs):
+        result = original(current_store, *args, **kwargs)
+        if field == 'state_dir': svc.get_session().state_dir = str(tmp_path / 'other')
+        elif field == 'session': svc.sessions.active = 'other'
+        else: svc.cfg.repo = str(tmp_path / 'other-repo')
+        return result
+    monkeypatch.setattr(type(store), method, switch)
+    code, _ = (get_cancellation_receipt(query(body), svc) if phase == 'receipt_read'
+               else post_swarm_cancel(body, svc))
+    assert code == 409
+    assert (receipt(store, body) is None) == (phase == 'before_write')
+
+
+def test_real_session_authority_does_not_recreate_state(real_session_case, monkeypatch):
+    store, _, svc, body = real_session_case
+    session = svc.get_session()
+    original = session.state
+    calls = []
+    def state():
+        calls.append(True)
+        return original()
+    monkeypatch.setattr(session, 'state', state)
+    assert post_swarm_cancel(body, svc)[0] == 200
+    assert len(calls) == 1
+    assert get_cancellation_receipt(query(body), svc)[0] == 200
+    assert len(calls) == 2
+    assert receipt(store, body).outcome == 'requested'
+
+
+@pytest.mark.parametrize('field', ['lease_owner', 'lease_id'])
+@pytest.mark.parametrize('length', [256, 257])
+def test_published_bindings_match_request_boundary(case, field, length):
+    store, task, svc, body = case
+    task = replace(task, **{field: 'a' * length})
+    store.save_task(task)
+    binding = asdict(task_binding(task))
+    body['selection']['bindings'] = [binding]
+    view = cancellation_view(store, JobRef(**body['selection']['job_ref']),
+                             [{'id': task.id, 'binding': binding}])
+    assert view['status'] == ('complete' if length == 256 else 'unavailable')
+    assert post_swarm_cancel(body, svc)[0] == (200 if length == 256 else 409)
+
+
+def test_recreated_store_path_cannot_cancel_same_id_successor(case, tmp_path, monkeypatch):
+    store, task, svc, body = case
+    root = store.root
+    root.rename(tmp_path / 'retired-primary')
+    replacement = create_store('sqlite', root)
+    monkeypatch.setattr('puppetmaster.models.new_id', lambda prefix: task.job_id if prefix == 'job' else 'task_successor')
+    successor = replacement.create_job('successor', origin='marionette', session_id='session-a')
+    replacement.save_task(Task(successor.id, 'worker', 'new work',
+        payload=stamp_task_payload({}, session_id='session-a', cwd=svc.cfg.repo)))
+    new_ref = replacement.job_ref(successor.id)
+    assert new_ref.state_id == body['selection']['job_ref']['state_id']
+    assert new_ref.incarnation != body['selection']['job_ref']['incarnation']
+    svc.get_session = lambda: SimpleNamespace(state=lambda: SimpleNamespace(store=replacement))
+    assert post_swarm_cancel(body, svc)[0] == 409
+    assert get_cancellation_receipt(query(body), svc)[0] == 409
+    assert replacement.get_cancellation_receipt(new_ref, body['request_id']) is None

--- a/tests/test_scoped_job_cancel.py
+++ b/tests/test_scoped_job_cancel.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
+from contextlib import closing
 
 import pytest
+from harness.api.scoped_cancellation import runtime_available
 from puppetmaster.cancellation import is_cancelled
 from puppetmaster.state import state_identity
 from tests.test_scoped_job_artifacts import stores
@@ -9,7 +11,7 @@ from harness.api import jobs
 
 def store_dump(store):
     import sqlite3
-    with sqlite3.connect(store.root / 'state.sqlite3') as connection:
+    with closing(sqlite3.connect(store.root / 'state.sqlite3')) as connection:
         return list(connection.iterdump())
 
 
@@ -18,6 +20,34 @@ def selection(qs, **changes):
     values.update(changes)
     return {'version': 1, 'job_ref': {'job_id': values.pop('job_id'),
             'state_id': values.pop('state_id')}, **values}
+
+
+@pytest.fixture
+def v2_stores(stores, monkeypatch):
+    if not runtime_available():
+        pytest.skip("requires exact PM cancellation contracts")
+    from puppetmaster.models import Task
+    from harness.job_scoping import job_label_for_session, stamp_task_payload
+
+    primary, cli, svc, qs = stores
+    # Keep the cross-store collision, using PM's generated-ID shape and ownership.
+    monkeypatch.setattr('puppetmaster.models.new_id', lambda prefix: prefix + '_0123456789ab')
+    for state in (primary, cli):
+        job = state.store.create_job('cancel test', label=job_label_for_session('session-a'),
+                                    origin='marionette', session_id='session-a')
+        state.store.save_task(Task(job_id=job.id, role='test', instruction='test',
+            payload=stamp_task_payload({}, session_id='session-a', cwd=svc.cfg.repo)))
+    return primary, cli, svc, {**qs, 'job_id': [job.id]}
+
+
+def v2_selection(qs, store, source='harness'):
+    from dataclasses import asdict
+    from puppetmaster.store_contracts import task_binding
+
+    jid = qs['job_id'][0]
+    return {**selection(qs, source=source), 'version': 2,
+            'job_ref': store.job_ref(jid).as_dict(),
+            'bindings': [asdict(task_binding(task)) for task in store.list_tasks(jid)]}
 
 
 @pytest.mark.parametrize('source', ['harness', 'cli'])
@@ -56,15 +86,23 @@ def test_missing_or_malformed_selection(stores, body):
     assert primary.store.get_job(qs['job_id'][0]).status == before
 
 
-@pytest.mark.parametrize('method', ['get_job', 'list_tasks'])
-def test_real_failure_is_503(stores, method):
-    primary, _, svc, qs = stores
+@pytest.mark.parametrize('method', ['list_job_summaries'])
+def test_real_failure_is_503(v2_stores, monkeypatch, method):
+    primary, cli, svc, qs = v2_stores
+    ref = v2_selection(qs, primary.store)
+    before = [store_dump(s.store) for s in (primary, cli)]
+    calls = []
     def fail(*args, **kwargs):
+        calls.append(kwargs)
         raise OSError('private store failure')
-    setattr(primary.store, method, fail)
-    code, result = jobs.post_swarm_cancel({'selection': selection(qs)}, svc)
+    # V2 ownership is read through bounded summaries, replacing legacy get_job.
+    monkeypatch.setattr(primary.store, method, fail)
+    code, result = jobs.post_swarm_cancel({'selection': ref, 'request_id': 'io-failure'}, svc)
+    assert len(calls) == 1
+    assert calls[0]['job_ref'].as_dict() == ref['job_ref']
     assert code == 503
     assert 'private' not in str(result)
+    assert [store_dump(s.store) for s in (primary, cli)] == before
     assert not is_cancelled(qs['job_id'][0])
 
 
@@ -86,10 +124,12 @@ def test_local_cancel_uses_only_captured_pilot(stores):
     cancelled = []
     pilot = SimpleNamespace(harness_session_id='session-a',
         get_local_job=lambda jid: {'id': jid, 'session_id': 'session-a', 'cwd': svc.cfg.repo},
-        cancel_local_job=lambda jid: cancelled.append(jid) or True)
+        cancel_local_job=lambda jid, **kwargs: cancelled.append(jid) or True,
+        _local_metadata=SimpleNamespace(incarnation="local-incarnation"))
     svc.get_pilot = lambda: pilot
     svc.get_session = lambda: pytest.fail('local selection must not open a durable session')
-    ref = selection(qs, source='local', job_id='local-test', state_id=None)
+    ref = {**selection(qs, source='local', job_id='local-test', state_id=None),
+           'local_incarnation': 'local-incarnation'}
     assert jobs.post_swarm_cancel({'selection': ref}, svc)[0] == 200
     assert cancelled == ['local-test']
     assert not is_cancelled('local-test')
@@ -119,6 +159,38 @@ def test_live_rows_expose_actual_store_refs(stores):
     ]
 
 
+@pytest.mark.parametrize('source', ['harness', 'cli'])
+def test_v2_store_refs_expose_complete_bindings_and_cancel_only_selected(v2_stores, source):
+    from harness.api.scoped_cancellation import cancellation_view
+
+    primary, cli, svc, qs = v2_stores
+    chosen, other = (primary, cli) if source == 'harness' else (cli, primary)
+    jid = qs['job_id'][0]
+    ref = chosen.store.job_ref(jid)
+    selection_v2 = v2_selection(qs, chosen.store, source)
+    assert ref.as_dict() == {'job_id': jid, 'state_id': state_identity(chosen.store.root),
+                             'version': 2, 'incarnation': chosen.store.incarnation}
+    assert ref != other.store.job_ref(jid)
+    tasks = [{'id': b['task_id'], 'binding': b} for b in selection_v2['bindings']]
+    assert tasks
+    before = [store_dump(s.store) for s in (chosen, other)]
+    view = cancellation_view(chosen.store, ref, tasks)
+    assert view['status'] == 'complete', view
+    assert view['bindings'] == [t['binding'] for t in tasks]
+    assert [store_dump(s.store) for s in (chosen, other)] == before
+    wrong = {**selection_v2, 'job_ref': other.store.job_ref(jid).as_dict()}
+    assert jobs.post_swarm_cancel({'selection': wrong, 'request_id': 'wrong-store'}, svc)[0] == 409
+    assert [store_dump(s.store) for s in (chosen, other)] == before
+    code, result = jobs.post_swarm_cancel({'selection': selection_v2, 'request_id': 'v2-cancel'}, svc)
+    assert code == 200
+    assert result['receipt']['outcome'] == 'requested'
+    assert result['receipt']['job_ref'] == ref.as_dict()
+    assert result['receipt']['bindings'] == tuple(view['bindings'])
+    assert chosen.store.get_cancellation_receipt(ref, 'v2-cancel') is not None
+    assert store_dump(other.store) == before[1]
+    assert not is_cancelled(jid)
+
+
 def test_legacy_unique_primary_refuses_running_worker(stores, monkeypatch):
     primary, _, svc, qs = stores
     monkeypatch.setattr('harness.cli_job_merge.resolve_cli_state_dir', lambda _: None)
@@ -129,15 +201,16 @@ def test_legacy_unique_primary_refuses_running_worker(stores, monkeypatch):
     assert not is_cancelled(jid)
 
 
-def test_legacy_local_can_cancel_without_touching_global_flag(stores):
+def test_legacy_local_refuses_without_touching_global_flag(stores):
     _, _, svc, qs = stores
     cancelled = []
     pilot = SimpleNamespace(harness_session_id='session-a',
         get_local_job=lambda jid: {'id': jid, 'session_id': 'session-a', 'cwd': svc.cfg.repo},
-        cancel_local_job=lambda jid: cancelled.append(jid) or True)
+        cancel_local_job=lambda jid, **kwargs: cancelled.append(jid) or True,
+        _local_metadata=SimpleNamespace(incarnation="local-incarnation"))
     svc.get_pilot = lambda: pilot
-    assert jobs.post_swarm_cancel({'job_id': 'local-test'}, svc)[0] == 200
-    assert cancelled == ['local-test']
+    assert jobs.post_swarm_cancel({'job_id': 'local-test'}, svc)[0] == 409
+    assert cancelled == []
     assert not is_cancelled('local-test')
 
 
@@ -148,8 +221,8 @@ def test_terminal_row_is_not_rewritten(stores, status):
     primary.store.update_job_status(jid, status)
     before = primary.store.get_job(jid)
     code, result = jobs.post_swarm_cancel({'selection': selection(qs)}, svc)
-    assert code == 200
-    assert result['marked'] is False
+    assert code == 409
+    assert result['code'] == 'scoped_kernel_cancellation_required'
     assert primary.store.get_job(jid) == before
 
 
@@ -159,7 +232,7 @@ def test_refusal_does_not_write_cli_records(stores, field, value):
     import sqlite3
     _, cli, svc, qs = stores
     def dump():
-        with sqlite3.connect(cli.store.root / 'state.sqlite3') as connection:
+        with closing(sqlite3.connect(cli.store.root / 'state.sqlite3')) as connection:
             return list(connection.iterdump())
     before = dump()
     ref = selection(qs, source='cli', state_id=state_identity(cli.store.root))
@@ -171,15 +244,20 @@ def test_refusal_does_not_write_cli_records(stores, field, value):
     assert dump() == before
 
 
-def test_cli_attach_failure_is_503(stores, monkeypatch):
-    _, cli, svc, qs = stores
+def test_cli_attach_failure_is_503(v2_stores, monkeypatch):
+    primary, cli, svc, qs = v2_stores
+    ref = v2_selection(qs, cli.store, 'cli')
+    before = [store_dump(s.store) for s in (primary, cli)]
+    calls = []
     def fail(*args, **kwargs):
+        calls.append((args, kwargs))
         raise OSError('private attach detail')
     monkeypatch.setattr('puppetmaster.store_factory.create_store', fail)
-    ref = selection(qs, source='cli', state_id=state_identity(cli.store.root))
-    code, result = jobs.post_swarm_cancel({'selection': ref}, svc)
+    code, result = jobs.post_swarm_cancel({'selection': ref, 'request_id': 'attach-failure'}, svc)
+    assert calls == [(('sqlite', str(cli.store.root)), {'mode': 'attach'})]
     assert code == 503
     assert 'private' not in str(result)
+    assert [store_dump(s.store) for s in (primary, cli)] == before
     assert not is_cancelled(qs['job_id'][0])
 
 
@@ -203,7 +281,9 @@ def test_local_real_event_and_record_are_scoped(stores, tmp_path):
                               'status': 'running'} for jid in ('local-selected', 'local-other')}
     pilot._local_job_cancels = {jid: threading.Event() for jid in pilot._local_jobs}
     svc.get_pilot = lambda: pilot
-    ref = selection(qs, source='local', job_id='local-selected', state_id=None)
+    pilot._initialize_local_metadata_locked()
+    ref = {**selection(qs, source='local', job_id='local-selected', state_id=None),
+           'local_incarnation': pilot.local_metadata_handle().incarnation}
     assert jobs.post_swarm_cancel({'selection': ref}, svc)[0] == 200
     assert pilot._local_job_cancels['local-selected'].is_set()
     assert not pilot._local_job_cancels['local-other'].is_set()
@@ -218,7 +298,7 @@ def test_refusal_on_fresh_harness_reader_does_not_initialize_store(stores):
     primary, _, svc, qs = stores
     root = primary.store.root
     def dump():
-        with sqlite3.connect(root / 'state.sqlite3') as connection:
+        with closing(sqlite3.connect(root / 'state.sqlite3')) as connection:
             return list(connection.iterdump())
     before = dump()
     primary.store = create_store('sqlite', root)
@@ -240,6 +320,6 @@ def test_task_authority_refusal_preserves_exact_stores(stores, source, field, va
     ref = selection(qs, source=source, state_id=state_identity(chosen.store.root))
     code, body = jobs.post_swarm_cancel({'selection': ref}, svc)
     assert code == 409
-    assert body['code'] == 'job_cancel_unavailable'
+    assert body['code'] == 'scoped_kernel_cancellation_required'
     assert [store_dump(s.store) for s in (primary, cli)] == before
     assert is_cancelled(jid) == flag_before


### PR DESCRIPTION
Publish native job observations when jobs load or change, so metadata lists read finite scalar pages instead of execution bodies. Selected views expose the chosen task, route, context, and receipt facts with explicit cost knowledge and a process incarnation.

Cancellation now requires an exact selection. PM requests carry the job incarnation, task generation/lease bindings, and retained request ID; ambiguous outcomes reconcile through the receipt endpoint. Native requests compare the captured incarnation under the job lock before setting the event. Legacy ID-only cancellation is refused, and provider job IDs cannot be reused within an observation incarnation.

Review `local_job_metadata.py` and the small `local_jobs.py` producer changes first, then `api/scoped_cancellation.py` and `api/jobs.py` for authorization and receipt handling. The shared raw-query helper matches #334. Metadata hosting depends on service #334; the corresponding client is #333. Transport is #332. Public package/version pins remain unchanged.

Validation: 176 focused composition checks passed against the four exact service modules and local Puppetmaster development commit `057a786b0e53302ceff0a271b8af73d86864c664`. This includes a real supervised subprocess reaching `observed_stop`, stale bindings, conflicting replay, cross-store ID collisions, recreated-store incarnations, finite native reads, and cursor expiry. Final boundary checks passed 43 tests on the candidate. Actual public PM 1.23 passed 40 checks; four v2-only fixture cases were skipped because the required API is absent. Existing refusal/native cases remain active. `git diff --check` passed.

Native cancellation remains cooperative and does not add child-wave propagation or a native receipt ledger. The retained receipt reconciliation in this PR is the PM contract; requested cancellation is not reported as confirmed cleanup.
