### PR TITLE
fix: preserve parked analysis prose (compact HTTP-reject inject)

### DIFF
--- a/pmharness/bridge.py
+++ b/pmharness/bridge.py
@@ -576,12 +576,16 @@ def _compact_artifact(a: Any) -> dict:
     # Provider HTTP rejects (esp. Codex OAuth http_status:400) must carry
     # stderr / provider body into compact.detail so Swarm/Jobs Alerts can show
     # the real reject instead of a green empty-findings completion.
+    # Do NOT run this for empty_or_unstructured_agentic_result / other
+    # no-structure tags: _provider_reject_detail falls back to the bare
+    # failure string and would clobber parked analysis prose in body,
+    # breaking rescue_analysis_compact promotion.
     detail = ""
-    if failure and (_is_http_status_failure(failure) or _is_no_structure_failure(failure)):
+    if failure and _is_http_status_failure(failure):
         detail = _provider_reject_detail(payload, failure)
         if detail and (not body or body == str(headline or "")):
             body = detail
-        if detail and _is_http_status_failure(failure):
+        if detail:
             if "HTTP" not in str(headline or "").upper() and "provider reject" not in str(headline or "").lower():
                 code = str(failure).rsplit(":", 1)[-1]
                 snippet = detail.splitlines()[0].strip()[:160] if detail else failure


### PR DESCRIPTION
## Summary
Promote fix for #386 regression that broke `test_agentic_analysis_promotes_verification_parked_prose` on main tip `99dc4def` / v0.9.452:
- Feature: https://github.com/professorpalmer/marionette/pull/389
- Gate provider-reject body overwrite on `http_status:*` only so `empty_or_unstructured` parked prose stays promotable

## Notes
- Version stays **0.9.452** / pin **puppetmaster-ai==1.27.6** (no invent)
- After green merge: FF `dev` to main 1:1; retag `v0.9.452` onto fixed tip if publish never landed

## Test plan
- [ ] CI green on this dest→main PR
- [ ] pytest-linux / windows no longer fail parked-prose promote