### PR TITLE
fix: send x-opencode-session for OpenCode Go/Zen

### DIFF
--- a/pmharness/drivers/anthropic.py
+++ b/pmharness/drivers/anthropic.py
@@ -429,7 +429,7 @@ class AnthropicDriver:
 
         return body
 
-    def _headers(self) -> dict:
+    def _headers(self, session_id: str | None = None) -> dict:
         key = self._key()
         headers = {
             "Content-Type": "application/json",
@@ -477,15 +477,24 @@ class AnthropicDriver:
                 betas.append("interleaved-thinking-2025-05-14")
             if betas:
                 headers["anthropic-beta"] = ",".join(betas)
+        try:
+            from .prompt_cache import maybe_attach_opencode_session_header
+            maybe_attach_opencode_session_header(
+                headers,
+                base_url=self.base_url,
+                session_id=session_id,
+            )
+        except Exception:
+            pass
         return headers
 
-    def chat(self, messages: list, *, tools: list | None = None, system: str | None = None) -> DriverResponse:
+    def chat(self, messages: list, *, tools: list | None = None, system: str | None = None, session_id: str | None = None) -> DriverResponse:
         url = f"{self.base_url}/messages"
         body = self._build_body(messages, tools, system)
         data = json.dumps(body).encode("utf-8")
 
         def _call() -> DriverResponse:
-            headers = self._headers()
+            headers = self._headers(session_id=session_id)
             t0 = time.time()
             raw = None
             for attempt in range(2):
@@ -502,7 +511,7 @@ class AnthropicDriver:
                     if attempt == 0:
                         nxt = self._pool_rotate_on_http_error(e.code, detail)
                         if nxt:
-                            headers = self._headers()
+                            headers = self._headers(session_id=session_id)
                             continue
                     return DriverResponse(
                         text="", model=self.name,
@@ -588,6 +597,7 @@ class AnthropicDriver:
         on_delta=None,
         on_reasoning_delta=None,
         on_tool_hint=None,
+        session_id: str | None = None,
     ) -> DriverResponse:
         """Streaming counterpart of chat() over Anthropic's SSE Messages API.
         Emits text deltas via on_delta(str) as they arrive, while assembling the
@@ -598,7 +608,7 @@ class AnthropicDriver:
         body = self._build_body(messages, tools, system)
         body["stream"] = True
         data = json.dumps(body).encode("utf-8")
-        headers = self._headers()
+        headers = self._headers(session_id=session_id)
         if on_delta is None:
             on_delta = lambda _t: None
 

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -1198,16 +1198,34 @@ class CodexResponsesDriver:
             pass
         return None
 
-    def _request_headers(self, access_token: str) -> Dict[str, str]:
+    def _request_headers(
+        self,
+        access_token: str,
+        *,
+        session_id: str | None = None,
+    ) -> Dict[str, str]:
         """Auth + transport headers for this host's Responses endpoint."""
         if self.chatgpt_backend:
-            return _codex_cloudflare_headers(access_token, streaming=True)
-        return {
-            "User-Agent": "pm-harness",
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {access_token}",
-            "Accept": "text/event-stream",
-        }
+            headers = _codex_cloudflare_headers(access_token, streaming=True)
+        else:
+            # OpenCode Go rejects generic SDK agents; identify as Marionette.
+            ua = "Marionette" if "opencode.ai" in (self.base_url or "").lower() else "pm-harness"
+            headers = {
+                "User-Agent": ua,
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "text/event-stream",
+            }
+        try:
+            from .prompt_cache import maybe_attach_opencode_session_header
+            maybe_attach_opencode_session_header(
+                headers,
+                base_url=self.base_url,
+                session_id=session_id,
+            )
+        except Exception:
+            pass
+        return headers
 
     def _build_body(
         self,
@@ -1303,11 +1321,12 @@ class CodexResponsesDriver:
         on_reasoning_delta: Optional[Callable[..., None]],
         on_stream_item_done: Optional[Callable[..., None]] = None,
         t0: float,
+        session_id: str | None = None,
     ) -> Tuple[Optional[dict], Optional[DriverResponse], bytes]:
         """POST once (with reasoning-strip / pool rotate). Returns (raw, err_resp, data)."""
         for attempt in range(3):
             token = self._key()
-            headers = self._request_headers(token)
+            headers = self._request_headers(token, session_id=session_id)
             if self.chatgpt_backend:
                 headers.update(
                     _codex_session_affinity_headers(body.get("prompt_cache_key"))
@@ -1470,6 +1489,7 @@ class CodexResponsesDriver:
         on_reasoning_delta: Optional[Callable[..., None]] = None,
         on_stream_item_done: Optional[Callable[..., None]] = None,
         on_wait_notice: Optional[Callable[[str], None]] = None,
+        session_id: str | None = None,
     ) -> DriverResponse:
         # Enforce stream even if a caller mutated the body.
         body = dict(body)
@@ -1615,6 +1635,7 @@ class CodexResponsesDriver:
                     on_reasoning_delta=on_reasoning_delta,
                     on_stream_item_done=on_stream_item_done,
                     t0=t0,
+                    session_id=session_id,
                 )
                 if err_resp is not None:
                     if _has_continuation_progress():
@@ -1785,7 +1806,7 @@ class CodexResponsesDriver:
             system=system,
             session_id=session_id,
         )
-        return self._post_stream(body)
+        return self._post_stream(body, session_id=session_id)
 
     def chat(
         self,
@@ -1798,7 +1819,7 @@ class CodexResponsesDriver:
         body = self._build_body(
             messages, tools=tools, system=system, session_id=session_id,
         )
-        return self._post_stream(body)
+        return self._post_stream(body, session_id=session_id)
 
     def chat_stream(
         self,
@@ -1827,6 +1848,7 @@ class CodexResponsesDriver:
             on_reasoning_delta=on_reasoning_delta,
             on_stream_item_done=on_stream_item_done,
             on_wait_notice=on_wait_notice,
+            session_id=session_id,
         )
         if on_tool_hint is not None:
             for tc in (resp.meta or {}).get("tool_calls") or []:

--- a/pmharness/drivers/openai_compat.py
+++ b/pmharness/drivers/openai_compat.py
@@ -21,6 +21,7 @@ from .base import DriverResponse, SYSTEM_PROMPT, chat_completions_messages
 from .prompt_cache import (
     apply_openai_compat_cache_control,
     maybe_attach_openrouter_session_id,
+    maybe_attach_opencode_session_header,
 )
 from .retry import with_retry
 from pmharness.reasoning import extract_reasoning, strip_think_blocks
@@ -729,6 +730,33 @@ class OpenAICompatDriver:
                                      or "invalid_request" in d or "not supported" in d
                                      or "unexpected" in d)
 
+    def _finalize_http_headers(
+        self,
+        headers: dict,
+        *,
+        session_id: str | None = None,
+        messages: list | None = None,
+        system: str | None = None,
+    ) -> dict:
+        """Merge extra_headers + OpenCode Go/Zen session routing header."""
+        headers.update(self.extra_headers)
+        maybe_attach_opencode_session_header(
+            headers,
+            base_url=self.base_url,
+            session_id=session_id if session_id is not None else self.session_id,
+            messages=messages,
+            system=system,
+        )
+        return headers
+        maybe_attach_opencode_session_header(
+            headers,
+            base_url=self.base_url,
+            session_id=session_id if session_id is not None else self.session_id,
+            messages=messages,
+            system=system,
+        )
+        return headers
+
     def _prepare_body(
         self,
         body: dict,
@@ -915,7 +943,9 @@ class OpenAICompatDriver:
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {self._key()}",
             }
-            headers.update(self.extra_headers)
+            self._finalize_http_headers(
+                headers, session_id=session_id, messages=body["messages"], system=system,
+            )
             t0 = time.time()
             raw = None
             last_err = None
@@ -1041,7 +1071,9 @@ class OpenAICompatDriver:
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {self._key()}",
             }
-            headers.update(self.extra_headers)
+            self._finalize_http_headers(
+                headers, session_id=session_id, messages=messages, system=system,
+            )
             t0 = time.time()
             raw = None
             try:
@@ -1253,7 +1285,9 @@ class OpenAICompatDriver:
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {self._key()}",
             }
-            headers.update(self.extra_headers)
+            self._finalize_http_headers(
+                headers, session_id=session_id, messages=messages, system=system,
+            )
             t0 = time.time()
             acc = _OpenAIChatSseAccumulator(
                 on_delta=on_delta,

--- a/pmharness/drivers/prompt_cache.py
+++ b/pmharness/drivers/prompt_cache.py
@@ -423,6 +423,43 @@ def maybe_attach_openrouter_session_id(
         return
 
 
+def is_opencode_host(base_url: str | None) -> bool:
+    """True when *base_url* points at OpenCode Go/Zen (opencode.ai)."""
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(base_url or "").netloc.lower()
+    except Exception:
+        host = (base_url or "").lower()
+    return host == "opencode.ai" or host.endswith(".opencode.ai") or "opencode.ai" in (base_url or "").lower()
+
+
+def maybe_attach_opencode_session_header(
+    headers: dict,
+    *,
+    base_url: str | None,
+    session_id: str | None = None,
+    messages: list | None = None,
+    system: str | None = None,
+) -> None:
+    """Set ``x-opencode-session`` for OpenCode Go/Zen routing. Best-effort.
+
+    OpenCode Go rejects requests that omit this header (MissingSessionID).
+    See https://opencode.ai/docs/go/#where-can-i-use-it
+    """
+    try:
+        if not isinstance(headers, dict) or not is_opencode_host(base_url):
+            return
+        sid = resolve_session_id(
+            session_id=session_id,
+            messages=messages,
+            system=system,
+        )
+        if sid:
+            headers["x-opencode-session"] = sid
+    except Exception:
+        return
+
+
 def supports_gpt56_explicit_prompt_cache(model: str | None) -> bool:
     """True for GPT-5.6+ families that accept prompt_cache_options/breakpoint."""
     m = (model or "").strip().lower().replace("_", "-")

--- a/tests/test_opencode_go.py
+++ b/tests/test_opencode_go.py
@@ -637,3 +637,56 @@ def test_catalog_keeps_informative_go_native_name(monkeypatch):
     ox = next(row for row in entries if row["model"] == "ox-alpha-free")
     assert ox["name"] == "Native Ox Label"
     assert seen == []
+
+# ── OpenCode Go session routing header ─────────────────────────────────────
+
+def test_openai_compat_go_sends_x_opencode_session_header():
+    from pmharness.drivers.openai_compat import OpenAICompatDriver
+    from pmharness.drivers.prompt_cache import maybe_attach_opencode_session_header
+
+    driver = prov.build_pilot("opencode-go:deepseek-v4-flash")
+    assert isinstance(driver, OpenAICompatDriver)
+    headers = {"Authorization": "Bearer test"}
+    driver._finalize_http_headers(headers, session_id="sess-go-1")
+    assert headers["User-Agent"] == go.USER_AGENT
+    assert headers["x-opencode-session"] == "sess-go-1"
+
+
+def test_anthropic_go_sends_x_opencode_session_header():
+    driver = prov.build_pilot("opencode-go:minimax-m3")
+    headers = driver._headers(session_id="sess-go-2")
+    assert headers["User-Agent"] == go.USER_AGENT
+    assert headers["x-opencode-session"] == "sess-go-2"
+
+
+def test_responses_go_sends_x_opencode_session_and_marionette_ua():
+    from pmharness.drivers.codex_responses import CodexResponsesDriver
+
+    driver = prov.build_pilot("opencode-go:gpt-5.6-luna")
+    assert isinstance(driver, CodexResponsesDriver)
+    headers = driver._request_headers("sk-go-test", session_id="sess-go-3")
+    assert headers["User-Agent"] == go.USER_AGENT
+    assert headers["x-opencode-session"] == "sess-go-3"
+    assert headers["Authorization"] == "Bearer sk-go-test"
+
+
+def test_opencode_session_header_omitted_without_session_id():
+    from pmharness.drivers.prompt_cache import maybe_attach_opencode_session_header
+
+    headers = {"User-Agent": "Marionette"}
+    maybe_attach_opencode_session_header(
+        headers, base_url=go.BASE_URL, session_id=None, messages=None, system=None,
+    )
+    assert "x-opencode-session" not in headers
+
+
+def test_opencode_session_header_skipped_for_non_opencode_hosts():
+    from pmharness.drivers.prompt_cache import maybe_attach_opencode_session_header
+
+    headers = {}
+    maybe_attach_opencode_session_header(
+        headers,
+        base_url="https://openrouter.ai/api/v1",
+        session_id="sess-x",
+    )
+    assert "x-opencode-session" not in headers


### PR DESCRIPTION
## Summary
- Attach `x-opencode-session` on OpenCode Go/Zen requests (chat, Anthropic messages, Responses)
- Use `User-Agent: Marionette` on Go Responses hosts instead of `pm-harness`
- Fixes Console Go `MissingSessionID` HTTP 400 blocking pilot chat

## Test plan
- [x] `pytest tests/test_opencode_go.py` (95 passed)
- [ ] After merge: Update to 0.9.452 and send a Go pilot message