### PR TITLE
Jobs tracker: collapse to PM right-rail embed

### DIFF
--- a/webapp/src/__tests__/LeftRail.artifacts.test.tsx
+++ b/webapp/src/__tests__/LeftRail.artifacts.test.tsx
@@ -1,83 +1,70 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
-import { api } from '../lib/api';
-import { fetchJobArtifacts } from '../lib/jobArtifacts';
 import LeftRail from '../components/LeftRail';
-import { expertDetail, expertMetadataFixture, expertSummary } from './metadataExpert.fixtures';
-import type { MetadataDetail, MetadataSelection } from '../lib/jobMetadata';
+import { openAgentSwarmJob } from '../lib/agentLinks';
+import { expertMetadataFixture, expertSummary } from './metadataExpert.fixtures';
+import type { MetadataSelection } from '../lib/jobMetadata';
 import { clearSWRCache } from '../lib/useStaleWhileRevalidate';
 
-vi.mock('../lib/api', () => ({ api: {
-  getWorkspace: vi.fn().mockResolvedValue({ repo: '/workspace', branch: 'main', is_git: true,
-    head_unborn: false, codegraph_status: 'ready', recents: [], home: '/home' }),
-  workspaces: vi.fn().mockResolvedValue([{ name: 'main', active: true, dirty: false }]),
-  sessions: vi.fn().mockResolvedValue([{ id: 'session-1', title: 'Current', active: true, repo: '/workspace' }]),
-  jobs: vi.fn(),
-} }));
-vi.mock('../lib/jobArtifacts', async importOriginal => ({
-  ...await importOriginal<typeof import('../lib/jobArtifacts')>(), fetchJobArtifacts: vi.fn(),
+vi.mock('../lib/api', () => ({
+  api: {
+    getWorkspace: vi.fn().mockResolvedValue({
+      repo: '/workspace',
+      branch: 'main',
+      is_git: true,
+      head_unborn: false,
+      codegraph_status: 'ready',
+      recents: [],
+      home: '/home',
+    }),
+    workspaces: vi.fn().mockResolvedValue([{ name: 'main', active: true, dirty: false }]),
+    sessions: vi.fn().mockResolvedValue([
+      { id: 'session-1', title: 'Current', active: true, repo: '/workspace' },
+    ]),
+    jobs: vi.fn(),
+  },
 }));
+vi.mock('../lib/agentLinks', () => ({ openAgentSwarmJob: vi.fn() }));
 vi.mock('../lib/usePolling', () => ({ usePolling: vi.fn() }));
 vi.mock('../lib/useOperationalDiagnostic', () => ({ useOperationalDiagnostic: () => null }));
 
-const selection: MetadataSelection = { job_ref: { job_id: 'job_one', state_id: 'state_one' },
-  source: 'harness', repo: '/workspace', session_id: 'session-1' };
+const selection: MetadataSelection = {
+  job_ref: { job_id: 'job_one', state_id: 'state_one' },
+  source: 'harness',
+  repo: '/workspace',
+  session_id: 'session-1',
+};
+
 let metadata: Awaited<ReturnType<typeof expertMetadataFixture>>;
+
 beforeEach(async () => {
   localStorage.clear();
   clearSWRCache();
-  vi.mocked(fetchJobArtifacts).mockReset();
-  metadata = await expertMetadataFixture([{ ...expertSummary(selection, 'Artifact test job'), lifecycle: 'complete' }], { browser: true });
+  vi.mocked(openAgentSwarmJob).mockReset();
+  metadata = await expertMetadataFixture(
+    [{ ...expertSummary(selection, 'Artifact test job'), lifecycle: 'complete' }],
+    { browser: true },
+  );
 });
-afterEach(() => { cleanup(); metadata.dispose(); vi.restoreAllMocks(); vi.unstubAllGlobals(); });
-function artifacts(type?: string): MetadataDetail {
-  const result = expertDetail(selection, metadata.context());
-  result.artifacts = { ...result.artifacts, rows: type ? [{ ...result.artifacts.rows[0], type }] : [] };
-  return result;
-}
-async function openCard() {
-  render(<metadata.Provider><LeftRail jobsRefresh={0} /></metadata.Provider>);
+
+afterEach(() => {
+  cleanup();
+  metadata.dispose();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it('opens the Jobs rail PM embed on hire click (no inline artifact expand)', async () => {
+  render(
+    <metadata.Provider>
+      <LeftRail jobsRefresh={0} />
+    </metadata.Provider>,
+  );
   await waitFor(() => expect(metadata.store.getSnapshot().view.kind).toBe('target'));
   await metadata.observe();
   fireEvent.click(await screen.findByRole('button', { name: /Artifact test job/ }));
-}
-it('shows a recorded summaryless gate rather than empty', async () => {
-  metadata.selected.mockResolvedValue(artifacts('gate'));
-  await openCard();
-  expect(await screen.findByText('1 artifact recorded without a summary')).toBeTruthy();
+  expect(openAgentSwarmJob).toHaveBeenCalledWith('job_one');
+  expect(screen.queryByText('Loading artifacts...')).toBeNull();
   expect(screen.queryByText('No artifacts recorded')).toBeNull();
-  expect(metadata.selected).toHaveBeenCalledWith(selection, expect.objectContaining({ task_cursor: null, artifact_cursor: null }));
-  expect(fetchJobArtifacts).not.toHaveBeenCalled();
-  expect(api.jobs).not.toHaveBeenCalled();
-});
-it('shows failure with Retry, then genuine loaded empty', async () => {
-  metadata.selected.mockRejectedValueOnce(new Error('network failed')).mockResolvedValueOnce(artifacts());
-  await openCard();
-  const retry = await screen.findByRole('button', { name: 'Retry', exact: true });
-  expect(screen.queryByText('No artifacts recorded')).toBeNull();
-  fireEvent.click(retry);
-  expect(await screen.findByText('No artifacts recorded')).toBeTruthy();
-});
-it.each(['harness-project-selected', 'harness-session-changed'])('fences late results after %s', async event => {
-  let finish: (value: MetadataDetail) => void = () => {};
-  metadata.selected.mockImplementation(() => new Promise(resolve => { finish = resolve; }));
-  await openCard();
-  expect(screen.getByText('Loading artifacts...')).toBeTruthy();
-  await act(async () => {
-    window.dispatchEvent(new CustomEvent(event, { detail: '/other' }));
-    finish({ ...artifacts('finding'), display: { kind: 'available', goal_preview: 'Old scope content', goal_preview_truncated: false, delivery: 'unverified', quality: 'unverified' } });
-  });
-  expect(screen.queryByText('Old scope content')).toBeNull();
-});
-it('renders an HTTP 503 through the real transport and retries the bound read', async () => {
-  metadata.selected.mockRejectedValueOnce(new Error('Store unavailable')).mockResolvedValueOnce(artifacts('gate'));
-  await openCard();
-  fireEvent.click(await screen.findByRole('button', { name: 'Retry', exact: true }));
-  expect(await screen.findByText('1 artifact recorded without a summary')).toBeTruthy();
-  // The shared metadata owner already performed one handshake before the card opened.
-  expect(metadata.browserFetch.mock.calls.filter(([path]) => String(path).endsWith('/api/endpoint'))).toHaveLength(1);
-  const details = metadata.browserFetch.mock.calls.filter(([path]) => String(path).includes('/api/jobs/metadata/detail?'));
-  expect(details).toHaveLength(2);
-  expect(String(details[0][0])).toContain('state_id=state_one');
-  expect(String(details[1][0])).toContain('state_id=state_one');
+  expect(screen.queryByRole('button', { name: 'Retry', exact: true })).toBeNull();
 });

--- a/webapp/src/__tests__/SwarmPane.reads.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.reads.test.tsx
@@ -78,7 +78,9 @@ it('shows transport failure instead of an empty tracker and retries', async () =
   await act(async () => { f.store.setTarget(f.context()); await f.store.readView(); });
   expect(await screen.findByRole('alert')).toHaveTextContent('Job updates unavailable');
   expect(screen.queryByText(/^No jobs observed in this view/)).not.toBeInTheDocument();
+  expect(screen.getByText(/Job observations could not be loaded/)).toBeInTheDocument();
   expect(screen.getByText(/an empty view does not establish no work/)).toBeInTheDocument();
+  expect(screen.queryByText('Job data unavailable')).not.toBeInTheDocument();
   f.request.mockImplementation(async (method, path) => {
     const result = await request(method, path);
     if (new URL(path, 'http://fixture').pathname === '/api/jobs/metadata') {

--- a/webapp/src/__tests__/jobDisplayTitle.test.ts
+++ b/webapp/src/__tests__/jobDisplayTitle.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { jobDisplayTitle, looksLikeRawJobJson } from "../lib/jobDisplayTitle";
+
+const provenance = JSON.stringify({
+  cost_provenance: "provider",
+  adapter: "agentic",
+  role: "implement",
+});
+
+describe("jobDisplayTitle", () => {
+  it("prefers a human goal or label", () => {
+    expect(jobDisplayTitle({ goal: "Review auth", id: "job_abcdef012345" })).toBe("Review auth");
+    expect(jobDisplayTitle({ label: "Native implement", goal: "Review auth" })).toBe("Native implement");
+  });
+
+  it("hides raw provenance JSON and falls back to role or kind", () => {
+    expect(looksLikeRawJobJson(provenance)).toBe(true);
+    expect(jobDisplayTitle({ goal: provenance, role: "implement" })).toBe("implement");
+    expect(jobDisplayTitle({ goal: provenance, job_kind: "run_swarm" })).toBe("run swarm");
+    expect(jobDisplayTitle({ goal: provenance, id: "job_abcdef012345" })).toBe("Job");
+  });
+
+  it("does not treat ordinary sentences as JSON", () => {
+    expect(looksLikeRawJobJson("Review {auth} flow")).toBe(false);
+    expect(jobDisplayTitle({ goal: "Review {auth} flow" })).toBe("Review {auth} flow");
+  });
+});

--- a/webapp/src/__tests__/jobsDashboard.test.ts
+++ b/webapp/src/__tests__/jobsDashboard.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import {
   buildDashboardEmbedUrl,
+  dashboardLocateError,
+  dashboardUnavailableMessage,
+  jobsListEmptyTruth,
   jobsRailIsPuppetmasterViewport,
   jobsRailViewportUrl,
   JOBS_RAIL_VIEWPORT,
@@ -46,5 +49,36 @@ describe("requestRightMinWidth", () => {
     const event = spy.mock.calls[0]?.[0] as CustomEvent<{ focused: boolean }>;
     expect(event.type).toBe(JOBS_DASHBOARD_CHROME_EVENT);
     expect(event.detail.focused).toBe(true);
+  });
+});
+
+
+describe("Jobs rail honesty", () => {
+  it("names locate/embed failures instead of Job data unavailable", () => {
+    expect(dashboardLocateError({
+      ok: false,
+      error: "state_dir_unavailable",
+      detail: "No Puppetmaster project store for this workspace.",
+    })).toBe("No Puppetmaster project store for this workspace.");
+    expect(dashboardUnavailableMessage()).toBe("Could not locate the Puppetmaster dashboard.");
+    expect(jobsListEmptyTruth({
+      failedRead: true,
+      viewReady: true,
+      working: false,
+      hiddenCount: 0,
+      filter: "all",
+      hasJobs: false,
+    })).toEqual({
+      title: "Job observations could not be loaded",
+      detail: "Retry updates; an empty view does not establish no work.",
+    });
+    expect(jobsListEmptyTruth({
+      failedRead: false,
+      viewReady: true,
+      working: false,
+      hiddenCount: 0,
+      filter: "all",
+      hasJobs: false,
+    }).title).toBe("No jobs yet");
   });
 });

--- a/webapp/src/components/JobDashboardHost.tsx
+++ b/webapp/src/components/JobDashboardHost.tsx
@@ -7,10 +7,13 @@ import { openAgentUrlExternal } from "../lib/agentLinks";
 import {
   JOBS_DASHBOARD_EXPAND_MIN_PX,
   JOBS_DASHBOARD_FOCUS_MIN_PX,
+  dashboardLocateError,
+  dashboardUnavailableMessage,
   notifyJobsDashboardChrome,
   requestRightMinWidth,
   type DashboardLocate,
 } from "../lib/jobsDashboard";
+import { jobDisplayTitle } from "../lib/jobDisplayTitle";
 import { lastSelectedProjectRoot } from "../lib/panelTransition";
 
 /**
@@ -33,7 +36,7 @@ export default function JobDashboardHost({
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
 
-  const title = (job.goal || "").trim() || job.id;
+  const title = jobDisplayTitle(job);
   const deepLinkId = dashboardJobId(job);
   const frameKey = deepLinkId || job.id;
   const embedUrl = locate?.embed_url || locate?.url || "";
@@ -53,7 +56,7 @@ export default function JobDashboardHost({
     const repo = lastSelectedProjectRoot() || undefined;
     const locateDashboard = api.dashboard;
     if (typeof locateDashboard !== "function") {
-      setError("Dashboard unavailable.");
+      setError(dashboardUnavailableMessage());
       setLoading(false);
       return;
     }
@@ -64,16 +67,12 @@ export default function JobDashboardHost({
         if (cancelled) return;
         setLocate(payload);
         if (!payload.ok || !(payload.embed_url || payload.url)) {
-          const stderr = typeof (payload as { stderr?: unknown }).stderr === "string"
-            ? String((payload as { stderr?: string }).stderr).trim()
-            : "";
-          const base = payload.detail || payload.error || "Dashboard unavailable.";
-          setError(stderr ? `${base}: ${stderr.slice(0, 280)}` : base);
+          setError(dashboardLocateError(payload));
         }
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : "Dashboard unavailable.");
+        setError(dashboardUnavailableMessage(err));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -1,4 +1,3 @@
-import { metadataSelectionKey } from '../lib/jobMetadata';
 import { nativeActiveStatuses } from '../lib/localJobMetadata';
 import { useSharedJobMetadata, metadataJobs, isJobsListRow } from '../lib/jobMetadataContext';
 import { MetadataStatus } from './MetadataJobs';
@@ -7,7 +6,6 @@ import { jobDisplayTitle } from '../lib/jobDisplayTitle';
 import { useCallback, useEffect, useRef, useState } from "react";
 import { GitBranch, Plus, MessageSquare, Check, Loader2, ChevronDown, ChevronRight, SquarePen, Folder, FolderGit2, CheckCircle2, Circle, Trash2, Brush, Search, X, Square } from "lucide-react";
 import { api, type Workspace, type WorkspaceInfo, type Session, type Job } from "../lib/api";
-import { jobArtifactKey, selectJobRef, type ArtifactLoad, type SelectedJobRef } from "../lib/jobArtifacts";
 import { pickFolder } from "../lib/transport";
 import { dispatchProjectSelected, dispatchProjectSwitching, panelOpacityClass } from "../lib/panelTransition";
 import { repoPathsEqual } from "../lib/pathNormalize";
@@ -93,7 +91,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
   jobsRefresh: number;
   onSessionChange?: (id: string | null, expectedPreviousId?: string) => void;
 }) {
-  const { store: metadataStore, state: metadata } = useSharedJobMetadata();
+  const { state: metadata } = useSharedJobMetadata();
   const [forkTarget, setForkTarget] = useState<Pick<Session, "id" | "title" | "forked_from"> | null>(null);
   const contextTrigger = useRef<HTMLElement | null>(null);
   const [forkTrigger, setForkTrigger] = useState<HTMLElement | null>(null);
@@ -144,7 +142,6 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     return () => window.removeEventListener("harness-job-scope-changed", onScope);
   }, []);
   const [showAllJobs, setShowAllJobs] = useState(false);
-  const [expandedJobs, setExpandedJobs] = useState<Record<string, boolean>>({});
   const [sessionJobsHeight, setSessionJobsHeight] = useState(loadSessionJobsHeight);
   const [branchesHeight, setBranchesHeight] = useState(loadBranchesHeight);
   const [pruningBranches, setPruningBranches] = useState(false);
@@ -156,21 +153,6 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     events.forEach(event => window.addEventListener(event, invalidate));
     return () => {
       invalidate();
-      events.forEach(event => window.removeEventListener(event, invalidate));
-    };
-  }, []);
-  const [artifactsByJob, setArtifactsByJob] = useState<Record<string, ArtifactLoad>>({});
-  const artifactEpoch = useRef(0);
-  useEffect(() => {
-    const invalidate = () => {
-      artifactEpoch.current += 1;
-      setArtifactsByJob({});
-      setExpandedJobs({});
-    };
-    const events = ["harness-project-switching", "harness-project-selected", "harness-session-changed", "harness-config-changed"];
-    events.forEach(event => window.addEventListener(event, invalidate));
-    return () => {
-      artifactEpoch.current += 1;
       events.forEach(event => window.removeEventListener(event, invalidate));
     };
   }, []);
@@ -283,17 +265,6 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
   useEffect(() => () => {
     branchesResizeCleanupRef.current?.();
   }, []);
-
-  const loadJobArtifacts = (selection: SelectedJobRef) => {
-    const match = metadata.observations.find(o => metadataSelectionKey(o.row.selection) === metadataSelectionKey({ ...selection, source: o.row.selection.source }) && o.row.selection.source === selection.source);
-    if (match && !metadata.working) { metadataStore.select(match.row.selection); void metadataStore.readDetail(); }
-  };
-
-  const toggleJobCard = (key: string, selection: SelectedJobRef | null) => {
-    const opening = !expandedJobs[key];
-    setExpandedJobs(previous => ({ ...previous, [key]: opening }));
-    if (opening && selection && artifactsByJob[key] === undefined) loadJobArtifacts(selection);
-  };
 
   const [expandedProjects, setExpandedProjects] = useState<Record<string, boolean>>({});
   const [selectedProjectPath, setSelectedProjectPath] = useState("");
@@ -1380,7 +1351,6 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
   const artifactContextRef = useRef(artifactContext);
   if (artifactContextRef.current !== artifactContext) {
     artifactContextRef.current = artifactContext;
-    artifactEpoch.current += 1;
   }
   const sortedJobs = filterJobsByScope(jobs.slice().reverse(), jobScope, activeSessionId)
     .filter(isJobsListRow)
@@ -2204,10 +2174,7 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
               <>
                 {displayedJobs.map((j) => {
                   const st = jobStatus(j);
-                  const selection = selectJobRef(j, selectedProjectPath, activeSessionId);
-                  const key = selection ? `${artifactEpoch.current}:${jobArtifactKey(selection)}`
-                    : JSON.stringify([j.metadata_key ?? j.id, j.source, selectedProjectPath, activeSessionId]);
-                  const isOpen = !!expandedJobs[key];
+                  const key = j.metadata_key ?? j.id;
                   return (
                     <div key={key} className="border-b border-edge/35 overflow-hidden min-w-0">
                       <button
@@ -2221,7 +2188,6 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                         >
                           {jobDisplayTitle(j)}
                         </span>
-                        <ChevronDown size={11} className={`text-faint shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`} />
                       </button>
                       {/* Selection opens Jobs rail PM embed via openAgentSwarmJob */}
 

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -1,7 +1,9 @@
 import { metadataSelectionKey } from '../lib/jobMetadata';
 import { nativeActiveStatuses } from '../lib/localJobMetadata';
 import { useSharedJobMetadata, metadataJobs, isJobsListRow } from '../lib/jobMetadataContext';
-import { MetadataInspection, MetadataStatus } from './MetadataJobs';
+import { MetadataStatus } from './MetadataJobs';
+import { openAgentSwarmJob } from '../lib/agentLinks';
+import { jobDisplayTitle } from '../lib/jobDisplayTitle';
 import { useCallback, useEffect, useRef, useState } from "react";
 import { GitBranch, Plus, MessageSquare, Check, Loader2, ChevronDown, ChevronRight, SquarePen, Folder, FolderGit2, CheckCircle2, Circle, Trash2, Brush, Search, X, Square } from "lucide-react";
 import { api, type Workspace, type WorkspaceInfo, type Session, type Job } from "../lib/api";
@@ -2209,19 +2211,19 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
                   return (
                     <div key={key} className="border-b border-edge/35 overflow-hidden min-w-0">
                       <button
-                        onClick={() => toggleJobCard(key, selection)}
+                        onClick={() => openAgentSwarmJob(j.id)}
                         className="w-full min-w-0 h-7 flex items-center gap-1.5 px-1.5 text-left hover:bg-panel2/50 transition-colors focus:outline-none"
                       >
                         <JobStatusIcon status={st} />
                         <span
                           className={`flex-1 min-w-0 truncate rail-job-title ${st === "completed" ? "text-muted" : st === "cancelled" ? "text-red-400/90" : "text-txt"}`}
-                          title={j.goal}
+                          title={jobDisplayTitle(j)}
                         >
-                          {j.goal}
+                          {jobDisplayTitle(j)}
                         </span>
                         <ChevronDown size={11} className={`text-faint shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`} />
                       </button>
-                      {isOpen && <MetadataInspection job={j} />}
+                      {/* Selection opens Jobs rail PM embed via openAgentSwarmJob */}
 
                     </div>
                   );

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -16,10 +16,12 @@ import { api } from '../lib/api';
 import { jobArtifactKey, selectJobRef } from '../lib/jobArtifacts';
 import type { Job } from '../lib/api';
 import { filterJobsByScope, JOB_SCOPE_CHANGED_EVENT, loadJobScope, saveJobScope, type JobScope } from '../lib/jobScope';
-// Jobs rail picker + PM embed host. Adapters locate the dashboard; they are
-// not a dual native tracker (see jobsDashboard.ts / JobDashboardHost).
+// Jobs rail picker + PM embed host. Selecting a hire hosts JobDashboardHost.
+// Adapters locate the dashboard; they are not a dual native tracker.
 import { useSharedJobMetadata, metadataActivity, metadataJobs, metadataViewSessionId, currentExpert, currentHeader } from '../lib/jobMetadataContext';
 import { isPmDashboardJob, isSwarmTrackerJob } from '../lib/jobClassification';
+import { jobDisplayTitle } from '../lib/jobDisplayTitle';
+import { jobsListEmptyTruth } from '../lib/jobsDashboard';
 import JobDashboardHost from './JobDashboardHost';
 import { metadataSelectionKey, metadataStreamKey, pmActiveStatuses } from '../lib/jobMetadata';
 import { localKey, nativeActiveStatuses, nativeAttentionStatuses } from '../lib/localJobMetadata';
@@ -502,7 +504,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     setPreferences(p => ({ ...p, dismissed: [...new Set([...p.dismissed, ...finishedRows.filter(j => j.read_status !== 'unavailable').flatMap(j => j.metadata_key ? [j.metadata_key] : [])])].slice(-200) }));
   };
   const renderJob = (job: Job) => {
-    const key = job.metadata_key ?? '', hostable = isPmDashboardJob(job), open = !hostable && preferences.expanded.includes(key);
+    const key = job.metadata_key ?? '', title = jobDisplayTitle(job), hostable = isPmDashboardJob(job), open = !hostable && preferences.expanded.includes(key);
     const expert = currentExpert(state, key), model = (expert ? expertJobModel(expert) : null) ?? expertHeaderModel(currentHeader(state, key));
     const routing = expert && expert.kind !== 'unavailable' && expert.coverage.tasks === 'complete' && expert.tasks.length === 0 && isActive(job) && !model;
     const header = currentHeader(state, key);
@@ -514,10 +516,10 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     const adapter = job.adapter || '';
     return <div className="relative shrink-0 flex flex-col border-b border-edge/25 last:border-b-0" key={key} hidden={isFinished(job) && !finishedOpen} data-job-id={job.id} data-job-source={job.source} data-quality={quality(job)}
       onFocus={() => { focusedRow.current = key; }} onBlur={event => { if (!event.currentTarget.contains(event.relatedTarget)) focusedRow.current = null; }}>
-      <button ref={element => { if (element) rowButtons.current.set(key, element); else rowButtons.current.delete(key); }} className={`w-full flex items-center gap-2 py-1 px-1.5 hover:bg-panel2/25 text-left select-none cursor-pointer min-h-[1.625rem] focus-visible:outline focus-visible:outline-accent ${isFinished(job) && job.read_status !== 'unavailable' ? 'pr-5' : ''}`} aria-label={`${job.goal} · ${metadataOutcomeLabel(job.status)}`} {...(hostable ? { 'aria-pressed': selectedKey === key } : { 'aria-expanded': open })} onClick={() => hostable ? setSelectedKey(key) : setPreferences(p => ({ ...p, expanded: open ? p.expanded.filter(k => k !== key) : [...p.expanded, key].slice(-8) }))}>
+      <button ref={element => { if (element) rowButtons.current.set(key, element); else rowButtons.current.delete(key); }} className={`w-full flex items-center gap-2 py-1 px-1.5 hover:bg-panel2/25 text-left select-none cursor-pointer min-h-[1.625rem] focus-visible:outline focus-visible:outline-accent ${isFinished(job) && job.read_status !== 'unavailable' ? 'pr-5' : ''}`} aria-label={`${title} · ${metadataOutcomeLabel(job.status)}`} {...(hostable ? { 'aria-pressed': selectedKey === key } : { 'aria-expanded': open })} onClick={() => hostable ? setSelectedKey(key) : setPreferences(p => ({ ...p, expanded: open ? p.expanded.filter(k => k !== key) : [...p.expanded, key].slice(-8) }))}>
         <span className="shrink-0 text-faint">{hostable || open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}</span>
         <span className="shrink-0">{runningIcon ? <MetadataActivityIndicator /> : isActive(job) ? <Loader2 size={12} className="animate-spin semantic-activity-spinner text-accent" /> : failedOutcomeStatuses.has(job.status) ? <XCircle size={12} className="text-risk" /> : quality(job) === 'degraded' ? <AlertTriangle size={12} className="text-warn" /> : ['completed', 'complete', 'done'].includes(job.status) ? <CheckCircle2 size={12} className="text-faint" /> : job.status === 'cancelled' ? <XCircle size={12} className="text-muted" /> : <Circle size={12} className="text-muted" />}</span>
-        <span className="font-semibold text-[11px] text-txt truncate min-w-0 flex-1">{job.goal}</span>
+        <span className="font-semibold text-[11px] text-txt truncate min-w-0 flex-1">{title}</span>
         {showWorkerProgress && <span className="inline-flex items-center gap-1 shrink-0">
           <span className="h-0.5 w-8 rounded-full bg-edge/50 overflow-hidden" aria-hidden>
             <span className={`block h-full rounded-full ${workerProgressFull ? (quality(job) === 'degraded' ? 'bg-warn/70 w-full' : 'bg-good/70 w-full') : 'bg-accent/70'}`} style={{ width: workerProgressFull ? '100%' : `${Math.max(8, Math.round((finishedWorkers / workerCount) * 100))}%` }} />
@@ -529,7 +531,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
         {routing && <span className="shrink-0"> · routing…</span>}
         <span className={`text-[9px] font-medium tabular-nums shrink-0 ${job.status === 'cancelled' ? 'text-muted' : failedOutcomeStatuses.has(job.status) ? 'text-risk/80' : quality(job) === 'degraded' ? 'text-warn/80' : quality(job) === 'ok' && ['complete', 'completed', 'done'].includes(job.status) ? 'text-good' : 'text-accent/80'}`}>{quality(job) === 'degraded' ? <span className="text-warn">degraded</span> : quality(job) === 'ok' && ['complete', 'completed', 'done'].includes(job.status) ? <span className="text-good">done</span> : <MetadataOutcomeLabel status={job.status} />}</span>
       </button>
-      {isFinished(job) && job.read_status !== 'unavailable' && <button type="button" className="absolute right-1 top-1 text-faint/50 hover:text-risk" aria-label={`Dismiss from Jobs: ${job.goal}`} title="Dismiss from Jobs (stays in Puppetmaster history)" onClick={() => setPreferences(p => ({ ...p, dismissed: [...p.dismissed.filter(k => k !== key), key].slice(-200) }))}><X size={12} /></button>}
+      {isFinished(job) && job.read_status !== 'unavailable' && <button type="button" className="absolute right-1 top-1 text-faint/50 hover:text-risk" aria-label={`Dismiss from Jobs: ${title}`} title="Dismiss from Jobs (stays in Puppetmaster history)" onClick={() => setPreferences(p => ({ ...p, dismissed: [...p.dismissed.filter(k => k !== key), key].slice(-200) }))}><X size={12} /></button>}
       {job.status === 'stalled' && <p className="px-2 text-xs text-muted">{job.local_ref ? 'May still be active; terminal state unconfirmed.' : 'Finished for liveness; recoverable.'}</p>}
       {open && <MetadataInspection compact revealed={inspected.includes(key)} onReveal={() => setInspected(p => p.includes(key) ? p : [...p, key].slice(-8))} job={job} navigation={enabled && visible && pending && handled.current === pending && navigationMatches(pending, context, job) ? pending : undefined} />}
     </div>;
@@ -636,13 +638,13 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     {!shown.length && filter !== 'untrustworthy' && <div className="flex flex-col items-center justify-center h-48 text-center px-6 gap-2">
       <Network size={20} className="text-faint/50" />
       <span className="text-[12px] text-muted font-medium">{failedRead
-        ? 'Job data unavailable'
+        ? jobsListEmptyTruth({ failedRead: true, viewReady: true, working: false, hiddenCount: 0, filter: 'all', hasJobs: false }).title
         : state.view.kind !== 'view' || !jobs.length && state.working
           ? <><span>Loading jobs...</span> Waiting for job metadata; no lifecycle result is known yet.</>
           : hidden.length && filter === 'all' ? 'Observed finished jobs are hidden. Show hidden jobs to restore them.'
             : !jobs.length ? 'No jobs yet'
               : 'No jobs match this filter'}</span>
-      {failedRead ? <span className="text-[10.5px] text-faint">Job observations are unavailable. Retry updates; an empty view does not establish no work.</span>
+      {failedRead ? <span className="text-[10.5px] text-faint">Retry updates; an empty view does not establish no work.</span>
         : filter !== 'all' && (jobs.length > 0 || hidden.length > 0) ? <button type="button" className="text-[10.5px] text-accent hover:underline focus:outline-none" onClick={() => setFilter('all')}>Clear filter</button>
         : hidden.length > 0 ? <button type="button" className="text-[10.5px] text-accent hover:underline focus:outline-none" onClick={() => setPreferences(p => ({ ...p, dismissed: [] }))}>Show {hidden.length} hidden</button>
         : !failedRead && state.view.kind === 'view' && !jobs.length && !state.working && (

--- a/webapp/src/lib/jobDisplayTitle.ts
+++ b/webapp/src/lib/jobDisplayTitle.ts
@@ -1,0 +1,54 @@
+/** Human job titles for Jobs chrome. Never paint raw provenance JSON. */
+
+export type JobTitleSource = {
+  goal?: string | null;
+  label?: string | null;
+  role?: string | null;
+  job_kind?: string | null;
+  id?: string | null;
+};
+
+function oneLine(value: unknown): string {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function humanizeStamp(value: unknown): string {
+  return oneLine(value).replaceAll("_", " ");
+}
+
+/** True when the string is (or is wrapped as) a JSON object/array dump. */
+export function looksLikeRawJobJson(value: unknown): boolean {
+  const text = oneLine(value);
+  if (!text) return false;
+  const start = text[0];
+  const end = text[text.length - 1];
+  if (!((start === "{" && end === "}") || (start === "[" && end === "]"))) return false;
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return parsed !== null && typeof parsed === "object";
+  } catch {
+    return false;
+  }
+}
+
+function usableTitle(value: unknown): string {
+  const text = oneLine(value);
+  if (!text || looksLikeRawJobJson(text)) return "";
+  return text;
+}
+
+/**
+ * Prefer goal / label. Skip provenance JSON blobs. Fall back to a
+ * humanized role/kind, then a short "Job" — never the raw dump.
+ */
+export function jobDisplayTitle(job: JobTitleSource, fallback = "Job"): string {
+  const fromLabel = usableTitle(job.label);
+  if (fromLabel) return fromLabel;
+  const fromGoal = usableTitle(job.goal);
+  if (fromGoal) return fromGoal;
+  const fromRole = usableTitle(humanizeStamp(job.role));
+  if (fromRole) return fromRole;
+  const fromKind = usableTitle(humanizeStamp(job.job_kind));
+  if (fromKind) return fromKind;
+  return fallback;
+}

--- a/webapp/src/lib/jobsDashboard.ts
+++ b/webapp/src/lib/jobsDashboard.ts
@@ -65,3 +65,44 @@ export function notifyJobsDashboardChrome(focused: boolean): void {
     /* ignore */
   }
 }
+
+export function dashboardUnavailableMessage(err?: unknown): string {
+  if (err instanceof Error && err.message.trim()) return err.message.trim();
+  if (typeof err === "string" && err.trim()) return err.trim();
+  return "Could not locate the Puppetmaster dashboard.";
+}
+
+export function dashboardLocateError(payload: DashboardLocate & { stderr?: string }): string {
+  const stderr = typeof payload.stderr === "string" ? payload.stderr.trim() : "";
+  const base = (payload.detail || payload.error || "").trim() || dashboardUnavailableMessage();
+  return stderr ? `${base}: ${stderr.slice(0, 280)}` : base;
+}
+
+export type JobsListEmptyInput = {
+  failedRead: boolean;
+  viewReady: boolean;
+  working: boolean;
+  hiddenCount: number;
+  filter: string;
+  hasJobs: boolean;
+};
+
+/** Honest empty-list copy — never "Job data unavailable" as a blank lie. */
+export function jobsListEmptyTruth(input: JobsListEmptyInput): { title: string; detail?: string } {
+  if (input.failedRead) {
+    return {
+      title: "Job observations could not be loaded",
+      detail: "Retry updates; an empty view does not establish no work.",
+    };
+  }
+  if (!input.viewReady || (!input.hasJobs && input.working)) {
+    return { title: "Loading jobs…" };
+  }
+  if (input.filter !== "all" && !input.hasJobs) {
+    return { title: "No jobs match this filter" };
+  }
+  if (input.hiddenCount > 0 && !input.hasJobs) {
+    return { title: "All jobs are hidden" };
+  }
+  return { title: "No jobs yet" };
+}


### PR DESCRIPTION
## Summary
- Land #381: LeftRail hire → Jobs tab + JobDashboardHost \`?job=&embed=1\` (no MetadataInspection expand)
- Human \`jobDisplayTitle\`; honest empty / locate errors
- No version invent

## Test plan
- [ ] CI green
- [ ] Click hire/swarm row opens right-rail embed, not full native inspection maze