### PR TITLE
fix: PM board for every hire (0.9.446)

### DIFF
--- a/harness/api/dashboard.py
+++ b/harness/api/dashboard.py
@@ -8,6 +8,7 @@ from .jobs import JobServices
 from ..pm_dashboard import (
     build_dashboard_url,
     ensure_local_dashboard,
+    is_benign_non_durable_job_token,
     is_dashboard_job_id,
     resolve_dashboard_state_dir,
 )
@@ -17,8 +18,13 @@ def get_dashboard(qs: dict, svc: JobServices) -> tuple[int, dict[str, Any]]:
     """Resolve or start the project dashboard. Never invents a second runtime."""
     raw_job = (qs.get("job") or qs.get("job_id") or [""])[0]
     job_id = str(raw_job or "").strip()
+    # Durable job_… deep-links. Benign local aliases open the board without
+    # ?job=. Path escapes and other unsafe tokens still 400.
     if job_id and not is_dashboard_job_id(job_id):
-        return 400, {"ok": False, "error": "invalid_job_id"}
+        if is_benign_non_durable_job_token(job_id):
+            job_id = ""
+        else:
+            return 400, {"ok": False, "error": "invalid_job_id"}
     repo = str((qs.get("repo") or [""])[0] or "").strip()
     if not repo:
         repo = str(getattr(svc.cfg, "repo", "") or "").strip()

--- a/harness/pm_dashboard.py
+++ b/harness/pm_dashboard.py
@@ -36,6 +36,19 @@ def is_dashboard_job_id(job_id: str) -> bool:
     return bool(body) and all(ch.isalnum() or ch in "_-" for ch in body)
 
 
+def is_benign_non_durable_job_token(job_id: str) -> bool:
+    """True for Jobs-rail aliases we may ignore (open board, no deep-link).
+
+    Path escapes and other unsafe tokens stay rejected at the API.
+    """
+    token = (job_id or "").strip()
+    if not token or len(token) > _JOB_ID_MAX:
+        return False
+    if is_dashboard_job_id(token):
+        return False
+    return all(ch.isalnum() or ch in "_-" for ch in token)
+
+
 def build_dashboard_url(
     host: str,
     port: int,

--- a/tests/test_pm_dashboard.py
+++ b/tests/test_pm_dashboard.py
@@ -28,6 +28,32 @@ def test_get_dashboard_rejects_unsafe_job_id():
     assert payload["ok"] is False
 
 
+def test_get_dashboard_strips_benign_local_alias(monkeypatch):
+    monkeypatch.setattr(
+        "harness.api.dashboard.resolve_dashboard_state_dir",
+        lambda repo, job_id: "/tmp/pm-state",
+    )
+    seen = {}
+
+    def _ensure(**kwargs):
+        seen.update(kwargs)
+        return {
+            "ok": True,
+            "reused": True,
+            "host": "127.0.0.1",
+            "port": 8788,
+            "url": "http://127.0.0.1:8788/?embed=1",
+        }
+
+    monkeypatch.setattr("harness.api.dashboard.ensure_local_dashboard", _ensure)
+    svc = make_job_services(cfg=type("Cfg", (), {"repo": "/work/repo"})())
+    status, payload = get_dashboard({"job": ["local-swarm-call_1799376"]}, svc)
+    assert status == 200
+    assert payload["ok"] is True
+    assert seen.get("job_id") in (None, "")
+    assert "job=" not in payload["embed_url"]
+
+
 def test_get_dashboard_reuses_tracked_runtime(monkeypatch):
     monkeypatch.setattr(
         "harness.api.dashboard.resolve_dashboard_state_dir",

--- a/webapp/src/__tests__/JobDashboardHost.test.tsx
+++ b/webapp/src/__tests__/JobDashboardHost.test.tsx
@@ -118,14 +118,28 @@ describe("JobDashboardHost", () => {
     expect(screen.queryByTestId("job-dashboard-frame")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Pop out/ })).toBeDisabled();
   });
-  it("fails fast when the hire has no durable job_ id yet", async () => {
+  it("opens the workspace board without deep-linking a local alias", async () => {
+    vi.mocked(api.dashboard).mockResolvedValue({
+      ok: true,
+      host: "127.0.0.1",
+      port: 8787,
+      url: "http://127.0.0.1:8787/?embed=1",
+      embed_url: "http://127.0.0.1:8787/?embed=1",
+    });
     const localOnly = { ...job, id: "local-swarm-call_1799376", goal: "Provider worker `local-swarm-call_1799376`" };
     delete (localOnly as { job_ref?: unknown }).job_ref;
     (localOnly as { local_ref?: unknown }).local_ref = { job_id: "local-swarm-call_1799376", incarnation: "n1" };
     render(<JobDashboardHost job={localOnly} onClose={() => {}} />);
-    expect(await screen.findByRole("alert")).toHaveTextContent(/Durable Puppetmaster job id is not ready/);
-    expect(api.dashboard).not.toHaveBeenCalled();
-    expect(screen.queryByText(/Opening Puppetmaster dashboard/)).toBeNull();
+    expect(await screen.findByTitle("Puppetmaster dashboard local-swarm-call_1799376")).toHaveAttribute(
+      "src",
+      "http://127.0.0.1:8787/?embed=1",
+    );
+    expect(api.dashboard).toHaveBeenCalledWith(undefined, undefined);
+    expect(screen.getByTestId("job-dashboard-host")).toHaveAttribute(
+      "data-dashboard-job-id",
+      "local-swarm-call_1799376",
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
 });

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -2781,7 +2781,7 @@ describe("SwarmPane v0.9.350 collapsed chrome", () => {
       fireEvent.click(await screen.findByRole("button", { name: /Provider worker/ }));
       const host = await screen.findByTestId("job-dashboard-host");
       expect(host).toHaveAttribute("data-job-id", "local-cedfbf8c");
-      expect(vi.mocked(api.dashboard).mock.calls[0]?.[0]).toBe("local-cedfbf8c");
+      expect(vi.mocked(api.dashboard).mock.calls[0]?.[0]).toBeUndefined();
     } finally {
       native.dispose();
     }

--- a/webapp/src/components/JobDashboardHost.tsx
+++ b/webapp/src/components/JobDashboardHost.tsx
@@ -13,6 +13,13 @@ import {
 } from "../lib/jobsDashboard";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
 
+/**
+ * Host the stock Puppetmaster dashboard in the Jobs rail.
+ *
+ * Every hire opens the workspace board. A durable ``job_…`` deep-links via
+ * ``?job=&embed=1``. Local aliases (``local-swarm-call_…``, provider workers)
+ * still open the board — they are never passed as CLI job tokens.
+ */
 export default function JobDashboardHost({
   job,
   onClose,
@@ -27,28 +34,22 @@ export default function JobDashboardHost({
   const [loading, setLoading] = useState(true);
 
   const title = (job.goal || "").trim() || job.id;
-  const embedId = dashboardJobId(job);
+  const deepLinkId = dashboardJobId(job);
+  const frameKey = deepLinkId || job.id;
   const embedUrl = locate?.embed_url || locate?.url || "";
-  const showId = embedId && embedId !== title;
+  const showId = Boolean(deepLinkId) && deepLinkId !== title;
 
   useEffect(() => {
     requestRightMinWidth(JOBS_DASHBOARD_FOCUS_MIN_PX);
     notifyJobsDashboardChrome(true);
     return () => notifyJobsDashboardChrome(false);
-  }, [embedId]);
+  }, [job.id, deepLinkId]);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError("");
     setLocate(null);
-    if (!embedId.startsWith("job_")) {
-      setError(
-        "Durable Puppetmaster job id is not ready for this hire yet (need job_…). Close and reopen once the store assigns one.",
-      );
-      setLoading(false);
-      return;
-    }
     const repo = lastSelectedProjectRoot() || undefined;
     const locateDashboard = api.dashboard;
     if (typeof locateDashboard !== "function") {
@@ -56,7 +57,9 @@ export default function JobDashboardHost({
       setLoading(false);
       return;
     }
-    locateDashboard(embedId, repo)
+    // Durable job_… only for deep-link; omit otherwise so the CLI lands on the list.
+    const locateArg = deepLinkId.startsWith("job_") ? deepLinkId : undefined;
+    locateDashboard(locateArg, repo)
       .then((payload) => {
         if (cancelled) return;
         setLocate(payload);
@@ -76,7 +79,7 @@ export default function JobDashboardHost({
         if (!cancelled) setLoading(false);
       });
     return () => { cancelled = true; };
-  }, [embedId]);
+  }, [deepLinkId, job.id]);
 
   const popOut = () => {
     if (embedUrl) openAgentUrlExternal(embedUrl);
@@ -86,7 +89,7 @@ export default function JobDashboardHost({
     <section
       data-testid="job-dashboard-host"
       data-job-id={job.id}
-      data-dashboard-job-id={embedId}
+      data-dashboard-job-id={frameKey}
       data-chrome="compact"
       aria-label={`Puppetmaster dashboard for ${title}`}
       className="job-dashboard-host flex flex-col h-full min-h-0 overflow-hidden text-txt"
@@ -97,8 +100,8 @@ export default function JobDashboardHost({
             {title}
           </h2>
           {showId && (
-            <span className="truncate font-mono text-[9px] leading-none text-faint" title={embedId}>
-              {embedId}
+            <span className="truncate font-mono text-[9px] leading-none text-faint" title={deepLinkId}>
+              {deepLinkId}
             </span>
           )}
         </div>
@@ -153,7 +156,7 @@ export default function JobDashboardHost({
         ) : (
           <iframe
             src={embedUrl}
-            title={`Puppetmaster dashboard ${embedId}`}
+            title={`Puppetmaster dashboard ${frameKey}`}
             data-testid="job-dashboard-frame"
             className="absolute inset-0 w-full h-full border-0 bg-[var(--shell-chat,#0f1113)]"
           />

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -345,11 +345,13 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   const liveJobs = useMemo(() => metadataJobs(state).filter(isSwarmTrackerJob), [state]);
   const retainedJobs = useRef<Job[]>([]);
   if (liveJobs.length > 0) retainedJobs.current = liveJobs;
-  // Keep last non-empty list while metadata polls (working / not-yet-view) so the
-  // empty-state marketing copy does not blink between refresh pages.
+  // Soft refresh only: keep the last page while working with a live view and no
+  // transport error. Never mask a failed read with stale rows.
   const jobs = liveJobs.length > 0
     ? liveJobs
-    : ((state.working || state.view.kind !== 'view') ? retainedJobs.current : liveJobs);
+    : (state.working && !state.error && state.view.kind === 'view'
+      ? retainedJobs.current
+      : liveJobs);
   const rowButtons = useRef(new Map<string, HTMLButtonElement>());
   const previousGroups = useRef(new Map<string, string>());
   const focusedRow = useRef<string | null>(null);


### PR DESCRIPTION
## Summary
- Every Jobs hire opens the workspace PM board (`embed=1`); deep-link `?job=` only for durable `job_…`
- Local aliases never hit the dashboard CLI (host omits token; API strips benign aliases; path escapes still 400)
- SWR retains Jobs list only on clean working views

## Test plan
- [x] JobDashboardHost + SwarmPane embed asserts
- [x] tests/test_pm_dashboard.py
- [ ] #368 frontend-build green after merge