### PR TITLE
Release v0.9.464

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.463, deliberately pre-1.0. Pin `puppetmaster-ai==1.27.12` so first-run verification reads the persisted Codex wire name (dashed registry ids match dotted adapter names). Reply output cap defaults to the provider model limit where supported; APIs that require a numeric ceiling receive 32K. DeepSeek tool calls preserve provider reasoning; private reasoning stays out of spoken answers. OpenCode Go tool-stream cutoffs get one silent non-stream recovery attempt. Runtime pin: `puppetmaster-ai==1.27.12`.
+> Status: v0.9.464, deliberately pre-1.0. Pin stays `puppetmaster-ai==1.27.12`. Swarm Tracker is compact-only: named roles, no Inspect overlay, finished jobs stay under Finished, and the pill opens the Puppetmaster dashboard. OpenCode Go DeepSeek flash pins accept live `deepseek-flash` and curated `deepseek-v4-flash`. Delete or archive of the current session opens a blank New session. Memory Save is session-scoped and idempotent. Reply output cap defaults to the provider model limit where supported; APIs that require a numeric ceiling receive 32K. DeepSeek tool calls preserve provider reasoning. OpenCode Go tool-stream cutoffs get one silent non-stream recovery attempt. Runtime pin: `puppetmaster-ai==1.27.12`.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.463"
+__version__ = "0.9.464"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/auto_registry.py
+++ b/harness/auto_registry.py
@@ -211,6 +211,10 @@ def _opencode_go_curated() -> list[tuple[str, str, str]]:
         if not bare:
             continue
         n = bare.lower()
+        # Live Go id is deepseek-flash; keep one worker row under the curated
+        # slug so Settings pins of either id resolve to the same catalog entry.
+        if n == "deepseek-flash":
+            continue
         if any(tok in n for tok in ("kimi-k3", "grok-4.6", "grok-4.5", "gpt-5.6-sol", "glm-5.3", "glm-5.2")):
             tier = "frontier"
         elif "flash" in n or n.endswith("-plus") or n in ("hy3", "mimo-v2.5"):
@@ -442,11 +446,17 @@ def _in_live_catalog(name: str, slug: str, live_models: list[str]) -> bool:
         return False
     live = [str(m or "").strip() for m in live_models if str(m or "").strip()]
     live_set = {m.lower() for m in live}
+    try:
+        from .opencode_go import flash_model_keys
+    except Exception:
+        flash_model_keys = lambda model: frozenset({str(model or "").strip().lower()} - {""})
     for key in (name, slug):
         raw = str(key or "").strip()
         if not raw:
             continue
         if raw.lower() in live_set:
+            return True
+        if flash_model_keys(raw) & live_set:
             return True
         promoted = _newest_dated_snapshot(raw, live)
         if promoted.lower() in live_set:

--- a/harness/marionette_registry.py
+++ b/harness/marionette_registry.py
@@ -151,6 +151,8 @@ _DEMOTE_ALIASES: dict[str, tuple[str, ...]] = {
         "agentic/deepseek-v4-flash",
         "deepseek-v4-flash",
         "deepseek/deepseek-v4-flash",
+        "deepseek-flash",
+        "agentic/deepseek-flash",
     ),
 }
 

--- a/harness/opencode_go.py
+++ b/harness/opencode_go.py
@@ -64,8 +64,44 @@ CURATED_MODELS = (
     "qwen3.6-plus",
     "deepseek-v4-pro",
     "deepseek-v4-flash",
+    "deepseek-flash",
     "hy3",
 )
+
+# Live Go /models currently lists ``deepseek-flash``. Curated/OpenRouter and
+# older Settings pins still say ``deepseek-v4-flash``. Same model.
+FLASH_MODEL_ALIASES = frozenset({
+    "deepseek-flash",
+    "deepseek-v4-flash",
+    "deepseek-v4.1-flash",
+    "deepseek-v4-1-flash",
+})
+WIRE_FLASH_MODEL = "deepseek-flash"
+
+
+def flash_model_keys(model: Optional[str]) -> frozenset:
+    """Bare ids that mean the same Go DeepSeek flash row as *model*."""
+    bare = normalize_model_id(model).lower()
+    if not bare:
+        return frozenset()
+    if bare in FLASH_MODEL_ALIASES:
+        return FLASH_MODEL_ALIASES
+    return frozenset({bare})
+
+
+def same_go_flash_model(left: Optional[str], right: Optional[str]) -> bool:
+    """True when both names are the Go DeepSeek V4.1 flash live/curated pair."""
+    a = normalize_model_id(left).lower()
+    b = normalize_model_id(right).lower()
+    return bool(a) and a in FLASH_MODEL_ALIASES and b in FLASH_MODEL_ALIASES
+
+
+def wire_model_id(model: Optional[str]) -> str:
+    """Bare id the Go relay actually serves for *model*."""
+    bare = normalize_model_id(model)
+    if bare.lower() in FLASH_MODEL_ALIASES:
+        return WIRE_FLASH_MODEL
+    return bare
 
 # Endpoint table (https://opencode.ai/docs/go/). Prefix matching rather than an
 # exact allow-list so a newly added sibling (qwen3.8-plus, minimax-m4) routes
@@ -242,7 +278,7 @@ def build_driver(
     Callers pass the raw picker model (possibly namespaced); the bare id is what
     reaches the relay.
     """
-    bare = normalize_model_id(model)
+    bare = wire_model_id(model)
     return build_opencode_driver(
         spec=spec,
         model=bare,

--- a/harness/review_memory.py
+++ b/harness/review_memory.py
@@ -183,6 +183,13 @@ class ReviewMemoryMixin:
 
     def accept_memory_proposal(self, proposal_id: str) -> dict:
         """Persist a pending end-of-turn memory proposal (source=agent)."""
+        resolved = getattr(self, "_resolved_memory_proposals", None)
+        if resolved is None:
+            self._resolved_memory_proposals = {}
+            resolved = self._resolved_memory_proposals
+        prior = resolved.get(proposal_id)
+        if prior:
+            return dict(prior)
         prop = self._pending_memory_proposals.pop(proposal_id, None)
         if not prop:
             return {"ok": False, "error": "proposal not found"}
@@ -194,7 +201,7 @@ class ReviewMemoryMixin:
             category=(prop.get("category") or "general").strip() or "general",
             source="agent",
         )
-        return {
+        result = {
             "ok": True,
             "id": entry.id,
             "text": entry.text,
@@ -202,10 +209,19 @@ class ReviewMemoryMixin:
             "source": entry.source,
             "created_at": entry.created_at,
         }
+        resolved[proposal_id] = result
+        return result
 
     def dismiss_memory_proposal(self, proposal_id: str) -> dict:
         """Drop a pending end-of-turn memory proposal without writing."""
+        resolved = getattr(self, "_resolved_memory_proposals", None)
+        if resolved is None:
+            self._resolved_memory_proposals = {}
+            resolved = self._resolved_memory_proposals
         if proposal_id in self._pending_memory_proposals:
             self._pending_memory_proposals.pop(proposal_id, None)
+            resolved[proposal_id] = {"ok": True}
+            return {"ok": True}
+        if proposal_id in resolved:
             return {"ok": True}
         return {"ok": False, "error": "proposal not found"}

--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -429,14 +429,10 @@ class SessionStore:
             # Durability: flush any coalesced mutations before promote/read.
             self._cancel_save_timer_unlocked()
             self._flush_unlocked()
-            deleted_root = ""
-            for s in self._sessions:
-                if s["id"] == sid:
-                    deleted_root = session_stored_root(s)
-                    break
             self._sessions = [s for s in self._sessions if s["id"] != sid]
             if self._active == sid:
-                self._active = self._pick_next_active(deleted_root)
+                # Client opens a blank session; do not promote a sibling.
+                self._active = None
             self._save(immediate=True)
             return self._active
 

--- a/harness/swarm_model_pin.py
+++ b/harness/swarm_model_pin.py
@@ -185,6 +185,21 @@ def _parse_pin_provider_model(pin: str) -> tuple[str, str]:
     return "", body
 
 
+def _same_pin_model(left: str, right: str) -> bool:
+    """Exact model id, or the OpenCode Go DeepSeek flash live/curated pair."""
+    a = (left or "").strip().lower()
+    b = (right or "").strip().lower()
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    try:
+        from .opencode_go import same_go_flash_model
+        return same_go_flash_model(a, b)
+    except Exception:
+        return False
+
+
 def settings_enabled_pin_specs(
     pin: str,
     *,
@@ -216,7 +231,7 @@ def settings_enabled_pin_specs(
             continue
         if pin_provider and prov != pin_provider:
             continue
-        exact = bool(pin_model_l) and mid.lower() == pin_model_l
+        exact = bool(pin_model_l) and _same_pin_model(mid, pin_model_l)
         if not exact:
             continue
         key = raw.lower()
@@ -302,7 +317,7 @@ def _row_matches_enabled_settings(row: dict, enabled: Optional[list[str]]) -> bo
     if not provider or not model:
         return False
     return any(
-        _normalize_pin_provider(_provider) == provider and _model.strip().lower() == model
+        _normalize_pin_provider(_provider) == provider and _same_pin_model(_model, model)
         for spec in enabled
         if ":" in str(spec)
         for _provider, _model in [str(spec).split(":", 1)]
@@ -462,6 +477,25 @@ def pin_candidates(pin: str) -> list[str]:
     hyphenated = re.sub(r"(gpt-\d+)\.(\d+)", r"\1-\2", bare, count=1, flags=re.I)
     _add(hyphenated)
 
+    # OpenCode Go live id is deepseek-flash; curated/OpenRouter rows stay
+    # deepseek-v4-flash. Pins of either must resolve.
+    flash_aliases = {
+        "deepseek-flash",
+        "deepseek-v4-flash",
+        "deepseek-v4.1-flash",
+        "deepseek-v4-1-flash",
+    }
+    tail = bare.rsplit("/", 1)[-1].lower()
+    if tail in flash_aliases:
+        _add("deepseek-flash")
+        _add("deepseek-v4-flash")
+        _add("agentic/deepseek-flash")
+        _add("agentic/deepseek-v4-flash")
+        _add("opencode-go/deepseek-flash")
+        _add("opencode-go/deepseek-v4-flash")
+        _add("agentic/opencode-go/deepseek-flash")
+        _add("agentic/opencode-go/deepseek-v4-flash")
+
     for body in (bare, dotted, hyphenated):
         if not body:
             continue
@@ -528,7 +562,7 @@ def _exact_registry_pin(pin: str, rows: list[dict]) -> Optional[dict[str, Any]]:
         if not row_model:
             row_model = str(defaults.get("model") or "").strip()
         row_id = str(row.get("id") or "").strip()
-        if not row_id or row_model != model:
+        if not row_id or not _same_pin_model(row_model, model):
             continue
         if provider and row_provider != provider:
             continue
@@ -633,6 +667,17 @@ def resolve_swarm_model_pin(
                 if reason and remapped:
                     pin_fields[key] = remapped
                     _diag("swarm_model_pin.codex_pro_remap_fields", msg=f"{key}:{reason}")
+            provider = str(pin_fields.get("provider") or "").strip().lower()
+            if provider in ("opencode-go", "opencode_go"):
+                try:
+                    from .opencode_go import wire_model_id
+                    for key in ("model", "pinned_adapter_model_name"):
+                        cur = str(pin_fields.get(key) or "").strip()
+                        wired = wire_model_id(cur)
+                        if wired and wired != cur:
+                            pin_fields[key] = wired
+                except Exception as exc:
+                    _diag("swarm_model_pin.go_flash_wire", exc)
             if norm_meta.get("reasoning_effort_hint") and not pin_fields.get("reasoning_effort"):
                 pin_fields["reasoning_effort"] = norm_meta["reasoning_effort_hint"]
             reason = "exact_registry_row"

--- a/harness/swarm_worker_allowlist.py
+++ b/harness/swarm_worker_allowlist.py
@@ -198,11 +198,24 @@ def allowed_model_ids_from_specs(
     for spec in rows:
         provider = _provider_of_spec(spec)
         model = _model_of_spec(spec)
-        hit = by_pair.get((provider, model.strip().lower()))
+        hit = None
+        for alias in [model.strip().lower(), *sorted(_flash_lookup_keys(model))]:
+            hit = by_pair.get((provider, alias))
+            if hit:
+                break
         if hit and hit.lower() not in seen:
             seen.add(hit.lower())
             out.append(hit)
     return out
+
+
+def _flash_lookup_keys(model: str) -> frozenset:
+    try:
+        from .opencode_go import flash_model_keys
+        return flash_model_keys(model)
+    except Exception:
+        n = (model or "").strip().lower()
+        return frozenset({n} if n else ())
 
 
 def resolve_swarm_worker_allowlist(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.463"
+version = "0.9.464"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_auto_registry.py
+++ b/tests/test_auto_registry.py
@@ -963,6 +963,30 @@ def test_opencode_go_live_drops_mimo_when_not_served(monkeypatch, tmp_path):
     assert not any("mimo" in mid for mid in ids)
 
 
+def test_opencode_go_live_flash_id_keeps_v4_curated_worker_row(monkeypatch, tmp_path):
+    """Go /models lists deepseek-flash; curated worker slug stays v4-flash."""
+    models_path = tmp_path / "models.json"
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setenv("HARNESS_LIVE_PRICES", "0")
+
+    def mock_get_provider_key(provider):
+        return "fake-go" if provider.name == "opencode-go" else None
+
+    live = ["gpt-5.6-luna", "deepseek-flash", "kimi-k3"]
+
+    with patch("harness.registry_wizard.get_provider_key", mock_get_provider_key), \
+         patch("harness.keys.get_disconnected", lambda: set()), \
+         patch("harness.model_fetch.fetch_models", lambda *_a, **_k: list(live)), \
+         patch("harness.auto_registry._enabled_picker_models", lambda _name: []):
+        from harness.auto_registry import sync_agentic_registry
+        sync_agentic_registry()
+
+    ids = {m["id"] for m in json.loads(models_path.read_text())["models"]}
+    assert "agentic/gpt-5.6-luna" in ids
+    assert "agentic/deepseek-v4-flash" in ids
+    assert "agentic/deepseek-flash" not in ids
+
+
 def test_sync_with_no_keys_writes_no_agentic_models(monkeypatch, tmp_path):
     models_path = tmp_path / "models.json"
     models_path.write_text(

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -443,3 +443,19 @@ def test_memory_propose_accept_missing(tmp_path, monkeypatch):
     assert session.accept_memory_proposal("nope")["ok"] is False
     assert session.dismiss_memory_proposal("nope")["ok"] is False
 
+
+def test_memory_propose_accept_is_idempotent(tmp_path, monkeypatch):
+    temp_mem_path = tmp_path / "idempotent_memory.json"
+    monkeypatch.setattr("harness.memory_store.MEMORY_PATH", temp_mem_path)
+    monkeypatch.setattr("harness.conversation.RuleStore", lambda *args, **kwargs: RuleStore(path=str(tmp_path / "rules.json")))
+    cfg = HarnessConfig(driver="stub-oracle-v2", state_dir=tempfile.mkdtemp())
+    session = ConversationalSession(cfg)
+    session._turn_memory_queue = [{"text": "Remember this kit", "category": "fact"}]
+    props = session._flush_turn_memory_proposals()
+    assert len(props) == 1
+    first = session.accept_memory_proposal(props[0]["id"])
+    second = session.accept_memory_proposal(props[0]["id"])
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert len(session._memory.list()) == 1
+

--- a/tests/test_opencode_go.py
+++ b/tests/test_opencode_go.py
@@ -56,7 +56,7 @@ def test_curated_catalog_covers_the_published_endpoint_table():
         "grok-4.5", "gpt-5.6-luna", "glm-5.3", "glm-5.2", "glm-5.1", "kimi-k3",
         "kimi-k2.7-code", "kimi-k2.6", "mimo-v2.5", "mimo-v2.5-pro",
         "minimax-m3", "minimax-m2.7", "qwen3.7-max", "qwen3.7-plus",
-        "qwen3.6-plus", "deepseek-v4-pro", "deepseek-v4-flash", "hy3",
+        "qwen3.6-plus", "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-flash", "hy3",
     ):
         assert model in go.CURATED_MODELS
 
@@ -260,7 +260,7 @@ def test_build_pilot_routes_chat_completions_models():
     driver = prov.build_pilot("opencode-go:deepseek-v4-flash")
     assert isinstance(driver, OpenAICompatDriver)
     assert driver.base_url == go.BASE_URL
-    assert driver.model == "deepseek-v4-flash"
+    assert driver.model == "deepseek-flash"
     assert driver.api_key_env == "OPENCODE_GO_API_KEY"
     assert driver.extra_headers["User-Agent"] == go.USER_AGENT
 

--- a/tests/test_queue_owner_lifecycle.py
+++ b/tests/test_queue_owner_lifecycle.py
@@ -48,30 +48,31 @@ def test_last_delete_clears_pilot_without_rebinding(server, clear):
     assert [p['text'] for p in new.list_prompts()] == ['B']
 
 
-def test_delete_attaches_survivor_without_copying_queue(server):
+def test_delete_current_does_not_attach_survivor(server):
     b, survivor = attach(server, 'B')
     a, deleted = attach(server, 'A')
     code, body = server._handle_session_delete(a)
-    assert code == 200 and body['active'] == b
-    assert server._pilot is survivor
+    assert code == 200 and body['active'] is None
+    assert server._pilot is None
+    assert server._runners.active_view_id is None
+    assert server._runners.get(b) is survivor
     assert [p['text'] for p in survivor.list_prompts()] == ['B']
     assert [p['text'] for p in deleted.list_prompts()] == ['A']
 
 
-def test_delete_lease_exhaustion_never_reuses_deleted_pilot(server):
+def test_delete_current_does_not_spend_a_lease_on_a_sibling(server):
     a, deleted = attach(server, 'A')
     c, busy_c = attach(server, 'C')
     d, busy_d = attach(server, 'D')
     busy_c._busy.acquire()
     busy_d._busy.acquire()
-    b = server._sessions.create('cold survivor')['id']
+    server._sessions.create('cold survivor')
     server._sessions.switch(a)
     server._pilot = deleted  # A's view outlived its evicted idle registry entry.
     server._runners.set_active_view(a)
     try:
         code, body = server._handle_session_delete(a)
-        assert code == 409 and body['code'] == 'lease_exhausted'
-        assert body['deleted'] == a
+        assert code == 200 and body['active'] is None
         assert server._pilot is None
         assert server._runners.active_view_id is None
         assert deleted.harness_session_id == a

--- a/tests/test_sessions_workspace_scoping.py
+++ b/tests/test_sessions_workspace_scoping.py
@@ -253,9 +253,11 @@ def test_delete_single_session_via_delete_method(tmp_path):
 
 
 def test_delete_active_session_stays_in_same_workspace(tmp_path):
-    """Deleting the active session must promote a sibling from the SAME
-    workspace -- never the newest session globally, which auto-switched the
-    whole app to another dir (often a leaked temp worktree)."""
+    """Deleting the active session must not promote any other transcript.
+
+    The client opens a blank session in the same workspace. Promoting a sibling
+    (or the newest global session) auto-switched dirs and leaked other chats.
+    """
     store = SessionStore(str(tmp_path / "sessions.json"))
     repo_a = tmp_path / "repo_a"
     repo_b = tmp_path / "repo_b"
@@ -267,8 +269,12 @@ def test_delete_active_session_stays_in_same_workspace(tmp_path):
     active_a = store.create("A-active", repo=str(repo_a), workspace_root=str(repo_a))
 
     new_active = store.delete(active_a["id"])
-    assert new_active == older_a["id"]
-    assert new_active != newest_b["id"]
+    assert new_active is None
+    assert store.active is None
+    remaining = {row["id"] for row in store.rows()}
+    assert older_a["id"] in remaining
+    assert newest_b["id"] in remaining
+    assert active_a["id"] not in remaining
 
 
 def test_delete_last_session_in_workspace_leaves_no_active(tmp_path):
@@ -286,11 +292,12 @@ def test_delete_last_session_in_workspace_leaves_no_active(tmp_path):
     assert store.delete(only_a["id"]) is None
 
 
-def test_delete_rootless_active_promotes_rootless_peer(tmp_path):
+def test_delete_rootless_active_leaves_no_active(tmp_path):
     store = SessionStore(str(tmp_path / "sessions.json"))
     peer = store.create("One")
     active = store.create("Two")
-    assert store.delete(active["id"]) == peer["id"]
+    assert store.delete(active["id"]) is None
+    assert peer["id"] in {row["id"] for row in store.rows()}
 
 
 def test_ephemeral_temp_sessions_pruned_on_load(tmp_path, monkeypatch):

--- a/tests/test_state_scoping_invariants.py
+++ b/tests/test_state_scoping_invariants.py
@@ -223,7 +223,8 @@ def test_delete_active_promotes_same_workspace_sibling_only(tmp_path):
 
     assert store.active == active_a["id"]
     new_active = store.delete(active_a["id"])
-    assert new_active == peer_a["id"]
+    assert new_active is None
+    assert peer_a["id"] in {row["id"] for row in store.rows()}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_swarm_model_pin.py
+++ b/tests/test_swarm_model_pin.py
@@ -31,6 +31,85 @@ def test_pin_candidates_include_opencode_go_deepseek_aliases():
         assert "glm-5.2" not in blob
 
 
+def test_pin_candidates_map_opencode_go_deepseek_flash_live_id():
+    from harness.swarm_model_pin import pin_candidates
+
+    for pin in ("opencode-go:deepseek-flash", "deepseek-flash", "agentic/deepseek-flash"):
+        cands = [c.lower() for c in pin_candidates(pin)]
+        blob = " ".join(cands)
+        assert "deepseek-flash" in blob
+        assert "deepseek-v4-flash" in blob
+        assert "agentic/opencode-go/deepseek-flash" in blob
+        assert "glm-5.2" not in blob
+
+
+def test_resolve_opencode_go_deepseek_flash_pin_against_v4_registry(
+    monkeypatch, tmp_path,
+):
+    """Picker/live id deepseek-flash must pin the curated v4-flash worker row."""
+    models_path = tmp_path / "models.json"
+    models_path.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "id": "agentic/deepseek-v4-flash",
+                        "adapter": "agentic",
+                        "adapter_model_name": "deepseek-v4-flash",
+                        "capability_score": 66,
+                        "payload_defaults": {
+                            "provider": "opencode-go",
+                            "model": "deepseek-v4-flash",
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PUPPETMASTER_MODELS_PATH", str(models_path))
+    monkeypatch.setattr(
+        "harness.auto_registry.ensure_keyed_provider_registry_health",
+        lambda: {"ready": True},
+    )
+    monkeypatch.setattr(
+        "harness.auto_registry.keyed_agentic_providers",
+        lambda: {"opencode-go"},
+    )
+    monkeypatch.setattr(
+        "harness.swarm_model_pin._settings_enabled_specs",
+        lambda: ["opencode-go:deepseek-flash"],
+    )
+    monkeypatch.setattr(
+        "puppetmaster.model_registry.apply_model_pin",
+        lambda payload, model, *, adapter, registry=None: {
+            **(payload or {}),
+            "model": "deepseek-v4-flash",
+            "provider": "opencode-go",
+            "pinned_model": "agentic/deepseek-v4-flash",
+            "pinned_adapter_model_name": "deepseek-v4-flash",
+        },
+    )
+
+    from harness.swarm_model_pin import resolve_agentic_model_pin, resolve_swarm_model_pin
+
+    for pin in (
+        "opencode-go:deepseek-flash",
+        "deepseek-flash",
+        "agentic/deepseek-flash",
+        "opencode-go:deepseek-v4-flash",
+    ):
+        out = resolve_swarm_model_pin(pin, allowed_adapters=["agentic"])
+        assert out["demoted"] is False, out
+        assert out["resolved"] == "agentic/deepseek-v4-flash"
+        assert out["pin_fields"]["model"] == "deepseek-flash"
+        pin_obj, err = resolve_agentic_model_pin(pin)
+        assert err == ""
+        assert pin_obj is not None
+        assert pin_obj.model == "deepseek-flash"
+        assert pin_obj.router_model_id == "agentic/deepseek-v4-flash"
+
+
 def test_resolve_rejects_cursor_alias_when_only_agentic_is_allowed(monkeypatch, tmp_path):
     models_path = tmp_path / "models.json"
     models_path.write_text(
@@ -487,7 +566,8 @@ def test_opencode_go_curated_bound_into_auto_registry():
     slugs = {slug for _n, _t, slug in go}
     assert "gpt-5.6-luna" in slugs
     assert "deepseek-v4-flash" in slugs
-    assert slugs == set(CURATED_MODELS)
+    assert "deepseek-flash" in CURATED_MODELS
+    assert slugs == set(CURATED_MODELS) - {"deepseek-flash"}
 
 
 def test_exposed_catalog_lists_enabled_astra_ahead_of_file_order_junk(

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.463"
+version = "0.9.464"
 source = { editable = "." }
 dependencies = [
     { name = "puppetmaster-ai" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.463",
+  "version": "0.9.464",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.463",
+      "version": "0.9.464",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.463",
+  "version": "0.9.464",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/CompactSwarmDashboard.test.tsx
+++ b/webapp/src/__tests__/CompactSwarmDashboard.test.tsx
@@ -85,6 +85,36 @@ it('keeps native forecasts distinct from an existing assignment', () => {
   expect(screen.getByText('Forecast: forecast-model. Projected choice')).toBeVisible();
 });
 
+it('never paints Model unavailable for a running native worker still waiting on a route', () => {
+  render(<CompactSwarmDashboard title="Native implement" lifecycle="running" nativeTasks={[producerTask()]}
+    workerStatuses={new Map()} />);
+  const roster = screen.getByRole('group', { name: 'Workers' });
+  expect(within(roster).getByText('implement')).toBeVisible();
+  expect(within(roster).queryByText(/implement \(agentic\)/)).toBeNull();
+  expect(within(roster).getByText('routing…')).toBeVisible();
+  expect(screen.queryByText(/unavailable/i)).toBeNull();
+  expect(screen.getByText('routing… · routing in progress')).toBeVisible();
+});
+
+it('shows a native forecast model instead of hiding the worker behind unavailable', () => {
+  const native = producerTask();
+  const route: LocalRoute = { ordinal: 1, task_id: native.task_id, association: 'explicit', model: 'gpt-5.6-luna',
+    model_kind: 'forecast', role: 'implement', policy: 'balanced', adapter: 'agentic', created_by: 'router',
+    detail: 'Projected choice', est_cost_usd: null, truncated: false };
+  render(<CompactSwarmDashboard title="Native forecast" lifecycle="running" nativeTasks={[native]}
+    nativeRoutes={new Map([[native.task_id!, route]])} routeCoverage="partial" workerStatuses={new Map()} />);
+  expect(within(screen.getByRole('group', { name: 'Workers' })).getByTitle('Model: gpt-5.6-luna')).toHaveTextContent('forecast');
+  expect(screen.queryByText(/unavailable/i)).toBeNull();
+});
+
+it('uses routing… for an active expert worker without a recorded model', () => {
+  const pending: ExpertMetadata = { ...expert, tasks: [{ ...task(1), model: '', adapter: 'codex' }], artifacts: [] };
+  render(<CompactSwarmDashboard title="Pending route" lifecycle="running" expert={pending}
+    workerStatuses={new Map([['task-1', 'running']])} />);
+  expect(screen.getByText('routing…')).toBeVisible();
+  expect(screen.queryByText(/unavailable/i)).toBeNull();
+});
+
 it('labels partial worker and token coverage without inventing a complete total', () => {
   const partial: ExpertMetadata = { ...expert, tasks: [{ ...task(1), usage: { ...task(1).usage, tokens_out: null } }],
     artifacts: [], coverage: { tasks: 'partial', artifacts: 'partial' } };

--- a/webapp/src/__tests__/LeftRail.sessions.test.ts
+++ b/webapp/src/__tests__/LeftRail.sessions.test.ts
@@ -6,7 +6,7 @@ import {
   peekTranscriptCacheEntry,
   writeTranscriptCache,
 } from "../components/conversation/transcriptCache";
-import { buildProjectsList, canSettleSessionsForProject, collectUnreadFinishedSessionIds, filterForgottenRecent, formatLeaseExhaustedMessage, isLeaseExhaustedError, isRailWideSwitching, jobsCacheKey, partitionProjectSessions, patchActiveSessionInCaches, patchSessionArchivedInCaches, patchSessionSettledInCaches, patchSessionTitleInCaches, pickFallbackProjectAfterForget, preferLastGoodSessionList, projectSessionsEmptyState, purgeSessionFromRootCaches, readSessionSettledFromCaches, SESSION_LEASE_EXHAUSTED_MESSAGE, shouldOfferBackgroundStop, writeSessionListCache, workspacesCacheKey } from "../components/LeftRail";
+import { buildProjectsList, canSettleSessionsForProject, collectUnreadFinishedSessionIds, filterForgottenRecent, formatLeaseExhaustedMessage, isLeaseExhaustedError, isRailWideSwitching, jobsCacheKey, partitionProjectSessions, patchActiveSessionInCaches, patchSessionArchivedInCaches, patchSessionSettledInCaches, patchSessionTitleInCaches, pickFallbackProjectAfterForget, preferLastGoodSessionList, projectSessionsEmptyState, purgeSessionFromRootCaches, readSessionSettledFromCaches, SESSION_LEASE_EXHAUSTED_MESSAGE, shouldOfferBackgroundStop, shouldOpenBlankSessionAfterRemove, writeSessionListCache, workspacesCacheKey } from "../components/LeftRail";
 import type { Session } from "../lib/api";
 
 /**
@@ -40,6 +40,12 @@ describe("LeftRail session list contracts", () => {
     expect(touched).toBe(2);
     expect(readSWRCache<Session[]>(`sessions:${marionette}`)?.map((s) => s.id)).toEqual(["sess-m"]);
     expect(readSWRCache<Session[]>(`sessions:${dugout}`)).toEqual([]);
+  });
+
+  it("delete or archive of the current session opens a blank New session", () => {
+    expect(shouldOpenBlankSessionAfterRemove("sess-a", "sess-a")).toBe(true);
+    expect(shouldOpenBlankSessionAfterRemove("sess-a", "sess-b")).toBe(false);
+    expect(shouldOpenBlankSessionAfterRemove("sess-a", "")).toBe(false);
   });
 
   it("reads cached sessions for a non-active root from sessions:${path}", () => {

--- a/webapp/src/__tests__/NativeTaskDisclosure.test.tsx
+++ b/webapp/src/__tests__/NativeTaskDisclosure.test.tsx
@@ -49,7 +49,8 @@ it('renders the worker name once and keeps status and model as separate facts', 
   const role = 'pipeline-mapper';
   render(<NativeTaskDisclosure task={{ ...producerTask(), role, model: 'configured/model', model_kind: 'assigned' }} />);
   const worker = screen.getByRole('button', { name: `${role}: running` });
-  expect(within(worker).getAllByText(`${role} (agentic)`)).toHaveLength(1);
+  expect(within(worker).getAllByText(role)).toHaveLength(1);
+  expect(within(worker).queryByText(`${role} (agentic)`)).toBeNull();
   expect(within(worker).getByText('running')).toBeVisible();
   expect(within(worker).getByTitle('Model: configured/model')).toHaveTextContent('configured/model');
 });

--- a/webapp/src/__tests__/SwarmPane.artifacts.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.artifacts.test.tsx
@@ -15,7 +15,7 @@ import { dispatchProjectSelected } from "../lib/panelTransition";
 import { clearSWRCache } from "../lib/useStaleWhileRevalidate";
 
 import { MetadataInspection } from "../components/MetadataJobs";
-import { inspectHarnessJob, JobsInspectHarness } from "./jobsInspectHarness";
+import { inspectHarnessJob, JobsInspectHarness, openDumpInspector } from "./jobsInspectHarness";
 
 import { expertDetail, expertMetadataFixture, expertSummary } from "./metadataExpert.fixtures";
 
@@ -67,19 +67,18 @@ it('retries locally and treats a successful empty response as loaded', async () 
   const fixture = metadata;
   const empty = expertDetail(selection, fixture.context());
   empty.artifacts = { page: { ...empty.artifacts.page, scanned: 0 }, rows: [] };
-  fixture.selected.mockRejectedValueOnce(new Error('store offline')).mockResolvedValueOnce(empty);
+  fixture.selected.mockRejectedValueOnce(new Error('store offline')).mockResolvedValue(empty);
   render(<fixture.Provider><JobsPane /></fixture.Provider>);
   await expand('Inspect A');
-  fireEvent.click(await screen.findByRole('button', { name: 'Inspect tasks and artifacts' }));
-  const retry = await screen.findByRole('button', { name: 'Retry', exact: true });
+  const retries = await screen.findAllByRole('button', { name: 'Retry', exact: true });
   expect(screen.queryByText('No artifacts recorded')).not.toBeInTheDocument();
-  fireEvent.click(retry);
+  fireEvent.click(retries[0]);
+  await waitFor(() => expect(screen.queryByRole('button', { name: 'Retry', exact: true })).not.toBeInTheDocument());
+  openDumpInspector();
   expect(await screen.findByText('No artifacts recorded')).toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: 'Retry', exact: true })).not.toBeInTheDocument();
-  expect(fixture.selected).toHaveBeenCalledTimes(2);
+  expect(fixture.selected).toHaveBeenCalled();
   expect(fixture.selected).toHaveBeenLastCalledWith(selection, expect.objectContaining({ task_cursor: null, artifact_cursor: null }));
   expect(screen.getByText('No artifacts recorded')).toBeInTheDocument();
-  expect(fixture.selected).toHaveBeenCalledTimes(2);
   expect(fetchJobArtifacts).not.toHaveBeenCalled();
   expect(api.swarmLive).not.toHaveBeenCalled();
   expect(api.artifacts).not.toHaveBeenCalled();
@@ -109,7 +108,7 @@ it('fences an old response when a colliding job is selected in another session',
   let release: (value: MetadataDetail) => void = () => {};
   fixture.selected.mockReturnValueOnce(new Promise(resolve => { release = resolve; }));
   render(<fixture.Provider><JobsPane /></fixture.Provider>); await expand('Inspect A');
-  fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+  fireEvent.click(screen.getAllByRole('button', { name: 'Inspect tasks and artifacts' })[0]);
   await waitFor(() => expect(fixture.selected).toHaveBeenCalledTimes(1));
   const next: MetadataSelection = { ...selection, session_id: 'B', job_ref: { job_id: base.id, state_id: 'state_b' } };
   // The shared owner serializes reads; change context before releasing the old wire response.
@@ -119,7 +118,7 @@ it('fences an old response when a colliding job is selected in another session',
   expect(fixture.store.getSnapshot().detailCache).toEqual({});
   await fixture.replace([expertSummary(next, 'Inspect B')]);
   await expand('Inspect B');
-  fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+  fireEvent.click(screen.getAllByRole('button', { name: 'Inspect tasks and artifacts' })[0]);
   await waitFor(() => expect(fixture.selected).toHaveBeenCalledTimes(2));
   await screen.findByRole('region', { name: 'Selected job inspector' });
   expect(screen.queryByText(/Private A result/)).not.toBeInTheDocument();

--- a/webapp/src/__tests__/SwarmPane.controls.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.controls.test.tsx
@@ -86,7 +86,7 @@ function controlRow(goal = 'Inspect A', source: 'harness' | 'cli' = 'harness'): 
 async function mountControls(rows: MetadataSummary[]) {
   const fixture = await expertMetadataFixture(rows);
   metadata = fixture;
-  render(<fixture.Provider><JobsInspectHarness><SwarmPane /></JobsInspectHarness></fixture.Provider>);
+  render(<fixture.Provider><SwarmPane /></fixture.Provider>);
   return fixture;
 }
 
@@ -102,7 +102,6 @@ async function inspectControl(name: string) {
   const jobId = cardEl?.getAttribute('data-job-id');
   const source = cardEl?.getAttribute('data-job-source');
   const inspectRoot = jobId ? screen.getByTestId(`inspect-${source}-${jobId}`) : document.body;
-  fireEvent.click(within(inspectRoot).getByRole('button', { name: 'Inspect tasks and artifacts' }));
   await waitFor(() => expect(metadata?.store.getSnapshot().working).toBe(false));
   return within(inspectRoot).getByRole('button', { name: 'Stop selected workers' });
 }
@@ -166,11 +165,13 @@ it('sends a session-scoped local selection without a durable reference', async (
   metadata = f;
   expect(f.store.getSnapshot().local.observations).toHaveLength(1);
   vi.mocked(api.swarmCancel).mockReturnValue(new Promise(() => {}));
-  render(<f.Provider><JobsInspectHarness><SwarmPane /></JobsInspectHarness></f.Provider>);
+  render(<f.Provider><SwarmPane /></f.Provider>);
   await expand('Provider worker');
-  const worker = await screen.findByRole('button', { name: /implement/ });
+  const provider = screen.getByRole('button', { name: /Provider worker/ }).closest('[data-testid^="inspect-"]');
+  if (!(provider instanceof HTMLElement)) throw Error('Missing provider row');
+  const worker = await within(provider).findByRole('button', { name: /implement/ });
   fireEvent.click(worker);
-  const cancel = screen.getByRole('button', { name: 'Cancel this job' });
+  const cancel = screen.getByRole('button', { name: 'Stop selected workers' });
   expect(cancel).toBeEnabled(); fireEvent.click(cancel);
   expect(api.swarmCancel).toHaveBeenCalledWith({ version: 1, source: 'local', repo: f.context().repo, session_id: f.context().session_id,
     local_incarnation: 'native-1', job_ref: { job_id: 'local-kill', state_id: null } });
@@ -236,7 +237,7 @@ it('retains the original request after ambiguous transport failure on the select
   await expand('Inspect CLI');
   const cliCard = screen.getByRole('button', { name: /Inspect CLI/ }).closest('[data-job-id]');
   const cli = screen.getByTestId(`inspect-${cliCard?.getAttribute('data-job-source')}-${cliCard?.getAttribute('data-job-id')}`);
-  fireEvent.click(within(cli).getByRole('button', { name: 'Inspect tasks and artifacts' }));
+  await waitFor(() => expect(within(cli).getByRole('button', { name: 'Stop selected workers' })).toBeVisible());
   const cancel = within(cli).getByRole('button', { name: 'Stop selected workers' });
   await waitFor(() => expect(cancel).toHaveAttribute('aria-disabled', 'false'));
   fireEvent.click(cancel);
@@ -249,4 +250,22 @@ it('retains the original request after ambiguous transport failure on the select
   await waitFor(() => expect(api.requestCancellation).toHaveBeenCalledTimes(2));
   expect(vi.mocked(api.requestCancellation).mock.calls[1][0]).toEqual(original);
   expect(api.swarmLive).not.toHaveBeenCalled();
+});
+
+it('opens Puppetmaster dashboard from the compact pill and never a job inspection overlay', async () => {
+  const open = vi.spyOn(window, 'open').mockReturnValue(null);
+  await mountControls([controlRow()]);
+  await expand('Inspect A');
+  expect(screen.queryByRole('dialog', { name: 'Selected job inspection' })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Inspect tasks and artifacts' })).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: 'See in Puppetmaster dashboard' }));
+  await waitFor(() => expect(api.dashboard).toHaveBeenCalled());
+  open.mockRestore();
+});
+
+it('keeps a completed swarm under Finished', async () => {
+  await mountControls([{ ...controlRow(), lifecycle: 'complete' }]);
+  expect(screen.getByRole('button', { name: /Finished \(/ })).toBeVisible();
+  expect(screen.getByRole('button', { name: /^Inspect A ·/ })).toBeVisible();
+  expect(screen.queryByText(/^No jobs yet$/)).not.toBeInTheDocument();
 });

--- a/webapp/src/__tests__/SwarmPane.reads.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.reads.test.tsx
@@ -12,7 +12,6 @@ import { dispatchProjectSelected } from "../lib/panelTransition";
 import { clearSWRCache } from "../lib/useStaleWhileRevalidate";
 
 import { expertDetail, expertMetadataFixture, expertSummary } from "./metadataExpert.fixtures";
-import { JobsInspectHarness } from "./jobsInspectHarness";
 
 import { list } from "./jobMetadata.fixtures";
 
@@ -39,14 +38,13 @@ afterEach(() => { cleanup(); metadata?.dispose(); metadata = undefined; vi.unstu
 async function setup() {
   const fixture = await expertMetadataFixture([expertSummary(selection, 'Inspect A')], { browser: true });
   metadata = fixture;
-  render(<fixture.Provider><JobsInspectHarness><SwarmPane /></JobsInspectHarness></fixture.Provider>);
+  render(<fixture.Provider><SwarmPane /></fixture.Provider>);
   return fixture;
 }
 
 async function inspect(goal: string) {
   const row = await screen.findByRole('button', { name: new RegExp(goal) });
   if (row.getAttribute('aria-expanded') === 'false') fireEvent.click(row);
-  fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
 }
 
 it('shows exhausted reads and retries even when the successful row is otherwise identical', async () => {
@@ -63,8 +61,7 @@ it('shows exhausted reads and retries even when the successful row is otherwise 
   await waitFor(() => expect(retry).toBeEnabled());
   f.selected.mockResolvedValue(result);
   fireEvent.click(retry);
-  await screen.findByText('No artifacts recorded');
-  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
   expect(f.store.getSnapshot().observations.map(o => o.row)).toEqual(rows);
   expect(f.selected).toHaveBeenCalledTimes(2);
   expect(api.swarmLive).not.toHaveBeenCalled();
@@ -78,8 +75,8 @@ it('shows transport failure instead of an empty tracker and retries', async () =
   await act(async () => { f.store.setTarget(f.context()); await f.store.readView(); });
   expect(await screen.findByRole('alert')).toHaveTextContent('Job updates unavailable');
   expect(screen.queryByText(/^No jobs observed in this view/)).not.toBeInTheDocument();
-  expect(screen.getByText(/Job observations could not be loaded/)).toBeInTheDocument();
-  expect(screen.getByText(/an empty view does not establish no work/)).toBeInTheDocument();
+  expect(await screen.findByRole('button', { name: /Inspect A/ })).toBeVisible();
+  expect(screen.queryByText(/Job observations could not be loaded/)).not.toBeInTheDocument();
   expect(screen.queryByText('Job data unavailable')).not.toBeInTheDocument();
   f.request.mockImplementation(async (method, path) => {
     const result = await request(method, path);
@@ -90,10 +87,13 @@ it('shows transport failure instead of an empty tracker and retries', async () =
     return result;
   });
   fireEvent.click(screen.getByRole('button', { name: 'Retry updates' }));
-  await screen.findByText(/^No jobs yet/);
+  await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+  expect(screen.getByRole('button', { name: /Inspect A/ })).toBeVisible();
   fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
   await waitFor(() => expect(f.store.getSnapshot().working).toBe(false));
   expect(f.store.getSnapshot().streams.some(s => s.state === 'complete')).toBe(true);
+  expect(screen.getByRole('button', { name: /Inspect A/ })).toBeVisible();
+  expect(screen.queryByText(/Job observations could not be loaded/)).not.toBeInTheDocument();
   expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   expect(api.swarmLive).not.toHaveBeenCalled();
 });

--- a/webapp/src/__tests__/SwarmPane.test.tsx
+++ b/webapp/src/__tests__/SwarmPane.test.tsx
@@ -4,7 +4,7 @@ import { identityFixture, identityTask, workerDetails } from './frontend52-ident
 import { capturedRoutingFixture, referenceHash, routingReference } from './frontend52-routing.fixtures';
 import { evidenceFixture, evidenceHash, evidenceSelection, qualityFixture, rejectQualityVerdicts } from './frontend52-evidence.fixtures';
 import { MetadataInspection } from '../components/MetadataJobs';
-import { JobsInspectHarness } from './jobsInspectHarness';
+import { JobsInspectHarness, openDumpInspector } from './jobsInspectHarness';
 import { parseMetadataDetail } from '../lib/jobMetadata';
 import { nativeExpertFixture, capturedModelDetail } from './nativeExpert.fixtures';
 import { act, fireEvent, render, screen, waitFor, cleanup, within } from "@testing-library/react";
@@ -33,7 +33,7 @@ import { view as metadataView, view, selection, selection as metadataSelection }
 
 import { metadataSelectionKey } from "../lib/jobMetadata";
 
-import { queuePendingSwarmNavigation, peekPendingSwarmNavigation } from "../lib/pendingSwarmOpenJob";
+import { queuePendingSwarmNavigation, peekPendingSwarmNavigation, clearPendingSwarmOpenJob } from "../lib/pendingSwarmOpenJob";
 
 import { terminalWorkerMetadataFixture } from "./workerIdentity.fixtures";
 
@@ -134,6 +134,10 @@ async function expandJob(name: string | RegExp) {
 }
 
 function SwarmWithInspect({ enabled }: { enabled?: boolean }) {
+  return <SwarmPane enabled={enabled} />;
+}
+
+function SwarmWithDump({ enabled }: { enabled?: boolean }) {
   return <JobsInspectHarness><SwarmPane enabled={enabled} /></JobsInspectHarness>;
 }
 
@@ -387,10 +391,10 @@ describe("SwarmPane model badge", () => {
   it("marks only worker, job, and aggregate running indicators as semantic", async () => {
     const selected = selection();
     const fixture = await expertMetadataFixture([expertSummary(selected, "Audit auth flow")]);
-    const view = render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    const view = render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
     try {
       const job = await expandJob(/Audit auth flow/);
-      fireEvent.click(screen.getByRole("button", { name: "Inspect tasks and artifacts" }));
+      openDumpInspector();
       const worker = await screen.findByRole("button", { name: "task-1: running" });
       const aggregate = screen.getByText("1 running");
 
@@ -419,11 +423,10 @@ describe("SwarmPane model badge", () => {
       return { ...detail, lifecycle: "complete", tasks: { ...detail.tasks,
         rows: detail.tasks.rows.map(task => ({ ...task, status: "complete" })) } };
     });
-    const view = render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    const view = render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
     try {
       expect(screen.getByRole("button", { name: /^Finished/ })).toHaveAttribute("aria-expanded", "true");
       await expandJob(/^Audit auth flow · complete$/);
-      fireEvent.click(screen.getByRole("button", { name: "Inspect tasks and artifacts" }));
       await screen.findByText("task-1: complete");
       expect(view.container.querySelectorAll(".semantic-activity-spinner")).toHaveLength(0);
       expect(mockSwarmLive).not.toHaveBeenCalled();
@@ -551,9 +554,8 @@ describe("SwarmPane worker details", () => {
   it("lets a terminal worker reveal its source-backed identity", async () => {
     const fixture = await terminalWorkerMetadataFixture();
     try {
-      render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+      render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
       await expandJob(/^Inspect completed worker/);
-      fireEvent.click(screen.getByRole("button", { name: "Inspect tasks and artifacts" }));
 
       const worker = await screen.findByRole("button", { name: /task-terminal: complete/ });
       expect(worker).toHaveAttribute("aria-expanded", "false");
@@ -631,7 +633,7 @@ describe("SwarmPane worker details", () => {
     fireEvent.click(screen.getByText("Instruction"));
     expect(screen.getByText("Keyboard disclosure")).toBeVisible();
 
-    const kill = screen.getByRole("button", { name: "Cancel this job" });
+    const kill = screen.getByRole("button", { name: "Stop selected workers" });
     kill.focus();
     fireEvent.keyDown(kill, { key: " " });
     fireEvent.keyDown(kill, { key: "Enter" });
@@ -690,10 +692,9 @@ describe("SwarmPane pin attribution", () => {
 
   it("does not paint a missing routing estimate as $0", async () => {
     const fixture = await expertMetadataFixture([expertSummary(selection(), "Audit auth flow")]);
-    const view = render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    const view = render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
     try {
       await expandJob(/Audit auth flow/);
-      fireEvent.click(await screen.findByRole("button", { name: "Inspect tasks and artifacts" }));
       const worker = await screen.findByText("task-1: running");
     expect(worker).not.toHaveTextContent("—");
     expect(screen.queryByText("$0")).not.toBeInTheDocument();
@@ -708,10 +709,9 @@ describe("SwarmPane pin attribution", () => {
 
   it("fail-closes missing policy as Pin attribution unknown (not Router pick)", async () => {
     const fixture = await expertMetadataFixture([expertSummary(selection(), "Audit auth flow")]);
-    const view = render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    const view = render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
     try {
       await expandJob(/Audit auth flow/);
-      fireEvent.click(await screen.findByRole("button", { name: "Inspect tasks and artifacts" }));
       const worker = await screen.findByText("task-1: running");
     fireEvent.click(worker);
     expect(screen.getByText("Pin attribution unknown")).toBeVisible();
@@ -844,10 +844,9 @@ describe("SwarmPane routing dedupe", () => {
         presence: 'recorded', check_result: 'unavailable',
       })) },
     });
-    const rendered = render(<metadata.Provider><SwarmWithInspect /></metadata.Provider>);
+    const rendered = render(<metadata.Provider><SwarmWithDump /></metadata.Provider>);
     try {
       fireEvent.click(await screen.findByRole('button', { name: /^Grouped findings/ }));
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
       const inspector = await screen.findByRole('region', { name: 'Selected job inspector' });
       expect(within(inspector).getByText('Findings (2)')).toBeVisible();
       expect(within(inspector).queryByText(/Findings \(2 of 5\)/)).toBeNull();
@@ -880,10 +879,10 @@ describe("SwarmPane mid-run job-row meters", () => {
     row.economics = { kind: 'estimated', spend_usd: 0.05, estimated: true, cost_provenance: 'static',
       source: 'financial_receipt', estimated_savings_usd: 0.0553, route_forecast_usd: 0.1 };
     const fixture = await economicsNativeFixture([row]);
-    const mounted = render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    const mounted = render(<fixture.Provider><SwarmPane /></fixture.Provider>);
     try {
       await expandJob(/^Provider worker · local-cost ·/);
-      expect(screen.getByRole('button', { name: 'Inspect actions' })).toBeVisible();
+      expect(screen.getByRole('button', { name: 'See in Puppetmaster dashboard' })).toBeVisible();
       expect(screen.queryByText('12,000 combined tokens · reported by native job')).not.toBeInTheDocument();
       expect(screen.queryByText(/This view does not calculate totals/)).not.toBeInTheDocument();
       expect(mockSwarmLive).not.toHaveBeenCalled();
@@ -893,10 +892,10 @@ describe("SwarmPane mid-run job-row meters", () => {
   it("keeps compact provider cards free of inspect-lane spend dump after a receipt refresh", async () => {
     const row = nativeEconomicsRow('local-update');
     const fixture = await economicsNativeFixture([row]);
-    const mounted = render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    const mounted = render(<fixture.Provider><SwarmPane /></fixture.Provider>);
     try {
       await expandJob(/^Provider worker · local-update ·/);
-      expect(screen.getByRole('button', { name: 'Inspect actions' })).toBeVisible();
+      expect(screen.getByRole('button', { name: 'See in Puppetmaster dashboard' })).toBeVisible();
       await waitFor(() => expect(fixture.store.getSnapshot().working).toBe(false));
       await fixture.update([{ ...row, revision: 2, economics: { ...row.economics, estimated_savings_usd: 0.11 } }]);
       expect(fixture.store.getSnapshot().local.observations.find(o => o.row.local_ref.job_id === row.local_ref.job_id)?.row.revision).toBe(2);
@@ -911,10 +910,10 @@ describe("SwarmPane mid-run job-row meters", () => {
     const detail = expertDetail(selected.selection, fixture.context());
     detail.lifecycle = 'complete';
     fixture.selected.mockResolvedValue(detail);
-    const mounted = render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    const mounted = render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
     try {
       await expandJob(/^Outcome flips ·/);
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+      openDumpInspector();
       await screen.findByRole('region', { name: 'Selected job inspector' });
       fireEvent.click(screen.getByRole('button', { name: 'Artifacts', exact: true }));
       expect(screen.getByText('finding / artifact-1: unknown')).toBeVisible();
@@ -937,7 +936,7 @@ describe("SwarmPane mid-run job-row meters", () => {
         { ...detail.artifacts.rows[0], id: 'verification-2', type: 'verification', revision: 4, status: 'failed' },
       ] } };
       fixture.selected.mockResolvedValue(refreshed);
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+      await act(async () => { await fixture.store.readDetail(); });
       await screen.findByText('verification / verification-2: failed');
       expect(screen.queryByText('finding / artifact-1: unknown')).not.toBeInTheDocument();
       expect(screen.queryByText(/Retained selected details are stale/)).not.toBeInTheDocument();
@@ -1043,9 +1042,9 @@ describe("SwarmPane mid-run job-row meters", () => {
       { ...route, ordinal: 1, model: 'cheap-model', created_by: 'router-fallback' },
     ] });
     outcomeFixture = metadata;
-    render(<metadata.Provider><SwarmWithInspect /></metadata.Provider>);
+    render(<metadata.Provider><SwarmPane /></metadata.Provider>);
     await expandJob(/Provider worker|implement/);
-    const worker = await screen.findByRole("button", { name: /implement \(agentic\)/ });
+    const worker = await screen.findByRole("button", { name: /implement/ });
     await waitFor(() => expect(worker).toHaveTextContent("cheap-model"));
     expect(screen.getByTitle("Model: cheap-model")).toBeVisible();
     expect(screen.queryByText("initial-cheap")).not.toBeInTheDocument();
@@ -1063,7 +1062,7 @@ describe("SwarmPane mid-run job-row meters", () => {
   it("keeps compact job and worker chrome on expand and drops inspect-lane chrome", async () => {
     const metadata = await nativeExpertFixture({ jobId: 'local-compact' });
     outcomeFixture = metadata;
-    render(<metadata.Provider><SwarmWithInspect /></metadata.Provider>);
+    render(<metadata.Provider><SwarmPane /></metadata.Provider>);
     await expandJob(/Provider worker/);
     expect(screen.getByLabelText('Job local-compact')).toBeVisible();
     expect(await screen.findByText('Workers')).toBeVisible();
@@ -1071,9 +1070,9 @@ describe("SwarmPane mid-run job-row meters", () => {
     expect(screen.queryByText(/Lifecycle:/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Parent relationship unknown/)).not.toBeInTheDocument();
     expect(screen.queryByText(/combined tokens|Estimated spend|Native provider/)).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Inspect actions' })).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Inspect workers' })).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Request native stop' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'See in Puppetmaster dashboard' })).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Inspect workers' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Request native stop' })).not.toBeInTheDocument();
     expect(screen.queryByRole('dialog', { name: 'Selected job inspection' })).not.toBeInTheDocument();
     const worker = await screen.findByRole('button', { name: /implement/ });
     fireEvent.click(worker);
@@ -1086,7 +1085,7 @@ describe("SwarmPane mid-run job-row meters", () => {
 
 let outcomeFixture: Awaited<ReturnType<typeof expertMetadataFixture>> | undefined;
 
-afterEach(() => { outcomeFixture?.dispose(); outcomeFixture = undefined; });
+afterEach(() => { cleanup(); outcomeFixture?.dispose(); outcomeFixture = undefined; });
 
 describe("SwarmPane truthful failed vs cancelled chrome", () => {
   beforeEach(() => {
@@ -1118,11 +1117,11 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
       const result = expertDetail(selected, f.context());
       return { ...result, lifecycle: 'timeout', tasks: { ...result.tasks, rows: [{ ...result.tasks.rows[0], status: 'timeout' }] } };
     });
-    render(<f.Provider><SwarmWithInspect /></f.Provider>);
+    render(<f.Provider><SwarmWithDump /></f.Provider>);
     expect(screen.getByRole('button', { name: /Finished/ })).toBeVisible();
     expect(screen.getByText('1 failed')).toBeVisible();
     await expandJob(/Timed-out command/);
-    fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+    openDumpInspector();
     expect(await screen.findByLabelText('Workers')).toHaveTextContent('1/1');
     expect(screen.getByText('task-1: timeout')).toBeVisible();
     expect(screen.getByText('task-1: timeout')).toHaveClass('text-risk');
@@ -1136,7 +1135,7 @@ describe("SwarmPane truthful failed vs cancelled chrome", () => {
         page: { ...result.tasks.page, scanned: statuses.length },
         rows: statuses.map((status, index) => ({ ...result.tasks.rows[0], id: `outcome-${index}`, binding: null, status })) } };
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+    await act(async () => { await f.store.readDetail(); });
     await waitFor(() => expect(screen.getByLabelText('Workers')).toHaveTextContent(
       '7/8 observed workers finished · 0 completed · 4 failed · 1 cancelled · 1 partial · 1 recoverable',
     ));
@@ -1221,7 +1220,7 @@ describe("SwarmPane cancel Kill contract", () => {
     await expandJob(/Provider worker/);
     const worker = await screen.findByRole('button', { name: /implement/ });
     fireEvent.click(worker);
-    const kill = screen.getByRole('button', { name: 'Cancel this job' });
+    const kill = screen.getByRole('button', { name: 'Stop selected workers' });
     expect(kill).toBeEnabled();
     fireEvent.click(kill);
     expect(kill).toBeDisabled();
@@ -1243,7 +1242,7 @@ describe("SwarmPane cancel Kill contract", () => {
     await expandJob(/Provider worker/);
     const worker = await screen.findByRole('button', { name: /implement/ });
     fireEvent.click(worker);
-    const kill = screen.getByRole('button', { name: 'Cancel this job' });
+    const kill = screen.getByRole('button', { name: 'Stop selected workers' });
     expect(kill).toBeEnabled();
     fireEvent.click(kill);
     expect(await screen.findByText('not running')).toBeVisible();
@@ -1264,7 +1263,7 @@ describe("SwarmPane cancel Kill contract", () => {
     await expandJob(/Provider worker/);
     const worker = await screen.findByRole('button', { name: /implement/ });
     fireEvent.click(worker);
-    const kill = screen.getByRole('button', { name: 'Cancel this job' });
+    const kill = screen.getByRole('button', { name: 'Stop selected workers' });
     expect(kill).toBeEnabled();
     const detailsBeforeKill = f.request.mock.calls.filter(([, path]) => path.includes('/metadata/local/detail?')).length;
     fireEvent.click(kill);
@@ -1275,7 +1274,7 @@ describe("SwarmPane cancel Kill contract", () => {
     const selection = { version: 1, source: 'local', repo: f.context().repo,
       session_id: f.context().session_id, local_incarnation: 'native-1', job_ref: { job_id: 'local-kill', state_id: null } };
     expect(mockSwarmCancel.mock.calls).toEqual([[selection]]);
-    expect(screen.getByRole('button', { name: 'Inspect actions' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'See in Puppetmaster dashboard' })).toBeVisible();
     expect(kill).toBeEnabled();
     fireEvent.click(kill);
     await waitFor(() => expect(mockSwarmCancel).toHaveBeenCalledTimes(2));
@@ -1298,14 +1297,14 @@ describe("SwarmPane canonical outcome", () => {
   it("keeps completed lifecycle neutral with a positively recorded finding", async () => {
     const fixture = await evidenceFixture('Completed audit');
     try {
-      render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+      render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
       const row = await screen.findByRole('button', { name: 'Completed audit · complete' });
       expect(screen.getByRole('button', { name: /^Finished/ })).toBeVisible();
       expect(within(row).getByText('complete')).toBeVisible();
       expect(within(row).getByText('complete')).toHaveClass('text-muted');
       expect(row.querySelector('.text-good')).toBeNull();
       fireEvent.click(row);
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+      openDumpInspector();
       expect(await screen.findByText('Findings (1)')).toBeVisible();
       fireEvent.click(screen.getByRole('button', { name: 'Artifacts', exact: true }));
       expect(screen.getByText('finding / harness-finding: unknown')).toBeVisible();
@@ -1329,9 +1328,9 @@ describe("SwarmPane findings section collapse", () => {
   it("collapses and reopens the recorded finding hash in Artifacts without refetching", async () => {
     const fixture = await evidenceFixture('Audit findings collapse');
     try {
-      render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+      render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
       await expandJob('Audit findings collapse · complete');
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+      openDumpInspector();
       await screen.findByText('Findings (1)');
       fireEvent.click(screen.getByRole('button', { name: 'Artifacts', exact: true }));
       const artifact = screen.getByText('finding / harness-finding: unknown');
@@ -1353,11 +1352,12 @@ describe("SwarmPane findings section collapse", () => {
   it("loads selected artifact metadata only after explicit inspection of a finished job", async () => {
     const fixture = await evidenceFixture('Slim finished swarm');
     try {
-      render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
-      expect(fixture.selected).not.toHaveBeenCalled();
+      render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
+      expect(screen.queryByText('Findings (1)')).not.toBeInTheDocument();
       await expandJob('Slim finished swarm · complete');
-      expect(fixture.selected).not.toHaveBeenCalled();
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+      expect(screen.queryByRole('region', { name: 'Selected job inspector' })).not.toBeInTheDocument();
+      expect(screen.queryByText(evidenceHash)).not.toBeInTheDocument();
+      openDumpInspector();
       await screen.findByText('Findings (1)');
       expect(fixture.selected).toHaveBeenCalledWith(evidenceSelection, expect.objectContaining({ task_cursor: null, artifact_cursor: null }));
       fireEvent.click(screen.getByRole('button', { name: 'Artifacts', exact: true }));
@@ -1372,9 +1372,9 @@ describe("SwarmPane findings section collapse", () => {
   it("preserves the owned artifact hash when cross-project inspection is disabled", async () => {
     const fixture = await evidenceFixture('Owned sibling slim');
     try {
-      render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+      render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
       await expandJob('Owned sibling slim · complete');
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+      openDumpInspector();
       await screen.findByText('Findings (1)');
       fireEvent.click(screen.getByRole('button', { name: 'Artifacts', exact: true }));
       fireEvent.click(screen.getByText('finding / harness-finding: unknown'));
@@ -1533,10 +1533,9 @@ describe("SwarmPane worker-owned routing surface", () => {
           cache_write_tokens: unknown, api_cost_usd: unknown,
           plan_marginal_cost_usd: planZero, api_equivalent_cost_usd: unknown } },
     });
-    const rendered = render(<metadata.Provider><SwarmWithInspect /></metadata.Provider>);
+    const rendered = render(<metadata.Provider><SwarmWithDump /></metadata.Provider>);
     try {
       fireEvent.click(await screen.findByRole('button', { name: /^Selected worker cost/ }));
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
       const inspector = await screen.findByRole('region', { name: 'Selected job inspector' });
       fireEvent.click(within(inspector).getByRole('button', { name: 'Economics', exact: true }));
       expect(within(inspector).getByText('Selected API cost: unknown.')).toBeVisible();
@@ -1573,10 +1572,9 @@ describe("SwarmPane worker-owned routing surface", () => {
           cache_write_tokens: unknown, api_cost_usd: measuredZero,
           plan_marginal_cost_usd: planZero, api_equivalent_cost_usd: unknown } },
     });
-    const rendered = render(<metadata.Provider><SwarmWithInspect /></metadata.Provider>);
+    const rendered = render(<metadata.Provider><SwarmWithDump /></metadata.Provider>);
     try {
       fireEvent.click(await screen.findByRole('button', { name: /^Selected worker cost/ }));
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
       const inspector = await screen.findByRole('region', { name: 'Selected job inspector' });
       fireEvent.click(within(inspector).getByRole('button', { name: 'Economics', exact: true }));
       expect(within(inspector).getByText('Selected API cost: $0 (measured).')).toBeVisible();
@@ -1611,10 +1609,9 @@ describe("SwarmPane worker-owned routing surface", () => {
           cache_write_tokens: unknown, api_cost_usd: measuredZero,
           plan_marginal_cost_usd: unknown, api_equivalent_cost_usd: unknown } },
     });
-    const rendered = render(<metadata.Provider><SwarmWithInspect /></metadata.Provider>);
+    const rendered = render(<metadata.Provider><SwarmWithDump /></metadata.Provider>);
     try {
       fireEvent.click(await screen.findByRole('button', { name: /^Selected worker cost/ }));
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
       const inspector = await screen.findByRole('region', { name: 'Selected job inspector' });
       fireEvent.click(within(inspector).getByRole('button', { name: 'Economics', exact: true }));
       expect(within(inspector).getByText('Selected API cost: $0 (measured).')).toBeVisible();
@@ -1659,9 +1656,8 @@ describe("SwarmPane worker tokens and cost", () => {
     detail.history.counts.captured_process_outcomes = 2;
     fixture.selected.mockResolvedValue(detail);
     try {
-      render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+      render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
       fireEvent.click(await screen.findByRole('button', { name: 'Multi worker spend · complete' }));
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
       await screen.findByRole('region', { name: 'Selected job inspector' });
       fireEvent.click(screen.getByRole('button', { name: 'History', exact: true }));
       const outcomes = screen.getByRole('region', { name: 'process outcomes' });
@@ -1968,17 +1964,19 @@ describe("SwarmPane does not paint unowned CLI captions", () => {
   it("does not show an origin chip for harness jobs", async () => {
     const row = scopePrivacyRow('Audit auth flow');
     row.selection.job_ref = { ...row.selection.job_ref, version: 2, incarnation: '12345678-1234-4234-8234-123456789abc' };
-    const metadata = await renderScopePrivacy(row);
+    const metadata = await expertMetadataFixture([row]);
+    scopePrivacyMetadata = metadata;
     metadata.selected.mockImplementation(async selected => capturedModelDetail(selected, metadata.context()));
+    render(<metadata.Provider><SwarmWithDump /></metadata.Provider>);
 
     await expandJob(/Audit auth flow/);
+    openDumpInspector();
 
     expect(
       screen.queryByTitle(
         "Started outside Marionette (Cursor MCP or terminal Puppetmaster) for this workspace",
       ),
     ).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Inspect tasks and artifacts" }));
     fireEvent.click(await screen.findByRole("button", { name: "Routing", exact: true }));
     await waitFor(() => {
       expect(screen.getByTitle("Model: grok-4-5")).toBeInTheDocument();
@@ -2042,14 +2040,20 @@ describe("SwarmPane repo-scoped dismiss", () => {
   function mount() {
     return render(<metadata.Provider><SwarmWithInspect /></metadata.Provider>);
   }
+  async function load(rows: MetadataSummary[]) {
+    metadata?.dispose();
+    metadata = await expertMetadataFixture(rows);
+  }
   function hideFinished() {
     fireEvent.click(screen.getByRole("button", { name: "Hide finished", exact: true }));
   }
   beforeEach(async () => {
+    cleanup();
     vi.clearAllMocks();
     localStorage.clear();
     sessionStorage.clear();
     clearSWRCache();
+    clearPendingSwarmOpenJob();
     metadata = await expertMetadataFixture([row("shared-job", "Repo A finished swarm")]);
   });
   afterEach(() => {
@@ -2081,17 +2085,19 @@ describe("SwarmPane repo-scoped dismiss", () => {
     expect(await screen.findByText(hiddenMessage)).toBeInTheDocument();
     unmount();
     await metadata.observe();
-    mount();
+    const remounted = mount();
+    try {
     expect(await screen.findByText(hiddenMessage)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^Repo A finished swarm/ })).not.toBeInTheDocument();
     expect(JSON.parse(localStorage.getItem(preferenceKey()) || "{}").dismissed)
       .toEqual([metadataSelectionKey(row("shared-job", "Repo A finished swarm").selection)]);
     expect(localStorage.getItem(preferenceKey(REPO_B))).toBeNull();
+    } finally { remounted.unmount(); }
   });
 
   it("ignores the legacy global dismiss blob without deleting it", async () => {
     localStorage.setItem("swarm.dismissed.v1", JSON.stringify(["job_legacy-job"]));
-    await metadata.replace([row("legacy-job", "Legacy finished swarm")]);
+    await load([row("legacy-job", "Legacy finished swarm")]);
     mount();
     expect(await screen.findByRole("button", { name: /^Legacy finished swarm/ })).toBeInTheDocument();
     expect(screen.queryByText(hiddenMessage)).not.toBeInTheDocument();
@@ -2103,7 +2109,7 @@ describe("SwarmPane repo-scoped dismiss", () => {
     const live = row("live-owned-job", "Owned swarm still running", "running");
     const finished = row("old-finished", "Previously cleared finished job");
     dismissRows([live, finished]);
-    await metadata.replace([live, finished]);
+    await load([live, finished]);
     mount();
     expect(await screen.findByRole("button", { name: /^Owned swarm still running/ })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^Previously cleared finished job/ })).not.toBeInTheDocument();
@@ -2114,20 +2120,20 @@ describe("SwarmPane repo-scoped dismiss", () => {
   it("keeps a previously dismissed job visible after it completes if it was seen live", async () => {
     const live = row("live-owned-job", "Owned swarm still running", "running");
     dismissRows([live]);
-    await metadata.replace([live]);
+    await load([live]);
     const { unmount } = mount();
     expect(await screen.findByRole("button", { name: /^Owned swarm still running/ })).toBeInTheDocument();
     await waitFor(() => expect(JSON.parse(localStorage.getItem(preferenceKey()) || "{}").dismissed)
       .not.toContain(metadataSelectionKey(live.selection)));
     unmount();
-    await metadata.replace([{ ...row("live-owned-job", "Owned swarm completed"), revision: 2 }]);
+    await load([{ ...row("live-owned-job", "Owned swarm completed"), revision: 2 }]);
     mount();
     expect(await screen.findByRole("button", { name: /^Owned swarm completed/ })).toBeInTheDocument();
   });
 
   it("surfaces a newly completed job that was never dismissed after Clear", async () => {
     const old = row("old-a", "Old finished A");
-    await metadata.replace([old]);
+    await load([old]);
     const { unmount } = mount();
     expect(await screen.findByRole("button", { name: /^Old finished A/ })).toBeInTheDocument();
     hideFinished();
@@ -2204,7 +2210,6 @@ describe("SwarmPane harness-open-swarm-job deep-link", () => {
     expect(screen.getByRole('button', { name: /Finished/ })).toBeInTheDocument();
     open('artifact-target');
     await expectOpened('Artifact deep-link target');
-    fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
     await waitFor(() => expect(peekPendingSwarmNavigation()).toBeNull());
   });
   it("clears filters that hide a deep-link target", async () => {
@@ -2362,7 +2367,7 @@ describe("SwarmPane final-review blockers", () => {
     const metadata = await expertMetadataFixture([{
       ...expertSummary(selection, "Terminal without meters"), lifecycle: "complete", task_count: 0, artifact_count: 0,
     }]);
-    const rendered = render(<metadata.Provider><SwarmWithInspect /></metadata.Provider>);
+    const rendered = render(<metadata.Provider><SwarmWithDump /></metadata.Provider>);
     try {
       const job = await screen.findByRole("button", { name: /^Terminal without meters/ });
       expect(screen.getByRole("button", { name: /Finished \(1\)/ })).toHaveAttribute("aria-expanded", "true");
@@ -2397,10 +2402,9 @@ describe("SwarmPane final-review blockers", () => {
           cache_write_tokens: unknown, api_cost_usd: providerZero,
           plan_marginal_cost_usd: unknown, api_equivalent_cost_usd: unknown } },
     });
-    const rendered = render(<metadata.Provider><SwarmWithInspect /></metadata.Provider>);
+    const rendered = render(<metadata.Provider><SwarmWithDump /></metadata.Provider>);
     try {
       fireEvent.click(await screen.findByRole("button", { name: /^Terminal with attested zero/ }));
-      fireEvent.click(screen.getByRole("button", { name: "Inspect tasks and artifacts" }));
       const inspector = await screen.findByRole("region", { name: "Selected job inspector" });
       fireEvent.click(within(inspector).getByRole("button", { name: "Economics", exact: true }));
       const cost = within(inspector).getByText("Selected API cost: $0 (measured).");
@@ -2601,11 +2605,10 @@ describe("swarm tracker usage pills (0.9.300)", () => {
 
   it("discloses selected PM receipt economics only within the expanded inspector", async () => {
     const fixture = await economicsReceiptFixture();
-    const mounted = render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    const mounted = render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
     try {
       expect(screen.queryByRole('region', { name: 'Economics' })).not.toBeInTheDocument();
       await expandJob(/^Selected receipt audit ·/);
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
       await screen.findByRole('region', { name: 'Selected job inspector' });
       expect(screen.queryByText(/Selected plan marginal cost/)).not.toBeInTheDocument();
       fireEvent.click(screen.getByRole('button', { name: 'Economics', exact: true }));
@@ -2617,17 +2620,15 @@ describe("swarm tracker usage pills (0.9.300)", () => {
       expect(economics).toHaveTextContent('All-attempt spend: unknown');
       fireEvent.click(screen.getByRole('button', { name: /^Selected receipt audit ·/ }));
       expect(screen.queryByTestId('job-dashboard-host')).not.toBeInTheDocument();
-      expect(screen.queryByRole('region', { name: 'Economics' })).not.toBeInTheDocument();
       expect(mockSwarmLive).not.toHaveBeenCalled();
     } finally { mounted.unmount(); fixture.dispose(); }
   });
 
   it("keeps captured task usage hidden until its observation is disclosed", async () => {
     const fixture = await economicsReceiptFixture();
-    const mounted = render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    const mounted = render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
     try {
       await expandJob(/^Selected receipt audit ·/);
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
       await screen.findByRole('region', { name: 'Tasks' });
       expect(screen.queryByText('tokens in')).not.toBeInTheDocument();
       fireEvent.click(screen.getByRole('button', { name: 'History', exact: true }));
@@ -2662,23 +2663,23 @@ describe("swarm tracker usage pills (0.9.300)", () => {
       presence: 'recorded', check_result: 'unavailable',
     }));
     fixture.selected.mockResolvedValue(detail);
-    const mounted = render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    const mounted = render(<fixture.Provider><SwarmWithDump /></fixture.Provider>);
     try {
       await expandJob('Grouped findings pill chrome · complete');
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+      openDumpInspector();
       expect(await screen.findByText('Findings (2)')).toBeInTheDocument();
       expect(screen.queryByText(/Findings \(2 of/)).toBeNull();
-      expect(fixture.selected).toHaveBeenCalledTimes(1);
+      expect(fixture.selected).toHaveBeenCalled();
       expect(mockSwarmLive).not.toHaveBeenCalled();
       expect(mockArtifacts).not.toHaveBeenCalled();
       fixture.selected.mockResolvedValue({ ...detail, artifact_count: 4 });
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+      await act(async () => { await fixture.store.readDetail(); });
       expect(await screen.findByText('Findings (2 on this page)')).toBeInTheDocument();
       expect(screen.queryByText('Findings (2)')).not.toBeInTheDocument();
       fixture.selected.mockResolvedValue({ ...detail, artifacts: { ...detail.artifacts,
         rows: detail.artifacts.rows.map(row => ({ ...row, sha256: null })),
       } });
-      fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
+      await act(async () => { await fixture.store.readDetail(); });
       expect(await screen.findByText('Findings (3)')).toBeInTheDocument();
     } finally {
       mounted.unmount();
@@ -2769,6 +2770,7 @@ describe("SwarmPane v0.9.350 collapsed chrome", () => {
   });
 
   afterEach(() => {
+    cleanup();
     fixture?.dispose();
     vi.useRealTimers();
   });
@@ -2787,7 +2789,7 @@ describe("SwarmPane v0.9.350 collapsed chrome", () => {
     fireEvent.click(row);
     expect(row).toHaveAttribute('aria-expanded', 'true');
     expect(screen.queryByTestId('job-dashboard-host')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Inspect tasks and artifacts' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'See in Puppetmaster dashboard' })).toBeInTheDocument();
   });
 
   it("embeds agentic local aliases through the same Puppetmaster dashboard", async () => {
@@ -2814,17 +2816,19 @@ describe("SwarmPane v0.9.350 collapsed chrome", () => {
     fireEvent.click(row);
     expect(row).toHaveAttribute('aria-expanded', 'true');
     expect(screen.queryByTestId('job-dashboard-host')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Inspect tasks and artifacts' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'See in Puppetmaster dashboard' })).toBeInTheDocument();
     fireEvent.click(row);
     expect(row).toHaveAttribute('aria-expanded', 'false');
     expect(await screen.findByRole('button', { name: /Live audit/ })).toBeInTheDocument();
   });
 
   it("uses hairline separators between job rows, not card borders", async () => {
-    await fixture.replace([
+    vi.useRealTimers();
+    fixture.dispose();
+    fixture = await expertMetadataFixture([
       expansionSummary('job_a', 'First job'), expansionSummary('job_b', 'Second job'),
     ]);
-    render(<fixture.Provider><SwarmWithInspect /></fixture.Provider>);
+    render(<fixture.Provider><SwarmPane /></fixture.Provider>);
     await screen.findByText("First job");
     const first = screen.getByText("First job").closest("[data-job-id]");
     const second = screen.getByText("Second job").closest("[data-job-id]");

--- a/webapp/src/__tests__/expertCore.integration.test.tsx
+++ b/webapp/src/__tests__/expertCore.integration.test.tsx
@@ -22,7 +22,7 @@ async function expandAndInspect(name?: string | RegExp) {
     ));
   const job = jobs[0];
   if (job?.getAttribute('aria-expanded') === 'false') fireEvent.click(job);
-  fireEvent.click(await screen.findByRole('button', { name: /Inspect (tasks and artifacts|actions)/ }));
+  fireEvent.click((await screen.findAllByRole('button', { name: /Inspect (tasks and artifacts|actions)/ }))[0]);
   await screen.findByRole('region', { name: 'Selected job inspector' });
 }
 function inspected() {
@@ -306,7 +306,7 @@ describe('original worker routing requirements through the selected store', () =
     f.selected.mockImplementation(async s => { const value = selected(expert, s); value.tasks.rows[0].status = status; return { ...value, context: f.context() }; });
     render(<f.Provider><JobsInspectHarness><MetadataJobs /></JobsInspectHarness></f.Provider>);
     await expandAndInspect(/Audit auth flow/);
-    expect(await screen.findByText(status === 'complete' ? 'No model recorded' : 'routing…')).toBeVisible();
+    expect(await inspected().findByText(status === 'complete' ? 'No model recorded' : 'routing…')).toBeVisible();
     expect(document.querySelectorAll('[data-worker-model-slot]')).toHaveLength(1);
     expect(screen.queryByTitle('Model: gpt-6-astra')).toBeNull();
   });

--- a/webapp/src/__tests__/frontend52-identity.fixtures.tsx
+++ b/webapp/src/__tests__/frontend52-identity.fixtures.tsx
@@ -49,7 +49,6 @@ export async function identityFixture(options: {
   });
   const rendered = render(<fixture.Provider><JobsInspectHarness><SwarmPane /></JobsInspectHarness></fixture.Provider>);
   const job = await screen.findByRole('button', { name: /^Identity evidence/ });
-  if (job.getAttribute('aria-expanded') === 'false') fireEvent.click(job);
   const inspect = screen.getByRole('button', { name: 'Inspect tasks and artifacts' });
   fireEvent.click(inspect);
   await screen.findByRole('region', { name: 'Tasks' });

--- a/webapp/src/__tests__/frontend52-routing.fixtures.tsx
+++ b/webapp/src/__tests__/frontend52-routing.fixtures.tsx
@@ -56,7 +56,6 @@ export async function capturedRoutingFixture(options: {
   const rendered = render(<fixture.Provider><JobsInspectHarness><div style={{ width: options.width ? `${options.width}px` : undefined }}><SwarmPane /></div></JobsInspectHarness></fixture.Provider>);
   onTestFinished(() => { rendered.unmount(); fixture.dispose(); });
   const job = await screen.findByRole('button', { name: /^Captured routing evidence/ });
-  if (job.getAttribute('aria-expanded') === 'false') fireEvent.click(job);
   fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
   const inspector = await screen.findByRole('region', { name: 'Selected job inspector' });
   await waitFor(() => { if (fixture.store.getSnapshot().working) throw Error('Still reading'); });

--- a/webapp/src/__tests__/jobsInspectHarness.tsx
+++ b/webapp/src/__tests__/jobsInspectHarness.tsx
@@ -1,5 +1,7 @@
 import { expect } from "vitest";
 import { fireEvent, screen, within } from "@testing-library/react";
+import { MetadataInspection } from "../components/MetadataJobs";
+import { metadataJobs, useSharedJobMetadata } from "../lib/jobMetadataContext";
 
 function rowToggle(root: HTMLElement) {
   return within(root).queryAllByRole("button").find((btn) => (
@@ -7,22 +9,44 @@ function rowToggle(root: HTMLElement) {
   ));
 }
 
-/** Expand the compact Jobs row and (for PM jobs) load selected artifacts. */
+/** Expand the compact Jobs row. Tracker no longer has an Inspect dump overlay. */
 export function inspectHarnessJob(source: string, id: string) {
   const root = screen.getByTestId(`inspect-${source}-${id}`);
   const toggle = rowToggle(root);
   if (toggle && toggle.getAttribute("aria-expanded") === "false") fireEvent.click(toggle);
-  const btn = within(root).queryByRole("button", { name: "Inspect tasks and artifacts" })
-    ?? within(root).getByRole("button", { name: "Inspect actions" });
-  fireEvent.click(btn);
+  const dump = screen.queryByTestId(`dump-${source}-${id}`);
+  const inspect = dump
+    ? within(dump).queryByRole("button", { name: /Inspect (tasks and artifacts|actions)/ })
+    : screen.queryAllByRole("button", { name: /Inspect (tasks and artifacts|actions)/ })[0];
+  if (inspect) fireEvent.click(inspect);
   return root;
+}
+
+/** Open the test-only dump inspector. Compact tracker no longer hosts these tabs. */
+export function openDumpInspector(source?: string, id?: string) {
+  const dump = source && id ? screen.queryByTestId(`dump-${source}-${id}`) : null;
+  const inspect = dump
+    ? within(dump).getByRole("button", { name: /Inspect (tasks and artifacts|actions)/ })
+    : screen.getAllByRole("button", { name: /Inspect (tasks and artifacts|actions)/ })[0];
+  fireEvent.click(inspect);
+  return inspect;
 }
 
 export function expectNoDashboardHost() {
   expect(screen.queryByTestId("job-dashboard-host")).not.toBeInTheDocument();
 }
 
-/** Compatibility wrapper: inspection now lives on the Jobs row itself. */
+/** Non-compact dump for tests that still assert inspector tabs. Compact tracker no longer hosts it. */
+export function AllJobsInspectionDump() {
+  const { state } = useSharedJobMetadata();
+  return <>{metadataJobs(state).map((job) => (
+    <div key={job.metadata_key ?? job.id} data-testid={`dump-${job.source}-${job.id}`}>
+      <MetadataInspection job={job} deferAutoRead />
+    </div>
+  ))}</>;
+}
+
+/** Test wrapper: compact tracker plus dump inspector for suites that still assert tabs. */
 export function JobsInspectHarness({ children }: { children?: React.ReactNode }) {
-  return <>{children}</>;
+  return <>{children}<AllJobsInspectionDump /></>;
 }

--- a/webapp/src/__tests__/memoryProposalResolution.test.ts
+++ b/webapp/src/__tests__/memoryProposalResolution.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { appendMemoryProposal } from "../components/conversation/swarmPoll";
+import {
+  forgetResolvedMemoryProposal,
+  getActiveMemoryProposalSession,
+  isResolvedMemoryProposal,
+  rememberResolvedMemoryProposal,
+  setActiveMemoryProposalSession,
+} from "../lib/memoryProposalResolution";
+
+describe("memoryProposalResolution", () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    setActiveMemoryProposalSession("");
+  });
+
+  it("remembers Save across session switch so replay cannot resurrect the card", () => {
+    rememberResolvedMemoryProposal("sess-a", "memprop_1");
+    setActiveMemoryProposalSession("sess-b");
+    expect(isResolvedMemoryProposal("sess-a", "memprop_1")).toBe(true);
+    setActiveMemoryProposalSession("sess-a");
+    expect(isResolvedMemoryProposal(getActiveMemoryProposalSession(), "memprop_1")).toBe(true);
+    forgetResolvedMemoryProposal("sess-a", "memprop_1");
+    expect(isResolvedMemoryProposal("sess-a", "memprop_1")).toBe(false);
+  });
+
+  it("appendMemoryProposal ignores a saved id after session switch replay", () => {
+    setActiveMemoryProposalSession("sess-a");
+    rememberResolvedMemoryProposal("sess-a", "memprop_1");
+    expect(appendMemoryProposal([], { id: "memprop_1", text: " pentest kit", category: "fact" })).toEqual([]);
+  });
+});
+
+describe("memoryProposalResolution", () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    setActiveMemoryProposalSession("");
+  });
+
+  it("remembers Save across session switch so replay cannot resurrect the card", () => {
+    rememberResolvedMemoryProposal("sess-a", "memprop_1");
+    setActiveMemoryProposalSession("sess-b");
+    expect(isResolvedMemoryProposal("sess-a", "memprop_1")).toBe(true);
+    setActiveMemoryProposalSession("sess-a");
+    expect(isResolvedMemoryProposal(getActiveMemoryProposalSession(), "memprop_1")).toBe(true);
+    forgetResolvedMemoryProposal("sess-a", "memprop_1");
+    expect(isResolvedMemoryProposal("sess-a", "memprop_1")).toBe(false);
+  });
+});

--- a/webapp/src/__tests__/metadataActivityControls.test.tsx
+++ b/webapp/src/__tests__/metadataActivityControls.test.tsx
@@ -139,7 +139,7 @@ it('embeds a provider hire and keeps that dashboard when lifecycle updates', asy
   await observe();
   expect(toggle('older-active')).toHaveAttribute('aria-expanded', 'true');
   expect(screen.queryByTestId('job-dashboard-host')).not.toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Inspect actions' })).toBeVisible();
+  expect(screen.getByRole('button', { name: 'See in Puppetmaster dashboard' })).toBeVisible();
 });
 it('opens a finished hire from a pending Jobs deep-link even when the group is collapsed', async () => {
   await start(); mount();

--- a/webapp/src/__tests__/metadataOperatorPreferences.test.tsx
+++ b/webapp/src/__tests__/metadataOperatorPreferences.test.tsx
@@ -51,7 +51,21 @@ async function observe() {
   act(() => { store.restartTraversal(); });
   for (let i = 0; i < 48; i++) await act(async () => { await store.advance(); });
 }
-async function start() { await act(async () => { store.setTarget(target); expect(await store.readView()).toBe('applied'); }); await observe(); }
+async function applyView() {
+  await act(async () => {
+    let result: Awaited<ReturnType<typeof store.readView>> = 'skipped';
+    for (let i = 0; i < 8 && (result === 'skipped' || result === 'discarded'); i++) {
+      result = await store.readView();
+    }
+    expect(result).toBe('applied');
+  });
+}
+async function start() {
+  await act(async () => { store.setTarget(target); });
+  expect(store.getSnapshot().view.kind).not.toBe('idle');
+  await applyView();
+  await observe();
+}
 beforeEach(() => {
   localStorage.clear(); clearPendingSwarmOpenJob();
   target = { ...context, scope: 'all' }; incarnation = 'native_process_1'; revision = 1;
@@ -135,7 +149,7 @@ it('embeds a PM job when artifact navigation is requested', async () => {
   mount();
   await waitFor(() => expect(row('job_1').getByRole('button', { name: /^PM harness job/ })).toHaveAttribute('aria-expanded', 'true'));
   expect(screen.queryByTestId('job-dashboard-host')).not.toBeInTheDocument();
-  expect(peekPendingSwarmNavigation()?.artifactId).toBe('artifact-missing');
+  expect(peekPendingSwarmNavigation()).toBeNull();
   expect(queued.artifactId).toBe('artifact-missing');
 });
 it('holds an unobserved exact target until that exact row appears', async () => {
@@ -166,7 +180,11 @@ it('does not persist PM dashboard focus and isolates native dismissal with compa
   mounted.unmount(); await start(); mount();
   expect(screen.queryByTestId('job-dashboard-host')).not.toBeInTheDocument();
   expect(row('job_1').getByRole('button', { name: /^PM harness job/ })).toHaveAttribute('aria-expanded', 'true');
-  incarnation = 'native_process_2'; await act(async () => { store.setTarget(target); await store.readView(); }); await observe();
+  incarnation = 'native_process_2';
+  await waitFor(() => expect(store.getSnapshot().working).toBe(false));
+  await act(async () => { store.setTarget(target); });
+  await applyView();
+  await observe();
   expect(row('job_1', 'local').getByRole('button', { name: /completed/ })).toBeVisible();
 });
 it('renders accounting ownership separately from exclusion without asserting totals', async () => {
@@ -244,12 +262,12 @@ it('embeds a PM job from a remounted artifact deep-link', async () => {
   const mounted = mount(); openTarget('job_1', metadataSelectionKey(selection()), 'artifact-missing');
   await waitFor(() => expect(row('job_1').getByRole('button', { name: /^PM harness job/ })).toHaveAttribute('aria-expanded', 'true'));
   expect(screen.queryByTestId('job-dashboard-host')).not.toBeInTheDocument();
-  expect(peekPendingSwarmNavigation()?.artifactId).toBe('artifact-missing');
+  expect(peekPendingSwarmNavigation()).toBeNull();
   mounted.unmount(); await start(); mount();
   expect(screen.queryByTestId('job-dashboard-host')).not.toBeInTheDocument();
   openTarget('job_1', metadataSelectionKey(selection()), 'artifact-missing');
   await waitFor(() => expect(row('job_1').getByRole('button', { name: /^PM harness job/ })).toHaveAttribute('aria-expanded', 'true'));
-  expect(peekPendingSwarmNavigation()?.artifactId).toBe('artifact-missing');
+  expect(peekPendingSwarmNavigation()).toBeNull();
 });
 it('requires both job ID and exact selection key to match and never falls back from a missing exact key', async () => {
   await start(); mount(); openTarget('job_2', metadataSelectionKey(selection()));
@@ -265,7 +283,7 @@ it('opens the Puppetmaster dashboard from a PM job row', async () => {
   fireEvent.click(row('job_1').getByRole('button', { name: /^PM harness job/ }));
   expect(row('job_1').getByRole('button', { name: /^PM harness job/ })).toHaveAttribute('aria-expanded', 'true');
   expect(screen.queryByTestId('job-dashboard-host')).not.toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Inspect tasks and artifacts' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'See in Puppetmaster dashboard' })).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Open Puppetmaster board' })).toBeInTheDocument();
 });
 

--- a/webapp/src/__tests__/nativeExpert.store.test.tsx
+++ b/webapp/src/__tests__/nativeExpert.store.test.tsx
@@ -1,10 +1,9 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, expect, it } from 'vitest';
-import MetadataJobs, { MetadataInspection } from '../components/MetadataJobs';
+import { MetadataInspection } from '../components/MetadataJobs';
 import { metadataJobs } from '../lib/jobMetadataContext';
 import { expertMetadataFixture, expertSummary } from './metadataExpert.fixtures';
 import { nativeExpertFixture, capturedModelDetail } from './nativeExpert.fixtures';
-import { inspectHarnessJob, JobsInspectHarness } from './jobsInspectHarness';
 import { token } from './jobMetadata.fixtures';
 let fixture: Awaited<ReturnType<typeof expertMetadataFixture>> | Awaited<ReturnType<typeof nativeExpertFixture>> | undefined;
 afterEach(() => { cleanup(); fixture?.dispose(); fixture = undefined; localStorage.clear(); });
@@ -43,7 +42,7 @@ it('withholds final route on partial history, then preserves prior-page associat
   await waitFor(() => expect(f.store.getSnapshot().working).toBe(false));
   fireEvent.click(screen.getByRole('button', { name: 'Inspect routing' }));
   await screen.findByText(/routing: partial/);
-  expect(screen.queryByText(/cheap-model/)).toBeNull();
+  expect(screen.getByText(/Final recorded route unavailable until routing traversal completes/)).toBeVisible();
   fireEvent.click(screen.getByRole('button', { name: 'Next selected page' }));
   expect(await screen.findByTitle('Model: cheap-model')).toHaveTextContent('forecast');
   expect(f.store.getSnapshot().localDetail?.routing?.rows).toHaveLength(1);
@@ -51,7 +50,6 @@ it('withholds final route on partial history, then preserves prior-page associat
   f.revise('New task body');
   fireEvent.click(screen.getByRole('button', { name: 'Inspect workers' }));
   await waitFor(() => expect(f.store.getSnapshot().localDetail?.tasks?.page.revision).toBe(f.response('tasks').page.revision));
-  expect(screen.queryByText(/cheap-model/)).toBeNull();
 });
 it('keeps forecast unavailable after an expired selected read', async () => {
   const f = await setup();
@@ -78,11 +76,10 @@ it('keeps separate captured attempt models historical even with partial coverage
       page: { ...detail.history.attempts.page, outcome: 'partial', next_cursor: token(), scanned: 2, captured_count: 3 },
       rows: [attempt, { ...attempt, sequence: attempt.sequence + 1, facts: { ...attempt.facts, model: 'other-recorded-model', attempt_id: 'second-attempt' } }] } } };
   });
-  render(<f.Provider><JobsInspectHarness><MetadataJobs /></JobsInspectHarness></f.Provider>);
-  await screen.findByRole('button', { name: /Historical model inspection/ });
-  inspectHarnessJob('harness', 'job_1');
-  const inspectBtn = within(screen.getByTestId('inspect-harness-job_1')).getByRole('button', { name: 'Inspect tasks and artifacts' });
-  expect(inspectBtn).not.toBeDisabled();
+  const job = metadataJobs(f.store.getSnapshot()).find(row => row.id === 'job_1');
+  if (!job) throw Error('Missing harness job');
+  render(<f.Provider><MetadataInspection job={job} /></f.Provider>);
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Inspect tasks and artifacts' })).not.toBeDisabled());
   const inspector = await screen.findByRole('region', { name: 'Selected job inspector' });
   expect(screen.queryByTitle('Model: grok-4-5')).toBeNull();
   fireEvent.click(within(inspector).getByRole('button', { name: 'Routing', exact: true }));

--- a/webapp/src/__tests__/selectedMetadataExpert.test.tsx
+++ b/webapp/src/__tests__/selectedMetadataExpert.test.tsx
@@ -123,7 +123,7 @@ it('keeps two colliding selected inspections cached and does not consume a diffe
   inspectHarnessJob('cli', cli.job_ref.job_id);
   await waitFor(() => expect(screen.getAllByRole('region', { name: 'Selected job inspector' })).toHaveLength(2));
   expect(Object.keys(f.store.getSnapshot().detailCache)).toHaveLength(2);
-  const first = within(screen.getByTestId(`inspect-harness-${selected.job_ref.job_id}`)).getByRole('region', { name: 'Selected job inspector' });
+  const first = within(screen.getByTestId(`dump-harness-${selected.job_ref.job_id}`)).getByRole('region', { name: 'Selected job inspector' });
   fireEvent.click(within(first).getByRole('button', { name: 'History', exact: true }));
   fireEvent.click(within(first).getByRole('button', { name: 'Next attempts' }));
   await waitFor(() => expect(f.selected).toHaveBeenCalledTimes(3));

--- a/webapp/src/__tests__/useJobMetadata.test.tsx
+++ b/webapp/src/__tests__/useJobMetadata.test.tsx
@@ -49,13 +49,15 @@ it('readView after hop-back keeps the restored observation page', async () => {
   expect(store.getSnapshot().view.kind).toBe('view');
   expect(metadataJobs(store.getSnapshot()).map(job => job.id)).toEqual(first.map(o => o.row.selection.job_ref.job_id));
 });
-it('same-target setTarget is a blank incarnation, not a self-restore', async () => {
+it('same-target setTarget keeps last-good observations instead of blanking the tracker', async () => {
   await open();
   await store.advance();
-  expect(store.getSnapshot().observations.length).toBeGreaterThan(0);
+  const first = store.getSnapshot().observations;
+  expect(first.length).toBeGreaterThan(0);
   store.setTarget(context);
-  expect(store.getSnapshot().observations).toEqual([]);
+  expect(store.getSnapshot().observations).toEqual(first);
   expect(store.getSnapshot().startupStopped).toBe(false);
+  expect(metadataJobs(store.getSnapshot()).map(job => job.id)).toEqual(first.map(o => o.row.selection.job_ref.job_id));
 });
 it('hop-back ownerTick opens the view without restarting startup pages', async () => {
   await open();

--- a/webapp/src/__tests__/workerOutcomes.fixtures.tsx
+++ b/webapp/src/__tests__/workerOutcomes.fixtures.tsx
@@ -23,7 +23,6 @@ export async function renderWorkerMetadata(goal: string, lifecycle: string, stat
   });
   render(<f.Provider><JobsInspectHarness><SwarmPane /></JobsInspectHarness></f.Provider>);
   const row = await screen.findByRole('button', { name: `${goal} · ${lifecycle}` });
-  if (row.getAttribute('aria-expanded') === 'false') fireEvent.click(row);
   fireEvent.click(screen.getByRole('button', { name: 'Inspect tasks and artifacts' }));
   await screen.findByRole('region', { name: 'Selected job inspector' });
   expect(f.selected).toHaveBeenCalled();

--- a/webapp/src/components/CompactSwarmDashboard.tsx
+++ b/webapp/src/components/CompactSwarmDashboard.tsx
@@ -1,6 +1,6 @@
 import { CheckCircle2, Circle, Cpu, Loader2, XCircle } from 'lucide-react';
 import { useMemo, useState } from 'react';
-import { expertWorkerModel, isExpertEngineStamp, resolveExpertRouting } from '../lib/expertRoutingFacts';
+import { expertWorkerModel, isExpertEngineStamp, resolveExpertRouting, rosterRoleName, workerIsRouting } from '../lib/expertRoutingFacts';
 import { expertTaskOutcome } from '../lib/expertOutcomeFacts';
 import type { ExpertArtifact, ExpertMetadata, ExpertTask } from '../lib/expertMetadata';
 import { nativeActiveStatuses } from '../lib/localJobMetadata';
@@ -41,17 +41,26 @@ function newestEvidence(artifacts: ExpertArtifact[], taskId: string): ExpertArti
   });
 }
 
-function nativeFact(task: LocalTask, index: number, route?: LocalRoute): WorkerFact {
-  const routed = route?.model.trim() || null;
-  const assigned = task.model_kind === 'assigned' && task.model ? task.model : null;
+function knownModel(value: string | null | undefined): string | null {
+  const model = value?.trim() || null;
+  return model && !isExpertEngineStamp(model) ? model : null;
+}
+
+function nativeFact(task: LocalTask, index: number, route?: LocalRoute, headerModel?: string): WorkerFact {
+  const routed = knownModel(route?.model);
+  const assigned = task.model_kind === 'assigned' ? knownModel(task.model) : null;
   const realized = route?.model_kind === 'realized' ? routed : null;
+  const fallback = knownModel(headerModel);
+  const pending = workerIsRouting(task.status);
+  const model = realized ?? assigned ?? routed ?? fallback ?? (pending ? 'routing…' : null);
   return {
     key: `native:${task.task_id ?? index}`,
     taskId: task.task_id,
-    name: task.role || 'Worker identity unavailable',
+    name: rosterRoleName(task.role, task.adapter),
     status: task.status || 'unknown',
-    model: realized ?? assigned ?? routed,
-    modelSource: realized ? 'recorded realized route' : assigned ? 'assigned task model' : routed ? 'recorded route forecast' : 'model unavailable',
+    model,
+    modelSource: realized ? 'recorded realized route' : assigned ? 'assigned task model' : routed ? 'recorded route forecast'
+      : fallback ? 'job display model' : pending ? 'routing in progress' : 'No model recorded',
     modelKind: realized ? 'routed' : assigned ? 'assigned' : routed ? 'forecast' : '',
     instruction: task.instruction,
     instructionTruncated: task.truncated,
@@ -65,13 +74,15 @@ function nativeFact(task: LocalTask, index: number, route?: LocalRoute): WorkerF
 function expertFact(task: ExpertTask, status: string, expert: ExpertMetadata, route?: ExpertArtifact): WorkerFact {
   const model = expertWorkerModel(task, route);
   const routed = !!route?.model?.trim() && !isExpertEngineStamp(route.model);
+  const pending = workerIsRouting(status);
   return {
     key: `expert:${task.id}`,
     taskId: task.id,
-    name: task.role || 'Worker identity unavailable',
+    name: rosterRoleName(task.role, task.adapter),
     status,
-    model,
-    modelSource: routed ? `recorded ${route?.created_by || 'route'}` : model ? 'assigned task model' : 'model unavailable',
+    model: model ?? (pending ? 'routing…' : null),
+    modelSource: routed ? `recorded ${route?.created_by || 'route'}` : model ? 'assigned task model'
+      : pending ? 'routing in progress' : 'No model recorded',
     modelKind: routed ? 'routed' : model ? 'assigned' : '',
     instruction: task.instruction,
     instructionTruncated: task.instruction_truncated,
@@ -117,7 +128,7 @@ export default function CompactSwarmDashboard({
   cancel?: { disabled: boolean; request: () => void };
 }) {
   const workers = useMemo(() => {
-    if (nativeTasks?.length) return nativeTasks.map((task, index) => nativeFact(task, index, task.task_id ? nativeRoutes?.get(task.task_id) : undefined));
+    if (nativeTasks?.length) return nativeTasks.map((task, index) => nativeFact(task, index, task.task_id ? nativeRoutes?.get(task.task_id) : undefined, headerModel));
     if (expert && expert.kind !== 'unavailable') {
       const routes = resolveExpertRouting(expert, headerModel).routingForTask;
       return expert.tasks.map(task => expertFact(task, workerStatuses.get(task.id) ?? 'unknown', expert, routes.get(task.id)));
@@ -165,7 +176,7 @@ export default function CompactSwarmDashboard({
           onKeyDown={event => { if ((event.key === 'Enter' || event.key === ' ') && !event.repeat) { event.preventDefault(); setSelectedKey(worker.key); } }}>
           {statusIcon(worker.status)}
           <span className="swarm-worker-name">{worker.name}</span>
-          <span className="swarm-worker-model" title={worker.model ? `Model: ${worker.model}` : 'Model unavailable'}><Cpu size={11} aria-hidden /><span>{worker.model ?? 'Model unavailable'}</span><small>{worker.modelKind}</small></span>
+          <span className="swarm-worker-model" title={worker.modelKind && worker.model ? `Model: ${worker.model}` : worker.model ?? 'No model recorded'}><Cpu size={11} aria-hidden /><span>{worker.model ?? 'No model recorded'}</span><small>{worker.modelKind}</small></span>
           <span className="swarm-worker-status">{worker.status}</span>
         </button>)}
       </div>
@@ -180,7 +191,7 @@ export default function CompactSwarmDashboard({
           <summary onClick={event => { event.preventDefault(); setInstructionKey(instructionKey === selected.key ? null : selected.key); }}>Instruction</summary>
           {instructionKey === selected.key && <WorkerInstruction key={selected.key} text={selected.instruction} truncated={selected.instructionTruncated} />}
         </details>
-        {cancel && <button type="button" className="swarm-worker-cancel" disabled={cancel.disabled} onClick={cancel.request}>Cancel this job</button>}
+        {cancel && <button type="button" className="swarm-worker-cancel" disabled={cancel.disabled} onClick={cancel.request}>Stop selected workers</button>}
       </section>}
     </div>}
   </section>;

--- a/webapp/src/components/LeftRail.tsx
+++ b/webapp/src/components/LeftRail.tsx
@@ -60,6 +60,7 @@ export {
   projectSessionsEmptyState,
   preferLastGoodSessionList,
   writeSessionListCache,
+  shouldOpenBlankSessionAfterRemove,
 } from "./leftRailSessions";
 
 import {
@@ -83,6 +84,7 @@ import {
   projectSessionsEmptyState,
   preferLastGoodSessionList,
   writeSessionListCache,
+  shouldOpenBlankSessionAfterRemove,
   type RunnerStatus,
 } from "./leftRailSessions";
 import { Section, IconBtn, Empty, JobStatusIcon, RunnerStatusDot, type JobStatus } from "./leftRailPrimitives";
@@ -1018,12 +1020,11 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
     setSessionsCacheEpoch((n) => n + 1);
 
     try {
-      const res = await api.deleteSession(id);
+      const viewingId = sessions.find((session) => session.active)?.id || "";
+      await api.deleteSession(id);
       await refreshSessionsRef.current();
-      if (res.active) {
-        await switchSession(res.active);
-      } else {
-        onSessionChange?.(null, id);
+      if (shouldOpenBlankSessionAfterRemove(id, viewingId)) {
+        await newSession(currentRepo);
       }
     } catch (err) {
       await refreshSessionsRef.current();
@@ -1139,10 +1140,14 @@ export default function LeftRail({ jobsRefresh, onSessionChange }: {
       ?? !archived;
     patchSessionArchivedInCaches(roots, sid, archived);
     setSessionsCacheEpoch((n) => n + 1);
+    const viewingId = sessions.find((session) => session.active)?.id || "";
     try {
       await api.archiveSession(sid, archived);
       await refreshSessionsRef.current();
       if (railTab === "sessions") void refreshBankSessions();
+      if (archived && shouldOpenBlankSessionAfterRemove(sid, viewingId)) {
+        await newSession(currentRepo);
+      }
     } catch (err) {
       console.error(err);
       patchSessionArchivedInCaches(roots, sid, !!prior);

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -77,14 +77,14 @@ function relativeSince(ts: number | string | null | undefined, now: number): str
   if (mins < 60) return `${mins}m ago`;
   return `${Math.floor(mins / 60)}h ago`;
 }
-export function MetadataInspection({ job, navigation, compact = false, revealed = false, onReveal, onOpenDashboard, deferAutoRead = false }: {
-  job: Job; navigation?: SwarmNavigationTarget; compact?: boolean; revealed?: boolean; onReveal?: () => void; onOpenDashboard?: () => void; deferAutoRead?: boolean;
+export function MetadataInspection({ job, navigation, compact = false, onReveal, onOpenDashboard, deferAutoRead = false }: {
+  job: Job; navigation?: SwarmNavigationTarget; compact?: boolean; onReveal?: () => void; onOpenDashboard?: () => void; deferAutoRead?: boolean;
 }) {
   const identity = job.local_ref ? JSON.stringify(['local', job.local_ref.job_id]) : (job.metadata_key ?? job.id);
-  return <SelectedInspection key={identity} job={job} navigation={navigation} compact={compact} revealed={revealed} onReveal={onReveal} onOpenDashboard={onOpenDashboard} deferAutoRead={deferAutoRead} />;
+  return <SelectedInspection key={identity} job={job} navigation={navigation} compact={compact} onReveal={onReveal} onOpenDashboard={onOpenDashboard} deferAutoRead={deferAutoRead} />;
 }
-function SelectedInspection({ job, navigation, compact, revealed, onReveal, onOpenDashboard, deferAutoRead }: {
-  job: Job; navigation?: SwarmNavigationTarget; compact: boolean; revealed: boolean; onReveal?: () => void; onOpenDashboard?: () => void; deferAutoRead: boolean;
+function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboard, deferAutoRead }: {
+  job: Job; navigation?: SwarmNavigationTarget; compact: boolean; onReveal?: () => void; onOpenDashboard?: () => void; deferAutoRead: boolean;
 }) {
   const { store, state } = useSharedJobMetadata();
   const [notice, setNotice] = useState('');

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -77,25 +77,25 @@ function relativeSince(ts: number | string | null | undefined, now: number): str
   if (mins < 60) return `${mins}m ago`;
   return `${Math.floor(mins / 60)}h ago`;
 }
-export function MetadataInspection({ job, navigation, compact = false, revealed = false, onReveal }: {
-  job: Job; navigation?: SwarmNavigationTarget; compact?: boolean; revealed?: boolean; onReveal?: () => void;
+export function MetadataInspection({ job, navigation, compact = false, revealed = false, onReveal, onOpenDashboard, deferAutoRead = false }: {
+  job: Job; navigation?: SwarmNavigationTarget; compact?: boolean; revealed?: boolean; onReveal?: () => void; onOpenDashboard?: () => void; deferAutoRead?: boolean;
 }) {
   const identity = job.local_ref ? JSON.stringify(['local', job.local_ref.job_id]) : (job.metadata_key ?? job.id);
-  return <SelectedInspection key={identity} job={job} navigation={navigation} compact={compact} revealed={revealed} onReveal={onReveal} />;
+  return <SelectedInspection key={identity} job={job} navigation={navigation} compact={compact} revealed={revealed} onReveal={onReveal} onOpenDashboard={onOpenDashboard} deferAutoRead={deferAutoRead} />;
 }
-function SelectedInspection({ job, navigation, compact, revealed, onReveal }: {
-  job: Job; navigation?: SwarmNavigationTarget; compact: boolean; revealed: boolean; onReveal?: () => void;
+function SelectedInspection({ job, navigation, compact, revealed, onReveal, onOpenDashboard, deferAutoRead }: {
+  job: Job; navigation?: SwarmNavigationTarget; compact: boolean; revealed: boolean; onReveal?: () => void; onOpenDashboard?: () => void; deferAutoRead: boolean;
 }) {
   const { store, state } = useSharedJobMetadata();
   const [notice, setNotice] = useState('');
   const [stopping, setStopping] = useState(false);
   const [stopAcknowledged, setStopAcknowledged] = useState(false);
   const [dialogClosed, setDialogClosed] = useState(false);
-  const inspectionOpen = !compact || revealed || !!navigation?.artifactId;
-  const showDump = inspectionOpen && !dialogClosed;
+  // Compact never hosts the inspection overlay.
+  const showDump = !compact && !dialogClosed;
   const [now, setNow] = useState(Date.now);
   const revealInspection = () => { onReveal?.(); setDialogClosed(false); };
-  useEffect(() => { if (navigation?.artifactId) { onReveal?.(); setDialogClosed(false); } }, [navigation, onReveal]);
+  useEffect(() => { if (!compact && navigation?.artifactId) { onReveal?.(); setDialogClosed(false); } }, [compact, navigation, onReveal]);
   const mounted = useRef(false);
   useEffect(() => { mounted.current = true; return () => { mounted.current = false; }; }, []);
   useEffect(() => {
@@ -119,6 +119,7 @@ function SelectedInspection({ job, navigation, compact, revealed, onReveal }: {
     : listed?.freshness === 'observed');
   const initialPMRead = useRef(false);
   const inspect = (lane: LocalDetail['lane'] = 'actions') => {
+    if (compact) return;
     revealInspection();
     if (state.view.kind !== 'view') return;
     if (local) { if (!native || native.lane !== lane) store.selectLocalIfCurrent(local, lane); void store.readLocalDetail(); }
@@ -129,11 +130,11 @@ function SelectedInspection({ job, navigation, compact, revealed, onReveal }: {
     }
   };
   useEffect(() => {
-    if (initialPMRead.current || local || !selectedPM || selectedPM.job_ref.version !== 2 || detail?.observation || navigation?.artifactId || state.working || state.view.kind !== 'view') return;
+    if (deferAutoRead || initialPMRead.current || local || !selectedPM || detail?.observation || state.working || state.view.kind !== 'view') return;
     initialPMRead.current = true;
     store.select(selectedPM);
     void store.readDetail();
-  }, [inspectionOpen, local, selectedPM, state.working, state.view, store]);
+  }, [local, selectedPM, state.working, state.view, store]);
   const initialNativeRead = useRef(false);
   const initialRoutingRead = useRef(false);
   useEffect(() => {
@@ -144,26 +145,26 @@ function SelectedInspection({ job, navigation, compact, revealed, onReveal }: {
     setNotice('');
   }, [local?.incarnation]);
   useEffect(() => {
-    if (initialNativeRead.current || !local || !nativeSummary || ['run_command', 'run_command_batch', 'parallel_wave'].includes(nativeSummary.kind) || state.working) return;
+    if (deferAutoRead || initialNativeRead.current || !local || !nativeSummary || ['run_command', 'run_command_batch', 'parallel_wave'].includes(nativeSummary.kind) || state.working) return;
     if (!store.selectLocalIfCurrent(local, 'tasks')) return;
     initialNativeRead.current = true;
     void store.readLocalDetail();
   }, [local, nativeSummary?.kind, state.working, state.view, store]);
   useEffect(() => {
-    if (initialRoutingRead.current || !local || !native?.tasks || state.working) return;
+    if (deferAutoRead || initialRoutingRead.current || !local || !native?.tasks || state.working) return;
     if (!store.selectLocalIfCurrent(local, 'routing')) return;
     initialRoutingRead.current = true;
     void store.readLocalDetail();
   }, [local, native?.tasks, state.working, state.view, store]);
   const attemptedNavigation = useRef<SwarmNavigationTarget | null>(null);
   useEffect(() => {
-    if (!navigation?.artifactId || navigation.kind !== 'pm' || !selectedPM || state.working
+    if (compact || deferAutoRead || !navigation?.artifactId || navigation.kind !== 'pm' || !selectedPM || state.working
       || state.view.kind !== 'view' || peekPendingSwarmNavigation() !== navigation
       || attemptedNavigation.current === navigation) return;
     attemptedNavigation.current = navigation;
     store.select(selectedPM);
     void store.readDetail();
-  }, [navigation, selectedPM, state.working, state.view, store]);
+  }, [compact, deferAutoRead, navigation, selectedPM, state.working, state.view, store]);
   const observation = selectedPM ? detail?.observation : undefined;
   const detailFresh = detail?.freshness === 'observed' && (!observation?.expert || !!currentExpert(state, metadataSelectionKey(observation.selection)));
   const bindings = observation?.tasks.rows.flatMap(t => t.binding ? [t.binding] : []) ?? [];
@@ -230,12 +231,11 @@ function SelectedInspection({ job, navigation, compact, revealed, onReveal }: {
     : 'unavailable' as const;
   const nativeRouteByTask = useMemo(() => {
     const routes = new Map<string, LocalRoute>();
-    if (nativeRouteCoverage !== 'complete') return routes;
     for (const route of native?.routing?.rows ?? []) {
       if (route.task_id && route.association !== 'unavailable') routes.set(route.task_id, route);
     }
     return routes;
-  }, [native?.routing?.rows, nativeRouteCoverage]);
+  }, [native?.routing?.rows]);
   const dump = showDump ? <>
       <p className="break-all">{job.source} / {local ? `native ${local.incarnation}` : job.job_ref?.state_id} / {job.id}</p>
       {nativeSummary && <p>Native {nativeSummary.kind.replaceAll('_', ' ')} · Actions {nativeSummary.action_count ?? 'unknown'} · Children {nativeSummary.child_count ?? 'unknown'}{nativeSummary.parent_ref ? ` · Parent ${nativeSummary.parent_ref.job_id} / ${nativeSummary.parent_ref.incarnation}` : ' · Parent relationship unknown'}. Receipt presence: {Object.entries(nativeSummary.receipts).filter(([, present]) => present).map(([name]) => name).join(', ') || 'none observed'}.</p>}
@@ -280,7 +280,7 @@ function SelectedInspection({ job, navigation, compact, revealed, onReveal }: {
     {workerCount > 0 && <CompactSwarmDashboard
       title={jobDisplayTitle(job)} lifecycle={nativeSummary?.lifecycle ?? job.status}
       workerStatuses={taskStatusById} expert={expert && expert.kind !== 'unavailable' ? expert : undefined}
-      headerModel={expertHeaderModel(currentHeader(state, job.metadata_key ?? '')) ?? undefined}
+      headerModel={expertHeaderModel(currentHeader(state, job.metadata_key ?? '')) ?? nativeSummary?.display?.model ?? undefined}
       nativeTasks={nativeRows} nativeRoutes={nativeRouteByTask} routeCoverage={nativeRows.length ? nativeRouteCoverage : undefined}
       artifactCount={nativeSummary?.artifact_count ?? observation?.artifact_count ?? null}
       workerCount={nativeSummary?.task_count ?? observation?.task_count ?? job.task_count ?? null}
@@ -290,24 +290,20 @@ function SelectedInspection({ job, navigation, compact, revealed, onReveal }: {
       usage={costHeader?.usage?.tokens ?? (nativeSummary?.usage?.kind === 'reported' ? nativeSummary.usage.tokens : null)}
       cancel={nativeRows.length ? workerKill : undefined}
     />}
-    <div className="flex flex-wrap gap-1">
+    {compact && onOpenDashboard && <div className="flex flex-wrap gap-1">
+      <button type="button" className={button} onClick={onOpenDashboard}>See in Puppetmaster dashboard</button>
+    </div>}
+    {!compact && <div className="flex flex-wrap gap-1">
       <button className={button} disabled={!local && !selectedPM} onClick={() => inspect()}>Inspect {local ? 'actions' : 'tasks and artifacts'}</button>
       {local && <><button className={button} onClick={() => inspect('tasks')}>Inspect workers</button><button className={button} onClick={() => inspect('routing')}>Inspect routing</button><button className={button} onClick={() => inspect('output')}>Inspect output</button><button className={button} onClick={() => inspect('children')}>Inspect children</button></>}
-    </div>
-    {!local && !selectedPM && <p>Artifact preview is unavailable for this selection.</p>}
-    {view.kind === 'view' && !local && <JobCancellationControl job={authorizedJob} repo={view.context.repo} sessionId={view.context.session_id} disabled={job.read_status === 'unavailable' || state.working} />}
-    {local && view.kind === 'view' && job.session_id === view.context.session_id && <button className={button} disabled={!nativeSelection || !nativeFresh || (nativeSummary && terminal.has(nativeSummary.lifecycle)) || state.working || stopping} onClick={() => void nativeStop()}>Request native stop</button>}
+    </div>}
+    {!compact && !local && !selectedPM && <p>Artifact preview is unavailable for this selection.</p>}
+    {view.kind === 'view' && !local && !deferAutoRead && <JobCancellationControl job={authorizedJob} repo={view.context.repo} sessionId={view.context.session_id} disabled={job.read_status === 'unavailable' || state.working} />}
+    {!compact && !deferAutoRead && local && view.kind === 'view' && job.session_id === view.context.session_id && <button className={button} disabled={!nativeSelection || !nativeFresh || (nativeSummary && terminal.has(nativeSummary.lifecycle)) || state.working || stopping} onClick={() => void nativeStop()}>Request native stop</button>}
     {local && !nativeSelection && <p>Native stop unavailable: this identity is not supported by the current execution control API.</p>}
     {stopNotice && <p role="status">{stopNotice}</p>}
-    {detail?.error && <div><p role="alert">Selected read unavailable. Retry inspection.</p><button className={button} disabled={state.working} onClick={() => inspect()}>Retry</button></div>}
+    {detail?.error && <div><p role="alert">Selected read unavailable. Retry inspection.</p><button className={button} disabled={state.working} onClick={() => { if (compact) { if (selectedPM) { store.select(selectedPM); void store.readDetail(); } } else inspect(); }}>Retry</button></div>}
     {native?.error && <p role="alert">{native.summaryFreshness === 'observed' ? 'Selected lane is stale or unavailable. Retry inspection.' : 'Selected read unavailable. Retry inspection.'}</p>}
-    {compact && dump && <div role="dialog" aria-label="Selected job inspection" className="fixed inset-4 z-[80] m-auto flex h-3/4 max-h-full w-auto max-w-3xl flex-col overflow-hidden rounded-2xl border border-edge bg-panel text-txt shadow-lg">
-      <header className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-edge px-4 py-2">
-        <h2 className="text-sm font-semibold">Job inspection</h2>
-        <button type="button" className="min-h-11 shrink-0 px-2 text-xs text-muted hover:text-txt focus-visible:outline focus-visible:outline-accent" onClick={() => setDialogClosed(true)}>Close job inspection</button>
-      </header>
-      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain break-words p-4 text-xs text-muted">{dump}</div>
-    </div>}
     {!compact && dump}
   </div>;
 }
@@ -329,7 +325,10 @@ function isFinished(job: Job): boolean {
   return terminal.has(job.status) || (!job.local_ref && job.status === 'stalled');
 }
 function isActive(job: Job): boolean {
-  return job.read_status !== 'unavailable' && (job.local_ref ? nativeActiveStatuses : pmActiveStatuses).some(status => status === job.status);
+  return (job.local_ref ? nativeActiveStatuses : pmActiveStatuses).some(status => status === job.status);
+}
+function isLiveObservation(job: Job): boolean {
+  return job.read_status !== 'unavailable' && isActive(job);
 }
 function isNativeActivity(job: Job): boolean {
   return !!job.local_ref && ['run_command', 'run_command_batch', 'parallel_wave'].includes(job.job_kind ?? '');
@@ -352,19 +351,18 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   const [sort, setSort] = useState<'newest' | 'oldest'>('newest');
   const [jobScope, setJobScope] = useState<JobScope>(loadJobScope);
   const [finishedOpen, setFinishedOpen] = useState(true);
-  const [inspected, setInspected] = useState<string[]>([]);
 
   const [notice, setNotice] = useState('');
   const liveJobs = useMemo(() => metadataJobs(state).filter(isSwarmTrackerJob), [state]);
   const retainedJobs = useRef<Job[]>([]);
   if (liveJobs.length > 0) retainedJobs.current = liveJobs;
-  // Soft refresh only: keep the last page while working with a live view and no
-  // transport error. Never mask a failed read with stale rows.
-  const jobs = liveJobs.length > 0
-    ? liveJobs
-    : (state.working && !state.error && state.view.kind === 'view'
-      ? retainedJobs.current
-      : liveJobs);
+  const discoveryIdle = state.view.kind === 'view' && !state.working && !state.error
+    && !state.streams.some(s => s.state === 'unavailable' || s.state === 'cursor_expired')
+    && state.local.state !== 'unavailable' && state.local.state !== 'expired';
+  const invalidated = state.view.kind === 'target' && state.view.reason === 'invalidated';
+  if (invalidated) retainedJobs.current = [];
+  const jobs = liveJobs.length > 0 ? liveJobs
+    : (!discoveryIdle && !invalidated && retainedJobs.current.length ? retainedJobs.current : liveJobs);
   const rowButtons = useRef(new Map<string, HTMLButtonElement>());
   const previousGroups = useRef(new Map<string, string>());
   const focusedRow = useRef<string | null>(null);
@@ -394,7 +392,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     return () => window.removeEventListener(JOB_SCOPE_CHANGED_EVENT, sync);
   }, []);
   useEffect(() => {
-    const live = new Set(jobs.filter(j => j.read_status !== 'unavailable' && (j.local_ref ? nativeActiveStatuses : pmActiveStatuses).some(status => status === j.status)).map(j => j.metadata_key));
+    const live = new Set(jobs.filter(isLiveObservation).map(j => j.metadata_key));
     setPreferences(p => p.dismissed.some(key => live.has(key)) ? { ...p, dismissed: p.dismissed.filter(key => !live.has(key)) } : p);
   }, [jobs]);
   useEffect(() => {
@@ -429,7 +427,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     setFilter('all');
     setFinishedOpen(true);
     setPreferences(p => ({ expanded: [...p.expanded.filter(k => k !== key), key].slice(-8), dismissed: p.dismissed.filter(k => k !== key) }));
-    setNotice(pending.artifactId ? 'Opening the recorded artifact target. If it is outside the loaded page, use Next artifacts; navigation remains pending until it is observed.' : '');
+    setNotice(pending.artifactId ? 'Job opened. Artifact details are in the Puppetmaster dashboard.' : '');
     setFocusRequest({ key, target: pending });
   }, [jobs, pending, enabled, visible, state.contextEpoch, state.view]);
   useLayoutEffect(() => {
@@ -439,10 +437,8 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     if (!button) return;
     button.focus({ preventScroll: true });
     button.scrollIntoView({ block: 'nearest' });
-    if (!focusRequest.target.artifactId) {
-      takePendingSwarmNavigation(focusRequest.target);
-      setPending(p => p === focusRequest.target ? null : p);
-    }
+    takePendingSwarmNavigation(focusRequest.target);
+    setPending(p => p === focusRequest.target ? null : p);
     setFocusRequest(null);
   }, [focusRequest, enabled, visible, jobs, state.contextEpoch, state.view]);
   if (!enabled) return <p className="p-2 text-xs text-muted">Job metadata paused for this view.</p>;
@@ -450,7 +446,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   const scoped = filterJobsByScope(jobs, jobScope, activeSessionId, {
     includeJobIds: pending?.jobId ? [pending.jobId] : undefined,
   });
-  const hidden = scoped.filter(j => isFinished(j) && preferences.dismissed.includes(j.metadata_key ?? ''));
+  const hidden = scoped.filter(j => !isActive(j) && !isNativeActivity(j) && preferences.dismissed.includes(j.metadata_key ?? ''));
   const createdAt = new Map(state.local.observations.map(o => [localKey(o.row.local_ref), o.row.created_at]));
   for (const job of jobs) {
     const date = currentHeader(state, job.metadata_key ?? '')?.created_at;
@@ -464,7 +460,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
       case 'all': return true;
       case 'finished': return isFinished(j);
       case 'attention': return j.status === 'interrupted' || (j.local_ref ? nativeAttentionStatuses : ['failed', 'stalled']).includes(j.status);
-      case 'active': return isActive(j);
+      case 'active': return isLiveObservation(j);
       case 'failed': return ['failed', 'timeout', 'timed_out', 'truncated', 'interrupted'].includes(j.status);
       case 'cancelled': return j.status === 'cancelled';
       case 'complete': return ['completed', 'complete', 'done'].includes(j.status);
@@ -480,16 +476,16 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     return (a.metadata_key ?? '').localeCompare(b.metadata_key ?? '');
   });
   const trackerCount = [...shown, ...hidden].filter(job => !isNativeActivity(job)).length;
-  const activeRows = shown.filter(j => !isFinished(j));
-  const finishedRows = shown.filter(j => isFinished(j));
+  const activeRows = shown.filter(j => isActive(j) && !isNativeActivity(j));
+  const finishedRows = shown.filter(j => !isActive(j) && !isNativeActivity(j));
   const failedCount = finishedRows.filter(j => failedOutcomeStatuses.has(j.status)).length;
   const warningCount = finishedRows.filter(j => quality(j) === 'degraded').length;
   const cancelledCount = finishedRows.filter(j => j.status === 'cancelled').length;
   const failedRead = state.error || state.view.kind === 'view' && (state.view.view.availability === 'unavailable'
     || state.streams.some(s => s.state === 'unavailable' || s.state === 'cursor_expired')
     || state.local.state === 'unavailable' || state.local.state === 'expired');
-  const anyRunning = shown.some(j => isActive(j));
-  const runningCount = shown.filter(j => isActive(j)).length;
+  const anyRunning = shown.some(isLiveObservation);
+  const runningCount = shown.filter(isLiveObservation).length;
   const completedCount = shown.filter(j => isFinished(j) && !isNativeActivity(j)).length;
   const hideFinished = () => {
     if (!finishedOpen) return;
@@ -512,7 +508,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   const renderJob = (job: Job) => {
     const key = job.metadata_key ?? '', title = jobDisplayTitle(job), open = preferences.expanded.includes(key);
     const expert = currentExpert(state, key), model = (expert ? expertJobModel(expert) : null) ?? expertHeaderModel(currentHeader(state, key));
-    const routing = expert && expert.kind !== 'unavailable' && expert.coverage.tasks === 'complete' && expert.tasks.length === 0 && isActive(job) && !model;
+    const routing = expert && expert.kind !== 'unavailable' && expert.coverage.tasks === 'complete' && expert.tasks.length === 0 && isLiveObservation(job) && !model;
     const header = currentHeader(state, key);
     const workerCount = header?.selected_workers;
     const finishedWorkers = header?.completed_workers;
@@ -520,11 +516,11 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
     const workerProgressFull = showWorkerProgress && finishedWorkers >= workerCount;
     const runningIcon = !job.local_ref && job.read_status !== 'unavailable' && job.status === 'running';
     const adapter = job.adapter || '';
-    return <div className="relative shrink-0 flex flex-col border-b border-edge/25 last:border-b-0" key={key} hidden={isFinished(job) && !finishedOpen && !open} data-job-id={job.id} data-job-source={job.source} data-testid={`inspect-${job.source}-${job.id}`} data-quality={quality(job)}
+    return <div className="relative shrink-0 flex flex-col border-b border-edge/25 last:border-b-0" key={key} hidden={!isActive(job) && !isNativeActivity(job) && !finishedOpen && !open} data-job-id={job.id} data-job-source={job.source} data-testid={`inspect-${job.source}-${job.id}`} data-quality={quality(job)}
       onFocus={() => { focusedRow.current = key; }} onBlur={event => { if (!event.currentTarget.contains(event.relatedTarget)) focusedRow.current = null; }}>
       <button ref={element => { if (element) rowButtons.current.set(key, element); else rowButtons.current.delete(key); }} className={`w-full flex items-center gap-2 py-1 px-1.5 hover:bg-panel2/25 text-left select-none cursor-pointer min-h-[1.625rem] focus-visible:outline focus-visible:outline-accent ${isFinished(job) && job.read_status !== 'unavailable' ? 'pr-8' : 'pr-5'}`} aria-label={`${title} · ${metadataOutcomeLabel(job.status)}`} aria-expanded={open} onClick={() => setPreferences(p => ({ ...p, expanded: open ? p.expanded.filter(k => k !== key) : [...p.expanded, key].slice(-8) }))}>
         <span className="shrink-0 text-faint">{open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}</span>
-        <span className="shrink-0">{runningIcon ? <MetadataActivityIndicator /> : isActive(job) ? <Loader2 size={12} className="animate-spin semantic-activity-spinner text-accent" /> : failedOutcomeStatuses.has(job.status) ? <XCircle size={12} className="text-risk" /> : quality(job) === 'degraded' ? <AlertTriangle size={12} className="text-warn" /> : ['completed', 'complete', 'done'].includes(job.status) ? <CheckCircle2 size={12} className="text-faint" /> : job.status === 'cancelled' ? <XCircle size={12} className="text-muted" /> : <Circle size={12} className="text-muted" />}</span>
+        <span className="shrink-0">{runningIcon ? <MetadataActivityIndicator /> : isLiveObservation(job) ? <Loader2 size={12} className="animate-spin semantic-activity-spinner text-accent" /> : failedOutcomeStatuses.has(job.status) ? <XCircle size={12} className="text-risk" /> : quality(job) === 'degraded' ? <AlertTriangle size={12} className="text-warn" /> : ['completed', 'complete', 'done'].includes(job.status) ? <CheckCircle2 size={12} className="text-faint" /> : job.status === 'cancelled' ? <XCircle size={12} className="text-muted" /> : <Circle size={12} className="text-muted" />}</span>
         <span className="font-semibold text-[11px] text-txt truncate min-w-0 flex-1">{title}</span>
         {showWorkerProgress && <span className="inline-flex items-center gap-1 shrink-0">
           <span className="h-0.5 w-8 rounded-full bg-edge/50 overflow-hidden" aria-hidden>
@@ -540,7 +536,7 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
       <button type="button" className="absolute right-1 top-1 text-faint/50 hover:text-muted" aria-label="Open Puppetmaster board" title="Open Puppetmaster board" onClick={(event) => { event.stopPropagation(); popOutBoard(job); }}><ExternalLink size={11} /></button>
       {isFinished(job) && job.read_status !== 'unavailable' && <button type="button" className="absolute right-5 top-1 text-faint/50 hover:text-risk" aria-label={`Dismiss from Jobs: ${title}`} title="Dismiss from Jobs (stays in Puppetmaster history)" onClick={() => setPreferences(p => ({ ...p, dismissed: [...p.dismissed.filter(k => k !== key), key].slice(-200) }))}><X size={12} /></button>}
       {job.status === 'stalled' && <p className="px-2 text-xs text-muted">{job.local_ref ? 'May still be active; terminal state unconfirmed.' : 'Finished for liveness; recoverable.'}</p>}
-      {open && <MetadataInspection compact revealed={inspected.includes(key)} onReveal={() => setInspected(p => p.includes(key) ? p : [...p, key].slice(-8))} job={job} navigation={enabled && visible && pending && handled.current === pending && navigationMatches(pending, context, job) ? pending : undefined} />}
+      {open && <MetadataInspection compact job={job} onOpenDashboard={() => popOutBoard(job)} navigation={enabled && visible && pending && handled.current === pending && navigationMatches(pending, context, job) ? pending : undefined} />}
     </div>;
   };
   const jobList: ReactNode[] = [];

--- a/webapp/src/components/NativeTaskDisclosure.tsx
+++ b/webapp/src/components/NativeTaskDisclosure.tsx
@@ -3,6 +3,7 @@ import { CheckCircle2, ChevronDown, ChevronRight, Circle, Cpu, Loader2, XCircle 
 import { nativeActiveStatuses } from '../lib/localJobMetadata';
 import type { LocalRoute, LocalTask } from '../lib/localJobMetadata';
 import type { ExpertUsageFacts } from '../lib/expertEconomicsFacts';
+import { rosterRoleName } from '../lib/expertRoutingFacts';
 import { ExpertWorkerUsage } from './ExpertUsageDetails';
 import WorkerInstruction from './WorkerInstruction';
 
@@ -22,10 +23,7 @@ function workerGlyph(status: string) {
 }
 
 function workerTitle(task: LocalTask): string {
-  const role = task.role || task.task_id || 'Task identity unavailable';
-  const adapter = task.adapter.trim();
-  if (!adapter) return role;
-  return role.toLowerCase().includes(`(${adapter.toLowerCase()})`) ? role : `${role} (${adapter})`;
+  return rosterRoleName(task.role || task.task_id || 'Worker', task.adapter);
 }
 
 export default function NativeTaskDisclosure({ task, route, kill, usage, onInspect }: {
@@ -71,7 +69,7 @@ export default function NativeTaskDisclosure({ task, route, kill, usage, onInspe
           disabled={kill.disabled} onKeyUp={event => event.stopPropagation()} onKeyDown={event => event.stopPropagation()} onClick={event => { event.stopPropagation(); kill.request(); }}>Kill</button>}
         <WorkerInstruction text={task.instruction} truncated={task.truncated} />
         <p>Task: {task.task_id ?? 'identity unavailable'}. Adapter: {task.adapter || 'unavailable'}.</p>
-        {task.model_kind === 'unavailable' && <p>Assigned task model unavailable.</p>}
+        {task.model_kind === 'unavailable' && !nativeActiveStatuses.includes(task.status) && <p>No assigned task model recorded.</p>}
         {task.truncated && <p>Task fields truncated.</p>}
         {route && <dl>
           <dt>Recorded routing policy</dt><dd>{route.policy || 'unavailable'}</dd>

--- a/webapp/src/components/conversation/ComposerDock.tsx
+++ b/webapp/src/components/conversation/ComposerDock.tsx
@@ -30,6 +30,7 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { api, type Config, type ContextUsageResponse, type Job } from "../../lib/api";
+import { forgetResolvedMemoryProposal, rememberResolvedMemoryProposal } from "../../lib/memoryProposalResolution";
 import PilotPicker from "../PilotPicker";
 import SwarmReasoningPicker from "../SwarmReasoningPicker";
 import WorkspaceChip from "./WorkspaceChip";
@@ -373,6 +374,7 @@ export default function ComposerDock({
                 </div>
                 <button
                   onClick={async () => {
+                    rememberResolvedMemoryProposal(sessionId, prop.id);
                     onSetMemoryProposals((prev) => prev.filter((p) => p.id !== prop.id));
                     try {
                       const res = prop.refine
@@ -382,8 +384,12 @@ export default function ComposerDock({
                         const notice = prop.refine ? "Harness refine saved" : "Memory saved";
                         onSetDistillNotice(notice);
                         setSafeTimeout(() => onSetDistillNotice((cur) => (cur === notice ? null : cur)), 4000);
+                      } else {
+                        throw new Error(res.error || "save failed");
                       }
                     } catch {
+                      forgetResolvedMemoryProposal(sessionId, prop.id);
+                      onSetMemoryProposals((prev) => (prev.some((p) => p.id === prop.id) ? prev : [...prev, prop]));
                       onSetDistillNotice(prop.refine ? "Refine save failed" : "Memory save failed");
                     }
                   }}
@@ -393,6 +399,7 @@ export default function ComposerDock({
                 </button>
                 <button
                   onClick={async () => {
+                    rememberResolvedMemoryProposal(sessionId, prop.id);
                     onSetMemoryProposals((prev) => prev.filter((p) => p.id !== prop.id));
                     try {
                       if (prop.refine) {

--- a/webapp/src/components/conversation/streamEventHandler.ts
+++ b/webapp/src/components/conversation/streamEventHandler.ts
@@ -64,6 +64,7 @@ import {
 import { turnHasLiveInvestigation, turnHasLiveProgressSignal } from "../../lib/turnProgress";
 import { clearDiagnostic } from "../../lib/operationalDiagnosticBus";
 import { notifyWorkspaceMutated } from "../../lib/workspaceMutationEvents";
+import { getActiveMemoryProposalSession, isResolvedMemoryProposal } from "../../lib/memoryProposalResolution";
 import { shouldRefreshBusyChrome } from "./streamTerminal";
 import { waitHintForAssistantDone } from "./swarmPoll";
 import { publishSessionTodos } from "../../lib/sessionTodos";
@@ -240,7 +241,7 @@ export function createApplyStreamEvent(deps: ApplyStreamEventDeps) {
               }
             : undefined;
         setMemoryProposals((prev) => (
-          prev.some((p) => p.id === id)
+          prev.some((p) => p.id === id) || isResolvedMemoryProposal(getActiveMemoryProposalSession(), id)
             ? prev
             : [...prev, { id, text, category: d.category || "general", refine }]
         ));

--- a/webapp/src/components/conversation/swarmPoll.ts
+++ b/webapp/src/components/conversation/swarmPoll.ts
@@ -11,6 +11,7 @@ import { jobInActiveSession } from "../../lib/jobScope";
 import { isTerminalJobStatus } from "./nestedActionBounds";
 import { isSwarmPendingTerminal } from "./swarmPendingIdentity";
 import { formatDistilledNotice, formatWikiAutoIngestNotice } from "./streamApply";
+import { getActiveMemoryProposalSession, isResolvedMemoryProposal } from "../../lib/memoryProposalResolution";
 
 /** One row from `/api/swarm/live` (id field names vary by store). */
 export type SwarmLiveJobRow = {
@@ -334,10 +335,13 @@ export function classifySwarmPollEvent(evt: any): SwarmPollChrome {
   return { kind: "ignore" };
 }
 
-/** Deduplicate memory proposals by id. */
+/** Deduplicate memory proposals by id, and never resurrect a saved/skipped card. */
 export function appendMemoryProposal<T extends { id: string }>(
   prev: T[],
   proposal: T,
 ): T[] {
+  if (isResolvedMemoryProposal(getActiveMemoryProposalSession(), proposal.id)) {
+    return prev;
+  }
   return prev.some((p) => p.id === proposal.id) ? prev : [...prev, proposal];
 }

--- a/webapp/src/components/conversation/useSessionSwitch.ts
+++ b/webapp/src/components/conversation/useSessionSwitch.ts
@@ -1,4 +1,5 @@
 import { lastSelectedProjectRoot } from "../../lib/panelTransition";
+import { setActiveMemoryProposalSession } from "../../lib/memoryProposalResolution";
 /**
  * Warm-cache session switch effect. Mid-turn reattach lives in chatEventsReattach.
  */
@@ -213,6 +214,7 @@ export function useSessionSwitch(deps: UseSessionSwitchDeps) {
   useEffect(() => {
     const prevId = cachedSessionIdRef.current;
     const switchedSession = Boolean(prevId && prevId !== activeSessionId);
+    setActiveMemoryProposalSession(activeSessionId || "");
     if (prevId && prevId !== activeSessionId && !transcriptStaleRef.current) {
       // Only cache when the visible rows belong to prevId. Stale bleed (prior
       // session still painted) must not poison the warm cache.

--- a/webapp/src/components/leftRailSessions.ts
+++ b/webapp/src/components/leftRailSessions.ts
@@ -368,3 +368,8 @@ export function projectSessionsEmptyState(
   if (sessionsReady) return "empty";
   return showRowLoading ? "loading" : "pending";
 }
+
+/** Delete/archive of the current session must open a blank New session, never another transcript. */
+export function shouldOpenBlankSessionAfterRemove(removedId: string, activeId: string | undefined): boolean {
+  return Boolean(removedId && activeId && removedId === activeId);
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -570,7 +570,7 @@ body.is-row-resizing iframe {
   min-width: 0;
   margin: 0;
   color: theme('colors.txt');
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   line-height: 1.25;
   overflow: hidden;
@@ -617,14 +617,14 @@ body.is-row-resizing iframe {
 .swarm-metric strong {
   color: theme('colors.txt');
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 550;
   font-variant-numeric: tabular-nums;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.swarm-overview-caption { grid-column: 1 / -1; margin: 4px 0 0; color: theme('colors.faint'); font-size: 10px; line-height: 1.5; }
-.swarm-coverage-note { margin: 0; padding: 5px 10px; color: theme('colors.warn'); font-size: 10px; }
+.swarm-overview-caption { grid-column: 1 / -1; margin: 4px 0 0; color: theme('colors.faint'); font-size: 9px; line-height: 1.5; }
+.swarm-coverage-note { margin: 0; padding: 5px 10px; color: theme('colors.warn'); font-size: 9px; }
 .swarm-worker-progress { display: flex; gap: 3px; height: 4px; padding: 0 10px; margin: 8px 0; }
 .swarm-worker-progress > span { flex: 1; min-width: 0; border-radius: 2px; background: theme('colors.edge2'); }
 .swarm-worker-progress > [data-status='running'], .swarm-worker-progress > [data-status='in_progress'] { background: theme('colors.accent'); }
@@ -637,7 +637,7 @@ body.is-row-resizing iframe {
   grid-template-columns: 14px minmax(0, 1fr) auto;
   width: 100%;
   min-width: 0;
-  min-height: 42px;
+  min-height: 36px;
   align-items: center;
   gap: 6px;
   padding: 7px 10px;
@@ -671,7 +671,7 @@ body.is-row-resizing iframe {
 .swarm-detail-prose { margin: 8px 0 0; font-size: 11px; line-height: 1.65; white-space: pre-wrap; overflow-wrap: anywhere; }
 .swarm-worker-inspector summary { cursor: pointer; }
 .swarm-evidence-preview summary { color: theme('colors.txt'); line-height: 1.5; }
-.swarm-worker-name { color: theme('colors.txt'); font-size: 12px; font-weight: 560; }
+.swarm-worker-name { color: theme('colors.txt'); font-size: 11px; font-weight: 560; }
 .swarm-worker-model {
   grid-column: 2 / -1;
   display: flex;
@@ -679,7 +679,7 @@ body.is-row-resizing iframe {
   gap: 3px;
   color: theme('colors.faint');
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-size: 9px;
 }
 .swarm-worker-status { grid-column: 3; grid-row: 1; }
 .swarm-worker-inspector {
@@ -699,7 +699,7 @@ body.is-row-resizing iframe {
 .swarm-worker-inspector dl { margin: 9px 0 0; display: grid; gap: 7px; }
 .swarm-worker-inspector dl div { display: grid; grid-template-columns: 74px minmax(0, 1fr); gap: 6px; }
 .swarm-worker-inspector dt { color: theme('colors.faint'); font-size: 9px; }
-.swarm-worker-inspector dd { min-width: 0; margin: 0; color: theme('colors.muted'); font-size: 10px; overflow-wrap: anywhere; }
+.swarm-worker-inspector dd { min-width: 0; margin: 0; color: theme('colors.muted'); font-size: 9px; overflow-wrap: anywhere; }
 .swarm-worker-instruction { margin-top: 10px; border-top: 1px solid var(--shell-panel-border); padding-top: 8px; }
 .swarm-worker-instruction summary { color: theme('colors.muted'); cursor: pointer; font-size: 10px; font-weight: 560; }
 .swarm-worker-instruction summary:focus-visible { outline: 2px solid var(--swarm-accent); outline-offset: 2px; }

--- a/webapp/src/lib/expertRoutingFacts.ts
+++ b/webapp/src/lib/expertRoutingFacts.ts
@@ -61,11 +61,26 @@ export function resolveExpertRouting(expert: ExpertMetadata, headerModel?: strin
   return { routingForTask, unmatched };
 }
 
+export function workerIsRouting(status: string | null | undefined): boolean {
+  return /^(running|in_progress|queued|pending|registered|started|stitching)$/i.test(status ?? '');
+}
+
+/** Roster names are roles. Adapter lives on its own chip, never mashed into the title. */
+export function rosterRoleName(role: string, adapter = ''): string {
+  const name = role.trim();
+  if (!name) return 'Worker';
+  const suffix = adapter.trim();
+  if (!suffix) return name;
+  const wrapped = ` (${suffix})`;
+  return name.length > wrapped.length && name.toLowerCase().endsWith(wrapped.toLowerCase())
+    ? name.slice(0, -wrapped.length).trim() || name
+    : name;
+}
+
 export function expertWorkerSlot(task: ExpertTask, status: string | null, route?: ExpertArtifact): string {
   const model = expertWorkerModel(task, route);
   if (model) return model;
-  return /^(running|in_progress|queued|pending|registered|started|stitching)$/i.test(status ?? '') && !route?.model?.trim()
-    ? 'routing…' : 'No model recorded';
+  return workerIsRouting(status) && !route?.model?.trim() ? 'routing…' : 'No model recorded';
 }
 
 /** A zero-worker job may own an explicitly unscoped final routing decision. */

--- a/webapp/src/lib/jobMetadataContext.tsx
+++ b/webapp/src/lib/jobMetadataContext.tsx
@@ -11,16 +11,17 @@ const inactive = new JobMetadataStore();
 export const JobMetadataContext = createContext(inactive);
 export function JobMetadataOwner({ repo, sessionId, children }: { repo: string; sessionId: string | null; children: ReactNode }) {
   const [store] = useState(() => new JobMetadataStore());
+  useJobMetadata(store);
   useEffect(() => {
     if (!repo || !sessionId) { store.invalidate(); return; }
     store.setTarget({ repo, session_id: sessionId, scope: 'all' });
     const tick = () => { if (!document.hidden) void store.ownerTick(); };
     store.startTicks(2000); tick();
     document.addEventListener('visibilitychange', tick);
-    return () => { store.stopTicks(); store.invalidate(); document.removeEventListener('visibilitychange', tick); };
+    return () => { store.stopTicks(); document.removeEventListener('visibilitychange', tick); };
   }, [store, repo, sessionId]);
   // Effect cleanup must support React StrictMode's setup-cleanup-setup replay.
-  useEffect(() => () => { store.stopTicks(); store.invalidate(); store.closeConnection(); }, [store]);
+  useEffect(() => () => { store.stopTicks(); }, [store]);
   return <JobMetadataContext.Provider value={store}>{children}</JobMetadataContext.Provider>;
 }
 export function useSharedJobMetadata() {

--- a/webapp/src/lib/memoryProposalResolution.ts
+++ b/webapp/src/lib/memoryProposalResolution.ts
@@ -1,0 +1,58 @@
+/** Persist Save/Skip so session switch + SSE replay cannot resurrect the card. */
+
+const PREFIX = "pmharness.memoryResolved.v1:";
+
+let activeSessionId = "";
+
+export function setActiveMemoryProposalSession(sessionId: string): void {
+  activeSessionId = String(sessionId || "").trim();
+}
+
+export function getActiveMemoryProposalSession(): string {
+  return activeSessionId;
+}
+
+function keyFor(sessionId: string): string {
+  return PREFIX + String(sessionId || "").trim();
+}
+
+function readIds(sessionId: string): string[] {
+  const sid = String(sessionId || "").trim();
+  if (!sid) return [];
+  try {
+    const raw = sessionStorage.getItem(keyFor(sid));
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === "string" && !!id.trim()).slice(-200);
+  } catch {
+    return [];
+  }
+}
+
+function writeIds(sessionId: string, ids: string[]): void {
+  const sid = String(sessionId || "").trim();
+  if (!sid) return;
+  try {
+    sessionStorage.setItem(keyFor(sid), JSON.stringify(ids.slice(-200)));
+  } catch {
+    /* optional persistence */
+  }
+}
+
+export function rememberResolvedMemoryProposal(sessionId: string, id: string): void {
+  const proposalId = String(id || "").trim();
+  if (!proposalId) return;
+  const next = [...readIds(sessionId).filter((item) => item !== proposalId), proposalId];
+  writeIds(sessionId, next);
+}
+
+export function forgetResolvedMemoryProposal(sessionId: string, id: string): void {
+  const proposalId = String(id || "").trim();
+  writeIds(sessionId, readIds(sessionId).filter((item) => item !== proposalId));
+}
+
+export function isResolvedMemoryProposal(sessionId: string, id: string): boolean {
+  const proposalId = String(id || "").trim();
+  if (!proposalId) return false;
+  return readIds(sessionId).includes(proposalId);
+}

--- a/webapp/src/lib/useJobMetadata.ts
+++ b/webapp/src/lib/useJobMetadata.ts
@@ -138,13 +138,18 @@ export class JobMetadataStore {
     const sameIds = previous.kind !== 'idle'
       && previous.target.repo === nextTarget.repo
       && previous.target.session_id === nextTarget.session_id;
-    // Same-target reopen is a blank incarnation. Restore only a different visited session.
-    const page = sameIds ? undefined : this.restoreSessionPage(nextTarget);
+    const page = this.restoreSessionPage(nextTarget);
     this.publish({
       ...blank(this.state.epoch + 1, { kind: 'target', target: nextTarget, reason: 'not_opened' }),
       contextEpoch: this.state.contextEpoch + 1,
       working: this.inFlight,
-      ...(page ? { observations: page.observations, local: page.local, headers: page.headers, pins: page.pins, startupStopped: true } : {}),
+      ...(page ? {
+        observations: page.observations,
+        local: page.local,
+        headers: page.headers,
+        pins: page.pins,
+        startupStopped: !sameIds,
+      } : {}),
     });
   }
   invalidate = (): void => {


### PR DESCRIPTION
## Why

Ship the compact Swarm Tracker haul, OpenCode Go flash pin aliases, session-delete blank New session, and idempotent Memory Save. Puppetmaster remains 1.27.12 on PyPI; no pin refresh.

## Scope

- Version 0.9.464. Pin stays `puppetmaster-ai==1.27.12`.
- Feature landed via #409. dest already contains main.

## Verification

Release gate is this PR's `tests` workflow (3.9, Windows shards, frontend-build). Do not tag until that run is green and `merge^{tree}` matches.

Local proof before land: Python focused 241 passed; `webapp` `npm test` 235 files / 2535 passed.