### PR TITLE
absorb #345: stop duplicate PILOT snapshot replay

### DIFF
--- a/harness/stream_identity.py
+++ b/harness/stream_identity.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import time
 from typing import Any, Dict, Optional, Tuple
 
+from pmharness.stream_snapshot import absorb_stream_snapshot
+
 # Coalesce same-(channel, stream_id) deltas until either threshold trips.
 # 16ms is one paint frame — enough to protect the 512-frame SSE ring from
 # word tokens without stacking a second visible wave on the client's 33ms

--- a/pmharness/drivers/openai_compat.py
+++ b/pmharness/drivers/openai_compat.py
@@ -25,6 +25,7 @@ from .prompt_cache import (
 from .retry import with_retry
 from pmharness.reasoning import extract_reasoning, strip_think_blocks
 from pmharness.think_scrubber import StreamingThinkScrubber
+from pmharness.stream_snapshot import absorb_stream_snapshot
 
 _SUCCESS_CHAT_FINISH = frozenset({"stop", "stop_sequence", "end_turn"})
 _TOOL_CHAT_FINISH = frozenset({"tool_calls", "function_call"})
@@ -272,11 +273,13 @@ class _OpenAIChatSseAccumulator:
 
         content_delta = delta.get("content") or ""
         if content_delta:
+            piece = absorb_stream_snapshot(self.full_text, content_delta)
             self.stream_started = True
-            self.full_text += content_delta
-            visible = self.think_scrubber.feed(content_delta)
-            if visible and self.on_delta is not None:
-                self.on_delta(visible)
+            if piece:
+                self.full_text += piece
+                visible = self.think_scrubber.feed(piece)
+                if visible and self.on_delta is not None:
+                    self.on_delta(visible)
 
         reasoning_delta = (
             delta.get("reasoning")

--- a/pmharness/stream_snapshot.py
+++ b/pmharness/stream_snapshot.py
@@ -1,0 +1,32 @@
+"""Absorb chat Completions snapshot replays into incremental text.
+
+OpenRouter/Gemini often resend the whole message (or message+message) after
+true token deltas. Cursor CLI already skips that; Completions did not.
+"""
+
+from __future__ import annotations
+
+# Suffix-replay skip floor. One-letter incremental tails must still append.
+STREAM_SNAPSHOT_MIN_CHUNK = 12
+
+
+def absorb_stream_snapshot(accumulated, incoming, min_chunk=STREAM_SNAPSHOT_MIN_CHUNK):
+    """Return the new suffix to append, or empty when ``incoming`` is a replay."""
+    acc = accumulated or ""
+    inc = incoming or ""
+    if not inc:
+        return ""
+    if not acc:
+        return inc
+    if inc == acc:
+        return ""
+    if acc.startswith(inc):
+        return ""
+    if inc.startswith(acc):
+        rest = inc[len(acc):]
+        if rest.strip() == acc.strip():
+            return ""
+        return rest
+    if len(inc) >= min_chunk and acc.endswith(inc):
+        return ""
+    return inc

--- a/tests/test_openai_compat_stream_terminals.py
+++ b/tests/test_openai_compat_stream_terminals.py
@@ -73,6 +73,20 @@ def test_clean_stop_succeeds(monkeypatch):
     assert resp.meta["malformed_sse_chunks"] == 0
 
 
+def test_duplicate_content_snapshot_does_not_double_text(monkeypatch):
+    phrase = "Received—single response."
+    seen = []
+    lines = [
+        _data({"choices": [{"delta": {"content": phrase}}]}),
+        _data({"choices": [{"delta": {"content": phrase}, "finish_reason": "stop"}]}),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(), lines, on_delta=seen.append)
+    assert resp.error is None
+    assert resp.text == phrase
+    assert "".join(seen) == phrase
+
+
 def test_finish_reason_length_is_explicit_incomplete(monkeypatch):
     lines = [
         _data({"choices": [{"delta": {"content": "partial "}}]}),

--- a/tests/test_stream_identity_batch.py
+++ b/tests/test_stream_identity_batch.py
@@ -7,7 +7,22 @@ import time
 
 from harness.api.sse import SseEventRing, _SSE_RING_CAP
 from harness.send_loop_phases import drain_stream_queue
-from harness.stream_identity import StreamDeltaBatch, normalize_delta_payload
+from harness.stream_identity import (
+    StreamDeltaBatch,
+    absorb_stream_snapshot,
+    normalize_delta_payload,
+)
+
+
+def test_absorb_stream_snapshot_skips_replay_and_keeps_true_deltas():
+    phrase = "Received—single response."
+    assert absorb_stream_snapshot("", phrase) == phrase
+    assert absorb_stream_snapshot(phrase, phrase) == ""
+    assert absorb_stream_snapshot(phrase, phrase + "\n\n" + phrase) == ""
+    assert absorb_stream_snapshot(phrase, phrase + phrase) == ""
+    assert absorb_stream_snapshot("Received", phrase) == "—single response."
+    assert absorb_stream_snapshot("Hello", " world") == " world"
+    assert absorb_stream_snapshot(phrase, "Received") == ""
 
 
 class _CountingGetQueue(queue.Queue):

--- a/webapp/src/__tests__/transcriptSurfaceStability.test.ts
+++ b/webapp/src/__tests__/transcriptSurfaceStability.test.ts
@@ -1274,4 +1274,22 @@ describe("transcript surface stability (no mid-turn reclassification)", () => {
       cmd: "make check",
     });
   });
+
+  it("open pilot bubble absorbs snapshot replay instead of concatenating Benton #345", () => {
+    const phrase = "Received—single response.";
+    let items: Item[] = [
+      { kind: "msg", msg: { role: "user", text: "ping" } },
+      { kind: "msg", msg: { role: "assistant", text: phrase, streaming: true } },
+    ];
+    items = appendStreamingTextToItems(items, phrase);
+    expect(assistantTexts(items)).toEqual([phrase]);
+    items = appendStreamingTextToItems(items, phrase);
+    expect(assistantTexts(items)).toEqual([phrase]);
+    items = appendStreamingTextToItems(items, `${phrase}\n\n${phrase}`);
+    expect(assistantTexts(items)).toEqual([phrase]);
+    items = appendStreamingTextToItems(items, "Received");
+    expect(assistantTexts(items)).toEqual([phrase]);
+    items = appendStreamingTextToItems(items, `${phrase} Next.`);
+    expect(assistantTexts(items)).toEqual([`${phrase} Next.`]);
+  });
 });

--- a/webapp/src/components/conversation/streamBubbles.ts
+++ b/webapp/src/components/conversation/streamBubbles.ts
@@ -25,6 +25,27 @@ export function assistantProseCovers(existing: string, incoming: string): boolea
   return false;
 }
 
+/**
+ * Open-bubble absorb: live token deltas still append; snapshot / ring replay
+ * of the same sentence (or sentence+sentence) does not concatenate.
+ */
+export function absorbOpenPilotDelta(existing: string, incoming: string): string {
+  const acc = existing || "";
+  const inc = incoming || "";
+  if (!inc) return acc;
+  if (isTrivialAssistantCrumb(inc)) return acc;
+  if (!acc || isTrivialAssistantCrumb(acc)) return sanitizeThinkingStatusGlue(inc);
+  if (inc === acc) return acc;
+  if (acc.startsWith(inc)) return acc;
+  if (inc.startsWith(acc)) {
+    const rest = inc.slice(acc.length);
+    if (rest.trim() === acc.trim()) return acc;
+    return sanitizeThinkingStatusGlue(inc);
+  }
+  if (inc.trim().length >= PROSE_COVER_MIN_CHUNK && acc.endsWith(inc)) return acc;
+  return sanitizeThinkingStatusGlue(acc + inc);
+}
+
 /** Current-turn sealed (non-streaming) assistant texts, newest last. */
 export function sealedAssistantTextsInTurn(items: Item[]): string[] {
   const texts: string[] = [];
@@ -178,9 +199,9 @@ export function appendStreamingTextToItems(
     const updated = [...items];
     const stampWorkerId =
       workerStream && workerId && !(bubble.msg.worker_id || "").trim();
-    const nextText = isTrivialAssistantCrumb(chunk)
-      ? bubble.msg.text
-      : sanitizeThinkingStatusGlue(bubble.msg.text + chunk);
+    const nextText = workerStream
+      ? (isTrivialAssistantCrumb(chunk) ? bubble.msg.text : sanitizeThinkingStatusGlue(bubble.msg.text + chunk))
+      : absorbOpenPilotDelta(bubble.msg.text, chunk);
     updated[idx] = {
       kind: "msg",
       msg: {


### PR DESCRIPTION
## Summary
- Completions streams from OpenRouter/Gemini often resend the whole answer (or the answer twice) after token deltas. The accumulator appended that snapshot, so Received-single response painted twice in one PILOT bubble.
- Open-bubble append now absorbs the same snapshot/ring replay. Thinking already coalesced snapshots; sealed-bubble cover still leaves a true longer post-tool answer alone.
- Cursor CLI already skipped the final full message. This is the Completions equivalent, not a display concat strip.

Fixes #345. Credit @kbentonferguson.

## Test plan
- [x] pytest stream identity + OpenAI Completions terminals + streaming say
- [x] Vitest transcriptSurfaceStability including Benton 345 open-bubble absorb
- [ ] dest tests matrix is the 3.9 floor
