### PR TITLE
docs: keep Windows CI on GitHub-hosted runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,10 @@ jobs:
 
   pytest-windows:
     # CI_WINDOWS_RUNNER swaps GitHub-hosted windows-latest for a faster
-    # machine (Blacksmith `blacksmith-4vcpu-windows-2025`) without a new
-    # workflow. Unset keeps windows-latest so CI never queues on a missing
-    # runner label.
+    # hosted machine without a new workflow. Unset keeps windows-latest so
+    # CI never queues on a missing runner label. Blacksmith labels need a
+    # GitHub org (professorpalmer is a user account); do not set the
+    # variable until a runner app is actually installed on this repo.
     runs-on: ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}
     strategy:
       fail-fast: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -78,15 +78,15 @@ tree; wait for `tests` on that commit.
 ### Faster Windows (optional)
 
 `tests.yml` reads `vars.CI_WINDOWS_RUNNER` and falls back to `windows-latest`.
-After the Blacksmith GitHub App is installed on this repo, set:
+Do not hardcode a third-party runner label: if the app is not installed on
+this repo, Windows jobs queue forever.
 
-```bash
-gh variable set CI_WINDOWS_RUNNER --body blacksmith-4vcpu-windows-2025 \
-  --repo professorpalmer/marionette
-```
-
-Same YAML, different machines. Do not hardcode the Blacksmith label until the
-app is installed or Windows jobs queue forever.
+Blacksmith (`blacksmith-4vcpu-windows-2025`) is organization-only. These
+repos stay on the `professorpalmer` user account, so that label will not
+provision runners. Leave `CI_WINDOWS_RUNNER` unset and keep GitHub-hosted
+`windows-latest`. Hosted alternatives that accept personal accounts
+(for example Namespace `nscloud-windows-2022-amd64-4x8`) can use the same
+variable later without a YAML change.
 
 ## Diverged / self-edited checkouts
 

--- a/tests/test_ci_release_gate.py
+++ b/tests/test_ci_release_gate.py
@@ -187,6 +187,10 @@ def test_tests_yml_windows_runner_is_swappable():
     text = (ROOT / ".github" / "workflows" / "tests.yml").read_text()
     assert "vars.CI_WINDOWS_RUNNER" in text
     assert "windows-latest" in text
+    # Do not default the job to a third-party label. Blacksmith is org-only
+    # and an unset/missing runner queues the gate forever.
+    assert "runs-on: blacksmith-" not in text
+    assert "runs-on: ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}" in text
 
 
 def test_tests_yml_is_the_fast_dest_into_main_gate():


### PR DESCRIPTION
## Summary
- Stop implying Blacksmith can be flipped on via `CI_WINDOWS_RUNNER`. It is org-only and these repos stay on the professorpalmer user account.
- Gate test now asserts Windows jobs keep the `windows-latest` fallback and do not hardcode a `blacksmith-*` label.

## Test plan
- [x] `pytest tests/test_ci_release_gate.py -q`
- [ ] Confirm `CI_WINDOWS_RUNNER` is unset on the repo so Windows jobs still use `windows-latest`