### PR TITLE
Release v0.9.461: remove factory reply cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.11` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.460, deliberately pre-1.0. DeepSeek tool calls preserve the provider reasoning field, while private reasoning stays out of spoken answers. Product workers use the agentic adapter and route within enabled provider/model pairs. Explicit unavailable pins fail clearly. Background completion notices preserve the current request, and command receipts keep script text separate from output. Runtime pin: `puppetmaster-ai==1.27.11`.
+> Status: v0.9.461, deliberately pre-1.0. The reply output cap now defaults to the provider's model-specific limit where supported; APIs that require a numeric ceiling receive 32K. Explicit user caps remain available in Settings. DeepSeek tool calls preserve the provider reasoning field, and private reasoning stays out of spoken answers. Runtime pin: `puppetmaster-ai==1.27.11`.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.460"
+__version__ = "0.9.461"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/opencode_common.py
+++ b/harness/opencode_common.py
@@ -21,6 +21,7 @@ SHARED_DISPLAY_NAMES = {
 CHAT_COMPLETIONS = "chat_completions"
 ANTHROPIC_MESSAGES = "anthropic_messages"
 OPENAI_RESPONSES = "openai_responses"
+REQUIRED_MAX_OUTPUT_TOKENS = 32000
 
 
 def informative_display_name(label: object, model: Optional[str]) -> str:
@@ -140,7 +141,7 @@ def build_opencode_driver(
     model: str,
     api_mode: str,
     api_key_env: str,
-    max_tokens: int,
+    max_tokens: Optional[int],
     base_url: str,
     temperature: Optional[float] = None,
     extra_body: Optional[dict] = None,
@@ -156,9 +157,12 @@ def build_opencode_driver(
     if api_mode == ANTHROPIC_MESSAGES:
         from pmharness.drivers.anthropic import AnthropicDriver
 
+        required_max_tokens = int(max_tokens or 0)
+        if required_max_tokens <= 0:
+            required_max_tokens = REQUIRED_MAX_OUTPUT_TOKENS
         return AnthropicDriver(
             name=spec, model=bare, base_url=base_url,
-            api_key_env=api_key_env, max_tokens=max_tokens,
+            api_key_env=api_key_env, max_tokens=required_max_tokens,
         )
     if api_mode == OPENAI_RESPONSES:
         from pmharness.drivers.codex_responses import CodexResponsesDriver

--- a/harness/opencode_zen.py
+++ b/harness/opencode_zen.py
@@ -137,7 +137,7 @@ def build_driver(
     spec: str,
     model: str,
     api_key_env: str = API_KEY_ENV,
-    max_tokens: int,
+    max_tokens: Optional[int],
     base_url: Optional[str] = None,
 ):
     """The driver Zen's endpoint table demands for *model*."""

--- a/harness/providers.py
+++ b/harness/providers.py
@@ -29,6 +29,7 @@ from typing import Optional
 
 from . import opencode_go as _opencode_go
 from . import opencode_zen as _opencode_zen
+from .opencode_common import REQUIRED_MAX_OUTPUT_TOKENS
 
 # GLM Coding Plan (subscription credits) vs pay-as-you-go API. Official docs:
 # Coding Plan OpenAI Chat Completions must use /api/coding/paas/v4 — the
@@ -475,24 +476,25 @@ def resolve_bare_model(model: str) -> tuple:
 
 
 _UNLIMITED_MAX_TOKENS = frozenset({"0", "off", "none", "unlimited"})
-_REQUIRED_MAX_TOKENS_FALLBACK = 128000
+_REQUIRED_MAX_TOKENS_FALLBACK = REQUIRED_MAX_OUTPUT_TOKENS
 
 
 def requested_max_output_tokens() -> Optional[int]:
     """HARNESS_MAX_TOKENS as a request-time ceiling.
 
-    None means omit ``max_tokens`` on hosts that allow it. Empty or invalid
-    values keep the historical 8000 default so tool-call JSON is not cut off.
+    None means omit ``max_tokens`` on hosts that allow it. The factory default
+    lets the provider choose its model-specific output limit; APIs that require
+    a field receive ``_REQUIRED_MAX_TOKENS_FALLBACK`` instead.
     """
     raw = (os.environ.get("HARNESS_MAX_TOKENS") or "").strip()
     if not raw:
-        return 8000
+        return None
     if raw.lower() in _UNLIMITED_MAX_TOKENS:
         return None
     try:
         n = int(raw)
     except (TypeError, ValueError):
-        return 8000
+        return None
     if n <= 0:
         return None
     return n
@@ -519,9 +521,9 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
     Returns a driver exposing .complete(prompt, system=...). Transport is OURS
     (pmharness drivers); only the routing DATA is Hermes-derived.
     """
-    # Output-token ceiling. Default to HARNESS_MAX_TOKENS (8000) so large edit_file
-    # / write_file tool calls are NOT truncated mid-arguments -- a 1500-token cap
-    # silently cut off big tool-call JSON, which is why edit_file "lost" its args.
+    # Optional output-token ceiling. The factory default omits it where the API
+    # allows so reasoning and tool-call JSON are not cut off by Marionette.
+    # Providers that require a field receive a 32K fallback below.
     if max_tokens is None:
         max_tokens = requested_max_output_tokens()
 
@@ -593,7 +595,7 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
         if burl and burl.rstrip("/").endswith("v1beta"):
             kwargs["base_url"] = burl
         return _finalize_driver(
-            GeminiDriver(name=spec, model=model, api_key_env=key_env, max_tokens=_required_max_tokens(max_tokens), **kwargs)
+            GeminiDriver(name=spec, model=model, api_key_env=key_env, max_tokens=max_tokens, **kwargs)
         )
 
     if provider.api_mode == "anthropic_messages":
@@ -631,7 +633,7 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
     if provider.api_mode == "bedrock":
         from pmharness.drivers.bedrock import BedrockDriver
         return _finalize_driver(
-            BedrockDriver(name=spec, model=model, max_tokens=_required_max_tokens(max_tokens))
+            BedrockDriver(name=spec, model=model, max_tokens=max_tokens)
         )
     if provider.api_mode in ("codex_responses", "responses"):
         from pmharness.drivers.codex_responses import CodexResponsesDriver
@@ -646,7 +648,7 @@ def build_pilot(spec: str, *, max_tokens: int | None = None):
                 model=model,
                 base_url=provider.base_url,
                 api_key_env=key_env or default_key_env,
-                max_tokens=_required_max_tokens(max_tokens),
+                max_tokens=max_tokens,
                 chatgpt_backend=(provider.api_mode == "codex_responses"),
             )
         )

--- a/harness/server.py
+++ b/harness/server.py
@@ -3183,7 +3183,7 @@ def _get_settings_dict():
         "session_trace_export": session_trace_export_enabled(),
         "commandTimeout": (os.environ.get("HARNESS_COMMAND_TIMEOUT", "").strip() or "120"),
         "maxPilotSteps": (os.environ.get("HARNESS_MAX_PILOT_STEPS", "").strip() or "40"),
-        "maxOutputTokens": (os.environ.get("HARNESS_MAX_TOKENS", "").strip() or "8000"),
+        "maxOutputTokens": (os.environ.get("HARNESS_MAX_TOKENS", "").strip() or "unlimited"),
         "pilotToolBudget": (
             os.environ.get("HARNESS_PILOT_TOOL_BUDGET", "").strip() or "25"
         ),

--- a/pmharness/drivers/bedrock.py
+++ b/pmharness/drivers/bedrock.py
@@ -196,7 +196,7 @@ class BedrockDriver:
         name: str,
         model: str,
         *,
-        max_tokens: int = 8000,
+        max_tokens: Optional[int] = 8000,
         temperature: float = 0.0,
         timeout: int = 300,
         send_temperature: bool = False,
@@ -230,7 +230,9 @@ class BedrockDriver:
             raise RuntimeError(missing_bedrock_credentials_message())
 
     def _extra(self) -> dict:
-        extra: dict[str, Any] = {"max_tokens": self.max_tokens}
+        extra: dict[str, Any] = {}
+        if isinstance(self.max_tokens, int) and self.max_tokens > 0:
+            extra["max_tokens"] = self.max_tokens
         if self.send_temperature and self.temperature is not None:
             extra["temperature"] = self.temperature
         # Claude-on-Bedrock extended thinking (same effort knob as Codex/Anthropic).
@@ -244,7 +246,7 @@ class BedrockDriver:
             if model_supports_anthropic_thinking(self.model):
                 budget = anthropic_thinking_budget()
                 if budget is not None and budget > 0:
-                    if int(extra.get("max_tokens") or 0) <= budget:
+                    if "max_tokens" in extra and int(extra["max_tokens"]) <= budget:
                         extra["max_tokens"] = budget + 1024
                     extra["additionalModelRequestFields"] = {
                         "thinking": {"type": "enabled", "budget_tokens": int(budget)},

--- a/pmharness/drivers/gemini.py
+++ b/pmharness/drivers/gemini.py
@@ -22,7 +22,7 @@ class GeminiDriver:
     def __init__(self, name: str, model: str, *,
                  base_url: str = "https://generativelanguage.googleapis.com/v1beta",
                  api_key_env: str = "GEMINI_API_KEY",
-                 max_tokens: int = 8000,
+                 max_tokens: Optional[int] = 8000,
                  temperature: float = 0.0,
                  timeout: int = 90,
                  send_temperature: bool = False,
@@ -59,7 +59,9 @@ class GeminiDriver:
         return new_schema
 
     def _generation_config(self, *, include_thoughts: bool = False) -> dict[str, Any]:
-        gen_config: dict[str, Any] = {"maxOutputTokens": self.max_tokens}
+        gen_config: dict[str, Any] = {}
+        if isinstance(self.max_tokens, int) and self.max_tokens > 0:
+            gen_config["maxOutputTokens"] = self.max_tokens
         if self.send_temperature and self.temperature is not None:
             gen_config["temperature"] = self.temperature
         if include_thoughts:

--- a/pmharness/registry.py
+++ b/pmharness/registry.py
@@ -771,13 +771,18 @@ def context_window(name: str, default: int = _CW_FLOOR) -> int:
 
 
 def build(name: str, *, reach: str = "openrouter") -> Driver:
-    import os as _os
-    _mt = int(_os.environ.get("HARNESS_MAX_TOKENS", "8000"))
     """Construct a Driver for a catalog model.
 
     reach='openrouter' routes through OpenRouter (one key for the whole field).
     reach='native' uses the provider's own endpoint where defined.
     """
+    import os as _os
+    _raw_mt = _os.environ.get("HARNESS_MAX_TOKENS", "").strip()
+    try:
+        _mt = max(0, int(_raw_mt)) if _raw_mt else 0
+    except (TypeError, ValueError):
+        _mt = 0
+    _required_mt = _mt or 32000
     if name == "stub-oracle":
         return StubDriver()
     if name == "stub-oracle-mt":
@@ -815,7 +820,7 @@ def build(name: str, *, reach: str = "openrouter") -> Driver:
             return AnthropicDriver(
                 name=name, model=nat["model"],
                 base_url=nat["base_url"], api_key_env=nat["api_key_env"],
-                max_tokens=_mt,
+                max_tokens=_required_mt,
             )
         if nat.get("driver") == "gemini":
             from .drivers.gemini import GeminiDriver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.460"
+version = "0.9.461"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_bedrock_pilot.py
+++ b/tests/test_bedrock_pilot.py
@@ -12,6 +12,29 @@ from harness import providers as prov
 from pmharness.drivers.bedrock import BedrockDriver
 
 
+def test_extra_omits_unset_output_cap():
+    driver = BedrockDriver("bedrock", "amazon.nova-lite-v1:0", max_tokens=None)
+    assert "max_tokens" not in driver._extra()
+
+
+def test_claude_thinking_does_not_invent_output_cap(monkeypatch):
+    monkeypatch.setenv("HARNESS_CODEX_REASONING_EFFORT", "high")
+    driver = BedrockDriver(
+        "bedrock", "us.anthropic.claude-sonnet-4-5-20250929-v1:0", max_tokens=None,
+    )
+    extra = driver._extra()
+    assert "max_tokens" not in extra
+    assert extra["additionalModelRequestFields"]["thinking"]["budget_tokens"] == 16000
+
+
+def test_claude_thinking_keeps_explicit_cap_above_budget(monkeypatch):
+    monkeypatch.setenv("HARNESS_CODEX_REASONING_EFFORT", "high")
+    driver = BedrockDriver(
+        "bedrock", "us.anthropic.claude-sonnet-4-5-20250929-v1:0", max_tokens=8000,
+    )
+    assert driver._extra()["max_tokens"] == 17024
+
+
 _BEDROCK_ENV = (
     "AWS_BEARER_TOKEN_BEDROCK",
     "AWS_ACCESS_KEY_ID",

--- a/tests/test_edit_file_args.py
+++ b/tests/test_edit_file_args.py
@@ -13,8 +13,8 @@ def test_native_anthropic_gets_max_tokens(monkeypatch):
     import harness.providers as prov
     importlib.reload(prov)
     d = prov.build_pilot("anthropic:claude-opus-4-8")
-    # Must be the 8000 default, NOT the AnthropicDriver class default of 1024.
-    assert getattr(d, "max_tokens", 0) >= 8000
+    # Anthropic requires a ceiling, so the unlimited product default uses 32K.
+    assert getattr(d, "max_tokens", 0) == 32000
 
 
 def test_max_tokens_env_override(monkeypatch):

--- a/tests/test_gemini_native.py
+++ b/tests/test_gemini_native.py
@@ -9,6 +9,11 @@ from pmharness import registry
 from harness.pilot import parse_tool_calls
 
 
+def test_generation_config_omits_unset_output_cap():
+    driver = GeminiDriver("gemini", "gemini-3.5-flash", max_tokens=None)
+    assert "maxOutputTokens" not in driver._generation_config()
+
+
 @pytest.fixture(autouse=True)
 def mock_retry_sleep(monkeypatch):
     orig_with_retry = pmharness.drivers.retry.with_retry

--- a/tests/test_opencode_go.py
+++ b/tests/test_opencode_go.py
@@ -143,6 +143,16 @@ def test_mimo_pro_output_ceiling_is_clamped_to_what_xiaomi_serves():
     assert go.max_tokens_for_model("deepseek-v4-flash", 8000) == 8000
 
 
+def test_deepseek_factory_default_omits_marionette_output_cap(monkeypatch):
+    monkeypatch.delenv("HARNESS_MAX_TOKENS", raising=False)
+    monkeypatch.setenv(go.API_KEY_ENV, "go-test")
+    driver = prov.build_pilot("opencode-go:deepseek-flash")
+    assert driver.max_tokens == 0
+    body = driver._build_chat_body([{"role": "user", "content": "continue"}])
+    assert "max_tokens" not in body
+    assert "max_completion_tokens" not in body
+
+
 def test_kimi_models_use_the_temperature_the_go_relay_accepts():
     assert go.temperature_for_model("kimi-k3") == 1.0
     assert go.temperature_for_model("opencode-go/kimi-k2.7-code") == 1.0
@@ -263,6 +273,7 @@ def test_build_pilot_routes_anthropic_messages_models():
     # AnthropicDriver appends /messages, so the base keeps its /v1 segment.
     assert driver.base_url == go.BASE_URL
     assert driver.model == "minimax-m3"
+    assert driver.max_tokens == 32000
     assert driver._headers()["User-Agent"] == go.USER_AGENT
 
 
@@ -274,6 +285,9 @@ def test_build_pilot_routes_openai_responses_models():
     assert driver.base_url == go.BASE_URL
     assert driver.chatgpt_backend is False
     assert driver.api_key_env == "OPENCODE_GO_API_KEY"
+    assert driver.max_tokens == 0
+    body = driver._build_body([{"role": "user", "content": "continue"}])
+    assert "max_output_tokens" not in body
 
 
 @pytest.mark.parametrize("model", ["grok-4.5", "muse-spark-1.2-contributor"])

--- a/tests/test_opencode_zen.py
+++ b/tests/test_opencode_zen.py
@@ -167,6 +167,16 @@ def test_zen_gpt_and_claude_follow_the_endpoint_table():
     assert zen.api_mode_for_model("unknown-new-model") == zen.CHAT_COMPLETIONS
 
 
+def test_zen_required_and_optional_protocol_defaults(monkeypatch):
+    monkeypatch.delenv("HARNESS_MAX_TOKENS", raising=False)
+    anthropic = prov.build_pilot("opencode-zen:claude-sonnet-4-6")
+    assert anthropic.max_tokens == 32000
+    responses = prov.build_pilot("opencode-zen:gpt-5.5")
+    assert responses.max_tokens is None
+    body = responses._build_body([{"role": "user", "content": "continue"}])
+    assert "max_output_tokens" not in body
+
+
 def test_build_pilot_routes_ox_alpha_to_chat(monkeypatch):
     from pmharness.drivers.openai_compat import OpenAICompatDriver
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -364,11 +364,15 @@ def test_build_pilot_bare_model_uses_canonical_provider_when_keyed(monkeypatch):
 
 def test_requested_max_output_tokens_default_and_unlimited(monkeypatch):
     monkeypatch.delenv("HARNESS_MAX_TOKENS", raising=False)
-    assert prov.requested_max_output_tokens() == 8000
+    assert prov.requested_max_output_tokens() is None
     monkeypatch.setenv("HARNESS_MAX_TOKENS", "16000")
     assert prov.requested_max_output_tokens() == 16000
     for raw in ("0", "off", "none", "unlimited", "-1"):
         monkeypatch.setenv("HARNESS_MAX_TOKENS", raw)
         assert prov.requested_max_output_tokens() is None
     monkeypatch.setenv("HARNESS_MAX_TOKENS", "nope")
-    assert prov.requested_max_output_tokens() == 8000
+    assert prov.requested_max_output_tokens() is None
+
+
+def test_required_max_tokens_uses_high_fallback():
+    assert prov._required_max_tokens(None) == 32000

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -38,16 +38,27 @@ def test_build_stub_needs_no_key():
     assert isinstance(d, StubDriver)
 
 
-def test_build_openrouter_driver_constructs():
+def test_build_openrouter_driver_constructs(monkeypatch):
     # constructs without a key (key only read at call time)
+    monkeypatch.delenv("HARNESS_MAX_TOKENS", raising=False)
     d = reg.build("kimi-k3", reach="openrouter")
     assert d.name == "kimi-k3"
     assert "openrouter.ai" in d.base_url
+    assert d.max_tokens == 0
 
 
-def test_build_native_driver_constructs():
+def test_build_native_driver_constructs(monkeypatch):
+    monkeypatch.delenv("HARNESS_MAX_TOKENS", raising=False)
     d = reg.build("glm-5.2", reach="native")
     assert "z.ai" in d.base_url
+    assert d.max_tokens == 0
+
+
+def test_build_native_gemini_omits_factory_cap(monkeypatch):
+    monkeypatch.delenv("HARNESS_MAX_TOKENS", raising=False)
+    d = reg.build("gemini-3.5-flash", reach="native")
+    assert d.max_tokens == 0
+    assert "maxOutputTokens" not in d._generation_config()
 
 
 def test_native_unavailable_raises():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -59,6 +59,7 @@ def test_settings_get_returns_expected_shape(monkeypatch):
         assert data["swarm_reasoning_effort"] == "medium"
         assert "compactionResidual" in data
         assert data["compactionResidual"] == "catalog"
+        assert data["maxOutputTokens"] == "unlimited"
         assert "browserRealProfile" in data
         assert data["browserRealProfile"] is False
         assert "state_dir" in data

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.460"
+version = "0.9.461"
 source = { editable = "." }
 dependencies = [
     { name = "puppetmaster-ai" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.460",
+  "version": "0.9.461",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.460",
+      "version": "0.9.461",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.460",
+  "version": "0.9.461",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/SettingsPane.pilotToolBudget.test.tsx
+++ b/webapp/src/__tests__/SettingsPane.pilotToolBudget.test.tsx
@@ -35,7 +35,7 @@ const sampleSettings: Settings = {
   state_dir: "/tmp/state",
   repo: "/tmp/repo",
   maxPilotSteps: "40",
-  maxOutputTokens: "8000",
+  maxOutputTokens: "unlimited",
   pilotToolBudget: "25",
 };
 
@@ -54,6 +54,7 @@ describe("SettingsPane pilotToolBudget control", () => {
     expect(screen.getByText("Per-turn tool-call cap")).toBeInTheDocument();
     expect(screen.getByDisplayValue("25")).toBeInTheDocument();
     expect(screen.getByDisplayValue("40")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("8000")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("unlimited")).toBeInTheDocument();
+    expect(screen.getByText(/factory default lets the provider decide/i)).toBeInTheDocument();
   });
 });

--- a/webapp/src/components/SettingsPane.tsx
+++ b/webapp/src/components/SettingsPane.tsx
@@ -1213,21 +1213,22 @@ export default function SettingsPane({ onOpenWizard, section = "general" }: { on
             <label className="text-[11px] text-muted shrink-0">Reply output cap</label>
             <input
               type="text"
-              defaultValue={settings.maxOutputTokens || "8000"}
+              defaultValue={settings.maxOutputTokens || "unlimited"}
               onBlur={(e) => {
                 const v = e.target.value.trim();
-                if (v !== (settings.maxOutputTokens || "8000")) update({ maxOutputTokens: v });
+                if (v !== (settings.maxOutputTokens || "unlimited")) update({ maxOutputTokens: v });
               }}
               disabled={saving}
               className="flex-1 px-2 py-1 rounded border border-edge bg-panel2 text-[11px] text-txt disabled:opacity-50"
-              placeholder="8000"
+              placeholder="unlimited"
             />
           </div>
           <p className="text-[10px] text-muted">
             Completion-token ceiling for the next pilot request (HARNESS_MAX_TOKENS).
-            The factory default is 8000. Use 0, off, or unlimited to omit the field so
-            the provider decides. Hitting this cap is a length stop, not a context
-            overflow — Compact will not raise it. Continue finishes the same reply.
+            The factory default lets the provider decide. APIs that require a ceiling use
+            32000. Enter a positive number to set a custom cap, or use 0, off, or unlimited
+            to omit the field where supported. Hitting a custom cap is a length stop, not a
+            context overflow — Compact will not raise it. Continue finishes the same reply.
             Applies on the next turn — no restart needed.
           </p>
           <div className="flex items-center gap-2 pt-1">


### PR DESCRIPTION
DeepSeek V4.1 Flash stopped twice at exactly 8,000 output tokens while preparing tool calls, even though the model supports much larger replies. Marionette was adding its own 8K request ceiling before the provider saw the request.

This release makes the factory setting `unlimited`: OpenAI, OpenCode chat/responses, Gemini, Bedrock, and compatible transports omit the output-token field and use the provider/model limit. Anthropic Messages still requires a numeric field, so unset caps use 32K there. A positive value in Settings continues to enforce an explicit user cap.

Validation:

- focused provider/protocol suite: 286 passed
- frontend: 2,526 Vitest tests and 400 Electron tests passed
- production web build and lint passed
- full Python 3.11 suite: 7,524 passed, 68 skipped
