### PR TITLE
v0.9.466: stream cadence, submit pin, single read slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.465, deliberately pre-1.0. Pin stays `puppetmaster-ai==1.27.12`. Opening a project with only archived sessions lands on a blank New session instead of resurrecting an archive. Swarm Tracker keeps discovering after a bad metadata page, treats an empty post-switch view as retryable, and hydrates named worker roster and routes from the bound Puppetmaster job onto the local placeholder. Compact remains compact-only. Runtime pin: `puppetmaster-ai==1.27.12`.
+> Status: v0.9.466, deliberately pre-1.0. Pin stays `puppetmaster-ai==1.27.12`. Submit pins the feed so a new prompt is not buried in the composer gap. Streaming uses velocity-limited catch-up with rAF on visible tabs and a caret on live markdown. read_file slice bounds are computed once so hash anchors cannot disagree with the header. Runtime pin: `puppetmaster-ai==1.27.12`.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.465"
+__version__ = "0.9.466"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -4211,6 +4211,16 @@ class ConversationalSession(
             # command is never wrongly threaded onto a stale tree ceiling.
             self._auto_budget = None
 
+    def _auto_halt_close(self, objective: str, budget: "AutoBudget", reason: str, extra=None):
+        payload = {"reason": reason, "snapshot": budget.snapshot()}
+        if extra:
+            payload.update(extra)
+        yield ConvEvent("auto_halt", payload)
+        distilled = self._maybe_auto_distill()
+        if distilled:
+            yield ConvEvent("distilled", distilled)
+        self._maybe_ingest(objective, [], [])
+
     def _run_auto_inner(self, objective: str, budget: "AutoBudget" = None,
                  *, require_codegraph: bool = True,
                  analysis_mode: bool = False,
@@ -4265,11 +4275,7 @@ class ConversationalSession(
                 return
             halt = budget.check()
             if halt:
-                yield ConvEvent("auto_halt", {"reason": halt, "snapshot": budget.snapshot()})
-                d = self._maybe_auto_distill()
-                if d:
-                    yield ConvEvent("distilled", d)
-                self._maybe_ingest(objective, [], [])
+                yield from self._auto_halt_close(objective, budget, halt)
                 return
             cycle += 1
             findings_before = 0
@@ -4331,11 +4337,7 @@ class ConversationalSession(
                 if tripped:
                     break
             if tripped:
-                yield ConvEvent("auto_halt", {"reason": tripped, "snapshot": budget.snapshot()})
-                d = self._maybe_auto_distill()
-                if d:
-                    yield ConvEvent("distilled", d)
-                self._maybe_ingest(objective, [], [])
+                yield from self._auto_halt_close(objective, budget, tripped)
                 return
 
             # Immediately reset loop_msg to default for subsequent cycles, unless overridden by verification failure.
@@ -4365,14 +4367,9 @@ class ConversationalSession(
                         # on non-empty mid-thought prose.
                         structured_ok = False
                     if structured_ok:
-                        yield ConvEvent("auto_halt", {
-                            "reason": "analysis findings submitted",
-                            "snapshot": budget.snapshot(),
-                        })
-                        d = self._maybe_auto_distill()
-                        if d:
-                            yield ConvEvent("distilled", d)
-                        self._maybe_ingest(objective, [], [])
+                        yield from self._auto_halt_close(
+                            objective, budget, "analysis findings submitted",
+                        )
                         return
                     loop_msg = (
                         "(system) Do not stop yet. End with a structured "
@@ -4385,11 +4382,10 @@ class ConversationalSession(
                     passed, out = self._run_verification()
                     yield ConvEvent("verification", {"passed": passed, "output": out[:1000]})
                     if passed:
-                        yield ConvEvent("auto_halt", {"reason": "objective met and verified (verify_cmd passed)", "snapshot": budget.snapshot()})
-                        d = self._maybe_auto_distill()
-                        if d:
-                            yield ConvEvent("distilled", d)
-                        self._maybe_ingest(objective, [], [])
+                        yield from self._auto_halt_close(
+                            objective, budget,
+                            "objective met and verified (verify_cmd passed)",
+                        )
                         return
                     else:
                         failed_verifications += 1
@@ -4401,25 +4397,19 @@ class ConversationalSession(
                             max_retries = 2
                         
                         if failed_verifications >= max_retries:
-                            yield ConvEvent("auto_halt", {
-                                "reason": f"objective NOT verified after {max_retries} retries (verify_cmd still failing)",
-                                "snapshot": budget.snapshot(),
-                                "last_output": out
-                            })
-                            d = self._maybe_auto_distill()
-                            if d:
-                                yield ConvEvent("distilled", d)
-                            self._maybe_ingest(objective, [], [])
+                            yield from self._auto_halt_close(
+                                objective, budget,
+                                f"objective NOT verified after {max_retries} retries (verify_cmd still failing)",
+                                extra={"last_output": out},
+                            )
                             return
                         else:
                             loop_msg = f"Verification command failed. Output:\n{out}\nFix the issue so the verification passes, then finish."
                 else:
-                    yield ConvEvent("auto_halt", {"reason": "pilot reports objective met "
-                        "(no further investigation)", "snapshot": budget.snapshot()})
-                    d = self._maybe_auto_distill()
-                    if d:
-                        yield ConvEvent("distilled", d)
-                    self._maybe_ingest(objective, [], [])
+                    yield from self._auto_halt_close(
+                        objective, budget,
+                        "pilot reports objective met (no further investigation)",
+                    )
                     return
             if analysis_mode and budget.max_tokens > 0:
                 # Near the token ceiling: nudge a FINDING summary before the

--- a/harness/tool_dispatch.py
+++ b/harness/tool_dispatch.py
@@ -61,6 +61,21 @@ _SEARCH_SKIP_DIRS = frozenset({
 _PROBE_MATCH_CAP = 50
 
 
+def _slice_bounds(
+    start_line: Optional[int],
+    limit: Optional[int],
+    total_lines: int,
+) -> tuple[int, int]:
+    """One 0-based half-open range for a ranged read (header and anchors)."""
+    s_line = start_line if start_line is not None else 1
+    s_idx = max(0, s_line - 1)
+    if limit is not None:
+        e_idx = min(total_lines, s_idx + limit)
+    else:
+        e_idx = total_lines
+    return s_idx, e_idx
+
+
 def _slice_header(start_line: int, end_line: int, total_lines: int) -> str:
     """Header line for a ranged read, naming the next offset when more remains.
 
@@ -303,6 +318,7 @@ class ToolDispatchMixin:
                 len(raw_text) > _READ_FILE_LARGE_BYTE_TRIGGER
                 or total_lines > _READ_FILE_LARGE_LINE_TRIGGER
             )
+            s_idx = e_idx = None
             if oversized and start_line is None and limit is None:
                 head_lines = lines[:_READ_FILE_DEFAULT_WINDOW_LINES]
                 shown = len(head_lines)
@@ -318,13 +334,7 @@ class ToolDispatchMixin:
                     )
             else:
                 if start_line is not None or limit is not None:
-                    s_line = start_line if start_line is not None else 1
-                    s_idx = max(0, s_line - 1)
-                    if limit is not None:
-                        e_idx = min(total_lines, s_idx + limit)
-                    else:
-                        e_idx = total_lines
-                    
+                    s_idx, e_idx = _slice_bounds(start_line, limit, total_lines)
                     sliced_lines = lines[s_idx:e_idx]
                     content = _slice_header(s_idx + 1, e_idx, total_lines) + "".join(sliced_lines)
                 else:
@@ -339,13 +349,7 @@ class ToolDispatchMixin:
             from .hash_edit import annotate_read_content
             slice_start = None
             slice_end = None
-            if start_line is not None or limit is not None:
-                s_line = start_line if start_line is not None else 1
-                s_idx = max(0, s_line - 1)
-                if limit is not None:
-                    e_idx = min(total_lines, s_idx + limit)
-                else:
-                    e_idx = total_lines
+            if s_idx is not None and e_idx is not None:
                 slice_start = s_idx + 1
                 slice_end = e_idx
             content = annotate_read_content(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.465"
+version = "0.9.466"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -15,6 +15,7 @@ from harness.context_budget import (
     _MIN_TURN_BUDGET_CHARS,
 )
 from harness.conversation import ConversationalSession
+from harness.tool_dispatch import _slice_bounds, _slice_header
 
 # Content above the shared offload floor (aligned with max_result_chars).
 # 2000 tokens ~= 8000 chars; keep a margin so spill stubs clearly pass the gate.
@@ -160,6 +161,12 @@ def test_read_file_offset_limit(tmp_path):
     assert ok is True
     assert status == "success"
     assert val == file_content
+
+    s_idx, e_idx = _slice_bounds(3, 4, 10)
+    assert (s_idx, e_idx) == (2, 6)
+    assert _slice_header(s_idx + 1, e_idx, 10) == "[lines 3-6 of 10; next start_line=7]\n"
+    assert _slice_bounds(8, None, 10) == (7, 10)
+    assert _slice_bounds(None, 2, 10) == (0, 2)
 
     # Read with start_line and limit
     act2 = DummyAction(kind="read_file", path="test.txt", start_line=3, limit=4)

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "pm-harness"
-version = "0.9.465"
+version = "0.9.466"
 source = { editable = "." }
 dependencies = [
     { name = "puppetmaster-ai" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.465",
+  "version": "0.9.466",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.465",
+      "version": "0.9.466",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.465",
+  "version": "0.9.466",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -1107,7 +1107,7 @@ describe("streamBubbles module", () => {
     expect(findStreamingBubbleIdx(items, { excludeWorkerStream: true })).toBe(-1);
     expect(typewriterCharsPerFrame(0, false)).toBe(0);
     expect(typewriterCharsPerFrame(3, false)).toBe(3);
-    expect(typewriterCharsPerFrame(40, false)).toBe(40);
+    expect(typewriterCharsPerFrame(40, false)).toBe(7);
     expect(typewriterCharsPerFrame(40, true)).toBe(40);
     expect(STREAM_PAINT_MS).toBe(33);
   });
@@ -3828,9 +3828,9 @@ describe("streamTypewriter first reveal", () => {
     const chunks: string[] = [];
     let cancelled = 0;
     startTypewriterLoop(refs, (c) => chunks.push(c), () => 3);
-    // Codex/Hermes paint: first reveal drains the arrived chunk.
-    expect(refs.typeBufRef.current).toBe("");
-    expect(chunks.join("")).toBe(text);
+    const first = typewriterCharsPerFrame(text.length, false);
+    expect(chunks.join("")).toBe(text.slice(0, first));
+    expect(refs.typeBufRef.current).toBe(text.slice(first));
     flushTypewriterBuffer(refs, (c) => chunks.push(c), () => {
       cancelled += 1;
     });
@@ -3851,16 +3851,17 @@ describe("streamTypewriter first reveal", () => {
     expect(cancelled).toBe(2);
   });
 
-  it("scheduled pump on leftover buffer drains the rest in one take", () => {
+  it("scheduled pump continues catch-up until the buffer is empty", () => {
     const text = "Hello world, this is buffered prose.";
     const refs = makeRefs(text);
     const chunks: string[] = [];
     startTypewriterLoop(refs, (c) => chunks.push(c), () => 11);
-    expect(chunks).toEqual([text]);
-    expect(refs.typeBufRef.current).toBe("");
+    const first = typewriterCharsPerFrame(text.length, false);
+    expect(chunks).toEqual([text.slice(0, first)]);
+    expect(refs.typeBufRef.current).toBe(text.slice(first));
     pumpTypewriterFrame(refs, (c) => chunks.push(c), () => 12);
-    expect(chunks).toEqual([text]);
-    expect(refs.typeBufRef.current).toBe("");
+    expect(chunks.join("").length).toBeGreaterThan(first);
+    expect(chunks.join("").length).toBeLessThanOrEqual(text.length);
   });
 
   it("empty-buffer pump with typeDone false reschedules without appending", () => {

--- a/webapp/src/__tests__/feedScroll.test.ts
+++ b/webapp/src/__tests__/feedScroll.test.ts
@@ -23,6 +23,7 @@ import {
   nextFeedPinState,
   scrollTopAfterFeedHeightChange,
   scrollToFeedEnd,
+  applyUserSubmitFeedPin,
   settleFrameResult,
   shouldCancelFeedResizeFollowForManualScrollAway,
   shouldDeferFollowDuringUserGesture,
@@ -836,6 +837,13 @@ describe("feedScroll layout contracts", () => {
   it("scrollToEnd lands at scrollHeight - clientHeight", () => {
     expect(scrollToFeedEnd(2000, client)).toBe(1600);
     expect(scrollToFeedEnd(350, client)).toBe(0);
+  });
+
+  it("user submit re-pins to the new tail even when the prior pin was stale", () => {
+    const next = applyUserSubmitFeedPin({ scrollHeight: 2000, clientHeight: client });
+    expect(next.pinned).toBe(true);
+    expect(next.settling).toBe(true);
+    expect(next.scrollTop).toBe(scrollToFeedEnd(2000, client));
   });
 
   it("last-row growth while pinned at first overflow follows in one write", () => {

--- a/webapp/src/__tests__/streamTypewriter.slowBatch.test.ts
+++ b/webapp/src/__tests__/streamTypewriter.slowBatch.test.ts
@@ -10,15 +10,16 @@ function refs(buf: string) {
 }
 
 describe("streamTypewriter slow-model batching", () => {
-  it("paints a large slow-model burst in one frame instead of dripping", () => {
+  it("paints a large burst as a catch-up slice, not the whole buffer", () => {
     const burst = "token ".repeat(40);
     const r = refs(burst);
     const painted: string[] = [];
     pumpTypewriterFrame(r, (chunk) => painted.push(chunk), () => {
       return 1;
     });
-    expect(painted.join("")).toBe(burst);
     expect(painted).toHaveLength(1);
-    expect(r.typeBufRef.current).toBe("");
+    expect(painted[0].length).toBeGreaterThan(0);
+    expect(painted[0].length).toBeLessThan(burst.length);
+    expect(r.typeBufRef.current).toBe(burst.slice(painted[0].length));
   });
 });

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -121,6 +121,7 @@ import {
   feedResizeScrollFollowDecision,
   isAtFeedTail,
   nextFeedPinState,
+  applyUserSubmitFeedPin,
   scrollToFeedEnd,
   settleFrameResult,
   shouldShowJumpToBottom,
@@ -605,7 +606,7 @@ export default function Conversation({
   const [pendingJobIds, setPendingJobIds] = useState<string[]>([]);
   const pendingJobIdsRef = useRef<string[]>([]);
   useEffect(() => { pendingJobIdsRef.current = pendingJobIds; }, [pendingJobIds]);
-  const processedSwarmJobIdsRef = useRef<string[]>([]);
+  const processedSwarmJobIdsRef = useRef<Set<string>>(new Set());
   const [backendPendingSwarms, setBackendPendingSwarms] = useState(false);
   const swarmLiveJobs = metadataJobs(metadata);
   useEffect(() => {
@@ -1843,7 +1844,7 @@ export default function Conversation({
 
   useEffect(() => {
     setPendingJobIds([]);
-    processedSwarmJobIdsRef.current = [];
+    processedSwarmJobIdsRef.current = new Set();
     setBackendPendingSwarms(false);
     if (activeSessionId) {
       // Peek first for pending_swarms / latch visibility. Consume only once we
@@ -2557,8 +2558,8 @@ export default function Conversation({
 
     // Ref is a fast path only — applySwarmResultToItems is the real idempotency
     // gate so poll/SSE/rehydrate stay safe after session-switch clears the ref.
-    if (!processedSwarmJobIdsRef.current.includes(job_id)) {
-      processedSwarmJobIdsRef.current.push(job_id);
+    if (!processedSwarmJobIdsRef.current.has(job_id)) {
+      processedSwarmJobIdsRef.current.add(job_id);
     }
 
     setItems((prevItems) => applySwarmResultToItems(prevItems, d));
@@ -2994,6 +2995,34 @@ export default function Conversation({
         kind: "msg",
         msg: optimisticUserEchoMsg({ text: msg, images: imgsToSend, id: echoId }),
       }]);
+      pinnedToBottomRef.current = true;
+      scrollReleasedByGestureRef.current = false;
+      scrollSettlingRef.current = true;
+      const pinSubmittedRow = () => {
+        const el = feedRef.current;
+        const scrollToEnd = scrollFeedToEndRef.current;
+        if (scrollToEnd) {
+          programmaticScrollRef.current = true;
+          scrollToEnd();
+        } else if (el) {
+          const next = applyUserSubmitFeedPin({
+            scrollHeight: el.scrollHeight,
+            clientHeight: el.clientHeight,
+          });
+          programmaticScrollRef.current = true;
+          el.scrollTop = next.scrollTop;
+        }
+        pinnedToBottomRef.current = true;
+      };
+      queueMicrotask(() => {
+        requestAnimationFrame(() => {
+          pinSubmittedRow();
+          requestAnimationFrame(() => {
+            pinSubmittedRow();
+            scrollSettlingRef.current = false;
+          });
+        });
+      });
       const hasPriorUserTurn = itemsRef.current.some(
         (it) => it.kind === "msg" && it.msg.role === "user",
       );

--- a/webapp/src/components/TranscriptList.tsx
+++ b/webapp/src/components/TranscriptList.tsx
@@ -3406,6 +3406,7 @@ const PrettyMarkdown = memo(function PrettyMarkdown({ text }: { text: string }) 
 function StreamingMarkdown({ text }: { text: string }) {
   const buf = splitStreamingMarkdown(text || "");
   const deferredFlushed = useDeferredValue(buf.flushed);
+  const caret = <span className="transcript-stream-caret" aria-hidden="true" />;
   // Never paint flushed-as-markdown plus a sibling lag <span>. That remounts
   // the trailing sentence as <p> then <span> then <p> again — the blink.
   if (buf.open) {
@@ -3419,6 +3420,7 @@ function StreamingMarkdown({ text }: { text: string }) {
         >
           {buf.open.body + buf.hold}
         </pre>
+        {caret}
       </>
     );
   }
@@ -3428,6 +3430,7 @@ function StreamingMarkdown({ text }: { text: string }) {
       {buf.hold ? (
         <span data-md-hold className="font-mono">{buf.hold}</span>
       ) : null}
+      {caret}
     </>
   );
 }

--- a/webapp/src/components/conversation/feedScroll.ts
+++ b/webapp/src/components/conversation/feedScroll.ts
@@ -98,6 +98,18 @@ export function scrollToFeedEnd(scrollHeight: number, clientHeight: number): num
   return Math.max(0, scrollHeight - clientHeight);
 }
 
+/** Submit always re-pins. Resize follow will not pick this up if the pin was stale. */
+export function applyUserSubmitFeedPin(opts: {
+  scrollHeight: number;
+  clientHeight: number;
+}): { pinned: true; settling: true; scrollTop: number } {
+  return {
+    pinned: true,
+    settling: true,
+    scrollTop: scrollToFeedEnd(opts.scrollHeight, opts.clientHeight),
+  };
+}
+
 export function isPinnedToBottom(
   scrollHeight: number,
   scrollTop: number,

--- a/webapp/src/components/conversation/streamBubbles.ts
+++ b/webapp/src/components/conversation/streamBubbles.ts
@@ -265,12 +265,19 @@ export function finalizeOpenPilotBubble(items: Item[]): Item[] {
 }
 
 /**
- * Paint whatever arrived this tick. Codex and Hermes flush the queued
- * chunk in one commit — a /8 drip on top of SSE coalescing is what made
- * Kimi (and every other bursty provider) look like spurts.
- *
- * ``done`` stays in the signature so callers and tests keep a stable API.
+ * Velocity-limited reveal with catch-up. Drain-all painted provider bursts
+ * at whatever size they arrived; a fixed /8 drip made Kimi look like spurts.
+ * Small backlogs stay near a floor; large backlogs accelerate up to a cap.
+ * ``done`` flushes the remainder so the last tokens do not trail the seal.
  */
-export function typewriterCharsPerFrame(bufLen: number, _done: boolean): number {
-  return bufLen > 0 ? bufLen : 0;
+export const TYPEWRITER_MIN_CHARS = 4;
+export const TYPEWRITER_MAX_CHARS = 96;
+export const TYPEWRITER_CATCHUP_DIVISOR = 6;
+
+export function typewriterCharsPerFrame(bufLen: number, done: boolean): number {
+  if (bufLen <= 0) return 0;
+  if (done) return bufLen;
+  const catchup = Math.ceil(bufLen / TYPEWRITER_CATCHUP_DIVISOR);
+  const paced = Math.max(TYPEWRITER_MIN_CHARS, Math.min(TYPEWRITER_MAX_CHARS, catchup));
+  return Math.min(bufLen, paced);
 }

--- a/webapp/src/components/conversation/streamTypewriter.ts
+++ b/webapp/src/components/conversation/streamTypewriter.ts
@@ -5,21 +5,44 @@
  * Hermes measured 33ms as the floor that batches ~2 tokens per React
  * commit at typical 60 tok/s without visible lag (30 fps of text growth).
  * They use a timer, not rAF: Chromium parks rAF on hidden/minimized
- * renderers, so a finished answer sits queued until refocus. Codex paints
- * the arrived chunk — no char drip. We do both.
+ * renderers, so a finished answer sits queued until refocus. Visible
+ * paints use rAF; hidden tabs keep the timeout fallback.
  */
 
 import { typewriterCharsPerFrame } from "./streamBubbles";
 
-/** Hermes ``STREAM_DELTA_FLUSH_MS`` — coalesce without a fake typewriter. */
+/** Hidden-tab fallback only. Visible paints use rAF so ticks land on vsync. */
 export const STREAM_PAINT_MS = 33;
 
+type PaintHandle = { kind: "raf" | "timeout"; id: number };
+const paintHandles = new Map<number, PaintHandle>();
+let nextPaintToken = 1;
+
 export function scheduleStreamPaint(cb: () => void): number {
-  return window.setTimeout(cb, STREAM_PAINT_MS);
+  const token = nextPaintToken++;
+  const hidden = typeof document !== "undefined" && document.visibilityState === "hidden";
+  if (hidden || typeof requestAnimationFrame !== "function") {
+    const id = window.setTimeout(() => {
+      paintHandles.delete(token);
+      cb();
+    }, STREAM_PAINT_MS);
+    paintHandles.set(token, { kind: "timeout", id });
+    return token;
+  }
+  const id = requestAnimationFrame(() => {
+    paintHandles.delete(token);
+    cb();
+  });
+  paintHandles.set(token, { kind: "raf", id });
+  return token;
 }
 
 export function cancelStreamPaint(id: number): void {
-  window.clearTimeout(id);
+  const handle = paintHandles.get(id);
+  if (!handle) return;
+  paintHandles.delete(id);
+  if (handle.kind === "raf") cancelAnimationFrame(handle.id);
+  else clearTimeout(handle.id);
 }
 
 export type TypewriterRefs = {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -886,3 +886,17 @@ body.is-row-resizing iframe {
 .session-rail [data-session-row],
 .session-rail [data-session-row] > .flex .truncate { font-size: var(--shell-rail-title-size); font-weight: 400; }
 .session-rail [data-session-row] > .flex .truncate { color: theme('colors.txt'); }
+
+.transcript-stream-caret {
+  display: inline-block;
+  width: 0.45em;
+  height: 0.95em;
+  margin-left: 0.12em;
+  vertical-align: text-bottom;
+  background: currentColor;
+  opacity: 0.65;
+  animation: transcript-stream-caret 1s steps(1) infinite;
+}
+@keyframes transcript-stream-caret {
+  50% { opacity: 0; }
+}


### PR DESCRIPTION
## Why
Land the DeepSeek audit items that held up on disk. Submit no longer dumps the new prompt into the composer gap. Streaming uses catch-up velocity plus rAF. read_file slice math is computed once.

## Not this PR
SSE error+done stays (framing vs turn result). Swarm poll stays (idle resume). Swarm-gate cap stays 1. No Conversation.tsx rewrite.

## Test plan
- [x] pytest context budget / hash edit / auto
- [x] vitest feedScroll, conversation.helpers, streamTypewriter
- [x] tsc -b
- [ ] dest-into-main tests matrix after merge