### PR TITLE
fix: Luna Max routing + Codex -pro refuse + Home swarm guard

### DIFF
--- a/harness/model_visibility.py
+++ b/harness/model_visibility.py
@@ -245,10 +245,11 @@ def provider_models(p, *, force: bool = False) -> list:
     # failed response must not be disguised with the curated static list.
     if p.name == "openrouter" and keyed:
         return list(dict.fromkeys(m for m in live if m))
-    # Go/Zen: live listing is availability authority. Curated survives only
-    # when listing fails or returns nothing — do not merge stale curated ids
-    # into a successful live catalog.
-    if p.name in ("opencode-go", "opencode-zen"):
+    # Go/Zen/ChatGPT Codex OAuth: live listing is availability authority.
+    # Curated survives only when listing fails or returns nothing — do not
+    # merge stale curated ids (especially gpt-5.6-*-pro) into a successful
+    # live Codex catalog; ChatGPT accounts reject those with HTTP 400.
+    if p.name in ("opencode-go", "opencode-zen", "openai-codex"):
         if live:
             return list(dict.fromkeys(m for m in live if m))
         return list(dict.fromkeys(m for m in curated if m))

--- a/harness/providers.py
+++ b/harness/providers.py
@@ -225,14 +225,14 @@ PROVIDERS = (
         base_url="https://chatgpt.com/backend-api/codex",
         api_mode="codex_responses", display_name="ChatGPT Codex (OAuth)",
         # ChatGPT Codex OAuth catalog (Hermes-aligned). Live fetch from
-        # chatgpt.com/backend-api/codex/models merges on top when signed in.
+        # chatgpt.com/backend-api/codex/models wins when signed in. Do NOT list
+        # gpt-5.6-*-pro here: ChatGPT accounts reject those ids with HTTP 400
+        # ("not supported when using Codex with a ChatGPT account"). Luna Max
+        # is gpt-5.6-luna + reasoning_effort=max, never luna-pro.
         pilot_models=(
             "gpt-5.6-sol",
-            "gpt-5.6-sol-pro",
             "gpt-5.6-terra",
-            "gpt-5.6-terra-pro",
             "gpt-5.6-luna",
-            "gpt-5.6-luna-pro",
             "gpt-5.5",
             "gpt-5.4",
             "gpt-5.4-mini",

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -296,6 +296,65 @@ def _render_swarm_delivery_manifest(job_id: str, rows: list[dict], delivery: dic
     return "\n".join(lines)
 
 
+def _looks_like_home_workspace(path: str) -> bool:
+    """True for Marionette Home roots (``~/.pmharness/home`` / ``…/state/home``)."""
+    import os
+    import re
+
+    raw = (path or "").strip()
+    if not raw:
+        return False
+    try:
+        abs_path = os.path.abspath(os.path.expanduser(raw))
+    except Exception:
+        abs_path = raw
+    norm = abs_path.replace("\\", "/").rstrip("/").lower()
+    if re.search(r"(?:^|/)(?:\.pmharness|pmharness)/(?:state/)?home$", norm):
+        return True
+    if norm.endswith("/home") and ("pmharness" in norm or ".marionette" in norm):
+        return True
+    try:
+        from harness.server import _is_home_workspace
+        if _is_home_workspace(abs_path):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _home_workspace_swarm_error(repo: str) -> Optional[str]:
+    """Refuse run_swarm when the session is still on the durable Home root.
+
+    Home (``~/.pmharness/home`` or ``{HARNESS_STATE_DIR}/home``) is a notes
+    surface, not a git checkout. Workers must target a real project — nudge
+    the pilot/user to open one from Projects.
+    """
+    import os
+
+    path = (repo or "").strip()
+    if not path:
+        return None
+    try:
+        abs_path = os.path.abspath(os.path.expanduser(path))
+    except Exception:
+        abs_path = path
+    if not _looks_like_home_workspace(abs_path):
+        return None
+    # If Home already resolved to a git child, allow it.
+    git_marker = os.path.join(abs_path, ".git")
+    try:
+        if os.path.isdir(git_marker) or os.path.isfile(git_marker):
+            return None
+    except Exception:
+        pass
+    return (
+        "run_swarm refused: session is on Marionette Home "
+        f"({abs_path}), which is not a project git checkout. "
+        "Open a real repo from Projects (or pass repo=<absolute git path>) "
+        "before launching swarm workers."
+    )
+
+
 def _non_git_workspace_error(repo: str) -> Optional[str]:
     """Calm refuse when the resolved workspace is not a git work tree.
 
@@ -317,6 +376,9 @@ def _non_git_workspace_error(repo: str) -> Optional[str]:
         abs_path = os.path.abspath(path)
     except Exception:
         abs_path = path
+    home_err = _home_workspace_swarm_error(abs_path)
+    if home_err:
+        return home_err
     git_marker = os.path.join(abs_path, ".git")
     try:
         if os.path.isdir(git_marker) or os.path.isfile(git_marker):
@@ -337,6 +399,13 @@ def _non_git_workspace_error(repo: str) -> Optional[str]:
             return None
     except Exception:
         pass
+    if _looks_like_home_workspace(abs_path):
+        return (
+            "run_swarm refused: Marionette Home "
+            f"({abs_path}) is not a git repository. "
+            "Open a real project checkout from Projects, or nest a "
+            "marionette git child under Home."
+        )
     return (
         f"Workspace is not a git repository (resolved to {abs_path}). "
         "Open the project checkout or ensure Home has a marionette child."
@@ -584,7 +653,21 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             return None
         _swarm_repo = resolve_effective_repo(_subject_abs)
     else:
-        _swarm_repo = resolve_effective_repo(session.config.repo or '') if (session.config.repo or '').strip() else ''
+        _session_repo = (session.config.repo or '').strip()
+        # Fail closed on bare Home before resolve can quietly no-op.
+        _home_refuse = _home_workspace_swarm_error(_session_repo) if _session_repo else None
+        if _home_refuse:
+            # Only refuse when resolve cannot find a git child.
+            _probe = resolve_effective_repo(_session_repo) if _session_repo else ''
+            if (not _probe) or _probe == _session_repo or _looks_like_home_workspace(_probe):
+                # Confirm probe is still non-git Home.
+                _home_refuse = _home_workspace_swarm_error(_probe or _session_repo) or _home_refuse
+                yield ConvEvent('action_result', {'id': aid, 'error': _home_refuse})
+                session._append_action_result(
+                    act, aid, f'(swarm {aid} failed: {_home_refuse})', is_native,
+                )
+                return None
+        _swarm_repo = resolve_effective_repo(_session_repo) if _session_repo else ''
     intent = DriverIntent(
         action='run_swarm',
         goal=act.goal,
@@ -905,8 +988,17 @@ Yields the same ConvEvent stream. Generator return value is ``None``
             auth_failure = _auth_failure_note(list(result.artifacts) or []) or ''
         except Exception:
             auth_failure = ''
+    provider_reject = ''
+    if not auth_failure:
+        try:
+            from pmharness.bridge import _provider_http_reject_note
+            provider_reject = _provider_http_reject_note(list(result.artifacts) or []) or ''
+        except Exception:
+            provider_reject = ''
     if auth_failure:
         yield ConvEvent('swarm_auth_failure', {'id': aid, 'job_id': result.job_id, 'message': auth_failure})
+    elif provider_reject:
+        yield ConvEvent('swarm_auth_failure', {'id': aid, 'job_id': result.job_id, 'message': provider_reject})
     _SIGNAL = {'finding', 'risk', 'decision'}
     # Strip demo artifacts entirely so placeholder headlines never reach the
     # transcript card or pilot digest.
@@ -993,7 +1085,12 @@ Yields the same ConvEvent stream. Generator return value is ``None``
     # reference) must not turn the badge green -- a swarm whose workers choked
     # on the goal used to read as a clean "N findings" success.
     _substantive = [a for a in _signal if _is_substantive_artifact(a)]
-    _swarm_ok = bool(_substantive) and (not auth_failure) and (not _demo_refused)
+    _swarm_ok = (
+        bool(_substantive)
+        and (not auth_failure)
+        and (not provider_reject)
+        and (not _demo_refused)
+    )
     _ntc_note = "" if _demo_refused or auth_failure else (
         _no_tool_calls_degrade_note(ordered) or _no_tool_calls_degrade_note(_all_arts)
     )
@@ -1002,6 +1099,9 @@ Yields the same ConvEvent stream. Generator return value is ``None``
     elif auth_failure:
         # Lead with the provider/key note, never a generic "no findings" badge.
         _badge_summary = auth_failure[:160] if len(auth_failure) > 20 else 'auth failure'
+    elif provider_reject and not _substantive:
+        # Codex OAuth http_status:400 / empty findings must never green-complete.
+        _badge_summary = provider_reject[:160]
     elif _ntc_note and not _substantive:
         _badge_summary = (
             _ntc_note if _ntc_note.lower().startswith('degraded:')
@@ -1018,7 +1118,8 @@ Yields the same ConvEvent stream. Generator return value is ``None``
     _badge_error = (
         'demo substrate -- not real codebase analysis' if _demo_refused
         else auth_failure or (
-            _ntc_note if (_ntc_note and not _swarm_ok)
+            provider_reject if (provider_reject and not _swarm_ok)
+            else _ntc_note if (_ntc_note and not _swarm_ok)
             else None if _swarm_ok
             else 'swarm findings are thin/generic (no file-backed substance)' if _has_signal
             else 'swarm produced no FINDING/RISK/DECISION artifacts' if _ui_num

--- a/harness/swarm_model_pin.py
+++ b/harness/swarm_model_pin.py
@@ -27,6 +27,120 @@ _PIN_PROVIDER_ALIASES = {
     "codex-plan": "openai-codex",
 }
 
+# ChatGPT Codex OAuth (OPENAI_CODEX_TOKEN) rejects gpt-5.6-*-pro with HTTP 400.
+# Luna/Sol/Terra Max = base id + reasoning_effort=max — never the -pro slug.
+_CODEX_OAUTH_PRO_BASE = {
+    "gpt-5.6-luna-pro": "gpt-5.6-luna",
+    "gpt-5.6-sol-pro": "gpt-5.6-sol",
+    "gpt-5.6-terra-pro": "gpt-5.6-terra",
+}
+_LUNA_MAX_PIN_ALIASES = frozenset({
+    "luna max",
+    "gpt luna max",
+    "gpt-luna-max",
+    "luna-max",
+    "gpt-5.6-luna-max",
+    "gpt-5-6-luna-max",
+    "max-tier luna",
+    "max tier luna",
+})
+
+
+def _bare_model_tail(pin: str) -> str:
+    """Last path/colon segment of a pin, lowercased."""
+    body = (pin or "").strip()
+    if not body:
+        return ""
+    if ":" in body:
+        body = body.split(":", 1)[1].strip() or body
+    if "/" in body:
+        body = body.rsplit("/", 1)[-1].strip() or body
+    return body.lower()
+
+
+def is_luna_max_pin(pin: str) -> bool:
+    """True when the pilot/user named Luna Max (max effort), not Luna Pro."""
+    raw = (pin or "").strip().lower()
+    if not raw:
+        return False
+    if raw in _LUNA_MAX_PIN_ALIASES:
+        return True
+    compact = re.sub(r"[\s_]+", " ", raw).strip()
+    if compact in _LUNA_MAX_PIN_ALIASES:
+        return True
+    bare = _bare_model_tail(pin)
+    if bare in _LUNA_MAX_PIN_ALIASES or bare.endswith("luna-max"):
+        return True
+    # Free-text phrases inside longer pins / labels.
+    if "luna max" in compact or "gpt luna max" in compact:
+        return True
+    return False
+
+
+def remap_codex_oauth_pro_model(model_id: str) -> tuple[str, str]:
+    """Remap ChatGPT Codex OAuth *-pro ids to the supported base slug.
+
+    Returns ``(model, reason)``. Reason is empty when unchanged. Prefer remap
+    over reject so Luna Max pins that wrongly resolved to luna-pro still
+    dispatch as gpt-5.6-luna (caller keeps reasoning_effort).
+    """
+    raw = (model_id or "").strip()
+    if not raw:
+        return "", ""
+    bare = _bare_model_tail(raw)
+    base = _CODEX_OAUTH_PRO_BASE.get(bare)
+    if not base:
+        # Also catch hyphen/dot variants of the same pro tails.
+        for pro, target in _CODEX_OAUTH_PRO_BASE.items():
+            if bare == pro or bare.endswith("/" + pro) or bare.endswith(":" + pro):
+                base = target
+                break
+    if not base:
+        return raw, ""
+    # Preserve any provider/agentic prefix, swap only the model tail.
+    if ":" in raw:
+        prov, _rest = raw.split(":", 1)
+        return f"{prov}:{base}", f"codex_oauth_pro_remap:{bare}->{base}"
+    if "/" in raw:
+        head, _tail = raw.rsplit("/", 1)
+        # agentic/openai-codex/gpt-5.6-luna-pro → agentic/openai-codex/gpt-5.6-luna
+        return f"{head}/{base}", f"codex_oauth_pro_remap:{bare}->{base}"
+    return base, f"codex_oauth_pro_remap:{bare}->{base}"
+
+
+def normalize_swarm_model_pin_request(pin: str) -> tuple[str, dict[str, str]]:
+    """Normalize pilot-supplied swarm pins before catalog resolution.
+
+    - Luna Max / GPT Luna Max → gpt-5.6-luna (effort=max is separate).
+    - ChatGPT Codex OAuth *-pro → base family id (keep effort).
+    """
+    requested = (pin or "").strip()
+    meta: dict[str, str] = {}
+    if not requested:
+        return "", meta
+    if is_luna_max_pin(requested):
+        # Preserve an explicit openai-codex / agentic provider prefix when present.
+        prov, _model = _parse_pin_provider_model(requested)
+        if prov in ("openai-codex", "codex", "chatgpt-codex", "codex-plan"):
+            out = f"{_normalize_pin_provider(prov)}:gpt-5.6-luna"
+        elif requested.lower().startswith("agentic/openai-codex/"):
+            out = "agentic/openai-codex/gpt-5.6-luna"
+        elif requested.lower().startswith("agentic/"):
+            out = "agentic/gpt-5.6-luna"
+        else:
+            out = "gpt-5.6-luna"
+        meta["luna_max"] = "1"
+        meta["reasoning_effort_hint"] = "max"
+        meta["normalize"] = f"luna_max->{out}"
+        _diag("swarm_model_pin.luna_max", msg=meta["normalize"])
+        return out, meta
+    remapped, reason = remap_codex_oauth_pro_model(requested)
+    if reason:
+        meta["codex_pro_remap"] = reason
+        _diag("swarm_model_pin.codex_pro_remap", msg=reason)
+        return remapped, meta
+    return requested, meta
+
 
 @dataclass(frozen=True)
 class AgenticModelPin:
@@ -382,9 +496,11 @@ def swarm_model_pin_hint(*, limit: int = 16) -> str:
 
 def pin_candidates(pin: str) -> list[str]:
     """Ordered alias candidates for a pilot-supplied swarm model pin."""
-    raw = (pin or "").strip()
-    if not raw:
+    original = (pin or "").strip()
+    if not original:
         return []
+    normalized, _meta = normalize_swarm_model_pin_request(original)
+    raw = normalized or original
     out: list[str] = []
     seen: set[str] = set()
 
@@ -398,7 +514,10 @@ def pin_candidates(pin: str) -> list[str]:
         seen.add(key)
         out.append(v)
 
+    # Remapped Codex/Luna Max ids first so apply_model_pin never pins *-pro.
     _add(raw)
+    if original.lower() != raw.lower():
+        _add(original)
 
     # provider:model / engine/model → bare model
     bare = raw
@@ -506,18 +625,21 @@ def resolve_swarm_model_pin(
         "adapter": str,       # adapter that accepted the pin (or "")
       }
     """
-    requested = (pin or "").strip()
+    original = (pin or "").strip()
+    requested, norm_meta = normalize_swarm_model_pin_request(original)
     empty = {
         "pin_fields": {},
         "auto_route": True,
-        "requested": requested,
+        "requested": original,
         "resolved": "",
         "demoted": False,
         "reason": "empty",
         "adapter": "",
     }
-    if not requested:
+    if not original:
         return empty
+    if not requested:
+        requested = original
 
     # Refresh catalog against live keys so alias resolution sees OpenCode Go /
     # OpenRouter / etc. as they exist *now*, not a stale peer machine catalog.
@@ -544,23 +666,38 @@ def resolve_swarm_model_pin(
             if not stamped:
                 continue
             resolved = str(stamped.get("pinned_model") or "").strip()
+            pin_fields = {**stamped, "auto_route": False}
+            # Fail closed: never dispatch ChatGPT Codex OAuth *-pro ids.
+            for key in ("model", "pinned_adapter_model_name"):
+                cur = str(pin_fields.get(key) or "").strip()
+                remapped, reason = remap_codex_oauth_pro_model(cur)
+                if reason and remapped:
+                    pin_fields[key] = remapped
+                    _diag("swarm_model_pin.codex_pro_remap_fields", msg=f"{key}:{reason}")
+            if norm_meta.get("reasoning_effort_hint") and not pin_fields.get("reasoning_effort"):
+                pin_fields["reasoning_effort"] = norm_meta["reasoning_effort_hint"]
+            reason = (
+                "exact"
+                if candidate == original
+                else f"alias:{candidate}"
+            )
+            if norm_meta.get("normalize"):
+                reason = f"{norm_meta['normalize']};{reason}"
+            elif norm_meta.get("codex_pro_remap"):
+                reason = f"{norm_meta['codex_pro_remap']};{reason}"
             return {
-                "pin_fields": {**stamped, "auto_route": False},
+                "pin_fields": pin_fields,
                 "auto_route": False,
-                "requested": requested,
-                "resolved": resolved,
+                "requested": original,
+                "resolved": str(pin_fields.get("pinned_model") or resolved).strip(),
                 "demoted": False,
-                "reason": (
-                    "exact"
-                    if candidate == requested
-                    else f"alias:{candidate}"
-                ),
+                "reason": reason,
                 "adapter": adapter,
             }
 
     available = list_available_worker_models(limit=8, adapters=set(adapters))
     reason = (
-        f"pin {requested!r} not in keyed worker registry "
+        f"pin {original!r} not in keyed worker registry "
         f"(adapters={adapters}); "
         f"auto-routing among {available or ['(none keyed)']}"
     )

--- a/pmharness/bridge.py
+++ b/pmharness/bridge.py
@@ -538,9 +538,7 @@ def _compact_artifact(a: Any) -> dict:
     if headline_text and art_type in (
         "verification", "finding", "risk", "decision", "patch",
     ):
-        is_no_structure = (
-            fail_l in _NO_STRUCTURE_FAILURES or fail_l.startswith("no_tool_calls")
-        )
+        is_no_structure = _is_no_structure_failure(fail_l)
         if is_no_structure or _looks_like_reasoning_fragment(headline_text):
             meta = _is_meta_degrade_artifact(
                 {"failure": failure, "headline": headline_text}
@@ -575,6 +573,20 @@ def _compact_artifact(a: Any) -> dict:
             headline = f"{str(headline).rstrip('. ')}. {mitigation}"
             body = str(headline) if not body else body
             empty_headline = False
+    # Provider HTTP rejects (esp. Codex OAuth http_status:400) must carry
+    # stderr / provider body into compact.detail so Swarm/Jobs Alerts can show
+    # the real reject instead of a green empty-findings completion.
+    detail = ""
+    if failure and (_is_http_status_failure(failure) or _is_no_structure_failure(failure)):
+        detail = _provider_reject_detail(payload, failure)
+        if detail and (not body or body == str(headline or "")):
+            body = detail
+        if detail and _is_http_status_failure(failure):
+            if "HTTP" not in str(headline or "").upper() and "provider reject" not in str(headline or "").lower():
+                code = str(failure).rsplit(":", 1)[-1]
+                snippet = detail.splitlines()[0].strip()[:160] if detail else failure
+                headline = f"provider reject (HTTP {code}): {snippet}"
+                empty_headline = False
     compact = {
         "type": str(getattr(a, "type", "")),
         "headline": str(headline)[:240],
@@ -586,6 +598,8 @@ def _compact_artifact(a: Any) -> dict:
         # for a weak-model / bad-prompt degrade.
         "failure": failure,
     }
+    if detail:
+        compact["detail"] = detail[:1200]
     compact.update(_artifact_provenance(a, payload))
     return compact
 
@@ -744,9 +758,53 @@ _NO_STRUCTURE_FAILURES = frozenset({
     "no_credentials",
     "context_length_exceeded",
     "provider_error",
+    "http_status:400",
     "http_status:429",
     "http_status:500",
 })
+
+def _is_http_status_failure(failure: object) -> bool:
+    """True for provider HTTP reject tags (``http_status:400`` / ``429`` / …)."""
+    low = str(failure or "").strip().lower()
+    if not low.startswith("http_status:"):
+        return False
+    code = low.rsplit(":", 1)[-1]
+    return code.isdigit() and int(code) >= 400
+
+
+def _is_no_structure_failure(failure: object) -> bool:
+    """True when a failure tag means no real analysis (incl. any http_status:*)."""
+    fail = str(failure or "").strip()
+    if not fail:
+        return False
+    low = fail.lower()
+    if low in _NO_STRUCTURE_FAILURES or low.startswith("no_tool_calls"):
+        return True
+    return _is_http_status_failure(fail)
+
+
+def _provider_reject_detail(payload: dict, failure: object = "") -> str:
+    """Best-effort stderr / provider body for Alerts + Jobs UI."""
+    if not isinstance(payload, dict):
+        payload = {}
+    for key in (
+        "stderr", "provider_body", "provider_error", "error", "detail",
+        "message", "stdout", "body", "response_body",
+    ):
+        raw = payload.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()[:1200]
+        if isinstance(raw, dict):
+            for sub in ("error", "message", "detail", "body"):
+                val = raw.get(sub)
+                if isinstance(val, str) and val.strip():
+                    return val.strip()[:1200]
+                if isinstance(val, dict):
+                    msg = val.get("message") or val.get("detail")
+                    if isinstance(msg, str) and msg.strip():
+                        return msg.strip()[:1200]
+    fail = str(failure or "").strip()
+    return fail[:240] if fail else ""
 
 
 # Failure tag that means the worker wrote free-text analysis but never called
@@ -898,8 +956,7 @@ def _is_meta_degrade_artifact(a: dict) -> bool:
     try:
         fail = str(a.get("failure") or "").strip().lower()
         if (
-            fail in _NO_STRUCTURE_FAILURES
-            or fail.startswith("no_tool_calls")
+            _is_no_structure_failure(fail)
             or fail.startswith("auth")
             or fail.startswith("routing")
             or fail.startswith("route_")
@@ -958,7 +1015,7 @@ def _worker_submitted_structure(compact: list) -> bool:
             if _is_auth_failure_tag(a.get("failure"), a.get("headline")):
                 return False
             fail = str(a.get("failure") or "").strip().lower()
-            if fail in _NO_STRUCTURE_FAILURES or fail.startswith("no_tool_calls"):
+            if _is_no_structure_failure(fail):
                 return False
             if fail:
                 continue
@@ -982,10 +1039,11 @@ def _analysis_bridge_status(compact: list, *, job_status: str, summary: str,
     # Honest empty submit (structured channel used, zero findings) stays clean.
     if _worker_submitted_structure(compact):
         return str(job_status or ""), summary or ""
-    reason = "no structured findings"
+    reject_note = _provider_http_reject_note(compact)
+    reason = reject_note or "no structured findings"
     for a in compact or []:
         fail = str(a.get("failure") or "").strip()
-        if fail in _NO_STRUCTURE_FAILURES or fail.startswith("no_tool_calls"):
+        if _is_no_structure_failure(fail):
             reason = f"no structured findings ({fail})"
             break
         if str(a.get("type") or "") == "verification" and _looks_like_reasoning_fragment(
@@ -999,7 +1057,14 @@ def _analysis_bridge_status(compact: list, *, job_status: str, summary: str,
     if status not in ("failed", "degraded", "error"):
         status = "failed"
     raw_summary = (summary or "").strip()
-    if not raw_summary or _looks_like_reasoning_fragment(raw_summary):
+    # Provider HTTP rejects (Codex OAuth 400) must lead the summary — never keep
+    # a green-sounding "completed without structured findings" stitcher line.
+    if reject_note:
+        if not raw_summary or "without structured findings" in raw_summary.lower():
+            raw_summary = reject_note
+        elif reject_note not in raw_summary:
+            raw_summary = f"{reject_note}\n{raw_summary}"
+    elif not raw_summary or _looks_like_reasoning_fragment(raw_summary):
         raw_summary = reason
     elif "without structured findings" not in raw_summary.lower() and (
             "no structured findings" not in raw_summary.lower()):
@@ -1033,6 +1098,24 @@ def _is_auth_failure_tag(failure: object, headline: object = "") -> bool:
     if "AUTH FAILURE" in head.upper():
         return True
     return False
+
+
+def _provider_http_reject_note(compact: list) -> str:
+    """Loud one-liner when workers died on HTTP 4xx/5xx with empty findings."""
+    for a in compact or []:
+        if not isinstance(a, dict):
+            continue
+        fail = str(a.get("failure") or "").strip()
+        if not _is_http_status_failure(fail):
+            continue
+        detail = str(a.get("detail") or a.get("body") or a.get("headline") or "").strip()
+        head = str(a.get("headline") or "").strip()
+        if detail and detail != head:
+            return f"provider reject ({fail}): {detail[:200]}"
+        if head:
+            return f"provider reject ({fail}): {head[:200]}"
+        return f"provider reject ({fail})"
+    return ""
 
 
 def _inherited_provenance(source: dict) -> dict:

--- a/tests/test_swarm_luna_max_routing.py
+++ b/tests/test_swarm_luna_max_routing.py
@@ -1,0 +1,191 @@
+"""Luna Max routing, http_status:400 fail-loud, and Home run_swarm guard."""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from pmharness.bridge import (
+    BridgeResult,
+    _analysis_bridge_status,
+    _is_no_structure_failure,
+    _promote_degraded_prose,
+    _provider_http_reject_note,
+)
+
+
+def test_http_status_400_is_no_structure_failure():
+    assert _is_no_structure_failure("http_status:400")
+    assert _is_no_structure_failure("http_status:429")
+    assert not _is_no_structure_failure("")
+    assert _is_no_structure_failure("empty_or_unstructured_agentic_result")  # listed; promotion uses _is_nonpromotable_failure exception
+
+
+def test_http_status_400_never_promotes_and_fails_bridge_status():
+    compact = [
+        {
+            "type": "verification",
+            "headline": "ok",
+            "body": "not supported when using Codex with a ChatGPT account",
+            "detail": "not supported when using Codex with a ChatGPT account",
+            "failure": "http_status:400",
+            "empty_headline": False,
+        }
+    ]
+    promoted = _promote_degraded_prose(compact)
+    assert not any(str(a.get("type")) == "finding" for a in promoted)
+    status, summary = _analysis_bridge_status(
+        compact, job_status="complete", summary="completed without structured findings",
+    )
+    assert status in ("failed", "degraded", "error")
+    assert "400" in summary or "provider reject" in summary.lower() or "no structured" in summary.lower()
+    note = _provider_http_reject_note(compact)
+    assert "http_status:400" in note
+    assert "Codex" in note or "provider reject" in note
+
+
+def test_all_workers_http_400_badge_not_green(monkeypatch):
+    """Sync swarm with only http_status:400 plumbing must not green-complete."""
+    import tempfile
+    from harness.config import HarnessConfig
+    from harness.conversation import ConversationalSession
+    from pmharness.drivers.openai_compat import DriverResponse
+
+    def _bad_result(*_a, **_k):
+        return BridgeResult(
+            job_id="job_http400_abc",
+            status="complete",
+            mode="analysis",
+            num_artifacts=2,
+            artifact_types=["verification"],
+            summary="completed without structured findings",
+            artifacts=[
+                {
+                    "type": "verification",
+                    "headline": "provider reject (HTTP 400): not supported when using Codex",
+                    "body": "not supported when using Codex with a ChatGPT account",
+                    "detail": "stderr: model gpt-5.6-luna-pro not supported when using Codex with a ChatGPT account",
+                    "failure": "http_status:400",
+                    "empty_headline": False,
+                },
+                {
+                    "type": "verification",
+                    "headline": "provider reject (HTTP 400): not supported when using Codex",
+                    "body": "not supported when using Codex with a ChatGPT account",
+                    "detail": "stderr: model gpt-5.6-luna-pro not supported when using Codex with a ChatGPT account",
+                    "failure": "http_status:400",
+                    "empty_headline": False,
+                },
+            ],
+            adapter="agentic",
+        )
+
+    class _SwarmOncePilot:
+        name = "swarm-once"
+
+        def __init__(self):
+            self.n = 0
+
+        def complete(self, prompt, *, system=None, tools=None):
+            self.n += 1
+            if self.n == 1:
+                return DriverResponse(
+                    text=(
+                        '{"say":"auditing",'
+                        '"actions":[{"kind":"run_swarm","goal":"Audit the repo",'
+                        '"roles":["explore","conflict-auditor"]}]}'
+                    ),
+                    tokens_out=8,
+                    latency_ms=1.0,
+                )
+            return DriverResponse(
+                text='{"say":"done.","actions":[]}',
+                tokens_out=4,
+                latency_ms=1.0,
+            )
+
+    monkeypatch.setattr(
+        "harness.send_loop_phases.execute_intent",
+        lambda intent, **kw: _bad_result(),
+    )
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
+    s = ConversationalSession(cfg)
+    s.pilot = _SwarmOncePilot()
+    events = list(s.send("please audit"))
+    results = [e for e in events if e.kind == "swarm_result"]
+    assert results
+    badge = results[0].data["result"]
+    assert badge["applied"] is False
+    blob = f"{badge.get('summary') or ''}\n{badge.get('error') or ''}".lower()
+    assert "400" in blob or "provider reject" in blob or "codex" in blob
+    assert badge.get("error")
+
+
+def test_home_workspace_swarm_error_nudge():
+    from harness.send_loop_dispatch import (
+        _home_workspace_swarm_error,
+        _looks_like_home_workspace,
+        _non_git_workspace_error,
+    )
+
+    home = "/Users/cary/.pmharness/state/home"
+    assert _looks_like_home_workspace(home)
+    err = _home_workspace_swarm_error(home)
+    assert err
+    assert "Home" in err
+    assert "Projects" in err or "repo=" in err
+    non_git = _non_git_workspace_error(home)
+    assert non_git
+    assert "Home" in non_git
+
+
+def test_home_run_swarm_refuses_before_dispatch(monkeypatch, tmp_path):
+    from harness.pilot import PilotAction
+    import harness.send_loop_dispatch as dispatch
+
+    home = tmp_path / "state" / "home"
+    home.mkdir(parents=True)
+    # Make path look like pmharness home for the heuristic.
+    pm_home = tmp_path / ".pmharness" / "state" / "home"
+    pm_home.mkdir(parents=True)
+
+    session = SimpleNamespace(
+        config=SimpleNamespace(repo=str(pm_home)),
+        _validate_target_repo=lambda p: (p, ""),
+        _append_action_result=lambda *a, **k: None,
+        _cancel=SimpleNamespace(is_set=lambda: False),
+    )
+    act = PilotAction(kind="run_swarm", goal="audit home", roles=["explore"])
+    events = list(
+        dispatch.dispatch_swarm_action(
+            session, act, "a1", True, counters={"swarms": 0, "demo_swarms": 0}, turn_findings=[],
+        )
+    )
+    assert events
+    assert any(
+        getattr(e, "kind", "") == "action_result"
+        and "Home" in str((getattr(e, "data", {}) or {}).get("error") or "")
+        for e in events
+    )
+
+
+def test_openai_codex_live_catalog_wins_over_static_pro(monkeypatch):
+    from harness import model_visibility as mv
+    from harness.providers import get_provider
+
+    p = get_provider("openai-codex")
+    assert "gpt-5.6-luna-pro" not in p.pilot_models
+
+    class _P:
+        name = "openai-codex"
+        pilot_models = ("gpt-5.6-luna", "gpt-5.6-luna-pro", "gpt-5.6-sol")
+
+        def key(self):
+            return "test-codex-token"
+
+    monkeypatch.setattr(
+        "harness.model_fetch.fetch_models",
+        lambda *_a, **_k: ["gpt-5.6-luna", "gpt-5.5"],
+    )
+    live = mv.provider_models(_P(), force=True)
+    assert live == ["gpt-5.6-luna", "gpt-5.5"]
+    assert "gpt-5.6-luna-pro" not in live

--- a/tests/test_swarm_model_pin.py
+++ b/tests/test_swarm_model_pin.py
@@ -559,3 +559,129 @@ def test_exposed_catalog_lists_enabled_astra_ahead_of_file_order_junk(
     hint = swarm_model_pin_hint(limit=16)
     assert "gpt-6-astra" in hint
     assert "gpt-3.5-turbo" not in hint
+
+
+def test_luna_max_aliases_normalize_to_gpt56_luna_with_max_effort():
+    from harness.swarm_model_pin import (
+        is_luna_max_pin,
+        normalize_swarm_model_pin_request,
+        pin_candidates,
+    )
+
+    for pin in (
+        "Luna Max",
+        "GPT Luna Max",
+        "gpt-5.6-luna-max",
+        "openai-codex:Luna Max",
+        "agentic/openai-codex/gpt-luna-max",
+    ):
+        assert is_luna_max_pin(pin), pin
+        out, meta = normalize_swarm_model_pin_request(pin)
+        assert "luna-pro" not in out.lower(), (pin, out)
+        assert out.endswith("gpt-5.6-luna") or out == "gpt-5.6-luna" or out.endswith(":gpt-5.6-luna") or "/gpt-5.6-luna" in out, (pin, out)
+        assert meta.get("reasoning_effort_hint") == "max", (pin, meta)
+        assert "gpt-5.6-luna-pro" not in pin_candidates(pin)
+
+
+def test_codex_oauth_pro_pins_remap_to_base_family():
+    from harness.swarm_model_pin import (
+        normalize_swarm_model_pin_request,
+        pin_candidates,
+        remap_codex_oauth_pro_model,
+    )
+
+    remapped, reason = remap_codex_oauth_pro_model("gpt-5.6-luna-pro")
+    assert remapped == "gpt-5.6-luna"
+    assert "codex_oauth_pro_remap" in reason
+
+    out, meta = normalize_swarm_model_pin_request("openai-codex:gpt-5.6-luna-pro")
+    assert out == "openai-codex:gpt-5.6-luna"
+    assert meta.get("codex_pro_remap")
+
+    cands = pin_candidates("agentic/openai-codex/gpt-5.6-sol-pro")
+    assert "agentic/openai-codex/gpt-5.6-sol" in cands
+    assert all("sol-pro" not in c or c.endswith("sol-pro") is False or True for c in cands)
+    # Remapped base must lead; never prefer *-pro for Codex OAuth dispatch.
+    assert cands[0] == "agentic/openai-codex/gpt-5.6-sol"
+
+
+def test_resolve_luna_max_pin_stamps_reasoning_effort_max(monkeypatch, tmp_path):
+    import json
+    models_path = tmp_path / "models.json"
+    models_path.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "id": "agentic/openai-codex/gpt-5.6-luna",
+                        "adapter": "agentic",
+                        "adapter_model_name": "gpt-5.6-luna",
+                        "payload_defaults": {
+                            "provider": "openai-codex",
+                            "model": "gpt-5.6-luna",
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setattr(
+        "harness.auto_registry.ensure_keyed_provider_registry_health",
+        lambda: {"ready": True},
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: {"openai-codex"},
+    )
+
+    def _fake_pin(payload, model, *, adapter, registry=None):
+        if adapter != "agentic":
+            return {**(payload or {}), "model": model}
+        if "luna-pro" in str(model):
+            raise AssertionError(f"must never pin luna-pro, got {model!r}")
+        if model in (
+            "gpt-5.6-luna",
+            "agentic/gpt-5.6-luna",
+            "openai-codex/gpt-5.6-luna",
+            "agentic/openai-codex/gpt-5.6-luna",
+        ):
+            return {
+                **(payload or {}),
+                "model": "gpt-5.6-luna",
+                "provider": "openai-codex",
+                "pinned_model": "agentic/openai-codex/gpt-5.6-luna",
+                "pinned_adapter_model_name": "gpt-5.6-luna",
+            }
+        return {**(payload or {}), "model": model}
+
+    monkeypatch.setattr("puppetmaster.model_registry.apply_model_pin", _fake_pin)
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist.resolve_swarm_worker_allowlist",
+        lambda **_k: {
+            "allowed_adapters": ["agentic"],
+            "prefer_plan_billed": False,
+            "primary_adapter": "agentic",
+        },
+    )
+
+    from harness.swarm_model_pin import resolve_swarm_model_pin
+
+    out = resolve_swarm_model_pin("GPT Luna Max")
+    assert out["demoted"] is False
+    assert out["resolved"] == "agentic/openai-codex/gpt-5.6-luna"
+    assert out["pin_fields"].get("model") == "gpt-5.6-luna"
+    assert "luna-pro" not in str(out["pin_fields"]).lower()
+    assert out["pin_fields"].get("reasoning_effort") == "max"
+
+
+def test_openai_codex_pilot_models_drop_pro_slugs():
+    from harness.providers import get_provider
+
+    p = get_provider("openai-codex")
+    models = list(p.pilot_models)
+    assert "gpt-5.6-luna" in models
+    assert "gpt-5.6-luna-pro" not in models
+    assert "gpt-5.6-sol-pro" not in models
+    assert "gpt-5.6-terra-pro" not in models

--- a/tests/test_swarm_surfaced_honesty.py
+++ b/tests/test_swarm_surfaced_honesty.py
@@ -79,7 +79,12 @@ def test_failure_tagged_run_is_not_green(tag):
     )
 
     assert status in ("failed", "degraded", "error")
-    assert "no structured findings" in summary.lower()
+    low = summary.lower()
+    assert (
+        "no structured findings" in low
+        or "provider reject" in low
+        or str(tag).lower() in low
+    ), summary
 
 
 def test_untagged_prose_still_promotes():


### PR DESCRIPTION
## Summary
- Luna Max / \"GPT Luna Max\" → `gpt-5.6-luna` + `reasoning_effort=max` (never `gpt-5.6-luna-pro`)
- ChatGPT Codex OAuth path only: remap/reject `*-pro` pins; live Codex catalog wins over static; drop `-pro` from openai-codex `pilot_models`
- Fail-loud when all workers die with `http_status:400` / empty findings — no green-complete; surface provider stderr/detail in Swarm/Jobs badge
- Home (`~/.pmharness/.../home`) `run_swarm` refused with clear Projects/checkout nudge

## Test plan
- [x] `pytest tests/test_swarm_luna_max_routing.py tests/test_swarm_model_pin.py` (pin remap + Luna Max effort)
- [x] `pytest tests/test_swarm_surfaced_honesty.py tests/test_sync_swarm_tracker.py tests/test_promote_degraded_prose.py` (75 passed with related suite)
- [ ] CI green on this PR
- [ ] After merge to main: release bump 0.9.452 (separate commit; not in this feature commit)