### PR TITLE
Marionette 0.9.462: recover incomplete OpenCode Go tool streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.11` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.461, deliberately pre-1.0. The reply output cap now defaults to the provider's model-specific limit where supported; APIs that require a numeric ceiling receive 32K. Explicit user caps remain available in Settings. DeepSeek tool calls preserve the provider reasoning field, and private reasoning stays out of spoken answers. Runtime pin: `puppetmaster-ai==1.27.11`.
+> Status: v0.9.462, deliberately pre-1.0. The reply output cap now defaults to the provider's model-specific limit where supported; APIs that require a numeric ceiling receive 32K. Explicit user caps remain available in Settings. DeepSeek tool calls preserve the provider reasoning field, and private reasoning stays out of spoken answers. OpenCode Go tool-stream cutoffs get one silent non-stream recovery attempt before Marionette reports an incomplete reply. Runtime pin: `puppetmaster-ai==1.27.11`.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.461"
+__version__ = "0.9.462"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/send_loop.py
+++ b/harness/send_loop.py
@@ -1596,6 +1596,8 @@ class SendLoopMixin:
             assistant_msg: dict[str, Any] = {"role": "assistant"}
             if is_native:
                 assistant_msg["content"] = _history_text or ""
+                if "reasoning_content" in (resp.meta or {}):
+                    assistant_msg["reasoning_content"] = resp.meta["reasoning_content"]
                 if tool_calls:
                     assistant_msg["tool_calls"] = tool_calls
             else:

--- a/pmharness/drivers/openai_compat.py
+++ b/pmharness/drivers/openai_compat.py
@@ -216,6 +216,8 @@ class _OpenAIChatSseAccumulator:
         self.end_on_finish = bool(end_on_finish)
         self.full_text = ""
         self.reasoning_pieces: list = []
+        self.reasoning_content_pieces: list[str] = []
+        self.reasoning_content_seen = False
         self.assembled_tool_calls: dict = {}
         self.last_tool_call_index = None
         self.finish_reason = ""
@@ -301,16 +303,17 @@ class _OpenAIChatSseAccumulator:
                 if visible and self.on_delta is not None:
                     self.on_delta(visible)
 
-        reasoning_delta = (
-            delta.get("reasoning")
-            or delta.get("reasoning_content")
-            or ""
-        )
+        if "reasoning_content" in delta:
+            self.reasoning_content_seen = True
+            raw_reasoning_content = delta.get("reasoning_content")
+            if raw_reasoning_content is not None:
+                self.reasoning_content_pieces.append(str(raw_reasoning_content))
+        reasoning_delta = delta.get("reasoning") or delta.get("reasoning_content") or ""
         if reasoning_delta:
             self.stream_started = True
-            self.reasoning_pieces.append(reasoning_delta)
+            self.reasoning_pieces.append(str(reasoning_delta))
             if self.on_reasoning_delta is not None:
-                self.on_reasoning_delta(reasoning_delta)
+                self.on_reasoning_delta(str(reasoning_delta))
 
         delta_tool_calls = delta.get("tool_calls") or []
         if delta_tool_calls:
@@ -373,7 +376,10 @@ class _OpenAIChatSseAccumulator:
         accumulated_reasoning = "".join(self.reasoning_pieces)
         if accumulated_reasoning:
             message_obj["reasoning"] = accumulated_reasoning
-            message_obj["reasoning_content"] = accumulated_reasoning
+        reasoning_content = None
+        if self.reasoning_content_seen:
+            reasoning_content = "".join(self.reasoning_content_pieces)
+            message_obj["reasoning_content"] = reasoning_content
         reasoning = extract_reasoning(message_obj)
         pure_text = strip_think_blocks(self.full_text)
         executable = _executable_stream_tool_calls(
@@ -394,6 +400,7 @@ class _OpenAIChatSseAccumulator:
         return {
             "text": pure_text,
             "reasoning": reasoning,
+            "reasoning_content": reasoning_content,
             "tool_calls": executable,
             "incomplete_tool_calls": incomplete_tools,
             "finish_reason": finish,
@@ -553,6 +560,31 @@ class OpenAICompatDriver:
             return False
         path = (parsed.path or "").lower()
         return "/zen/go" in path
+
+    def _incomplete_tool_retry_eligible(
+        self, resp: DriverResponse, *, tools: list | None,
+    ) -> bool:
+        """Allow one silent Go-relay retry when a tool turn ends mid-call.
+
+        OpenCode Go can close a streamed tool turn after emitting text or a
+        partial call. The first response is already visible, so only the
+        follow-up ``chat`` call may be used for execution. Keep this narrow to
+        the known relay and to tool-bearing responses; other providers retain
+        their fail-closed terminal behavior.
+        """
+        if not tools or not self._is_opencode_go_host():
+            return False
+        meta = resp.meta if isinstance(resp.meta, dict) else {}
+        stream_terminal = _norm_chat_finish(meta.get("stream_terminal"))
+        finish_reason = _norm_chat_finish(meta.get("finish_reason"))
+        if stream_terminal in {"error", "transport_error"}:
+            return False
+        if meta.get("incomplete_tool_calls"):
+            return (
+                stream_terminal == "incomplete"
+                or finish_reason in _TOOL_CHAT_FINISH
+            )
+        return finish_reason in _TOOL_CHAT_FINISH and not meta.get("tool_calls")
 
     def _apply_openrouter_parallel_tool_calls(self, body: dict, tools) -> None:
         """OpenRouter accepts parallel_tool_calls; OpenCode Go/unknown relays do not."""
@@ -1235,6 +1267,12 @@ class OpenAICompatDriver:
                 "finish_reason": finish_reason,
                 "stream_terminal": stream_terminal,
             })
+            if "reasoning_content" in message_obj:
+                raw_reasoning_content = message_obj.get("reasoning_content")
+                meta["reasoning_content"] = (
+                    "" if raw_reasoning_content is None
+                    else str(raw_reasoning_content)
+                )
             if incomplete_tools:
                 meta["incomplete_tool_calls"] = incomplete_tools
             served = self._served_model_from_payload(raw if isinstance(raw, dict) else {})
@@ -1286,6 +1324,8 @@ class OpenAICompatDriver:
                 "malformed_sse_chunks": parsed["malformed_sse_chunks"],
                 "saw_done": parsed["saw_done"],
             }
+            if parsed["reasoning_content"] is not None:
+                meta["reasoning_content"] = parsed["reasoning_content"]
             if parsed["incomplete_tool_calls"]:
                 meta["incomplete_tool_calls"] = parsed["incomplete_tool_calls"]
             if parsed["stream_has_cache_read"]:
@@ -1384,6 +1424,43 @@ class OpenAICompatDriver:
             return with_retry(_call)
 
         first = _one_stream(list(messages))
+        if self._incomplete_tool_retry_eligible(first, tools=tools):
+            retry = self.chat(
+                messages,
+                tools=tools,
+                system=system,
+                session_id=session_id,
+            )
+            first_meta = dict(first.meta or {})
+            first_meta["incomplete_retry_attempted"] = True
+            recovered_tool_calls = (
+                retry.error is None
+                and isinstance(retry.meta, dict)
+                and bool(retry.meta.get("tool_calls"))
+            )
+            first_meta["incomplete_retry_recovered"] = recovered_tool_calls
+            if recovered_tool_calls:
+                retry_meta = dict(retry.meta or {})
+                retry_meta["incomplete_retry_attempted"] = True
+                retry_meta["incomplete_retry_recovered"] = True
+                return DriverResponse(
+                    text="" if first.text else retry.text,
+                    tokens_in=first.tokens_in + retry.tokens_in,
+                    tokens_out=first.tokens_out + retry.tokens_out,
+                    latency_ms=first.latency_ms + retry.latency_ms,
+                    model=retry.model or first.model,
+                    error=None,
+                    meta=retry_meta,
+                )
+            return DriverResponse(
+                text=first.text,
+                tokens_in=first.tokens_in,
+                tokens_out=first.tokens_out,
+                latency_ms=first.latency_ms,
+                model=first.model,
+                error=first.error,
+                meta=first_meta,
+            )
         if not _length_continue_eligible(first):
             return first
 
@@ -1441,4 +1518,3 @@ class OpenAICompatDriver:
             ),
             meta=meta,
         )
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.461"
+version = "0.9.462"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_openai_compat_stream_terminals.py
+++ b/tests/test_openai_compat_stream_terminals.py
@@ -306,6 +306,172 @@ def test_truncated_args_with_tool_calls_finish_still_withheld(monkeypatch):
     assert resp.meta["incomplete_tool_calls"][0]["function"]["name"] == "read_file"
 
 
+def test_opencode_go_retries_incomplete_tool_stream_without_reemitting_text(monkeypatch):
+    """A Go relay cutoff may emit text/name, then no complete tool JSON.
+
+    The retry is silent so the first visible announcement is not duplicated;
+    only the complete second response may reach the action parser.
+    """
+    first = [
+        _data({"choices": [{"delta": {"content": "Fanning out..."}}]}),
+        _data({"choices": [{"delta": {"tool_calls": [{
+            "index": 0,
+            "id": "call_partial",
+            "type": "function",
+            "function": {"name": "run_parallel", "arguments": '{"goals": ['},
+        }]}, "finish_reason": "tool_calls"}]}),
+        b"data: [DONE]\n",
+    ]
+    second = {
+        "choices": [{
+            "message": {"content": "", "tool_calls": [{
+                "id": "call_recovered",
+                "type": "function",
+                "function": {"name": "run_parallel", "arguments": '{"goals": []}'},
+            }]},
+            "finish_reason": "tool_calls",
+        }],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 3},
+    }
+
+    class _JsonResp:
+        def __init__(self, payload):
+            self._data = json.dumps(payload).encode("utf-8")
+
+        def read(self):
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    calls = []
+
+    def urlopen(req, timeout=None):
+        body = json.loads(req.data.decode("utf-8"))
+        calls.append(body)
+        if body.get("stream"):
+            return _SseResp(first)
+        return _JsonResp(second)
+
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+    seen = []
+    resp = _driver(
+        base_url="https://opencode.ai/zen/go/v1", model="deepseek-flash",
+    ).chat_stream(
+        [{"role": "user", "content": "do the protocol test"}],
+        tools=[{"type": "function", "function": {
+            "name": "run_parallel", "parameters": {"type": "object"},
+        }}],
+        on_delta=seen.append,
+    )
+
+    assert len(calls) == 2
+    assert calls[0]["stream"] is True
+    assert "stream" not in calls[1]
+    assert seen == ["Fanning out..."]
+    assert resp.error is None
+    assert resp.text == ""
+    assert resp.meta["tool_calls"][0]["function"]["name"] == "run_parallel"
+    assert resp.meta["incomplete_retry_recovered"] is True
+
+
+def test_opencode_go_retries_tool_finish_without_assembled_call(monkeypatch):
+    """A relay can report tool_calls after dropping every tool delta."""
+    first = [
+        _data({"choices": [{"delta": {"content": "Working"}}]}),
+        _data({"choices": [{"delta": {}, "finish_reason": "tool_calls"}]}),
+        b"data: [DONE]\n",
+    ]
+    second = {
+        "choices": [{
+            "message": {"content": "", "tool_calls": [{
+                "id": "call_recovered",
+                "type": "function",
+                "function": {"name": "run_parallel", "arguments": "{}"},
+            }]},
+            "finish_reason": "tool_calls",
+        }],
+    }
+
+    class _JsonResp:
+        def read(self):
+            return json.dumps(second).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    calls = []
+
+    def urlopen(req, timeout=None):
+        body = json.loads(req.data.decode("utf-8"))
+        calls.append(body)
+        return _SseResp(first) if body.get("stream") else _JsonResp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+    resp = _driver(
+        base_url="https://opencode.ai/zen/go/v1", model="deepseek-flash",
+    ).chat_stream(
+        [{"role": "user", "content": "do the protocol test"}],
+        tools=[{"type": "function", "function": {
+            "name": "run_parallel", "parameters": {"type": "object"},
+        }}],
+        on_delta=lambda _text: None,
+    )
+
+    assert len(calls) == 2
+    assert resp.error is None
+    assert resp.meta["incomplete_retry_recovered"] is True
+    assert resp.meta["tool_calls"][0]["function"]["name"] == "run_parallel"
+
+
+def test_reasoning_content_presence_survives_stream_parser(monkeypatch):
+    """DeepSeek's native field must remain distinct from normalized reasoning."""
+    lines = [
+        _data({"choices": [{"delta": {"reasoning_content": "plan"}}]}),
+        _data({"choices": [{"delta": {"content": "done"}, "finish_reason": "stop"}]}),
+        b"data: [DONE]\n",
+    ]
+    resp = _run_stream(monkeypatch, _driver(model="deepseek-flash"), lines)
+
+    assert resp.meta["reasoning"] == "plan"
+    assert resp.meta["reasoning_content"] == "plan"
+
+
+def test_empty_reasoning_content_field_is_preserved_in_sync_response(monkeypatch):
+    class _JsonResp:
+        def read(self):
+            return json.dumps({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "ok",
+                        "reasoning_content": "",
+                    },
+                    "finish_reason": "stop",
+                }],
+            }).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _JsonResp())
+    resp = _driver(model="deepseek-flash").chat(
+        [{"role": "user", "content": "hi"}],
+    )
+
+    assert resp.meta["reasoning"] == ""
+    assert resp.meta["reasoning_content"] == ""
+
+
 def test_duplicate_and_out_of_order_index_assembly(monkeypatch):
     lines = [
         _data({

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -38,6 +38,7 @@ class FakeStreamingDriver:
                         }
                     ],
                     "reasoning": "Let me read the file first.",
+                    "reasoning_content": "Let me read the file first.",
                     "finish_reason": "tool_calls",
                     "stream_terminal": "tool_calls",
                 }
@@ -81,6 +82,7 @@ class FakeStreamingDriver:
                         }
                     ],
                     "reasoning": "Let me read the file first.",
+                    "reasoning_content": "Let me read the file first.",
                     "finish_reason": "tool_calls",
                     "stream_terminal": "tool_calls",
                     "stream_started": True,
@@ -374,6 +376,7 @@ def test_conversational_loop_streaming():
         item for item in s._history if item.get("role") == "assistant"
     ]
     assert assistant_history[0]["content"] == "Reading..."
+    assert assistant_history[0]["reasoning_content"] == "Let me read the file first."
     assert assistant_history[0]["phase"] == "commentary"
     assert assistant_history[-1]["content"] == "Done."
     assert assistant_history[-1]["phase"] == "final_answer"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.461"
+version = "0.9.462"
 source = { editable = "." }
 dependencies = [
     { name = "puppetmaster-ai" },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.461",
+  "version": "0.9.462",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Problem

The OpenCode Go relay can close a streamed tool turn after emitting prose or a partial tool call. Marionette correctly withheld the incomplete call, but the user was left with `Reply incomplete.` even when a fresh provider response could recover the complete call. DeepSeek's `reasoning_content` field was also normalized into generic reasoning and dropped from native assistant history, which can make the next tool roundtrip invalid.

## Change

- Add one bounded, silent non-streaming recovery attempt for OpenCode Go tool-call cutoffs. The first streamed text is emitted once; only a complete retry tool call can execute. Transport errors and other providers remain fail-closed.
- Preserve `reasoning_content` field presence and value through streaming and synchronous OpenAI-compatible responses, and include it in native assistant history without rendering private reasoning as user prose.
- Add regression coverage for partial calls, dropped tool deltas, transport errors, empty reasoning fields, and history roundtrips.
- Bump Marionette to `0.9.462` and document the recovery behavior.

## Validation

- Python: `7,528 passed, 68 skipped` on the full offline suite; focused retry/streaming/version tests pass.
- Web: `2,526 passed` across 234 Vitest files; `400` Electron tests pass; production build and lint exit successfully (lint reports existing warnings).

Release tagging remains gated on green CI for this exact tree.
