### PR TITLE
fix: drop unused @ts-expect-error on Electron webview

### DIFF
--- a/webapp/src/components/JobDashboardHost.tsx
+++ b/webapp/src/components/JobDashboardHost.tsx
@@ -132,7 +132,6 @@ export default function JobDashboardHost({
           <p role="status" className="px-2.5 py-2 text-[11px] text-muted">Opening Puppetmaster dashboard…</p>
         )}
         {embedUrl && (isDesktop ? (
-          // @ts-expect-error -- webview is an Electron element
           <webview
             ref={webviewRef}
             src={embedUrl}


### PR DESCRIPTION
## Summary
- CI `tsc` failed on Release #362: unused `@ts-expect-error` above `<webview>` in `JobDashboardHost.tsx`
- Remove the directive so `0.9.444` dest→main can go green

## Test plan
- [ ] frontend-build / release linux build pass