### PR TITLE
Prepare Marionette 0.9.428 for the Puppetmaster 1.25 pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.25.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.427, deliberately pre-1.0. Session selection uses one compact, full-width grey bar; session and Jobs titles share a smaller scale than chat text. Pins puppetmaster-ai==1.25.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
+> Status: v0.9.428, deliberately pre-1.0. Session selection uses one compact, full-width grey bar; session and Jobs titles share a smaller scale than chat text. Pins puppetmaster-ai==1.25.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.427"
+__version__ = "0.9.428"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.427"
+version = "0.9.428"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_job_evidence.py
+++ b/tests/test_job_evidence.py
@@ -276,12 +276,17 @@ def test_wheel_terminal_report_selects_one_usage_record_per_task(tmp_path):
     from puppetmaster.cost import build_current_registry_cost_report, PRICING_SOURCE_TERMINAL
     from puppetmaster.models import JobStatus
     store, job, task, _, _ = setup_job(tmp_path)
+    store.save_artifact(Artifact(job_id=job.id, task_id=task.id, type=ArtifactType.VERIFICATION,
+        created_by='orchestrator', payload={'check': 'execution_billing', 'result': 'pinned', 'billing': 'api'},
+        confidence=1, evidence=['fixture']))
     for result, cost in [('failed', 7), ('success', 3)]:
         store.save_artifact(Artifact(job_id=job.id, task_id=task.id, type=ArtifactType.VERIFICATION,
             created_by='worker', payload={'check': 'execution', 'result': result, 'tokens_in': 10, 'tokens_out': 2,
                 'tokens_estimated': False, 'real_cost_usd': cost}, confidence=1, evidence=['fixture']))
     receipt = build_current_registry_cost_report(job.id, store.list_artifacts(job.id), registry=[])
     assert receipt['actual_cost']['total_marginal_cost_usd'] == 3
+    assert receipt['actual_cost']['priced_tasks'] == 1
+    assert receipt['actual_cost']['unpriced_tasks'] == 0
     receipt['pricing_source'] = PRICING_SOURCE_TERMINAL
     data = project_job_evidence(store, replace(job, status=JobStatus.COMPLETE, cost_receipt=receipt), [task])
     assert data['cost']['selected_usd'] == 3
@@ -356,12 +361,12 @@ def test_consumption_bases_tokens_and_single_ledger_reads(tmp_path, backend, mon
 
 
 @pytest.mark.parametrize('backend', ['file', 'sqlite'])
-def test_public_observation_validation_and_overflow(tmp_path, backend):
+def test_public_observation_validation_and_overflow(tmp_path, backend, monkeypatch):
     store = create_store(backend, tmp_path / backend)
     job = store.create_job('private')
     task = Task(job_id=job.id, role='test', instruction='private')
     store.save_task(task)
-    for invalid in (float('nan'), float('inf'), -1, True, '3'):
+    for invalid in (float('nan'), float('inf'), 1e308, -1, True, '3'):
         with pytest.raises(ValueError):
             UsageObservation(job.id, 'attempt', 'event', 'provider', 'today',
                 cost_state='measured', cost_usd=invalid, cost_basis='api')
@@ -372,7 +377,14 @@ def test_public_observation_validation_and_overflow(tmp_path, backend):
         name = str(index)
         store.record_attempt(ExecutionAttempt(job.id, task.id, name, name, 'today', 'local'))
         store.record_usage_observation(UsageObservation(job.id, name, 'event', 'provider', 'today',
-            cost_state='measured', cost_usd=1e308, cost_basis='api'))
+            cost_state='measured', cost_usd=1, cost_basis='api'))
+    from puppetmaster.consumption import build_attempt_consumption_report
+    report = build_attempt_consumption_report(store, job.id)
+    # Exercise the consumer's nonfinite guard at the report boundary; public
+    # observations reject out-of-range values before persistence.
+    overflow = replace(report.totals.api_cost_usd, total=float('inf'), known_subtotal=float('inf'))
+    report = replace(report, totals=replace(report.totals, api_cost_usd=overflow))
+    monkeypatch.setattr('harness.job_evidence.build_attempt_consumption_report', lambda *_: report)
     data = project_job_evidence(store, job, [task])
     metric = data['cost']['recorded_attempts']['api_cost_usd']
     assert metric['total'] is None and metric['known_subtotal'] is None

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.427"
+version = "0.9.428"
 source = { editable = "." }
 dependencies = [
     { name = "puppetmaster-ai" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.427",
+  "version": "0.9.428",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.427",
+      "version": "0.9.428",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.427",
+  "version": "0.9.428",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Prepare Marionette 0.9.428 with the published Puppetmaster 1.25.0 dependency already merged in #336. Align application versions and lockfiles, and update evidence fixtures for 1.25's explicit billing provenance and bounded observation validation.

Local validation: 2,010 frontend tests, 308 Electron tests and the production build passed. The backend release run passed 7,103 tests and identified three outdated evidence fixtures; after correcting those fixtures, all 50 evidence/version/release-gate tests passed. The dev-to-main PR will run the required release CI before tagging.
