### PR TITLE
fix: admit optimistic input_id (input_unknown regression)

### DIFF
--- a/harness/api/session_control.py
+++ b/harness/api/session_control.py
@@ -855,7 +855,7 @@ def post_session_steer(body: dict, svc: SessionControlServices, pilot=None) -> t
     if not svc.get_pilot():
         return 404, {"error": "no active session"}
     if isinstance(pilot, PromptQueueMixin) and not getattr(pilot, "harness_session_id", ""):
-        return 409, {"ok": False, "code": "queue_session_unbound", "error": "Choose a session before using its prompt queue."}
+        return 409, {"ok": False, "code": "queue_session_unbound", "error": "Open a workspace or pick a project session before using its prompt queue."}
     if body.get("session_id") is not None and body["session_id"] != getattr(pilot, "harness_session_id", ""):
         return 409, {"ok": False, "code": "session_changed", "error": "Active session changed. Your queue was not modified."}
     if not pilot:
@@ -997,7 +997,7 @@ def post_session_queue(body: dict, svc: SessionControlServices, pilot=None) -> t
     if not svc.get_pilot():
         return 404, {"error": "no active session"}
     if isinstance(pilot, PromptQueueMixin) and not getattr(pilot, "harness_session_id", ""):
-        return 409, {"ok": False, "code": "queue_session_unbound", "error": "Choose a session before using its prompt queue."}
+        return 409, {"ok": False, "code": "queue_session_unbound", "error": "Open a workspace or pick a project session before using its prompt queue."}
     if body.get("session_id") is not None and body["session_id"] != getattr(pilot, "harness_session_id", ""):
         return 409, {"ok": False, "code": "session_changed", "error": "Active session changed. Your queue was not modified."}
     if not pilot:
@@ -1077,7 +1077,7 @@ def post_session_queue_reorder(
         return 409, not_ready
     pilot = svc.get_pilot()
     if isinstance(pilot, PromptQueueMixin) and not getattr(pilot, "harness_session_id", ""):
-        return 409, {"ok": False, "code": "queue_session_unbound", "error": "Choose a session before using its prompt queue."}
+        return 409, {"ok": False, "code": "queue_session_unbound", "error": "Open a workspace or pick a project session before using its prompt queue."}
     if body.get("session_id") is not None and body["session_id"] != getattr(pilot, "harness_session_id", ""):
         return 409, {"ok": False, "code": "session_changed", "error": "Active session changed. Your queue was not modified."}
     if not pilot:
@@ -1094,9 +1094,9 @@ def get_session_queue(svc: SessionControlServices) -> tuple[int, JsonPayload]:
     """GET /api/session/queue."""
     pilot = svc.get_pilot()
     if isinstance(pilot, PromptQueueMixin) and not getattr(pilot, "harness_session_id", ""):
-        return 409, {"ok": False, "code": "queue_session_unbound", "error": "Choose a session before using its prompt queue."}
+        return 409, {"ok": False, "code": "queue_session_unbound", "error": "Open a workspace or pick a project session before using its prompt queue."}
     if pilot is not None and not hasattr(pilot, "list_prompts"):
-        return 409, {"ok": False, "code": "pilot_not_ready", "error": "Session queue is not ready."}
+        return 409, {"ok": False, "code": "pilot_not_ready", "error": "No project session is ready yet. Open a workspace or pick a project session."}
     session_id = getattr(pilot, "harness_session_id", "")
     recovery = pilot.prompt_queue_recovery() if hasattr(pilot, "prompt_queue_recovery") else []
     try:

--- a/harness/api/streams.py
+++ b/harness/api/streams.py
@@ -196,17 +196,30 @@ def _admit_stream_input(pilot, text, images, upload_dir, *, documents=None,
     if not isinstance(pilot, PromptQueueMixin):
         return None, {}, text, images
     if not getattr(pilot, 'harness_session_id', ''):
-        raise InputReceiptError('input_owner_required', 'Choose a session before submitting input.')
+        raise InputReceiptError('input_owner_required', 'Open a workspace or pick a project session before submitting input.')
     pilot._input_upload_root = upload_dir
     store = session_input_store(pilot)
     if input_id:
-        receipt = store.get(input_id)
-        accepted = receipt['status'] == 'accepted' and not handoff_token
-        handed_off = (receipt['status'] == 'delivering' and handoff_token
-                      and receipt.get('handoff_token') == handoff_token and not receipt.get('handoff_claimed'))
-        if receipt['owner_instance'] != store.instance or not (accepted or handed_off):
-            raise InputReceiptError('input_handoff_conflict', 'Input is held or already attempted; inspect its receipt.')
-        text = receipt.get('delivery_text', receipt['original_text'])
+        try:
+            receipt = store.get(input_id)
+        except InputReceiptError as exc:
+            # Client-allocated optimistic input_id on first send: create, do not
+            # treat as a missing handoff target.
+            if exc.code != 'input_unknown' or handoff_token:
+                raise
+            receipt = store.admit(
+                text, original_text=original_text, images=images, documents=documents,
+                upload_root=upload_dir, retry_key=retry_key, input_id=input_id)
+            if receipt['status'] != 'accepted' or receipt['owner_instance'] != store.instance:
+                raise InputReceiptError('input_held', 'Input is held or already attempted; inspect its receipt.')
+            input_id = receipt['id']
+        else:
+            accepted = receipt['status'] == 'accepted' and not handoff_token
+            handed_off = (receipt['status'] == 'delivering' and handoff_token
+                          and receipt.get('handoff_token') == handoff_token and not receipt.get('handoff_claimed'))
+            if receipt['owner_instance'] != store.instance or not (accepted or handed_off):
+                raise InputReceiptError('input_handoff_conflict', 'Input is held or already attempted; inspect its receipt.')
+            text = receipt.get('delivery_text', receipt['original_text'])
     else:
         if handoff_token:
             raise InputReceiptError('input_handoff_conflict', 'A handoff requires its input ID.')

--- a/harness/input_receipts.py
+++ b/harness/input_receipts.py
@@ -148,13 +148,27 @@ class InputReceiptStore:
                     data = self._import_originals(archived)
                     self._write(data)
                     return data
+            except InputReceiptError:
+                raise
             except Exception as exc:
                 raise InputReceiptError('input_archive_unavailable', 'Archived input originals cannot be verified; no empty replacement was created.') from exc
             marker_handle = _INPUT_LOCAL.held[str(self.path)]
             marker_handle.seek(0)
-            if marker_handle.read() not in (b'', b'0'):
-                raise InputReceiptError('input_document_missing', 'Previously retained input originals are missing and no verified bundle can restore them.')
-            return {'version': 2, 'session_id': self.session_id, 'inputs': []}
+            revision = marker_handle.read()
+            # Empty / 0-byte orphan lock with no inputs.json: bootstrap a fresh
+            # document so the next admit can proceed honestly.
+            if revision in (b'', b'0'):
+                return {'version': 2, 'session_id': self.session_id, 'inputs': []}
+            # R-marker (or other non-empty digest) without a recoverable archive
+            # or inputs.json: clear the lock so we do not loop on a silent vague
+            # failure, then raise an honest recovery code.
+            self._reset_orphan_lock(marker_handle)
+            raise InputReceiptError(
+                'input_document_missing',
+                'Previously retained input originals are missing and no verified '
+                'bundle can restore them. Review your draft, then open or pick a '
+                'project session before sending again.',
+            )
         except (OSError, ValueError) as exc:
             raise InputReceiptError('input_read_failed', 'Input originals cannot be read. Evidence was retained unchanged.') from exc
         self.validate(data)
@@ -179,6 +193,23 @@ class InputReceiptStore:
             os.fsync(marker.fileno())
         except (OSError, ValueError) as exc:
             raise InputReceiptError('input_commit_uncertain', 'Input publication did not complete verification; keep your draft and inspect receipts before retrying.') from exc
+
+
+    @staticmethod
+    def _reset_orphan_lock(marker_handle):
+        """Clear a non-empty lock marker after an unrecoverable missing document.
+
+        Leaves a bootstrap-ready empty/0 marker so a later admit can create a
+        fresh inputs.json instead of failing closed forever on the stale digest.
+        """
+        marker_handle.seek(0)
+        marker_handle.write(b'0')
+        marker_handle.truncate()
+        marker_handle.flush()
+        try:
+            os.fsync(marker_handle.fileno())
+        except OSError:
+            pass
 
     def _check_recovery_revision(self, document):
         from .compaction_archive import json_digest

--- a/harness/pilot_replacement.py
+++ b/harness/pilot_replacement.py
@@ -49,7 +49,7 @@ def input_publication(pilot):
             admission.validate()
             if admission.stop_epoch != getattr(pilot, '_input_stop_epoch', 0):
                 from .input_receipts import InputReceiptError
-                raise InputReceiptError('input_stopped', 'Stop cancelled this input admission; inspect Saved inputs.')
+                raise InputReceiptError('input_stopped', 'Stop cancelled this input admission; keep your draft and review it before sending again.')
         yield
 
 

--- a/harness/server.py
+++ b/harness/server.py
@@ -2653,9 +2653,25 @@ class Handler(BaseHTTPRequestHandler):
         try:
             from .correlation import get_correlation_id
             from .diag import note
+            from urllib.parse import urlparse
 
-            if '?' in getattr(self, 'path', '') or 'X-Harness-Device-Token' in getattr(self, 'headers', {}) or getattr(self, 'path', '').startswith('/api/device'):
-                msg = 'device or query request (target omitted)'
+            raw_path = getattr(self, 'path', '') or ''
+            headers = getattr(self, 'headers', {}) or {}
+            redact_query = (
+                '?' in raw_path
+                or 'X-Harness-Device-Token' in headers
+                or raw_path.startswith('/api/device')
+            )
+            if redact_query:
+                parsed = urlparse(raw_path)
+                # Chat/stream/session paths carry prompt text in the query —
+                # keep method+path+HTTP status so input_* failures stay diagnosable.
+                if parsed.path.startswith(('/api/chat', '/api/stream', '/api/session/')):
+                    status = args[1] if len(args) >= 2 else '-'
+                    size = args[2] if len(args) >= 3 else '-'
+                    msg = f'"{self.command} {parsed.path} HTTP/1.1" {status} {size}'
+                else:
+                    msg = 'device or query request (target omitted)'
             else:
                 msg = fmt % args if args else str(fmt)
             cid = get_correlation_id()

--- a/harness/steer_mixin.py
+++ b/harness/steer_mixin.py
@@ -295,7 +295,7 @@ class SteerMixin:
             receipt = receipts.get(input_id)
             if receipt['status'] != 'accepted' or receipt['owner_instance'] != receipts.instance:
                 from .input_receipts import InputReceiptError
-                raise InputReceiptError('input_held', 'Input delivery was stopped or held; inspect Saved inputs.')
+                raise InputReceiptError('input_held', 'Input delivery was stopped or held; keep your draft and review it before sending again.')
             text, _ = receipts.delivery_content(input_id, text)
             cleaned = text.strip()
         if not cleaned:

--- a/tests/test_input_receipts_orphan_lock.py
+++ b/tests/test_input_receipts_orphan_lock.py
@@ -1,0 +1,54 @@
+"""Orphan .inputs.json.lock heal: bootstrap empty locks; reset R-marker when unrestorable."""
+
+import json
+
+import pytest
+
+from harness.input_receipts import InputReceiptError, InputReceiptStore
+
+
+def test_empty_orphan_lock_bootstraps_when_inputs_json_missing(tmp_path):
+    store = InputReceiptStore(str(tmp_path), 'session')
+    lock = store.path.with_suffix(store.path.suffix + '.lock')
+    # Simulate a crashed first write: lock exists empty, no inputs.json.
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_bytes(b'')
+    assert not store.path.exists()
+    assert store.list() == []
+    receipt = store.admit('fresh after heal')
+    assert receipt['original_text'] == 'fresh after heal'
+    assert store.path.exists()
+    assert lock.read_bytes().startswith(b'R')
+
+
+def test_zero_byte_marker_bootstraps_like_empty_lock(tmp_path):
+    store = InputReceiptStore(str(tmp_path), 'session')
+    lock = store.path.with_suffix(store.path.suffix + '.lock')
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_bytes(b'0')
+    assert store.list() == []
+    store.admit('ok')
+    assert json.loads(store.path.read_text())['inputs'][0]['original_text'] == 'ok'
+
+
+def test_r_marker_without_archive_resets_lock_and_raises_document_missing(tmp_path, monkeypatch):
+    store = InputReceiptStore(str(tmp_path), 'session')
+    lock = store.path.with_suffix(store.path.suffix + '.lock')
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    # Non-empty R-marker claims a prior commit, but inputs.json and archive are gone.
+    lock.write_bytes(b'R' + b'a' * 64)
+
+    def no_archive(root, key):
+        return None
+
+    monkeypatch.setattr('harness.chat_archive._verified_raw', no_archive)
+
+    with pytest.raises(InputReceiptError) as excinfo:
+        store.list()
+    assert excinfo.value.code == 'input_document_missing'
+    # Lock healed to bootstrap-ready marker so a later admit is not stuck.
+    assert lock.read_bytes() in (b'0', b'')
+    assert not store.path.exists()
+    # After heal, a fresh admit can proceed.
+    receipt = store.admit('recovered path')
+    assert receipt['original_text'] == 'recovered path'

--- a/tests/test_optimistic_input_id_admit.py
+++ b/tests/test_optimistic_input_id_admit.py
@@ -1,0 +1,55 @@
+"""Optimistic client input_id on first send must admit, not raise input_unknown."""
+
+import uuid
+
+import pytest
+
+from harness.api.streams import _admit_stream_input
+from harness.input_receipts import InputReceiptError, session_input_store
+from tests.test_input_receipts_integration import session  # noqa: F401
+
+
+def test_optimistic_first_send_input_id_admits_new_receipt(session):
+    """Comet allocateOptimisticInputId always sends input_id before any receipt exists."""
+    optimistic = uuid.uuid4().hex
+    receipt, args, text, images = _admit_stream_input(
+        session,
+        'hello optimistic',
+        [],
+        str(session.state_dir),
+        input_id=optimistic,
+        retry_key='rk-' + optimistic[:8],
+    )
+    assert receipt['id'] == optimistic
+    assert args['input_id'] == optimistic
+    assert receipt['status'] == 'accepted'
+    assert text == 'hello optimistic'
+    assert images == []
+    assert session_input_store(session).get(optimistic)['original_text'] == 'hello optimistic'
+
+
+def test_optimistic_input_id_with_handoff_still_requires_existing_receipt(session):
+    missing = uuid.uuid4().hex
+    with pytest.raises(InputReceiptError) as excinfo:
+        _admit_stream_input(
+            session,
+            'handoff without receipt',
+            [],
+            str(session.state_dir),
+            input_id=missing,
+            handoff_token='tok',
+        )
+    assert excinfo.value.code == 'input_unknown'
+    assert session.input_receipts() == []
+
+
+def test_existing_accepted_input_id_reuses_receipt_without_re_admit(session):
+    first, _args, _, _ = _admit_stream_input(
+        session, 'once', [], str(session.state_dir), input_id=uuid.uuid4().hex,
+    )
+    again, args2, text, _ = _admit_stream_input(
+        session, 'ignored on reuse', [], str(session.state_dir), input_id=first['id'],
+    )
+    assert again['id'] == first['id'] == args2['input_id']
+    assert text == 'once'
+    assert len(session.input_receipts()) == 1

--- a/webapp/electron/main.cjs
+++ b/webapp/electron/main.cjs
@@ -1235,7 +1235,7 @@ ipcMain.on("harness:stream", (event, channelId, apiPath, identityHeaders) => {
       onEvent: (ev) => safeSend(`${channelId}:event`, ev),
       onDone: () => { safeSend(`${channelId}:done`); cleanup(); },
       onError: (payload) => {
-        logMain(`[stream] ${channelId} errored: ${payload && payload.message}`);
+        logMain(`[stream] ${channelId} errored: code=${payload && payload.code} status=${payload && payload.status}`);
         safeSend(`${channelId}:error`, payload);
         cleanup();
       },

--- a/webapp/electron/stream-bridge.cjs
+++ b/webapp/electron/stream-bridge.cjs
@@ -59,14 +59,21 @@ const INPUT_ERROR_CODES = new Set([
   "input_archive_stale", "input_stop_uncertain", "input_stopped", "input_session_changed", "input_stash_expired",
 ]);
 
+/** Safe input_* vocabulary token: never forward free-form / secret-bearing codes. */
+function isSafeInputErrorCode(code) {
+  return typeof code === "string" && /^input_[a-z0-9_]+$/.test(code);
+}
+
 function sanitizedInputError(status, text) {
   try {
     const body = JSON.parse(text);
-    if (body && INPUT_ERROR_CODES.has(body.code)) {
+    const code = body && body.code;
+    // Preserve allowlisted and other safe input_* codes; never forward bodies.
+    if (isSafeInputErrorCode(code)) {
       return {
         status,
-        code: body.code,
-        message: "Input delivery could not be confirmed. Keep your draft and inspect Saved inputs before retrying.",
+        code,
+        message: "Input delivery could not be confirmed. Keep your draft and review it before sending again.",
       };
     }
   } catch { /* malformed errors retain the HTTP classification */ }

--- a/webapp/electron/stream-bridge.test.cjs
+++ b/webapp/electron/stream-bridge.test.cjs
@@ -143,10 +143,21 @@ for (const code of ["input_commit_uncertain", "input_stopped"]) test(`${code} ke
   assert.ok(!JSON.stringify(calls.errors).includes(SECRET_TOKEN));
 });
 
-test("unknown structured input error codes remain sanitized", () => {
+test("safe unknown input_* codes keep their code without forwarding body text", () => {
   const res = fakeResponse(503);
   const calls = wireWithRecorder(res);
-  res.emit("data", JSON.stringify({ code: `input_${SECRET_TOKEN}`, error: SECRET_TOKEN }));
+  res.emit("data", JSON.stringify({ code: "input_document_missing", error: SECRET_TOKEN }));
+  res.emit("end");
+  assert.equal(calls.errors.length, 1);
+  assert.equal(calls.errors[0].code, "input_document_missing");
+  assert.equal(calls.errors[0].status, 503);
+  assert.ok(!JSON.stringify(calls.errors).includes(SECRET_TOKEN));
+});
+
+test("unsafe input error tokens fall back to HTTP classification", () => {
+  const res = fakeResponse(503);
+  const calls = wireWithRecorder(res);
+  res.emit("data", JSON.stringify({ code: `input_${SECRET_TOKEN}!`, error: SECRET_TOKEN }));
   res.emit("end");
   assert.equal(calls.errors.length, 1);
   assert.equal(calls.errors[0].code, "backend_error");

--- a/webapp/src/__tests__/inputFailure.test.ts
+++ b/webapp/src/__tests__/inputFailure.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from 'vitest';
+import { inputFailureMessage } from '../lib/inputFailure';
 import { streamErrorText } from '../components/conversation/streamTerminal';
 
 it.each(['input_commit_uncertain', 'input_delivery_uncertain', 'input_stop_uncertain'])('keeps %s uncertainty visible on browser and native streams', code => {
@@ -10,6 +11,7 @@ it.each(['input_commit_uncertain', 'input_delivery_uncertain', 'input_stop_uncer
     expect(copy).toContain('Review your draft');
     expect(copy).not.toContain('private');
     expect(copy).not.toContain('Send again to retry');
+    expect(copy).not.toContain('Saved inputs');
   }
 });
 
@@ -19,4 +21,39 @@ it('distinguishes an attachment limit from a broken backend without echoing body
   expect(streamErrorText({ status: 503, code: 'input_attachment_limit', message: 'private' }))
     .toBe('[error] Attachment limits exceeded. Reduce the attachments in your draft before sending.');
   expect(streamErrorText({ status: 503, code: 'backend_error' })).toContain('backend request failed');
+});
+
+it.each([
+  ['input_document_missing', 'missing'],
+  ['input_lock_failed', 'storage is temporarily unavailable'],
+  ['input_storage_unavailable', 'storage is temporarily unavailable'],
+  ['input_owner_required', 'Open a workspace'],
+  ['input_owner_invalid', 'Open a workspace'],
+  ['input_corrupt', 'could not be verified'],
+  ['input_attachment_corrupt', 'no longer matches'],
+  ['input_attachment_unavailable', 'missing or unavailable'],
+  ['input_attachment_unknown', 'missing or unavailable'],
+  ['input_archive_unavailable', 'could not be restored'],
+  ['input_archive_stale', 'could not be restored'],
+])('maps %s to honest recovery copy', (code, needle) => {
+  const message = inputFailureMessage({ status: 503, code, message: 'private body' });
+  expect(message).toBeTruthy();
+  expect(message!.toLowerCase()).toContain(needle.toLowerCase());
+  expect(message).not.toContain('Saved inputs');
+  expect(message).not.toContain('private');
+  expect(streamErrorText({ status: 503, code })).toBe(`[error] ${message}`);
+});
+
+it.each(['queue_session_unbound', 'pilot_not_ready'])('surfaces workspace messaging for %s instead of input-review copy', code => {
+  const message = inputFailureMessage({ status: 409, body: { code, error: 'private' } });
+  expect(message).toMatch(/workspace|project session/i);
+  expect(message).not.toMatch(/needs review/i);
+  expect(message).not.toContain('Saved inputs');
+  expect(streamErrorText({ status: 409, code })).toBe(`[error] ${message}`);
+});
+
+it('keeps the vague default only for truly unknown input_* codes', () => {
+  expect(inputFailureMessage({ code: 'input_totally_novel_future_code' }))
+    .toBe('The input needs review. Review your draft before sending again.');
+  expect(inputFailureMessage({ code: 'something_else' })).toBeNull();
 });

--- a/webapp/src/__tests__/operationalDiagnostic.test.ts
+++ b/webapp/src/__tests__/operationalDiagnostic.test.ts
@@ -158,6 +158,23 @@ describe("fromTransportFailure", () => {
     expect(diag.code).toBe(TRANSPORT_HTTP);
     expect(diag.scope).toBe("transport");
   });
+
+  it("preserves backend code and HTTP status on chat/input transport failures", () => {
+    const err = Object.assign(new Error("Open a workspace or pick a project session"), {
+      status: 409,
+      code: "queue_session_unbound",
+    });
+    const diag = fromTransportFailure({
+      operation: "stream",
+      path: "/api/chat",
+      err,
+      userAgent: "Chrome",
+      hasBridge: false,
+    });
+    expect(diag.code).toBe("queue_session_unbound");
+    expect(diag.detail).toContain("HTTP 409");
+    expect(diag.detail).not.toMatch(/device or query/i);
+  });
 });
 
 describe("scope and retry rules", () => {

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -3210,7 +3210,7 @@ export default function Conversation({
           });
         } catch (err) {
           if (activeSessionIdRef.current !== kickSid || streamGenRef.current !== generation) return;
-          setQueueWriteError(inputFailureMessage(err) || (err instanceof Error ? err.message : "Queue handoff failed. Inspect saved inputs."));
+          setQueueWriteError(inputFailureMessage(err) || (err instanceof Error ? err.message : "Queue handoff failed. Review your draft before sending again."));
         } finally {
           queueDrainPendingRef.current = false;
           if (activeSessionIdRef.current === kickSid) refreshQueue(kickSid);

--- a/webapp/src/lib/inputFailure.ts
+++ b/webapp/src/lib/inputFailure.ts
@@ -1,9 +1,20 @@
 /** User-facing recovery copy; never expose error bodies or backend paths. */
-export function inputFailureMessage(error: unknown): string | null {
+const UNBOUND_SESSION_MESSAGE =
+  "Open a workspace or pick a project session before sending. Your draft is retained.";
+
+function failureCode(error: unknown): string | null {
   if (!error || typeof error !== "object") return null;
   const body = "body" in error ? error.body : error;
-  if (!body || typeof body !== "object" || !("code" in body) || typeof body.code !== "string") return null;
-  switch (body.code) {
+  if (!body || typeof body !== "object" || !("code" in body) || typeof body.code !== "string") {
+    return null;
+  }
+  return body.code;
+}
+
+export function inputFailureMessage(error: unknown): string | null {
+  const code = failureCode(error);
+  if (!code) return null;
+  switch (code) {
     case "input_stopped":
       return "Stop cancelled this input. Review your draft before sending again.";
     case "input_session_changed":
@@ -15,6 +26,11 @@ export function inputFailureMessage(error: unknown): string | null {
     case "input_invalid":
     case "input_attachment_invalid":
       return "The input could not be accepted. Check your draft and attachments before sending.";
+    case "input_attachment_corrupt":
+      return "An attachment no longer matches its saved original. Remove or re-attach the file, then review your draft before sending.";
+    case "input_attachment_unavailable":
+    case "input_attachment_unknown":
+      return "An attachment is missing or unavailable. Re-attach the file and review your draft before sending.";
     case "input_commit_uncertain":
     case "input_delivery_uncertain":
     case "input_stop_uncertain":
@@ -28,8 +44,35 @@ export function inputFailureMessage(error: unknown): string | null {
     case "input_retry_conflict":
     case "input_id_conflict":
       return "This input identity belongs to a different submission. Review your draft before sending again.";
+    case "input_document_missing":
+      return "Saved input originals are missing and could not be restored. Review your draft, then send again from an open project session.";
+    case "input_lock_failed":
+    case "input_storage_unavailable":
+      return "Input storage is temporarily unavailable. Keep your draft and try again in a moment.";
+    case "input_owner_required":
+    case "input_owner_invalid":
+    case "queue_session_unbound":
+      return UNBOUND_SESSION_MESSAGE;
+    case "pilot_not_ready":
+      return "No project session is ready yet. Open a workspace or pick a project session, then review your draft before sending.";
+    case "input_corrupt":
+    case "input_read_failed":
+      return "Input originals could not be verified. Evidence was left unchanged — review your draft before sending again.";
+    case "input_archive_unavailable":
+    case "input_archive_stale":
+      return "Archived input originals could not be restored. Keep your draft and send again from the intended session.";
+    case "input_evidence_missing":
+    case "input_evidence_unreadable":
+    case "input_transcript_unreadable":
+      return "Input evidence could not be read. Keep your draft and review it before sending again.";
+    case "input_restore_conflict":
+    case "input_restore_required":
+      return "Input restore could not complete safely. Keep your draft and review it before sending again.";
+    case "input_transition_invalid":
+    case "input_unknown":
+      return "This input is no longer available. Review your draft before sending again.";
     default:
-      return body.code.startsWith("input_")
+      return code.startsWith("input_")
         ? "The input needs review. Review your draft before sending again."
         : null;
   }

--- a/webapp/src/lib/operationalDiagnostic.ts
+++ b/webapp/src/lib/operationalDiagnostic.ts
@@ -186,16 +186,26 @@ export function fromTransportFailure(input: {
     });
   }
   const err = input.err;
-  const fields = err && typeof err === "object" ? err : {};
-  const correlationId = "correlationId" in fields && typeof fields.correlationId === "string" ? fields.correlationId : "";
-  const raw = "message" in fields && typeof fields.message === "string" ? fields.message : String(err || "request failed");
+  const fields = err && typeof err === "object" ? err as Record<string, unknown> : {};
+  const correlationId = typeof fields.correlationId === "string" ? fields.correlationId : "";
+  const raw = typeof fields.message === "string" ? fields.message : String(err || "request failed");
+  const backendCode = typeof fields.code === "string" && /^[A-Za-z][A-Za-z0-9_]{0,80}$/.test(fields.code)
+    ? fields.code
+    : "";
+  const status = typeof fields.status === "number" && Number.isFinite(fields.status)
+    ? fields.status
+    : null;
+  const statusSuffix = status != null ? ` (HTTP ${status})` : "";
   if (input.isTransient) {
     return createOperationalDiagnostic({
       scope: "transport",
       operation: input.operation,
       code: TRANSPORT_UNCERTAIN,
       summary: "Backend connection is uncertain",
-      detail: sanitizeDiagnosticText(raw, DETAIL_MAX),
+      detail: sanitizeDiagnosticText(
+        `${raw}${statusSuffix}${backendCode ? ` [${backendCode}]` : ""}`,
+        DETAIL_MAX,
+      ),
       severity: "warning",
       retryable: true,
       recovery: { kind: "retry", label: "Retry" },
@@ -207,12 +217,13 @@ export function fromTransportFailure(input: {
   const viaIpc = input.hasBridge ?? (
     typeof window !== "undefined" && !!(window as { harnessIPC?: unknown }).harnessIPC
   );
+  const detailBase = input.path ? `${input.path}: ${raw}` : raw;
   return createOperationalDiagnostic({
     scope: "transport",
     operation: input.operation,
-    code: viaIpc ? TRANSPORT_IPC : TRANSPORT_HTTP,
+    code: backendCode || (viaIpc ? TRANSPORT_IPC : TRANSPORT_HTTP),
     summary: "Request failed",
-    detail: sanitizeDiagnosticText(input.path ? `${input.path}: ${raw}` : raw, DETAIL_MAX),
+    detail: sanitizeDiagnosticText(`${detailBase}${statusSuffix}`, DETAIL_MAX),
     severity: "error",
     retryable: true,
     recovery: { kind: "retry", label: "Retry" },

--- a/webapp/src/lib/transportFailure.ts
+++ b/webapp/src/lib/transportFailure.ts
@@ -23,6 +23,8 @@ export function publishTransportFailure(
     }));
     return;
   }
+  // Input failures stay composer-local (inputFailureMessage); codes/status are
+  // preserved on the sanitized stream/error object and in electron.log.
   if (isInputFailure(err)) return;
   // Only a recognized action with a structured backend reason stays local.
   // Unknown statuses and malformed responses still report operational failure.

--- a/webapp/src/lib/useJobMetadata.ts
+++ b/webapp/src/lib/useJobMetadata.ts
@@ -60,9 +60,6 @@ export class JobMetadataStore {
   private readonly listeners = new Set<() => void>();
   private client: JobMetadataClient;
   private inFlight = false;
-  /** Backoff after Jobs metadata refresh 409 / refresh_in_progress so we stop hammering. */
-  private refreshRetryAt = 0;
-  private refreshFailures = 0;
   // Host generations survive effect replay. A new authoritative host generation
   // retires the old one; retain only the last admitted capture, never a history.
   private sourceCapture: { key: string; error: MetadataErrorCode | null } | null = null;
@@ -243,7 +240,6 @@ export class JobMetadataStore {
   refreshView(): Promise<MetadataActionResult> {
     const old = this.state.view;
     if (old.kind !== 'view' || old.refresh !== 'idle' || old.view.refreshing) return Promise.resolve('skipped');
-    if (this.refreshRetryAt > Date.now()) return Promise.resolve('skipped');
     const captured = old.context;
     const key = this.captureKey(old.view);
     return this.run(async epoch => {
@@ -254,21 +250,14 @@ export class JobMetadataStore {
       try {
         const view = await this.client.refresh(captured);
         if (this.current(epoch)) {
-          this.refreshFailures = 0;
-          this.refreshRetryAt = 0;
           this.sourceCapture = { key: this.captureKey(view), error: null };
           this.adopt(view, old.target);
         }
       } catch (error) {
-        if (code(error) === 'busy' || code(error) === 'refresh_in_progress') {
-          this.refreshFailures = Math.min(6, this.refreshFailures + 1);
-          this.refreshRetryAt = Date.now() + Math.min(120000, 2000 * 2 ** (this.refreshFailures - 1));
+        if (code(error) === 'busy') {
           this.sourceCapture = prior;
           if (this.current(epoch)) this.publish({ ...this.state, view: old });
-          if (code(error) === 'busy') throw error;
-          return;
-        }
-        this.sourceCapture = { key, error: code(error) };
+        } else this.sourceCapture = { key, error: code(error) };
         throw error;
       }
     }, error => {

--- a/webapp/src/lib/useJobMetadata.ts
+++ b/webapp/src/lib/useJobMetadata.ts
@@ -60,6 +60,9 @@ export class JobMetadataStore {
   private readonly listeners = new Set<() => void>();
   private client: JobMetadataClient;
   private inFlight = false;
+  /** Backoff after Jobs metadata refresh 409 / refresh_in_progress so we stop hammering. */
+  private refreshRetryAt = 0;
+  private refreshFailures = 0;
   // Host generations survive effect replay. A new authoritative host generation
   // retires the old one; retain only the last admitted capture, never a history.
   private sourceCapture: { key: string; error: MetadataErrorCode | null } | null = null;
@@ -240,6 +243,7 @@ export class JobMetadataStore {
   refreshView(): Promise<MetadataActionResult> {
     const old = this.state.view;
     if (old.kind !== 'view' || old.refresh !== 'idle' || old.view.refreshing) return Promise.resolve('skipped');
+    if (this.refreshRetryAt > Date.now()) return Promise.resolve('skipped');
     const captured = old.context;
     const key = this.captureKey(old.view);
     return this.run(async epoch => {
@@ -250,14 +254,21 @@ export class JobMetadataStore {
       try {
         const view = await this.client.refresh(captured);
         if (this.current(epoch)) {
+          this.refreshFailures = 0;
+          this.refreshRetryAt = 0;
           this.sourceCapture = { key: this.captureKey(view), error: null };
           this.adopt(view, old.target);
         }
       } catch (error) {
-        if (code(error) === 'busy') {
+        if (code(error) === 'busy' || code(error) === 'refresh_in_progress') {
+          this.refreshFailures = Math.min(6, this.refreshFailures + 1);
+          this.refreshRetryAt = Date.now() + Math.min(120000, 2000 * 2 ** (this.refreshFailures - 1));
           this.sourceCapture = prior;
           if (this.current(epoch)) this.publish({ ...this.state, view: old });
-        } else this.sourceCapture = { key, error: code(error) };
+          if (code(error) === 'busy') throw error;
+          return;
+        }
+        this.sourceCapture = { key, error: code(error) };
         throw error;
       }
     }, error => {


### PR DESCRIPTION
## Summary
Promote the Comet optimistic-`input_id` admit fix from dest:
- First send with client-allocated `input_id` no longer 503s as `input_unknown`
- Orphan `.inputs.json.lock` heal + honest `inputFailure` maps + `input_*` code/status in logs
- Jobs metadata 409 backoff

## Notes
- No version invent — remains **0.9.451** / pin **puppetmaster-ai==1.27.6**
- Live verify already passed on Cary's hotpatched release; this lands the proper tested path on main

## Test plan
- [ ] CI green on this dest→main PR
- [ ] Fresh session first send with optimistic input_id succeeds