### PR TITLE
Release v0.9.428

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.23.0
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.25.0
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.23.0"
+          pip install -e ".[dev]" "puppetmaster-ai==1.25.0"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.23.0"
+          pip install -e ".[dev]" "puppetmaster-ai==1.25.0"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -57,7 +57,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.23.0"
+          pip install -e ".[dev]" "puppetmaster-ai==1.25.0"
 
       - name: Run the offline test suite (shard)
         env:
@@ -103,7 +103,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.23.0"
+          pip install -e ".[dev]" "puppetmaster-ai==1.25.0"
 
       - name: Run offline pmharness/intent/registry units
         run: python -m pytest -q -p no:cacheprovider tests/test_intent.py tests/test_registry.py tests/test_registry_wizard.py tests/test_pilot_driver_templates.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.23.0"
+uv pip install --python .venv -e . "puppetmaster-ai==1.25.0"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.23.0` (desktop
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.25.0` (desktop
    bootstrap, install/doctor, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.23.0` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.25.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.427, deliberately pre-1.0. Session selection uses one compact, full-width grey bar; session and Jobs titles share a smaller scale than chat text. Pins puppetmaster-ai==1.23.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
+> Status: v0.9.427, deliberately pre-1.0. Session selection uses one compact, full-width grey bar; session and Jobs titles share a smaller scale than chat text. Pins puppetmaster-ai==1.25.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | `run_swarm`, `run_implement`, and `run_parallel` run bounded workers as durable jobs. Inspect recorded attempts, acceptance evidence, uncertain outcomes, and measured or estimated consumption. Marionette pins `puppetmaster-ai==1.23.0`; the installer and self-update use the same version. |
+| **Puppetmaster delegation** | `run_swarm`, `run_implement`, and `run_parallel` run bounded workers as durable jobs. Inspect recorded attempts, acceptance evidence, uncertain outcomes, and measured or estimated consumption. Marionette pins `puppetmaster-ai==1.25.0`; the installer and self-update use the same version. |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Durable memory graph** | Local durable facts/preferences (`MemoryStore`) plus optional relations via `MemoryGraph` (`GET /api/memory/graph`, shape `{nodes,edges}` like the wiki graph; sqlite + append-only jsonl). |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.25.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.427, deliberately pre-1.0. Session selection uses one compact, full-width grey bar; session and Jobs titles share a smaller scale than chat text. Pins puppetmaster-ai==1.25.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
+> Status: v0.9.428, deliberately pre-1.0. Session selection uses one compact, full-width grey bar; session and Jobs titles share a smaller scale than chat text. Pins puppetmaster-ai==1.25.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.427"
+__version__ = "0.9.428"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/diag_bundle.py
+++ b/harness/diag_bundle.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 DEFAULT_SESSION_LIMIT = 20
-PIN_FALLBACK = "puppetmaster-ai==1.23.0"
+PIN_FALLBACK = "puppetmaster-ai==1.25.0"
 _PIN_RE = re.compile(r"puppetmaster-ai==[0-9]+(?:\.[0-9]+)*")
 _SECRET_KEY_FRAGMENTS = (
     "api_key",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.427"
+version = "0.9.428"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "pypdf",
     # Runtime ownership: a standalone `pip install pm-harness` must pull the
     # pinned Puppetmaster bridge. Desktop/Electron still re-checks the same pin.
-    "puppetmaster-ai==1.23.0",
+    "puppetmaster-ai==1.25.0",
     "tzdata>=2026.3",
 ]
 

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.23.0" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.25.0" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.23.0"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.25.0"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.23.0" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.25.0" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.23.0}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.25.0}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/tests/test_job_evidence.py
+++ b/tests/test_job_evidence.py
@@ -276,12 +276,17 @@ def test_wheel_terminal_report_selects_one_usage_record_per_task(tmp_path):
     from puppetmaster.cost import build_current_registry_cost_report, PRICING_SOURCE_TERMINAL
     from puppetmaster.models import JobStatus
     store, job, task, _, _ = setup_job(tmp_path)
+    store.save_artifact(Artifact(job_id=job.id, task_id=task.id, type=ArtifactType.VERIFICATION,
+        created_by='orchestrator', payload={'check': 'execution_billing', 'result': 'pinned', 'billing': 'api'},
+        confidence=1, evidence=['fixture']))
     for result, cost in [('failed', 7), ('success', 3)]:
         store.save_artifact(Artifact(job_id=job.id, task_id=task.id, type=ArtifactType.VERIFICATION,
             created_by='worker', payload={'check': 'execution', 'result': result, 'tokens_in': 10, 'tokens_out': 2,
                 'tokens_estimated': False, 'real_cost_usd': cost}, confidence=1, evidence=['fixture']))
     receipt = build_current_registry_cost_report(job.id, store.list_artifacts(job.id), registry=[])
     assert receipt['actual_cost']['total_marginal_cost_usd'] == 3
+    assert receipt['actual_cost']['priced_tasks'] == 1
+    assert receipt['actual_cost']['unpriced_tasks'] == 0
     receipt['pricing_source'] = PRICING_SOURCE_TERMINAL
     data = project_job_evidence(store, replace(job, status=JobStatus.COMPLETE, cost_receipt=receipt), [task])
     assert data['cost']['selected_usd'] == 3
@@ -356,12 +361,12 @@ def test_consumption_bases_tokens_and_single_ledger_reads(tmp_path, backend, mon
 
 
 @pytest.mark.parametrize('backend', ['file', 'sqlite'])
-def test_public_observation_validation_and_overflow(tmp_path, backend):
+def test_public_observation_validation_and_overflow(tmp_path, backend, monkeypatch):
     store = create_store(backend, tmp_path / backend)
     job = store.create_job('private')
     task = Task(job_id=job.id, role='test', instruction='private')
     store.save_task(task)
-    for invalid in (float('nan'), float('inf'), -1, True, '3'):
+    for invalid in (float('nan'), float('inf'), 1e308, -1, True, '3'):
         with pytest.raises(ValueError):
             UsageObservation(job.id, 'attempt', 'event', 'provider', 'today',
                 cost_state='measured', cost_usd=invalid, cost_basis='api')
@@ -372,7 +377,14 @@ def test_public_observation_validation_and_overflow(tmp_path, backend):
         name = str(index)
         store.record_attempt(ExecutionAttempt(job.id, task.id, name, name, 'today', 'local'))
         store.record_usage_observation(UsageObservation(job.id, name, 'event', 'provider', 'today',
-            cost_state='measured', cost_usd=1e308, cost_basis='api'))
+            cost_state='measured', cost_usd=1, cost_basis='api'))
+    from puppetmaster.consumption import build_attempt_consumption_report
+    report = build_attempt_consumption_report(store, job.id)
+    # Exercise the consumer's nonfinite guard at the report boundary; public
+    # observations reject out-of-range values before persistence.
+    overflow = replace(report.totals.api_cost_usd, total=float('inf'), known_subtotal=float('inf'))
+    report = replace(report, totals=replace(report.totals, api_cost_usd=overflow))
+    monkeypatch.setattr('harness.job_evidence.build_attempt_consumption_report', lambda *_: report)
     data = project_job_evidence(store, job, [task])
     metric = data['cost']['recorded_attempts']['api_cost_usd']
     assert metric['total'] is None and metric['known_subtotal'] is None

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -72,3 +72,22 @@ def test_pyproject_declares_pinned_puppetmaster_runtime_dependency():
         "(standalone install ownership)"
     )
     assert pin.group(1), "empty Puppetmaster pin"
+
+
+def test_puppetmaster_install_and_packaging_pins_match():
+    expected = re.search(
+        r'"(puppetmaster-ai==\d+\.\d+\.\d+)"',
+        (ROOT / "pyproject.toml").read_text(),
+    ).group(1)
+    paths = (
+        "scripts/install.sh", "scripts/install.ps1",
+        "scripts/doctor.sh", "scripts/doctor.ps1",
+        "webapp/electron/bootstrap.cjs", "webapp/electron/update-pm.cjs",
+        "harness/diag_bundle.py",
+        ".github/workflows/tests.yml", ".github/workflows/tests-full.yml",
+        ".github/workflows/release.yml", "README.md", "CONTRIBUTING.md",
+    )
+    for path in paths:
+        pins = re.findall(r"puppetmaster-ai==\d+\.\d+\.\d+", (ROOT / path).read_text())
+        assert pins, f"{path} has no Puppetmaster pin"
+        assert set(pins) == {expected}, f"{path}: {pins} differs from {expected}"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.427"
+version = "0.9.428"
 source = { editable = "." }
 dependencies = [
     { name = "puppetmaster-ai" },

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.422"
+version = "0.9.427"
 source = { editable = "." }
 dependencies = [
     { name = "puppetmaster-ai" },
@@ -97,7 +97,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "puppetmaster-ai", specifier = "==1.23.0" },
+    { name = "puppetmaster-ai", specifier = "==1.25.0" },
     { name = "pypdf" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
@@ -107,11 +107,11 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "puppetmaster-ai"
-version = "1.23.0"
+version = "1.25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0e/ba/b67fdbf17ccef44bb3b6200f4eb31080e731738ecbd9c39dda9cbd26be17/puppetmaster_ai-1.23.0.tar.gz", hash = "sha256:2e38cf02f906785ac17a16cfafd2aa3162371650c81803a4a5be1b0a5ef0c099", size = 1467981, upload-time = "2026-09-06T11:01:50.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/26/c1b1ff97929db7e694244b22831431f1b5e50339b99f075f13760e72cfda/puppetmaster_ai-1.25.0.tar.gz", hash = "sha256:944ed3921731a2393601baa193007c7b8728a199229a84152f391041874f9dd9", size = 1935726, upload-time = "2026-09-08T04:50:40.615Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/14/d567be6e43c585b5e57164417e23fd6fd79a5fae2d0758683b287927d897/puppetmaster_ai-1.23.0-py3-none-any.whl", hash = "sha256:c3d63a55a8394a502dc01db0f4fddb117a6f0ad8b2e5702ef6a93d560721bfbd", size = 994382, upload-time = "2026-09-06T11:01:48.671Z" },
+    { url = "https://files.pythonhosted.org/packages/72/42/322b8321e0d7f56ed34b714d597004ae8819d7ef75f79d5c00e797906e5c/puppetmaster_ai-1.25.0-py3-none-any.whl", hash = "sha256:c9b69367c6effc370f1958236664f6a51d58996dc13cc9f582fb30484a380c51", size = 1064692, upload-time = "2026-09-08T04:50:38.466Z" },
 ]
 
 [[package]]

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -90,7 +90,7 @@ function installIdentity(dir, target) {
   return { schema: 1, mode: target.mode, repo: target.repo,
     revision: gitValue(dir, ["rev-parse", "HEAD"]), inputs: hash.digest("hex"),
     platform: process.platform, arch: process.arch,
-    puppetmaster: process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.23.0" };
+    puppetmaster: process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.25.0" };
 }
 
 function venvPython(dir) {
@@ -378,7 +378,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.23.0";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.25.0";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.23.0";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.25.0";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 const HARNESS_DIST_NAME = "pm-harness";
 
@@ -95,7 +95,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.23.0" }    -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.25.0" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.427",
+  "version": "0.9.428",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.427",
+      "version": "0.9.428",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.427",
+  "version": "0.9.428",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release Marionette 0.9.428 with Puppetmaster 1.25.0 pinned consistently across package installation, lockfiles, desktop bootstrap and updates, doctor scripts, and CI. Evidence fixtures now supply explicit billing provenance and exercise the 1.25 observation bounds at the consumer boundary.

Local validation passed 2,010 frontend tests, 308 Electron tests, the production build, version consistency and lockfile checks. The backend run passed 7,103 tests; its three outdated 1.25 fixtures were corrected and all 50 evidence/version/release-gate checks then passed. The required release CI on this PR must pass before main is merged or the version is tagged.
