### PR TITLE
v0.9.463: pin puppetmaster-ai==1.27.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 # Operational pin (installers inherit Puppetmaster from the checkout).
 # Kept here so desktop/CI pin-parity tests stay honest.
 env:
-  PUPPETMASTER_SPEC: puppetmaster-ai==1.27.11
+  PUPPETMASTER_SPEC: puppetmaster-ai==1.27.12
 
 permissions:
   contents: write

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.27.11"
+          pip install -e ".[dev]" "puppetmaster-ai==1.27.12"
 
       - name: Run the offline test suite
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.27.11"
+          pip install -e ".[dev]" "puppetmaster-ai==1.27.12"
 
       - name: Run the offline test suite
         run: python -m pytest -q -p no:cacheprovider -n 4 --dist loadscope
@@ -58,7 +58,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.27.11"
+          pip install -e ".[dev]" "puppetmaster-ai==1.27.12"
 
       - name: Run the offline test suite (shard)
         env:
@@ -104,7 +104,7 @@ jobs:
       - name: Install (rig + dev extras + Puppetmaster from PyPI)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" "puppetmaster-ai==1.27.11"
+          pip install -e ".[dev]" "puppetmaster-ai==1.27.12"
 
       - name: Run offline pmharness/intent/registry units
         run: python -m pytest -q -p no:cacheprovider tests/test_intent.py tests/test_registry.py tests/test_registry_wizard.py tests/test_pilot_driver_templates.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Or set up a checkout by hand. Backend (uv provides Python per `.python-version`)
 
 ```bash
 uv venv .venv
-uv pip install --python .venv -e . "puppetmaster-ai==1.27.11"
+uv pip install --python .venv -e . "puppetmaster-ai==1.27.12"
 .venv/bin/python -m pytest -q          # full offline suite -- must be green
 ```
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -51,7 +51,7 @@ architecture gap; no core change required.
 2. The driver loop's contract is exact: emit a structured intent that maps to
    `Orchestrator.run` args; fold `RunResult.artifacts` back. That is the entire
    token-thesis mechanism, and it is concrete.
-3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.27.11` (desktop
+3. Puppetmaster runtime is pinned at `puppetmaster-ai==1.27.12` (desktop
    bootstrap, install/doctor, and CONTRIBUTING); the old 0.9.x wiki note is obsolete.
 
 ## Stage 2 -- The driver eval rig (built, green offline)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and both the chat **pilot** and agentic **workers** (swarm / implement) run on
 that credential. No Cursor, Claude, or Codex CLI install is required.
 
 Puppetmaster is the bundled kernel — not a second product to set up.
-stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.11` is the one
+stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.462, deliberately pre-1.0. The reply output cap now defaults to the provider's model-specific limit where supported; APIs that require a numeric ceiling receive 32K. Explicit user caps remain available in Settings. DeepSeek tool calls preserve the provider reasoning field, and private reasoning stays out of spoken answers. OpenCode Go tool-stream cutoffs get one silent non-stream recovery attempt before Marionette reports an incomplete reply. Runtime pin: `puppetmaster-ai==1.27.11`.
+> Status: v0.9.463, deliberately pre-1.0. Pin `puppetmaster-ai==1.27.12` so first-run verification reads the persisted Codex wire name (dashed registry ids match dotted adapter names). Reply output cap defaults to the provider model limit where supported; APIs that require a numeric ceiling receive 32K. DeepSeek tool calls preserve provider reasoning; private reasoning stays out of spoken answers. OpenCode Go tool-stream cutoffs get one silent non-stream recovery attempt. Runtime pin: `puppetmaster-ai==1.27.12`.
 
 ## Documentation
 
@@ -92,7 +92,7 @@ The cost thesis is measured, not asserted:
 |---|---|
 | **Provider-native pilot** | One driver, every OpenAI-compatible endpoint (OpenRouter or native). Frontier control models (Claude, GPT) and open-weights (GLM, DeepSeek, Kimi, Qwen, MiniMax) drive the same loop. |
 | **CodeGraph-first retrieval** | Per-turn structural context is auto-injected (symbols, defs, call sites) before the model acts, so it leans on the graph instead of dumping whole files. Self-healing: the index detects edits, additions, and deletions and refreshes in the background. |
-| **Puppetmaster delegation** | `run_swarm`, `run_implement`, and `run_parallel` run bounded workers as durable jobs. Inspect recorded attempts, acceptance evidence, uncertain outcomes, and measured or estimated consumption. Marionette pins `puppetmaster-ai==1.27.11`; the installer and self-update use the same version. |
+| **Puppetmaster delegation** | `run_swarm`, `run_implement`, and `run_parallel` run bounded workers as durable jobs. Inspect recorded attempts, acceptance evidence, uncertain outcomes, and measured or estimated consumption. Marionette pins `puppetmaster-ai==1.27.12`; the installer and self-update use the same version. |
 | **Portable LLM Wiki** | Cross-session, cross-LLM durable memory. A local model structures a session digest into entity/concept/decision pages (the "backwards" orchestration) cheaply, then ingests them -- human-approved by default. |
 | **Durable memory graph** | Local durable facts/preferences (`MemoryStore`) plus optional relations via `MemoryGraph` (`GET /api/memory/graph`, shape `{nodes,edges}` like the wiki graph; sqlite + append-only jsonl). |
 | **Vision on any driver** | Paste or drop a screenshot and even a text-only driver "sees" it. A VLM sidecar transcribes the image, resolved in tiers: an explicit `HARNESS_VLM_REACH` override, then a dedicated Gemini/OpenRouter vision key, then -- with zero extra setup -- **any provider key you already have that exposes a vision model** (Anthropic, OpenAI, xAI, ...). No separate vision key required if your driver's provider can see. |

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.462"
+__version__ = "0.9.463"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/diag_bundle.py
+++ b/harness/diag_bundle.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 DEFAULT_SESSION_LIMIT = 20
-PIN_FALLBACK = "puppetmaster-ai==1.27.11"
+PIN_FALLBACK = "puppetmaster-ai==1.27.12"
 _PIN_RE = re.compile(r"puppetmaster-ai==[0-9]+(?:\.[0-9]+)*")
 _SECRET_KEY_FRAGMENTS = (
     "api_key",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.462"
+version = "0.9.463"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [
     "pypdf",
     # Runtime ownership: a standalone `pip install pm-harness` must pull the
     # pinned Puppetmaster bridge. Desktop/Electron still re-checks the same pin.
-    "puppetmaster-ai==1.27.11",
+    "puppetmaster-ai==1.27.12",
     "tzdata>=2026.3",
 ]
 

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ if (Test-Path $Py) {
     & $Py -c "import harness" 2>$null
     if ($LASTEXITCODE -eq 0) { Ok "imports 'harness'" } else { Bad "cannot import 'harness' -- run: uv pip install --python .venv -e ." }
     & $Py -c "import puppetmaster" 2>$null
-    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.27.11" }
+    if ($LASTEXITCODE -eq 0) { Ok "imports 'puppetmaster'" } else { Bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.27.12" }
 } else {
     Bad "no .venv\Scripts\python.exe -- run: uv venv .venv && uv pip install --python .venv -e ."
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -24,7 +24,7 @@ PY=".venv/bin/python"
 if [ -x "$PY" ]; then
   ok "python venv present ($($PY --version 2>&1))"
   if $PY -c "import harness" 2>/dev/null; then ok "imports 'harness'"; else bad "cannot import 'harness' -- run: uv pip install --python .venv -e ."; fi
-  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.27.11"; fi
+  if $PY -c "import puppetmaster" 2>/dev/null; then ok "imports 'puppetmaster'"; else bad "cannot import 'puppetmaster' -- run: uv pip install --python .venv puppetmaster-ai==1.27.12"; fi
 else
   bad "no .venv/bin/python -- run: uv venv .venv && uv pip install --python .venv -e ."
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,7 +211,7 @@ if (Test-Path ".venv") {
 
 Say "Installing Marionette (editable) + Puppetmaster into .venv"
 & uv pip install --python .venv -e .
-$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.27.11" }
+$puppetSpec = if ($env:MARIONETTE_PUPPETMASTER_SPEC) { $env:MARIONETTE_PUPPETMASTER_SPEC } else { "puppetmaster-ai==1.27.12" }
 & uv pip install --python .venv $puppetSpec
 
 Say "Installing node deps + building the renderer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,7 +145,7 @@ uv pip install --python .venv -e .
 # Puppetmaster is the one real runtime dependency; it ships on PyPI as
 # puppetmaster-ai. MARIONETTE_PUPPETMASTER_SPEC lets a contributor point at a
 # local editable checkout instead (e.g. an absolute path).
-uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.27.11}"
+uv pip install --python .venv "${MARIONETTE_PUPPETMASTER_SPEC:-puppetmaster-ai==1.27.12}"
 
 # --- 6. renderer -------------------------------------------------------------
 say "Installing node deps + building the renderer"

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.462"
+version = "0.9.463"
 source = { editable = "." }
 dependencies = [
     { name = "puppetmaster-ai" },
@@ -97,7 +97,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "puppetmaster-ai", specifier = "==1.27.11" },
+    { name = "puppetmaster-ai", specifier = "==1.27.12" },
     { name = "pypdf" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
@@ -107,11 +107,11 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "puppetmaster-ai"
-version = "1.27.11"
+version = "1.27.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/06/973a1dc56a472bc4a5da605e6910e969fb9fc05fc339e23729d405550fce/puppetmaster_ai-1.27.11.tar.gz", hash = "sha256:a2a51ebc84fa6a1d223ccd0f6fd51294e79d5e58cb7c1371075e721daa89cf58", size = 1990761, upload-time = "2026-09-11T05:43:13.482Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/20/708d101ff39dacc22d1b58e542901a30fc02f50f4260d35fff579ddb33f0/puppetmaster_ai-1.27.12.tar.gz", hash = "sha256:d82f1786f6c56496944e0c59280cf674af358c567070a32b4803ef6c6ae01924", size = 1991285, upload-time = "2026-09-11T15:14:07.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/14/2483004da47ed90017410efdaac288d2de8282dc5e0e010ebc7c91f4e972/puppetmaster_ai-1.27.11-py3-none-any.whl", hash = "sha256:e4025cab1cd05be0dfdcde2b5104ae537d8fe9c796c3d725993d3ee39fe22a5d", size = 1093784, upload-time = "2026-09-11T05:43:12.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/0cb39ccc1b4670308157cc3eafbed778d07dbf0564807fba4c1ea6858299/puppetmaster_ai-1.27.12-py3-none-any.whl", hash = "sha256:daa8de0df2bb7ad86770d997f79ba66bd8f8b9d4ea53b1d9cb93771074e74023", size = 1093869, upload-time = "2026-09-11T15:14:06.381Z" },
 ]
 
 [[package]]

--- a/webapp/electron/bootstrap.cjs
+++ b/webapp/electron/bootstrap.cjs
@@ -90,7 +90,7 @@ function installIdentity(dir, target) {
   return { schema: 1, mode: target.mode, repo: target.repo,
     revision: gitValue(dir, ["rev-parse", "HEAD"]), inputs: hash.digest("hex"),
     platform: process.platform, arch: process.arch,
-    puppetmaster: process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.27.11" };
+    puppetmaster: process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.27.12" };
 }
 
 function venvPython(dir) {
@@ -378,7 +378,7 @@ async function provisionPython(dest, onProgress) {
   }
   await reportProgress(onProgress, "Installing Marionette + Puppetmaster...", 55);
   await runAsync("uv", ["pip", "install", "--python", ".venv", "-e", "."], { cwd: dest });
-  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.27.11";
+  const spec = process.env.MARIONETTE_PUPPETMASTER_SPEC || "puppetmaster-ai==1.27.12";
   await runAsync("uv", ["pip", "install", "--python", ".venv", spec], { cwd: dest });
 }
 

--- a/webapp/electron/update-pm.cjs
+++ b/webapp/electron/update-pm.cjs
@@ -21,7 +21,7 @@
 
 const path = require("node:path");
 
-const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.27.11";
+const DEFAULT_PUPPETMASTER_SPEC = "puppetmaster-ai==1.27.12";
 const PUPPETMASTER_DIST_NAME = "puppetmaster-ai";
 const HARNESS_DIST_NAME = "pm-harness";
 
@@ -95,7 +95,7 @@ function installedPuppetmasterVersion(pipShowOutput) {
 // Decide whether the updater should upgrade Puppetmaster, given the environment
 // and the current install's `pip show` text. Returns either
 //   { skip: true, reason }                       -- leave the install untouched
-//   { skip: false, spec: "puppetmaster-ai==1.27.11" }    -- install the pinned PyPI release
+//   { skip: false, spec: "puppetmaster-ai==1.27.12" }    -- install the pinned PyPI release
 function planPuppetmasterUpgrade({ specEnv, pipShowOutput, pinnedSpec } = {}) {
   const spec = String(specEnv || "").trim();
   if (spec) {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.461",
+  "version": "0.9.463",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.461",
+      "version": "0.9.463",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.462",
+  "version": "0.9.463",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Why

Puppetmaster **1.27.12** is on PyPI. Desktop first-run and self-update must install the same string CI uses, or installers stay on 1.27.11 (v0.9.108 class of drift).

## Scope

Pin `puppetmaster-ai==1.27.12` in pyproject, Electron bootstrap / update-pm, install and doctor scripts, CI workflows, README, CONTRIBUTING, FINDINGS, diag fallback, and uv.lock. Version stamps **0.9.463** in pyproject, `harness.__version__`, package.json, and package-lock.

1.27.12 makes `setup --verify-first-run` read the persisted Codex wire name so dashed registry ids match dotted adapter names (absorb of Puppetmaster #181).

## Verification

`tests/test_version_consistency.py` functions all passed locally. PyPI JSON serves 1.27.12.