### PR TITLE
Comet/Zeron feed stick + stable rows + PM Jobs viewport

### DIFF
--- a/webapp/electron/feed-scroll.cjs
+++ b/webapp/electron/feed-scroll.cjs
@@ -5,4 +5,10 @@ function scrollToFeedEnd(scrollHeight, clientHeight) {
   return Math.max(0, scrollHeight - clientHeight);
 }
 
-module.exports = { scrollToFeedEnd };
+/** Same-frame feed-forward: keep distance-from-end across content growth. */
+function feedForwardFollowTop(scrollTop, contentDeltaPx, maxScrollTop) {
+  const forwarded = scrollTop + Math.max(0, contentDeltaPx);
+  return Math.max(0, Math.min(maxScrollTop, forwarded));
+}
+
+module.exports = { scrollToFeedEnd, feedForwardFollowTop };

--- a/webapp/electron/feed-scroll.test.cjs
+++ b/webapp/electron/feed-scroll.test.cjs
@@ -1,7 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { scrollToFeedEnd } = require("./feed-scroll.cjs");
+const { scrollToFeedEnd, feedForwardFollowTop } = require("./feed-scroll.cjs");
 
 /**
  * Electron-side feed scroll contract (jsdom layout tests live in feedScroll.test.ts).
@@ -10,6 +10,16 @@ const { scrollToFeedEnd } = require("./feed-scroll.cjs");
 test("scrollToEnd contract matches Marionette feedScroll helper", () => {
   assert.equal(scrollToFeedEnd(2000, 400), 1600);
   assert.equal(scrollToFeedEnd(350, 400), 0);
+});
+
+test("feed-forward follow absorbs content growth without an independent max snap", () => {
+  const client = 400;
+  const oldHeight = 2000;
+  const oldTop = scrollToFeedEnd(oldHeight, client);
+  const grown = 80;
+  const max = scrollToFeedEnd(oldHeight + grown, client);
+  assert.equal(feedForwardFollowTop(oldTop, grown, max), max);
+  assert.equal(feedForwardFollowTop(oldTop - 12, grown, max), oldTop - 12 + grown);
 });
 
 test("stream-to-fold live tail growth outside the virtual window still pins to the true end", () => {

--- a/webapp/src/__tests__/Conversation.inputOriginals.test.tsx
+++ b/webapp/src/__tests__/Conversation.inputOriginals.test.tsx
@@ -50,9 +50,16 @@ function streamMock() {
   const chat = vi.spyOn(api, 'chat').mockImplementation((_message, onEvent, onDone, onError) => {
     event = onEvent; done = () => onDone?.(); error = err => onError?.(err); return () => {};
   });
-  return { chat, accept: () => act(async () => event({ kind: 'input_receipt', data: { input_id: 'new', status: 'accepted' } })),
+  return {
+    chat,
+    accept: () => act(async () => {
+      const last = chat.mock.calls.at(-1);
+      const submittedId = String(last?.[6]?.input_id || '').trim() || 'new';
+      event({ kind: 'input_receipt', data: { input_id: submittedId, status: 'accepted' } });
+    }),
     finish: () => act(async () => { event({ kind: 'assistant_done', data: {} }); done(); }),
-    fail: () => act(async () => error(new Error('transport interrupted'))) };
+    fail: () => act(async () => error(new Error('transport interrupted'))),
+  };
 }
 
 it('shows held originals after reload and copies exact text, images and documents locally without draining', async () => {

--- a/webapp/src/__tests__/Conversation.warmCache.test.ts
+++ b/webapp/src/__tests__/Conversation.warmCache.test.ts
@@ -32,8 +32,8 @@ import type { Item } from "../components/TranscriptList";
  * Mirrors Conversation.tsx session-switch behavior without mounting the full UI.
  */
 
-function makeMsg(role: "user" | "assistant", text: string): Item {
-  return { kind: "msg", msg: { role, text } };
+function makeMsg(role: "user" | "assistant", text: string, id?: string): Item {
+  return { kind: "msg", msg: { role, text, ...(id ? { id } : {}) } };
 }
 
 describe("transcript warm cache", () => {
@@ -61,7 +61,7 @@ describe("transcript warm cache", () => {
       ],
     });
     expect(items).toHaveLength(2);
-    expect(items[0]).toEqual(makeMsg("user", "hi"));
+    expect(items[0]).toEqual(makeMsg("user", "hi", "msg:_draft:user:0"));
     expect(items[1].kind).toBe("msg");
     if (items[1].kind === "msg") {
       expect(items[1].msg.text).toBe("hello there!");
@@ -106,7 +106,7 @@ describe("transcript warm cache", () => {
 
     await switchTo("sess-b");
     expect(sessionTranscript).toHaveBeenCalledWith("sess-b");
-    expect(visible).toEqual([makeMsg("user", "fresh sess-b")]);
+    expect(visible).toEqual([makeMsg("user", "fresh sess-b", "msg:_draft:user:0")]);
     // Outgoing session was saved before hydrate.
     expect(cache.get("sess-a")?.items).toEqual([makeMsg("user", "from A")]);
   });

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -3592,7 +3592,7 @@ describe("completionNotify / feedScroll / streamTerminal / swarmPoll", () => {
     {
       const height = 2000;
       const client = 400;
-      // 40px from bottom — inside old 120px band, outside tight repin.
+      // 40px from bottom — inside the 120px pin band; released+away stays unpinned.
       const lightUpTop = height - client - 40;
       expect(
         nextFeedPinState({

--- a/webapp/src/__tests__/feedScroll.test.ts
+++ b/webapp/src/__tests__/feedScroll.test.ts
@@ -4,6 +4,11 @@ import {
   FEED_CONTENT_PADDING_BOTTOM_PX,
   FEED_GESTURE_IDLE_MS,
   FEED_REPIN_THRESHOLD_PX,
+  FEED_PIN_THRESHOLD_PX,
+  feedForwardFollowTop,
+  isFeedInputInterrupt,
+  nextFeedSpringFollow,
+  shouldUnpinOnKeyboard,
   FEED_SCROLLPORT_OVERFLOW_ANCHOR,
   FEED_SCROLLPORT_SCROLL_PADDING_BOTTOM_PX,
   FEED_TAIL_EPSILON_PX,
@@ -452,6 +457,96 @@ describe("shouldCancelFeedResizeFollowForManualScrollAway", () => {
   });
 });
 
+describe("feedScroll spring follow", () => {
+  it("feed-forwards content growth instead of an independent max snap", () => {
+    expect(FEED_REPIN_THRESHOLD_PX).toBe(70);
+    expect(FEED_REPIN_THRESHOLD_PX).toBeLessThan(FEED_PIN_THRESHOLD_PX);
+    expect(feedForwardFollowTop(1200, 80, 1280)).toBe(1280);
+    const sprung = nextFeedSpringFollow({
+      scrollTop: 1200,
+      maxScrollTop: 1280,
+      contentDeltaPx: 80,
+      velocityPxPerMs: 0,
+    });
+    expect(sprung.scrollTop).toBe(1280);
+    expect(sprung.velocityPxPerMs).toBe(0);
+  });
+
+  it("preserves distance-from-end then springs residual pin error", () => {
+    const sprung = nextFeedSpringFollow({
+      scrollTop: 1198,
+      maxScrollTop: 1280,
+      contentDeltaPx: 80,
+      velocityPxPerMs: 0,
+    });
+    expect(sprung.scrollTop).toBeGreaterThan(1198);
+    expect(sprung.scrollTop).toBeLessThanOrEqual(1280);
+  });
+
+  it("unpins on keyboard input and treats wheel/touch/keyboard as interrupts", () => {
+    expect(shouldUnpinOnKeyboard("PageUp")).toBe(true);
+    expect(shouldUnpinOnKeyboard("ArrowUp")).toBe(true);
+    expect(shouldUnpinOnKeyboard("Home")).toBe(true);
+    expect(shouldUnpinOnKeyboard("ArrowDown")).toBe(false);
+    expect(isFeedInputInterrupt("wheel")).toBe(true);
+    expect(isFeedInputInterrupt("keyboard")).toBe(true);
+    expect(
+      nextFeedPinState({
+        wasPinned: true,
+        releasedByGesture: false,
+        scrollHeight: 2000,
+        scrollTop: 800,
+        clientHeight: 400,
+        prevScrollTop: 1600,
+        settling: false,
+        inputInterrupt: false,
+      }),
+    ).toEqual({ pinned: true, releasedByGesture: false });
+    expect(
+      nextFeedPinState({
+        wasPinned: true,
+        releasedByGesture: false,
+        scrollHeight: 2000,
+        scrollTop: 800,
+        clientHeight: 400,
+        prevScrollTop: 1600,
+        settling: false,
+        inputInterrupt: true,
+      }),
+    ).toEqual({ pinned: false, releasedByGesture: true });
+  });
+
+  it("re-pins after idle when the viewport is inside the 70px restick band", () => {
+    const height = 2000;
+    const client = 400;
+    const fiftyFromEnd = height - client - 50;
+    expect(
+      nextFeedPinState({
+        wasPinned: false,
+        releasedByGesture: true,
+        scrollHeight: height,
+        scrollTop: fiftyFromEnd,
+        clientHeight: client,
+        prevScrollTop: fiftyFromEnd - 20,
+        settling: false,
+        userGestureActive: false,
+      }),
+    ).toEqual({ pinned: true, releasedByGesture: false });
+    expect(
+      nextFeedPinState({
+        wasPinned: false,
+        releasedByGesture: true,
+        scrollHeight: height,
+        scrollTop: height - client - 90,
+        clientHeight: client,
+        prevScrollTop: height - client - 110,
+        settling: false,
+        userGestureActive: false,
+      }),
+    ).toEqual({ pinned: false, releasedByGesture: true });
+  });
+});
+
 describe("chooseFeedFollowFlush", () => {
   it("applies stick-to-bottom before paint (not rAF)", () => {
     expect(chooseFeedFollowFlush()).toBe("before_paint");
@@ -502,7 +597,7 @@ describe("feedScroll user-gesture deferral", () => {
     expect(FEED_GESTURE_IDLE_MS).toBe(150);
   });
 
-  it("does not re-pin into the 28px band while the user gesture is still active", () => {
+  it("does not re-pin into the restick band while the user gesture is still active", () => {
     const lightUpTop = height - client - 40;
     expect(
       nextFeedPinState({

--- a/webapp/src/__tests__/jobsDashboard.test.ts
+++ b/webapp/src/__tests__/jobsDashboard.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import {
   buildDashboardEmbedUrl,
+  jobsRailIsPuppetmasterViewport,
+  jobsRailViewportUrl,
+  JOBS_RAIL_VIEWPORT,
   JOBS_DASHBOARD_CHROME_EVENT,
   JOBS_DASHBOARD_EXPAND_MIN_PX,
   JOBS_DASHBOARD_FOCUS_MIN_PX,
@@ -15,6 +18,11 @@ describe("jobsDashboard URLs", () => {
       "http://127.0.0.1:8787/?job=job_abcdef012345&embed=1",
     );
     expect(buildDashboardEmbedUrl("127.0.0.1", 8790)).toBe("http://127.0.0.1:8790/?embed=1");
+    expect(jobsRailViewportUrl("127.0.0.1", 8787, "job_abcdef012345")).toBe(
+      buildDashboardEmbedUrl("127.0.0.1", 8787, "job_abcdef012345"),
+    );
+    expect(jobsRailIsPuppetmasterViewport()).toBe(true);
+    expect(JOBS_RAIL_VIEWPORT).toBe("puppetmaster-embed");
   });
 });
 

--- a/webapp/src/__tests__/sessionContinuity.test.ts
+++ b/webapp/src/__tests__/sessionContinuity.test.ts
@@ -11,7 +11,13 @@ vi.mock("../lib/api", () => ({ api: {
  readEventsSince: vi.fn(), chatEventsLive: vi.fn(), interruptSession: vi.fn(),
 } }));
 const ref = <T,>(current: T) => ({ current });
-const msg = (text: string): Item => ({ kind: "msg", msg: { role: "user", text } });
+const msg = (text: string, id?: string): Item => ({
+  kind: "msg",
+  msg: { role: "user", text, ...(id ? { id } : {}) },
+});
+/** Hydrate stamps ordinal ids for session A user rows. */
+const hydratedUser = (text: string, ordinal = 0): Item =>
+  msg(text, `msg:A:user:${ordinal}`);
 function deferred<T>() {
  let resolve!: (value: T) => void;
  const promise = new Promise<T>((r) => { resolve = r; });
@@ -117,7 +123,7 @@ it("arms recovery after all transcript failures and can recover later", async ()
  expect(api.readEventsSince).toHaveBeenCalledTimes(1);
  vi.mocked(api.sessionTranscript).mockResolvedValue({history:[{role:"user",content:"recovered"}]});
  await act(async () => recovery.resolve({session_id:"A",cursor:0,events:[{id:0,kind:"ring_miss",data:{code:"ring_miss",missed:true,available:false}}]}));
- expect(d.itemsRef.current).toEqual([msg("recovered")]);
+ expect(d.itemsRef.current).toEqual([hydratedUser("recovered")]);
 });
 it("arms recovery after an empty warm refresh", async () => {
  writeTranscriptCache("A", [msg("warm")]);
@@ -132,7 +138,7 @@ it("cold resume hydrates then attaches exactly one live owner", async () => {
  vi.mocked(api.getSessionState).mockResolvedValue({ runners: { A: "running" } });
  const d = fixture(); renderHook(() => useSessionSwitch(d));
  await act(async () => {});
- expect(d.itemsRef.current).toEqual([msg("cold")]);
+ expect(d.itemsRef.current).toEqual([hydratedUser("cold")]);
  expect(api.chatEventsLive).toHaveBeenCalledTimes(1);
  expect(api.readEventsSince).not.toHaveBeenCalled();
  d.ensureChatEventsReattachRef.current();
@@ -149,7 +155,7 @@ it("rapid A-B-A rejects old responses and only detaches the backend stream", asy
  h.rerender({sid:"B"}); h.rerender({sid:"A"});
  await act(async () => latest.resolve({history:[{role:"user",content:"latest"}]}));
  await act(async () => { a.resolve({history:[{role:"user",content:"old A"}]}); b.resolve({history:[{role:"user",content:"old B"}]}); });
- expect(d.itemsRef.current).toEqual([msg("latest")]);
+ expect(d.itemsRef.current).toEqual([hydratedUser("latest")]);
  expect(close).toHaveBeenCalledTimes(1);
  expect(api.interruptSession).not.toHaveBeenCalled();
 });
@@ -177,7 +183,7 @@ it("recovers a failed cold transcript while the idle event store reports no ring
  expect(d.itemsRef.current).toEqual([]);
  vi.mocked(api.sessionTranscript).mockResolvedValue({history:[{role:"user",content:"durable"}]});
  await act(async () => vi.advanceTimersByTimeAsync(2000));
- expect(d.itemsRef.current).toEqual([msg("durable")]);
+ expect(d.itemsRef.current).toEqual([hydratedUser("durable")]);
 });
 it("bounds failed cold recovery", async () => {
  vi.mocked(api.sessionTranscript).mockRejectedValue(new Error("offline"));

--- a/webapp/src/__tests__/transcriptRowHeight.test.ts
+++ b/webapp/src/__tests__/transcriptRowHeight.test.ts
@@ -16,6 +16,7 @@ import {
   transcriptBubbleMaxWidth,
   transcriptFeedInnerWidth,
   transcriptRowCacheKey,
+  transcriptRowHeightMemoKey,
   TRANSCRIPT_ROW_FALLBACK_PX,
   TRANSCRIPT_USER_CLAMP_PX,
 } from "../components/conversation/transcriptRowHeight";
@@ -31,6 +32,8 @@ vi.mock("@chenglou/pretext", () => ({
     return { height: lineCount * lineHeight, lineCount };
   }),
 }));
+
+import { layout } from "@chenglou/pretext";
 
 function msg(
   role: "user" | "assistant",
@@ -57,6 +60,28 @@ describe("transcriptRowHeight", () => {
   it("applies role-specific bubble width ratios", () => {
     expect(transcriptBubbleMaxWidth(600, "user")).toBe(510);
     expect(transcriptBubbleMaxWidth(600, "assistant")).toBe(570);
+  });
+
+  it("memos height by id, content length, and width", () => {
+    expect(transcriptRowHeightMemoKey("u-1", 11, 510)).toBe(
+      transcriptRowHeightMemoKey("u-1", 11, 510),
+    );
+    expect(transcriptRowHeightMemoKey("u-1", 11, 510)).not.toBe(
+      transcriptRowHeightMemoKey("u-1", 12, 510),
+    );
+    expect(transcriptRowHeightMemoKey("u-1", 11, 510)).not.toBe(
+      transcriptRowHeightMemoKey("u-1", 11, 400),
+    );
+    const cache = createTranscriptRowHeightCache();
+    const first = msg("user", "hello world");
+    const persistHandoff = msg("user", "hello world");
+    cache.estimateRowHeight(first, "u-1", 600);
+    cache.estimateRowHeight(persistHandoff, "u-1", 600);
+    expect(layout).toHaveBeenCalledTimes(1);
+    cache.estimateRowHeight(first, "u-1", 400);
+    expect(layout).toHaveBeenCalledTimes(2);
+    cache.estimateRowHeight(msg("user", "hello worlds"), "u-1", 600);
+    expect(layout).toHaveBeenCalledTimes(3);
   });
 
   it("builds stable cache keys from row id, text, and font", () => {

--- a/webapp/src/__tests__/transcriptRowIdentity.test.ts
+++ b/webapp/src/__tests__/transcriptRowIdentity.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { stableItemKey, type Item } from "../components/TranscriptList";
+import { transcriptResponseToItems } from "../components/conversation/transcriptItems";
+import {
+  allocateOptimisticInputId,
+  durableMessageId,
+  messageBlockId,
+  optimisticUserEchoMsg,
+  ordinalMessageId,
+  stampTranscriptMessageIds,
+  transcriptBlockRowId,
+  withLiveMessageId,
+} from "../components/conversation/transcriptRowIdentity";
+
+describe("transcriptRowIdentity", () => {
+  it("uses input_id as the optimistic echo and persist id", () => {
+    const inputId = "aabbccddeeff00112233445566778899";
+    const echo = optimisticUserEchoMsg({ text: "hello", id: inputId });
+    const live: Item[] = [{ kind: "msg", msg: echo }];
+    const hydrated = transcriptResponseToItems({
+      display: [{ type: "message", role: "user", text: "hello", input_id: inputId }],
+      session_id: "sess-1",
+    }, "sess-1");
+    expect(hydrated[0]).toMatchObject({ kind: "msg", msg: { id: inputId, text: "hello" } });
+    expect(stableItemKey(live[0]!, 0)).toBe(stableItemKey(hydrated[0]!, 0));
+    expect(stableItemKey(live[0]!, 0)).toBe(transcriptBlockRowId(inputId, "body"));
+  });
+
+  it("stamps ordinal ids so live assistant rows match cold hydrate", () => {
+    const live = stampTranscriptMessageIds([
+      { kind: "msg", msg: { role: "user", text: "q" } },
+      { kind: "msg", msg: { role: "assistant", text: "a" } },
+    ], "sess-1");
+    const hydrated = transcriptResponseToItems({
+      display: [
+        { type: "message", role: "user", text: "q" },
+        { type: "message", role: "assistant", text: "a" },
+      ],
+    }, "sess-1");
+    expect(live[1]?.kind === "msg" && live[1].msg.id).toBe(ordinalMessageId("sess-1", "assistant", 0));
+    expect(stableItemKey(live[1]!, 1)).toBe(stableItemKey(hydrated[1]!, 1));
+    expect(stableItemKey(live[1]!, 1)).toBe(
+      transcriptBlockRowId(ordinalMessageId("sess-1", "assistant", 0), "body"),
+    );
+  });
+
+  it("namespaces ids by session so a cold swap cannot reuse the prior row", () => {
+    const a = stampTranscriptMessageIds(
+      [{ kind: "msg", msg: { role: "user", text: "same" } }],
+      "sess-a",
+    );
+    const b = stampTranscriptMessageIds(
+      [{ kind: "msg", msg: { role: "user", text: "same" } }],
+      "sess-b",
+    );
+    expect(stableItemKey(a[0]!, 0)).not.toBe(stableItemKey(b[0]!, 0));
+  });
+
+  it("keeps worker/progress blocks on distinct ids under the same message", () => {
+    expect(messageBlockId({ workerStream: true })).toBe("worker");
+    expect(messageBlockId({ channel: "progress" })).toBe("progress");
+    const msg = withLiveMessageId([], {
+      role: "assistant",
+      text: "…",
+      workerStream: true,
+    }, "sess-1");
+    expect(transcriptBlockRowId(msg.id || "", messageBlockId(msg))).toMatch(/#worker$/);
+  });
+
+  it("prefers explicit / input ids over ordinals", () => {
+    expect(durableMessageId({
+      explicitId: "kept",
+      inputId: "ignored",
+      sessionId: "s",
+      role: "user",
+      ordinal: 3,
+    })).toBe("kept");
+    expect(allocateOptimisticInputId().length).toBeGreaterThan(8);
+  });
+});

--- a/webapp/src/__tests__/transcriptVirtualWindow.test.ts
+++ b/webapp/src/__tests__/transcriptVirtualWindow.test.ts
@@ -5,6 +5,7 @@ import {
   isOccludedScrollParentSize,
   restoreFeedScrollAfterFocus,
   shouldUseVirtualTranscriptWindow,
+  transcriptRowHeightMemoKey,
 } from "../components/conversation/transcriptVirtualWindow";
 
 describe("transcriptVirtualWindow", () => {
@@ -72,5 +73,11 @@ describe("transcriptVirtualWindow", () => {
     expect(file).toContain("invisible");
     expect(file).toContain("absolute");
     expect(file).not.toContain("hidden");
+  });
+
+  it("exposes the Pretext height memo key contract (id, length, width)", () => {
+    expect(transcriptRowHeightMemoKey("msg:s:user:0#body", 12, 510)).toBe(
+      ["msg:s:user:0#body", "12", "510"].join("\0"),
+    );
   });
 });

--- a/webapp/src/__tests__/transcriptVirtualizer.test.tsx
+++ b/webapp/src/__tests__/transcriptVirtualizer.test.tsx
@@ -13,8 +13,10 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   TranscriptList,
+  stableItemKey,
   type Item,
 } from "../components/TranscriptList";
+import { stampTranscriptMessageIds } from "../components/conversation/transcriptRowIdentity";
 
 afterEach(() => {
   cleanup();
@@ -225,5 +227,20 @@ describe("transcript feed virtualizer", () => {
     expect(list.className).toContain("relative");
     expect(list.className).not.toContain("flex-col");
     expect(screen.queryAllByTestId("transcript-virtual-row").length).toBeLessThan(80);
+  });
+
+  it("uses msgId#blockId keys that survive a persist-shaped remint", () => {
+    const live = stampTranscriptMessageIds(longTranscript(2), "sess-virt");
+    const persist = stampTranscriptMessageIds(
+      live.map((item) => (
+        item.kind === "msg"
+          ? { kind: "msg" as const, msg: { role: item.msg.role, text: item.msg.text, id: item.msg.id } }
+          : item
+      )),
+      "sess-virt",
+    );
+    expect(stableItemKey(live[0]!, 0)).toMatch(/#body$/);
+    expect(stableItemKey(live[0]!, 0)).toBe(stableItemKey(persist[0]!, 0));
+    expect(stableItemKey(live[0]!, 0)).not.toBe(stableItemKey(live[1]!, 1));
   });
 });

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -45,6 +45,11 @@ import {
   transcriptFingerprint,
   transcriptResponseToItems,
 } from "./conversation/transcriptItems";
+import {
+  allocateOptimisticInputId,
+  optimisticUserEchoMsg,
+  stampTranscriptMessageIds,
+} from "./conversation/transcriptRowIdentity";
 import { hoistCardsBeforeTrailingFinals, newThinkingId } from "./conversation/thinkingToolPrep";
 import {
   type MentionListingCap,
@@ -119,6 +124,7 @@ import {
   scrollToFeedEnd,
   settleFrameResult,
   shouldShowJumpToBottom,
+  shouldUnpinOnKeyboard,
   shouldUnpinOnTouchMove,
   FEED_UNPIN_BUBBLE_EVENT,
   feedWheelUnpinListenerOptions,
@@ -261,10 +267,11 @@ export default function Conversation({
   // Mirror of items for session-switch cache writes without stale closures.
   const itemsRef = useRef<Item[]>([]);
   const setItems = useCallback((update: SetStateAction<Item[]>) => {
-    const next = typeof update === "function" ? update(itemsRef.current) : update;
+    const raw = typeof update === "function" ? update(itemsRef.current) : update;
+    const next = stampTranscriptMessageIds(raw, activeSessionId);
     itemsRef.current = next;
     setRenderedItems(next);
-  }, []);
+  }, [activeSessionId]);
   // Tracks which session the visible transcript belongs to (for warm-cache save).
   const cachedSessionIdRef = useRef<string | null>(null);
   // Monotonic id so a slow sessionTranscript response for a prior switch is ignored.
@@ -1356,6 +1363,7 @@ export default function Conversation({
         settling: scrollSettlingRef.current,
         repinPx: FEED_REPIN_THRESHOLD_PX,
         userGestureActive: userScrollGestureRef.current,
+        inputInterrupt: userScrollGestureRef.current || scrollReleasedByGestureRef.current,
       });
       pinnedToBottomRef.current = next.pinned;
       scrollReleasedByGestureRef.current = next.releasedByGesture;
@@ -1391,6 +1399,14 @@ export default function Conversation({
       pinnedToBottomRef.current = false;
       publishJumpVisibilityRef.current();
     };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!shouldUnpinOnKeyboard(e.key)) return;
+      markUserScrollGesture();
+      scrollSettlingRef.current = false;
+      scrollReleasedByGestureRef.current = true;
+      pinnedToBottomRef.current = false;
+      publishJumpVisibilityRef.current();
+    };
     let touchY: number | null = null;
     const onTouchStart = (e: TouchEvent) => {
       touchY = e.touches[0]?.clientY ?? null;
@@ -1418,6 +1434,7 @@ export default function Conversation({
     el.addEventListener("touchmove", onTouchMove, { passive: true });
     el.addEventListener("touchend", onTouchEnd, { passive: true });
     el.addEventListener("touchcancel", onTouchEnd, { passive: true });
+    el.addEventListener("keydown", onKeyDown);
     return () => {
       clearGestureIdleTimer();
       el.removeEventListener("scroll", onScroll);
@@ -1427,6 +1444,7 @@ export default function Conversation({
       el.removeEventListener("touchmove", onTouchMove);
       el.removeEventListener("touchend", onTouchEnd);
       el.removeEventListener("touchcancel", onTouchEnd);
+      el.removeEventListener("keydown", onKeyDown);
     };
   }, []);
   const applyFeedResizeFollow = (
@@ -2395,7 +2413,8 @@ export default function Conversation({
         const restored = transcriptResponseToItems({
           display: res.display,
           history: res.history,
-        });
+          session_id: activeSessionId || undefined,
+        }, activeSessionId || undefined);
         setItems(restored);
         writeTranscriptCache(activeSessionId || "", restored);
         setEditingIndex(null);
@@ -2864,7 +2883,7 @@ export default function Conversation({
     if (!sid) return;
     void api.sessionTranscript(sid).then((tres) => {
       if (cachedSessionIdRef.current !== sid) return;
-      const loadedItems = transcriptResponseToItems(tres);
+      const loadedItems = transcriptResponseToItems(tres, sid);
       setItems((prev) => {
         if (cachedSessionIdRef.current !== sid) return prev;
         const next = applyLocalTurnSettle(
@@ -2963,10 +2982,18 @@ export default function Conversation({
         text: msg, original_text: submission.original_text, images: imgPaths, documents: submission.documents ?? attachedDocuments, model: config?.driver,
       }),
     };
+    if (!requestSubmission.input_id && !resume) {
+      requestSubmission.input_id = allocateOptimisticInputId();
+    }
     if (!resume) {
       // A resume turn carries no new user message -- the pilot is continuing off
       // a finished background job, so we don't add a user bubble or send images.
-      setItems((p) => [...p, { kind: "msg", msg: { role: "user", text: msg, images: imgsToSend } }]);
+      // Echo id matches the persisted display `input_id` so hydrate does not remount.
+      const echoId = String(requestSubmission.input_id || "").trim();
+      setItems((p) => [...p, {
+        kind: "msg",
+        msg: optimisticUserEchoMsg({ text: msg, images: imgsToSend, id: echoId }),
+      }]);
       const hasPriorUserTurn = itemsRef.current.some(
         (it) => it.kind === "msg" && it.msg.role === "user",
       );
@@ -3622,7 +3649,7 @@ export default function Conversation({
             if (!stopLive()) return;
             const tres = await api.sessionTranscript(sid);
             if (!stopLive()) return;
-            const loadedItems = transcriptResponseToItems(tres);
+            const loadedItems = transcriptResponseToItems(tres, sid);
             const settle = lastSettleRef.current;
             const liveIds = liveNonLocalSwarmJobIds();
             setItems((prev) => {

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -16,6 +16,8 @@ import { api } from '../lib/api';
 import { jobArtifactKey, selectJobRef } from '../lib/jobArtifacts';
 import type { Job } from '../lib/api';
 import { filterJobsByScope, JOB_SCOPE_CHANGED_EVENT, loadJobScope, saveJobScope, type JobScope } from '../lib/jobScope';
+// Jobs rail picker + PM embed host. Adapters locate the dashboard; they are
+// not a dual native tracker (see jobsDashboard.ts / JobDashboardHost).
 import { useSharedJobMetadata, metadataActivity, metadataJobs, metadataViewSessionId, currentExpert, currentHeader } from '../lib/jobMetadataContext';
 import { isPmDashboardJob, isSwarmTrackerJob } from '../lib/jobClassification';
 import JobDashboardHost from './JobDashboardHost';

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -98,6 +98,10 @@ import {
   shouldUseVirtualTranscriptWindow,
 } from "./conversation/transcriptVirtualWindow";
 import {
+  messageBlockId,
+  transcriptBlockRowId,
+} from "./conversation/transcriptRowIdentity";
+import {
   assistantTextForMeasure,
   createTranscriptRowHeightCache,
   rowMeasureSignal,
@@ -116,6 +120,8 @@ import {
 export type Msg = {
   role: "user" | "assistant";
   text: string;
+  /** Durable identity — optimistic echo and persist hydrate share this. */
+  id?: string;
   isPlan?: boolean;
   images?: { path: string; name: string; previewUrl: string }[];
   streaming?: boolean;
@@ -1070,7 +1076,7 @@ export function transcriptViewportKeys(items: readonly GroupedItem[]): string[] 
   const occurrences = new Map<string, number>();
   return items.map((item, index) => {
     let key = stableItemKey(item, index);
-    if (item.kind === "msg") {
+    if (item.kind === "msg" && !(item.msg.id || "").trim()) {
       let hash = 2166136261;
       for (let i = 0; i < item.msg.text.length; i++) {
         hash = Math.imul(hash ^ item.msg.text.charCodeAt(i), 16777619);
@@ -1085,8 +1091,10 @@ export function transcriptViewportKeys(items: readonly GroupedItem[]): string[] 
 
 export function stableItemKey(it: GroupedItem, i: number): string {
   switch (it.kind) {
-    case "msg":
-      return `msg-${objKey(it.msg)}`;
+    case "msg": {
+      const msgId = (it.msg.id || "").trim() || `msg-${objKey(it.msg)}`;
+      return transcriptBlockRowId(msgId, messageBlockId(it.msg));
+    }
     case "activity_group":
       // React key keeps the index so duplicate-card corruption cannot collide;
       // ActivityGroup's groupId (open map) stays on the canon alone.
@@ -1128,7 +1136,9 @@ export function stableItemKey(it: GroupedItem, i: number): string {
     case "verification":
       return `verification-${i}-${it.passed ? "ok" : "fail"}`;
     case "thinking":
-      return it.id ? `think-${it.id}` : `think-${i}`;
+      return it.id
+        ? transcriptBlockRowId(it.id, "think")
+        : `think-${i}`;
     default:
       return `item-${i}`;
   }

--- a/webapp/src/components/conversation/chatEventsReattach.ts
+++ b/webapp/src/components/conversation/chatEventsReattach.ts
@@ -213,7 +213,7 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
       const tres = await api.sessionTranscript(missSid);
       if (missHydrateGen !== runnerBusyPollGenRef.current) return;
       if (!subscriptionFencesStillPass(missSid) || !readStillCurrent()) return;
-      const loadedItems = transcriptResponseToItems(tres);
+      const loadedItems = transcriptResponseToItems(tres, missSid);
       const next = mergeTranscriptItems(itemsRef.current, loadedItems);
       const fp = transcriptFingerprint(next);
       if (fp === transcriptFpRef.current) return;
@@ -246,7 +246,7 @@ export function createChatEventsReattach(deps: ChatEventsReattachDeps) {
       const tres = await api.sessionTranscript(sid);
       if (!transcriptRefreshStillCurrent(pollGen, sid) || !readStillCurrent()) return;
       const terminalSwarmCalls = collectTerminalRunSwarmCalls(tres.display);
-      const loadedItems = transcriptResponseToItems(tres);
+      const loadedItems = transcriptResponseToItems(tres, sid);
       const local = itemsRef.current.filter((item) => {
         if (item.kind !== "card" || item.card.kind !== "run_swarm") return true;
         const live = liveRunSwarmIdentity(item.card);

--- a/webapp/src/components/conversation/feedScroll.ts
+++ b/webapp/src/components/conversation/feedScroll.ts
@@ -6,15 +6,20 @@ import { isOccludedScrollParentSize } from "./transcriptVirtualWindow";
 
 export const FEED_PIN_THRESHOLD_PX = 120;
 /**
- * Re-attach stick-to-bottom only when the viewport is this close to the true
- * end. Kept tight so a light Mac trackpad nudge cannot "still count as pinned"
- * and fight streaming growth.
+ * Re-attach stick-to-bottom after an input interrupt. ~70px is wide enough to
+ * catch a flick that lands near the end without treating a light trackpad
+ * nudge (still well above this band) as pinned. Unpin is input-based, not
+ * "distance exceeded this number".
  */
-export const FEED_REPIN_THRESHOLD_PX = 28;
-/** After the last wheel/touch/user-scroll event, wait this long before re-pin. */
+export const FEED_REPIN_THRESHOLD_PX = 70;
+/** After the last wheel/touch/keyboard/user-scroll event, wait this long before re-pin. */
 export const FEED_GESTURE_IDLE_MS = 150;
-/** Treat the viewport as at the true tail (not merely the 28px re-pin band). */
+/** Treat the viewport as at the true tail (not merely the re-pin band). */
 export const FEED_TAIL_EPSILON_PX = 0.5;
+/** Discrete spring: close residual error after feed-forwarding content growth. */
+export const FEED_FOLLOW_STIFFNESS = 0.42;
+export const FEED_FOLLOW_DAMPING = 0.78;
+export const FEED_FOLLOW_SETTLE_PX = 0.5;
 /** Inner live-reasoning pane re-pin threshold (smaller than outer feed). */
 export const THINKING_INNER_PIN_THRESHOLD_PX = 48;
 export const FEED_SETTLE_STABLE_FRAMES = 5;
@@ -128,13 +133,15 @@ export function pinStateFromScrollGeometry(
  * onScroll re-pins and the next stream token yanks the feed back — stutter.
  *
  * Rules:
- * - Upward wheel/touch sets ``releasedByGesture``; stay unpinned until the user
- *   scrolls toward the bottom AND lands within ``repinPx`` of the end.
- * - A still-active user gesture does not re-pin merely by entering the 28px
+ * - Input interrupt (wheel/touch/keyboard) sets ``releasedByGesture``; stay
+ *   unpinned until the user scrolls toward the bottom AND lands within
+ *   ``repinPx`` of the end.
+ * - A still-active user gesture does not re-pin merely by entering the restick
  *   band (mid-flick). Hitting the true tail (distance ~ 0) latches pin.
  * - ``wasPinned && !releasedByGesture`` survives content growth that pushes
  *   distance past the re-pin band — follow still owns the new max.
- * - Without a gesture release, pin follows the tight re-pin threshold only.
+ * - Geometry-only scrollTop changes (overflow-anchor, compositor) do not
+ *   unpin; ``inputInterrupt`` is required.
  */
 export function shouldDeferFollowDuringUserGesture(
   userGestureActive: boolean,
@@ -164,9 +171,12 @@ export function nextFeedPinState(opts: {
   repinPx?: number;
   /** Wheel/touch/scrollbar/keyboard gesture still in flight. */
   userGestureActive?: boolean;
+  /** Explicit input (wheel/touch/keyboard/scrollbar), not geometry alone. */
+  inputInterrupt?: boolean;
 }): { pinned: boolean; releasedByGesture: boolean } {
   const repinPx = opts.repinPx ?? FEED_REPIN_THRESHOLD_PX;
   const userGestureActive = opts.userGestureActive ?? false;
+  const inputInterrupt = opts.inputInterrupt ?? userGestureActive;
   const distance =
     opts.scrollHeight - opts.scrollTop - opts.clientHeight;
   const nearBottom = distance < repinPx;
@@ -185,7 +195,7 @@ export function nextFeedPinState(opts: {
   }
 
   if (opts.releasedByGesture) {
-    // Mid-flick above the tail: do not latch just because we entered 28px.
+    // Mid-flick above the tail: do not latch just because we entered the band.
     if (userGestureActive && !atTail) {
       return { pinned: false, releasedByGesture: true };
     }
@@ -196,10 +206,12 @@ export function nextFeedPinState(opts: {
   }
 
   // Keep stick-to-bottom across token growth. Height can jump so the old
-  // max sits well outside the 28px band before follow writes the new max.
+  // max sits well outside the restick band before follow writes the new max.
+  // Unpin only on input — overflow-anchor / compositor scrollTop noise must
+  // not release the pin.
   if (opts.wasPinned) {
-    if (scrolledAway && !nearBottom) {
-      return { pinned: false, releasedByGesture: false };
+    if (inputInterrupt && scrolledAway && !nearBottom) {
+      return { pinned: false, releasedByGesture: true };
     }
     return { pinned: true, releasedByGesture: false };
   }
@@ -234,6 +246,25 @@ export function shouldShowJumpToBottom(opts: {
 export function shouldUnpinOnWheel(deltaY: number, _settling: boolean): boolean {
   void _settling;
   return deltaY < 0;
+}
+
+const FEED_UNPIN_KEYS = new Set(["PageUp", "ArrowUp", "Home"]);
+
+/** Keyboard interrupt — PageUp / ArrowUp / Home. Composer is outside the feed. */
+export function shouldUnpinOnKeyboard(key: string): boolean {
+  return FEED_UNPIN_KEYS.has(key);
+}
+
+/** Wheel, touch, keyboard — not a scrollbar-position inference. */
+export function isFeedInputInterrupt(
+  source: "wheel" | "touch" | "keyboard" | "scrollbar",
+): boolean {
+  return (
+    source === "wheel"
+    || source === "touch"
+    || source === "keyboard"
+    || source === "scrollbar"
+  );
 }
 
 /**
@@ -277,6 +308,59 @@ export function shouldUnpinOnTouchMove(
  * Gesture release wins over session-switch settling so manual scroll-up during
  * settle glue is not overwritten by ResizeObserver follow.
  */
+export type FeedSpringFollowState = {
+  scrollTop: number;
+  velocityPxPerMs: number;
+};
+
+/**
+ * Stick-to-bottom follow: absorb content growth in the same frame (feed-
+ * forward), then spring any residual error toward max. A bare
+ * ``scrollTop = max`` snap fights overflow-anchor and hitchs when chrome
+ * shrinks a frame behind layout.
+ */
+export function nextFeedSpringFollow(opts: {
+  scrollTop: number;
+  maxScrollTop: number;
+  contentDeltaPx: number;
+  velocityPxPerMs: number;
+  dtMs?: number;
+  stiffness?: number;
+  damping?: number;
+}): FeedSpringFollowState {
+  const stiffness = opts.stiffness ?? FEED_FOLLOW_STIFFNESS;
+  const damping = opts.damping ?? FEED_FOLLOW_DAMPING;
+  void opts.dtMs;
+  // Feed-forward content growth so a pinned tail stays a pinned tail in the
+  // same frame. Spring only the leftover error (chrome / subpixel).
+  const forwarded = feedForwardFollowTop(
+    opts.scrollTop,
+    opts.contentDeltaPx,
+    opts.maxScrollTop,
+  );
+  const error = opts.maxScrollTop - forwarded;
+  if (Math.abs(error) < FEED_FOLLOW_SETTLE_PX) {
+    return { scrollTop: forwarded, velocityPxPerMs: 0 };
+  }
+  const velocity = (opts.velocityPxPerMs + error * stiffness) * damping;
+  const next = forwarded + velocity;
+  const clamped = Math.max(0, Math.min(opts.maxScrollTop, next));
+  if (Math.abs(opts.maxScrollTop - clamped) < FEED_FOLLOW_SETTLE_PX) {
+    return { scrollTop: opts.maxScrollTop, velocityPxPerMs: 0 };
+  }
+  return { scrollTop: clamped, velocityPxPerMs: velocity };
+}
+
+/** Same-frame feed-forward: keep distance-from-end across content growth. */
+export function feedForwardFollowTop(
+  scrollTop: number,
+  contentDeltaPx: number,
+  maxScrollTop: number,
+): number {
+  const forwarded = scrollTop + Math.max(0, contentDeltaPx);
+  return Math.max(0, Math.min(maxScrollTop, forwarded));
+}
+
 export function scrollTopAfterFeedHeightChange(opts: {
   scrollHeight: number;
   scrollTop: number;
@@ -285,6 +369,10 @@ export function scrollTopAfterFeedHeightChange(opts: {
   settling: boolean;
   releasedByGesture: boolean;
   userGestureActive?: boolean;
+  /** Prior scrollHeight so follow can feed-forward the growth delta. */
+  prevScrollHeight?: number;
+  velocityPxPerMs?: number;
+  dtMs?: number;
 }): number | null {
   if (opts.releasedByGesture) {
     return null;
@@ -303,10 +391,30 @@ export function scrollTopAfterFeedHeightChange(opts: {
     return null;
   }
   const maxScrollTop = Math.max(0, opts.scrollHeight - opts.clientHeight);
-  if (Math.abs(opts.scrollTop - maxScrollTop) < 0.5) {
+  if (opts.prevScrollHeight == null) {
+    if (Math.abs(opts.scrollTop - maxScrollTop) < FEED_FOLLOW_SETTLE_PX) {
+      return null;
+    }
+    return maxScrollTop;
+  }
+  const contentDeltaPx = opts.scrollHeight - opts.prevScrollHeight;
+  if (contentDeltaPx <= 0) {
+    if (Math.abs(opts.scrollTop - maxScrollTop) < FEED_FOLLOW_SETTLE_PX) {
+      return null;
+    }
+    return maxScrollTop;
+  }
+  const sprung = nextFeedSpringFollow({
+    scrollTop: opts.scrollTop,
+    maxScrollTop,
+    contentDeltaPx,
+    velocityPxPerMs: opts.velocityPxPerMs ?? 0,
+    dtMs: opts.dtMs ?? 16,
+  });
+  if (Math.abs(opts.scrollTop - sprung.scrollTop) < FEED_FOLLOW_SETTLE_PX) {
     return null;
   }
-  return maxScrollTop;
+  return sprung.scrollTop;
 }
 
 export type FeedResizeFollowResult =
@@ -411,6 +519,7 @@ export function feedResizeScrollFollowDecision(opts: {
     pinned: opts.snapshotPinned,
     settling: opts.snapshotSettling,
     releasedByGesture: false,
+    prevScrollHeight: opts.snapshotScrollHeight,
   });
   if (top != null) {
     return { kind: "follow", scrollTop: top };

--- a/webapp/src/components/conversation/reexports.ts
+++ b/webapp/src/components/conversation/reexports.ts
@@ -305,7 +305,10 @@ export {
   shouldStopNestedWheelBubble,
   shouldUnpinInnerOnWheel,
   shouldUnpinOnWheel,
+  shouldUnpinOnKeyboard,
   shouldUnpinOnTouchMove,
+  nextFeedSpringFollow,
+  feedForwardFollowTop,
   settleFrameResult,
   THINKING_INNER_PIN_THRESHOLD_PX,
 } from "./feedScroll";

--- a/webapp/src/components/conversation/transcriptItems.ts
+++ b/webapp/src/components/conversation/transcriptItems.ts
@@ -1,4 +1,5 @@
 import type { Item, Msg } from "../TranscriptList";
+import { stampTranscriptMessageIds } from "./transcriptRowIdentity";
 import {
   mergeSwarmPendingItems,
   normalizeSwarmJobIds,
@@ -211,6 +212,7 @@ export function deduplicateAssistantNarration(items: Item[]): Item[] {
               ...item.msg,
               text: newText,
               streaming: false,
+              id: prev.msg.id || item.msg.id,
             },
           };
         } else if (prev.msg.streaming) {
@@ -220,6 +222,7 @@ export function deduplicateAssistantNarration(items: Item[]): Item[] {
               ...prev.msg,
               text: prevText,
               streaming: false,
+              id: prev.msg.id || item.msg.id,
             },
           };
         }
@@ -342,7 +345,9 @@ export function dedupeDisplayItems(items: Item[]): Item[] {
 export function transcriptResponseToItems(res: {
   history?: any[];
   display?: any[];
-}): Item[] {
+  session_id?: string;
+}, sessionId?: string): Item[] {
+  const scope = sessionId || res.session_id;
   let loadedItems: Item[] = [];
   if (res.display && res.display.length > 0) {
     loadedItems = res.display.flatMap((m: any): Item[] => {
@@ -546,11 +551,13 @@ export function transcriptResponseToItems(res: {
       } else {
         const rawText = m.text || "";
         const role = m.role as "user" | "assistant";
+        const persistedId = String(m.id || m.input_id || "").trim();
         return [{
           kind: "msg" as const,
           msg: {
             role,
             text: role === "user" ? stripUserVisibleText(rawText) : rawText,
+            ...(persistedId ? { id: persistedId } : {}),
           }
         }];
       }
@@ -561,19 +568,24 @@ export function transcriptResponseToItems(res: {
       .map((m: any) => {
         const role = m.role as "user" | "assistant";
         const rawText = m.content || "";
+        const persistedId = String(m.id || m.input_id || "").trim();
         return {
           kind: "msg" as const,
           msg: {
             role,
             text: role === "user" ? stripUserVisibleText(rawText) : rawText,
+            ...(persistedId ? { id: persistedId } : {}),
           }
         };
       });
   }
   // Cursor CLI may persist tool cards after a flushed finale; hoist on hydrate
   // so Explored sits above the answer after reload (same as assistant_done).
-  return hoistCardsBeforeTrailingFinals(
-    deduplicateConsecutiveAssistantMessages(dedupeDisplayItems(loadedItems)),
+  return stampTranscriptMessageIds(
+    hoistCardsBeforeTrailingFinals(
+      deduplicateConsecutiveAssistantMessages(dedupeDisplayItems(loadedItems)),
+    ),
+    scope,
   );
 }
 

--- a/webapp/src/components/conversation/transcriptPrefetch.ts
+++ b/webapp/src/components/conversation/transcriptPrefetch.ts
@@ -24,7 +24,7 @@ export function prefetchSessionTranscript(sessionId: string): Promise<boolean> {
       const res = await api.sessionTranscript(id);
       // Another path may have filled the cache while we were in flight.
       if (peekTranscriptCacheEntry(id)) return false;
-      writeTranscriptCache(id, transcriptResponseToItems(res));
+      writeTranscriptCache(id, transcriptResponseToItems(res, id));
       return true;
     } catch {
       return false;

--- a/webapp/src/components/conversation/transcriptRowHeight.ts
+++ b/webapp/src/components/conversation/transcriptRowHeight.ts
@@ -89,6 +89,15 @@ export function transcriptRowCacheKey(
   return `${rowId}\0${font}\0${whiteSpace}\0${text}`;
 }
 
+/** Cheng Lou height memo: prepare is text+font; height is (id, length, width). */
+export function transcriptRowHeightMemoKey(
+  rowId: string,
+  contentLength: number,
+  width: number,
+): string {
+  return `${rowId}\0${contentLength}\0${Math.round(width)}`;
+}
+
 export function hasMarkdownCodeFence(text: string): boolean {
   return /```/.test(text);
 }
@@ -292,11 +301,20 @@ export type TranscriptRowHeightCache = {
 
 export function createTranscriptRowHeightCache(): TranscriptRowHeightCache {
   const preparedByKey = new Map<string, PreparedText>();
+  const heightByMemo = new Map<string, number>();
 
   function layoutHeight(
     rowId: string,
     spec: TranscriptRowPretextSpec,
   ): number {
+    const memoKey = transcriptRowHeightMemoKey(
+      rowId,
+      spec.text.length,
+      spec.maxWidth,
+    );
+    const memoHit = heightByMemo.get(memoKey);
+    if (memoHit != null) return memoHit;
+
     const cacheKey = transcriptRowCacheKey(
       rowId,
       spec.text,
@@ -324,7 +342,9 @@ export function createTranscriptRowHeightCache(): TranscriptRowHeightCache {
         spec.maxProsePx != null
           ? Math.min(prose, spec.maxProsePx)
           : prose;
-      return Math.max(24, Math.ceil(capped + spec.chromePx));
+      const next = Math.max(24, Math.ceil(capped + spec.chromePx));
+      heightByMemo.set(memoKey, next);
+      return next;
     } catch {
       return TRANSCRIPT_ROW_FALLBACK_PX;
     }
@@ -349,7 +369,10 @@ export function createTranscriptRowHeightCache(): TranscriptRowHeightCache {
 
   return {
     estimateRowHeight,
-    clear: () => preparedByKey.clear(),
+    clear: () => {
+      preparedByKey.clear();
+      heightByMemo.clear();
+    },
   };
 }
 

--- a/webapp/src/components/conversation/transcriptRowIdentity.ts
+++ b/webapp/src/components/conversation/transcriptRowIdentity.ts
@@ -1,0 +1,134 @@
+/**
+ * Durable transcript row identities.
+ *
+ * Live streaming and disk hydrate mint different object references. React keys
+ * must survive that handoff (`msgId#blockId`) so virtual rows do not remount.
+ * Optimistic user echoes use the same id the backend persists as `input_id`.
+ */
+
+import type { Item, Msg } from "../TranscriptList";
+
+export const TRANSCRIPT_BODY_BLOCK_ID = "body";
+export const TRANSCRIPT_PROGRESS_BLOCK_ID = "progress";
+export const TRANSCRIPT_WORKER_BLOCK_ID = "worker";
+export const TRANSCRIPT_IDENTITY_SEP = "#";
+export const TRANSCRIPT_DRAFT_SESSION_ID = "_draft";
+
+export function allocateOptimisticInputId(): string {
+  const cryptoObj = globalThis.crypto;
+  if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
+    return cryptoObj.randomUUID().replace(/-/g, "");
+  }
+  return `in${Date.now().toString(16)}${Math.random().toString(16).slice(2, 10)}`;
+}
+
+export function transcriptSessionScope(sessionId?: string | null): string {
+  const trimmed = String(sessionId || "").trim();
+  return trimmed || TRANSCRIPT_DRAFT_SESSION_ID;
+}
+
+export function ordinalMessageId(
+  sessionId: string | null | undefined,
+  role: Msg["role"],
+  ordinal: number,
+): string {
+  return `msg:${transcriptSessionScope(sessionId)}:${role}:${ordinal}`;
+}
+
+export function durableMessageId(opts: {
+  explicitId?: string | null;
+  inputId?: string | null;
+  sessionId?: string | null;
+  role: Msg["role"];
+  ordinal: number;
+}): string {
+  const explicit = String(opts.explicitId || "").trim();
+  if (explicit) return explicit;
+  const inputId = String(opts.inputId || "").trim();
+  if (inputId) return inputId;
+  return ordinalMessageId(opts.sessionId, opts.role, opts.ordinal);
+}
+
+export function messageBlockId(msg: Pick<Msg, "workerStream" | "channel">): string {
+  if (msg.workerStream) return TRANSCRIPT_WORKER_BLOCK_ID;
+  if (msg.channel === "progress") return TRANSCRIPT_PROGRESS_BLOCK_ID;
+  return TRANSCRIPT_BODY_BLOCK_ID;
+}
+
+export function transcriptBlockRowId(msgId: string, blockId: string): string {
+  return `${msgId}${TRANSCRIPT_IDENTITY_SEP}${blockId}`;
+}
+
+export function countRoleMessages(
+  items: readonly Item[],
+  role: Msg["role"],
+): number {
+  let count = 0;
+  for (const item of items) {
+    if (item.kind === "msg" && item.msg.role === role) count += 1;
+  }
+  return count;
+}
+
+export function stampMessageIdentity(
+  msg: Msg,
+  ordinal: number,
+  sessionId?: string | null,
+): Msg {
+  if (msg.id) return msg;
+  return {
+    ...msg,
+    id: durableMessageId({
+      sessionId,
+      role: msg.role,
+      ordinal,
+    }),
+  };
+}
+
+/** Stamp every message that still lacks a durable id (hydrate / live mint). */
+export function stampTranscriptMessageIds(
+  items: Item[],
+  sessionId?: string | null,
+): Item[] {
+  let userOrdinal = 0;
+  let assistantOrdinal = 0;
+  let changed = false;
+  const next = items.map((item) => {
+    if (item.kind !== "msg") return item;
+    const ordinal = item.msg.role === "user" ? userOrdinal++ : assistantOrdinal++;
+    if (item.msg.id) return item;
+    changed = true;
+    return {
+      ...item,
+      msg: stampMessageIdentity(item.msg, ordinal, sessionId),
+    };
+  });
+  return changed ? next : items;
+}
+
+export function withLiveMessageId(
+  items: readonly Item[],
+  msg: Msg,
+  sessionId?: string | null,
+): Msg {
+  if (msg.id) return msg;
+  return stampMessageIdentity(
+    msg,
+    countRoleMessages(items, msg.role),
+    sessionId,
+  );
+}
+
+export function optimisticUserEchoMsg(opts: {
+  text: string;
+  images?: Msg["images"];
+  id: string;
+}): Msg {
+  return {
+    role: "user",
+    text: opts.text,
+    images: opts.images,
+    id: opts.id,
+  };
+}

--- a/webapp/src/components/conversation/transcriptVirtualWindow.ts
+++ b/webapp/src/components/conversation/transcriptVirtualWindow.ts
@@ -5,7 +5,15 @@
  * blurred or occluded (alt-tab). Falling back to the unvirtualized list
  * remounts every bubble and snaps the feed to the top. Latch virtualization
  * once the scroll parent has been sized, and ignore zero-size resizes.
+ *
+ * Height estimates finish the Pretext / Cheng Lou contract: `prepare` once
+ * per row text+font, `layout` per width, and a height memo keyed by
+ * (id, content length, width). Virtual rows never take Motion layoutScroll.
  */
+
+import { transcriptRowHeightMemoKey } from "./transcriptRowHeight";
+
+export { transcriptRowHeightMemoKey };
 
 export function isOccludedScrollParentSize(
   clientHeight: number,

--- a/webapp/src/components/conversation/useSessionSwitch.ts
+++ b/webapp/src/components/conversation/useSessionSwitch.ts
@@ -519,7 +519,7 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
         try {
           const res = await api.sessionTranscript(sid);
           if (gen !== transcriptLoadGenRef.current) return null;
-          const loadedItems = transcriptResponseToItems(res);
+          const loadedItems = transcriptResponseToItems(res, sid);
           if (shouldRetryEmptyTranscript({
             loadedCount: loadedItems.length,
             attempt,

--- a/webapp/src/lib/jobsDashboard.ts
+++ b/webapp/src/lib/jobsDashboard.ts
@@ -1,4 +1,10 @@
-/** Puppetmaster dashboard deep-links hosted in the Jobs tool. */
+/**
+ * Jobs rail is a viewport over Puppetmaster (`?job=&embed=1`).
+ * Marionette adapters locate and embed that dashboard — they are transports,
+ * not a second native tracker.
+ */
+
+export const JOBS_RAIL_VIEWPORT = "puppetmaster-embed" as const;
 
 export const JOBS_DASHBOARD_FOCUS_MIN_PX = 640;
 export const JOBS_DASHBOARD_EXPAND_MIN_PX = 800;
@@ -23,6 +29,19 @@ export function buildDashboardEmbedUrl(host: string, port: number, jobId?: strin
   if (id) params.set("job", id);
   params.set("embed", "1");
   return `http://${host}:${port}/?${params.toString()}`;
+}
+
+/** Alias: the Jobs rail hosts only this PM embed, never a dual native tracker. */
+export function jobsRailViewportUrl(
+  host: string,
+  port: number,
+  jobId?: string | null,
+): string {
+  return buildDashboardEmbedUrl(host, port, jobId);
+}
+
+export function jobsRailIsPuppetmasterViewport(): true {
+  return true;
 }
 
 export function requestRightMinWidth(minPx: number): void {


### PR DESCRIPTION
## Summary
- Stick-to-bottom spring with input interrupt + 70px restick
- Stable msgId#blockId rows + height memo + optimistic echo ids
- Jobs rail remains PM embed viewport only
- No version bump (stays 0.9.450 / pin 1.27.5)

From #379 into-dev.

## Test plan
- [ ] CI green
- [ ] Spot-check streaming stick + cold swap