### PR TITLE
Release v0.9.430

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.25.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.429, deliberately pre-1.0. Restores expert Swarm Tracker facts on Puppetmaster 1.25 bounded metadata. Pins puppetmaster-ai==1.25.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
+> Status: v0.9.430, deliberately pre-1.0. Restores Swarm Tracker card chrome (Session/Repo/All, All statuses) on Puppetmaster 1.25 bounded metadata. Removes Settings Driver (Model). Pins enabled Models to the top of each provider list. Pins puppetmaster-ai==1.25.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.429"
+__version__ = "0.9.430"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.429"
+version = "0.9.430"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.429",
+  "version": "0.9.430",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.429",
+      "version": "0.9.430",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.429",
+  "version": "0.9.430",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/ModelsSettingsPage.cache.test.tsx
+++ b/webapp/src/__tests__/ModelsSettingsPage.cache.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import ModelsSettingsPage, { clearCatalogSnapshot } from "../components/ModelsSettingsPage";
+import ModelsSettingsPage, { clearCatalogSnapshot, orderModelsEnabledFirst } from "../components/ModelsSettingsPage";
 import { api, type ModelCatalogEntry } from "../lib/api";
 
 vi.mock("../lib/api", () => ({
@@ -242,5 +242,22 @@ describe("ModelsSettingsPage cached first paint", () => {
     expect(screen.getByText("MiMo-V2.5 Free")).toBeInTheDocument();
     expect(screen.queryByText("Ox Alpha Free")).toBeNull();
     expect(screen.queryByText("Big Pickle")).toBeNull();
+  });
+
+  it("pins enabled models above disabled siblings", async () => {
+    const mixed: ModelCatalogEntry[] = [
+      { spec: "openrouter:off-a", model: "off-a", name: "Off A", provider: "openrouter", provider_display: "OpenRouter", available: true, enabled: false },
+      { spec: "openrouter:on-b", model: "on-b", name: "On B", provider: "openrouter", provider_display: "OpenRouter", available: true, enabled: true },
+      { spec: "openrouter:off-c", model: "off-c", name: "Off C", provider: "openrouter", provider_display: "OpenRouter", available: true, enabled: false },
+      { spec: "openrouter:on-a", model: "on-a", name: "On A", provider: "openrouter", provider_display: "OpenRouter", available: true, enabled: true },
+    ];
+    expect(orderModelsEnabledFirst(mixed).map((row) => row.model)).toEqual(["on-a", "on-b", "off-a", "off-c"]);
+    mockModelCatalog.mockResolvedValue({ catalog: mixed, all: mixed, enabled: mixed.filter((row) => row.enabled) });
+    render(<ModelsSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("On A")).toBeInTheDocument();
+    });
+    const labels = screen.getAllByText(/^(On A|On B|Off A|Off C)$/).map((node) => node.textContent);
+    expect(labels).toEqual(["On A", "On B", "Off A", "Off C"]);
   });
 });

--- a/webapp/src/__tests__/SettingsPane.cache.test.tsx
+++ b/webapp/src/__tests__/SettingsPane.cache.test.tsx
@@ -65,7 +65,7 @@ describe("SettingsPane cached first paint", () => {
     render(<SettingsPane onOpenWizard={vi.fn()} section="general" />);
 
     expect(screen.queryByText("Loading settings...")).toBeNull();
-    expect(screen.getByText("Driver (Model)")).toBeInTheDocument();
+    expect(screen.getByText("Budget (Steps)")).toBeInTheDocument();
   });
 
   it("shows loading gate only when no snapshot exists", async () => {
@@ -94,7 +94,7 @@ describe("SettingsPane cached first paint", () => {
     });
 
     expect(screen.queryByText("Failed to load settings")).toBeNull();
-    expect(screen.getByText("Driver (Model)")).toBeInTheDocument();
+    expect(screen.getByText("Budget (Steps)")).toBeInTheDocument();
   });
 });
 

--- a/webapp/src/__tests__/SwarmPane.controls.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.controls.test.tsx
@@ -203,6 +203,7 @@ it.each(['legacy reference', 'cross project', 'foreign session', 'mismatched sel
       ...expertDetail(row.selection, f.context()), selection: { ...row.selection, job_ref: { ...row.selection.job_ref, job_id: 'different' } },
     }));
     render(<f.Provider><SwarmPane /></f.Provider>);
+    if (mode === 'foreign session') fireEvent.click(screen.getByRole('button', { name: 'All projects' }));
     const cancel = await inspectControl('Inspect A');
     expect(cancel).toHaveAttribute('aria-disabled', 'true');
     fireEvent.click(cancel);

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -1881,7 +1881,7 @@ describe("SwarmPane session scope before a project event", () => {
     if (!active) throw Error('Missing backend active session');
     row.selection.session_id = active.id;
     const metadata = await renderScopePrivacy(row);
-    fireEvent.change(screen.getByRole('combobox', { name: 'Filter swarms' }), { target: { value: 'session' } });
+    fireEvent.click(screen.getByRole('button', { name: 'This session' }));
     expect(await screen.findByRole('button', { name: /Running before project event.*running/ })).toBeVisible();
     expect(metadata.store.getSnapshot().view).toMatchObject({ context: { session_id: active.id } });
     expect(api.sessions).toHaveBeenCalledWith(undefined);
@@ -1992,6 +1992,7 @@ describe("SwarmPane does not paint unowned CLI captions", () => {
     });
     await act(async () => { await metadata.store.readView(); });
     expect(metadata.store.getSnapshot().view).toMatchObject({ view: { sources: [expect.objectContaining({ cross_project: true })] } });
+    fireEvent.click(screen.getByRole('button', { name: 'All projects' }));
     await expandJob(/Foreign swarm/);
     expect(screen.queryByTitle('/Users/x/other-repo')).toBeNull();
     expect(screen.queryByText('visibility only')).toBeNull();

--- a/webapp/src/__tests__/metadataOperatorPreferences.test.tsx
+++ b/webapp/src/__tests__/metadataOperatorPreferences.test.tsx
@@ -81,9 +81,10 @@ it('drops dismissal on observed live reappearance so later completion stays visi
 it('hides finished only within the shown session filter', async () => {
   pm.push({ ...summary(2), lifecycle: 'failed', ownership: { ...summary(2).ownership, session_id: 'other' } });
   await start(); mount();
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'session' } });
+  fireEvent.click(screen.getByRole('button', { name: 'All projects' }));
+  fireEvent.click(screen.getByRole('button', { name: 'This session' }));
   fireEvent.click(screen.getByRole('button', { name: 'Hide finished' }));
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'all' } });
+  fireEvent.click(screen.getByRole('button', { name: 'All projects' }));
   expect(row('job_2').getByRole('button', { name: /failed/ })).toBeVisible();
   expect(preference().dismissed).toEqual([metadataSelectionKey(selection())]);
 });
@@ -179,7 +180,7 @@ it('renders accounting ownership separately from exclusion without asserting tot
   expect(screen.queryByText(/Not included in totals/)).toBeNull();
 });
 
-it.each(['repo', 'attention', 'active'])('keeps Hide finished within the %s filter', async filter => {
+it.each(['attention', 'active'])('keeps Hide finished within the %s filter', async filter => {
   pm = [{ ...summary(), lifecycle: 'failed' }, { ...summary(2), lifecycle: 'complete', selection: { ...selection(2), source: 'cli', job_ref: { job_id: 'job_2', state_id: 'store-B' } } }];
   await start();
   pinned = [pm[1]]; store.setPendingSelections(pinned.map(r => r.selection), []); await store.refreshPins();
@@ -189,6 +190,17 @@ it.each(['repo', 'attention', 'active'])('keeps Hide finished within the %s filt
   fireEvent.change(screen.getByRole('combobox'), { target: { value: 'all' } });
   expect(row('job_2', 'cli').getByRole('button', { name: /^PM CLI job/ })).toBeVisible();
   expect(preference().dismissed).toHaveLength(filter === 'active' ? 0 : 1);
+});
+it('keeps Hide finished within the repo filter', async () => {
+  pm = [{ ...summary(), lifecycle: 'failed' }, { ...summary(2), lifecycle: 'complete', selection: { ...selection(2), source: 'cli', job_ref: { job_id: 'job_2', state_id: 'store-B' } } }];
+  await start();
+  pinned = [pm[1]]; store.setPendingSelections(pinned.map(r => r.selection), []); await store.refreshPins();
+  mount();
+  fireEvent.click(screen.getByRole('button', { name: 'This repo' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Hide finished' }));
+  fireEvent.click(screen.getByRole('button', { name: 'All projects' }));
+  expect(row('job_2', 'cli').getByRole('button', { name: /^PM CLI job/ })).toBeVisible();
+  expect(preference().dismissed).toHaveLength(1);
 });
 it.each(['session', 'repo'])('isolates persisted preferences after a %s switch and restores the original scope', async scope => {
   native = [{ ...nativeSummary(1), lifecycle: 'completed' }];

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -9,40 +9,43 @@ import MetadataExpertPanels from './MetadataExpertPanels';
 import { navigationMatches, peekPendingSwarmNavigation, queuePendingSwarmNavigation, swarmNavigationTarget, takePendingSwarmNavigation } from '../lib/pendingSwarmOpenJob';
 import type { SwarmNavigationTarget } from '../lib/pendingSwarmOpenJob';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { CheckCircle2, ChevronDown, ChevronRight, Loader2, Network, RefreshCw } from 'lucide-react';
 import { selectNativeMetadataControl } from '../lib/jobControl';
 import { api } from '../lib/api';
 import { jobArtifactKey, selectJobRef } from '../lib/jobArtifacts';
 import type { Job } from '../lib/api';
+import { filterJobsByScope, JOB_SCOPE_CHANGED_EVENT, loadJobScope, saveJobScope, type JobScope } from '../lib/jobScope';
 import { useSharedJobMetadata, metadataActivity, metadataJobs, currentExpert, currentHeader } from '../lib/jobMetadataContext';
 import { metadataSelectionKey, metadataStreamKey, pmActiveStatuses } from '../lib/jobMetadata';
 import { localKey, nativeActiveStatuses, nativeAttentionStatuses } from '../lib/localJobMetadata';
 import type { LocalDetail, LocalSummary } from '../lib/localJobMetadata';
 import JobCancellationControl from './JobCancellationControl';
 
-const button = 'min-h-11 px-2 text-sm text-muted hover:text-txt focus-visible:outline focus-visible:outline-accent disabled:opacity-50';
+const button = 'px-1.5 py-0.5 text-[10.5px] text-muted hover:text-txt focus-visible:outline focus-visible:outline-accent disabled:opacity-50';
+const compactSelect = 'w-full h-6 rounded border border-edge bg-panel2/40 px-1.5 text-[10px] text-muted focus:outline-none focus:border-accent/60';
 export function MetadataStatus() {
   const { store, state } = useSharedJobMetadata();
   const activity = metadataActivity(state);
   const [now, setNow] = useState(Date.now);
   useEffect(() => { const clock = setInterval(() => { if (!document.hidden) setNow(Date.now()); }, 10000); return () => clearInterval(clock); }, []);
   const times = [...Object.values(state.observedAt), ...(state.local.observedAt === null ? [] : [state.local.observedAt]), ...(state.localActive.observedAt === null ? [] : [state.localActive.observedAt])];
-  const running = metadataJobs(state).filter(job => !job.local_ref && job.read_status !== 'unavailable' && job.status === 'running').length;
   const oldest = times.length ? Math.max(0, Math.floor((now - Math.min(...times)) / 1000)) : null;
-  return <div className="px-2 py-1 text-xs text-muted">
-    {running > 0 && <div className="flex items-center gap-2"><span title={`${running} running`} className="h-2 w-2 rounded-full bg-accent animate-pulse" /><span><MetadataActivityIndicator /> {running} running</span><span>observed PM jobs; coverage incomplete</span></div>}
-    <p role="status">{activity.label}{oldest === null ? '' : ` · Oldest observation ${oldest}s ago`}</p>
+  return <div className="px-2 py-1 text-[10px] text-muted">
     {state.error && <p role="alert">Job updates unavailable ({state.error.replaceAll('_', ' ')}). Retained observations may be stale.</p>}
+    <p role="status" className={activity.count > 0 ? "text-[10px] text-accent" : "sr-only"}>{activity.label}{oldest === null ? '' : ` · Oldest observation ${oldest}s ago`}</p>
     <div className="flex flex-wrap gap-1">
       <button className={button} disabled={state.working} onClick={() => { store.restartTraversal(); void store.readView(); }}>Retry updates</button>
       <button className={button} disabled={state.working} onClick={() => void store.advance()}>Next page</button>
       <button className={button} disabled={state.working || state.view.kind !== 'view'} onClick={() => void store.refreshView()}>Refresh sources</button>
     </div>
-    <details><summary className="cursor-pointer focus-visible:outline">Coverage</summary>
+    <details className="mt-0.5"><summary className="cursor-pointer focus-visible:outline text-faint">Coverage</summary>
       <p>Only observed jobs are shown. Older and undiscovered work may be missing. Native spend is shown only when reported with provenance. Observations do not authorize totals.</p>
       {state.displayLimited && <p>Display window limited to 200 observations, with up to 100 native jobs.</p>}
       <p>Native active: {state.localActive.state} · {state.localActive.missing.join(', ').replaceAll('_', ' ')}</p>
       <p>Native history: {state.local.state} · {state.local.missing.join(', ').replaceAll('_', ' ')}</p>
-      {state.streams.map(s => <p key={metadataStreamKey(s.stream)} className="break-all">{s.stream.store.source} / {s.stream.store.state_id}: {s.state} {s.stream.status ?? 'history'}{state.observedAt[metadataStreamKey(s.stream)] ? ` · ${Math.max(0, Math.floor((now - state.observedAt[metadataStreamKey(s.stream)]) / 1000))}s ago` : ' · not observed'}</p>)}
+      <details><summary className="cursor-pointer focus-visible:outline">Sources</summary>
+        {state.streams.map(s => <p key={metadataStreamKey(s.stream)} className="break-all">{s.stream.store.source} / {s.stream.store.state_id}: {s.state} {s.stream.status ?? 'history'}{state.observedAt[metadataStreamKey(s.stream)] ? ` · ${Math.max(0, Math.floor((now - state.observedAt[metadataStreamKey(s.stream)]) / 1000))}s ago` : ' · not observed'}</p>)}
+      </details>
     </details>
   </div>;
 }
@@ -255,6 +258,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   const [preferences, setPreferences] = useState(() => readPreferences(preferenceKey));
   const [filter, setFilter] = useState('all');
   const [sort, setSort] = useState<'newest' | 'oldest'>('newest');
+  const [jobScope, setJobScope] = useState<JobScope>(loadJobScope);
   const [collapsedGroups, setCollapsedGroups] = useState<string[]>([]);
   const [notice, setNotice] = useState('');
   const jobs = useMemo(() => metadataJobs(state), [state]);
@@ -280,6 +284,11 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   const [focusRequest, setFocusRequest] = useState<{ key: string; target: SwarmNavigationTarget } | null>(null);
   const context = state.view.kind === 'idle' ? null : { ...state.view.target, contextEpoch: state.contextEpoch };
   useEffect(() => { try { localStorage.setItem(preferenceKey, JSON.stringify(preferences)); } catch { /* Optional UI preference. */ } }, [preferences, preferenceKey]);
+  useEffect(() => {
+    const sync = () => setJobScope(loadJobScope());
+    window.addEventListener(JOB_SCOPE_CHANGED_EVENT, sync);
+    return () => window.removeEventListener(JOB_SCOPE_CHANGED_EVENT, sync);
+  }, []);
   useEffect(() => {
     const live = new Set(jobs.filter(j => j.read_status !== 'unavailable' && (j.local_ref ? nativeActiveStatuses : pmActiveStatuses).some(status => status === j.status)).map(j => j.metadata_key));
     setPreferences(p => p.dismissed.some(key => live.has(key)) ? { ...p, dismissed: p.dismissed.filter(key => !live.has(key)) } : p);
@@ -333,7 +342,11 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     setFocusRequest(null);
   }, [focusRequest, enabled, visible, jobs, state.contextEpoch, state.view]);
   if (!enabled) return <p className="p-2 text-xs text-muted">Job metadata paused for this view.</p>;
-  const hidden = jobs.filter(j => isFinished(j) && preferences.dismissed.includes(j.metadata_key ?? ''));
+  const activeSessionId = state.view.kind === 'view' ? state.view.context.session_id : '';
+  const scoped = filterJobsByScope(jobs, jobScope, activeSessionId, {
+    includeJobIds: pending?.jobId ? [pending.jobId] : undefined,
+  });
+  const hidden = scoped.filter(j => isFinished(j) && preferences.dismissed.includes(j.metadata_key ?? ''));
   const createdAt = new Map(state.local.observations.map(o => [localKey(o.row.local_ref), o.row.created_at]));
   for (const job of jobs) {
     const date = currentHeader(state, job.metadata_key ?? '')?.created_at;
@@ -342,11 +355,9 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   const quality = (job: Job) => { const expert = currentExpert(state, job.metadata_key ?? ''); return expert ? expertJobQuality(expert) : currentHeader(state, job.metadata_key ?? '')?.quality ?? 'unverified'; };
   const selectedSummary = state.localDetail?.observation?.summary;
   if (selectedSummary && !createdAt.has(localKey(selectedSummary.local_ref))) createdAt.set(localKey(selectedSummary.local_ref), selectedSummary.created_at);
-  const shown = jobs.filter(j => !hidden.includes(j)).filter(j => {
+  const shown = scoped.filter(j => !hidden.includes(j)).filter(j => {
     switch (filter) {
       case 'all': return true;
-      case 'session': return state.view.kind === 'view' && j.session_id === state.view.context.session_id;
-      case 'repo': return !j.cross_project;
       case 'finished': return isFinished(j);
       case 'attention': return j.status === 'interrupted' || (j.local_ref ? nativeAttentionStatuses : ['failed', 'stalled']).includes(j.status);
       case 'active': return isActive(j);
@@ -374,42 +385,79 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   const failedRead = state.error || state.view.kind === 'view' && (state.view.view.availability === 'unavailable'
     || state.streams.some(s => s.state === 'unavailable' || s.state === 'cursor_expired')
     || state.local.state === 'unavailable' || state.local.state === 'expired');
-  return <section aria-label="Jobs" className="h-full overflow-auto text-txt">
-    <h2 className="px-2 text-sm font-medium"><span>Swarm Tracker</span> ({trackerCount} observed)</h2>
+  const anyRunning = shown.some(j => isActive(j));
+  const runningCount = shown.filter(j => isActive(j)).length;
+  const completedCount = shown.filter(j => isFinished(j) && !isNativeActivity(j)).length;
+  return <section aria-label="Jobs" className="flex flex-col h-full overflow-hidden text-txt">
+    <div className="shrink-0 flex items-center justify-between px-3 py-2 border-b border-[var(--shell-panel-border)] select-none">
+      <h2 className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-faint font-semibold">
+        <span className="relative inline-flex">
+          <Network size={11} className={anyRunning ? "text-accent" : "text-faint/70"} />
+          {anyRunning ? <span className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-accent animate-pulse" title={`${runningCount} running`} aria-hidden /> : null}
+        </span>
+        <span>Swarm Tracker</span>
+        <span className="text-faint/60 normal-case tracking-normal">({trackerCount} observed)</span>
+        <button type="button" className={button} disabled={state.working} aria-label="Refresh job headers" onClick={() => { void store.refreshHeaders(); void store.refreshView(); }}>
+          <RefreshCw size={11} className={state.working ? "animate-spin" : ""} />
+        </button>
+      </h2>
+      <div className="flex items-center gap-2.5 text-[10px]">
+        {anyRunning && <span className="flex items-center gap-1 text-accent"><Loader2 size={10} className="animate-spin semantic-activity-spinner" /> {runningCount} running</span>}
+        {completedCount > 0 && <span className="flex items-center gap-1 text-good/80"><CheckCircle2 size={10} /> {completedCount}</span>}
+      </div>
+    </div>
     {trackerCount === 0 && state.view.kind === 'view' && !state.working && <p className="px-2 text-xs text-muted">No swarm jobs observed in this view.</p>}
     <MetadataStatus />
     <SessionWorkerUsage />
-    <button className={button} disabled={state.working} onClick={() => void store.refreshHeaders()}>Refresh job headers</button>
     {state.headerError && <p role="status" className="px-2 text-xs text-muted">Job headers could not be refreshed. Retry header refresh; list observations remain available.</p>}
-    <div className="grid grid-cols-2 gap-1 px-2 text-sm">
-      <select aria-label="Filter swarms" className="min-h-11 w-full min-w-0 bg-panel text-txt focus-visible:outline focus-visible:outline-accent" value={filter} onChange={e => setFilter(e.target.value)}>
-        <option value="all">All observed</option><option value="session">This session</option><option value="repo">This repo</option>
-        <option value="active">Active</option><option value="attention">Needs attention</option><option value="finished">Finished</option>
-        <option value="failed">Failed</option><option value="cancelled">Cancelled</option><option value="complete">Completed lifecycle</option>
+    <div className="shrink-0 grid grid-cols-2 gap-1.5 px-2 py-1.5 border-b border-[var(--shell-panel-border)] bg-panel2/10">
+      <select aria-label="Filter swarms" className={compactSelect} value={filter} onChange={e => setFilter(e.target.value)}>
+        <option value="all">All statuses</option>
+        <option value="active">Active</option>
+        <option value="attention">Needs attention</option>
+        <option value="finished">Finished</option>
+        <option value="failed">Failed</option>
+        <option value="cancelled">Cancelled</option>
+        <option value="complete">Completed lifecycle</option>
         <option value="untrustworthy">Untrustworthy</option>
       </select>
-      <button className={`${button} w-full min-w-0`} aria-label="Sort swarms" onClick={() => setSort(s => s === 'newest' ? 'oldest' : 'newest')}>{sort === 'newest' ? 'Newest' : 'Oldest'} first</button>
+      <button className={`${button} w-full min-w-0 h-6 rounded border border-edge bg-panel2/40`} aria-label="Sort swarms" onClick={() => setSort(s => s === 'newest' ? 'oldest' : 'newest')}>{sort === 'newest' ? 'Newest' : 'Oldest'} first</button>
+      <div className="col-span-2 flex h-6 overflow-hidden rounded border border-edge">
+        {(["session", "repo", "all"] as const).map((scope) => (
+          <button
+            key={scope}
+            type="button"
+            aria-pressed={jobScope === scope}
+            aria-label={scope === "session" ? "This session" : scope === "repo" ? "This repo" : "All projects"}
+            onClick={() => { setJobScope(scope); saveJobScope(scope); }}
+            className={`flex-1 text-[10px] ${jobScope === scope ? "bg-accent/15 text-txt" : "bg-panel2/40 text-muted hover:text-txt"}`}
+          >
+            {scope === "session" ? "Session" : scope === "repo" ? "Repo" : "All"}
+          </button>
+        ))}
+      </div>
     </div>
-    <p className="px-2 text-xs text-muted">Sorting and filters apply only to observed jobs; history coverage is incomplete. Known creation times are ordered within each lifecycle group; undated jobs remain last.</p>
-    <div className="flex flex-wrap items-center gap-1 px-2 text-sm">
+    <p className="px-2 text-[9px] text-faint">Sorting and filters apply only to observed jobs; history coverage is incomplete. Known creation times are ordered within each lifecycle group; undated jobs remain last.</p>
+    <div className="flex flex-wrap items-center gap-1 px-2 text-[10.5px]">
       <button className={button} onClick={() => setPreferences(p => ({ ...p, dismissed: [...new Set([...p.dismissed, ...groups.filter(g => !collapsedGroups.includes(g.key)).flatMap(g => g.rows).filter(j => isFinished(j) && j.read_status !== 'unavailable').flatMap(j => j.metadata_key ? [j.metadata_key] : [])])].slice(-200) }))}>Hide finished</button>
       {hidden.length > 0 && <button className={button} onClick={() => setPreferences(p => ({ ...p, dismissed: [] }))}>Show {hidden.length} hidden</button>}
       {filter !== 'all' && <button className={button} onClick={() => setFilter('all')}>Clear filter</button>}
     </div>
-    {filter === 'untrustworthy' && <p role="status" className="px-2 text-sm text-muted">Showing recorded degraded quality. Failed lifecycle is separate from failed verification.</p>}
+    {filter === 'untrustworthy' && <p role="status" className="px-2 text-xs text-muted">Showing recorded degraded quality. Failed lifecycle is separate from failed verification.</p>}
     {filter === 'complete' && <p className="px-2 text-xs text-muted">Completed lifecycle does not establish successful verification.</p>}
     {notice && <p role="status" className="px-2 text-sm text-muted">{notice}</p>}
     <MetadataOutcomeCounts jobs={shown} />
+    <div className="flex-1 min-h-0 overflow-y-auto px-2 py-1 flex flex-col gap-0.5">
     {groups.flatMap(group => group.rows.length === 0 ? [] : [
-      <button key={`group:${group.key}`} className={`${button} w-full text-left font-medium`} aria-expanded={!collapsedGroups.includes(group.key)} onClick={() => setCollapsedGroups(current => current.includes(group.key) ? current.filter(key => key !== group.key) : [...current, group.key])}>{group.label} ({group.rows.length} observed)</button>,
+      <button key={`group:${group.key}`} className={`${button} w-full text-left font-medium uppercase tracking-wider text-faint`} aria-expanded={!collapsedGroups.includes(group.key)} onClick={() => setCollapsedGroups(current => current.includes(group.key) ? current.filter(key => key !== group.key) : [...current, group.key])}>{collapsedGroups.includes(group.key) ? <ChevronRight size={11} className="inline" /> : <ChevronDown size={11} className="inline" />} {group.label} ({group.rows.length} observed)</button>,
       ...group.rows.map(job => {
         const key = job.metadata_key ?? '', open = preferences.expanded.includes(key);
         const expert = currentExpert(state, key), model = (expert ? expertJobModel(expert) : null) ?? expertHeaderModel(currentHeader(state, key));
         const routing = expert && expert.kind !== 'unavailable' && expert.coverage.tasks === 'complete' && expert.tasks.length === 0 && isActive(job) && !model;
         // Keep one keyed sibling list so group changes preserve inspector state and focus.
-        return <div className="border-b border-edge" key={key} hidden={collapsedGroups.includes(group.key)} data-job-id={job.id} data-job-source={job.source} data-quality={quality(job)}
+        return <div className="border-b border-edge/40" key={key} hidden={collapsedGroups.includes(group.key)} data-job-id={job.id} data-job-source={job.source} data-quality={quality(job)}
           onFocus={() => { focusedRow.current = key; }} onBlur={event => { if (!event.currentTarget.contains(event.relatedTarget)) focusedRow.current = null; }}>
-          <button ref={element => { if (element) rowButtons.current.set(key, element); else rowButtons.current.delete(key); }} className={`${button} flex items-center w-full text-left`} aria-label={`${job.goal} · ${metadataOutcomeLabel(job.status)}`} aria-expanded={open} onClick={() => setPreferences(p => ({ ...p, expanded: open ? p.expanded.filter(k => k !== key) : [...p.expanded, key].slice(-8) }))}>{!job.local_ref && job.read_status !== 'unavailable' && job.status === 'running' && <MetadataActivityIndicator />}<span className="truncate">{job.goal}</span>{model && <span title={`Model: ${model}`} className="min-w-0 truncate"> · {model}</span>}{routing && <span className="shrink-0"> · routing…</span>}{currentHeader(state, key)?.completed_workers !== undefined && <span className="shrink-0"> {currentHeader(state, key)?.completed_workers}/{currentHeader(state, key)?.selected_workers}</span>}<span className="shrink-0"> · {quality(job) === 'degraded' ? <span className="text-warn">degraded</span> : quality(job) === 'ok' && ['complete', 'completed', 'done'].includes(job.status) ? <span className="text-good">done</span> : <MetadataOutcomeLabel status={job.status} />}</span></button>
+          <button ref={element => { if (element) rowButtons.current.set(key, element); else rowButtons.current.delete(key); }} className={`${button} flex items-center gap-1 w-full text-left min-h-0 py-1`} aria-label={`${job.goal} · ${metadataOutcomeLabel(job.status)}`} aria-expanded={open} onClick={() => setPreferences(p => ({ ...p, expanded: open ? p.expanded.filter(k => k !== key) : [...p.expanded, key].slice(-8) }))}>{open ? <ChevronDown size={11} className="shrink-0 text-faint" /> : <ChevronRight size={11} className="shrink-0 text-faint" />}{!job.local_ref && job.read_status !== 'unavailable' && job.status === 'running' && <MetadataActivityIndicator />}<span className="truncate font-semibold text-[11px] text-txt">{job.goal}</span>{model && <span title={`Model: ${model}`} className="min-w-0 truncate text-faint"> · {model}</span>}{routing && <span className="shrink-0"> · routing…</span>}{currentHeader(state, key)?.completed_workers !== undefined && <span className="shrink-0"> {currentHeader(state, key)?.completed_workers}/{currentHeader(state, key)?.selected_workers}</span>}<span className="shrink-0"> · {quality(job) === 'degraded' ? <span className="text-warn">degraded</span> : quality(job) === 'ok' && ['complete', 'completed', 'done'].includes(job.status) ? <span className="text-good">done</span> : <MetadataOutcomeLabel status={job.status} />}</span></button>
           {job.read_status === 'unavailable' && <p className="px-2 text-xs text-muted">Retained observation is stale; current lifecycle is unconfirmed.</p>}
           {job.status === 'stalled' && <p className="px-2 text-xs text-muted">{job.local_ref ? 'May still be active; terminal state unconfirmed.' : 'Finished for liveness; recoverable.'}</p>}
           {isFinished(job) && job.read_status !== 'unavailable' && <button className={button} aria-label={`Dismiss from tracker: ${job.goal}`} onClick={() => setPreferences(p => ({ ...p, dismissed: [...p.dismissed.filter(k => k !== key), key].slice(-200) }))}>Dismiss</button>}
@@ -417,12 +465,23 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
         </div>;
       }),
     ])}
-    {!shown.length && filter !== 'untrustworthy' && <p className="p-2 text-sm text-muted">{failedRead
+    {!shown.length && filter !== 'untrustworthy' && <div className="flex flex-col items-center justify-center h-48 text-center px-6 gap-2 text-muted">
+      <Network size={20} className="text-faint/50" />
+      <span className="text-[12px] font-medium">{failedRead
       ? 'Job observations are unavailable. Retry updates; an empty view does not establish no work.'
       : state.view.kind !== 'view' || !jobs.length && state.working
         ? <><span>Loading swarm jobs...</span> Waiting for job metadata; no lifecycle result is known yet.</>
         : hidden.length && filter === 'all' ? 'Observed finished jobs are hidden. Show hidden jobs to restore them.'
           : !jobs.length ? 'No jobs observed in this view. Older or undiscovered work may still exist.'
-            : 'No jobs observed in this filter. Coverage may be incomplete.'}</p>}
+            : 'No jobs observed in this filter. Coverage may be incomplete.'}</span>
+      {!failedRead && state.view.kind === 'view' && !jobs.length && !state.working && (
+        <span className="text-[10.5px] text-faint leading-relaxed">
+          Every dispatched worker lands here -- run_implement, run_parallel,
+          and run_swarm alike -- with its phase, router choice, live workers,
+          and streamed findings. Inline tool calls stay in the chat.
+        </span>
+      )}
+    </div>}
+    </div>
   </section>;
 }

--- a/webapp/src/components/ModelsSettingsPage.tsx
+++ b/webapp/src/components/ModelsSettingsPage.tsx
@@ -9,6 +9,12 @@ let didForceRefreshThisSession = false;
 
 type ProviderGroup = { provider: string; display: string; items: ModelCatalogEntry[] };
 
+export function orderModelsEnabledFirst(items: ModelCatalogEntry[]): ModelCatalogEntry[] {
+  return [...items].sort((a, b) => Number(b.enabled) - Number(a.enabled)
+    || (a.name || a.model).localeCompare(b.name || b.model)
+    || a.model.localeCompare(b.model));
+}
+
 export function clearCatalogSnapshot() {
   memoryCatalogSnapshot = null;
   didForceRefreshThisSession = false;
@@ -132,7 +138,7 @@ export default function ModelsSettingsPage() {
       }
       g.items.push(c);
     }
-    return out;
+    return out.map((g) => ({ ...g, items: orderModelsEnabledFirst(g.items) }));
   }, [catalog, q]);
 
   const enabledCount = catalog.filter((c) => c.enabled).length;
@@ -140,10 +146,9 @@ export default function ModelsSettingsPage() {
   const defaultCollapsed = useMemo(() => {
     const map: Record<string, boolean> = {};
     for (const g of groups) {
-      // Search: keep matching groups open. Otherwise collapse huge catalogs
-      // (OpenRouter) even when some models are enabled — the header shows
-      // "N on" so curation stays visible without scrolling past hundreds of rows.
-      map[g.provider] = !q && g.items.length > COLLAPSE_THRESHOLD;
+      // Search stays open. Huge catalogs collapse only when nothing in the
+      // group is enabled, so a pinned OpenRouter model stays reachable.
+      map[g.provider] = !q && g.items.length > COLLAPSE_THRESHOLD && g.items.every((item) => !item.enabled);
     }
     return map;
   }, [groups, q]);

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -1043,30 +1043,6 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
         {gate("general", "transparent background glass vibrancy acrylic mica frost window") && (
           <WindowGlassSettings />
         )}
-        {gate("general", "driver model select") && settings && (<>
-        {/* Driver Select */}
-        <div className="space-y-1.5">
-          <label className="block uppercase tracking-wider text-[10px] text-faint font-semibold">
-            Driver (Model)
-          </label>
-          <select
-            value={settings.driver}
-            onChange={(e) => update({ driver: e.target.value })}
-            disabled={saving}
-            className="w-full bg-panel2 border border-edge rounded px-2.5 py-1.5 text-txt focus:outline-none focus:border-accent disabled:opacity-50"
-          >
-            {settings.models.map((m) => (
-              <option key={m} value={m}>
-                {m}
-              </option>
-            ))}
-          </select>
-          <p className="text-[10px] text-muted">
-            The pilot model driver. Changes take effect live on the chat session.
-          </p>
-        </div>
-
-        </>)}
         {gate("general", "budget steps per run") && settings && (<>
         {/* Budget Stepper / Number */}
         <div className="space-y-1.5">
@@ -1622,10 +1598,7 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
                 </span>
               </div>
               <p className="text-[10px] text-muted mt-1 leading-normal">
-                Optional. Burns Cursor plan credits via the local Agent CLI when the
-                `agent` binary is on PATH. Sign in here, or set CURSOR_API_KEY — the
-                Agent CLI accepts either. Not required if you already have a Full stack
-                chat key (OpenRouter, Anthropic, …).
+                Optional Cursor plan via Agent CLI or CURSOR_API_KEY. Skip if a Full stack chat key is already set.
               </p>
               <div className="flex items-center gap-2 flex-wrap mt-1.5">
                 <button


### PR DESCRIPTION
## Why

After the Puppetmaster 1.25 metadata swap, Swarm Tracker showed an observed-jobs dump instead of the card chrome operators already knew. Settings still had an unused Driver (Model) picker. Enabled OpenRouter models sat buried in a collapsed hundred-row list.

## Scope

- `MetadataJobs` chrome: Network header, All statuses, Newest/Oldest, Session/Repo/All, hairline rows. Coverage streams stay nested.
- Remove Settings Driver (Model). Pick the pilot in the composer.
- Shorten the Cursor CLI plan footnote.
- Sort enabled models to the top of each Settings Models group. A group with any enabled model stays open.
- Version stamps `0.9.430`. Pin stays `puppetmaster-ai==1.25.0`.

## Tradeoffs

Session scope is the default again. Foreign-session rows stay hidden until All. The status filter no longer owns session/repo.

The data layer stays on bounded metadata. This does not restore `/api/swarm/live`.

## Blast radius

Swarm Tracker list membership (session default). Settings General and Models. Composer picker is unchanged.

## Verification

- `webapp` vitest: 221 files, 2428 passed.
- `tests/test_version_consistency.py`: 4 passed.
- Local full pytest is not the 3.9 floor here (Puppetmaster `attempts` import vs the 1.25 pin). CI matrix is the gate.

## Test plan

- Open Swarm Tracker: Network header, Session/Repo/All, no Coverage stream wall.
- Dispatch a swarm in this session. It appears under Session.
- Settings General has no Driver (Model).
- Optional Plan Sign-in shows the short Cursor CLI footnote.
- Settings Models: enable a mid-list OpenRouter model. It sorts to the top and the group stays open.