### PR TITLE
Release v0.9.460: DeepSeek output and agentic routing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.27.10
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.27.11
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.27.10"
+          pip install -e ".[dev]" "puppetmaster-ai==1.27.11"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.27.10"
+          pip install -e ".[dev]" "puppetmaster-ai==1.27.11"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -58,7 +58,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.27.10"
+          pip install -e ".[dev]" "puppetmaster-ai==1.27.11"
 
       - name: Run the offline test suite (shard)
         env:
@@ -104,7 +104,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.27.10"
+          pip install -e ".[dev]" "puppetmaster-ai==1.27.11"
 
       - name: Run offline pmharness/intent/registry units
         run: python -m pytest -q -p no:cacheprovider tests/test_intent.py tests/test_registry.py tests/test_registry_wizard.py tests/test_pilot_driver_templates.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.27.10"
+uv pip install --python .venv -e . "puppetmaster-ai==1.27.11"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.27.10` (desktop
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.27.11` (desktop
    bootstrap, install/doctor, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.10` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.11` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.459, deliberately pre-1.0. Swarm Tracker presents named workers, recorded model routes, individual statuses, and evidence in a compact responsive panel. Long instructions open in a Markdown reader with copy support. New swarms replace their local placeholder with the exact Puppetmaster job while metadata is current, preserving a fallback when the source is unavailable. Runtime pin: `puppetmaster-ai==1.27.10`.
+> Status: v0.9.460, deliberately pre-1.0. DeepSeek tool calls preserve the provider reasoning field, while private reasoning stays out of spoken answers. Product workers use the agentic adapter and route within enabled provider/model pairs. Explicit unavailable pins fail clearly. Background completion notices preserve the current request, and command receipts keep script text separate from output. Runtime pin: `puppetmaster-ai==1.27.11`.
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | `run_swarm`, `run_implement`, and `run_parallel` run bounded workers as durable jobs. Inspect recorded attempts, acceptance evidence, uncertain outcomes, and measured or estimated consumption. Marionette pins `puppetmaster-ai==1.27.10`; the installer and self-update use the same version. |
+| **Puppetmaster delegation** | `run_swarm`, `run_implement`, and `run_parallel` run bounded workers as durable jobs. Inspect recorded attempts, acceptance evidence, uncertain outcomes, and measured or estimated consumption. Marionette pins `puppetmaster-ai==1.27.11`; the installer and self-update use the same version. |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Durable memory graph** | Local durable facts/preferences (`MemoryStore`) plus optional relations via `MemoryGraph` (`GET /api/memory/graph`, shape `{nodes,edges}` like the wiki graph; sqlite + append-only jsonl). |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.459"
+__version__ = "0.9.460"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/adapter_resolve.py
+++ b/harness/adapter_resolve.py
@@ -178,35 +178,21 @@ class AdapterResolveMixin:
         return "", note
 
     def _active_adapters_system_note(self) -> str:
-        """Live platform-lock snapshot injected each turn so the pilot cannot
-        keep requesting a previously-enabled adapter after the operator flips
-        Settings > Platform."""
+        """Report the product worker adapter without advertising CLI fallbacks."""
         try:
             from puppetmaster.platform_lock import enabled_adapters
-
-            enabled = sorted(enabled_adapters())
+            enabled = set(enabled_adapters())
         except Exception:
-            return ""
-        if not enabled:
+            enabled = set()
+        if "agentic" not in enabled:
             return (
-                "ACTIVE IMPLEMENT PLATFORMS (live): none enabled. "
-                "Omit adapter on run_implement (standalone agentic/native only)."
+                "PRODUCT WORKERS: agentic is not enabled by the platform lock. "
+                "Worker dispatch is unavailable; do not substitute another adapter."
             )
-        preferred = "agentic" if "agentic" in enabled else enabled[0]
-        disabled_hint = ""
-        try:
-            from puppetmaster.platform_lock import KNOWN_ADAPTERS
-
-            disabled = sorted(set(KNOWN_ADAPTERS) - set(enabled))
-            if disabled:
-                disabled_hint = (
-                    f" Do NOT pass adapter={{{', '.join(disabled)}}} — those are disabled."
-                )
-        except Exception:
-            pass
         return (
-            f"ACTIVE IMPLEMENT PLATFORMS (live, re-read every turn): {', '.join(enabled)}. "
-            f"Default run_implement MUST omit adapter or use '{preferred}'.{disabled_hint}"
+            "PRODUCT WORKERS: use only agentic. Omit adapter or set adapter=agentic. "
+            "Auto-routing uses enabled, available provider/model pairs; an explicit "
+            "model pin must identify one of those pairs."
         )
 
     def _detect_default_implement_adapter(self) -> str:

--- a/harness/conversation_jobs.py
+++ b/harness/conversation_jobs.py
@@ -53,6 +53,15 @@ _EMPTY_WORKTREE_MARKERS = (
     "worker produced no changes",
 )
 
+_BACKGROUND_RESUME_CONTROL = (
+    "[Host control: background-job completion notice; not user input] "
+    "The latest real user request remains authoritative. Use only newly "
+    "completed job evidence that is relevant to that request; otherwise "
+    "continue the latest request without reviving the job's superseded "
+    "objective. Do not repeat a prior final summary or report unrelated "
+    "historical worker results."
+)
+
 
 def _non_generic_failure_reason(*candidates) -> str:
     """Prefer a specific reason over the generic incomplete-tasks string."""
@@ -1933,6 +1942,7 @@ class ConversationJobsMixin:
                     def _fail_resume(job_id: str, err: str) -> str:
                         if is_preflight_worker_error(err):
                             return (
+                                f"{_BACKGROUND_RESUME_CONTROL}\n"
                                 f"[background job {job_id} FAILED before work started] "
                                 f"Setup/preflight error — no patch was attempted: {err}. "
                                 "Tell the user clearly. Prefer Open Project / pass "
@@ -1941,6 +1951,7 @@ class ConversationJobsMixin:
                                 "claim a patch failed to land."
                             )
                         return (
+                            f"{_BACKGROUND_RESUME_CONTROL}\n"
                             f"[background job {job_id} FAILED] The swarm result above "
                             "did NOT land a patch. Report this failure to the user "
                             "clearly; do not pretend the patch was applied. Decide "
@@ -1963,6 +1974,7 @@ class ConversationJobsMixin:
                             resume_text = _fail_resume(job_id, err)
                         else:
                             resume_text = (
+                                f"{_BACKGROUND_RESUME_CONTROL}\n"
                                 f"[background job {job_id} finished] The result above is now "
                                 "available. Report the outcome to the user concisely and take "
                                 "the appropriate next step (validate, run tests, apply/fix, or "
@@ -1981,6 +1993,7 @@ class ConversationJobsMixin:
                                 else:
                                     fail_bits.append(jid)
                             resume_text = (
+                                f"{_BACKGROUND_RESUME_CONTROL}\n"
                                 f"[background jobs {ids} finished; FAILED: "
                                 f"{', '.join(fail_bits)}] "
                                 "One or more swarm results above FAILED. Report "
@@ -1991,6 +2004,7 @@ class ConversationJobsMixin:
                             )
                         else:
                             resume_text = (
+                                f"{_BACKGROUND_RESUME_CONTROL}\n"
                                 f"[background jobs {ids} finished] The results above are now "
                                 "available. Report the outcomes to the user concisely and take "
                                 "the appropriate next step (validate, run tests, apply/fix, or "
@@ -2026,12 +2040,14 @@ class ConversationJobsMixin:
                                     from harness.implement_guards import is_preflight_worker_error
                                     if is_preflight_worker_error(err):
                                         resume_text = (
+                                            f"{_BACKGROUND_RESUME_CONTROL}\n"
                                             f"[background job {job_id} FAILED before work started] "
                                             f"Setup/preflight error — no patch was attempted: {err}. "
                                             "Tell the user clearly; do not claim a patch failed to land."
                                         )
                                     else:
                                         resume_text = (
+                                            f"{_BACKGROUND_RESUME_CONTROL}\n"
                                             f"[background job {job_id} FAILED] The swarm result above "
                                             "did NOT land a patch. Report this failure to the user "
                                             "clearly; do not pretend the patch was applied. Decide "
@@ -2040,6 +2056,7 @@ class ConversationJobsMixin:
                                         )
                                 except Exception:
                                     resume_text = (
+                                        f"{_BACKGROUND_RESUME_CONTROL}\n"
                                         f"[background job {job_id} FAILED] The swarm result above "
                                         "did NOT land a patch. Report this failure to the user "
                                         "clearly; do not pretend the patch was applied. Decide "
@@ -2048,6 +2065,7 @@ class ConversationJobsMixin:
                                     )
                             else:
                                 resume_text = (
+                                    f"{_BACKGROUND_RESUME_CONTROL}\n"
                                     f"[background job {job_id} finished] The result above is now "
                                     "available. Report the outcome to the user concisely and take "
                                     "the appropriate next step (validate, run tests, apply/fix, or "

--- a/harness/diag_bundle.py
+++ b/harness/diag_bundle.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 DEFAULT_SESSION_LIMIT = 20
-PIN_FALLBACK = "puppetmaster-ai==1.27.10"
+PIN_FALLBACK = "puppetmaster-ai==1.27.11"
 _PIN_RE = re.compile(r"puppetmaster-ai==[0-9]+(?:\.[0-9]+)*")
 _SECRET_KEY_FRAGMENTS = (
     "api_key",

--- a/harness/edit_engines.py
+++ b/harness/edit_engines.py
@@ -900,7 +900,6 @@ def _stamp_settings_model_allowlist(payload: dict) -> dict:
     balanced routing and returned empty managed worktrees.
     """
     try:
-        from harness.model_visibility import get_enabled
         from harness.swarm_worker_allowlist import resolve_swarm_worker_allowlist
 
         allow = resolve_swarm_worker_allowlist()
@@ -909,14 +908,15 @@ def _stamp_settings_model_allowlist(payload: dict) -> dict:
             for item in (allow.get("allowed_model_ids") or [])
             if str(item).strip()
         ]
-        if ids:
-            payload["allowed_model_ids"] = ids
-        elif get_enabled():
-            payload["allowed_model_ids"] = [
-                str(spec).strip() for spec in get_enabled() if str(spec).strip()
-            ]
+        payload["allowed_adapters"] = ["agentic"]
+        payload["allowed_model_ids"] = ids
     except Exception as exc:
         _diag("edit_engines.settings_model_allowlist", exc)
+        # An allowlist lookup failure must never widen routing to the whole
+        # registry or permit a provider/CLI adapter outside the product
+        # contract. An explicit empty list makes Puppetmaster fail closed.
+        payload["allowed_adapters"] = ["agentic"]
+        payload["allowed_model_ids"] = []
     return payload
 
 
@@ -1019,9 +1019,9 @@ def run_implement(
     job_id: str = "", session_id: str = "", cwd: str = "",
     expects_diff: bool = True,
     agentic_pin: Optional["AgenticModelPin"] = None,
-    strict_adapter: bool = False,
+    strict_adapter: bool = True,
 ) -> "WorkerResult":
-    """Dispatch a single implement worker (agentic or native)."""
+    """Dispatch a product implement worker through the agentic adapter."""
     return run_edit_worker(
         config, goal, requested_adapter=requested_adapter,
         job_id=job_id, session_id=session_id, cwd=cwd,
@@ -1036,9 +1036,9 @@ def run_parallel(
     session_id: str = "", cwd: str = "",
     expects_diff: bool = True,
     agentic_pin: Optional["AgenticModelPin"] = None,
-    strict_adapter: bool = False,
+    strict_adapter: bool = True,
 ) -> list["WorkerResult"]:
-    """Run several implement workers sequentially (caller fans out concurrency)."""
+    """Run product implement workers through the agentic adapter."""
     results = []
     for goal in goals or []:
         if not (goal or "").strip():

--- a/harness/local_job_routing.py
+++ b/harness/local_job_routing.py
@@ -118,10 +118,11 @@ def preview_agentic_route(goal: str, *, role: str = "implement") -> dict[str, An
             )
             if str(item).strip()
         ]
-        if preview_ids:
-            signals_kwargs["allowed_model_ids"] = frozenset(preview_ids)
+        signals_kwargs["allowed_model_ids"] = frozenset(preview_ids)
     except Exception:
-        pass
+        # Do not forecast against the unrestricted registry when Settings
+        # allowlist resolution fails; the live dispatch path is fail-closed.
+        signals_kwargs["allowed_model_ids"] = frozenset()
     if max_cap is not None:
         try:
             from pmharness.bridge import _router_supports_max_capability

--- a/harness/pilot.py
+++ b/harness/pilot.py
@@ -874,7 +874,7 @@ def _coerce_actions(raw_actions) -> list:
 def _run_swarm_model_pin_description() -> str:
     """Tool-schema text for run_swarm.model, including live agentic catalog."""
     base = (
-        "Optional worker model pin (agentic registry id or adapter model name). "
+        "Optional worker model pin (canonical registry ID or exact provider:model). "
         "Pass it when the user names a swarm worker model. Omitting auto-routes "
         "only among Models-enabled workers, not the full agentic catalog. "
         "Prompt text alone does not pin a model. "
@@ -885,8 +885,8 @@ def _run_swarm_model_pin_description() -> str:
         return base + swarm_model_pin_hint()
     except Exception:
         return base + (
-            "Omit model to auto-route among Models-enabled workers. Session "
-            "pilot ids remap when a matching worker row exists."
+            "Omit model for routing among enabled, available agentic models. "
+            "Unavailable explicit pins fail without substitution."
         )
 
 
@@ -1680,7 +1680,7 @@ def build_tools_schema(
                     "type": "object",
                     "properties": {
                         "goal": {"type": "string", "description": "The coding objective / task description to implement"},
-                        "adapter": {"type": "string", "description": "Optional edit engine. Default is 'agentic' -- Puppetmaster's standalone keys-only worker (routes directly through your provider API, no external CLI). 'native' forces Marionette's own richer pilot loop. 'cursor'/'codex'/'claude-code' use those external agent CLIs when installed."},
+                        "adapter": {"type": "string", "enum": ["agentic"], "description": "Optional adapter; the only supported value is 'agentic'. Omit it for normal routing among enabled provider/model pairs."},
                         "model": {"type": "string", "description": "Optional strict agentic worker model pin (registry id or provider/model, for example openrouter/stealth/ox-alpha). A model pin implies adapter=agentic, never falls back, and must be omitted for normal auto-routing."},
                         "mode": {"type": "string", "enum": ["implement", "analysis", "review"], "description": "Worker execution mode: 'implement' (expects a patch; default) or 'analysis'/'review' (read-only report; empty diff is success)."},
                         "reasoning_effort": _worker_reasoning_effort_schema(),
@@ -1716,7 +1716,7 @@ def build_tools_schema(
                                 "Example: [\"Fix the flaky login test\", \"Update CONTRIBUTING.md setup steps\"]."
                             ),
                         },
-                        "adapter": {"type": "string", "description": "Optional edit engine (default 'agentic' -- standalone keys-only; 'native' for the richer pilot; 'cursor'/'codex'/'claude-code' for external CLIs when installed)"},
+                        "adapter": {"type": "string", "enum": ["agentic"], "description": "Optional adapter; the only supported value is 'agentic'. Omit it for normal routing among enabled provider/model pairs."},
                         "model": {"type": "string", "description": "Optional strict agentic model pin shared by every child goal (registry id or provider/model). Implies adapter=agentic and disables fallback/auto-substitution."},
                         "mode": {"type": "string", "enum": ["implement", "analysis", "review"], "description": "Worker execution mode: 'implement' (can edit) or 'analysis'/'review' (read-only)"},
                         "reasoning_effort": _worker_reasoning_effort_schema(),
@@ -2825,8 +2825,8 @@ You have direct access to a local CodeGraph-indexed workspace and can explore/ed
 - `wait`: stay on this turn while background jobs run (Cursor-style Await). Sleeps up to `seconds` (default 2, max 30) and returns whether jobs settled. After run_implement / run_parallel, call wait instead of ending the turn.
 - `todo`: nested phased checklist for multi-step work. `init` a `{list:[{phase, items}]}` tree, then `start` / `done` / `append` / `block` / `view`. Address tasks by their full content text. One in_progress task at a time; the result names Next. Do not restate the whole plan in prose.
 - `list_dir`: list the files and folders inside a directory. `path` is optional.
-- `run_swarm`: dispatch a parallel agent swarm for complex/broad investigations. Requires `goal`. One worker runs per role -- for a broad ask (audit, "review the platform", "find ways to improve quality/robustness/scale") pass SEVERAL `roles` (explore, pipeline-mapper, decision-explainer, conflict-auditor, test-coverage-reviewer) so it fans out into real parallel coverage; pass all five for a full audit. Omit roles only for a single narrow question. Prefer omitting `model` so the harness auto-routes among currently keyed agentic worker providers (ChatGPT Codex OAuth, OpenCode Go, OpenRouter, …). Pass `model` only when the user names a worker from the live agentic catalog in the tool schema; session pilot ids (openai-codex:…, cursor/…, codex/…) remap to matching worker rows when present. Unknown pins demote to auto-route; they do not fail the swarm. Prompt text alone does not pin a model. To audit a DIFFERENT checkout than the open workspace, pass `repo`=<absolute git path>: the workers read that subject, while your own writes/edits/commands stay in the open session workspace.
-- `run_implement`: dispatch an edit-capable worker that edits the repo in an isolated worktree and produces a reviewable patch. Requires `goal`. Default engine is standalone `agentic` (routes directly through your provider keys, no external CLI); pass `adapter` only to force a specific engine. Optional `mode` (`implement` default, or `analysis`/`review` for read-only reports).
+- `run_swarm`: dispatch a parallel agent swarm for complex/broad investigations. Requires `goal`. One worker runs per role -- for a broad ask (audit, "review the platform", "find ways to improve quality/robustness/scale") pass SEVERAL `roles` (explore, pipeline-mapper, decision-explainer, conflict-auditor, test-coverage-reviewer) so it fans out into real parallel coverage; pass all five for a full audit. Omit roles only for a single narrow question. Prefer omitting `model` so the harness auto-routes among currently keyed agentic worker providers (ChatGPT Codex OAuth, OpenCode Go, OpenRouter, …). Pass `model` only when the user names a worker from the live agentic catalog in the tool schema; use an exact enabled provider:model pair or canonical registry ID. An unavailable explicit pin fails; it never authorizes choosing a different model. Prompt text alone does not pin a model. To audit a DIFFERENT checkout than the open workspace, pass `repo`=<absolute git path>: the workers read that subject, while your own writes/edits/commands stay in the open session workspace.
+- `run_implement`: dispatch an edit-capable worker that edits the repo in an isolated worktree and produces a reviewable patch. Requires `goal`. The only worker adapter is `agentic`; omit `adapter` or set it to `agentic`. Providers and models are selected within that adapter from enabled, available pairs. Optional `mode` (`implement` default, or `analysis`/`review` for read-only reports).
 - `run_parallel`: dispatch multiple Puppetmaster workers concurrently. Requires `goals` as a JSON array of 2-8 independent goal strings (example: ["Add unit tests for auth.py", "Document the API routes in README"]), optional `adapter`, optional `mode`.
 - Worker `reasoning_effort` (`none`/`low`/`medium`/`high`/`xhigh`/`max`) on `run_swarm` / `run_implement` / `run_parallel` pins that one dispatch. Omit it to use Settings worker reasoning (factory medium). This is not the chat-pilot picker.
 - `route_task`: preview which model the router would pick + estimated cost for a given instruction without executing it. Requires `instruction`.
@@ -2883,7 +2883,7 @@ TINY / STATIC WORKSPACE AFTER IMPLEMENT (mandatory): After a successful implemen
 
 NO DUPLICATE IMPLEMENT SWARMS (mandatory): One objective gets ONE in-flight implement/parallel worker. Do NOT emit two run_implement tool calls in the same turn for the same work, do NOT re-dispatch the same change while its worker is still running, and do NOT fan out multiple workers that edit the SAME files -- the first patch applies and every overlapping one then fails with "PATCH DID NOT APPLY" because the files already moved. Decompose parallel waves into DISJOINT file sets. When a "[background job ... finished]" continuation arrives you are already being resumed automatically to handle it -- assess it, do not fire a redundant copy.
 
-ADAPTERS FOLLOW THE LIVE PLATFORM LOCK (mandatory): Each turn's system prompt lists ACTIVE IMPLEMENT PLATFORMS. Omit `adapter` on run_implement/run_parallel unless you need a listed platform. Never request a disabled adapter (especially cursor when it is off) -- the harness remaps it, but requesting it wastes a turn.
+PRODUCT WORKER ROUTING (mandatory): run_swarm, run_implement, and run_parallel use only the agentic adapter. Omit `adapter` or pass `agentic`. Codex OAuth, OpenRouter, and OpenCode Go are providers beneath it. Auto-routing stays within enabled, available provider/model pairs; unsupported adapters and unavailable explicit pins fail without substitution.
 
 WHEN A PATCH DID NOT APPLY: If a result says "PATCH DID NOT APPLY", the stale diff is dead -- never re-apply or re-dispatch the identical change. The files moved (an overlapping edit landed, or the base shifted). Re-derive the change against the CURRENT file contents: read the target file(s) as they are now, confirm whether the intended change is already present (if so, report it as done), and only if it is genuinely missing dispatch a fresh run_implement scoped to the current state.
 

--- a/harness/send_loop_dispatch.py
+++ b/harness/send_loop_dispatch.py
@@ -34,23 +34,30 @@ DISPATCH_ACTION_KINDS: frozenset[str] = frozenset({
 
 
 def _strict_agentic_dispatch(act) -> tuple[object, bool, str]:
-    """Resolve an explicit action model/agentic adapter before any fallback."""
+    """Resolve the product action's agentic pin before any fallback.
+
+    Product implement/parallel actions have one adapter contract: agentic.
+    Providers and models are selected beneath that adapter, so an omitted
+    adapter is still strict rather than permission to select another engine.
+    """
 
     requested_model = str(getattr(act, "model", "") or "").strip()
     requested_adapter = str(getattr(act, "adapter", "") or "").strip().lower()
-    strict_agentic = bool(
-        requested_model or requested_adapter == "agentic"
-    )
-    if not strict_agentic:
-        return None, False, ""
-    if requested_model and requested_adapter not in ("", "agentic"):
+    if requested_adapter not in ("", "agentic"):
+        if requested_model:
+            return (
+                None,
+                True,
+                (
+                    f"model={requested_model!r} is an agentic worker pin and "
+                    f"cannot be combined with adapter={requested_adapter!r}"
+                ),
+            )
         return (
             None,
             True,
-            (
-                f"model={requested_model!r} is an agentic worker pin and "
-                f"cannot be combined with adapter={requested_adapter!r}"
-            ),
+            f"adapter={requested_adapter!r} is unsupported for product "
+            "implement/parallel actions; use adapter='agentic'",
         )
     if not requested_model:
         return None, True, ""

--- a/harness/send_loop_phases.py
+++ b/harness/send_loop_phases.py
@@ -700,8 +700,7 @@ def _run_command_artifact_headline(
 def _with_command_footer(history_text: str, payload: Dict[str, Any]) -> str:
     """Append cwd / recovery-hint / spill footer lines to model-visible history.
 
-    Kept as a footer so the existing ``(run_command '...' completed with exit
-    code N)`` header and raw output stay byte-identical for every consumer.
+    Keep execution metadata after the command status and process output.
     """
     footer = []
     cwd = payload.get("cwd")
@@ -1370,16 +1369,25 @@ def resolve_emit_say_texts(
     resp_meta = getattr(resp, "meta", None) or {}
     if not isinstance(resp_meta, dict):
         resp_meta = {}
-    promoted_say = promote_trailing_reasoning_to_say(
-        say_text=cleaned_say_text,
-        streamed_reasoning=str(resp_meta.get("streamed_reasoning") or ""),
-        stream_ended_on_reasoning=bool(
-            resp_meta.get("stream_ended_on_reasoning")
-        ),
-        meta_reasoning=str(
-            resp_meta.get("reasoning") or turn_thinking or ""
-        ),
+    # Only Cursor transports have the legacy contract that a thought-channel
+    # terminal may be rendered as the assistant's final readout. Other
+    # providers (including OpenAI-compatible DeepSeek) keep reasoning private.
+    is_cursor_transport = (
+        resp_meta.get("cursor_cli") is True
+        or resp_meta.get("cursor_acp") is True
     )
+    promoted_say = ""
+    if is_cursor_transport and not resp_meta.get("tool_calls"):
+        promoted_say = promote_trailing_reasoning_to_say(
+            say_text=cleaned_say_text,
+            streamed_reasoning=str(resp_meta.get("streamed_reasoning") or ""),
+            stream_ended_on_reasoning=bool(
+                resp_meta.get("stream_ended_on_reasoning")
+            ),
+            meta_reasoning=str(
+                resp_meta.get("reasoning") or turn_thinking or ""
+            ),
+        )
     if resp_phase == "commentary":
         promoted_say = ""
     if promoted_say:
@@ -3668,7 +3676,7 @@ def dispatch_local_action(
                     act,
                     aid,
                     _with_command_footer(
-                        f"(run_command '{command}' {run_status} with exit code {exit_code})\n{output}",
+                        f"(run_command {aid} {run_status} with exit code {exit_code})\n{output}",
                         val,
                     ),
                     is_native,
@@ -3728,13 +3736,13 @@ def dispatch_local_action(
         yield ConvEvent("action_result", result)
         if run_status == "ok":
             hist = (
-                f"(run_command '{command}' completed with exit code {exit_code})\n"
+                f"(run_command {aid} completed with exit code {exit_code})\n"
                 f"{output}"
             )
         else:
             # e.g. truncated: still a finished process, but not a clean ok.
             hist = (
-                f"(run_command '{command}' {run_status} with exit code {exit_code})\n"
+                f"(run_command {aid} {run_status} with exit code {exit_code})\n"
                 f"{output}"
             )
         session._append_action_result(

--- a/harness/swarm_model_pin.py
+++ b/harness/swarm_model_pin.py
@@ -1,13 +1,6 @@
 from __future__ import annotations
 
-"""Resolve run_swarm model pins against the live worker adapter union.
-
-Pilots often pass their session model (``cursor/gpt-5-6-luna``,
-``openai-codex:gpt-5.6-luna``, ``cursor/grok-4-5``). Those aliases remap to
-keyed agentic rows when a matching worker auth exists, or to platform cursor
-rows when Settings/platform allow Cursor workers. Unresolved pins demote to
-auto-route across the live union catalog instead of failing.
-"""
+"""Resolve product worker pins to exact enabled agentic provider/model rows."""
 
 import re
 from dataclasses import dataclass
@@ -15,12 +8,6 @@ from typing import Any, Optional
 
 from .diag import note as _diag
 
-# Prefer agentic (API-billed) remaps before platform cursor when both match.
-_PIN_ADAPTER_ORDER = ("agentic", "cursor", "openai")
-_GENERIC_MODEL_TOKENS = frozenset({
-    "pro", "mini", "nano", "fast", "high", "low", "max", "latest",
-    "free", "exp", "preview", "flash", "plus", "chat", "code",
-})
 _PIN_PROVIDER_ALIASES = {
     "codex": "openai-codex",
     "chatgpt-codex": "openai-codex",
@@ -167,18 +154,6 @@ class AgenticModelPin:
         }
 
 
-def _model_family_token(model_id: str) -> str:
-    """Distinctive last token (``astra``, ``luna``), or empty for generic tails."""
-    bare = (model_id or "").rsplit("/", 1)[-1].strip().lower()
-    parts = [p for p in re.split(r"[-_.]+", bare) if p]
-    if not parts:
-        return ""
-    token = parts[-1]
-    if token.isdigit() or token in _GENERIC_MODEL_TOKENS or len(token) < 3:
-        return ""
-    return token
-
-
 def _normalize_pin_provider(provider: str) -> str:
     raw = (provider or "").strip().lower()
     return _PIN_PROVIDER_ALIASES.get(raw, raw)
@@ -215,12 +190,7 @@ def settings_enabled_pin_specs(
     *,
     enabled: Optional[list[str]] = None,
 ) -> list[str]:
-    """Settings specs for the same enabled model — never a different sibling.
-
-    ``gpt-5.6-astra`` maps to enabled ``openai-codex:gpt-6-astra``. It does
-    not map to Sol or Luna. Generic tails (``pro``, ``mini``) match exact ids
-    only.
-    """
+    """Settings specs matching the requested provider and exact model ID."""
     requested = (pin or "").strip()
     if not requested:
         return []
@@ -233,7 +203,6 @@ def settings_enabled_pin_specs(
             enabled = []
     pin_provider, pin_model = _parse_pin_provider_model(requested)
     pin_model_l = (pin_model or "").strip().lower()
-    pin_token = _model_family_token(pin_model or requested)
     out: list[str] = []
     seen: set[str] = set()
     for spec in enabled or []:
@@ -248,8 +217,7 @@ def settings_enabled_pin_specs(
         if pin_provider and prov != pin_provider:
             continue
         exact = bool(pin_model_l) and mid.lower() == pin_model_l
-        token = bool(pin_token) and _model_family_token(mid) == pin_token
-        if not (exact or token):
+        if not exact:
             continue
         key = raw.lower()
         if key in seen:
@@ -257,47 +225,6 @@ def settings_enabled_pin_specs(
         seen.add(key)
         out.append(raw)
     return out
-
-
-def _direct_agentic_provider_model(pin: str) -> Optional[AgenticModelPin]:
-    """Resolve ``provider/model`` when a keyed live model is not in the registry."""
-
-    requested = (pin or "").strip()
-    matches = settings_enabled_pin_specs(requested)
-    if len(matches) == 1:
-        provider, model = matches[0].split(":", 1)
-        provider = _normalize_pin_provider(provider)
-        model = model.strip()
-    else:
-        body = requested
-        if body.lower().startswith("agentic/"):
-            body = body.split("/", 1)[1].strip()
-        if ":" in body:
-            provider, model = body.split(":", 1)
-        elif "/" in body:
-            provider, model = body.split("/", 1)
-        else:
-            return None
-        provider = _normalize_pin_provider(provider)
-        model = model.strip()
-    if not provider or not model:
-        return None
-    try:
-        from .auto_registry import keyed_agentic_providers
-
-        keyed = {str(item).strip().lower() for item in keyed_agentic_providers()}
-    except Exception as exc:
-        _diag("swarm_model_pin.direct_keyed", exc)
-        keyed = set()
-    if provider not in keyed:
-        return None
-    return AgenticModelPin(
-        requested=requested,
-        provider=provider,
-        model=model,
-        router_model_id=f"agentic/{provider}/{model}",
-        reason="direct_provider_model",
-    )
 
 
 def _registry_rows(*, adapters: Optional[set[str]] = None) -> list[dict]:
@@ -337,12 +264,55 @@ def _row_is_keyed_agentic(row: dict, keyed: set) -> bool:
     provider = ""
     if isinstance(defaults, dict):
         provider = str(defaults.get("provider") or "").strip()
-    if keyed and provider and provider not in keyed:
+    # An empty keyed set is authoritative: an agentic row is never usable
+    # merely because it exists in the static registry.
+    return bool(provider) and provider in {
+        str(item).strip().lower() for item in (keyed or set()) if str(item).strip()
+    }
+
+
+def _settings_enabled_specs() -> Optional[list[str]]:
+    """Return curated settings, preserving the distinction from unset."""
+    try:
+        from . import model_visibility
+        current = model_visibility.get_enabled()
+        if current:
+            return [str(x).strip() for x in current if str(x).strip()]
+        data = model_visibility._load()
+        if isinstance(data, dict) and "enabled" in data:
+            enabled = data.get("enabled")
+            if isinstance(enabled, list):
+                return [str(x).strip() for x in enabled if str(x).strip()]
+            return []
+    except Exception as exc:
+        _diag("swarm_model_pin.settings_state", exc)
+        return []
+    return None
+
+
+def _row_matches_enabled_settings(row: dict, enabled: Optional[list[str]]) -> bool:
+    """Require an exact provider/model Settings pair when curated."""
+    if enabled is None:
+        return True
+    defaults = row.get("payload_defaults")
+    if not isinstance(defaults, dict):
         return False
-    return True
+    provider = str(defaults.get("provider") or "").strip().lower()
+    model = str(row.get("adapter_model_name") or defaults.get("model") or "").strip().lower()
+    if not provider or not model:
+        return False
+    return any(
+        _normalize_pin_provider(_provider) == provider and _model.strip().lower() == model
+        for spec in enabled
+        if ":" in str(spec)
+        for _provider, _model in [str(spec).split(":", 1)]
+    )
 
 
-def _usable_registry_rows(*, adapters: Optional[set[str]] = None) -> list[dict]:
+def _usable_registry_rows(
+    *, adapters: Optional[set[str]] = None,
+    enabled_specs: Optional[list[str]] = None,
+) -> list[dict]:
     try:
         from .auto_registry import keyed_agentic_providers
 
@@ -352,86 +322,31 @@ def _usable_registry_rows(*, adapters: Optional[set[str]] = None) -> list[dict]:
         keyed = set()
     out: list[dict] = []
     seen: set[str] = set()
+    enabled = _settings_enabled_specs() if enabled_specs is None else enabled_specs
     for row in _registry_rows(adapters=adapters):
         mid = str(row.get("id") or "").strip()
         if not mid or mid.lower() in seen:
             continue
         if not _row_is_keyed_agentic(row, keyed):
             continue
+        if row.get("enabled", True) is not True or row.get("retired", False) is True:
+            continue
+        if not _row_matches_enabled_settings(row, enabled):
+            continue
         seen.add(mid.lower())
         out.append(row)
     return out
 
 
-def _spec_preferred_registry_ids(spec: str) -> list[str]:
-    """Best registry ids for a Settings spec — agentic provider rows first."""
-    provider, model = _parse_pin_provider_model(spec)
-    out: list[str] = []
-    cursor_providers = {"cursor", "cursor-cli", "cursor-sdk"}
-    if provider and model:
-        if provider in cursor_providers:
-            out.append(f"cursor/{model}")
-        else:
-            out.append(f"agentic/{provider}/{model}")
-            out.append(f"agentic/{model}")
-    out.extend(pin_candidates(spec))
-    seen: set[str] = set()
-    uniq: list[str] = []
-    for item in out:
-        key = item.lower()
-        if not item or key in seen:
-            continue
-        seen.add(key)
-        uniq.append(item)
-    return uniq
-
-
 def _enabled_registry_ids(rows: list[dict]) -> list[str]:
-    """Settings-enabled picker specs mapped onto ids that exist in *rows*."""
-    try:
-        from .model_visibility import get_enabled
-
-        enabled = get_enabled()
-    except Exception as exc:
-        _diag("swarm_model_pin.enabled_ids", exc)
-        return []
-    if not enabled:
-        return []
-    by_id = {}
-    for row in rows:
-        mid = str(row.get("id") or "").strip()
-        if mid:
-            by_id[mid.lower()] = mid
+    """Order eligible registry rows by their exact Settings provider/model pair."""
+    enabled = _settings_enabled_specs() or []
     out: list[str] = []
-    seen: set[str] = set()
     for spec in enabled:
-        hit = ""
-        for cand in _spec_preferred_registry_ids(spec):
-            found = by_id.get(cand.lower())
-            if found:
-                hit = found
-                break
-        if not hit:
-            provider, model = _parse_pin_provider_model(spec)
-            token = _model_family_token(model or spec)
-            if token and provider:
-                for row in rows:
-                    mid = str(row.get("id") or "").strip()
-                    if not mid or mid.lower() in seen:
-                        continue
-                    defaults = row.get("payload_defaults")
-                    row_prov = ""
-                    if isinstance(defaults, dict):
-                        row_prov = str(defaults.get("provider") or "").strip().lower()
-                    adapter = str(row.get("adapter") or "").strip().lower()
-                    if adapter != "agentic" or row_prov != provider:
-                        continue
-                    if _model_family_token(mid) == token:
-                        hit = mid
-                        break
-        if hit and hit.lower() not in seen:
-            seen.add(hit.lower())
-            out.append(hit)
+        for row in rows:
+            model_id = str(row.get("id") or "").strip()
+            if model_id and model_id not in out and _row_matches_enabled_settings(row, [spec]):
+                out.append(model_id)
     return out
 
 
@@ -471,27 +386,22 @@ def list_available_worker_models(
 
 
 def swarm_model_pin_hint(*, limit: int = 16) -> str:
-    """Short tool-schema suffix listing live worker models (or auto-route)."""
+    """Describe the exact model choices available to product workers."""
     try:
         from .swarm_worker_allowlist import resolve_swarm_worker_allowlist
-
         allow = set(resolve_swarm_worker_allowlist().get("allowed_adapters") or [])
     except Exception:
-        allow = {"agentic"}
-    available = list_available_worker_models(limit=limit, adapters=allow or None)
-    if not available:
-        return (
-            "Omit model to auto-route among Models-enabled workers "
-            "(OpenCode Go, OpenRouter, ChatGPT Codex OAuth, Cursor API, …). "
-            "Session pilot ids are remapped when a matching worker row exists."
-        )
-    shown = ", ".join(available)
-    return (
-        "Omit model to auto-route among Models-enabled workers. Live catalog: "
-        f"{shown}. Session pilot ids (openai-codex:…, cursor/…, codex/…) remap "
-        "to a matching row when present; unknown pins demote to auto-route "
-        "inside the enabled set."
+        allow = set()
+    available = list_available_worker_models(limit=limit, adapters=allow)
+    rule = (
+        "Workers use only adapter=agentic. Omit model for auto-routing within "
+        "enabled, available provider/model pairs. An explicit model must match "
+        "an enabled provider:model pair or registry ID; unavailable pins fail "
+        "without choosing a different model."
     )
+    if not available:
+        return rule + " No eligible worker models are currently available."
+    return rule + " Live catalog: " + ", ".join(available) + "."
 
 
 def pin_candidates(pin: str) -> list[str]:
@@ -573,48 +483,91 @@ def pin_candidates(pin: str) -> list[str]:
     return out
 
 
-def _try_apply_pin(candidate: str, *, adapter: str) -> Optional[dict]:
-    try:
-        from puppetmaster.model_registry import (
-            AmbiguousModelPinError,
-            apply_model_pin,
-        )
-    except Exception as e:
-        _diag("swarm_model_pin.apply_import", e)
+def _exact_registry_pin(pin: str, rows: list[dict]) -> Optional[dict[str, Any]]:
+    """Return payload fields for one exact agentic registry row."""
+    requested = (pin or "").strip()
+    wanted_id = requested.lower()
+    # Canonical ids are opaque. In particular, agentic/vendor/model must not
+    # be interpreted as provider=vendor when the registry row says the wire
+    # provider is something else (OpenRouter and OpenCode Go do this).
+    for row in rows:
+        row_id = str(row.get("id") or "").strip()
+        if row_id and row_id.lower() == wanted_id:
+            defaults = row.get("payload_defaults")
+            if not isinstance(defaults, dict):
+                return None
+            provider = str(defaults.get("provider") or "").strip().lower()
+            model = str(row.get("adapter_model_name") or defaults.get("model") or "").strip()
+            if provider and model:
+                return {
+                    "provider": provider,
+                    "model": model,
+                    "pinned_model": row_id,
+                    "pinned_adapter_model_name": model,
+                    "_registry_row": row,
+                }
+            return None
+    body = requested
+    if body.lower().startswith("agentic/"):
+        body = body[8:].strip()
+    provider = ""
+    model = body
+    if ":" in body:
+        provider, model = body.split(":", 1)
+    elif "/" in body:
+        provider, model = body.split("/", 1)
+    provider = _normalize_pin_provider(provider)
+    model = model.strip()
+    matches: list[dict] = []
+    for row in rows:
+        defaults = row.get("payload_defaults")
+        if not isinstance(defaults, dict):
+            continue
+        row_provider = str(defaults.get("provider") or "").strip().lower()
+        row_model = str(row.get("adapter_model_name") or "").strip()
+        if not row_model:
+            row_model = str(defaults.get("model") or "").strip()
+        row_id = str(row.get("id") or "").strip()
+        if not row_id or row_model != model:
+            continue
+        if provider and row_provider != provider:
+            continue
+        matches.append({
+            "provider": row_provider,
+            "model": row_model,
+            "pinned_model": row_id,
+            "pinned_adapter_model_name": row_model,
+            "_registry_row": row,
+        })
+    if len(matches) != 1:
         return None
-    try:
-        stamped = apply_model_pin({}, candidate, adapter=adapter)
-    except AmbiguousModelPinError as exc:
-        _diag("swarm_model_pin.ambiguous", msg=f"pin={candidate!r} err={exc}")
-        return None
-    except Exception as e:
-        _diag("swarm_model_pin.apply", e, msg=f"pin={candidate!r} adapter={adapter}")
-        return None
-    if not isinstance(stamped, dict) or not stamped.get("pinned_model"):
-        return None
-    stamped = dict(stamped)
-    stamped["pinned_adapter"] = adapter
+    return matches[0]
+
+
+def _apply_exact_registry_pin(row: dict) -> dict[str, Any]:
+    """Stamp the same eligible registry snapshot used to resolve the pin."""
+    from puppetmaster.model_registry import ModelSpec, apply_model_pin
+
+    spec = ModelSpec(**{
+        key: value for key, value in row.items()
+        if key in ModelSpec.__dataclass_fields__
+    })
+    stamped = apply_model_pin({}, spec.id, adapter="agentic", registry=[spec])
+    if stamped.get("pinned_model") != spec.id:
+        raise ValueError(f"Could not stamp selected worker model {spec.id!r}")
     return stamped
 
 
 def _allowed_pin_adapters(
     allowed_adapters: Optional[list[str] | set[str] | tuple[str, ...]],
 ) -> list[str]:
-    if allowed_adapters:
-        ordered = [a for a in _PIN_ADAPTER_ORDER if a in set(allowed_adapters)]
-        for a in allowed_adapters:
-            name = str(a or "").strip().lower()
-            if name and name not in ordered:
-                ordered.append(name)
-        return ordered or ["agentic"]
-    try:
-        from .swarm_worker_allowlist import resolve_swarm_worker_allowlist
-
-        return list(
-            resolve_swarm_worker_allowlist().get("allowed_adapters") or ["agentic"]
-        )
-    except Exception:
-        return ["agentic"]
+    if allowed_adapters is None:
+        try:
+            from .swarm_worker_allowlist import resolve_swarm_worker_allowlist
+            allowed_adapters = resolve_swarm_worker_allowlist().get("allowed_adapters") or []
+        except Exception:
+            return []
+    return ["agentic"] if "agentic" in allowed_adapters else []
 
 
 def resolve_swarm_model_pin(
@@ -622,11 +575,10 @@ def resolve_swarm_model_pin(
     *,
     allowed_adapters: Optional[list[str] | set[str] | tuple[str, ...]] = None,
 ) -> dict[str, Any]:
-    """Resolve a swarm model pin or demote to auto-route.
+    """Resolve a swarm model pin against one exact live agentic row.
 
-    Tries each adapter in the Settings/platform union (agentic first, then
-    cursor, then openai) so a Cursor Grok pin is not rejected just because the
-    agentic catalog lacks that id.
+    An unavailable explicit pin is returned as demoted for callers that need
+    to render an actionable error; product dispatch must not auto-route it.
 
     Returns:
       {
@@ -665,22 +617,15 @@ def resolve_swarm_model_pin(
         _diag("swarm_model_pin.health", e)
 
     adapters = _allowed_pin_adapters(allowed_adapters)
-    candidates = list(pin_candidates(requested))
-    seen_cands = {c.lower() for c in candidates}
-    for spec in settings_enabled_pin_specs(requested):
-        for extra in pin_candidates(spec):
-            key = extra.lower()
-            if key in seen_cands:
-                continue
-            seen_cands.add(key)
-            candidates.append(extra)
-    for candidate in candidates:
-        for adapter in adapters:
-            stamped = _try_apply_pin(candidate, adapter=adapter)
-            if not stamped:
-                continue
-            resolved = str(stamped.get("pinned_model") or "").strip()
-            pin_fields = {**stamped, "auto_route": False}
+    if "agentic" in adapters:
+        exact = _exact_registry_pin(requested, _usable_registry_rows(adapters={"agentic"}))
+        if exact:
+            row = exact.pop("_registry_row", {})
+            pin_fields = {
+                **_apply_exact_registry_pin(row),
+                "auto_route": False,
+                "pinned_adapter": "agentic",
+            }
             # Fail closed: never dispatch ChatGPT Codex OAuth *-pro ids.
             for key in ("model", "pinned_adapter_model_name"):
                 cur = str(pin_fields.get(key) or "").strip()
@@ -690,11 +635,7 @@ def resolve_swarm_model_pin(
                     _diag("swarm_model_pin.codex_pro_remap_fields", msg=f"{key}:{reason}")
             if norm_meta.get("reasoning_effort_hint") and not pin_fields.get("reasoning_effort"):
                 pin_fields["reasoning_effort"] = norm_meta["reasoning_effort_hint"]
-            reason = (
-                "exact"
-                if candidate == original
-                else f"alias:{candidate}"
-            )
+            reason = "exact_registry_row"
             if norm_meta.get("normalize"):
                 reason = f"{norm_meta['normalize']};{reason}"
             elif norm_meta.get("codex_pro_remap"):
@@ -703,17 +644,17 @@ def resolve_swarm_model_pin(
                 "pin_fields": pin_fields,
                 "auto_route": False,
                 "requested": original,
-                "resolved": str(pin_fields.get("pinned_model") or resolved).strip(),
+                "resolved": str(pin_fields["pinned_model"]).strip(),
                 "demoted": False,
                 "reason": reason,
-                "adapter": adapter,
+                "adapter": "agentic",
             }
 
     available = list_available_worker_models(limit=8, adapters=set(adapters))
     reason = (
         f"pin {original!r} not in keyed worker registry "
         f"(adapters={adapters}); "
-        f"auto-routing among {available or ['(none keyed)']}"
+        f"choose an enabled model from {available or ['(none keyed)']}"
     )
     _diag("swarm_model_pin.demote", msg=reason)
     return {
@@ -757,10 +698,6 @@ def resolve_agentic_model_pin(pin: str) -> tuple[Optional[AgenticModelPin], str]
                 router_model_id=router_model_id,
                 reason=str(resolved.get("reason") or "exact"),
             ), ""
-
-    direct = _direct_agentic_provider_model(requested)
-    if direct is not None:
-        return direct, ""
 
     available = list_available_agentic_worker_models(limit=8)
     reason = str(resolved.get("reason") or "").strip()

--- a/harness/swarm_worker_allowlist.py
+++ b/harness/swarm_worker_allowlist.py
@@ -1,20 +1,13 @@
 from __future__ import annotations
 
-"""Settings + platform driven worker adapter allowlist for product swarms.
+"""Models-enabled allowlist for product swarms.
 
-Product bar: any Models-enabled / catalog-visible worker-capable model must be
-reachable as a swarm worker. The bridge must not hardcode ``allowed_adapters=
-['agentic']`` when Settings also enables Cursor Grok/Composer (or other
-platform-locked adapters).
+Product workers use the agentic adapter. Provider credentials and model names
+remain choices inside that adapter; they are not alternate worker adapters.
 
 Rules:
-  * Union adapters for Models-enabled (or full catalog-visible when unset)
-    worker-capable providers.
-  * Intersect with Puppetmaster platform lock when restricted.
-  * Prefer ``prefer_plan_billed=False`` whenever any API-billed agentic model
-    is eligible so OpenRouter cash models are not starved by $0 plan picks.
-  * Do not exclude Cursor when Settings enables Grok/Composer and platform
-    cursor workers are ready + unlocked.
+  * Canonicalize allowlisted IDs against the live registry.
+  * Fail closed when no exact enabled/live row exists.
 """
 
 from typing import Any, Optional
@@ -22,7 +15,7 @@ from typing import Any, Optional
 from .diag import note as _diag
 
 # Adapters Marionette can actually drive for product analysis swarms.
-_PRODUCT_WORKER_ADAPTERS = ("agentic", "cursor", "openai")
+_PRODUCT_WORKER_ADAPTERS = ("agentic",)
 
 
 def _enabled_or_visible_specs() -> list[str]:
@@ -42,6 +35,15 @@ def _enabled_or_visible_specs() -> list[str]:
             for spec in (_mv.get_enabled() or [])
             if str(spec or "").strip()
         ]
+        # Empty is meaningful when the user explicitly saved an empty
+        # selection. Only an absent setting gets the legacy available-model
+        # fallback.
+        try:
+            stored = _mv._load()
+            if isinstance(stored, dict) and "enabled" in stored:
+                return curated
+        except Exception:
+            pass
         if curated:
             # Models toggles are the only discretionary allowlist. Do not
             # union enabled_pilots() here — that function falls back to every
@@ -167,25 +169,39 @@ def adapters_from_visibility(specs: Optional[list[str]] = None) -> set[str]:
 def allowed_model_ids_from_specs(
     specs: Optional[list[str]] = None,
 ) -> list[str]:
-    """Map Models-enabled specs to Puppetmaster ``allowed_model_ids``.
+    """Return only exact IDs present in the live agentic registry.
 
-    Uses the same alias expansion as ``run_swarm`` pins so
-    ``openai-codex:gpt-5.6-luna`` matches ``agentic/openai-codex/gpt-5.6-luna``.
-    An empty result must be omitted from the worker payload (empty array
-    fails closed in Puppetmaster).
+    Provider and model strings are opaque. Matching is deliberately against
+    registry payload fields, not aliases or sibling provider IDs.
     """
-    from .swarm_model_pin import pin_candidates
-
+    from .swarm_model_pin import _usable_registry_rows
     rows = list(specs) if specs is not None else _enabled_or_visible_specs()
-    out = []
-    seen = set()
+    # An explicit specs argument is the caller's Settings snapshot and must
+    # override the process-global snapshot used by normal dispatch/tests.
+    registry = _usable_registry_rows(adapters={"agentic"}, enabled_specs=rows)
+    by_pair: dict[tuple[str, str], str] = {}
+    for row in registry:
+        defaults = row.get("payload_defaults")
+        if not isinstance(defaults, dict):
+            continue
+        provider = str(defaults.get("provider") or "").strip().lower()
+        model = str(row.get("adapter_model_name") or "").strip()
+        if not model:
+            # Legacy rows used payload_defaults.model before the adapter field
+            # became mandatory; retain compatibility only for that same row.
+            model = str(defaults.get("model") or "").strip()
+        model_id = str(row.get("id") or "").strip()
+        if provider and model and model_id:
+            by_pair.setdefault((provider, model.lower()), model_id)
+    out: list[str] = []
+    seen: set[str] = set()
     for spec in rows:
-        for cand in pin_candidates(spec):
-            key = cand.strip().lower()
-            if not key or key in seen:
-                continue
-            seen.add(key)
-            out.append(cand.strip())
+        provider = _provider_of_spec(spec)
+        model = _model_of_spec(spec)
+        hit = by_pair.get((provider, model.strip().lower()))
+        if hit and hit.lower() not in seen:
+            seen.add(hit.lower())
+            out.append(hit)
     return out
 
 
@@ -202,81 +218,26 @@ def resolve_swarm_worker_allowlist(
         "primary_adapter": str,         # WorkerSpec.adapter default
         "visibility_adapters": list[str],
         "platform_lock": list[str] | None,
-        "allowed_model_ids": list[str], # empty => do not constrain catalog
+        "allowed_model_ids": list[str], # always explicit; empty fails closed
       }
     """
-    visibility = adapters_from_visibility(specs)
-
-    # Live credentials also enlarge the union: a keyed agentic provider must
-    # stay eligible even when Models curation is empty/stale, and CURSOR_API_KEY
-    # keeps platform cursor reachable when Settings enabled Grok/Composer OR
-    # when visibility already selected cursor.
-    if _agentic_eligible():
-        visibility.add("agentic")
-    cursor_ready = _cursor_platform_ready()
-    if cursor_ready and ("cursor" in visibility or _cursor_intent_from_specs(specs)):
-        visibility.add("cursor")
-
-    # Fallback when visibility yielded nothing but credentials exist.
-    if not visibility:
-        if _agentic_eligible():
-            visibility.add("agentic")
-        elif cursor_ready:
-            visibility.add("cursor")
-
+    allowed_ids = allowed_model_ids_from_specs(specs)
+    visibility = {"agentic"} if (_agentic_eligible() or allowed_ids) else set()
+    allowed = {"agentic"} if visibility else set()
     lock = _platform_locked_adapters()
-    if lock is None:
-        allowed = {a for a in visibility if a in _PRODUCT_WORKER_ADAPTERS}
-    else:
-        allowed = {
-            a for a in visibility
-            if a in _PRODUCT_WORKER_ADAPTERS and a in lock
-        }
-        # Platform may still allow openai/codex under alternate names.
-        if "codex" in lock and "openai" in visibility:
-            allowed.add("openai")
-
-    # Never return an empty allowlist when we know a real adapter is ready —
-    # fail open to agentic (or cursor-only fallback) so routing can still run.
-    if not allowed:
-        if _agentic_eligible() and (lock is None or "agentic" in lock):
-            allowed = {"agentic"}
-        elif cursor_ready and (lock is None or "cursor" in lock):
-            allowed = {"cursor"}
-        elif lock:
-            allowed = {a for a in _PRODUCT_WORKER_ADAPTERS if a in lock}
-        else:
-            allowed = {"agentic"}
-
-    ordered = [a for a in _PRODUCT_WORKER_ADAPTERS if a in allowed]
-    for a in sorted(allowed):
-        if a not in ordered:
-            ordered.append(a)
-
-    has_agentic = "agentic" in allowed
-    # API-billed agentic eligible → never prefer $0 plan-billed Cursor first.
-    prefer_plan = False if has_agentic else ("cursor" in allowed)
-
-    if has_agentic:
-        primary = "agentic"
-    elif "cursor" in allowed:
-        primary = "cursor"
-    elif "openai" in allowed:
-        primary = "openai"
-    else:
-        primary = ordered[0]
+    if lock is not None and "agentic" not in lock:
+        allowed = set()
+    ordered = ["agentic"] if allowed else []
 
     return {
         "allowed_adapters": ordered,
-        "prefer_plan_billed": prefer_plan,
-        "primary_adapter": primary,
+        "prefer_plan_billed": False,
+        "primary_adapter": "agentic",
         "visibility_adapters": sorted(visibility),
         "platform_lock": sorted(lock) if lock is not None else None,
-        # Empty means "do not constrain the live catalog" (two-tier among
-        # keyed rows). Non-empty is fail-closed to Models toggles so a
-        # disabled gpt-5-3-codex cannot win auto-route while Luna is the
-        # only enabled picker row.
-        "allowed_model_ids": allowed_model_ids_from_specs(specs),
+        # Always present, including empty, so an empty eligible set fails
+        # closed instead of removing the router constraint.
+        "allowed_model_ids": allowed_ids,
     }
 
 

--- a/harness/swarm_worker_route.py
+++ b/harness/swarm_worker_route.py
@@ -1,60 +1,10 @@
 from __future__ import annotations
 
-"""Choose product swarm/implement worker adapter from live credentials.
-
-Default remains agentic (keyed HTTP). When no agentic provider is keyed but
-CURSOR_API_KEY is present, fall back to platform ``cursor`` so Cursor-plan
-installs can still run swarms/implements. Agent-login alone (cursor-cli) is
-never treated as sufficient for this path.
-"""
+"""Product workers use the agentic adapter with routed provider/model pairs."""
 
 from typing import Optional
 
-from .diag import note as _diag
 
-
-def resolve_product_worker_adapter(
-    configured: Optional[str] = None,
-) -> str:
-    """Return ``agentic``, ``openai``, or ``cursor`` for product dispatches."""
-    try:
-        from .swarm_adapter import resolve_bridge_swarm_adapter
-
-        base = resolve_bridge_swarm_adapter(configured)
-    except Exception as e:
-        _diag("swarm_worker_route.base", e)
-        base = "agentic"
-
-    if base in ("openai",):
-        return base
-    if base == "cursor":
-        return "cursor" if _cursor_platform_ready() else "agentic"
-    if base != "agentic":
-        return "agentic"
-
-    try:
-        from .auto_registry import keyed_agentic_providers
-
-        if keyed_agentic_providers():
-            return "agentic"
-    except Exception as e:
-        _diag("swarm_worker_route.keyed", e)
-        return "agentic"
-
-    if _cursor_platform_ready():
-        _diag(
-            "swarm_worker_route.cursor_fallback",
-            msg="no keyed agentic providers; CURSOR_API_KEY ready → cursor",
-        )
-        return "cursor"
+def resolve_product_worker_adapter(configured: Optional[str] = None) -> str:
+    """Return the only adapter permitted for Marionette product workers."""
     return "agentic"
-
-
-def _cursor_platform_ready() -> bool:
-    try:
-        from .provider_capabilities import cursor_platform_workers_ready
-
-        return bool(cursor_platform_workers_ready())
-    except Exception as e:
-        _diag("swarm_worker_route.cursor_ready", e)
-        return False

--- a/pmharness/bridge.py
+++ b/pmharness/bridge.py
@@ -1672,17 +1672,8 @@ def execute_intent(
         #   demo (no-repo / ALLOW_DEMO only) -> built-in local substrate for eval.
         # A live repo NEVER silently falls through to demo -- that produces
         # generic placeholder findings that read as a successful audit.
-        try:
-            from harness.swarm_worker_route import resolve_product_worker_adapter
-            swarm_adapter = resolve_product_worker_adapter()
-        except Exception:
-            try:
-                from harness.swarm_adapter import resolve_bridge_swarm_adapter
-                swarm_adapter = resolve_bridge_swarm_adapter(repo_cwd=repo_cwd)
-            except Exception:
-                swarm_adapter = (_os.environ.get("HARNESS_SWARM_ADAPTER", "demo") or "demo").lower()
-                if repo_cwd and swarm_adapter not in ("agentic", "openai", "cursor"):
-                    swarm_adapter = "agentic"
+        from harness.swarm_worker_route import resolve_product_worker_adapter
+        swarm_adapter = resolve_product_worker_adapter()
 
         if swarm_adapter == "cursor" and repo_cwd:
             # Platform Cursor SDK workers (CURSOR_API_KEY). Used when no agentic
@@ -1725,13 +1716,7 @@ def execute_intent(
             )
             adapter = "cursor"
         elif swarm_adapter == "agentic" and repo_cwd:
-            # Product swarm path: Settings + platform driven worker allowlist.
-            # Agentic (OpenRouter / OpenCode Go / Codex OAuth / …) stays the
-            # default primary when keyed, but Models-enabled Cursor
-            # Grok/Composer must also be reachable — never hard-lock
-            # allowed_adapters=['agentic'] when the union includes cursor.
-            # prefer_plan_billed=False whenever any API-billed agentic model
-            # is eligible so $0 plan picks do not starve OR cash models.
+            # Settings constrain exact provider/model pairs within agentic.
             _warn_if_unindexed(repo_cwd)
             from puppetmaster.workers import WorkerSpec
             try:
@@ -1741,13 +1726,15 @@ def execute_intent(
                 _allow = resolve_swarm_worker_allowlist()
             except Exception:
                 _allow = {
-                    "allowed_adapters": ["agentic"],
+                    # Resolution failures are fail-closed. Omitting the
+                    # allowlist would silently widen routing to the whole PM
+                    # catalog and violate the Settings contract.
+                    "allowed_adapters": [],
                     "prefer_plan_billed": False,
                     "primary_adapter": "agentic",
+                    "allowed_model_ids": [],
                 }
-            allowed_adapters = list(
-                _allow.get("allowed_adapters") or ["agentic"]
-            )
+            allowed_adapters = list(_allow.get("allowed_adapters") or [])
             prefer_plan_billed = bool(_allow.get("prefer_plan_billed"))
             primary_adapter = str(
                 _allow.get("primary_adapter") or "agentic"
@@ -1763,8 +1750,7 @@ def execute_intent(
             pin_fields: dict = {}
             pin_adapter = primary_adapter
             if pinned_model:
-                # Resolve against the Settings/platform worker adapter union
-                # (not agentic-only remap). Unknown pins demote to auto-route.
+                # Resolve against an exact Models-enabled live agentic row.
                 from harness.swarm_model_pin import resolve_swarm_model_pin
 
                 resolved = resolve_swarm_model_pin(
@@ -1772,8 +1758,11 @@ def execute_intent(
                 )
                 pin_fields = dict(resolved.get("pin_fields") or {})
                 if resolved.get("demoted"):
-                    pin_fields = {}
-                    pin_adapter = primary_adapter
+                    raise ValueError(
+                        str(resolved.get("reason") or (
+                            f"model pin {pinned_model!r} is unavailable"
+                        )) + ". Choose an exact Models-enabled live worker model."
+                    )
                 elif pin_fields.get("pinned_model"):
                     pin_fields["auto_route"] = False
                     pin_adapter = (
@@ -1787,9 +1776,8 @@ def execute_intent(
                     "read_only": True, "no_edit": True, "dry_run": True,
                     "cwd": repo_cwd, "prompt": intent.goal,
                     "auto_route": True,
-                    # Settings+platform union (agentic / cursor / openai),
-                    # never a hard agentic-only lock that rejects Cursor
-                    # Grok when Models toggles enable it.
+                    # Product workers are always agentic; provider/model is
+                    # selected inside that adapter.
                     "allowed_adapters": list(allowed_adapters),
                     # False whenever API-billed agentic is eligible so OR
                     # cash models are not starved by plan-billed Cursor.
@@ -1820,9 +1808,9 @@ def execute_intent(
                     "routing_policy": "balanced",
                     **_analysis_capability_payload(),
                 }
-                if allowed_model_ids and not pin_fields:
-                    # Fail-closed to Settings Models toggles. A global
-                    # intent.model pin still wins via pin_fields below.
+                if not pin_fields:
+                    # Always stamp this field, including empty, so no eligible
+                    # model cannot widen routing back to the whole catalog.
                     base_payload["allowed_model_ids"] = list(allowed_model_ids)
                 if pin_fields:
                     base_payload.update(pin_fields)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.459"
+version = "0.9.460"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [
     "pypdf",
     # Runtime ownership: a standalone `pip install pm-harness` must pull the
     # pinned Puppetmaster bridge. Desktop/Electron still re-checks the same pin.
-    "puppetmaster-ai==1.27.10",
+    "puppetmaster-ai==1.27.11",
     "tzdata>=2026.3",
 ]
 

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.27.10" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.27.11" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.27.10"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.27.11"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.27.10" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.27.11" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.27.10}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.27.11}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,16 @@ def force_throwaway_harness_state_dir() -> str:
 
 
 force_throwaway_harness_state_dir()
+# Registry sync uses its own path, independently of HARNESS_STATE_DIR.
+# Bind it before collection so pin tests cannot rewrite the running app's rows.
+os.environ["PUPPETMASTER_MODELS_PATH"] = os.path.join(
+    os.environ["HARNESS_STATE_DIR"], "marionette-models.json",
+)
+from harness import model_visibility as _model_visibility
+
+_model_visibility._store_path = lambda: os.path.join(
+    os.environ["HARNESS_STATE_DIR"], "models.json",
+)
 
 # Checkpoint metadata uses Path.home independently of HARNESS_STATE_DIR.
 # Bind only that module's path facade before collection constructs any stores.
@@ -376,6 +386,7 @@ def _isolate_provider_state(monkeypatch, tmp_path_factory):
 
     d = tmp_path_factory.mktemp("pmstate")
     monkeypatch.setenv("HARNESS_STATE_DIR", str(d))
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(d / "marionette-models.json"))
 
     server_mod = sys.modules.get("harness.server")
     test_store = None

--- a/tests/test_bridge_agentic_swarm_routing.py
+++ b/tests/test_bridge_agentic_swarm_routing.py
@@ -341,8 +341,8 @@ def test_agentic_swarm_explicit_model_pin_disables_auto_route(monkeypatch, tmp_p
     assert payload.get("allowed_adapters") == ["agentic"]
 
 
-def test_agentic_swarm_unknown_model_pin_demotes_to_auto_route(monkeypatch, tmp_path):
-    """Unknown/pilot-session pins must not fail the swarm — demote to auto-route."""
+def test_agentic_swarm_unknown_model_pin_fails_without_dispatch(monkeypatch, tmp_path):
+    """An unavailable explicit pin must not dispatch a different model."""
     _CapturingWorkerSpec._last_captured = []
     monkeypatch.setenv("HARNESS_SWARM_ADAPTER", "agentic")
     monkeypatch.setenv("HARNESS_REPO", str(tmp_path))
@@ -369,20 +369,15 @@ def test_agentic_swarm_unknown_model_pin_demotes_to_auto_route(monkeypatch, tmp_
         roles=["explore"],
         model="cursor/gpt-5-6-luna",
     )
-    result = bridge.execute_intent(intent, state_dir=str(tmp_path / "state"))
-    assert result is not None
-    assert _CapturingWorkerSpec._last_captured
-    payload = _CapturingWorkerSpec._last_captured[0].payload
-    assert payload.get("auto_route") is True
-    assert not payload.get("pinned_model")
-    assert not payload.get("model")
-    assert payload.get("allowed_adapters") == ["agentic"]
+    with pytest.raises(ValueError, match="Choose an exact Models-enabled"):
+        bridge.execute_intent(intent, state_dir=str(tmp_path / "state"))
+    assert _CapturingWorkerSpec._last_captured == []
 
 
-def test_swarm_falls_back_to_platform_cursor_when_no_agentic_keys(
+def test_swarm_keeps_agentic_constraints_when_no_agentic_keys(
     monkeypatch, tmp_path,
 ):
-    """CURSOR_API_KEY alone must still drive real swarms (not agentic-empty fail)."""
+    """Cursor credentials do not grant permission to a different worker adapter."""
     _CapturingWorkerSpec._last_captured = []
     monkeypatch.setenv("HARNESS_SWARM_ADAPTER", "agentic")
     monkeypatch.setenv("HARNESS_REPO", str(tmp_path))
@@ -402,12 +397,12 @@ def test_swarm_falls_back_to_platform_cursor_when_no_agentic_keys(
     )
     result = bridge.execute_intent(intent, state_dir=str(tmp_path / "state"))
     assert result is not None
-    assert result.adapter == "cursor"
+    assert result.adapter == "agentic"
     assert _CapturingWorkerSpec._last_captured
     spec = _CapturingWorkerSpec._last_captured[0]
-    assert spec.adapter == "cursor"
-    assert spec.payload.get("allowed_adapters") == ["cursor"]
-    assert spec.payload.get("prefer_plan_billed") is True
+    assert spec.adapter == "agentic"
+    assert spec.payload["allowed_adapters"] == []
+    assert spec.payload["allowed_model_ids"] == []
 
 
 def test_swarm_cursor_model_pin_uses_cursor_adapter_in_union(monkeypatch, tmp_path):
@@ -648,7 +643,11 @@ def _install_two_tier_product_path(monkeypatch, tmp_path):
     _RoutingOrchestrator.last_decisions = []
     monkeypatch.setenv("HARNESS_SWARM_ADAPTER", "agentic")
     monkeypatch.setenv("HARNESS_REPO", str(tmp_path))
-    _pin_agentic_only_allowlist(monkeypatch)
+    monkeypatch.setattr("harness.auto_registry.keyed_agentic_providers", lambda: {"openai-codex"})
+    monkeypatch.setattr("harness.swarm_worker_allowlist._platform_locked_adapters", lambda: frozenset({"agentic"}))
+    monkeypatch.setattr("harness.swarm_worker_allowlist._enabled_or_visible_specs", lambda: [
+        "openai-codex:gpt-5.6-luna", "openai-codex:gpt-5.6-sol",
+    ])
     monkeypatch.setattr("puppetmaster.workers.WorkerSpec", _CapturingWorkerSpec)
     monkeypatch.setattr("puppetmaster.orchestrator.Orchestrator", _RoutingOrchestrator)
     monkeypatch.setattr(bridge, "_warn_if_unindexed", lambda *_a, **_k: None)

--- a/tests/test_edit_engines.py
+++ b/tests/test_edit_engines.py
@@ -789,6 +789,27 @@ def test_agentic_payload_stamps_settings_allowlist_not_glm(monkeypatch):
             ],
         )
         monkeypatch.setattr(
+            "harness.swarm_model_pin._registry_rows",
+            lambda **_: [
+                {
+                    "id": "agentic/openai-codex/gpt-5.6-luna",
+                    "adapter": "agentic",
+                    "adapter_model_name": "gpt-5.6-luna",
+                    "payload_defaults": {"provider": "openai-codex"},
+                },
+                {
+                    "id": "agentic/google/gemini-3.8-flash",
+                    "adapter": "agentic",
+                    "adapter_model_name": "google/gemini-3.8-flash",
+                    "payload_defaults": {"provider": "openrouter"},
+                },
+            ],
+        )
+        monkeypatch.setattr(
+            "harness.auto_registry.keyed_agentic_providers",
+            lambda: {"openai-codex", "openrouter"},
+        )
+        monkeypatch.setattr(
             "harness.edit_engines.finalize_worktree_patch",
             lambda _wt: ("diff content", ["test.txt"]),
         )
@@ -826,6 +847,22 @@ def test_agentic_payload_token_budget_from_env(monkeypatch):
         assert captured[0]["token_budget"] == 77777
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+def test_settings_allowlist_resolution_failure_fails_closed(monkeypatch):
+    from harness.edit_engines import _stamp_settings_model_allowlist
+
+    def explode():
+        raise RuntimeError("allowlist unavailable")
+
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist.resolve_swarm_worker_allowlist",
+        explode,
+    )
+    payload = _stamp_settings_model_allowlist({"auto_route": True})
+
+    assert payload["allowed_adapters"] == ["agentic"]
+    assert payload["allowed_model_ids"] == []
 
 
 def test_agentic_edit_stamps_routed_model_from_routing_artifact(monkeypatch):

--- a/tests/test_full_gas.py
+++ b/tests/test_full_gas.py
@@ -125,7 +125,7 @@ def _wait_for_swarms(session, timeout=10.0):
         _t.sleep(0.05)
     return list(session.drain_swarm_results())
 
-def test_executor_smoke_run_implement():
+def test_executor_smoke_run_implement(monkeypatch):
     import os
     import shutil
     import subprocess
@@ -200,25 +200,28 @@ def test_executor_smoke_run_implement():
             mock_run.side_effect = side_effect
             
             session = ConversationalSession(cfg)
+            from harness.worker import WorkerResult
+            monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+            monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
+            monkeypatch.setattr(
+                "harness.edit_engines.run_agentic_edit",
+                lambda config, goal, **kwargs: WorkerResult(
+                    ok=True,
+                    patch="diff --git a/src/main.py b/src/main.py\nnew file mode 100644\n--- /dev/null\n+++ b/src/main.py\n@@ -0,0 +1 @@\n+print('hello')\n",
+                    files_changed=["src/main.py"],
+                    summary="agentic patch",
+                ),
+            )
             
-            # We inject our detect function mock to always return "cursor"
-            session._detect_default_implement_adapter = MagicMock(return_value="cursor")
-            # This smoke test exercises the EXTERNAL puppetmaster-CLI dispatch path,
-            # so force puppetmaster availability and request an external adapter
-            # explicitly (the default path is now the provider-native worker, which
-            # does not Popen the CLI -- covered by test_run_implement_provider.py).
+            # Keep the old process probes installed so this test proves the
+            # agentic path does not launch a provider CLI.
             import harness.conversation as _convmod
-            session_pm_orig = getattr(_convmod, "_puppetmaster_available", None)
-            _convmod._puppetmaster_available = lambda: True
-            # Force the external CLI adapter to read as available so this test keeps
-            # exercising the external dispatch path (the requested CLI is not installed
-            # in CI; without this the implement correctly falls back to the
-            # provider-native worker, which is covered separately).
+            monkeypatch.setattr(_convmod, "_puppetmaster_available", lambda: True)
             session._external_adapter_available = lambda adapter: True
             
-            # Send a prompt triggering a pilot action (explicit external adapter)
+            # Send a prompt triggering an explicit agentic action.
             from harness.pilot import PilotAction
-            action = PilotAction(kind="run_implement", goal="Add print statement", adapter="cursor")
+            action = PilotAction(kind="run_implement", goal="Add print statement", adapter="agentic")
             
             # Directly invoke our send logic or trigger actions processing
             class FakePilot:
@@ -229,7 +232,7 @@ def test_executor_smoke_run_implement():
                     from pmharness.drivers.openai_compat import DriverResponse
                     self.calls += 1
                     if self.calls == 1:
-                        txt = '{"say": "Starting implement worker.", "actions": [{"kind": "run_implement", "goal": "Add print statement", "adapter": "cursor"}]}'
+                        txt = '{"say": "Starting implement worker.", "actions": [{"kind": "run_implement", "goal": "Add print statement", "adapter": "agentic"}]}'
                     else:
                         txt = '{"say": "Done.", "actions": []}'
                     return DriverResponse(text=txt, tokens_out=10, latency_ms=1.0)
@@ -245,8 +248,12 @@ def test_executor_smoke_run_implement():
             # patch applies in a background future.
             assert "swarm_pending" in kinds
             
-            # Verify mock_popen was called at least once
-            assert mock_popen.call_count >= 1
+            # Product dispatch is agentic and must not launch a provider CLI.
+            assert not any(
+                any("puppetmaster" in str(arg) for arg in call.args[0])
+                for call in mock_popen.call_args_list
+                if call.args
+            )
             
             # Wait for the background apply to complete, then assert the file landed.
             _wait_for_swarms(session)
@@ -260,7 +267,7 @@ def test_executor_smoke_run_implement():
         shutil.rmtree(temp_repo, ignore_errors=True)
 
 
-def test_executor_smoke_run_parallel():
+def test_executor_smoke_run_parallel(monkeypatch):
     import os
     import shutil
     import subprocess
@@ -350,9 +357,20 @@ def test_executor_smoke_run_parallel():
             mock_run.side_effect = side_effect
             
             session = ConversationalSession(cfg)
+            from harness.worker import WorkerResult
+            monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+            monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
+            def fake_agentic(config, goal, **kwargs):
+                name = "job_abcdef111111" if goal == "Audit auth" else "job_abcdef222222"
+                filename = f"src/{name}.py"
+                return WorkerResult(
+                    ok=True,
+                    patch=f"diff --git a/{filename} b/{filename}\nnew file mode 100644\n--- /dev/null\n+++ b/{filename}\n@@ -0,0 +1 @@\n+print('{name}')\n",
+                    files_changed=[filename], summary="agentic patch",
+                )
+            monkeypatch.setattr("harness.edit_engines.run_agentic_edit", fake_agentic)
             session._detect_default_implement_adapter = MagicMock(return_value="hermes")
-            # Keep exercising the external dispatch path even though the requested
-            # CLI is not installed in CI (otherwise it falls back to provider-native).
+            # An available provider CLI must not change agentic dispatch.
             session._external_adapter_available = lambda adapter: True
             
             class FakeParallelPilot:
@@ -363,7 +381,7 @@ def test_executor_smoke_run_parallel():
                     from pmharness.drivers.openai_compat import DriverResponse
                     self.calls += 1
                     if self.calls == 1:
-                        txt = '{"say": "Running in parallel.", "actions": [{"kind": "run_parallel", "adapter": "cursor", "goals": ["Audit auth", "Audit cache"], "mode": "implement"}]}'
+                        txt = '{"say": "Running in parallel.", "actions": [{"kind": "run_parallel", "adapter": "agentic", "goals": ["Audit auth", "Audit cache"], "mode": "implement"}]}'
                     else:
                         txt = '{"say": "Done.", "actions": []}'
                     return DriverResponse(text=txt, tokens_out=10, latency_ms=1.0)
@@ -371,8 +389,8 @@ def test_executor_smoke_run_parallel():
             session.pilot = FakeParallelPilot()
             events = list(session.send("Run parallel checks!"))
             
-            # Let's verify our processes were fanned out
-            assert len(p_calls) == 2
+            # Workers run through agentic without spawning provider CLIs.
+            assert len(p_calls) == 0
             # Verify aggregate result is returned
             kinds = [e.kind for e in events]
             assert "action_result" in kinds
@@ -400,7 +418,7 @@ def test_executor_smoke_run_parallel():
 @patch("shutil.rmtree")
 @patch("subprocess.Popen")
 @patch("subprocess.run")
-def test_run_parallel_state_dir_and_fallback(mock_run, mock_popen, mock_rmtree, mock_mkdtemp, mock_which, tmp_path):
+def test_run_parallel_explicit_cursor_is_rejected(mock_run, mock_popen, mock_rmtree, mock_mkdtemp, mock_which, tmp_path):
     mock_which.return_value = None
     mock_mkdtemp.side_effect = ["/tmp/pmh-par-1", "/tmp/pmh-par-2"]
 
@@ -458,8 +476,7 @@ def test_run_parallel_state_dir_and_fallback(mock_run, mock_popen, mock_rmtree, 
     
     session = ConversationalSession(cfg)
     session._detect_default_implement_adapter = MagicMock(return_value="hermes")
-    # Keep exercising the external dispatch path even though the requested CLI is
-    # not installed in CI (otherwise it falls back to the provider-native worker).
+    # Explicit unsupported adapters fail even when their CLI is available.
     session._external_adapter_available = lambda adapter: True
     
     class FakeParallelPilot:
@@ -477,34 +494,9 @@ def test_run_parallel_state_dir_and_fallback(mock_run, mock_popen, mock_rmtree, 
             
     session.pilot = FakeParallelPilot()
     events = list(session.send("Run parallel checks!"))
-    # New offload model: dispatch (Popen) is synchronous in-turn, but await/artifacts/last/rmtree
-    # run in the background futures -- wait for them before asserting on those calls.
+    # Explicit CLI adapters are unsupported product inputs and fail closed.
     kinds = [e.kind for e in events]
-    assert "swarm_pending" in kinds
-    _wait_for_swarms(session)
-    
-    assert mock_popen.call_count == 2
-    args1 = mock_popen.call_args_list[0][0][0]
-    args2 = mock_popen.call_args_list[1][0][0]
-    
-    assert args1[1:5] == ["-m", "puppetmaster", "--state-dir", "/tmp/pmh-par-1"]
-    assert args2[1:5] == ["-m", "puppetmaster", "--state-dir", "/tmp/pmh-par-2"]
-    
-    last_calls = [c[0][0] for c in mock_run.call_args_list if "last" in c[0][0]]
-    assert len(last_calls) == 1
-    assert last_calls[0] == [sys.executable, "-m", "puppetmaster", "--state-dir", "/tmp/pmh-par-2", "last"]
-    
-    await_calls = [c[0][0] for c in mock_run.call_args_list if "await" in c[0][0]]
-    assert len(await_calls) == 2
-    assert ["--state-dir", "/tmp/pmh-par-1"] in [await_calls[0][3:5], await_calls[1][3:5]]
-    assert ["--state-dir", "/tmp/pmh-par-2"] in [await_calls[0][3:5], await_calls[1][3:5]]
-    
-    art_calls = [c[0][0] for c in mock_run.call_args_list if "artifacts" in c[0][0]]
-    assert len(art_calls) == 2
-    assert ["--state-dir", "/tmp/pmh-par-1"] in [art_calls[0][3:5], art_calls[1][3:5]]
-    assert ["--state-dir", "/tmp/pmh-par-2"] in [art_calls[0][3:5], art_calls[1][3:5]]
-    
-    assert mock_rmtree.call_count == 2
-    mock_rmtree.assert_any_call("/tmp/pmh-par-1", ignore_errors=True)
-    mock_rmtree.assert_any_call("/tmp/pmh-par-2", ignore_errors=True)
-
+    assert "swarm_pending" not in kinds
+    results = [e for e in events if e.kind == "action_result"]
+    assert results and "unsupported" in (results[-1].data.get("error") or "").lower()
+    assert mock_popen.call_count == 0

--- a/tests/test_no_progress_loop.py
+++ b/tests/test_no_progress_loop.py
@@ -328,10 +328,8 @@ def test_bare_run_implement_forces_analysis_for_audit_goal(monkeypatch):
         "harness.implement_guards.check_oversized_single_file_rewrite",
         lambda *a, **k: None,
     )
-    monkeypatch.setattr(
-        "harness.edit_engines.select_edit_engine",
-        lambda *a, **k: "native",
-    )
+    monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+    monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
     monkeypatch.setattr(
         "harness.send_loop_dispatch._puppetmaster_available",
         lambda: False,
@@ -357,8 +355,10 @@ def test_bare_run_implement_forces_analysis_for_audit_goal(monkeypatch):
     role = kw.get("role") or (args[2] if len(args) > 2 else None)
     assert role == "analysis"
     submit_args = session._submit_swarm.call_args.args
-    # (fn, job_id, goal, adapter, repo, expects_diff)
-    assert submit_args[-1] is False
+    # (fn, job_id, goal, adapter, repo, expects_diff, agentic_pin, strict_adapter)
+    assert submit_args[4] == "/tmp/repo"
+    assert submit_args[5] is False
+    assert submit_args[7] is True
 
 
 def test_failed_objective_resume_cap_suppresses_pilot_resume():

--- a/tests/test_openai_compat_stream_terminals.py
+++ b/tests/test_openai_compat_stream_terminals.py
@@ -73,6 +73,28 @@ def test_clean_stop_succeeds(monkeypatch):
     assert resp.meta["malformed_sse_chunks"] == 0
 
 
+@pytest.mark.parametrize("answer,with_tool", [("", True), ("Answer", False), ("", False)])
+def test_deepseek_sse_reasoning_never_becomes_spoken_answer(monkeypatch, answer, with_tool):
+    from harness.send_loop_phases import resolve_emit_say_texts
+
+    reasoning = "fixture private planning"
+    delta = {"content": answer}
+    if with_tool:
+        delta["tool_calls"] = [{"index": 0, "id": "call-1", "type": "function", "function": {
+            "name": "read_file", "arguments": '{"path":"fixture.txt"}',
+        }}]
+    seen = []
+    resp = _run_stream(monkeypatch, _driver(model="deepseek-flash"), [
+        _data({"choices": [{"delta": {"reasoning_content": reasoning}}]}),
+        _data({"choices": [{"delta": delta, "finish_reason": "tool_calls" if with_tool else "stop"}]}),
+        b"data: [DONE]\n",
+    ], on_reasoning_delta=seen.append)
+    assert "".join(seen) == reasoning
+    assert resolve_emit_say_texts(cleaned_say_text=resp.text or "", resp=resp) == (answer, "", "")
+    if with_tool:
+        assert resp.meta["tool_calls"][0]["function"]["name"] == "read_file"
+
+
 def test_duplicate_content_snapshot_does_not_double_text(monkeypatch):
     phrase = "Received—single response."
     seen = []

--- a/tests/test_post_swarm_synthesis.py
+++ b/tests/test_post_swarm_synthesis.py
@@ -322,10 +322,10 @@ def test_streamed_answer_does_not_get_a_second_synthesis(monkeypatch):
     assert events[-1].kind == "assistant_done"
 
 
-def test_reasoning_only_post_swarm_synthesis_is_promoted_before_done(monkeypatch):
+def test_cursor_reasoning_only_post_swarm_synthesis_is_promoted_before_done(monkeypatch):
     def reasoning_only(**kwargs: Any) -> DriverResponse:
         kwargs["on_reasoning_delta"]("The audit found one issue.")
-        return DriverResponse(text="")
+        return DriverResponse(text="", meta={"cursor_cli": True})
 
     pilot = _SequencePilot([
         _pilot_envelope(actions=[{"kind": "run_swarm", "goal": "audit findings"}]),

--- a/tests/test_product_agentic_allowlist.py
+++ b/tests/test_product_agentic_allowlist.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import pytest
+
+from harness.swarm_model_pin import resolve_swarm_model_pin
+from harness.swarm_worker_allowlist import (
+    allowed_model_ids_from_specs,
+    resolve_swarm_worker_allowlist,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_routing(monkeypatch):
+    monkeypatch.setattr("harness.auto_registry.ensure_keyed_provider_registry_health", lambda: {"ready": True})
+    monkeypatch.setattr("harness.swarm_model_pin._settings_enabled_specs", lambda: None)
+
+
+def _rows():
+    return [
+        {
+            "id": "agentic/openai-codex/gpt-5.6-luna",
+            "adapter": "agentic",
+            "adapter_model_name": "gpt-5.6-luna",
+            "payload_defaults": {"provider": "openai-codex"},
+        },
+        {
+            "id": "agentic/gpt-5.6-luna",
+            "adapter": "agentic",
+            "adapter_model_name": "gpt-5.6-luna",
+            "payload_defaults": {"provider": "opencode-go"},
+        },
+    ]
+
+
+def test_allowlist_emits_only_exact_provider_model_registry_id(monkeypatch):
+    monkeypatch.setattr("harness.swarm_model_pin._registry_rows", lambda **_: _rows())
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: {"openai-codex", "opencode-go"},
+    )
+
+    assert allowed_model_ids_from_specs(
+        ["openai-codex:gpt-5.6-luna"]
+    ) == ["agentic/openai-codex/gpt-5.6-luna"]
+
+
+def test_allowlist_empty_ids_and_adapters_fail_closed(monkeypatch):
+    monkeypatch.setattr("harness.swarm_model_pin._registry_rows", lambda **_: _rows())
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._agentic_eligible", lambda: True
+    )
+    monkeypatch.setattr(
+        "harness.swarm_worker_allowlist._platform_locked_adapters", lambda: None
+    )
+
+    out = resolve_swarm_worker_allowlist(specs=["openrouter:not-live"])
+    assert out["allowed_adapters"] == ["agentic"]
+    assert out["allowed_model_ids"] == []
+
+
+def test_explicit_pin_cannot_cross_provider_or_synthesize_id(monkeypatch):
+    monkeypatch.setattr("harness.swarm_model_pin._registry_rows", lambda **_: _rows())
+    monkeypatch.setattr(
+        "harness.auto_registry.ensure_keyed_provider_registry_health",
+        lambda: {"ready": True},
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: {"openai-codex", "opencode-go"},
+    )
+
+    out = resolve_swarm_model_pin(
+        "openai-codex:gpt-5.6-luna", allowed_adapters=["agentic"]
+    )
+    assert out["resolved"] == "agentic/openai-codex/gpt-5.6-luna"
+    assert out["pin_fields"]["provider"] == "openai-codex"
+
+    missing = resolve_swarm_model_pin(
+        "openrouter:gpt-5.6-luna", allowed_adapters=["agentic"]
+    )
+    assert missing["demoted"] is True
+    assert "not in keyed worker registry" in missing["reason"]
+
+
+def test_disabled_and_unkeyed_rows_are_not_pin_eligible(monkeypatch):
+    rows = [
+        {
+            **_rows()[0],
+            "enabled": False,
+        },
+        {
+            "id": "agentic/openrouter/google/gemini-3.8-flash",
+            "adapter": "agentic",
+            "adapter_model_name": "google/gemini-3.8-flash",
+            "payload_defaults": {"provider": "openrouter"},
+        },
+    ]
+    monkeypatch.setattr("harness.swarm_model_pin._registry_rows", lambda **_: rows)
+    monkeypatch.setattr(
+        "harness.swarm_model_pin._settings_enabled_specs",
+        lambda: [
+            "openai-codex:gpt-5.6-luna",
+            "openrouter:google/gemini-3.8-flash",
+        ],
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: {"openai-codex"},
+    )
+
+    disabled = resolve_swarm_model_pin(
+        "openai-codex:gpt-5.6-luna", allowed_adapters=["agentic"]
+    )
+    unkeyed = resolve_swarm_model_pin(
+        "agentic/openrouter/google/gemini-3.8-flash", allowed_adapters=["agentic"]
+    )
+    assert disabled["demoted"] is True
+    assert unkeyed["demoted"] is True
+
+
+def test_canonical_id_uses_registry_provider_and_defaults(monkeypatch):
+    row = {
+        "id": "agentic/openrouter/google/gemini-3.8-flash",
+        "adapter": "agentic",
+        "adapter_model_name": "google/gemini-3.8-flash",
+        "billing": "api",
+        "payload_defaults": {
+            "provider": "openrouter",
+            "params": ["temperature", "max_tokens"],
+        },
+    }
+    monkeypatch.setattr("harness.swarm_model_pin._registry_rows", lambda **_: [row])
+    monkeypatch.setattr(
+        "harness.swarm_model_pin._settings_enabled_specs",
+        lambda: ["openrouter:google/gemini-3.8-flash"],
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: {"openrouter"},
+    )
+
+    out = resolve_swarm_model_pin(
+        "agentic/openrouter/google/gemini-3.8-flash", allowed_adapters=["agentic"]
+    )
+    assert out["resolved"] == row["id"]
+    assert out["pin_fields"]["provider"] == "openrouter"
+    assert out["pin_fields"]["params"] == ["temperature", "max_tokens"]

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -43,7 +43,7 @@ def test_annotate_provider_row_stamps_labels():
     assert "workers" in row["worker_capability_hint"].lower()
 
 
-def test_product_worker_adapter_falls_back_to_cursor(monkeypatch):
+def test_product_worker_adapter_does_not_fall_back_to_cursor(monkeypatch):
     monkeypatch.setattr(
         "harness.auto_registry.keyed_agentic_providers",
         lambda: set(),
@@ -58,7 +58,7 @@ def test_product_worker_adapter_falls_back_to_cursor(monkeypatch):
     )
     from harness.swarm_worker_route import resolve_product_worker_adapter
 
-    assert resolve_product_worker_adapter() == "cursor"
+    assert resolve_product_worker_adapter() == "agentic"
 
 
 def test_product_worker_adapter_prefers_keyed_agentic(monkeypatch):

--- a/tests/test_provider_result_acceptance.py
+++ b/tests/test_provider_result_acceptance.py
@@ -150,7 +150,7 @@ def test_foreground_command_call_sites_preserve_outcome(tmp_path, monkeypatch, e
     assert receipt['status'] == status
     assert receipt.get('is_error') is error
     if error is False:
-        assert receipt['content'].startswith("(run_command 'echo done' completed with exit code 0)")
+        assert receipt['content'].startswith("(run_command foreground-call completed with exit code 0)")
 
 
 @pytest.mark.parametrize('status', ['ok', 'success', 'completed', 'done', 'no_op', 'native_image'])

--- a/tests/test_queue_concurrency.py
+++ b/tests/test_queue_concurrency.py
@@ -79,7 +79,7 @@ def test_await_and_apply_job_characterization(tmp_path):
     assert file_path.read_text() == "Hello World\nHello New World\n"
 
 
-def test_queue_drains_while_swarm_pending(tmp_path):
+def test_queue_drains_while_swarm_pending(tmp_path, monkeypatch):
     # Set up a git repo in tmp_path
     subprocess.run(["git", "init"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
@@ -88,6 +88,8 @@ def test_queue_drains_while_swarm_pending(tmp_path):
     cfg = HarnessConfig()
     cfg.repo = str(tmp_path)
     session = ConversationalSession(cfg)
+    monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+    monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
     
     # Mock puppetmaster being available
     with patch("harness.send_loop_dispatch._puppetmaster_available", return_value=True), \
@@ -97,7 +99,7 @@ def test_queue_drains_while_swarm_pending(tmp_path):
         first_resp = MagicMock()
         first_resp.text = json.dumps({
             "say": "I will run implement now.",
-            "actions": [{"kind": "run_implement", "goal": "Apply fix to hello.txt", "adapter": "cursor"}]
+            "actions": [{"kind": "run_implement", "goal": "Apply fix to hello.txt", "adapter": "agentic"}]
         })
         first_resp.meta = {}
         first_resp.error = None
@@ -143,6 +145,15 @@ def test_queue_drains_while_swarm_pending(tmp_path):
             }
         
         session._await_and_apply_job = mock_await_and_apply
+
+        # Agentic local jobs enter the same background pool; hold the worker
+        # boundary so the second user turn can run while the first is pending.
+        from harness.worker import WorkerResult
+        def blocked_worker(*args, **kwargs):
+            block_event.wait()
+            return WorkerResult(ok=True, patch="", files_changed=[], summary="completed")
+
+        monkeypatch.setattr(session, "_run_edit_worker_bounded", blocked_worker)
         
         with patch("subprocess.Popen", return_value=mock_proc):
             events_one = list(session.send("turn one"))
@@ -150,7 +161,8 @@ def test_queue_drains_while_swarm_pending(tmp_path):
         # Assert a swarm_pending event was emitted
         pending_events = [e for e in events_one if e.kind == "swarm_pending"]
         assert len(pending_events) == 1
-        assert pending_events[0].data["job_ids"] == ["job_123456789012"]
+        assert len(pending_events[0].data["job_ids"]) == 1
+        assert pending_events[0].data["job_ids"][0].startswith("local-")
         assert pending_events[0].data["objective"] == "Apply fix to hello.txt"
         
         # After send returns, self._busy is NOT held!
@@ -175,7 +187,7 @@ def test_queue_drains_while_swarm_pending(tmp_path):
         drain_events = list(session.drain_swarm_results())
         swarm_results = [e for e in drain_events if e.kind == "swarm_result"]
         assert len(swarm_results) == 1
-        assert swarm_results[0].data["job_id"] == "job_123456789012"
+        assert swarm_results[0].data["job_id"] == pending_events[0].data["job_ids"][0]
         
         # Check that history has exactly one follow-up assistant message for the result.
         # Model-visible drain is the complete delivery receipt; full summary stays on
@@ -345,4 +357,3 @@ def test_api_session_state_endpoint():
         assert data["pending_swarms"] is False
     finally:
         httpd.shutdown()
-

--- a/tests/test_run_implement_provider.py
+++ b/tests/test_run_implement_provider.py
@@ -5,8 +5,9 @@ import sys
 import tempfile
 import subprocess
 from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
 
-from harness.worker import ProviderWorker, WorkerResult
+from harness.worker import WorkerResult
 from harness.conversation import ConversationalSession, ConvEvent
 from harness.config import HarnessConfig
 
@@ -31,13 +32,11 @@ def test_run_implement_provider_default(monkeypatch):
         cfg.repo = repo_dir
         session = ConversationalSession(cfg)
 
-        # Pin the native engine so this exercises Marionette's own pilot + the
-        # apply pipeline deterministically regardless of which provider keys the
-        # test host happens to have (agentic is the default only when a key exists).
-        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
-        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
+        # Supply an available agentic worker independently of host credentials.
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+        monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
 
-        # Mock ProviderWorker.run to return a canned patch
+        # Return a patch at the agentic worker boundary.
         canned_patch = (
             "diff --git a/test.txt b/test.txt\n"
             "--- a/test.txt\n"
@@ -64,7 +63,7 @@ def test_run_implement_provider_default(monkeypatch):
             assert self.goal == "Add world to test.txt"
             return canned_result
 
-        monkeypatch.setattr(ProviderWorker, "run", mock_worker_run)
+        monkeypatch.setattr("harness.edit_engines.run_agentic_edit", lambda config, goal, **kwargs: mock_worker_run(SimpleNamespace(goal=goal, repo=config.repo)))
 
         # Mock pilot completing and returning run_implement action with NO adapter
         mock_pilot = MagicMock()
@@ -87,7 +86,7 @@ def test_run_implement_provider_default(monkeypatch):
         # The specific action_start should be the last one
         specific_start = action_starts[-1]
         assert specific_start.data["kind"] == "run_implement"
-        assert specific_start.data["mode"] == "native"
+        assert specific_start.data["mode"] == "agentic"
 
         swarm_pendings = [e for e in events if e.kind == "swarm_pending"]
         assert len(swarm_pendings) == 1
@@ -122,7 +121,7 @@ def test_run_implement_provider_default(monkeypatch):
         shutil.rmtree(repo_dir, ignore_errors=True)
 
 
-def test_run_implement_external_fallback(monkeypatch):
+def test_run_implement_explicit_external_adapter_is_rejected(monkeypatch):
     repo_dir = create_temp_git_repo()
     try:
         cfg = HarnessConfig()
@@ -131,9 +130,7 @@ def test_run_implement_external_fallback(monkeypatch):
 
         # Mock puppetmaster available (dispatch lives in send_loop after the peel)
         monkeypatch.setattr("harness.send_loop_dispatch._puppetmaster_available", lambda: True)
-        # Mock the external adapter CLI as available so this test exercises the
-        # external dispatch path (cursor is not installed in CI; without this it
-        # would correctly fall back to the provider-native worker).
+        # CLI availability must not authorize an unsupported product adapter.
         monkeypatch.setattr(ConversationalSession, "_external_adapter_available", lambda self, adapter: True)
 
         # Mock puppetmaster cmd
@@ -160,20 +157,17 @@ def test_run_implement_external_fallback(monkeypatch):
         # Send a message to start the action
         events = list(session.send("start implement"))
 
-        # Assert action_start is emitted and DOES NOT have mode="provider" (meaning it took the external path)
+        # Explicit non-agentic adapters fail closed; no CLI fallback is allowed.
         action_starts = [e for e in events if e.kind == "action_start"]
         assert len(action_starts) >= 1
         specific_start = action_starts[-1]
         assert specific_start.data["kind"] == "run_implement"
         assert "mode" not in specific_start.data
 
-        # Assert correct swarm_pending is emitted with the mocked job_id from puppetmaster CLI output
-        swarm_pendings = [e for e in events if e.kind == "swarm_pending"]
-        assert len(swarm_pendings) == 1
-        assert swarm_pendings[0].data["job_ids"] == ["job_123456789012"]
-
-        assert len(pm_cmd_called) > 0
-        assert "cursor" in pm_cmd_called[0]
+        results = [e for e in events if e.kind == "action_result"]
+        assert any("unsupported" in (e.data.get("error") or "").lower() for e in results)
+        assert not any(e.kind == "swarm_pending" for e in events)
+        assert not pm_cmd_called
 
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)
@@ -194,9 +188,9 @@ def test_run_implement_falls_back_to_provider_when_cli_absent(monkeypatch):
         monkeypatch.setattr("harness.send_loop_dispatch._puppetmaster_available", lambda: True)
         # The external adapter CLI is NOT available.
         monkeypatch.setattr(ConversationalSession, "_external_adapter_available", lambda self, adapter: False)
-        # Pin the native engine so the in-process fallback is deterministic here.
-        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
-        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
+        # An available agentic engine must not silently replace an explicit pin.
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+        monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
 
         # If the external path were taken it would call the pm CLI; assert it does NOT.
         pm_cmd_called = []
@@ -218,17 +212,17 @@ def test_run_implement_falls_back_to_provider_when_cli_absent(monkeypatch):
 
         events = list(session.send("start implement"))
 
-        # The in-process fallback path emits action_start with the engine label.
+        # Rejection starts no worker and emits no engine label.
         action_starts = [e for e in events if e.kind == "action_start" and e.data.get("kind") == "run_implement"]
         assert len(action_starts) >= 1
-        assert action_starts[-1].data.get("mode") == "native"
+        assert "mode" not in action_starts[-1].data
 
         # The external CLI must NOT have been invoked for the implement dispatch.
         assert not any("cursor" in c for c in pm_cmd_called)
 
-        # A swarm_pending should still be emitted (the in-process worker is dispatched).
-        swarm_pendings = [e for e in events if e.kind == "swarm_pending"]
-        assert len(swarm_pendings) == 1
+        results = [e for e in events if e.kind == "action_result"]
+        assert any("unsupported" in (e.data.get("error") or "").lower() for e in results)
+        assert not any(e.kind == "swarm_pending" for e in events)
     finally:
         shutil.rmtree(repo_dir, ignore_errors=True)
 

--- a/tests/test_run_parallel_provider.py
+++ b/tests/test_run_parallel_provider.py
@@ -4,8 +4,9 @@ import shutil
 import tempfile
 import subprocess
 from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
 
-from harness.worker import ProviderWorker, WorkerResult
+from harness.worker import WorkerResult
 from harness.conversation import ConversationalSession, ConvEvent
 from harness.config import HarnessConfig
 
@@ -30,10 +31,9 @@ def test_run_parallel_provider_default(monkeypatch):
         cfg.repo = repo_dir
         session = ConversationalSession(cfg)
 
-        # Pin the native engine so the parallel apply pipeline is deterministic
-        # regardless of provider keys on the test host.
-        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
-        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
+        # Supply an available agentic worker independently of host credentials.
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+        monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
 
         goals_seen = []
         def mock_worker_run(self):
@@ -71,7 +71,7 @@ def test_run_parallel_provider_default(monkeypatch):
             else:
                 return WorkerResult(ok=False, error="unknown goal")
 
-        monkeypatch.setattr(ProviderWorker, "run", mock_worker_run)
+        monkeypatch.setattr("harness.edit_engines.run_agentic_edit", lambda config, goal, **kwargs: mock_worker_run(SimpleNamespace(goal=goal, repo=config.repo, expects_diff=kwargs.get("expects_diff", True))))
 
         # Mock pilot to complete and return run_parallel action with NO adapter
         mock_pilot = MagicMock()
@@ -93,7 +93,7 @@ def test_run_parallel_provider_default(monkeypatch):
         assert len(action_starts) >= 1
         specific_start = action_starts[-1]
         assert specific_start.data["kind"] == "run_parallel"
-        assert specific_start.data["mode"] == "native"
+        assert specific_start.data["mode"] == "agentic"
         assert specific_start.data["goals"] == ["Goal A", "Goal B"]
 
         # Assert a single swarm_pending with 2 job_ids is emitted
@@ -143,8 +143,8 @@ def test_run_parallel_analysis_empty_diff_applied(monkeypatch):
         cfg = HarnessConfig()
         cfg.repo = repo_dir
         session = ConversationalSession(cfg)
-        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
-        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+        monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
 
         expects_seen = []
         substantive = (
@@ -161,7 +161,7 @@ def test_run_parallel_analysis_empty_diff_applied(monkeypatch):
                 summary=substantive,
             )
 
-        monkeypatch.setattr(ProviderWorker, "run", mock_worker_run)
+        monkeypatch.setattr("harness.edit_engines.run_agentic_edit", lambda config, goal, **kwargs: mock_worker_run(SimpleNamespace(goal=goal, repo=config.repo, expects_diff=kwargs.get("expects_diff", True))))
 
         mock_pilot = MagicMock()
         first_resp = MagicMock()
@@ -243,8 +243,8 @@ def test_run_parallel_analysis_discards_seed_patch_persists_findings(monkeypatch
         cfg = HarnessConfig()
         cfg.repo = repo_dir
         session = ConversationalSession(cfg)
-        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
-        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+        monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
 
         finding_line = (
             "FINDING: harness/auth.py:42 token refresh never validates expiry"
@@ -271,7 +271,7 @@ def test_run_parallel_analysis_discards_seed_patch_persists_findings(monkeypatch
                 }],
             )
 
-        monkeypatch.setattr(ProviderWorker, "run", mock_worker_run)
+        monkeypatch.setattr("harness.edit_engines.run_agentic_edit", lambda config, goal, **kwargs: mock_worker_run(SimpleNamespace(goal=goal, repo=config.repo, expects_diff=kwargs.get("expects_diff", True))))
 
         mock_pilot = MagicMock()
         first_resp = MagicMock()
@@ -351,8 +351,8 @@ def test_run_parallel_analysis_verification_only_degraded(monkeypatch):
         cfg = HarnessConfig()
         cfg.repo = repo_dir
         session = ConversationalSession(cfg)
-        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
-        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+        monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
 
         def mock_worker_run(self):
             return WorkerResult(
@@ -362,7 +362,7 @@ def test_run_parallel_analysis_verification_only_degraded(monkeypatch):
                 summary="Last assistant message: Audit findings: none.",
             )
 
-        monkeypatch.setattr(ProviderWorker, "run", mock_worker_run)
+        monkeypatch.setattr("harness.edit_engines.run_agentic_edit", lambda config, goal, **kwargs: mock_worker_run(SimpleNamespace(goal=goal, repo=config.repo, expects_diff=kwargs.get("expects_diff", True))))
 
         mock_pilot = MagicMock()
         first_resp = MagicMock()
@@ -416,8 +416,8 @@ def test_run_parallel_implement_empty_diff_not_applied(monkeypatch):
         cfg = HarnessConfig()
         cfg.repo = repo_dir
         session = ConversationalSession(cfg)
-        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: False)
-        monkeypatch.setattr("harness.edit_engines.cursor_platform_available", lambda: False)
+        monkeypatch.setattr("harness.edit_engines.agentic_available", lambda: True)
+        monkeypatch.setattr("harness.edit_engines.agentic_platform_enabled", lambda: True)
 
         def mock_worker_run(self):
             assert getattr(self, "expects_diff", True) is True
@@ -427,7 +427,7 @@ def test_run_parallel_implement_empty_diff_not_applied(monkeypatch):
                 summary="no changes captured in the worktree diff (worktree=/tmp/x)",
             )
 
-        monkeypatch.setattr(ProviderWorker, "run", mock_worker_run)
+        monkeypatch.setattr("harness.edit_engines.run_agentic_edit", lambda config, goal, **kwargs: mock_worker_run(SimpleNamespace(goal=goal, repo=config.repo, expects_diff=kwargs.get("expects_diff", True))))
 
         mock_pilot = MagicMock()
         first_resp = MagicMock()

--- a/tests/test_send_loop_dispatch.py
+++ b/tests/test_send_loop_dispatch.py
@@ -284,119 +284,47 @@ def test_dispatch_implement_requires_workspace():
     session._append_action_result.assert_called_once()
 
 
-def test_dispatch_implement_keeps_target_repo_for_patch_landing(tmp_path, monkeypatch):
+def _check_agentic_target_repo(kind, tmp_path, monkeypatch):
     import subprocess
     import harness.send_loop_dispatch as dispatch
 
     target = tmp_path / "terraform"
     subprocess.run(["git", "init", str(target)], check=True, capture_output=True)
-    act = PilotAction(
-        kind="run_implement", goal="edit terraform", repo=str(target),
-        adapter="codex",
-    )
+    session = ConversationalSession(HarnessConfig(
+        repo=str(tmp_path), driver="stub-oracle-v2", state_dir=str(tmp_path / "state"),
+    ))
     submit = MagicMock(return_value=True)
     background = MagicMock()
-    session = SimpleNamespace(
-        config=SimpleNamespace(repo=str(tmp_path), driver="test"),
-        _session_job_ids=[],
-        _append_action_result=MagicMock(),
-        _validate_target_repo=MagicMock(return_value=(str(target), "")),
-        _resolve_requested_implement_adapter=MagicMock(return_value=("codex", "")),
-        _external_adapter_available=MagicMock(return_value=True),
-        _claim_objective=MagicMock(return_value=True),
-        _release_objective=MagicMock(),
-        _submit_swarm=submit,
-        _run_swarm_background=background,
-        _job_dispatch_label_args=MagicMock(return_value=[]),
-        _answer_remaining_tool_calls=MagicMock(return_value=iter(())),
-    )
-    proc = SimpleNamespace(
-        stdout=iter(["started job_abcdef123456\n"]),
-        wait=MagicMock(return_value=0),
-    )
-    monkeypatch.setattr(dispatch, "_puppetmaster_available", lambda: True)
-    monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda _repo: None)
-    monkeypatch.setattr(dispatch.subprocess, "Popen", MagicMock(return_value=proc))
-    monkeypatch.setattr(
-        "harness.implement_guards.check_implement_workspace", lambda *_a, **_k: None,
-    )
-    monkeypatch.setattr(
-        "harness.implement_guards.check_oversized_single_file_rewrite",
-        lambda *_a, **_k: None,
-    )
-
-    list(dispatch_implement_action(
-        session, act, "a-cross", True, turn_actions=[act], action_idx=0,
+    monkeypatch.setattr(session, "_submit_swarm", submit)
+    monkeypatch.setattr(session, "_run_provider_worker_background", background)
+    monkeypatch.setattr(session, "_register_local_job", MagicMock())
+    monkeypatch.setattr(session, "_validate_target_repo", lambda _: (str(target), ""))
+    monkeypatch.setattr(session, "_resolve_requested_implement_adapter", lambda _: ("agentic", ""))
+    monkeypatch.setattr("harness.conversation._prewarm_worker_imports", lambda: None)
+    monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda _: None)
+    monkeypatch.setattr("harness.implement_guards.check_implement_workspace", lambda *a, **k: None)
+    monkeypatch.setattr("harness.implement_guards.check_oversized_single_file_rewrite", lambda *a, **k: None)
+    act = PilotAction(kind=kind, goal="edit terraform", goals=["edit terraform"], repo=str(target))
+    call = dispatch_implement_action if kind == "run_implement" else dispatch_parallel_action
+    events = list(call(
+        session, act, "cross-repo", True, turn_actions=[act], action_idx=0,
         action_seq=1, step=0, swarms=0,
     ))
+    assert any(event.kind == "swarm_pending" for event in events)
+    submit.assert_called_once()
+    args, kwargs = submit.call_args
+    assert args[0] is background
+    assert args[2:8] == ("edit terraform", "agentic", str(target), True, None, True)
+    if kind == "run_parallel":
+        assert kwargs["admission_group"] == "parallel-cross-repo"
 
-    submit.assert_called_once_with(
-        background, "job_abcdef123456", "edit terraform", None, str(target),
-    )
+
+def test_dispatch_implement_keeps_target_repo_for_patch_landing(tmp_path, monkeypatch):
+    _check_agentic_target_repo("run_implement", tmp_path, monkeypatch)
 
 
 def test_dispatch_parallel_keeps_target_repo_for_patch_landing(tmp_path, monkeypatch):
-    import subprocess
-    import harness.send_loop_dispatch as dispatch
-
-    target = tmp_path / "terraform"
-    subprocess.run(["git", "init", str(target)], check=True, capture_output=True)
-    act = PilotAction(
-        kind="run_parallel",
-        goals=["edit terraform"],
-        repo=str(target),
-        adapter="codex",
-    )
-    submit = MagicMock(return_value=True)
-    background = MagicMock()
-    session = SimpleNamespace(
-        config=SimpleNamespace(repo=str(tmp_path), driver="test"),
-        _session_job_ids=[],
-        _append_action_result=MagicMock(),
-        _validate_target_repo=MagicMock(return_value=(str(target), "")),
-        _resolve_requested_implement_adapter=MagicMock(return_value=("codex", "")),
-        _external_adapter_available=MagicMock(return_value=True),
-        _submit_swarm=submit,
-        _run_swarm_background=background,
-        _job_dispatch_label_args=MagicMock(return_value=[]),
-        _swarm_submit_reject_message=MagicMock(return_value="at capacity"),
-        _last_swarm_submit_reason="",
-    )
-    proc = SimpleNamespace(
-        stdout=iter(["started job_abcdef123456\n"]),
-        wait=MagicMock(return_value=0),
-        returncode=0,
-        kill=MagicMock(),
-    )
-
-    def fake_read(p_info):
-        p_info["job_id"] = "job_abcdef123456"
-        p_info["lines"].append("started job_abcdef123456\n")
-
-    monkeypatch.setattr(dispatch, "_puppetmaster_available", lambda: True)
-    monkeypatch.setattr(dispatch, "_non_git_workspace_error", lambda _repo: None)
-    monkeypatch.setattr(dispatch, "read_stdout_thread", fake_read)
-    monkeypatch.setattr(dispatch.subprocess, "Popen", MagicMock(return_value=proc))
-    monkeypatch.setattr(
-        "harness.implement_guards.check_implement_workspace", lambda *_a, **_k: None,
-    )
-    monkeypatch.setattr(
-        "harness.implement_guards.check_oversized_single_file_rewrite",
-        lambda *_a, **_k: None,
-    )
-
-    list(dispatch_parallel_action(
-        session, act, "a-par", True, turn_actions=[act], action_idx=0,
-        action_seq=1, step=0, swarms=0,
-    ))
-
-    assert submit.call_args is not None
-    args, kwargs = submit.call_args
-    assert args[0] is background
-    assert args[1] == "job_abcdef123456"
-    assert args[2] == "edit terraform"
-    assert args[4] == str(target)
-    assert kwargs["admission_group"] == "parallel-a-par"
+    _check_agentic_target_repo("run_parallel", tmp_path, monkeypatch)
 
 
 def test_dispatch_parallel_requires_goals():
@@ -662,6 +590,29 @@ def test_model_pin_implies_strict_agentic_dispatch(monkeypatch):
     assert pin is expected
     assert strict is True
     assert error == ""
+
+
+def test_unpinned_product_dispatch_is_strict_agentic():
+    from harness.send_loop_dispatch import _strict_agentic_dispatch
+
+    pin, strict, error = _strict_agentic_dispatch(SimpleNamespace())
+
+    assert pin is None
+    assert strict is True
+    assert error == ""
+
+
+def test_product_dispatch_rejects_explicit_non_agentic_adapter():
+    from harness.send_loop_dispatch import _strict_agentic_dispatch
+
+    pin, strict, error = _strict_agentic_dispatch(
+        SimpleNamespace(model="", adapter="cursor")
+    )
+
+    assert pin is None
+    assert strict is True
+    assert "unsupported" in error
+    assert "agentic" in error
 
 
 def test_model_pin_rejects_conflicting_adapter():

--- a/tests/test_send_loop_phases.py
+++ b/tests/test_send_loop_phases.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from harness.pilot import PilotAction
 from harness.send_loop import SendLoopMixin
 from harness.send_loop_phases import (
@@ -32,6 +34,7 @@ from harness.send_loop_phases import (
     StreamIdleStuckError,
     meter_pilot_step,
     promote_trailing_reasoning_to_say,
+    resolve_emit_say_texts,
     read_stdout_thread,
     run_auto_verify,
     run_parallel_prefetch,
@@ -850,6 +853,47 @@ def test_promote_trailing_reasoning_empty_say():
         )
         == body
     )
+
+
+def test_resolve_emit_does_not_promote_non_cursor_reasoning():
+    resp = SimpleNamespace(
+        text="",
+        assistant_phase="final_answer",
+        meta={
+            "reasoning": "private planning, not an answer",
+            "tool_calls": [{"id": "c1"}],
+        },
+    )
+    assert resolve_emit_say_texts(cleaned_say_text="", resp=resp) == ("", "", "")
+
+
+def test_resolve_emit_keeps_real_answer_and_cursor_legacy_promotion():
+    cursor = SimpleNamespace(
+        text="",
+        assistant_phase="final_answer",
+        meta={"reasoning": "Cursor final readout", "cursor_cli": True},
+    )
+    assert resolve_emit_say_texts(cleaned_say_text="", resp=cursor)[2] == "Cursor final readout"
+
+    answer = SimpleNamespace(
+        text="",
+        assistant_phase="final_answer",
+        meta={"reasoning": "private planning", "cursor_cli": True},
+    )
+    assert resolve_emit_say_texts(cleaned_say_text="Answer", resp=answer)[2] == ""
+
+
+def test_resolve_emit_never_fabricates_final_from_pure_thinking_with_tools():
+    resp = SimpleNamespace(
+        text="",
+        assistant_phase="final_answer",
+        meta={
+            "reasoning": "private planning",
+            "tool_calls": [{"id": "c1"}],
+            "cursor_acp": True,
+        },
+    )
+    assert resolve_emit_say_texts(cleaned_say_text="", resp=resp) == ("", "", "")
 
 
 def test_promote_trailing_reasoning_short_preamble():
@@ -1837,6 +1881,29 @@ def test_dispatch_local_action_run_command_action_result_includes_ui_output(tmp_
     assert "completed with exit code 1" in receipt["output"]
     assert long_output in receipt["output"]
     assert session._append_action_result.call_args.kwargs["ok"] is False
+
+
+@pytest.mark.parametrize("status,exit_code", [("ok", 0), ("ok", 1), ("truncated", 0)])
+def test_command_receipt_does_not_echo_script_as_output(tmp_path, status, exit_code):
+    command = "python3 - <<'PY'\nprint('=== RESULT ===')\n" + "# padding\n" * 300 + "PY"
+    output = "=== RESULT ===\nactual result\n"
+    act = PilotAction(kind="run_command", command=command)
+    session = _durable_command_session(
+        tmp_path,
+        _do_run_command=MagicMock(return_value=(True, "success", {
+            "output": output, "exit_code": exit_code, "status": status,
+        })),
+        _append_action_result=MagicMock(),
+    )
+    events = list(dispatch_local_action(session, act, "receipt-id", True, []))
+    assert events[0].data["command"] == command
+    receipt = session._append_action_result.call_args[0][2]
+    if status != "ok" or exit_code != 0:
+        receipt = json.loads(receipt)["output"]
+    assert command not in receipt
+    assert receipt.count("=== RESULT ===") == 1
+    assert output in receipt
+    assert f"exit code {exit_code}" in receipt
 
 
 def test_dispatch_local_action_run_command_folds_validate_gate(tmp_path):

--- a/tests/test_swarm_drain_nonblock.py
+++ b/tests/test_swarm_drain_nonblock.py
@@ -136,6 +136,27 @@ def test_drain_injects_pilot_resume_continuation():
     assert "without waiting for the user to ask" in resume[0]["content"]
 
 
+def test_drain_marks_completion_as_control_and_preserves_latest_user_priority():
+    """A late result must not turn an older worker objective into the new ask."""
+    s = _session()
+    latest_request = "Is the linked repo useful for this question?"
+    s._history.append({"role": "user", "content": latest_request})
+    s._history.append({"role": "assistant", "content": "I am checking that."})
+    s._swarm_results.put(_queued_result("old-job", "implement the superseded plan"))
+
+    events = list(s.drain_swarm_results())
+
+    assert any(event.kind == "pilot_resume" for event in events)
+    assert latest_request in s._history[1]["content"]
+    continuation = s._history[-1]
+    assert continuation["role"] == "user"
+    assert "[Host control: background-job completion notice; not user input]" in continuation["content"]
+    assert "latest real user request remains authoritative" in continuation["content"]
+    assert "only newly completed job evidence that is relevant" in continuation["content"]
+    assert "without reviving" in continuation["content"]
+    assert "do not repeat a prior final summary or report unrelated historical worker results" in continuation["content"].lower()
+
+
 def test_drain_coalesces_multiple_results_to_one_pilot_resume():
     """Three queued results emit per-job swarm_result badges but exactly one
     pilot_resume and one merged user continuation naming all finished job ids."""

--- a/tests/test_swarm_model_pin.py
+++ b/tests/test_swarm_model_pin.py
@@ -31,7 +31,7 @@ def test_pin_candidates_include_opencode_go_deepseek_aliases():
         assert "glm-5.2" not in blob
 
 
-def test_resolve_demotes_unknown_pin_to_auto_route(monkeypatch, tmp_path):
+def test_resolve_rejects_cursor_alias_when_only_agentic_is_allowed(monkeypatch, tmp_path):
     models_path = tmp_path / "models.json"
     models_path.write_text(
         json.dumps(
@@ -86,11 +86,11 @@ def test_resolve_demotes_unknown_pin_to_auto_route(monkeypatch, tmp_path):
     from harness.swarm_model_pin import resolve_swarm_model_pin
 
     out = resolve_swarm_model_pin("cursor/gpt-5-6-luna")
-    assert out["demoted"] is False
-    assert out["auto_route"] is False
-    assert out["resolved"] == "agentic/gpt-5.6-luna"
-    assert out["adapter"] == "agentic"
-    assert out["pin_fields"].get("provider") == "opencode-go"
+    assert out["demoted"] is True
+    assert out["auto_route"] is True
+    assert out["resolved"] == ""
+    assert out["adapter"] == ""
+    assert out["pin_fields"] == {}
 
 
 def test_resolve_unknown_pin_demotes_instead_of_raising(monkeypatch, tmp_path):
@@ -152,13 +152,8 @@ def test_resolve_direct_openrouter_agentic_pin_strict(monkeypatch, tmp_path):
     from harness.swarm_model_pin import resolve_agentic_model_pin
 
     pin, error = resolve_agentic_model_pin("openrouter/stealth/ox-alpha")
-    assert error == ""
-    assert pin is not None
-    assert pin.provider == "openrouter"
-    assert pin.model == "stealth/ox-alpha"
-    assert pin.router_model_id == "agentic/openrouter/stealth/ox-alpha"
-    assert pin.payload_fields()["auto_route"] is False
-    assert pin.payload_fields()["allowed_adapters"] == ["agentic"]
+    assert pin is None
+    assert "not in keyed worker registry" in error
 
 
 def test_resolve_direct_agentic_pin_requires_keyed_provider(monkeypatch, tmp_path):
@@ -207,7 +202,7 @@ def test_run_swarm_model_description_mentions_live_catalog(monkeypatch):
 
     text = _run_swarm_model_pin_description()
     assert "agentic/gpt-5.6-luna" in text
-    assert "remap" in text.lower()
+    assert "unavailable pins fail without choosing a different model" in text.lower()
 
 
 def test_implement_and_parallel_tool_schemas_expose_model_pin():
@@ -318,20 +313,20 @@ def test_resolve_openai_codex_colon_pin_to_namespaced_row(monkeypatch, tmp_path)
 
     from harness.swarm_model_pin import resolve_swarm_model_pin
 
-    for pin in (
-        "openai-codex:gpt-5.6-luna",
-        "codex/gpt-5.6-luna",
-        "cursor/gpt-5-6-luna",
-    ):
+    for pin in ("openai-codex:gpt-5.6-luna", "codex/gpt-5.6-luna"):
         out = resolve_swarm_model_pin(pin)
         assert out["demoted"] is False, pin
         assert out["auto_route"] is False, pin
         assert out["resolved"] == "agentic/openai-codex/gpt-5.6-luna", pin
         assert out["pin_fields"].get("provider") == "openai-codex", pin
 
+    cursor = resolve_swarm_model_pin("cursor/gpt-5-6-luna")
+    assert cursor["demoted"] is True
+    assert cursor["resolved"] == ""
 
-def test_resolve_cursor_pin_across_adapter_union(monkeypatch, tmp_path):
-    """Cursor Grok pins resolve on the cursor adapter when agentic lacks the id."""
+
+def test_resolve_cursor_pin_is_rejected_even_when_union_is_requested(monkeypatch, tmp_path):
+    """Product swarms reject the former cross-adapter Cursor fallback."""
     models_path = tmp_path / "models.json"
     models_path.write_text(json.dumps({"models": []}), encoding="utf-8")
     monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
@@ -359,12 +354,12 @@ def test_resolve_cursor_pin_across_adapter_union(monkeypatch, tmp_path):
     out = resolve_swarm_model_pin(
         "cursor/grok-4-5", allowed_adapters=["agentic", "cursor"],
     )
-    assert out["demoted"] is False
-    assert out["adapter"] == "cursor"
-    assert out["resolved"] == "cursor/grok-4-5"
+    assert out["demoted"] is True
+    assert out["adapter"] == ""
+    assert out["resolved"] == ""
 
 
-def test_settings_enabled_pin_specs_maps_astra_generation_not_sol():
+def test_settings_enabled_pin_specs_requires_exact_astra_id():
     from harness.swarm_model_pin import settings_enabled_pin_specs
 
     enabled = [
@@ -372,9 +367,10 @@ def test_settings_enabled_pin_specs_maps_astra_generation_not_sol():
         "openai-codex:gpt-5.6-luna",
         "openai-codex:gpt-6-astra",
     ]
+    # A similarly named generation is not the requested model.
     assert settings_enabled_pin_specs(
         "agentic/openai-codex/gpt-5.6-astra", enabled=enabled,
-    ) == ["openai-codex:gpt-6-astra"]
+    ) == []
     assert settings_enabled_pin_specs(
         "openai-codex:gpt-6-astra", enabled=enabled,
     ) == ["openai-codex:gpt-6-astra"]
@@ -387,8 +383,8 @@ def test_settings_enabled_pin_specs_maps_astra_generation_not_sol():
     ]) == []
 
 
-def test_resolve_gpt56_astra_pin_to_enabled_gpt6_astra(monkeypatch, tmp_path):
-    """Pilot 'GPT 5.6 Astra' pins must resolve to the Settings-enabled wire id."""
+def test_resolve_gpt56_astra_pin_does_not_remap_to_gpt6_astra(monkeypatch, tmp_path):
+    """A GPT 5.6 Astra typo must not silently select GPT 6 Astra."""
     models_path = tmp_path / "models.json"
     models_path.write_text(
         json.dumps(
@@ -470,14 +466,16 @@ def test_resolve_gpt56_astra_pin_to_enabled_gpt6_astra(monkeypatch, tmp_path):
     from harness.swarm_model_pin import resolve_agentic_model_pin, resolve_swarm_model_pin
 
     out = resolve_swarm_model_pin("agentic/openai-codex/gpt-5.6-astra")
-    assert out["demoted"] is False
-    assert out["resolved"] == "agentic/openai-codex/gpt-6-astra"
-    assert out["pin_fields"].get("provider") == "openai-codex"
+    assert out["demoted"] is True
+    assert out["resolved"] == ""
+    assert out["pin_fields"] == {}
     pin, error = resolve_agentic_model_pin("agentic/openai-codex/gpt-5.6-astra")
-    assert error == ""
-    assert pin is not None
-    assert pin.model == "gpt-6-astra"
-    assert pin.router_model_id == "agentic/openai-codex/gpt-6-astra"
+    assert pin is None
+    assert "not in keyed worker registry" in error
+
+    exact = resolve_swarm_model_pin("agentic/openai-codex/gpt-6-astra")
+    assert exact["demoted"] is False
+    assert exact["resolved"] == "agentic/openai-codex/gpt-6-astra"
 
 
 def test_opencode_go_curated_bound_into_auto_registry():

--- a/tests/test_swarm_worker_allowlist.py
+++ b/tests/test_swarm_worker_allowlist.py
@@ -42,7 +42,7 @@ def test_allowlist_includes_cursor_when_settings_enable_grok(monkeypatch):
     from harness.swarm_worker_allowlist import resolve_swarm_worker_allowlist
 
     out = resolve_swarm_worker_allowlist()
-    assert out["allowed_adapters"] == ["agentic", "cursor"]
+    assert out["allowed_adapters"] == ["agentic"]
     assert out["prefer_plan_billed"] is False
     assert out["primary_adapter"] == "agentic"
 
@@ -131,7 +131,7 @@ def test_enabled_specs_keep_cursor_cli_intent_when_pilots_drop_it(monkeypatch):
     specs = swa._enabled_or_visible_specs()
     assert "cursor-cli:cursor-grok-4.5-high-fast" in specs
     out = swa.resolve_swarm_worker_allowlist()
-    assert out["allowed_adapters"] == ["agentic", "cursor"]
+    assert out["allowed_adapters"] == ["agentic"]
     assert out["prefer_plan_billed"] is False
 
 
@@ -176,7 +176,20 @@ def test_enabled_specs_do_not_union_full_keyed_catalog_when_curated(monkeypatch)
     assert "glm-5-2" not in id_blob
 
 
-def test_singleton_enabled_spec_maps_luna_not_gpt53():
+def test_singleton_enabled_spec_maps_luna_not_gpt53(monkeypatch):
+    monkeypatch.setattr(
+        "harness.swarm_model_pin._registry_rows",
+        lambda **_: [{
+            "id": "agentic/openai-codex/gpt-5.6-luna",
+            "adapter": "agentic",
+            "adapter_model_name": "gpt-5.6-luna",
+            "payload_defaults": {"provider": "openai-codex"},
+        }],
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: {"openai-codex"},
+    )
     from harness.swarm_worker_allowlist import allowed_model_ids_from_specs
 
     ids = allowed_model_ids_from_specs(["openai-codex:gpt-5.6-luna"])
@@ -186,8 +199,30 @@ def test_singleton_enabled_spec_maps_luna_not_gpt53():
     assert "gpt-5.3" not in blob
 
 
-def test_cary_enabled_subset_never_aliases_mimo():
+def test_cary_enabled_subset_never_aliases_mimo(monkeypatch):
     """Live Go/OR catalogs list MIMO; Settings toggles must not expand to it."""
+    rows = []
+    for provider, model in (
+        ("opencode-go", "deepseek-v4-flash"),
+        ("openai-codex", "gpt-6-astra"),
+        ("openai-codex", "gpt-5.6-sol"),
+        ("openai-codex", "gpt-5.6-luna"),
+        ("openrouter", "google/gemini-3.8-flash"),
+        ("openrouter", "google/gemini-3.7-flash"),
+    ):
+        rows.append({
+            "id": f"agentic/{provider}/{model}",
+            "adapter": "agentic",
+            "adapter_model_name": model,
+            "payload_defaults": {"provider": provider},
+        })
+    monkeypatch.setattr(
+        "harness.swarm_model_pin._registry_rows", lambda **_: rows,
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: {"opencode-go", "openai-codex", "openrouter"},
+    )
     from harness.swarm_worker_allowlist import allowed_model_ids_from_specs
 
     ids = allowed_model_ids_from_specs([
@@ -227,6 +262,6 @@ def test_prefer_plan_billed_true_only_when_cursor_only(monkeypatch):
     from harness.swarm_worker_allowlist import resolve_swarm_worker_allowlist
 
     out = resolve_swarm_worker_allowlist()
-    assert out["allowed_adapters"] == ["cursor"]
-    assert out["prefer_plan_billed"] is True
-    assert out["primary_adapter"] == "cursor"
+    assert out["allowed_adapters"] == []
+    assert out["prefer_plan_billed"] is False
+    assert out["primary_adapter"] == "agentic"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.457"
+version = "0.9.460"
 source = { editable = "." }
 dependencies = [
     { name = "puppetmaster-ai" },
@@ -97,7 +97,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "puppetmaster-ai", specifier = "==1.27.10" },
+    { name = "puppetmaster-ai", specifier = "==1.27.11" },
     { name = "pypdf" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
@@ -107,11 +107,11 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "puppetmaster-ai"
-version = "1.27.10"
+version = "1.27.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/d1/e0e600a15754190619b1eaa21481f39b7891a81e5ceaa88f56eaf8997a3c/puppetmaster_ai-1.27.10.tar.gz", hash = "sha256:e550a77fadea22319b3613b09d272730cfb1f159711ce5e72b422a438a590d75", size = 1986817, upload-time = "2026-09-11T00:22:04.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/06/973a1dc56a472bc4a5da605e6910e969fb9fc05fc339e23729d405550fce/puppetmaster_ai-1.27.11.tar.gz", hash = "sha256:a2a51ebc84fa6a1d223ccd0f6fd51294e79d5e58cb7c1371075e721daa89cf58", size = 1990761, upload-time = "2026-09-11T05:43:13.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/61/9e3c4485fe992d6860c0828f40f3b05eb3aa4db6675c13a5089ed498df6b/puppetmaster_ai-1.27.10-py3-none-any.whl", hash = "sha256:a9f8945646f86b796eb911ceae13ac20f7176d10d73517def37db313ef8f6126", size = 1093337, upload-time = "2026-09-11T00:22:02.392Z" },
+    { url = "https://files.pythonhosted.org/packages/19/14/2483004da47ed90017410efdaac288d2de8282dc5e0e010ebc7c91f4e972/puppetmaster_ai-1.27.11-py3-none-any.whl", hash = "sha256:e4025cab1cd05be0dfdcde2b5104ae537d8fe9c796c3d725993d3ee39fe22a5d", size = 1093784, upload-time = "2026-09-11T05:43:12.039Z" },
 ]
 
 [[package]]

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -90,7 +90,7 @@ function installIdentity(dir, target) {
   return { schema: 1, mode: target.mode, repo: target.repo,
     revision: gitValue(dir, ["rev-parse", "HEAD"]), inputs: hash.digest("hex"),
     platform: process.platform, arch: process.arch,
-    puppetmaster: process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.27.10" };
+    puppetmaster: process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.27.11" };
 }
 
 function venvPython(dir) {
@@ -378,7 +378,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.27.10";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.27.11";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.27.10";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.27.11";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 const HARNESS_DIST_NAME = "pm-harness";
 
@@ -95,7 +95,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.27.10" }    -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.27.11" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.459",
+  "version": "0.9.460",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.459",
+      "version": "0.9.460",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.459",
+  "version": "0.9.460",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/DeviceAccess.test.tsx
+++ b/webapp/src/__tests__/DeviceAccess.test.tsx
@@ -57,7 +57,7 @@ describe('Device access', () => {
     await ready(); draft();
     fireEvent.click(screen.getByRole('button', { name: 'Enroll device' }));
     const show = await screen.findByRole('button', { name: 'Show credential' });
-    expect(show).toHaveFocus();
+    await waitFor(() => expect(show).toHaveFocus());
     expect(screen.queryByText(fixtureCredential)).not.toBeInTheDocument();
     expect(writeText).not.toHaveBeenCalled();
     fireEvent.click(show);


### PR DESCRIPTION
DeepSeek tool-only replies could appear as completed answers because Marionette promoted provider reasoning into spoken text. Restrict that fallback to explicit Cursor transports, preserve real tool continuations, and use Puppetmaster 1.27.11 to keep DeepSeek reasoning intact across worker tool calls.

Product workers now use `agentic` with canonical allowlists for exact enabled, keyed provider/model pairs. Unavailable explicit pins fail without choosing a different model. Command receipts identify the call without echoing its script before stdout. Background completion notices keep the current user request in charge. Test registry and Settings storage are isolated from the running app.

Validation:
- Full Python 3.11 backend suite against published Puppetmaster 1.27.11: 7,516 passed, 68 skipped, exit 0.
- Electron: 400 passed, exit 0.
- Frontend: all 2,526 tests passed, exit 0. Synchronize the existing credential-focus assertion with React's focus effect.
- Real SSE parser, tool-loop, pin rejection, provider isolation, and real router regressions passed.
- Live DeepSeek worker probes passed on both Go model IDs with the required reasoning field on the second request. A real Marionette bridge dispatch also held the exact `opencode-go:deepseek-flash` pin through both requests and returned a finding.
- CI passed on the final tree: Python 3.9 on Linux and all four Windows shards, frontend, harness units, and Python 3.11 on macOS with resource soak. All three installer builds passed; the macOS universal ZIP passed its Developer ID signature check after one successful notarization.
