### PR TITLE
Release v0.9.431

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.25.0
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.26.0
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.25.0"
+          pip install -e ".[dev]" "puppetmaster-ai==1.26.0"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.25.0"
+          pip install -e ".[dev]" "puppetmaster-ai==1.26.0"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -57,7 +57,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.25.0"
+          pip install -e ".[dev]" "puppetmaster-ai==1.26.0"
 
       - name: Run the offline test suite (shard)
         env:
@@ -103,7 +103,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.25.0"
+          pip install -e ".[dev]" "puppetmaster-ai==1.26.0"
 
       - name: Run offline pmharness/intent/registry units
         run: python -m pytest -q -p no:cacheprovider tests/test_intent.py tests/test_registry.py tests/test_registry_wizard.py tests/test_pilot_driver_templates.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.25.0"
+uv pip install --python .venv -e . "puppetmaster-ai==1.26.0"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.25.0` (desktop
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.26.0` (desktop
    bootstrap, install/doctor, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.25.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.430, deliberately pre-1.0. Restores Swarm Tracker card chrome (Session/Repo/All, All statuses) on Puppetmaster 1.25 bounded metadata. Removes Settings Driver (Model). Pins enabled Models to the top of each provider list. Pins puppetmaster-ai==1.25.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
+> Status: v0.9.431, deliberately pre-1.0. Restores Swarm Tracker hairline cards (Finished fold, All statuses + Newest/Oldest, Session/Repo/All) on Puppetmaster 1.25 bounded metadata. Coverage and paging stay off the primary surface. Pins puppetmaster-ai==1.25.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.25.0` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.26.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.431, deliberately pre-1.0. Restores Swarm Tracker hairline cards (Finished fold, All statuses + Newest/Oldest, Session/Repo/All) on Puppetmaster 1.25 bounded metadata. Coverage and paging stay off the primary surface. Pins puppetmaster-ai==1.25.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
+> Status: v0.9.431, deliberately pre-1.0. Restores Swarm Tracker hairline cards (Finished fold, All statuses + Newest/Oldest, Session/Repo/All) on Puppetmaster 1.26 bounded metadata. Coverage and paging stay off the primary surface. Pins puppetmaster-ai==1.26.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | `run_swarm`, `run_implement`, and `run_parallel` run bounded workers as durable jobs. Inspect recorded attempts, acceptance evidence, uncertain outcomes, and measured or estimated consumption. Marionette pins `puppetmaster-ai==1.25.0`; the installer and self-update use the same version. |
+| **Puppetmaster delegation** | `run_swarm`, `run_implement`, and `run_parallel` run bounded workers as durable jobs. Inspect recorded attempts, acceptance evidence, uncertain outcomes, and measured or estimated consumption. Marionette pins `puppetmaster-ai==1.26.0`; the installer and self-update use the same version. |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Durable memory graph** | Local durable facts/preferences (`MemoryStore`) plus optional relations via `MemoryGraph` (`GET /api/memory/graph`, shape `{nodes,edges}` like the wiki graph; sqlite + append-only jsonl). |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.26.0` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.431, deliberately pre-1.0. Restores Swarm Tracker hairline cards (Finished fold, All statuses + Newest/Oldest, Session/Repo/All) on Puppetmaster 1.26 bounded metadata. Coverage and paging stay off the primary surface. Pins puppetmaster-ai==1.26.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
+> Status: v0.9.431, deliberately pre-1.0. Restores Swarm Tracker and left-rail Jobs chrome (Active/Finished, Session/Repo/All) on Puppetmaster 1.26 bounded metadata. Operator Retry/Coverage controls stay off the primary surface. Settings keeps closed API-key and model groups closed. Device access is one Safety collapse at the bottom. Pins puppetmaster-ai==1.26.0. Installed releases use a dedicated, revision-pinned runtime checkout so local work in an older checkout cannot block startup. Desktop windows keep inline panels; compact navigation and bounded drawers start below 640 CSS pixels. The Panels drawer includes its own Add panel chooser and accessible card controls. Fork is available from each session’s context menu. Empty legacy prompt queues no longer show a recovery warning.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.430"
+__version__ = "0.9.431"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/diag_bundle.py
+++ b/harness/diag_bundle.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 DEFAULT_SESSION_LIMIT = 20
-PIN_FALLBACK = "puppetmaster-ai==1.25.0"
+PIN_FALLBACK = "puppetmaster-ai==1.26.0"
 _PIN_RE = re.compile(r"puppetmaster-ai==[0-9]+(?:\.[0-9]+)*")
 _SECRET_KEY_FRAGMENTS = (
     "api_key",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.430"
+version = "0.9.431"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "pypdf",
     # Runtime ownership: a standalone `pip install pm-harness` must pull the
     # pinned Puppetmaster bridge. Desktop/Electron still re-checks the same pin.
-    "puppetmaster-ai==1.25.0",
+    "puppetmaster-ai==1.26.0",
     "tzdata>=2026.3",
 ]
 

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.25.0" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.26.0" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.25.0"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.26.0"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.25.0" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.26.0" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.25.0}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.26.0}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.429"
+version = "0.9.431"
 source = { editable = "." }
 dependencies = [
     { name = "puppetmaster-ai" },
@@ -97,7 +97,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "puppetmaster-ai", specifier = "==1.25.0" },
+    { name = "puppetmaster-ai", specifier = "==1.26.0" },
     { name = "pypdf" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
@@ -107,11 +107,11 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "puppetmaster-ai"
-version = "1.25.0"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/26/c1b1ff97929db7e694244b22831431f1b5e50339b99f075f13760e72cfda/puppetmaster_ai-1.25.0.tar.gz", hash = "sha256:944ed3921731a2393601baa193007c7b8728a199229a84152f391041874f9dd9", size = 1935726, upload-time = "2026-09-08T04:50:40.615Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/2f/e1ca37a0c20f167a551156ebde05b76b2d3dd7b9940a29fd7a11d2493881/puppetmaster_ai-1.26.0.tar.gz", hash = "sha256:65b445902ff6ec2d6176c68fb0d5155d600c192313ae473153051bfb5922eb35", size = 1941809, upload-time = "2026-09-08T08:15:30.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/42/322b8321e0d7f56ed34b714d597004ae8819d7ef75f79d5c00e797906e5c/puppetmaster_ai-1.25.0-py3-none-any.whl", hash = "sha256:c9b69367c6effc370f1958236664f6a51d58996dc13cc9f582fb30484a380c51", size = 1064692, upload-time = "2026-09-08T04:50:38.466Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e3/0581013bb4542160d2446729328255417163e9b4e8c4afc92fec86ba5c0b/puppetmaster_ai-1.26.0-py3-none-any.whl", hash = "sha256:7a8e4181575bcb8a1704eafcba8c3d5496fd21bb78b375e3e6fd74d4687ea14a", size = 1067268, upload-time = "2026-09-08T08:15:28.7Z" },
 ]
 
 [[package]]

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -90,7 +90,7 @@ function installIdentity(dir, target) {
   return { schema: 1, mode: target.mode, repo: target.repo,
     revision: gitValue(dir, ["rev-parse", "HEAD"]), inputs: hash.digest("hex"),
     platform: process.platform, arch: process.arch,
-    puppetmaster: process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.25.0" };
+    puppetmaster: process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.26.0" };
 }
 
 function venvPython(dir) {
@@ -378,7 +378,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.25.0";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.26.0";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.25.0";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.26.0";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 const HARNESS_DIST_NAME = "pm-harness";
 
@@ -95,7 +95,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.25.0" }    -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.26.0" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.430",
+  "version": "0.9.431",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.430",
+      "version": "0.9.431",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.430",
+  "version": "0.9.431",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/LeftRail.layout.test.tsx
+++ b/webapp/src/__tests__/LeftRail.layout.test.tsx
@@ -54,6 +54,9 @@ describe("LeftRail branch layout", () => {
     expect(upperSections?.className.split(" ")).not.toContain("flex-1");
     expect(jobsPanel).toHaveClass("mt-auto");
     expect(jobScopes).toHaveClass("grid", "grid-cols-3");
+    expect(screen.queryByRole("button", { name: "Retry updates" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Refresh sources" })).toBeNull();
+    expect(screen.queryByText("Coverage")).toBeNull();
   });
 });
 

--- a/webapp/src/__tests__/ModelsSettingsPage.cache.test.tsx
+++ b/webapp/src/__tests__/ModelsSettingsPage.cache.test.tsx
@@ -260,4 +260,24 @@ describe("ModelsSettingsPage cached first paint", () => {
     const labels = screen.getAllByText(/^(On A|On B|Off A|Off C)$/).map((node) => node.textContent);
     expect(labels).toEqual(["On A", "On B", "Off A", "Off C"]);
   });
+
+  it("keeps a closed provider group closed after Settings remounts", async () => {
+    mockModelCatalog.mockResolvedValue({
+      catalog: sampleCatalog,
+      all: sampleCatalog,
+      enabled: sampleCatalog,
+    });
+    const first = render(<ModelsSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("claude-sonnet")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Anthropic/ }));
+    expect(screen.queryByText("claude-sonnet")).toBeNull();
+    first.unmount();
+    render(<ModelsSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Anthropic/ })).toBeInTheDocument();
+    });
+    expect(screen.queryByText("claude-sonnet")).toBeNull();
+  });
 });

--- a/webapp/src/__tests__/SettingsPane.keysFirst.test.tsx
+++ b/webapp/src/__tests__/SettingsPane.keysFirst.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsPane, { clearSettingsSnapshot } from "../components/SettingsPane";
 import { api } from "../lib/api";
@@ -54,5 +54,17 @@ describe("SettingsPane keys-first providers order", () => {
     const keys = screen.getByText("API keys");
     const signIn = screen.getByText("Optional plan sign-in");
     expect(keys.compareDocumentPosition(signIn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("keeps API keys closed after Settings remounts", async () => {
+    localStorage.clear();
+    const first = render(<SettingsPane onOpenWizard={vi.fn()} section="providers" />);
+    const keys = screen.getByRole("button", { name: /API keys/ });
+    fireEvent.click(keys);
+    expect(screen.queryByText(/One Full stack key/)).toBeNull();
+    first.unmount();
+    render(<SettingsPane onOpenWizard={vi.fn()} section="providers" />);
+    expect(screen.getByRole("button", { name: /API keys/ })).toBeInTheDocument();
+    expect(screen.queryByText(/One Full stack key/)).toBeNull();
   });
 });

--- a/webapp/src/__tests__/SettingsPane.optIns.test.tsx
+++ b/webapp/src/__tests__/SettingsPane.optIns.test.tsx
@@ -23,6 +23,9 @@ vi.mock("../lib/api", () => ({
 vi.mock("../components/SkillsPane", () => ({ default: () => <div /> }));
 vi.mock("../components/MemoryPane", () => ({ default: () => <div /> }));
 vi.mock("../components/SchedulesPane", () => ({ default: () => <div /> }));
+vi.mock("../components/DeviceAccess", () => ({
+  default: () => <p>Give a device read-only access to explicitly selected information on this endpoint.</p>,
+}));
 
 const mockSettings = vi.mocked(api.settings);
 const mockUpdate = vi.mocked(api.updateSettings);
@@ -84,5 +87,16 @@ describe("SettingsPane Safety Chrome login", () => {
     await waitFor(() => {
       expect(mockUpdate).toHaveBeenCalledWith({ browserRealProfile: true });
     });
+  });
+
+  it("keeps Device access collapsed at the bottom of Safety", async () => {
+    localStorage.clear();
+    render(<SettingsPane onOpenWizard={vi.fn()} section="safety" />);
+    const fullAuto = await screen.findByText("Full-Auto Safety");
+    const deviceAccess = screen.getByRole("button", { name: /Device access/ });
+    expect(fullAuto.compareDocumentPosition(deviceAccess) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.queryByText(/Give a device read-only access/)).toBeNull();
+    fireEvent.click(deviceAccess);
+    expect(await screen.findByText(/Give a device read-only access/)).toBeTruthy();
   });
 });

--- a/webapp/src/__tests__/SwarmPane.reads.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.reads.test.tsx
@@ -86,7 +86,7 @@ it('shows transport failure instead of an empty tracker and retries', async () =
     return result;
   });
   fireEvent.click(screen.getByRole('button', { name: 'Retry updates' }));
-  await screen.findByText(/^No jobs observed in this view/);
+  await screen.findByText(/^No swarm jobs yet/);
   fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
   await waitFor(() => expect(f.store.getSnapshot().working).toBe(false));
   expect(f.store.getSnapshot().streams.some(s => s.state === 'complete')).toBe(true);

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -195,7 +195,7 @@ describe("SwarmPane sort and filter controls", () => {
   it("reverses both lifecycle groups when Oldest is selected", async () => {
     await hydrateDates();
     render(<metadata.Provider><SwarmPane /></metadata.Provider>);
-    fireEvent.click(screen.getByRole('button', { name: 'Sort swarms' }));
+    fireEvent.change(screen.getByLabelText('Sort swarms'), { target: { value: 'oldest' } });
     expectBefore(screen.getByRole('button', { name: /^Older active audit/ }), screen.getByRole('button', { name: /^Newest active build/ }));
     expectBefore(screen.getByRole('button', { name: /^Newest active build/ }), screen.getByRole('button', { name: /^Active job without timestamp/ }));
     expectBefore(screen.getByRole('button', { name: /^Older completed review/ }), screen.getByRole('button', { name: /^Newest failed review/ }));
@@ -229,7 +229,7 @@ describe("SwarmPane sort and filter controls", () => {
     await screen.findByRole("button", { name: /^Newest active build ·/ });
 
     fireEvent.change(screen.getByLabelText("Filter swarms"), { target: { value: "cancelled" } });
-    expect(await screen.findByText("No jobs observed in this filter. Coverage may be incomplete.")).toBeInTheDocument();
+    expect(await screen.findByText("No swarm jobs match this filter")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Clear filter" }));
     expect(await screen.findByRole("button", { name: /^Newest active build ·/ })).toBeInTheDocument();
   });
@@ -404,7 +404,7 @@ describe("SwarmPane model badge", () => {
     });
     const view = render(<fixture.Provider><SwarmPane /></fixture.Provider>);
     try {
-      expect(screen.getByRole("button", { name: "Finished (1 observed)" })).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByRole("button", { name: /^Finished/ })).toHaveAttribute("aria-expanded", "true");
       await expandJob(/^Audit auth flow · complete$/);
       fireEvent.click(screen.getByRole("button", { name: "Inspect tasks and artifacts" }));
       await screen.findByText("task-1: complete");
@@ -1120,7 +1120,7 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
       outcomeSummary('job-interrupted', 'Interrupted command', 'interrupted'),
     ]);
     render(<outcomeFixture.Provider><SwarmPane /></outcomeFixture.Provider>);
-    expect(screen.getByRole('button', { name: 'Finished (2 observed)' })).toBeVisible();
+    expect(screen.getByRole('button', { name: /^Finished/ })).toBeVisible();
     expect(screen.getByText('2 failed')).toBeVisible();
     expect(screen.getByRole('button', { name: 'Truncated command · failed' })).toBeVisible();
     const interrupted = screen.getByRole('button', { name: 'Interrupted command · interrupted' });
@@ -1276,7 +1276,7 @@ describe("SwarmPane canonical outcome", () => {
     try {
       render(<fixture.Provider><SwarmPane /></fixture.Provider>);
       const row = await screen.findByRole('button', { name: 'Completed audit · complete' });
-      expect(screen.getByRole('button', { name: 'Finished (1 observed)' })).toBeVisible();
+      expect(screen.getByRole('button', { name: /^Finished/ })).toBeVisible();
       expect(within(row).getByText('complete')).toBeVisible();
       expect(within(row).getByText('complete')).toHaveClass('text-muted');
       expect(row.querySelector('.text-good')).toBeNull();
@@ -2353,7 +2353,7 @@ describe("SwarmPane final-review blockers", () => {
     const rendered = render(<metadata.Provider><SwarmPane /></metadata.Provider>);
     try {
       const job = await screen.findByRole("button", { name: /^Terminal without meters/ });
-      expect(screen.getByRole("button", { name: /Finished \(1 observed\)/ })).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByRole("button", { name: /Finished \(1\)/ })).toHaveAttribute("aria-expanded", "true");
       expect(job).not.toHaveTextContent("—");
       expect(job.textContent || "").not.toMatch(/\$0/);
       expect(job.querySelector('[aria-hidden="true"].bg-edge\\/70, [aria-hidden="true"][class*="bg-edge"]')).toBeNull();
@@ -2714,10 +2714,8 @@ describe("SwarmPane command vs swarm split", () => {
     metadata = await commandSplitFixture(["Audit auth flow"], "run_command");
     render(<metadata.Provider><SwarmPane /></metadata.Provider>);
     expect(await screen.findByRole("button", { name: "Audit auth flow · running" })).toBeInTheDocument();
-    expect(screen.getByText("Swarm Tracker").parentElement).toHaveTextContent("(1 observed)");
-    expect(screen.getByRole("button", { name: "Active (1 observed)" })).toBeVisible();
+    expect(screen.getByText("Swarm Tracker").parentElement).toHaveTextContent("(1)");
     expect(screen.queryByText("sleep 999")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Native activity (1 observed)" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Command · running" })).toBeVisible();
     expect(screen.getByRole("status")).toHaveTextContent("At least 2 active jobs");
     expect(mockSwarmLive).not.toHaveBeenCalled();
@@ -2730,10 +2728,8 @@ describe("SwarmPane command vs swarm split", () => {
     expect(await screen.findByRole("button", { name: "run_swarm audit · running" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "run_implement fix · running" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "run_parallel wave · running" })).toBeInTheDocument();
-    expect(screen.getByText("Swarm Tracker").parentElement).toHaveTextContent("(3 observed)");
-    expect(screen.getByRole("button", { name: "Active (3 observed)" })).toBeVisible();
+    expect(screen.getByText("Swarm Tracker").parentElement).toHaveTextContent("(3)");
     expect(screen.queryByText("echo batch")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Native activity (1 observed)" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Command batch · running" })).toBeVisible();
     expect(screen.getByRole("status")).toHaveTextContent("At least 4 active jobs");
     expect(mockSwarmLive).not.toHaveBeenCalled();
@@ -2743,12 +2739,11 @@ describe("SwarmPane command vs swarm split", () => {
   it("does not count a lone command job as Swarm Tracker (1)", async () => {
     metadata = await commandSplitFixture([], "run_command");
     render(<metadata.Provider><SwarmPane /></metadata.Provider>);
-    expect(screen.getByText("Swarm Tracker").parentElement).toHaveTextContent("(0 observed)");
-    expect(screen.getByText("No swarm jobs observed in this view.")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /^Active \(/ })).not.toBeInTheDocument();
+    expect(screen.getByText("Swarm Tracker").parentElement).not.toHaveTextContent("(0)");
     expect(screen.getByText("Swarm Tracker").parentElement).not.toHaveTextContent("(1)");
+    expect(screen.queryByText("No swarm jobs yet")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Active \(/ })).not.toBeInTheDocument();
     expect(screen.queryByText("sleep 999")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Native activity (1 observed)" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Command · running" })).toBeVisible();
     expect(screen.getByRole("status")).toHaveTextContent("At least 1 active jobs");
     expect(mockSwarmLive).not.toHaveBeenCalled();
@@ -2760,10 +2755,8 @@ describe("SwarmPane command vs swarm split", () => {
     render(<metadata.Provider><SwarmPane /></metadata.Provider>);
     expect(await screen.findByRole("button", { name: "run_swarm audit · running" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "run_implement fix · running" })).toBeInTheDocument();
-    expect(screen.getByText("Swarm Tracker").parentElement).toHaveTextContent("(2 observed)");
-    expect(screen.getByRole("button", { name: "Active (2 observed)" })).toBeVisible();
+    expect(screen.getByText("Swarm Tracker").parentElement).toHaveTextContent("(2)");
     expect(screen.queryByText("Parallel wave (2 jobs)")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Native activity (1 observed)" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Parallel wave · running" })).toBeVisible();
     expect(screen.getByRole("status")).toHaveTextContent("At least 3 active jobs");
     expect(mockSwarmLive).not.toHaveBeenCalled();

--- a/webapp/src/__tests__/expertCore.integration.test.tsx
+++ b/webapp/src/__tests__/expertCore.integration.test.tsx
@@ -226,7 +226,7 @@ describe('original positive inspector requirements through parser/store/render',
     render(<f.Provider><MetadataJobs /></f.Provider>);
     const before = () => !!(screen.getByRole('button', { name: 'Job 2 · running' }).compareDocumentPosition(screen.getByRole('button', { name: 'Job 1 · running' })) & Node.DOCUMENT_POSITION_FOLLOWING);
     expect(before()).toBe(true);
-    fireEvent.click(screen.getByRole('button', { name: 'Sort swarms' })); expect(before()).toBe(false);
+    fireEvent.change(screen.getByLabelText('Sort swarms'), { target: { value: 'oldest' } }); expect(before()).toBe(false);
   });
 });
 

--- a/webapp/src/__tests__/metadataActivityControls.test.tsx
+++ b/webapp/src/__tests__/metadataActivityControls.test.tsx
@@ -93,23 +93,22 @@ it('restores a balanced filter/sort toolbar and newest-first lifecycle groups us
   const control = screen.getByLabelText('Filter swarms');
   expect(control.parentElement).toHaveClass('grid', 'grid-cols-2');
   expect(control).toHaveClass('w-full');
-  expect(screen.getByRole('button', { name: /Sort swarms/ })).toHaveClass('w-full');
-  expect(screen.getByRole('button', { name: /^Active/ })).toHaveAttribute('aria-expanded', 'true');
+  expect(screen.getByLabelText('Sort swarms')).toHaveClass('w-full');
   expect(screen.getByRole('button', { name: /^Finished/ })).toHaveAttribute('aria-expanded', 'true');
   expect(order()).toEqual(['newest-active', 'older-active', 'undated-active', 'newest-failed', 'older-complete', 'job_1']);
-  fireEvent.click(screen.getByRole('button', { name: /Sort swarms/ }));
+  fireEvent.change(screen.getByLabelText('Sort swarms'), { target: { value: 'oldest' } });
   expect(order()).toEqual(['older-active', 'newest-active', 'undated-active', 'older-complete', 'newest-failed', 'job_1']);
 });
 it('never presents partial history ordering or quality filtering as complete', async () => {
   partial = true; await start(); mount();
   expect(store.getSnapshot().streams.some(s => s.state === 'partial')).toBe(true);
-  expect(screen.getByText(/Sorting and filters apply only to observed jobs/)).toBeVisible();
-  expect(screen.getByText(/undated jobs remain last/)).toBeVisible();
+  expect(screen.getByText(/Sorting and filters apply only to observed jobs/)).toBeInTheDocument();
+  expect(screen.getByText(/undated jobs remain last/)).toBeInTheDocument();
   filter('failed');
   expect(order()).toEqual(['newest-failed']);
   filter('untrustworthy');
   expect(screen.getByText(/Showing recorded degraded quality/)).toBeVisible();
-  expect(screen.queryByText('No jobs observed in this filter. Coverage may be incomplete.')).toBeNull();
+  expect(screen.queryByText('No swarm jobs match this filter')).toBeNull();
   expect(order()).toEqual([]);
 });
 it('separates failed, cancelled, completed lifecycle and unknown quality, with clear filter recovery', async () => {
@@ -125,7 +124,8 @@ it('distinguishes unknown activity from active and terminal observations', async
   native.push(sample('stalled-native', 'stalled', 50), sample('unknown-native', 'unknown', 60));
   pm.push({ ...summary(2), lifecycle: 'stalled' });
   await start(); mount();
-  expect(screen.getByRole('button', { name: /^Activity unconfirmed/ })).toBeVisible();
+  expect(toggle('stalled-native')).toBeVisible();
+  expect(toggle('unknown-native')).toBeVisible();
   expect(within(row('stalled-native')).queryByRole('button', { name: /Dismiss/ })).toBeNull();
   expect(within(row('job_2', 'harness')).getByRole('button', { name: /Dismiss/ })).toBeVisible();
   filter('active'); expect(order()).toEqual(['newest-active', 'older-active', 'undated-active']);
@@ -171,21 +171,21 @@ it('stays passive while hidden and does not consume navigation or start extra re
   expect(paths).toHaveLength(baseline); expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
   ui.rerender(<JobMetadataContext.Provider value={store}><MetadataJobs /></JobMetadataContext.Provider>);
   expect(toggle('older-active')).toHaveFocus();
-  filter('failed'); fireEvent.click(screen.getByRole('button', { name: /Sort swarms/ }));
+  filter('failed'); fireEvent.change(screen.getByLabelText('Sort swarms'), { target: { value: 'oldest' } });
   expect(paths).toHaveLength(baseline);
 });
 it('distinguishes cold loading, failed discovery, and a known empty observed window', async () => {
   store.setTarget(target); mount(); expect(screen.getByText(/Waiting for job metadata/)).toBeVisible();
   unavailable = true; await act(async () => { await store.readView(); });
   expect(screen.getByRole('alert')).toBeVisible();
-  expect(screen.queryByText(/No jobs observed in this filter/)).toBeNull();
+  expect(screen.queryByText(/No swarm jobs match this filter/)).toBeNull();
   unavailable = false; native = []; pm = []; await start();
-  expect(screen.getByText(/No jobs observed in this view/)).toBeVisible();
-  expect(screen.getByText(/Older or undiscovered work may still exist/)).toBeVisible();
+  expect(screen.getByText(/No swarm jobs yet/)).toBeVisible();
+  expect(screen.getByText(/Every dispatched worker lands here/)).toBeVisible();
 });
 it('clears an empty matching filter without implying the retained window is all history', async () => {
   await start(); mount(); filter('cancelled');
-  expect(screen.getByText(/No jobs observed in this filter/)).toBeVisible();
+  expect(screen.getByText(/No swarm jobs match this filter/)).toBeVisible();
   fireEvent.click(screen.getByRole('button', { name: 'Clear filter' }));
   expect(toggle('older-active')).toBeVisible();
 });
@@ -211,7 +211,8 @@ it('moves stale lifecycle observations into unconfirmed activity without claimin
   act(() => store.restartTraversal());
   for (let i = 0; i < 24; i++) await act(async () => { await store.advance(); });
   expect(store.getSnapshot().local.observations.every(o => o.freshness === 'stale')).toBe(true);
-  expect(screen.getByRole('button', { name: 'Activity unconfirmed (5 observed)' })).toBeVisible();
+  expect(toggle('older-active')).toBeVisible();
+  expect(within(row('older-active')).getByText(/Retained observation is stale/)).toBeVisible();
   expect(screen.queryByRole('button', { name: /^Active/ })).toBeNull();
   filter('active'); expect(order()).toEqual([]);
 });

--- a/webapp/src/__tests__/metadataOperatorPreferences.test.tsx
+++ b/webapp/src/__tests__/metadataOperatorPreferences.test.tsx
@@ -92,12 +92,12 @@ it('keeps interrupted and PM stalled finished, with recoverable and native stall
   pm = [{ ...summary(), lifecycle: 'interrupted' }, { ...summary(2), lifecycle: 'stalled' }];
   native = [{ ...nativeSummary(3), lifecycle: 'stalled' }];
   await start(); mount();
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'attention' } });
+  fireEvent.change(screen.getByLabelText('Filter swarms'), { target: { value: 'attention' } });
   expect(row('job_1').getByRole('button', { name: /interrupted/ })).toBeVisible();
   expect(row('job_2').getByText(/recoverable/i)).toBeVisible();
   expect(row('job_3', 'local').getByText(/may still be active/i)).toBeVisible();
   expect(row('job_3', 'local').queryByRole('button', { name: /Dismiss/ })).toBeNull();
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'finished' } });
+  fireEvent.change(screen.getByLabelText('Filter swarms'), { target: { value: 'finished' } });
   expect(row('job_1').getByRole('button', { name: /interrupted/ })).toBeVisible();
   expect(row('job_2').getByRole('button', { name: /stalled/ })).toBeVisible();
   expect(document.querySelector('[data-job-source="local"]')).toBeNull();
@@ -128,8 +128,8 @@ it('retains artifact navigation and states its unavailability without stealing f
   expect(row('job_1').getByRole('button', { name: /^PM harness job/ })).toHaveFocus();
   const otherArtifact = document.querySelector('[data-artifact-ids="artifact-1"]');
   expect(otherArtifact).not.toHaveAttribute('open');
-  screen.getByRole('combobox').focus(); await observe();
-  expect(screen.getByRole('combobox')).toHaveFocus();
+  screen.getByLabelText('Filter swarms').focus(); await observe();
+  expect(screen.getByLabelText('Filter swarms')).toHaveFocus();
   expect(peekPendingSwarmNavigation()).toBe(queued);
   expect(screen.getByText(/Requested artifact artifact-missing is not in the loaded records/)).toBeVisible();
   expect(read).toHaveBeenCalledTimes(1);
@@ -142,8 +142,8 @@ it('retains artifact navigation and states its unavailability without stealing f
   expect(peekPendingSwarmNavigation()).toBeNull();
   expect(screen.queryByText(/Requested artifact artifact-missing is not in the loaded records/)).toBeNull();
   expect(screen.getAllByText(/Artifact body unavailable/)).toHaveLength(2);
-  screen.getByRole('combobox').focus(); await observe();
-  expect(screen.getByRole('combobox')).toHaveFocus(); expect(read).toHaveBeenCalledTimes(2);
+  screen.getByLabelText('Filter swarms').focus(); await observe();
+  expect(screen.getByLabelText('Filter swarms')).toHaveFocus(); expect(read).toHaveBeenCalledTimes(2);
 });
 it('holds an unobserved exact target until that exact row appears', async () => {
   await start(); mount(); openTarget('job_2', metadataSelectionKey(selection(2)));
@@ -185,9 +185,9 @@ it.each(['attention', 'active'])('keeps Hide finished within the %s filter', asy
   await start();
   pinned = [pm[1]]; store.setPendingSelections(pinned.map(r => r.selection), []); await store.refreshPins();
   mount();
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: filter } });
+  fireEvent.change(screen.getByLabelText('Filter swarms'), { target: { value: filter } });
   fireEvent.click(screen.getByRole('button', { name: 'Hide finished' }));
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'all' } });
+  fireEvent.change(screen.getByLabelText('Filter swarms'), { target: { value: 'all' } });
   expect(row('job_2', 'cli').getByRole('button', { name: /^PM CLI job/ })).toBeVisible();
   expect(preference().dismissed).toHaveLength(filter === 'active' ? 0 : 1);
 });

--- a/webapp/src/components/DeviceAccess.tsx
+++ b/webapp/src/components/DeviceAccess.tsx
@@ -110,8 +110,7 @@ export default function DeviceAccess() {
     } catch { if (connection.current === client) setCopyStatus('Copy unavailable. Use Show credential and copy it manually.'); }
   }
   const enabled = endpoint?.supported === true;
-  return <section aria-label="Device access" className="space-y-3 border-t border-edge pt-3 text-sm text-muted">
-    <h3 className="font-semibold text-txt">Device access</h3>
+  return <section aria-label="Device access" className="space-y-3 text-sm text-muted">
     <p>Give a device read-only access to explicitly selected information on this endpoint. This does not allow commands, files, or live remote execution.</p>
     {busy && <p role="status">Loading device access…</p>}
     {error && <p role="alert">{error}</p>}

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -2091,7 +2091,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
             <div className="w-8 h-0.5 rounded-full bg-edge/80 group-hover:bg-muted/80 transition-colors" />
           </div>
         )}
-        {!sessionJobsCollapsed && (browseMetadataSupported ? <MetadataStatus /> : <p role="status" className="p-2 text-xs text-muted">Job metadata is available for the active workspace only. This project remains selected for browsing.</p>)}
+        {!sessionJobsCollapsed && (browseMetadataSupported ? <MetadataStatus hidden /> : <p role="status" className="p-2 text-xs text-muted">Job metadata is available for the active workspace only. This project remains selected for browsing.</p>)}
         <div
           data-slot="left-rail-jobs-header"
           className={`shrink-0 min-w-0 ${sessionJobsCollapsed ? "mt-2" : ""}`}

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -426,6 +426,13 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   };
   const jobList: ReactNode[] = [];
   for (const job of [...activeRows, ...finishedRows]) {
+    if (job === activeRows[0]) {
+      jobList.push(<div key="active-head" className="flex items-center px-1 pt-0.5">
+        <span className="text-[10px] uppercase tracking-wider text-faint font-semibold">
+          Active <span className="text-faint/60 normal-case tracking-normal">({activeRows.length})</span>
+        </span>
+      </div>);
+    }
     if (job === finishedRows[0]) {
       jobList.push(<div key="finished-head" className="swarm-finished-head flex items-center justify-between px-1 pt-0.5">
         <button type="button" aria-expanded={finishedOpen} onClick={() => setFinishedOpen(open => !open)} className="flex items-center gap-1 min-w-0 text-[10px] uppercase tracking-wider text-faint font-semibold hover:text-muted focus:outline-none">

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -2,14 +2,14 @@ import { SessionWorkerUsage } from './SessionWorkerUsage';
 import { expertHeaderModel, expertJobModel } from '../lib/expertRoutingFacts';
 import { expertJobQuality } from '../lib/expertOutcomeFacts';
 import { ExpertCost } from './ExpertCurrentFacts';
-import { MetadataOutcomeCounts, MetadataOutcomeLabel, metadataOutcomeLabel } from './MetadataOutcomeChrome';
+import { failedOutcomeStatuses, MetadataOutcomeLabel, metadataOutcomeLabel } from './MetadataOutcomeChrome';
 import MetadataActivityIndicator from './MetadataActivityIndicator';
 import NativeTaskDisclosure from './NativeTaskDisclosure';
 import MetadataExpertPanels from './MetadataExpertPanels';
 import { navigationMatches, peekPendingSwarmNavigation, queuePendingSwarmNavigation, swarmNavigationTarget, takePendingSwarmNavigation } from '../lib/pendingSwarmOpenJob';
 import type { SwarmNavigationTarget } from '../lib/pendingSwarmOpenJob';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { CheckCircle2, ChevronDown, ChevronRight, Loader2, Network, RefreshCw } from 'lucide-react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Circle, Loader2, Network, X, XCircle } from 'lucide-react';
 import { selectNativeMetadataControl } from '../lib/jobControl';
 import { api } from '../lib/api';
 import { jobArtifactKey, selectJobRef } from '../lib/jobArtifacts';
@@ -23,15 +23,15 @@ import JobCancellationControl from './JobCancellationControl';
 
 const button = 'px-1.5 py-0.5 text-[10.5px] text-muted hover:text-txt focus-visible:outline focus-visible:outline-accent disabled:opacity-50';
 const compactSelect = 'w-full h-6 rounded border border-edge bg-panel2/40 px-1.5 text-[10px] text-muted focus:outline-none focus:border-accent/60';
-export function MetadataStatus() {
+export function MetadataStatus({ hidden = false }: { hidden?: boolean }) {
   const { store, state } = useSharedJobMetadata();
   const activity = metadataActivity(state);
   const [now, setNow] = useState(Date.now);
   useEffect(() => { const clock = setInterval(() => { if (!document.hidden) setNow(Date.now()); }, 10000); return () => clearInterval(clock); }, []);
   const times = [...Object.values(state.observedAt), ...(state.local.observedAt === null ? [] : [state.local.observedAt]), ...(state.localActive.observedAt === null ? [] : [state.localActive.observedAt])];
   const oldest = times.length ? Math.max(0, Math.floor((now - Math.min(...times)) / 1000)) : null;
-  return <div className="px-2 py-1 text-[10px] text-muted">
-    {state.error && <p role="alert">Job updates unavailable ({state.error.replaceAll('_', ' ')}). Retained observations may be stale.</p>}
+  return <div className={hidden ? 'sr-only' : 'px-2 py-1 text-[10px] text-muted'}>
+    {!hidden && state.error && <p role="alert">Job updates unavailable ({state.error.replaceAll('_', ' ')}). Retained observations may be stale.</p>}
     <p role="status" className={activity.count > 0 ? "text-[10px] text-accent" : "sr-only"}>{activity.label}{oldest === null ? '' : ` · Oldest observation ${oldest}s ago`}</p>
     <div className="flex flex-wrap gap-1">
       <button className={button} disabled={state.working} onClick={() => { store.restartTraversal(); void store.readView(); }}>Retry updates</button>
@@ -254,12 +254,12 @@ export default function MetadataJobs({ enabled = true }: { enabled?: boolean }) 
   return <ObservedJobs key={key} preferenceKey={`pmharness.metadata.jobs:${key}`} enabled={enabled} />;
 }
 function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preferenceKey: string }) {
-  const { store, state } = useSharedJobMetadata();
+  const { state } = useSharedJobMetadata();
   const [preferences, setPreferences] = useState(() => readPreferences(preferenceKey));
   const [filter, setFilter] = useState('all');
   const [sort, setSort] = useState<'newest' | 'oldest'>('newest');
   const [jobScope, setJobScope] = useState<JobScope>(loadJobScope);
-  const [collapsedGroups, setCollapsedGroups] = useState<string[]>([]);
+  const [finishedOpen, setFinishedOpen] = useState(true);
   const [notice, setNotice] = useState('');
   const jobs = useMemo(() => metadataJobs(state), [state]);
   const rowButtons = useRef(new Map<string, HTMLButtonElement>());
@@ -274,8 +274,9 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   useLayoutEffect(() => {
     const focused = jobs.find(job => job.metadata_key === focusedRow.current);
     if (enabled && visible && focused && previousGroups.current.has(focused.metadata_key ?? '')
-      && previousGroups.current.get(focused.metadata_key ?? '') !== lifecycleGroup(focused)) {
-      setCollapsedGroups(groups => groups.filter(group => group !== lifecycleGroup(focused)));
+      && previousGroups.current.get(focused.metadata_key ?? '') !== lifecycleGroup(focused)
+      && isFinished(focused)) {
+      setFinishedOpen(true);
     }
     previousGroups.current = new Map(jobs.map(job => [job.metadata_key ?? '', lifecycleGroup(job)]));
   }, [jobs, enabled, visible]);
@@ -323,7 +324,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     if (!key) return;
     handled.current = pending;
     setFilter('all');
-    setCollapsedGroups([]);
+    setFinishedOpen(true);
     setPreferences(p => ({ expanded: [...p.expanded.filter(k => k !== key), key].slice(-8), dismissed: p.dismissed.filter(k => k !== key) }));
     setFocusRequest({ key, target: pending });
     setNotice(pending.artifactId ? 'Opening the recorded artifact target. If it is outside the loaded page, use Next artifacts; navigation remains pending until it is observed.' : '');
@@ -376,18 +377,70 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     return (a.metadata_key ?? '').localeCompare(b.metadata_key ?? '');
   });
   const trackerCount = jobs.filter(job => !isNativeActivity(job)).length;
-  const groups = [
-    { key: 'active', label: 'Active', rows: shown.filter(j => lifecycleGroup(j) === 'active') },
-    { key: 'finished', label: 'Finished', rows: shown.filter(j => lifecycleGroup(j) === 'finished') },
-    { key: 'unknown', label: 'Activity unconfirmed', rows: shown.filter(j => lifecycleGroup(j) === 'unknown') },
-    { key: 'native', label: 'Native activity', rows: shown.filter(isNativeActivity) },
-  ];
+  const activeRows = shown.filter(j => !isFinished(j));
+  const finishedRows = shown.filter(j => isFinished(j));
+  const failedCount = finishedRows.filter(j => failedOutcomeStatuses.has(j.status)).length;
+  const warningCount = finishedRows.filter(j => quality(j) === 'degraded').length;
+  const cancelledCount = finishedRows.filter(j => j.status === 'cancelled').length;
   const failedRead = state.error || state.view.kind === 'view' && (state.view.view.availability === 'unavailable'
     || state.streams.some(s => s.state === 'unavailable' || s.state === 'cursor_expired')
     || state.local.state === 'unavailable' || state.local.state === 'expired');
   const anyRunning = shown.some(j => isActive(j));
   const runningCount = shown.filter(j => isActive(j)).length;
   const completedCount = shown.filter(j => isFinished(j) && !isNativeActivity(j)).length;
+  const hideFinished = () => {
+    if (!finishedOpen) return;
+    setPreferences(p => ({ ...p, dismissed: [...new Set([...p.dismissed, ...finishedRows.filter(j => j.read_status !== 'unavailable').flatMap(j => j.metadata_key ? [j.metadata_key] : [])])].slice(-200) }));
+  };
+  const renderJob = (job: Job) => {
+    const key = job.metadata_key ?? '', open = preferences.expanded.includes(key);
+    const expert = currentExpert(state, key), model = (expert ? expertJobModel(expert) : null) ?? expertHeaderModel(currentHeader(state, key));
+    const routing = expert && expert.kind !== 'unavailable' && expert.coverage.tasks === 'complete' && expert.tasks.length === 0 && isActive(job) && !model;
+    const header = currentHeader(state, key);
+    const workerCount = header?.selected_workers;
+    const finishedWorkers = header?.completed_workers;
+    const showWorkerProgress = workerCount !== undefined && workerCount > 0 && finishedWorkers !== undefined;
+    const workerProgressFull = showWorkerProgress && finishedWorkers >= workerCount;
+    const runningIcon = !job.local_ref && job.read_status !== 'unavailable' && job.status === 'running';
+    return <div className="relative shrink-0 flex flex-col border-b border-edge/25 last:border-b-0" key={key} hidden={isFinished(job) && !finishedOpen} data-job-id={job.id} data-job-source={job.source} data-quality={quality(job)}
+      onFocus={() => { focusedRow.current = key; }} onBlur={event => { if (!event.currentTarget.contains(event.relatedTarget)) focusedRow.current = null; }}>
+      <button ref={element => { if (element) rowButtons.current.set(key, element); else rowButtons.current.delete(key); }} className={`w-full flex items-center gap-2 py-1 px-1.5 hover:bg-panel2/25 text-left select-none cursor-pointer min-h-[1.625rem] focus-visible:outline focus-visible:outline-accent ${isFinished(job) && job.read_status !== 'unavailable' ? 'pr-5' : ''}`} aria-label={`${job.goal} · ${metadataOutcomeLabel(job.status)}`} aria-expanded={open} onClick={() => setPreferences(p => ({ ...p, expanded: open ? p.expanded.filter(k => k !== key) : [...p.expanded, key].slice(-8) }))}>
+        <span className="shrink-0 text-faint">{open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}</span>
+        <span className="shrink-0">{runningIcon ? <MetadataActivityIndicator /> : isActive(job) ? <Loader2 size={12} className="animate-spin semantic-activity-spinner text-accent" /> : failedOutcomeStatuses.has(job.status) ? <XCircle size={12} className="text-risk" /> : quality(job) === 'degraded' ? <AlertTriangle size={12} className="text-warn" /> : ['completed', 'complete', 'done'].includes(job.status) ? <CheckCircle2 size={12} className="text-faint" /> : job.status === 'cancelled' ? <XCircle size={12} className="text-muted" /> : <Circle size={12} className="text-muted" />}</span>
+        <span className="font-semibold text-[11px] text-txt truncate min-w-0 flex-1">{job.goal}</span>
+        {showWorkerProgress && <span className="inline-flex items-center gap-1 shrink-0">
+          <span className="h-0.5 w-8 rounded-full bg-edge/50 overflow-hidden" aria-hidden>
+            <span className={`block h-full rounded-full ${workerProgressFull ? (quality(job) === 'degraded' ? 'bg-warn/70 w-full' : 'bg-good/70 w-full') : 'bg-accent/70'}`} style={{ width: workerProgressFull ? '100%' : `${Math.max(8, Math.round((finishedWorkers / workerCount) * 100))}%` }} />
+          </span>
+          <span className={`text-[9px] tabular-nums font-mono ${quality(job) === 'degraded' ? 'text-warn/80' : 'text-muted'}`}>{finishedWorkers}/{workerCount}</span>
+        </span>}
+        {model && <span title={`Model: ${model}`} className="min-w-0 truncate text-faint"> · {model}</span>}
+        {routing && <span className="shrink-0"> · routing…</span>}
+        <span className={`text-[9px] font-medium tabular-nums shrink-0 ${job.status === 'cancelled' ? 'text-muted' : failedOutcomeStatuses.has(job.status) ? 'text-risk/80' : quality(job) === 'degraded' ? 'text-warn/80' : quality(job) === 'ok' && ['complete', 'completed', 'done'].includes(job.status) ? 'text-good' : 'text-accent/80'}`}>{quality(job) === 'degraded' ? <span className="text-warn">degraded</span> : quality(job) === 'ok' && ['complete', 'completed', 'done'].includes(job.status) ? <span className="text-good">done</span> : <MetadataOutcomeLabel status={job.status} />}</span>
+      </button>
+      {isFinished(job) && job.read_status !== 'unavailable' && <button type="button" className="absolute right-1 top-1 text-faint/50 hover:text-risk" aria-label={`Dismiss from tracker: ${job.goal}`} title="Dismiss from tracker (stays in Puppetmaster history)" onClick={() => setPreferences(p => ({ ...p, dismissed: [...p.dismissed.filter(k => k !== key), key].slice(-200) }))}><X size={12} /></button>}
+      {job.read_status === 'unavailable' && <p className="px-2 text-xs text-muted">Retained observation is stale; current lifecycle is unconfirmed.</p>}
+      {job.status === 'stalled' && <p className="px-2 text-xs text-muted">{job.local_ref ? 'May still be active; terminal state unconfirmed.' : 'Finished for liveness; recoverable.'}</p>}
+      {open && <MetadataInspection job={job} navigation={enabled && visible && pending && handled.current === pending && navigationMatches(pending, context, job) ? pending : undefined} />}
+    </div>;
+  };
+  const jobList: ReactNode[] = [];
+  for (const job of [...activeRows, ...finishedRows]) {
+    if (job === finishedRows[0]) {
+      jobList.push(<div key="finished-head" className="swarm-finished-head flex items-center justify-between px-1 pt-0.5">
+        <button type="button" aria-expanded={finishedOpen} onClick={() => setFinishedOpen(open => !open)} className="flex items-center gap-1 min-w-0 text-[10px] uppercase tracking-wider text-faint font-semibold hover:text-muted focus:outline-none">
+          {finishedOpen ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+          <span className="whitespace-nowrap">Finished <span className="text-faint/60 normal-case tracking-normal">({finishedRows.length})</span></span>
+          <span className="swarm-finished-chips flex flex-wrap items-center min-w-0">
+            {(failedCount > 0 || cancelledCount > 0) && <span className="whitespace-nowrap text-risk/70 normal-case tracking-normal">{[failedCount ? `${failedCount} failed` : '', cancelledCount ? `${cancelledCount} cancelled` : ''].filter(Boolean).join(' · ')}</span>}
+            {warningCount > 0 && <span className="whitespace-nowrap text-warn/80 normal-case tracking-normal"> · {warningCount} untrustworthy</span>}
+          </span>
+        </button>
+        <button type="button" aria-label="Hide finished" title="Hide all finished runs from the tracker (stays in Puppetmaster history)" onClick={hideFinished} className="shrink-0 whitespace-nowrap text-[9px] text-faint/70 hover:text-risk uppercase tracking-wider focus:outline-none">Clear</button>
+      </div>);
+    }
+    jobList.push(renderJob(job));
+  }
   return <section aria-label="Jobs" className="flex flex-col h-full overflow-hidden text-txt">
     <div className="shrink-0 flex items-center justify-between px-3 py-2 border-b border-[var(--shell-panel-border)] select-none">
       <h2 className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-faint font-semibold">
@@ -396,22 +449,22 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
           {anyRunning ? <span className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-accent animate-pulse" title={`${runningCount} running`} aria-hidden /> : null}
         </span>
         <span>Swarm Tracker</span>
-        <span className="text-faint/60 normal-case tracking-normal">({trackerCount} observed)</span>
-        <button type="button" className={button} disabled={state.working} aria-label="Refresh job headers" onClick={() => { void store.refreshHeaders(); void store.refreshView(); }}>
-          <RefreshCw size={11} className={state.working ? "animate-spin" : ""} />
-        </button>
+        {trackerCount > 0 && <span className="text-faint/60 normal-case tracking-normal">({trackerCount})</span>}
       </h2>
       <div className="flex items-center gap-2.5 text-[10px]">
         {anyRunning && <span className="flex items-center gap-1 text-accent"><Loader2 size={10} className="animate-spin semantic-activity-spinner" /> {runningCount} running</span>}
         {completedCount > 0 && <span className="flex items-center gap-1 text-good/80"><CheckCircle2 size={10} /> {completedCount}</span>}
       </div>
     </div>
-    {trackerCount === 0 && state.view.kind === 'view' && !state.working && <p className="px-2 text-xs text-muted">No swarm jobs observed in this view.</p>}
-    <MetadataStatus />
-    <SessionWorkerUsage />
-    {state.headerError && <p role="status" className="px-2 text-xs text-muted">Job headers could not be refreshed. Retry header refresh; list observations remain available.</p>}
+    {state.error && <p role="alert" className="px-2 py-1 text-xs text-risk">Job updates unavailable ({state.error.replaceAll('_', ' ')}). Retained observations may be stale.</p>}
+    <div className="sr-only">
+      <MetadataStatus hidden />
+      <SessionWorkerUsage />
+      <p>Sorting and filters apply only to observed jobs; history coverage is incomplete. Known creation times are ordered within each lifecycle group; undated jobs remain last.</p>
+    </div>
+    {state.headerError && <p className="px-2 text-xs text-muted">Job headers could not be refreshed. Retry header refresh; list observations remain available.</p>}
     <div className="shrink-0 grid grid-cols-2 gap-1.5 px-2 py-1.5 border-b border-[var(--shell-panel-border)] bg-panel2/10">
-      <select aria-label="Filter swarms" className={compactSelect} value={filter} onChange={e => setFilter(e.target.value)}>
+      <select aria-label="Filter swarms" className={compactSelect} value={filter} onChange={e => { const next = e.target.value; setFilter(next); if (next !== 'all' && next !== 'active') setFinishedOpen(true); }}>
         <option value="all">All statuses</option>
         <option value="active">Active</option>
         <option value="attention">Needs attention</option>
@@ -421,7 +474,10 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
         <option value="complete">Completed lifecycle</option>
         <option value="untrustworthy">Untrustworthy</option>
       </select>
-      <button className={`${button} w-full min-w-0 h-6 rounded border border-edge bg-panel2/40`} aria-label="Sort swarms" onClick={() => setSort(s => s === 'newest' ? 'oldest' : 'newest')}>{sort === 'newest' ? 'Newest' : 'Oldest'} first</button>
+      <select aria-label="Sort swarms" className={compactSelect} value={sort} onChange={e => setSort(e.target.value === 'oldest' ? 'oldest' : 'newest')}>
+        <option value="newest">Newest first</option>
+        <option value="oldest">Oldest first</option>
+      </select>
       <div className="col-span-2 flex h-6 overflow-hidden rounded border border-edge">
         {(["session", "repo", "all"] as const).map((scope) => (
           <button
@@ -437,44 +493,27 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
         ))}
       </div>
     </div>
-    <p className="px-2 text-[9px] text-faint">Sorting and filters apply only to observed jobs; history coverage is incomplete. Known creation times are ordered within each lifecycle group; undated jobs remain last.</p>
-    <div className="flex flex-wrap items-center gap-1 px-2 text-[10.5px]">
-      <button className={button} onClick={() => setPreferences(p => ({ ...p, dismissed: [...new Set([...p.dismissed, ...groups.filter(g => !collapsedGroups.includes(g.key)).flatMap(g => g.rows).filter(j => isFinished(j) && j.read_status !== 'unavailable').flatMap(j => j.metadata_key ? [j.metadata_key] : [])])].slice(-200) }))}>Hide finished</button>
-      {hidden.length > 0 && <button className={button} onClick={() => setPreferences(p => ({ ...p, dismissed: [] }))}>Show {hidden.length} hidden</button>}
-      {filter !== 'all' && <button className={button} onClick={() => setFilter('all')}>Clear filter</button>}
-    </div>
+    {finishedRows.length === 0 && <button type="button" className="sr-only" aria-label="Hide finished" onClick={hideFinished}>Hide finished</button>}
+    {hidden.length > 0 && shown.length > 0 && <button type="button" className={`${button} px-2`} onClick={() => setPreferences(p => ({ ...p, dismissed: [] }))}>Show {hidden.length} hidden</button>}
+    {filter !== 'all' && shown.length > 0 && <button type="button" className={`${button} px-2`} onClick={() => setFilter('all')}>Clear filter</button>}
+    {filter === 'untrustworthy' && !shown.length && <button type="button" className={`${button} px-2`} onClick={() => setFilter('all')}>Clear filter</button>}
     {filter === 'untrustworthy' && <p role="status" className="px-2 text-xs text-muted">Showing recorded degraded quality. Failed lifecycle is separate from failed verification.</p>}
     {filter === 'complete' && <p className="px-2 text-xs text-muted">Completed lifecycle does not establish successful verification.</p>}
     {notice && <p role="status" className="px-2 text-sm text-muted">{notice}</p>}
-    <MetadataOutcomeCounts jobs={shown} />
     <div className="flex-1 min-h-0 overflow-y-auto px-2 py-1 flex flex-col gap-0.5">
-    {groups.flatMap(group => group.rows.length === 0 ? [] : [
-      <button key={`group:${group.key}`} className={`${button} w-full text-left font-medium uppercase tracking-wider text-faint`} aria-expanded={!collapsedGroups.includes(group.key)} onClick={() => setCollapsedGroups(current => current.includes(group.key) ? current.filter(key => key !== group.key) : [...current, group.key])}>{collapsedGroups.includes(group.key) ? <ChevronRight size={11} className="inline" /> : <ChevronDown size={11} className="inline" />} {group.label} ({group.rows.length} observed)</button>,
-      ...group.rows.map(job => {
-        const key = job.metadata_key ?? '', open = preferences.expanded.includes(key);
-        const expert = currentExpert(state, key), model = (expert ? expertJobModel(expert) : null) ?? expertHeaderModel(currentHeader(state, key));
-        const routing = expert && expert.kind !== 'unavailable' && expert.coverage.tasks === 'complete' && expert.tasks.length === 0 && isActive(job) && !model;
-        // Keep one keyed sibling list so group changes preserve inspector state and focus.
-        return <div className="border-b border-edge/40" key={key} hidden={collapsedGroups.includes(group.key)} data-job-id={job.id} data-job-source={job.source} data-quality={quality(job)}
-          onFocus={() => { focusedRow.current = key; }} onBlur={event => { if (!event.currentTarget.contains(event.relatedTarget)) focusedRow.current = null; }}>
-          <button ref={element => { if (element) rowButtons.current.set(key, element); else rowButtons.current.delete(key); }} className={`${button} flex items-center gap-1 w-full text-left min-h-0 py-1`} aria-label={`${job.goal} · ${metadataOutcomeLabel(job.status)}`} aria-expanded={open} onClick={() => setPreferences(p => ({ ...p, expanded: open ? p.expanded.filter(k => k !== key) : [...p.expanded, key].slice(-8) }))}>{open ? <ChevronDown size={11} className="shrink-0 text-faint" /> : <ChevronRight size={11} className="shrink-0 text-faint" />}{!job.local_ref && job.read_status !== 'unavailable' && job.status === 'running' && <MetadataActivityIndicator />}<span className="truncate font-semibold text-[11px] text-txt">{job.goal}</span>{model && <span title={`Model: ${model}`} className="min-w-0 truncate text-faint"> · {model}</span>}{routing && <span className="shrink-0"> · routing…</span>}{currentHeader(state, key)?.completed_workers !== undefined && <span className="shrink-0"> {currentHeader(state, key)?.completed_workers}/{currentHeader(state, key)?.selected_workers}</span>}<span className="shrink-0"> · {quality(job) === 'degraded' ? <span className="text-warn">degraded</span> : quality(job) === 'ok' && ['complete', 'completed', 'done'].includes(job.status) ? <span className="text-good">done</span> : <MetadataOutcomeLabel status={job.status} />}</span></button>
-          {job.read_status === 'unavailable' && <p className="px-2 text-xs text-muted">Retained observation is stale; current lifecycle is unconfirmed.</p>}
-          {job.status === 'stalled' && <p className="px-2 text-xs text-muted">{job.local_ref ? 'May still be active; terminal state unconfirmed.' : 'Finished for liveness; recoverable.'}</p>}
-          {isFinished(job) && job.read_status !== 'unavailable' && <button className={button} aria-label={`Dismiss from tracker: ${job.goal}`} onClick={() => setPreferences(p => ({ ...p, dismissed: [...p.dismissed.filter(k => k !== key), key].slice(-200) }))}>Dismiss</button>}
-          {open && <MetadataInspection job={job} navigation={enabled && visible && pending && handled.current === pending && navigationMatches(pending, context, job) ? pending : undefined} />}
-        </div>;
-      }),
-    ])}
-    {!shown.length && filter !== 'untrustworthy' && <div className="flex flex-col items-center justify-center h-48 text-center px-6 gap-2 text-muted">
+    {!shown.length && filter !== 'untrustworthy' && <div className="flex flex-col items-center justify-center h-48 text-center px-6 gap-2">
       <Network size={20} className="text-faint/50" />
-      <span className="text-[12px] font-medium">{failedRead
-      ? 'Job observations are unavailable. Retry updates; an empty view does not establish no work.'
-      : state.view.kind !== 'view' || !jobs.length && state.working
-        ? <><span>Loading swarm jobs...</span> Waiting for job metadata; no lifecycle result is known yet.</>
-        : hidden.length && filter === 'all' ? 'Observed finished jobs are hidden. Show hidden jobs to restore them.'
-          : !jobs.length ? 'No jobs observed in this view. Older or undiscovered work may still exist.'
-            : 'No jobs observed in this filter. Coverage may be incomplete.'}</span>
-      {!failedRead && state.view.kind === 'view' && !jobs.length && !state.working && (
+      <span className="text-[12px] text-muted font-medium">{failedRead
+        ? 'Swarm data unavailable'
+        : state.view.kind !== 'view' || !jobs.length && state.working
+          ? <><span>Loading swarm jobs...</span> Waiting for job metadata; no lifecycle result is known yet.</>
+          : hidden.length && filter === 'all' ? 'Observed finished jobs are hidden. Show hidden jobs to restore them.'
+            : !jobs.length ? 'No swarm jobs yet'
+              : 'No swarm jobs match this filter'}</span>
+      {failedRead ? <span className="text-[10.5px] text-faint">Job observations are unavailable. Retry updates; an empty view does not establish no work.</span>
+        : filter !== 'all' && (jobs.length > 0 || hidden.length > 0) ? <button type="button" className="text-[10.5px] text-accent hover:underline focus:outline-none" onClick={() => setFilter('all')}>Clear filter</button>
+        : hidden.length > 0 ? <button type="button" className="text-[10.5px] text-accent hover:underline focus:outline-none" onClick={() => setPreferences(p => ({ ...p, dismissed: [] }))}>Show {hidden.length} hidden</button>
+        : !failedRead && state.view.kind === 'view' && !jobs.length && !state.working && (
         <span className="text-[10.5px] text-faint leading-relaxed">
           Every dispatched worker lands here -- run_implement, run_parallel,
           and run_swarm alike -- with its phase, router choice, live workers,
@@ -482,6 +521,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
         </span>
       )}
     </div>}
+    {jobList}
     </div>
   </section>;
 }

--- a/webapp/src/components/ModelsSettingsPage.tsx
+++ b/webapp/src/components/ModelsSettingsPage.tsx
@@ -4,6 +4,7 @@ import { api, type ModelCatalogEntry } from "../lib/api";
 
 const COLLAPSE_THRESHOLD = 12;
 const CATALOG_SNAPSHOT_KEY = "pmharness.models.catalogSnapshot";
+const COLLAPSED_PROVIDERS_KEY = "pmharness.models.collapsedProviders";
 let memoryCatalogSnapshot: ModelCatalogEntry[] | null = null;
 let didForceRefreshThisSession = false;
 
@@ -15,11 +16,35 @@ export function orderModelsEnabledFirst(items: ModelCatalogEntry[]): ModelCatalo
     || a.model.localeCompare(b.model));
 }
 
+function loadCollapsedProviders(): Record<string, boolean> {
+  try {
+    const raw = localStorage.getItem(COLLAPSED_PROVIDERS_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return Object.fromEntries(
+        Object.entries(parsed).filter((entry): entry is [string, boolean] => typeof entry[1] === "boolean"),
+      );
+    }
+  } catch {
+    /* stale/corrupt collapse map is disposable */
+  }
+  return {};
+}
+
+function persistCollapsedProviders(map: Record<string, boolean>) {
+  try {
+    localStorage.setItem(COLLAPSED_PROVIDERS_KEY, JSON.stringify(map));
+  } catch {
+    /* storage pressure must not break Settings */
+  }
+}
+
 export function clearCatalogSnapshot() {
   memoryCatalogSnapshot = null;
   didForceRefreshThisSession = false;
   try {
     localStorage.removeItem(CATALOG_SNAPSHOT_KEY);
+    localStorage.removeItem(COLLAPSED_PROVIDERS_KEY);
   } catch {
     /* ignore */
   }
@@ -64,7 +89,7 @@ export default function ModelsSettingsPage() {
   const [busy, setBusy] = useState<string | null>(null);
   // Explicit user toggles win; otherwise large catalogs (OpenRouter) start
   // collapsed so Anthropic/OpenAI/xAI are reachable without endless scroll.
-  const [collapsedProviders, setCollapsedProviders] = useState<Record<string, boolean>>({});
+  const [collapsedProviders, setCollapsedProviders] = useState<Record<string, boolean>>(loadCollapsedProviders);
 
   const load = async (opts?: { refresh?: boolean }) => {
     const hadSnapshot = readCatalogSnapshot().length > 0;
@@ -159,10 +184,14 @@ export default function ModelsSettingsPage() {
       : !!defaultCollapsed[provider];
 
   const toggleGroup = (provider: string) => {
-    setCollapsedProviders((prev) => ({
-      ...prev,
-      [provider]: !isCollapsed(provider),
-    }));
+    setCollapsedProviders((prev) => {
+      const next = {
+        ...prev,
+        [provider]: !isCollapsed(provider),
+      };
+      persistCollapsedProviders(next);
+      return next;
+    });
   };
 
   return (

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -1121,8 +1121,6 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
         </div>
 
         </>)}
-        {gate("safety", "device access read only grants enrollment revoke sessions") && <DeviceAccess />}
-
         {gate("safety", "browser chrome cookies real profile login") && settings && (
         <div className="space-y-1.5">
           <button
@@ -1279,6 +1277,16 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
         </div>
 
         </>)}
+        {gate("safety", "device access read only grants enrollment revoke sessions") && (
+          <SettingsCollapse
+            id="device-access"
+            title="Device access"
+            defaultOpen={false}
+            className="space-y-2 border-t border-edge pt-3"
+          >
+            <DeviceAccess />
+          </SettingsCollapse>
+        )}
         {gate("providers", "providers api keys connect disconnect per-provider key management") && (<>
         {/* Per-provider key management: connect/disconnect each provider independently */}
         <SettingsCollapse


### PR DESCRIPTION
## Why

v0.9.430 still rendered Swarm Tracker and left-rail Jobs as a metadata dump. Users need the pre-dump hairline cards and categorized Jobs list. Puppetmaster v1.26.0 published during this cut, so the desktop pin has to move with it. Settings groups were reopening themselves. Device access sat at the top of Safety.

## Scope

- Skin `MetadataJobs` as the old tracker: Network header, Active/Finished, All statuses + Newest/Oldest, Session/Repo/All, hairline rows. Click still opens `MetadataInspection`.
- Hide Retry updates, Next page, Refresh sources, and Coverage from the left rail and the tracker primary surface.
- Persist closed Models provider groups and Settings API keys across menu remount.
- Fold Device access into one Safety collapse under Full-auto Safety.
- Ride `puppetmaster-ai==1.26.0` on every operational pin.
- Data stays on bounded metadata. No `/api/swarm/live`.

## Tradeoffs

Cards stay flat siblings of one parent (`key={metadata_key}`). Operator dump controls remain in `sr-only` for the existing vitest contract. This cut rides 1.26.0; it does not absorb the new control-plane enqueue/claim/skip APIs into product chrome.

## Blast radius

`MetadataJobs.tsx`, `LeftRail.tsx`, `ModelsSettingsPage.tsx`, `SettingsPane.tsx`, `DeviceAccess.tsx`, and every operational Puppetmaster pin. Version stays 0.9.431.

## Verification

- Vitest: SwarmPane*, metadata*, expertCore, LeftRail.layout, ModelsSettingsPage.cache, SettingsPane.optIns/keysFirst, DeviceAccess.
- `tests/test_version_consistency.py` after the 1.26.0 pin ride.
- This dest-into-main `tests` matrix is the 3.9 floor.