### PR TITLE
Swarm Tracker surfaces the Puppetmaster job (v0.9.467)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.466, deliberately pre-1.0. Pin stays `puppetmaster-ai==1.27.12`. Submit pins the feed so a new prompt is not buried in the composer gap. Streaming uses velocity-limited catch-up with rAF on visible tabs and a caret on live markdown. read_file slice bounds are computed once so hash anchors cannot disagree with the header. Runtime pin: `puppetmaster-ai==1.27.12`.
+> Status: v0.9.467, deliberately pre-1.0. Pin stays `puppetmaster-ai==1.27.12`. Swarm Tracker surfaces the Puppetmaster job for every local alias: session snapshots read known canonical refs before the membership scan, the metadata store keeps its traversal across retargets, alias cards hydrate the PM roster cache-only, active rows dedupe by job id, and a mid-flight task/artifact revision skew degrades to a typed unavailable instead of an invalid-metadata banner. Runtime pin: `puppetmaster-ai==1.27.12`.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.466"
+__version__ = "0.9.467"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/job_expert.py
+++ b/harness/job_expert.py
@@ -27,13 +27,23 @@ def number(value):
 
 
 def timestamp(value):
+    """Wire timestamps must end in Z or ±HH:MM; normalize colon-less offsets."""
     if not isinstance(value, str) or len(value) > 64:
         return None
     try:
         parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
-        return value if parsed.tzinfo else None
     except ValueError:
         return None
+    if not parsed.tzinfo:
+        return None
+    if value.endswith('Z') or (len(value) >= 6 and value[-6] in '+-' and value[-3] == ':'):
+        return value
+    return parsed.isoformat()
+
+
+def confidence_value(value):
+    amount = number(value)
+    return None if amount is None or amount > 1 else amount
 
 
 def unavailable(reason):
@@ -130,6 +140,13 @@ def current_artifact(artifact, task):
                 >= datetime.fromisoformat(start.replace('Z', '+00:00')))
 
 
+def model_name(value):
+    name = text(value)
+    if name is None or not name.strip() or len(name) > 256:
+        return None
+    return name
+
+
 def task_projection(task, usage):
     payload = task.payload
     instruction = text(task.instruction, 2048) or ''
@@ -137,7 +154,7 @@ def task_projection(task, usage):
     cost = number(facts.get('real_cost_usd'))
     return dict(id=task.id, role=text(task.role) or '', instruction=instruction,
                 instruction_truncated=len(task.instruction) > 2048,
-                adapter=text(task.adapter) or '', model=text(payload.get('model')),
+                adapter=text(task.adapter) or '', model=model_name(payload.get('model')),
                 created_at=timestamp(task.created_at), updated_at=timestamp(task.updated_at),
                 usage=dict(tokens_in=number(facts.get('tokens_in')), tokens_out=number(facts.get('tokens_out')),
                            est_cost_usd=cost, estimated=False if cost is not None else None,
@@ -162,10 +179,11 @@ def artifact_projection(artifact):
         created_by=text(artifact.created_by) or '', created_at=timestamp(artifact.created_at),
         headline=headline, detail=text(p.get('detail', p.get('reason', p.get('why', p.get('mitigation')))), 2048),
         result=result, failure=text(p.get('failure', p.get('failure_class'))),
-        confidence=number(artifact.confidence), model=text(p.get('adapter_model_name') or p.get('model') or p.get('model_id')),
+        confidence=confidence_value(artifact.confidence),
+        model=model_name(p.get('adapter_model_name') or p.get('model') or p.get('model_id')),
         adapter=text(p.get('adapter')), policy=text(p.get('policy')), provider=text(p.get('provider')),
         role=text(p.get('role')), est_cost_usd=number(p.get('estimated_cost_usd', p.get('est_cost_usd'))),
-        rejected=[dict(model=text(r.get('model', r.get('model_id'))) or '', reason=text(r.get('reason')) or '')
+        rejected=[dict(model=model_name(r.get('model', r.get('model_id'))) or '', reason=text(r.get('reason')) or '')
                   for r in rejected[:8] if isinstance(r, dict)] if isinstance(rejected, list) else [],
         check_result=check)
 

--- a/harness/job_readmodel.py
+++ b/harness/job_readmodel.py
@@ -253,6 +253,81 @@ class MetadataReader:
                           display=self._display(row), economics=dict(kind='unavailable', reason='selected_only'))
         return result
 
+    @staticmethod
+    def _coerce_store_job_ref(value, state_id):
+        if isinstance(value, JobRef):
+            return value if value.state_id == state_id else None
+        if not isinstance(value, dict):
+            return None
+        raw = value.get('job_ref') if isinstance(value.get('job_ref'), dict) else value
+        if not isinstance(raw, dict):
+            return None
+        try:
+            version = raw.get('version', 1)
+            ref = JobRef(raw['job_id'], raw['state_id'], version=int(version),
+                         incarnation=raw.get('incarnation'))
+        except (ValueError, KeyError, TypeError):
+            return None
+        return ref if ref.state_id == state_id else None
+
+    def _session_known_job_refs(self, ctx, selection):
+        """PM refs the harness already associates with this session (local + registry)."""
+        found = {}
+
+        def remember(ref):
+            if ref is not None and ref.job_id not in found:
+                found[ref.job_id] = ref
+
+        handle = self.local_handle
+        if handle is not None:
+            rows = getattr(handle, 'rows', None)
+            if isinstance(rows, dict):
+                def collect_local():
+                    for jid in sorted(rows):
+                        row = rows[jid]
+                        if not isinstance(row, dict) or row.get('deleted'):
+                            continue
+                        if row.get('session_id') != ctx.session_id:
+                            continue
+                        canonical = row.get('canonical')
+                        if (not isinstance(canonical, dict) or canonical.get('source') != 'harness'
+                                or canonical.get('session_id') != ctx.session_id):
+                            continue
+                        remember(self._coerce_store_job_ref(canonical.get('job_ref'), selection.state_id))
+                lock = getattr(handle, 'lock', None)
+                if lock is not None:
+                    with lock:
+                        collect_local()
+                else:
+                    collect_local()
+        for entry in self._registry:
+            if isinstance(entry, dict):
+                sid = entry.get('session_id')
+                payload = entry
+            else:
+                sid = getattr(entry, 'session_id', None)
+                payload = getattr(entry, 'job_ref', None)
+                if payload is None:
+                    payload = entry
+            if sid != ctx.session_id:
+                continue
+            remember(self._coerce_store_job_ref(payload, selection.state_id))
+        return tuple(found[key] for key in sorted(found)[:50])
+
+    def _exact_owned_row(self, store, job_ref, known, ctx, status):
+        try:
+            page = store.list_job_summaries(job_ref=job_ref, **EXACT_BUDGET)
+        except Exception:
+            return None
+        if page.outcome != 'complete' or len(page.items) != 1 or page.items[0].deleted:
+            return None
+        row = page.items[0]
+        if row.job_ref != job_ref or not self._owned(row, known, ctx):
+            return None
+        if status is not None and row.status != status:
+            return None
+        return row
+
     def read_job_page(self, ctx, selection, *, mode='snapshot', cursor=None, after_revision=0, status=None):
         if (mode not in ('snapshot', 'changes') or type(after_revision) is not int or after_revision < 0
                 or (status is not None and status not in PM_STATUSES)):
@@ -281,6 +356,15 @@ class MetadataReader:
             return result
         filters = dict(session_id=ctx.session_id if ctx.scope == 'session' else None,
                        origin='marionette' if selection.source == 'cli' else None, status=status)
+        # Exact reads run before the scan so every prepended row's revision is
+        # <= the scan page revision (the client parser requires it).
+        prepended = []
+        if (mode == 'snapshot' and pm_cursor is None and ctx.scope == 'session'
+                and selection.source == 'harness' and not known.cross_project):
+            for ref in self._session_known_job_refs(ctx, selection):
+                row = self._exact_owned_row(store, ref, known, ctx, status)
+                if row is not None:
+                    prepended.append(row)
         method = store.list_job_summaries if mode == 'snapshot' else store.read_job_summary_changes
         try:
             page = method(cursor=pm_cursor, after_revision=after_revision, **filters, **PAGE_BUDGET)
@@ -296,10 +380,23 @@ class MetadataReader:
             seen = self._seen.get(key, {})
             updates = []
             uncertain = False
+            present = set()
+            for row in prepended:
+                if len(result['rows']) >= 50 or row.job_ref in present:
+                    continue
+                present.add(row.job_ref)
+                result['rows'].append(self._summary(row, ctx, selection))
+                updates.append((row.job_ref, row.revision))
             for row in page.items:
                 owned = not row.deleted and self._owned(row, known, ctx)
                 previous_owned = self._previous_owned(row, known, ctx, status)
                 if owned:
+                    if row.job_ref in present:
+                        updates.append((row.job_ref, row.revision))
+                        continue
+                    if len(result['rows']) >= 50:
+                        continue
+                    present.add(row.job_ref)
                     result['rows'].append(self._summary(row, ctx, selection))
                     updates.append((row.job_ref, row.revision))
                 elif row.job_ref in seen or previous_owned:
@@ -310,6 +407,8 @@ class MetadataReader:
             if uncertain:
                 result.update(page=_page(checkpoint=after_revision), rows=[])
                 result['missing'].append('previous_membership_unavailable')
+            elif prepended and result['page']['outcome'] in ('complete', 'partial'):
+                result['page']['scanned'] = max(result['page']['scanned'], len(result['rows']))
             if _size(result) > 65536:
                 result.update(page=_page(checkpoint=after_revision), rows=[])
                 result['missing'].append('response_budget')

--- a/harness/job_readmodel.py
+++ b/harness/job_readmodel.py
@@ -406,11 +406,17 @@ class MetadataReader:
             return result
         result.update(lifecycle=row.status, display=self._display(row),
                       task_count=row.task_count, artifact_count=row.artifact_count)
+        # Task and artifact lanes are separate bounded reads; a write landing between
+        # them skews their revisions. Re-read a bounded number of times for a matched pair.
         selected_pages = {}
-        for lane, method in (('tasks', store.list_task_refs), ('artifacts', store.list_artifact_refs)):
-            self.check(ctx)
-            page = method(selection.job_ref, cursor=cursors[lane], **PAGE_BUDGET)
-            selected_pages[lane] = page
+        for _ in range(3):
+            selected_pages = {}
+            for lane, method in (('tasks', store.list_task_refs), ('artifacts', store.list_artifact_refs)):
+                self.check(ctx)
+                selected_pages[lane] = method(selection.job_ref, cursor=cursors[lane], **PAGE_BUDGET)
+            if selected_pages['tasks'].revision == selected_pages['artifacts'].revision:
+                break
+        for lane, page in selected_pages.items():
             rows = []
             for item in page.items:
                 if item.job_ref != selection.job_ref:
@@ -434,7 +440,10 @@ class MetadataReader:
             result['history'] = self._history(store, selection, bindings, history_cursors)
             if result['history']['kind'] == 'available':
                 result['missing'].remove('history')
-        result['expert'] = self._expert(store, row, selection, selected_pages, cursors)
+        if selected_pages['tasks'].revision != selected_pages['artifacts'].revision:
+            result['expert'] = job_expert.unavailable('lane_revision_skew')
+        else:
+            result['expert'] = self._expert(store, row, selection, selected_pages, cursors)
         # Separate bounded reads are not a transaction. Never return lanes from a
         # selection that lost ownership or changed while they were being read.
         _, current, reason = self._selected(selection)
@@ -468,10 +477,16 @@ class MetadataReader:
         if job.id != row.job_ref.job_id or str(job.status) != row.status:
             return None
         cursors = dict(tasks=None, artifacts=None)
-        pages = {lane: method(selection.job_ref, cursor=None, **PAGE_BUDGET)
-                 for lane, method in (('tasks', store.list_task_refs), ('artifacts', store.list_artifact_refs))}
-        expert = self._expert(store, row, selection, pages, cursors, job=job, pin=True, for_header=True)
-        header = job_expert.summary_header(job, expert)
+        for _ in range(3):
+            pages = {lane: method(selection.job_ref, cursor=None, **PAGE_BUDGET)
+                     for lane, method in (('tasks', store.list_task_refs), ('artifacts', store.list_artifact_refs))}
+            if pages['tasks'].revision == pages['artifacts'].revision:
+                break
+        if pages['tasks'].revision != pages['artifacts'].revision:
+            header = job_expert.summary_header(job, job_expert.unavailable('lane_revision_skew'))
+        else:
+            expert = self._expert(store, row, selection, pages, cursors, job=job, pin=True, for_header=True)
+            header = job_expert.summary_header(job, expert)
         with self._lock:
             self._headers[key] = (time.monotonic(), header)
             self._headers.move_to_end(key)
@@ -482,6 +497,8 @@ class MetadataReader:
     def _expert(self, store, row, selection, pages, cursors, *, job=None, pin=False, for_header=False):
         if selection.job_ref.version != 2:
             return job_expert.unavailable('legacy_ref')
+        if pages['tasks'].revision != pages['artifacts'].revision:
+            return job_expert.unavailable('lane_revision_skew')
         deadline = time.monotonic() + 2
         _, current, reason = self._selected(selection, pin=pin)
         if reason or current.revision != row.revision:
@@ -538,6 +555,8 @@ class MetadataReader:
             current = method(selection.job_ref, cursor=cursors[lane], **PAGE_BUDGET)
             if current != pages[lane]:
                 return job_expert.unavailable('selection_changed')
+        if pages['tasks'].revision != pages['artifacts'].revision:
+            return job_expert.unavailable('lane_revision_skew')
         if time.monotonic() >= deadline:
             return job_expert.unavailable('deadline')
         projected = job_expert.project(job, tasks, artifacts, coverage, registry=self._registry, compaction=compaction)
@@ -550,6 +569,20 @@ class MetadataReader:
             omitted = projected[lane].pop()
             if lane == 'tasks':
                 projected['economics']['tasks'].pop(omitted['id'], None)
+                header = projected['economics']['header']
+                remaining = len(projected['tasks'])
+                header['selected_workers'] = remaining
+                header['completed_workers'] = min(header.get('completed_workers', 0), remaining)
+                header['usage']['selected_workers'] = remaining
+                header['usage']['tokens_known_workers'] = min(header['usage']['tokens_known_workers'], remaining)
+                header['usage']['cost_known_workers'] = min(header['usage']['cost_known_workers'], remaining)
+                if header['cost'].get('plan_workers') is not None:
+                    header['cost']['plan_workers'] = min(header['cost']['plan_workers'], remaining)
+            else:
+                omitted_id = omitted['id']
+                for usage in projected['economics']['tasks'].values():
+                    if usage.get('source_artifact_id') == omitted_id:
+                        usage['source_artifact_id'] = None
             projected['coverage'][lane] = 'partial'
             projected.update(kind='partial', reason='response_budget', quality='unverified')
             projected['economics']['header']['usage']['complete'] = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.466"
+version = "0.9.467"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_job_readmodel.py
+++ b/tests/test_job_readmodel.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 import shutil
 import sqlite3
+import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -649,3 +651,49 @@ def test_reader_safety_instrumentation_rejects_source_reads_and_writes(env, monk
         with connection(reader.sources.stores[0].handle, metadata_only=True) as c:
             c.execute('CREATE TABLE forbidden_write (id INTEGER)')
     assert hashes(store.root) == before
+
+
+def test_session_snapshot_prepends_known_canonical_beyond_page_scan(env):
+    """First session page surfaces a known PM job even when id-order buries it."""
+    store, _, ctx, _, active = env
+    jobs = []
+    for i in range(70):
+        created = store.create_job(f'foreign-{i}', origin='marionette', session_id='other')
+        store.save_job(replace(created, status=JobStatus.RUNNING))
+        jobs.append(created)
+    target = max(jobs, key=lambda item: item.id)
+    store.save_job(replace(target, session_id=ctx.session_id, goal='session-owned-beyond-page',
+                           status=JobStatus.RUNNING))
+    ref = store.job_ref(target.id)
+    local = SimpleNamespace(lock=threading.RLock(), rows={
+        'local-swarm-target': dict(
+            session_id=ctx.session_id, deleted=False,
+            canonical=dict(source='harness', job_ref=ref.as_dict(),
+                           session_id=ctx.session_id, dispatch_id='dispatch-target'),
+        ),
+    })
+    sources = KnownSources.from_roots([
+        ('harness', store.root, store.backend_name, False),
+    ])
+    selection = sources.stores[0].selection
+    reader = MetadataReader(lambda: active[0], sources, local)
+
+    without = store.list_job_summaries(
+        session_id=ctx.session_id, status='running', **dict(limit=50, max_scan=51, max_bytes=32768))
+    assert without.outcome == 'partial' and without.scanned == 51 and not without.items
+
+    code, result = get_job_metadata(query(ctx, selection, mode='snapshot', status='running'), reader)
+    assert code == 200
+    ids = [row['selection']['job_ref']['job_id'] for row in result['rows']]
+    assert target.id in ids
+    assert len(result['rows']) <= result['page']['scanned']
+    assert all(row['revision'] <= result['page']['revision'] for row in result['rows'])
+    assert len(ids) == len(set(ids))
+
+    other = replace(ctx, session_id='session-B')
+    active[0] = ActiveContext(other.session_id, other.repo, other.view_generation)
+    other_reader = MetadataReader(lambda: active[0], sources, local)
+    code, foreign = get_job_metadata(query(other, selection, mode='snapshot', status='running'),
+                                     other_reader)
+    assert code == 200
+    assert all(row['selection']['job_ref']['job_id'] != target.id for row in foreign['rows'])

--- a/tests/test_job_readmodel_expert_midflight.py
+++ b/tests/test_job_readmodel_expert_midflight.py
@@ -1,0 +1,139 @@
+"""Mid-flight producer/parser parity: RUNNING jobs must not trip invalid_metadata."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, replace
+from pathlib import Path
+
+import pytest
+
+from harness.job_metadata_capability import bounded_metadata_available
+
+if not bounded_metadata_available():
+    pytest.skip("public PM lacks bounded metadata APIs", allow_module_level=True)
+
+from puppetmaster.attempts import ExecutionAttempt, UsageObservation
+from puppetmaster.models import AgentRun, Artifact, ArtifactType, Task, TaskStatus
+from puppetmaster.store_factory import create_store
+
+from harness import job_expert
+from harness.job_readmodel import ActiveContext, KnownSources, MetadataReader, PMSelection, ReadContext
+
+FIXTURE = Path(__file__).resolve().parents[1] / 'webapp' / 'src' / '__tests__' / 'fixtures' / 'midflight-running.json'
+
+
+def _midflight_store(tmp_path):
+    store = create_store('sqlite', tmp_path / 'store', mode='ensure')
+    store.init()
+    job = store.create_job('midflight parity swarm', origin='marionette', session_id='session-A')
+    store.update_job_status(job.id, 'running')
+    job = store.get_job(job.id)
+    specs = [
+        ('explore', TaskStatus.QUEUED, {'model': 'deepseek-v4-flash'}),
+        ('review', TaskStatus.RUNNING, {'model': 'deepseek-v4-flash'}),
+        ('test', TaskStatus.COMPLETE, {'model': 'deepseek-v4-flash'}),
+        ('security', TaskStatus.QUEUED, {'model': ''}),
+    ]
+    tasks = []
+    for index, (role, status, payload) in enumerate(specs):
+        task = Task(job.id, role, f'instruction for {role}', adapter='agentic', status=status,
+                    payload={'session_id': 'session-A', **payload})
+        if index == 3:
+            task = replace(task, created_at=None, updated_at=None)
+        store.save_task(task)
+        tasks.append(store.get_task_by_id(task.id))
+    claimed = store.claim_next_task(job.id, 'worker-1')
+    assert claimed is not None
+    tasks = [store.get_task_by_id(task.id) for task in tasks]
+    nostart = Task(job.id, 'nostart', 'not started yet', adapter='agentic', status=TaskStatus.QUEUED,
+                   payload={'session_id': 'session-A'}, created_at=None, updated_at=None)
+    store.save_task(nostart)
+    tasks.append(store.get_task_by_id(nostart.id))
+    for task in tasks[:3]:
+        store.save_artifact(Artifact(job.id, task.id, ArtifactType.ROUTING, 'router', {
+            'model_id': 'deepseek-v4-flash', 'adapter': 'agentic', 'policy': 'balanced',
+            'estimated_cost_usd': 0.02, 'baseline_cost_usd': 0.1, 'role': task.role,
+            'task_generation': task.generation, 'lease_id': task.lease_id,
+        }, 0.9, ['route']))
+    store.save_artifact(Artifact(job.id, tasks[2].id, ArtifactType.FINDING, 'worker', {
+        'claim': 'tests passed', 'tokens_in': 1000, 'tokens_out': 200, 'real_cost_usd': 0.05,
+        'task_generation': tasks[2].generation, 'lease_id': tasks[2].lease_id,
+    }, 0.8, ['usage']))
+    store.save_artifact(Artifact(job.id, tasks[1].id, ArtifactType.FINDING, 'worker', {
+        'claim': 'still looking', 'tokens_in': 500, 'tokens_out': 10,
+        'task_generation': tasks[1].generation, 'lease_id': tasks[1].lease_id,
+    }, 0.4, ['usage']))
+    run = AgentRun(job.id, tasks[1].id, tasks[1].role, 'worker-1')
+    store.save_run(run)
+    store.record_attempt(ExecutionAttempt.from_run(
+        run, adapter='agentic', model='deepseek-v4-flash', provider='deepseek'))
+    store.record_usage_observation(UsageObservation(
+        job.id, run.id, 'obs-1', 'sdk', run.started_at, usage_state='measured',
+        tokens_in=10, tokens_out=1, cost_state='measured', cost_usd=0.01, cost_basis='api'))
+    return store, job, tasks
+
+
+def test_timestamp_normalizes_offset_without_colon():
+    assert job_expert.timestamp('2026-09-11T12:00:00+0000').endswith('+00:00')
+    assert job_expert.timestamp('2026-09-11T12:00:00') is None
+    assert job_expert.model_name('') is None
+    assert job_expert.model_name('  ') is None
+    assert job_expert.confidence_value(1.5) is None
+
+
+def test_midflight_selected_pins_and_running_page_dump_fixture(tmp_path):
+    store, job, tasks = _midflight_store(tmp_path)
+    sources = KnownSources.from_roots([('harness', store.root, 'sqlite', False)])
+    ctx = ReadContext('session-A', '/repo', 'generation-1', 'session')
+    reader = MetadataReader(lambda: ActiveContext(ctx.session_id, ctx.repo, ctx.view_generation), sources)
+    selection = PMSelection(ctx, sources.stores[0].selection, store.job_ref(job.id))
+    detail = reader.read_selected_metadata(selection)
+    pins = reader.read_pins(ctx, [selection])
+    page = reader.read_job_page(ctx, sources.stores[0].selection, status='running')
+
+    assert detail['lifecycle'] == 'running'
+    assert detail['tasks']['page']['revision'] == detail['artifacts']['page']['revision']
+    assert detail['expert']['kind'] in ('available', 'partial', 'unavailable')
+    assert {task['role'] for task in detail['expert']['tasks']} <= {task.role for task in tasks}
+    assert all(task['model'] in (None, 'deepseek-v4-flash') for task in detail['expert']['tasks'])
+    nostart = next(task for task in detail['expert']['tasks'] if task['role'] == 'nostart')
+    assert nostart['created_at'] is None and nostart['updated_at'] is None
+    assert detail['cost']['kind'] == 'unavailable'
+    assert detail['history']['kind'] == 'available'
+    assert detail['history']['attempts']['rows']
+    assert pins['results'][0]['result']['kind'] == 'present'
+    assert page['rows'] and page['rows'][0]['lifecycle'] == 'running'
+
+    payload = {
+        'detail': detail,
+        'pins': pins,
+        'page': page,
+        'context': asdict(ctx),
+        'selection': selection.wire(),
+    }
+    FIXTURE.parent.mkdir(parents=True, exist_ok=True)
+    FIXTURE.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str) + '\n')
+    assert FIXTURE.stat().st_size > 1000
+
+
+def test_lane_revision_skew_degrades_expert_not_lanes(tmp_path):
+    from harness.job_readmodel import PAGE_BUDGET
+
+    store, job, _ = _midflight_store(tmp_path)
+    sources = KnownSources.from_roots([('harness', store.root, 'sqlite', False)])
+    ctx = ReadContext('session-A', str(tmp_path / 'repo'), 'generation-1', 'session')
+    reader = MetadataReader(lambda: ActiveContext(ctx.session_id, ctx.repo, ctx.view_generation), sources)
+    selection = PMSelection(ctx, sources.stores[0].selection, store.job_ref(job.id))
+    attached, row, reason = reader._selected(selection)
+    assert reason is None and attached is not None
+    pages = {
+        'tasks': attached.list_task_refs(selection.job_ref, cursor=None, **PAGE_BUDGET),
+        'artifacts': attached.list_artifact_refs(selection.job_ref, cursor=None, **PAGE_BUDGET),
+    }
+    assert pages['tasks'].revision == pages['artifacts'].revision
+    skewed = {
+        'tasks': pages['tasks'],
+        'artifacts': replace(pages['artifacts'], revision=pages['artifacts'].revision + 1),
+    }
+    expert = reader._expert(attached, row, selection, skewed, dict(tasks=None, artifacts=None))
+    assert expert == job_expert.unavailable('lane_revision_skew')

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.466",
+  "version": "0.9.467",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.466",
+      "version": "0.9.467",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.466",
+  "version": "0.9.467",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/MetadataJobs.canonicalAlias.test.tsx
+++ b/webapp/src/__tests__/MetadataJobs.canonicalAlias.test.tsx
@@ -1,0 +1,556 @@
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import SwarmPane from '../components/SwarmPane';
+import { currentExpert, metadataJobs, JobMetadataContext } from '../lib/jobMetadataContext';
+import { JobMetadataClient, metadataSelectionKey } from '../lib/jobMetadata';
+import type { MetadataContext, MetadataSelection, MetadataSummary } from '../lib/jobMetadata';
+import { JobMetadataStore } from '../lib/useJobMetadata';
+import type { JobMetadataState } from '../lib/useJobMetadata';
+import type { LocalObservation, LocalSummary } from '../lib/localJobMetadata';
+import { nativeActiveStatuses, nativeAttentionStatuses } from '../lib/localJobMetadata';
+import { handshake, list, view } from './jobMetadata.fixtures';
+import { clearSWRCache } from '../lib/useStaleWhileRevalidate';
+
+vi.mock('../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/api')>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      swarmLive: vi.fn(),
+      swarmCancel: vi.fn(),
+      artifacts: vi.fn(),
+      dashboard: vi.fn().mockResolvedValue({
+        ok: true, reused: true, host: '127.0.0.1', port: 8787,
+        url: 'http://127.0.0.1:8787/?job=job_canonical&embed=1',
+        embed_url: 'http://127.0.0.1:8787/?job=job_canonical&embed=1',
+      }),
+      sessions: vi.fn().mockResolvedValue([]),
+    },
+  };
+});
+
+const incarnation = 'fbd538fe321b61223e2ad6903f225d52';
+const canonical = {
+  source: 'harness' as const,
+  job_ref: {
+    job_id: 'job_4ba915d01102',
+    state_id: 'state_canonical',
+    version: 2 as const,
+    incarnation: '7e62abcd-1234-4234-8234-123456789abc',
+  },
+  session_id: 'sess-test',
+  dispatch_id: 'dispatch-canonical',
+};
+
+function context(session_id = 'sess-test'): MetadataContext {
+  return { session_id, repo: '/repo', view_generation: `generation-${session_id}`, scope: 'all' };
+}
+
+function pmSelection(c: MetadataContext = context()): MetadataSelection {
+  return {
+    source: 'harness',
+    session_id: c.session_id,
+    repo: c.repo,
+    job_ref: canonical.job_ref,
+  };
+}
+
+function localSummary(overrides: Partial<LocalSummary> = {}): LocalSummary {
+  return {
+    local_ref: { job_id: 'local-swarm-call_00_alias', incarnation },
+    revision: 7,
+    deleted: false,
+    session_id: canonical.session_id,
+    lifecycle: 'running',
+    kind: 'provider',
+    parent_ref: null,
+    task_count: 1,
+    action_count: 0,
+    artifact_count: 0,
+    child_count: null,
+    created_at: 1,
+    updated_at: 1,
+    receipts: { terminal: false, launch: false, recovery: false, child: false },
+    economics: { kind: 'unavailable' },
+    display: { label: 'Provider worker', model: '', adapter: 'agentic', truncated: false },
+    canonical,
+    ...overrides,
+  };
+}
+
+function pmRow(c: MetadataContext = context()): MetadataSummary {
+  return {
+    selection: pmSelection(c),
+    revision: 11,
+    deleted: false,
+    lifecycle: 'running',
+    ownership: { origin: 'marionette', session_id: canonical.session_id, project_id: null },
+    task_count: 4,
+    artifact_count: 8,
+    stamp: 'known',
+    display: {
+      kind: 'available',
+      goal_preview: 'canonical swarm goal',
+      goal_preview_truncated: false,
+      delivery: 'pending',
+      quality: 'unverified',
+    },
+    economics: { kind: 'unavailable', reason: 'selected_only' },
+  };
+}
+
+function fourTaskDetail(selected: MetadataSelection, c: MetadataContext) {
+  const ids = ['task-a', 'task-b', 'task-c', 'task-d'];
+  const revision = 100;
+  const tasks = ids.map((id, index) => ({
+    id,
+    status: index === 0 ? 'running' : 'queued',
+    stamp: 'known',
+    revision: 2,
+    binding: { task_id: id, generation: 1, lease_id: `lease-${id}`, owner: 'worker' },
+  }));
+  const findings = ids.map((id) => ({
+    id: `artifact-${id}`,
+    status: null,
+    stamp: 'known',
+    revision: 3,
+    task_id: id,
+    type: 'finding',
+    sha256: 'a'.repeat(64),
+    presence: 'recorded',
+    check_result: 'unavailable',
+  }));
+  const routes = ids.map((id) => ({
+    id: `route-${id}`,
+    status: null,
+    stamp: 'known',
+    revision: 3,
+    task_id: id,
+    type: 'routing',
+    sha256: 'b'.repeat(64),
+    presence: 'recorded',
+    check_result: 'unavailable',
+  }));
+  const artifactRows = [...findings, ...routes];
+  return {
+    version: 1,
+    selection: selected,
+    context: c,
+    lifecycle: 'running',
+    display: {
+      kind: 'available',
+      goal_preview: 'canonical swarm goal',
+      goal_preview_truncated: false,
+      delivery: 'pending',
+      quality: 'unverified',
+    },
+    task_count: 4,
+    artifact_count: artifactRows.length,
+    tasks: {
+      page: { outcome: 'complete', revision, scanned: tasks.length, checkpoint: revision, next_cursor: null },
+      rows: tasks,
+    },
+    artifacts: {
+      page: { outcome: 'complete', revision, scanned: artifactRows.length, checkpoint: revision, next_cursor: null },
+      rows: artifactRows,
+    },
+    expert: {
+      kind: 'available',
+      reason: null,
+      header: {
+        created_at: '2026-09-11T12:00:00Z',
+        completed_at: null,
+        selected_workers: 4,
+        completed_workers: 0,
+        workers_complete: false,
+        model: 'deepseek-v4-flash',
+        model_provenance: 'job_routing',
+        usage: {
+          tokens: 1690000,
+          tokens_known_workers: 4,
+          cost_known_workers: 0,
+          selected_workers: 4,
+          complete: true,
+        },
+        savings: {
+          routing_usd: null,
+          cache_usd: null,
+          compaction_usd: null,
+          compact_tokens: null,
+          selected_usd: null,
+          basis: 'estimated',
+          source: 'selected_current_records',
+        },
+        cost: {
+          selected_usd: null,
+          source: 'selected_current_records',
+          basis: 'estimated',
+          measured_cost_usd: null,
+          estimated_cost_usd: null,
+          complete: true,
+          plan_workers: 0,
+        },
+      },
+      tasks: ids.map((id, index) => ({
+        id,
+        role: `Worker ${index + 1}`,
+        instruction: `Do work ${index + 1}`,
+        instruction_truncated: false,
+        adapter: 'agentic',
+        model: 'deepseek-v4-flash',
+        created_at: null,
+        updated_at: null,
+        usage: { tokens_in: 10, tokens_out: 5, est_cost_usd: null, estimated: null, cost_provenance: null },
+      })),
+      artifacts: [
+        ...findings.map((row, index) => ({
+          id: row.id,
+          task_id: row.task_id,
+          type: 'FINDING',
+          created_by: 'worker',
+          created_at: `2026-09-11T12:0${index}:00Z`,
+          headline: `Evidence ${index + 1}`,
+          detail: null,
+          result: 'recorded',
+          failure: null,
+          confidence: null,
+          model: null,
+          adapter: null,
+          policy: null,
+          provider: null,
+          role: null,
+          est_cost_usd: null,
+          rejected: [],
+          check_result: 'unavailable',
+        })),
+        ...routes.map((row, index) => ({
+          id: row.id,
+          task_id: row.task_id,
+          type: 'ROUTING',
+          created_by: 'router',
+          created_at: `2026-09-11T12:0${index}:00Z`,
+          headline: 'route',
+          detail: 'matched',
+          result: null,
+          failure: null,
+          confidence: null,
+          model: 'deepseek-v4-flash',
+          adapter: 'agentic',
+          policy: 'balanced',
+          provider: null,
+          role: null,
+          est_cost_usd: null,
+          rejected: [],
+          check_result: 'unavailable',
+        })),
+      ],
+      coverage: { tasks: 'complete', artifacts: 'complete' },
+      quality: 'unverified',
+    },
+    history: { kind: 'unavailable', reason: 'public_read_unbounded' },
+    cost: { kind: 'unavailable', reason: 'not_in_metadata' },
+    cancellation_authority: false,
+    missing: ['history', 'cost'],
+  };
+}
+
+function localEnvelope(c: MetadataContext, rows: LocalSummary[], lane: 'active' | 'history' = 'active') {
+  return {
+    version: 1,
+    context: c,
+    incarnation,
+    lane,
+    rows,
+    page: { outcome: 'complete', revision: 11, checkpoint: 11, scanned: rows.length, next_cursor: null },
+    coverage: {
+      membership: lane === 'active' ? 'retained_local_active' : 'retained_local_history',
+      metadata: 'live_during_traversal',
+      historical: 'unavailable',
+      ordering: 'id',
+    },
+    missing: [],
+  };
+}
+
+const stores: JobMetadataStore[] = [];
+
+afterEach(() => {
+  cleanup();
+  stores.forEach((store) => store.dispose());
+  stores.length = 0;
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(window, 'harnessIPC');
+  localStorage.clear();
+  sessionStorage.clear();
+  clearSWRCache();
+});
+
+async function mountCanonicalAlias(options: { includePmList?: boolean } = {}) {
+  let pmPresent = options.includePmList === true;
+  const c = context();
+  const selected = pmSelection(c);
+  const summary = localSummary();
+  const requestJSON = vi.fn(async (_method: string, path: string) => {
+    const url = new URL(path, 'http://fixture');
+    if (url.pathname === '/api/endpoint') {
+      return { kind: 'response', status: 200, correlationId: '', text: JSON.stringify(handshake) };
+    }
+    if (url.pathname.endsWith('/view')) {
+      return {
+        kind: 'response',
+        status: 200,
+        correlationId: '',
+        text: JSON.stringify({
+          ...view(c.view_generation),
+          context: { session_id: c.session_id, repo: c.repo, view_generation: c.view_generation },
+          local: {
+            available: true,
+            incarnation,
+            version: 1,
+            lanes: ['active', 'history'],
+            active_statuses: nativeActiveStatuses,
+            attention_statuses: nativeAttentionStatuses,
+          },
+          sources: [{ source: 'harness', state_id: canonical.job_ref.state_id, cross_project: false, available: true }],
+        }),
+      };
+    }
+    if (url.pathname.endsWith('/local') || url.pathname.includes('/metadata/local')) {
+      if (url.pathname.endsWith('/detail')) {
+        const lane = url.searchParams.get('lane') ?? 'tasks';
+        const rows = lane === 'tasks'
+          ? [{
+            task_id: `${summary.local_ref.job_id}-w0`,
+            role: 'explore (agentic)',
+            instruction: 'Synthetic alias instruction',
+            status: 'running',
+            adapter: 'agentic',
+            model: '',
+            model_kind: 'unavailable',
+            truncated: false,
+          }]
+          : [];
+        return {
+          kind: 'response',
+          status: 200,
+          correlationId: '',
+          text: JSON.stringify({
+            version: 1,
+            context: c,
+            local_ref: summary.local_ref,
+            summary,
+            lane,
+            rows,
+            total: rows.length,
+            selected_context: {
+              source: 'goal',
+              request: { text: 'Synthetic alias instruction', truncated: false },
+              cwd: null,
+              omission: 'none',
+            },
+            page: { outcome: 'complete', revision: summary.revision, checkpoint: summary.revision, scanned: rows.length, next_cursor: null },
+            coverage: { membership: 'retained_local_active', ordering: 'id', historical: 'unavailable' },
+            missing: [],
+            cancellation_authority: false,
+          }),
+        };
+      }
+      const lane = (url.searchParams.get('lane') ?? 'history') as 'active' | 'history';
+      return {
+        kind: 'response',
+        status: 200,
+        correlationId: '',
+        text: JSON.stringify(localEnvelope(c, [summary], lane)),
+      };
+    }
+    if (url.pathname === '/api/jobs/metadata') {
+      const status = url.searchParams.get('status');
+      const rows = pmPresent && (!status || status === 'running') ? [pmRow(c)] : [];
+      return {
+        kind: 'response',
+        status: 200,
+        correlationId: '',
+        text: JSON.stringify({
+          ...list(rows),
+          context: c,
+          store: { source: 'harness', state_id: canonical.job_ref.state_id },
+          mode: url.searchParams.get('mode'),
+          page: {
+            outcome: 'complete',
+            revision: 11,
+            checkpoint: 11,
+            scanned: rows.length,
+            next_cursor: null,
+          },
+        }),
+      };
+    }
+    if (url.pathname.endsWith('/detail')) {
+      return {
+        kind: 'response',
+        status: 200,
+        correlationId: '',
+        text: JSON.stringify(fourTaskDetail(selected, c)),
+      };
+    }
+    throw Error(`unexpected ${path}`);
+  });
+  Object.defineProperty(window, 'harnessIPC', {
+    configurable: true,
+    value: { endpointHeaders: true, requestJSON },
+  });
+  const store = new JobMetadataStore(new JobMetadataClient(1000));
+  stores.push(store);
+  await act(async () => {
+    store.setTarget({ repo: c.repo, session_id: c.session_id, scope: 'all' });
+    await store.readView();
+    await store.advance(true);
+    await (store as unknown as { advanceLocal: (lane: 'active' | 'history') => Promise<unknown> }).advanceLocal('active');
+    for (let turn = 0; turn < 24; turn++) await store.advance();
+  });
+  localStorage.setItem('marionette.jobScope.v1', 'repo');
+  const ui = render(
+    <JobMetadataContext.Provider value={store}>
+      <SwarmPane />
+    </JobMetadataContext.Provider>,
+  );
+  return {
+    store,
+    requestJSON,
+    setPmPresent(value: boolean) { pmPresent = value; },
+    ...ui,
+  };
+}
+
+describe('metadataJobs alias dedupe', () => {
+  it('dedupes the same local job_id from observations and localDetail by freshest revision', () => {
+    const older = localSummary({ revision: 3, local_ref: { job_id: 'local-swarm-call_00_alias', incarnation: 'old-incarnation' } });
+    const newer = localSummary({ revision: 9 });
+    const c = context();
+    const state = {
+      view: {
+        kind: 'view',
+        target: { repo: c.repo, session_id: c.session_id, scope: 'all' },
+        context: c,
+        view: {
+          ...view(c.view_generation),
+          context: { session_id: c.session_id, repo: c.repo, view_generation: c.view_generation },
+          local: { available: true, incarnation, version: 1 },
+        },
+        refresh: 'idle',
+      },
+      observations: [],
+      pins: [],
+      local: {
+        observations: [
+          { row: older, freshness: 'observed', observedAt: 1 },
+          { row: newer, freshness: 'observed', observedAt: 2 },
+        ] satisfies LocalObservation[],
+        traversal: { mode: 'snapshot', after_revision: 0, cursor: null },
+        state: 'complete',
+        missing: [],
+        observedAt: 2,
+      },
+      localDetail: {
+        selection: newer.local_ref,
+        lane: 'tasks',
+        observation: {
+          lane: 'tasks',
+          local_ref: newer.local_ref,
+          summary: { ...newer, revision: 12 },
+          rows: [],
+          page: { outcome: 'complete', revision: 12, checkpoint: 12, scanned: 0, next_cursor: null },
+          missing: [],
+          total: 0,
+        },
+        summaryFreshness: 'observed',
+        laneFreshness: 'observed',
+        error: null,
+      },
+      detail: { kind: 'none' },
+      detailCache: {},
+      headers: {},
+      working: false,
+      error: null,
+    } as unknown as JobMetadataState;
+    const jobs = metadataJobs(state);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].id).toBe('local-swarm-call_00_alias');
+    expect(jobs[0].local_ref?.incarnation).toBe(incarnation);
+  });
+
+  it('keeps a hydrated expert when detail freshness is stale from an unrelated lane error', () => {
+    const c = context();
+    const selected = pmSelection(c);
+    const key = metadataSelectionKey(selected);
+    const detail = fourTaskDetail(selected, c);
+    const state = {
+      view: { kind: 'view', target: { repo: c.repo, session_id: c.session_id, scope: 'all' }, context: c, view: view(c.view_generation), refresh: 'idle' },
+      observations: [{ row: pmRow(c), freshness: 'observed' }],
+      pins: [],
+      detail: { kind: 'none' },
+      detailCache: {
+        [key]: {
+          kind: 'selected',
+          selection: selected,
+          cursors: { task_cursor: null, artifact_cursor: null },
+          observation: detail,
+          freshness: 'stale',
+          error: null,
+        },
+      },
+      headers: {},
+      error: 'invalid_metadata',
+      working: false,
+    } as unknown as JobMetadataState;
+    const expert = currentExpert(state, key);
+    expect(expert?.kind).toBe('available');
+    expect(expert?.tasks).toHaveLength(4);
+  });
+});
+
+describe('SwarmPane canonical alias presentation', () => {
+  it('renders canonical goal, job id, and a 4-worker PM roster for an alias with canonical', async () => {
+    const fixture = await mountCanonicalAlias({ includePmList: false });
+    try {
+      const row = await screen.findByTestId(`inspect-local-${localSummary().local_ref.job_id}`);
+      expect(within(row).queryAllByRole('button', { name: /Provider worker|canonical swarm goal/ })).toHaveLength(1);
+      fireEvent.click(within(row).getByRole('button', { name: /Provider worker|canonical swarm goal|Synthetic alias/ }));
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: `Job ${canonical.job_ref.job_id}` })).toBeVisible();
+      });
+      await waitFor(() => {
+        expect(screen.getAllByText('canonical swarm goal').length).toBeGreaterThan(0);
+      });
+      const roster = await screen.findByRole('group', { name: 'Workers' });
+      expect(within(roster).getByText('Worker 1')).toBeVisible();
+      expect(within(roster).getByText('Worker 2')).toBeVisible();
+      expect(within(roster).getByText('Worker 3')).toBeVisible();
+      expect(within(roster).getByText('Worker 4')).toBeVisible();
+      expect(screen.queryByText(/workers loaded · partial coverage/i)).toBeNull();
+      expect(screen.getAllByTestId(`inspect-local-${localSummary().local_ref.job_id}`)).toHaveLength(1);
+    } finally {
+      fixture.unmount();
+    }
+  });
+
+  it('hides the alias once the canonical PM row is observed', async () => {
+    const fixture = await mountCanonicalAlias({ includePmList: false });
+    try {
+      expect(await screen.findByTestId(`inspect-local-${localSummary().local_ref.job_id}`)).toBeVisible();
+      fixture.setPmPresent(true);
+      await act(async () => {
+        fixture.store.restartTraversal();
+        for (let turn = 0; turn < 24; turn++) await fixture.store.advance();
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId(`inspect-local-${localSummary().local_ref.job_id}`)).toBeNull();
+      });
+      expect(screen.getByTestId(`inspect-harness-${canonical.job_ref.job_id}`)).toBeVisible();
+      expect(metadataJobs(fixture.store.getSnapshot()).map((job) => job.id)).toEqual([canonical.job_ref.job_id]);
+    } finally {
+      fixture.unmount();
+    }
+  });
+});

--- a/webapp/src/__tests__/expertCore.integration.test.tsx
+++ b/webapp/src/__tests__/expertCore.integration.test.tsx
@@ -45,21 +45,24 @@ describe('current expert contract boundary', () => {
     expect(parsed.expert?.tasks[0].usage).toMatchObject({ tokens: 120, est_cost_usd: 0, cost_provenance: 'provider', source_artifact_id: 'artifact-1' });
     expect(parsed.expert?.header?.cost.source).toBe('unavailable');
     const foreign = structuredClone(backend); foreign.economics.tasks['task-1'].source_artifact_id = 'foreign';
-    expect(() => parseExpertMetadata(foreign)).toThrow();
+    expect(parseExpertMetadata(foreign).tasks[0].usage.source_artifact_id).toBeNull();
   });
   it('binds current bodies to exact selected task and artifact refs and page revisions', () => {
     expect(parseMetadataDetail(selected(), context, selection(), cursors).expert?.tasks[0].model).toBe('gpt-6-astra');
     const bad = selected(); bad.expert!.tasks[0].id = 'foreign';
-    expect(() => parseMetadataDetail(bad, context, selection(), cursors)).toThrow();
+    expect(parseMetadataDetail(bad, context, selection(), cursors).expert?.kind).toBe('unavailable');
     const badLink = selected(); badLink.expert!.artifacts[0].task_id = 'foreign';
-    expect(() => parseMetadataDetail(badLink, context, selection(), cursors)).toThrow();
-    const badRevision = selected(); badRevision.artifacts.page.revision++;
-    expect(() => parseMetadataDetail(badRevision, context, selection(), cursors)).toThrow();
+    expect(parseMetadataDetail(badLink, context, selection(), cursors).expert?.kind).toBe('unavailable');
+    const badRevision = selected();
+    badRevision.artifacts.page = { ...badRevision.artifacts.page, revision: badRevision.artifacts.page.revision + 1, checkpoint: badRevision.artifacts.page.revision + 1 };
+    const skewed = parseMetadataDetail(badRevision, context, selection(), cursors);
+    expect(skewed.expert?.kind).toBe('unavailable');
+    expect(skewed.expert?.reason).toBe('lane_revision_skew');
     expect(() => parseMetadataDetail(selected(), context, { ...selection(), source: 'cli' }, cursors)).toThrow();
   });
   it('rejects unknown keys, unsafe timestamps, duplicate refs and invalid numeric facts', () => {
     expect(() => parseExpertMetadata({ ...facts(), secret: 'unexpected' })).toThrow();
-    expect(() => parseExpertHeader({ ...facts().header, created_at: 'not-a-clock' })).toThrow();
+    expect(parseExpertHeader({ ...facts().header, created_at: 'not-a-clock' })?.created_at).toBeNull();
     const duplicate = facts(); duplicate.tasks.push(duplicate.tasks[0]);
     expect(() => parseExpertMetadata(duplicate)).toThrow();
     const invalid = facts(); invalid.tasks[0].usage.tokens_in = Infinity;
@@ -74,7 +77,8 @@ describe('current expert contract boundary', () => {
     } };
     const accepted = parseMetadataDetail({ ...payload, expert: capped }, context, selection(), cursors);
     expect(accepted.expert?.tasks[0].usage.source_artifact_id).toBe('artifact-1');
-    expect(() => parseMetadataDetail({ ...payload, artifacts: { ...payload.artifacts, rows: [] }, expert: capped }, context, selection(), cursors)).toThrow();
+    const orphaned = parseMetadataDetail({ ...payload, artifacts: { ...payload.artifacts, rows: [] }, expert: capped }, context, selection(), cursors);
+    expect(orphaned.expert?.tasks[0].usage.source_artifact_id).toBeNull();
   });
   it('preserves live economics independently from the terminal header and rejects incomplete shapes', () => {
     const live = { created_at: null, completed_at: null, updated_at: null, latest_task_updated_at: null,

--- a/webapp/src/__tests__/expertMetadata.midflight.test.ts
+++ b/webapp/src/__tests__/expertMetadata.midflight.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import payload from './fixtures/midflight-running.json';
+import { MetadataError, parseMetadataDetail, parseMetadataList, parseMetadataPins } from '../lib/jobMetadata';
+import { parseExpertHeader, parseExpertMetadata } from '../lib/expertMetadata';
+import type { MetadataContext, MetadataSelection } from '../lib/jobMetadata';
+
+const ctx = payload.context as MetadataContext;
+const selection = payload.selection as MetadataSelection;
+const cursors = { task_cursor: null, artifact_cursor: null };
+
+describe('mid-flight running job fixtures', () => {
+  it('parses producer detail, pins, and running membership page', () => {
+    const detail = parseMetadataDetail(payload.detail, ctx, selection, cursors);
+    expect(detail.lifecycle).toBe('running');
+    expect(detail.expert?.kind === 'unavailable' || (detail.expert?.tasks.length ?? 0) > 0).toBe(true);
+    const pins = parseMetadataPins(payload.pins, ctx, [selection]);
+    expect(pins.results[0].result.kind).toBe('present');
+    const stream = { store: { source: selection.source, state_id: selection.job_ref.state_id }, status: 'running' as const };
+    const page = parseMetadataList(payload.page, ctx, stream, { mode: 'snapshot', after_revision: 0, cursor: null });
+    expect(page.rows.some(row => !row.deleted && row.lifecycle === 'running')).toBe(true);
+  });
+
+  it('degrades lane revision skew to unavailable expert instead of throwing', () => {
+    const skewed = structuredClone(payload.detail);
+    skewed.artifacts.page.revision += 1;
+    skewed.artifacts.page.checkpoint = skewed.artifacts.page.revision;
+    const parsed = parseMetadataDetail(skewed, ctx, selection, cursors);
+    expect(parsed.expert?.kind).toBe('unavailable');
+    expect(parsed.expert?.reason).toBe('lane_revision_skew');
+    expect(parsed.tasks.rows.length).toBeGreaterThan(0);
+  });
+
+  it('names failing fields on MetadataError.detail', () => {
+    try {
+      parseExpertHeader({
+        created_at: null, completed_at: null,
+        completed_workers: 3, selected_workers: 1, workers_complete: true,
+        usage: { tokens: 1, tokens_known_workers: 1, cost_known_workers: 1, selected_workers: 1, complete: false },
+        cost: { selected_usd: 1, source: 'selected_current_records', basis: 'estimated', measured_cost_usd: null, estimated_cost_usd: 1, complete: false, plan_workers: 0 },
+        savings: { routing_usd: null, cache_usd: null, compaction_usd: null, compact_tokens: null, selected_usd: null, basis: 'estimated', source: 'selected_current_records' },
+      });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain('invalid_metadata');
+      expect((error as Error & { detail?: string }).detail).toBe('header.usage');
+    }
+    try {
+      parseMetadataDetail({ ...payload.detail, version: 2 }, ctx, selection, cursors);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(MetadataError);
+      expect((error as MetadataError).code).toBe('invalid_metadata');
+    }
+  });
+
+  it('degrades orphan sources, blank models, bad clocks, and over-confidence', () => {
+    const expert = structuredClone(payload.detail.expert);
+    if (!expert?.tasks?.[0] || !expert.artifacts?.[0]) return;
+    expert.tasks[0].model = '';
+    expert.tasks[0].created_at = '2026-09-11T12:00:00+0000';
+    expert.artifacts[0].confidence = 1.5;
+    expert.artifacts[0].check_result = 'pending';
+    if (expert.economics?.tasks?.[expert.tasks[0].id]) {
+      expert.economics.tasks[expert.tasks[0].id].source_artifact_id = 'missing-artifact';
+    }
+    const parsed = parseExpertMetadata(expert, payload.detail.artifacts.rows);
+    expect(parsed.tasks[0].model).toBeNull();
+    expect(parsed.tasks[0].created_at).toBeNull();
+    expect(parsed.artifacts[0].confidence).toBeNull();
+    expect(parsed.artifacts[0].check_result).toBe('unavailable');
+    if (parsed.tasks[0].usage.source_artifact_id !== undefined) {
+      expect(parsed.tasks[0].usage.source_artifact_id).toBeNull();
+    }
+  });
+});

--- a/webapp/src/__tests__/fixtures/midflight-running.json
+++ b/webapp/src/__tests__/fixtures/midflight-running.json
@@ -18,58 +18,58 @@
       "rows": [
         {
           "check_result": "unavailable",
-          "id": "artifact_170b97181e00",
+          "id": "artifact_31edec2b2a15",
           "presence": "recorded",
           "revision": 15,
-          "sha256": "be97d7a2a4a86f9d6a7e048be835bafac5a15e8b55dc77793e24189be5e9dd42",
+          "sha256": "d385354af95a40e9131f704592f79c0fcde0aabbe435db519372a9d48383b69c",
           "stamp": "known",
           "status": "unknown",
-          "task_id": "task_752f663cd361",
+          "task_id": "task_2fa1153f008c",
           "type": "routing"
         },
         {
           "check_result": "unavailable",
-          "id": "artifact_2032ec841e34",
+          "id": "artifact_4c1e09d47801",
           "presence": "recorded",
           "revision": 21,
-          "sha256": "8fbd0ebdf51075817d70e705d85e9831b9fa99b6d1757fc0939127dd097e1c89",
+          "sha256": "601ebf4a6f03a19ecef9df29b493a45cf990ba638a80ed4601da1f212dd8d47a",
           "stamp": "known",
           "status": "unknown",
-          "task_id": "task_a44cab447d6c",
+          "task_id": "task_2a568f666725",
           "type": "finding"
         },
         {
           "check_result": "unavailable",
-          "id": "artifact_57ae03057f9e",
+          "id": "artifact_6265f46e383e",
           "presence": "recorded",
           "revision": 17,
-          "sha256": "ae8a433de9f557a7df6edaceecfc6596598037afb6644e34b269d67c82e4e40b",
+          "sha256": "026d985302b114659214fa33c033130f301daaa1da9b2c05b3913b2aebb01b0d",
           "stamp": "known",
           "status": "unknown",
-          "task_id": "task_2da04ad40d5a",
+          "task_id": "task_becff782f9fb",
           "type": "routing"
         },
         {
           "check_result": "unavailable",
-          "id": "artifact_b26d8ca3328a",
-          "presence": "recorded",
-          "revision": 19,
-          "sha256": "e78ef4b0f20bebeb3f4c252d0bd98a971b1d8c88d5f01871f3a111f6f3cf7c9e",
-          "stamp": "known",
-          "status": "unknown",
-          "task_id": "task_a44cab447d6c",
-          "type": "routing"
-        },
-        {
-          "check_result": "unavailable",
-          "id": "artifact_d3bf77ae9aef",
+          "id": "artifact_681e93b90e9a",
           "presence": "recorded",
           "revision": 23,
-          "sha256": "7da0ec3e28677c0b207656bd69af9fc497b3218e2bffbb37b5cf87609e574c8b",
+          "sha256": "12d209f4227725619f4ce2268ab03b6557c90fb0121cd6790c8c5eebaa41a338",
           "stamp": "known",
           "status": "unknown",
-          "task_id": "task_2da04ad40d5a",
+          "task_id": "task_becff782f9fb",
           "type": "finding"
+        },
+        {
+          "check_result": "unavailable",
+          "id": "artifact_da25adc5aaa4",
+          "presence": "recorded",
+          "revision": 19,
+          "sha256": "4ba11dfa977839aabd8501651a84eae7878c052c61725fb6dddca0603f4acc92",
+          "stamp": "known",
+          "status": "unknown",
+          "task_id": "task_2a568f666725",
+          "type": "routing"
         }
       ]
     },
@@ -83,9 +83,9 @@
     "cost": {
       "coverage": "unknown",
       "job_ref": {
-        "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
-        "job_id": "job_40179a544e84",
-        "state_id": "state_a99677cccf03a326",
+        "incarnation": "5440ef08-3364-45e0-8349-2c2106286a0f",
+        "job_id": "job_197af2ae19e0",
+        "state_id": "state_dbb49fdaf92e99c9",
         "version": 2
       },
       "kind": "unavailable",
@@ -111,101 +111,101 @@
           "adapter": "agentic",
           "check_result": "unavailable",
           "confidence": 0.9,
-          "created_at": "2026-09-12T01:20:30+00:00",
+          "created_at": "2026-09-12T01:23:58+00:00",
           "created_by": "router",
           "detail": null,
           "est_cost_usd": 0.02,
           "failure": null,
           "headline": "",
-          "id": "artifact_170b97181e00",
+          "id": "artifact_31edec2b2a15",
           "model": "deepseek-v4-flash",
           "policy": "balanced",
           "provider": null,
           "rejected": [],
           "result": null,
           "role": "explore",
-          "task_id": "task_752f663cd361",
+          "task_id": "task_2fa1153f008c",
           "type": "routing"
         },
         {
           "adapter": null,
           "check_result": "unavailable",
           "confidence": 0.8,
-          "created_at": "2026-09-12T01:20:30+00:00",
+          "created_at": "2026-09-12T01:23:58+00:00",
           "created_by": "worker",
           "detail": null,
           "est_cost_usd": null,
           "failure": null,
           "headline": "tests passed",
-          "id": "artifact_2032ec841e34",
+          "id": "artifact_4c1e09d47801",
           "model": null,
           "policy": null,
           "provider": null,
           "rejected": [],
           "result": null,
           "role": null,
-          "task_id": "task_a44cab447d6c",
+          "task_id": "task_2a568f666725",
           "type": "finding"
         },
         {
           "adapter": "agentic",
           "check_result": "unavailable",
           "confidence": 0.9,
-          "created_at": "2026-09-12T01:20:30+00:00",
+          "created_at": "2026-09-12T01:23:58+00:00",
           "created_by": "router",
           "detail": null,
           "est_cost_usd": 0.02,
           "failure": null,
           "headline": "",
-          "id": "artifact_57ae03057f9e",
+          "id": "artifact_6265f46e383e",
           "model": "deepseek-v4-flash",
           "policy": "balanced",
           "provider": null,
           "rejected": [],
           "result": null,
           "role": "review",
-          "task_id": "task_2da04ad40d5a",
-          "type": "routing"
-        },
-        {
-          "adapter": "agentic",
-          "check_result": "unavailable",
-          "confidence": 0.9,
-          "created_at": "2026-09-12T01:20:30+00:00",
-          "created_by": "router",
-          "detail": null,
-          "est_cost_usd": 0.02,
-          "failure": null,
-          "headline": "",
-          "id": "artifact_b26d8ca3328a",
-          "model": "deepseek-v4-flash",
-          "policy": "balanced",
-          "provider": null,
-          "rejected": [],
-          "result": null,
-          "role": "test",
-          "task_id": "task_a44cab447d6c",
+          "task_id": "task_becff782f9fb",
           "type": "routing"
         },
         {
           "adapter": null,
           "check_result": "unavailable",
           "confidence": 0.4,
-          "created_at": "2026-09-12T01:20:30+00:00",
+          "created_at": "2026-09-12T01:23:58+00:00",
           "created_by": "worker",
           "detail": null,
           "est_cost_usd": null,
           "failure": null,
           "headline": "still looking",
-          "id": "artifact_d3bf77ae9aef",
+          "id": "artifact_681e93b90e9a",
           "model": null,
           "policy": null,
           "provider": null,
           "rejected": [],
           "result": null,
           "role": null,
-          "task_id": "task_2da04ad40d5a",
+          "task_id": "task_becff782f9fb",
           "type": "finding"
+        },
+        {
+          "adapter": "agentic",
+          "check_result": "unavailable",
+          "confidence": 0.9,
+          "created_at": "2026-09-12T01:23:58+00:00",
+          "created_by": "router",
+          "detail": null,
+          "est_cost_usd": 0.02,
+          "failure": null,
+          "headline": "",
+          "id": "artifact_da25adc5aaa4",
+          "model": "deepseek-v4-flash",
+          "policy": "balanced",
+          "provider": null,
+          "rejected": [],
+          "result": null,
+          "role": "test",
+          "task_id": "task_2a568f666725",
+          "type": "routing"
         }
       ],
       "coverage": {
@@ -229,8 +229,8 @@
             "selected_usd": 0.05,
             "source": "selected_current_records"
           },
-          "created_at": "2026-09-12T01:20:30+00:00",
-          "latest_task_updated_at": "2026-09-12T01:20:30+00:00",
+          "created_at": "2026-09-12T01:23:58+00:00",
+          "latest_task_updated_at": "2026-09-12T01:23:58+00:00",
           "savings": {
             "basis": "estimated",
             "cache_usd": null,
@@ -252,40 +252,40 @@
           "workers_complete": true
         },
         "tasks": {
-          "task_2da04ad40d5a": {
+          "task_091c41ecc0b1": {
             "cost_provenance": "unknown",
             "est_cost_usd": null,
             "estimated": null,
             "plan_billed": false,
-            "route_forecast_usd": 0.02,
-            "source_artifact_id": "artifact_d3bf77ae9aef",
-            "tokens": 510,
-            "tokens_in": 500,
-            "tokens_out": 10
-          },
-          "task_752f663cd361": {
-            "cost_provenance": "unknown",
-            "est_cost_usd": null,
-            "estimated": null,
-            "plan_billed": false,
-            "route_forecast_usd": 0.02,
+            "route_forecast_usd": null,
             "source_artifact_id": null,
             "tokens": null,
             "tokens_in": null,
             "tokens_out": null
           },
-          "task_a44cab447d6c": {
+          "task_2a568f666725": {
             "cost_provenance": "provider",
             "est_cost_usd": 0.05,
             "estimated": false,
             "plan_billed": false,
             "route_forecast_usd": 0.02,
-            "source_artifact_id": "artifact_2032ec841e34",
+            "source_artifact_id": "artifact_4c1e09d47801",
             "tokens": 1200,
             "tokens_in": 1000,
             "tokens_out": 200
           },
-          "task_c46c035a0065": {
+          "task_2fa1153f008c": {
+            "cost_provenance": "unknown",
+            "est_cost_usd": null,
+            "estimated": null,
+            "plan_billed": false,
+            "route_forecast_usd": 0.02,
+            "source_artifact_id": null,
+            "tokens": null,
+            "tokens_in": null,
+            "tokens_out": null
+          },
+          "task_51c67ffe5a87": {
             "cost_provenance": "unknown",
             "est_cost_usd": null,
             "estimated": null,
@@ -296,16 +296,16 @@
             "tokens_in": null,
             "tokens_out": null
           },
-          "task_ccae9baacb09": {
+          "task_becff782f9fb": {
             "cost_provenance": "unknown",
             "est_cost_usd": null,
             "estimated": null,
             "plan_billed": false,
-            "route_forecast_usd": null,
-            "source_artifact_id": null,
-            "tokens": null,
-            "tokens_in": null,
-            "tokens_out": null
+            "route_forecast_usd": 0.02,
+            "source_artifact_id": "artifact_681e93b90e9a",
+            "tokens": 510,
+            "tokens_in": 500,
+            "tokens_out": 10
           }
         }
       },
@@ -318,7 +318,7 @@
           "selected_usd": null,
           "source": "unavailable"
         },
-        "created_at": "2026-09-12T01:20:30+00:00"
+        "created_at": "2026-09-12T01:23:58+00:00"
       },
       "kind": "available",
       "quality": "unverified",
@@ -326,59 +326,8 @@
       "tasks": [
         {
           "adapter": "agentic",
-          "created_at": "2026-09-12T01:20:30+00:00",
-          "id": "task_2da04ad40d5a",
-          "instruction": "instruction for review",
-          "instruction_truncated": false,
-          "model": "deepseek-v4-flash",
-          "role": "review",
-          "updated_at": "2026-09-12T01:20:30+00:00",
-          "usage": {
-            "cost_provenance": null,
-            "est_cost_usd": null,
-            "estimated": null,
-            "tokens_in": null,
-            "tokens_out": null
-          }
-        },
-        {
-          "adapter": "agentic",
-          "created_at": "2026-09-12T01:20:30+00:00",
-          "id": "task_752f663cd361",
-          "instruction": "instruction for explore",
-          "instruction_truncated": false,
-          "model": "deepseek-v4-flash",
-          "role": "explore",
-          "updated_at": "2026-09-12T01:20:30+00:00",
-          "usage": {
-            "cost_provenance": null,
-            "est_cost_usd": null,
-            "estimated": null,
-            "tokens_in": null,
-            "tokens_out": null
-          }
-        },
-        {
-          "adapter": "agentic",
-          "created_at": "2026-09-12T01:20:30+00:00",
-          "id": "task_a44cab447d6c",
-          "instruction": "instruction for test",
-          "instruction_truncated": false,
-          "model": "deepseek-v4-flash",
-          "role": "test",
-          "updated_at": "2026-09-12T01:20:30+00:00",
-          "usage": {
-            "cost_provenance": "provider",
-            "est_cost_usd": 0.05,
-            "estimated": false,
-            "tokens_in": null,
-            "tokens_out": null
-          }
-        },
-        {
-          "adapter": "agentic",
           "created_at": null,
-          "id": "task_c46c035a0065",
+          "id": "task_091c41ecc0b1",
           "instruction": "instruction for security",
           "instruction_truncated": false,
           "model": null,
@@ -394,13 +343,64 @@
         },
         {
           "adapter": "agentic",
+          "created_at": "2026-09-12T01:23:58+00:00",
+          "id": "task_2a568f666725",
+          "instruction": "instruction for test",
+          "instruction_truncated": false,
+          "model": "deepseek-v4-flash",
+          "role": "test",
+          "updated_at": "2026-09-12T01:23:58+00:00",
+          "usage": {
+            "cost_provenance": "provider",
+            "est_cost_usd": 0.05,
+            "estimated": false,
+            "tokens_in": null,
+            "tokens_out": null
+          }
+        },
+        {
+          "adapter": "agentic",
+          "created_at": "2026-09-12T01:23:58+00:00",
+          "id": "task_2fa1153f008c",
+          "instruction": "instruction for explore",
+          "instruction_truncated": false,
+          "model": "deepseek-v4-flash",
+          "role": "explore",
+          "updated_at": "2026-09-12T01:23:58+00:00",
+          "usage": {
+            "cost_provenance": null,
+            "est_cost_usd": null,
+            "estimated": null,
+            "tokens_in": null,
+            "tokens_out": null
+          }
+        },
+        {
+          "adapter": "agentic",
           "created_at": null,
-          "id": "task_ccae9baacb09",
+          "id": "task_51c67ffe5a87",
           "instruction": "not started yet",
           "instruction_truncated": false,
           "model": null,
           "role": "nostart",
           "updated_at": null,
+          "usage": {
+            "cost_provenance": null,
+            "est_cost_usd": null,
+            "estimated": null,
+            "tokens_in": null,
+            "tokens_out": null
+          }
+        },
+        {
+          "adapter": "agentic",
+          "created_at": "2026-09-12T01:23:58+00:00",
+          "id": "task_becff782f9fb",
+          "instruction": "instruction for review",
+          "instruction_truncated": false,
+          "model": "deepseek-v4-flash",
+          "role": "review",
+          "updated_at": "2026-09-12T01:23:58+00:00",
           "usage": {
             "cost_provenance": null,
             "est_cost_usd": null,
@@ -425,18 +425,18 @@
           {
             "facts": {
               "adapter": "agentic",
-              "attempt_id": "run_db98bba4ded2",
-              "job_id": "job_40179a544e84",
+              "attempt_id": "run_19f1f177e884",
+              "job_id": "job_197af2ae19e0",
               "model": "deepseek-v4-flash",
               "provider": "deepseek",
-              "run_id": "run_db98bba4ded2",
-              "started_at": "2026-09-12T01:20:30+00:00",
-              "task_id": "task_2da04ad40d5a"
+              "run_id": "run_19f1f177e884",
+              "started_at": "2026-09-12T01:23:58+00:00",
+              "task_id": "task_becff782f9fb"
             },
             "job_ref": {
-              "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
-              "job_id": "job_40179a544e84",
-              "state_id": "state_a99677cccf03a326",
+              "incarnation": "5440ef08-3364-45e0-8349-2c2106286a0f",
+              "job_id": "job_197af2ae19e0",
+              "state_id": "state_dbb49fdaf92e99c9",
               "version": 2
             },
             "kind": "attempt",
@@ -467,29 +467,29 @@
         "rows": [
           {
             "facts": {
-              "attempt_id": "run_db98bba4ded2",
+              "attempt_id": "run_19f1f177e884",
               "cache_read_tokens": null,
               "cache_write_tokens": null,
               "cost_basis": "api",
               "cost_state": "measured",
               "cost_usd": 0.01,
               "identity_state": "available",
-              "job_id": "job_40179a544e84",
+              "job_id": "job_197af2ae19e0",
               "observation_id": "obs-1",
-              "observed_at": "2026-09-12T01:20:30+00:00",
+              "observed_at": "2026-09-12T01:23:58+00:00",
               "returncode": null,
-              "run_id": "run_db98bba4ded2",
+              "run_id": "run_19f1f177e884",
               "source": "sdk",
-              "task_id": "task_2da04ad40d5a",
+              "task_id": "task_becff782f9fb",
               "timed_out": null,
               "tokens_in": 10,
               "tokens_out": 1,
               "usage_state": "measured"
             },
             "job_ref": {
-              "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
-              "job_id": "job_40179a544e84",
-              "state_id": "state_a99677cccf03a326",
+              "incarnation": "5440ef08-3364-45e0-8349-2c2106286a0f",
+              "job_id": "job_197af2ae19e0",
+              "state_id": "state_dbb49fdaf92e99c9",
               "version": 2
             },
             "kind": "observation",
@@ -522,28 +522,28 @@
             "completion": {
               "intent_digest": null,
               "job_ref": {
-                "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
-                "job_id": "job_40179a544e84",
-                "state_id": "state_a99677cccf03a326",
+                "incarnation": "5440ef08-3364-45e0-8349-2c2106286a0f",
+                "job_id": "job_197af2ae19e0",
+                "state_id": "state_dbb49fdaf92e99c9",
                 "version": 2
               },
               "outcome": "legacy_unknown",
-              "run_id": "run_db98bba4ded2"
+              "run_id": "run_19f1f177e884"
             },
             "facts": {
               "completed_at": null,
-              "id": "run_db98bba4ded2",
-              "job_id": "job_40179a544e84",
+              "id": "run_19f1f177e884",
+              "job_id": "job_197af2ae19e0",
               "role": "review",
-              "started_at": "2026-09-12T01:20:30+00:00",
+              "started_at": "2026-09-12T01:23:58+00:00",
               "status": "running",
-              "task_id": "task_2da04ad40d5a",
+              "task_id": "task_becff782f9fb",
               "worker_id": "worker-1"
             },
             "job_ref": {
-              "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
-              "job_id": "job_40179a544e84",
-              "state_id": "state_a99677cccf03a326",
+              "incarnation": "5440ef08-3364-45e0-8349-2c2106286a0f",
+              "job_id": "job_197af2ae19e0",
+              "state_id": "state_dbb49fdaf92e99c9",
               "version": 2
             },
             "kind": "run",
@@ -558,9 +558,9 @@
     ],
     "selection": {
       "job_ref": {
-        "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
-        "job_id": "job_40179a544e84",
-        "state_id": "state_a99677cccf03a326",
+        "incarnation": "5440ef08-3364-45e0-8349-2c2106286a0f",
+        "job_id": "job_197af2ae19e0",
+        "state_id": "state_dbb49fdaf92e99c9",
         "version": 2
       },
       "repo": "/repo",
@@ -582,45 +582,9 @@
             "generation": 0,
             "lease_id": null,
             "owner": null,
-            "task_id": "task_2da04ad40d5a"
+            "task_id": "task_091c41ecc0b1"
           },
-          "id": "task_2da04ad40d5a",
-          "revision": 5,
-          "stamp": "known",
-          "status": "running"
-        },
-        {
-          "binding": {
-            "generation": 1,
-            "lease_id": "lease_95eeed327ecc",
-            "owner": "worker-1",
-            "task_id": "task_752f663cd361"
-          },
-          "id": "task_752f663cd361",
-          "revision": 11,
-          "stamp": "known",
-          "status": "running"
-        },
-        {
-          "binding": {
-            "generation": 0,
-            "lease_id": null,
-            "owner": null,
-            "task_id": "task_a44cab447d6c"
-          },
-          "id": "task_a44cab447d6c",
-          "revision": 7,
-          "stamp": "known",
-          "status": "complete"
-        },
-        {
-          "binding": {
-            "generation": 0,
-            "lease_id": null,
-            "owner": null,
-            "task_id": "task_c46c035a0065"
-          },
-          "id": "task_c46c035a0065",
+          "id": "task_091c41ecc0b1",
           "revision": 9,
           "stamp": "known",
           "status": "queued"
@@ -630,12 +594,48 @@
             "generation": 0,
             "lease_id": null,
             "owner": null,
-            "task_id": "task_ccae9baacb09"
+            "task_id": "task_2a568f666725"
           },
-          "id": "task_ccae9baacb09",
+          "id": "task_2a568f666725",
+          "revision": 7,
+          "stamp": "known",
+          "status": "complete"
+        },
+        {
+          "binding": {
+            "generation": 1,
+            "lease_id": "lease_d9fc21d4672d",
+            "owner": "worker-1",
+            "task_id": "task_2fa1153f008c"
+          },
+          "id": "task_2fa1153f008c",
+          "revision": 11,
+          "stamp": "known",
+          "status": "running"
+        },
+        {
+          "binding": {
+            "generation": 0,
+            "lease_id": null,
+            "owner": null,
+            "task_id": "task_51c67ffe5a87"
+          },
+          "id": "task_51c67ffe5a87",
           "revision": 13,
           "stamp": "known",
           "status": "queued"
+        },
+        {
+          "binding": {
+            "generation": 0,
+            "lease_id": null,
+            "owner": null,
+            "task_id": "task_becff782f9fb"
+          },
+          "id": "task_becff782f9fb",
+          "revision": 5,
+          "stamp": "known",
+          "status": "running"
         }
       ]
     },
@@ -717,9 +717,9 @@
         "revision": 27,
         "selection": {
           "job_ref": {
-            "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
-            "job_id": "job_40179a544e84",
-            "state_id": "state_a99677cccf03a326",
+            "incarnation": "5440ef08-3364-45e0-8349-2c2106286a0f",
+            "job_id": "job_197af2ae19e0",
+            "state_id": "state_dbb49fdaf92e99c9",
             "version": 2
           },
           "repo": "/repo",
@@ -732,7 +732,7 @@
     ],
     "store": {
       "source": "harness",
-      "state_id": "state_a99677cccf03a326"
+      "state_id": "state_dbb49fdaf92e99c9"
     },
     "version": 1
   },
@@ -774,8 +774,8 @@
                 "selected_usd": 0.05,
                 "source": "selected_current_records"
               },
-              "created_at": "2026-09-12T01:20:30+00:00",
-              "latest_task_updated_at": "2026-09-12T01:20:30+00:00",
+              "created_at": "2026-09-12T01:23:58+00:00",
+              "latest_task_updated_at": "2026-09-12T01:23:58+00:00",
               "model": null,
               "model_provenance": "unknown",
               "quality": "unverified",
@@ -808,9 +808,9 @@
             "revision": 27,
             "selection": {
               "job_ref": {
-                "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
-                "job_id": "job_40179a544e84",
-                "state_id": "state_a99677cccf03a326",
+                "incarnation": "5440ef08-3364-45e0-8349-2c2106286a0f",
+                "job_id": "job_197af2ae19e0",
+                "state_id": "state_dbb49fdaf92e99c9",
                 "version": 2
               },
               "repo": "/repo",
@@ -823,9 +823,9 @@
         },
         "selection": {
           "job_ref": {
-            "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
-            "job_id": "job_40179a544e84",
-            "state_id": "state_a99677cccf03a326",
+            "incarnation": "5440ef08-3364-45e0-8349-2c2106286a0f",
+            "job_id": "job_197af2ae19e0",
+            "state_id": "state_dbb49fdaf92e99c9",
             "version": 2
           },
           "repo": "/repo",
@@ -838,9 +838,9 @@
   },
   "selection": {
     "job_ref": {
-      "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
-      "job_id": "job_40179a544e84",
-      "state_id": "state_a99677cccf03a326",
+      "incarnation": "5440ef08-3364-45e0-8349-2c2106286a0f",
+      "job_id": "job_197af2ae19e0",
+      "state_id": "state_dbb49fdaf92e99c9",
       "version": 2
     },
     "repo": "/repo",

--- a/webapp/src/__tests__/fixtures/midflight-running.json
+++ b/webapp/src/__tests__/fixtures/midflight-running.json
@@ -1,0 +1,850 @@
+{
+  "context": {
+    "repo": "/repo",
+    "scope": "session",
+    "session_id": "session-A",
+    "view_generation": "generation-1"
+  },
+  "detail": {
+    "artifact_count": 5,
+    "artifacts": {
+      "page": {
+        "checkpoint": 27,
+        "next_cursor": null,
+        "outcome": "complete",
+        "revision": 27,
+        "scanned": 5
+      },
+      "rows": [
+        {
+          "check_result": "unavailable",
+          "id": "artifact_170b97181e00",
+          "presence": "recorded",
+          "revision": 15,
+          "sha256": "be97d7a2a4a86f9d6a7e048be835bafac5a15e8b55dc77793e24189be5e9dd42",
+          "stamp": "known",
+          "status": "unknown",
+          "task_id": "task_752f663cd361",
+          "type": "routing"
+        },
+        {
+          "check_result": "unavailable",
+          "id": "artifact_2032ec841e34",
+          "presence": "recorded",
+          "revision": 21,
+          "sha256": "8fbd0ebdf51075817d70e705d85e9831b9fa99b6d1757fc0939127dd097e1c89",
+          "stamp": "known",
+          "status": "unknown",
+          "task_id": "task_a44cab447d6c",
+          "type": "finding"
+        },
+        {
+          "check_result": "unavailable",
+          "id": "artifact_57ae03057f9e",
+          "presence": "recorded",
+          "revision": 17,
+          "sha256": "ae8a433de9f557a7df6edaceecfc6596598037afb6644e34b269d67c82e4e40b",
+          "stamp": "known",
+          "status": "unknown",
+          "task_id": "task_2da04ad40d5a",
+          "type": "routing"
+        },
+        {
+          "check_result": "unavailable",
+          "id": "artifact_b26d8ca3328a",
+          "presence": "recorded",
+          "revision": 19,
+          "sha256": "e78ef4b0f20bebeb3f4c252d0bd98a971b1d8c88d5f01871f3a111f6f3cf7c9e",
+          "stamp": "known",
+          "status": "unknown",
+          "task_id": "task_a44cab447d6c",
+          "type": "routing"
+        },
+        {
+          "check_result": "unavailable",
+          "id": "artifact_d3bf77ae9aef",
+          "presence": "recorded",
+          "revision": 23,
+          "sha256": "7da0ec3e28677c0b207656bd69af9fc497b3218e2bffbb37b5cf87609e574c8b",
+          "stamp": "known",
+          "status": "unknown",
+          "task_id": "task_2da04ad40d5a",
+          "type": "finding"
+        }
+      ]
+    },
+    "cancellation_authority": false,
+    "context": {
+      "repo": "/repo",
+      "scope": "session",
+      "session_id": "session-A",
+      "view_generation": "generation-1"
+    },
+    "cost": {
+      "coverage": "unknown",
+      "job_ref": {
+        "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
+        "job_id": "job_40179a544e84",
+        "state_id": "state_a99677cccf03a326",
+        "version": 2
+      },
+      "kind": "unavailable",
+      "outcome": "unavailable",
+      "reason": "no_terminal_receipt",
+      "receipt_digest": null,
+      "retry_after_ms": null,
+      "selected_count": null,
+      "source": "unavailable",
+      "summary_revision": 27,
+      "totals": null
+    },
+    "display": {
+      "delivery": "pending",
+      "goal_preview": "midflight parity swarm",
+      "goal_preview_truncated": false,
+      "kind": "available",
+      "quality": "unverified"
+    },
+    "expert": {
+      "artifacts": [
+        {
+          "adapter": "agentic",
+          "check_result": "unavailable",
+          "confidence": 0.9,
+          "created_at": "2026-09-12T01:20:30+00:00",
+          "created_by": "router",
+          "detail": null,
+          "est_cost_usd": 0.02,
+          "failure": null,
+          "headline": "",
+          "id": "artifact_170b97181e00",
+          "model": "deepseek-v4-flash",
+          "policy": "balanced",
+          "provider": null,
+          "rejected": [],
+          "result": null,
+          "role": "explore",
+          "task_id": "task_752f663cd361",
+          "type": "routing"
+        },
+        {
+          "adapter": null,
+          "check_result": "unavailable",
+          "confidence": 0.8,
+          "created_at": "2026-09-12T01:20:30+00:00",
+          "created_by": "worker",
+          "detail": null,
+          "est_cost_usd": null,
+          "failure": null,
+          "headline": "tests passed",
+          "id": "artifact_2032ec841e34",
+          "model": null,
+          "policy": null,
+          "provider": null,
+          "rejected": [],
+          "result": null,
+          "role": null,
+          "task_id": "task_a44cab447d6c",
+          "type": "finding"
+        },
+        {
+          "adapter": "agentic",
+          "check_result": "unavailable",
+          "confidence": 0.9,
+          "created_at": "2026-09-12T01:20:30+00:00",
+          "created_by": "router",
+          "detail": null,
+          "est_cost_usd": 0.02,
+          "failure": null,
+          "headline": "",
+          "id": "artifact_57ae03057f9e",
+          "model": "deepseek-v4-flash",
+          "policy": "balanced",
+          "provider": null,
+          "rejected": [],
+          "result": null,
+          "role": "review",
+          "task_id": "task_2da04ad40d5a",
+          "type": "routing"
+        },
+        {
+          "adapter": "agentic",
+          "check_result": "unavailable",
+          "confidence": 0.9,
+          "created_at": "2026-09-12T01:20:30+00:00",
+          "created_by": "router",
+          "detail": null,
+          "est_cost_usd": 0.02,
+          "failure": null,
+          "headline": "",
+          "id": "artifact_b26d8ca3328a",
+          "model": "deepseek-v4-flash",
+          "policy": "balanced",
+          "provider": null,
+          "rejected": [],
+          "result": null,
+          "role": "test",
+          "task_id": "task_a44cab447d6c",
+          "type": "routing"
+        },
+        {
+          "adapter": null,
+          "check_result": "unavailable",
+          "confidence": 0.4,
+          "created_at": "2026-09-12T01:20:30+00:00",
+          "created_by": "worker",
+          "detail": null,
+          "est_cost_usd": null,
+          "failure": null,
+          "headline": "still looking",
+          "id": "artifact_d3bf77ae9aef",
+          "model": null,
+          "policy": null,
+          "provider": null,
+          "rejected": [],
+          "result": null,
+          "role": null,
+          "task_id": "task_2da04ad40d5a",
+          "type": "finding"
+        }
+      ],
+      "coverage": {
+        "artifacts": "complete",
+        "tasks": "complete"
+      },
+      "economics": {
+        "compaction": {
+          "coverage": "unavailable",
+          "reason": "source_absent"
+        },
+        "header": {
+          "completed_at": null,
+          "completed_workers": 1,
+          "cost": {
+            "basis": "measured",
+            "complete": false,
+            "estimated_cost_usd": null,
+            "measured_cost_usd": 0.05,
+            "plan_workers": 0,
+            "selected_usd": 0.05,
+            "source": "selected_current_records"
+          },
+          "created_at": "2026-09-12T01:20:30+00:00",
+          "latest_task_updated_at": "2026-09-12T01:20:30+00:00",
+          "savings": {
+            "basis": "estimated",
+            "cache_usd": null,
+            "compact_tokens": null,
+            "compaction_usd": null,
+            "routing_usd": 0.08,
+            "selected_usd": 0.08,
+            "source": "selected_current_records"
+          },
+          "selected_workers": 5,
+          "updated_at": null,
+          "usage": {
+            "complete": false,
+            "cost_known_workers": 1,
+            "selected_workers": 5,
+            "tokens": 1710,
+            "tokens_known_workers": 2
+          },
+          "workers_complete": true
+        },
+        "tasks": {
+          "task_2da04ad40d5a": {
+            "cost_provenance": "unknown",
+            "est_cost_usd": null,
+            "estimated": null,
+            "plan_billed": false,
+            "route_forecast_usd": 0.02,
+            "source_artifact_id": "artifact_d3bf77ae9aef",
+            "tokens": 510,
+            "tokens_in": 500,
+            "tokens_out": 10
+          },
+          "task_752f663cd361": {
+            "cost_provenance": "unknown",
+            "est_cost_usd": null,
+            "estimated": null,
+            "plan_billed": false,
+            "route_forecast_usd": 0.02,
+            "source_artifact_id": null,
+            "tokens": null,
+            "tokens_in": null,
+            "tokens_out": null
+          },
+          "task_a44cab447d6c": {
+            "cost_provenance": "provider",
+            "est_cost_usd": 0.05,
+            "estimated": false,
+            "plan_billed": false,
+            "route_forecast_usd": 0.02,
+            "source_artifact_id": "artifact_2032ec841e34",
+            "tokens": 1200,
+            "tokens_in": 1000,
+            "tokens_out": 200
+          },
+          "task_c46c035a0065": {
+            "cost_provenance": "unknown",
+            "est_cost_usd": null,
+            "estimated": null,
+            "plan_billed": false,
+            "route_forecast_usd": null,
+            "source_artifact_id": null,
+            "tokens": null,
+            "tokens_in": null,
+            "tokens_out": null
+          },
+          "task_ccae9baacb09": {
+            "cost_provenance": "unknown",
+            "est_cost_usd": null,
+            "estimated": null,
+            "plan_billed": false,
+            "route_forecast_usd": null,
+            "source_artifact_id": null,
+            "tokens": null,
+            "tokens_in": null,
+            "tokens_out": null
+          }
+        }
+      },
+      "header": {
+        "completed_at": null,
+        "cost": {
+          "basis": "unknown",
+          "estimated_cost_usd": null,
+          "measured_cost_usd": null,
+          "selected_usd": null,
+          "source": "unavailable"
+        },
+        "created_at": "2026-09-12T01:20:30+00:00"
+      },
+      "kind": "available",
+      "quality": "unverified",
+      "reason": null,
+      "tasks": [
+        {
+          "adapter": "agentic",
+          "created_at": "2026-09-12T01:20:30+00:00",
+          "id": "task_2da04ad40d5a",
+          "instruction": "instruction for review",
+          "instruction_truncated": false,
+          "model": "deepseek-v4-flash",
+          "role": "review",
+          "updated_at": "2026-09-12T01:20:30+00:00",
+          "usage": {
+            "cost_provenance": null,
+            "est_cost_usd": null,
+            "estimated": null,
+            "tokens_in": null,
+            "tokens_out": null
+          }
+        },
+        {
+          "adapter": "agentic",
+          "created_at": "2026-09-12T01:20:30+00:00",
+          "id": "task_752f663cd361",
+          "instruction": "instruction for explore",
+          "instruction_truncated": false,
+          "model": "deepseek-v4-flash",
+          "role": "explore",
+          "updated_at": "2026-09-12T01:20:30+00:00",
+          "usage": {
+            "cost_provenance": null,
+            "est_cost_usd": null,
+            "estimated": null,
+            "tokens_in": null,
+            "tokens_out": null
+          }
+        },
+        {
+          "adapter": "agentic",
+          "created_at": "2026-09-12T01:20:30+00:00",
+          "id": "task_a44cab447d6c",
+          "instruction": "instruction for test",
+          "instruction_truncated": false,
+          "model": "deepseek-v4-flash",
+          "role": "test",
+          "updated_at": "2026-09-12T01:20:30+00:00",
+          "usage": {
+            "cost_provenance": "provider",
+            "est_cost_usd": 0.05,
+            "estimated": false,
+            "tokens_in": null,
+            "tokens_out": null
+          }
+        },
+        {
+          "adapter": "agentic",
+          "created_at": null,
+          "id": "task_c46c035a0065",
+          "instruction": "instruction for security",
+          "instruction_truncated": false,
+          "model": null,
+          "role": "security",
+          "updated_at": null,
+          "usage": {
+            "cost_provenance": null,
+            "est_cost_usd": null,
+            "estimated": null,
+            "tokens_in": null,
+            "tokens_out": null
+          }
+        },
+        {
+          "adapter": "agentic",
+          "created_at": null,
+          "id": "task_ccae9baacb09",
+          "instruction": "not started yet",
+          "instruction_truncated": false,
+          "model": null,
+          "role": "nostart",
+          "updated_at": null,
+          "usage": {
+            "cost_provenance": null,
+            "est_cost_usd": null,
+            "estimated": null,
+            "tokens_in": null,
+            "tokens_out": null
+          }
+        }
+      ]
+    },
+    "history": {
+      "attempts": {
+        "page": {
+          "captured_count": 1,
+          "complete_invocation_history": false,
+          "coverage": "captured",
+          "next_cursor": null,
+          "outcome": "complete",
+          "scanned": 1
+        },
+        "rows": [
+          {
+            "facts": {
+              "adapter": "agentic",
+              "attempt_id": "run_db98bba4ded2",
+              "job_id": "job_40179a544e84",
+              "model": "deepseek-v4-flash",
+              "provider": "deepseek",
+              "run_id": "run_db98bba4ded2",
+              "started_at": "2026-09-12T01:20:30+00:00",
+              "task_id": "task_2da04ad40d5a"
+            },
+            "job_ref": {
+              "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
+              "job_id": "job_40179a544e84",
+              "state_id": "state_a99677cccf03a326",
+              "version": 2
+            },
+            "kind": "attempt",
+            "sequence": 2
+          }
+        ]
+      },
+      "counts": {
+        "captured_attempts": 1,
+        "captured_observations": 1,
+        "captured_process_outcomes": 0,
+        "captured_runs": 1,
+        "complete_invocation_history": false,
+        "coverage": "captured",
+        "outcome": "available"
+      },
+      "kind": "available",
+      "missing": [],
+      "observations": {
+        "page": {
+          "captured_count": 1,
+          "complete_invocation_history": false,
+          "coverage": "captured",
+          "next_cursor": null,
+          "outcome": "complete",
+          "scanned": 1
+        },
+        "rows": [
+          {
+            "facts": {
+              "attempt_id": "run_db98bba4ded2",
+              "cache_read_tokens": null,
+              "cache_write_tokens": null,
+              "cost_basis": "api",
+              "cost_state": "measured",
+              "cost_usd": 0.01,
+              "identity_state": "available",
+              "job_id": "job_40179a544e84",
+              "observation_id": "obs-1",
+              "observed_at": "2026-09-12T01:20:30+00:00",
+              "returncode": null,
+              "run_id": "run_db98bba4ded2",
+              "source": "sdk",
+              "task_id": "task_2da04ad40d5a",
+              "timed_out": null,
+              "tokens_in": 10,
+              "tokens_out": 1,
+              "usage_state": "measured"
+            },
+            "job_ref": {
+              "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
+              "job_id": "job_40179a544e84",
+              "state_id": "state_a99677cccf03a326",
+              "version": 2
+            },
+            "kind": "observation",
+            "sequence": 3
+          }
+        ]
+      },
+      "process_outcomes": {
+        "page": {
+          "captured_count": 0,
+          "complete_invocation_history": false,
+          "coverage": "unknown",
+          "next_cursor": null,
+          "outcome": "complete",
+          "scanned": 0
+        },
+        "rows": []
+      },
+      "runs": {
+        "page": {
+          "captured_count": 1,
+          "complete_invocation_history": false,
+          "coverage": "captured",
+          "next_cursor": null,
+          "outcome": "complete",
+          "scanned": 1
+        },
+        "rows": [
+          {
+            "completion": {
+              "intent_digest": null,
+              "job_ref": {
+                "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
+                "job_id": "job_40179a544e84",
+                "state_id": "state_a99677cccf03a326",
+                "version": 2
+              },
+              "outcome": "legacy_unknown",
+              "run_id": "run_db98bba4ded2"
+            },
+            "facts": {
+              "completed_at": null,
+              "id": "run_db98bba4ded2",
+              "job_id": "job_40179a544e84",
+              "role": "review",
+              "started_at": "2026-09-12T01:20:30+00:00",
+              "status": "running",
+              "task_id": "task_2da04ad40d5a",
+              "worker_id": "worker-1"
+            },
+            "job_ref": {
+              "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
+              "job_id": "job_40179a544e84",
+              "state_id": "state_a99677cccf03a326",
+              "version": 2
+            },
+            "kind": "run",
+            "sequence": 1
+          }
+        ]
+      }
+    },
+    "lifecycle": "running",
+    "missing": [
+      "cost"
+    ],
+    "selection": {
+      "job_ref": {
+        "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
+        "job_id": "job_40179a544e84",
+        "state_id": "state_a99677cccf03a326",
+        "version": 2
+      },
+      "repo": "/repo",
+      "session_id": "session-A",
+      "source": "harness"
+    },
+    "task_count": 5,
+    "tasks": {
+      "page": {
+        "checkpoint": 27,
+        "next_cursor": null,
+        "outcome": "complete",
+        "revision": 27,
+        "scanned": 5
+      },
+      "rows": [
+        {
+          "binding": {
+            "generation": 0,
+            "lease_id": null,
+            "owner": null,
+            "task_id": "task_2da04ad40d5a"
+          },
+          "id": "task_2da04ad40d5a",
+          "revision": 5,
+          "stamp": "known",
+          "status": "running"
+        },
+        {
+          "binding": {
+            "generation": 1,
+            "lease_id": "lease_95eeed327ecc",
+            "owner": "worker-1",
+            "task_id": "task_752f663cd361"
+          },
+          "id": "task_752f663cd361",
+          "revision": 11,
+          "stamp": "known",
+          "status": "running"
+        },
+        {
+          "binding": {
+            "generation": 0,
+            "lease_id": null,
+            "owner": null,
+            "task_id": "task_a44cab447d6c"
+          },
+          "id": "task_a44cab447d6c",
+          "revision": 7,
+          "stamp": "known",
+          "status": "complete"
+        },
+        {
+          "binding": {
+            "generation": 0,
+            "lease_id": null,
+            "owner": null,
+            "task_id": "task_c46c035a0065"
+          },
+          "id": "task_c46c035a0065",
+          "revision": 9,
+          "stamp": "known",
+          "status": "queued"
+        },
+        {
+          "binding": {
+            "generation": 0,
+            "lease_id": null,
+            "owner": null,
+            "task_id": "task_ccae9baacb09"
+          },
+          "id": "task_ccae9baacb09",
+          "revision": 13,
+          "stamp": "known",
+          "status": "queued"
+        }
+      ]
+    },
+    "version": 1
+  },
+  "page": {
+    "context": {
+      "repo": "/repo",
+      "scope": "session",
+      "session_id": "session-A",
+      "view_generation": "generation-1"
+    },
+    "coverage": {
+      "legacy": "unavailable",
+      "membership": "known_metadata",
+      "ordering": "id",
+      "store_set": "known_sources"
+    },
+    "lanes": {
+      "active_statuses": [
+        "in_progress",
+        "pending",
+        "queued",
+        "running",
+        "started",
+        "stitching"
+      ],
+      "attention_statuses": [
+        "failed",
+        "stalled"
+      ],
+      "statuses": [
+        "cancelled",
+        "complete",
+        "failed",
+        "in_progress",
+        "pending",
+        "queued",
+        "running",
+        "stalled",
+        "started",
+        "stitching"
+      ]
+    },
+    "missing": [
+      "legacy_ownership",
+      "economics"
+    ],
+    "mode": "snapshot",
+    "page": {
+      "checkpoint": 27,
+      "next_cursor": null,
+      "outcome": "complete",
+      "revision": 27,
+      "scanned": 1
+    },
+    "rows": [
+      {
+        "activity": "active",
+        "artifact_count": 5,
+        "deleted": false,
+        "display": {
+          "delivery": "pending",
+          "goal_preview": "midflight parity swarm",
+          "goal_preview_truncated": false,
+          "kind": "available",
+          "quality": "unverified"
+        },
+        "economics": {
+          "kind": "unavailable",
+          "reason": "selected_only"
+        },
+        "lifecycle": "running",
+        "ownership": {
+          "origin": "marionette",
+          "project_id": null,
+          "session_id": "session-A"
+        },
+        "revision": 27,
+        "selection": {
+          "job_ref": {
+            "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
+            "job_id": "job_40179a544e84",
+            "state_id": "state_a99677cccf03a326",
+            "version": 2
+          },
+          "repo": "/repo",
+          "session_id": "session-A",
+          "source": "harness"
+        },
+        "stamp": "known",
+        "task_count": 5
+      }
+    ],
+    "store": {
+      "source": "harness",
+      "state_id": "state_a99677cccf03a326"
+    },
+    "version": 1
+  },
+  "pins": {
+    "context": {
+      "repo": "/repo",
+      "scope": "session",
+      "session_id": "session-A",
+      "view_generation": "generation-1"
+    },
+    "results": [
+      {
+        "result": {
+          "kind": "present",
+          "row": {
+            "activity": "active",
+            "artifact_count": 5,
+            "deleted": false,
+            "display": {
+              "delivery": "pending",
+              "goal_preview": "midflight parity swarm",
+              "goal_preview_truncated": false,
+              "kind": "available",
+              "quality": "unverified"
+            },
+            "economics": {
+              "kind": "unavailable",
+              "reason": "selected_only"
+            },
+            "header": {
+              "completed_at": null,
+              "completed_workers": 1,
+              "cost": {
+                "basis": "measured",
+                "complete": false,
+                "estimated_cost_usd": null,
+                "measured_cost_usd": 0.05,
+                "plan_workers": 0,
+                "selected_usd": 0.05,
+                "source": "selected_current_records"
+              },
+              "created_at": "2026-09-12T01:20:30+00:00",
+              "latest_task_updated_at": "2026-09-12T01:20:30+00:00",
+              "model": null,
+              "model_provenance": "unknown",
+              "quality": "unverified",
+              "savings": {
+                "basis": "estimated",
+                "cache_usd": null,
+                "compact_tokens": null,
+                "compaction_usd": null,
+                "routing_usd": 0.08,
+                "selected_usd": 0.08,
+                "source": "selected_current_records"
+              },
+              "selected_workers": 5,
+              "updated_at": null,
+              "usage": {
+                "complete": false,
+                "cost_known_workers": 1,
+                "selected_workers": 5,
+                "tokens": 1710,
+                "tokens_known_workers": 2
+              },
+              "workers_complete": true
+            },
+            "lifecycle": "running",
+            "ownership": {
+              "origin": "marionette",
+              "project_id": null,
+              "session_id": "session-A"
+            },
+            "revision": 27,
+            "selection": {
+              "job_ref": {
+                "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
+                "job_id": "job_40179a544e84",
+                "state_id": "state_a99677cccf03a326",
+                "version": 2
+              },
+              "repo": "/repo",
+              "session_id": "session-A",
+              "source": "harness"
+            },
+            "stamp": "known",
+            "task_count": 5
+          }
+        },
+        "selection": {
+          "job_ref": {
+            "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
+            "job_id": "job_40179a544e84",
+            "state_id": "state_a99677cccf03a326",
+            "version": 2
+          },
+          "repo": "/repo",
+          "session_id": "session-A",
+          "source": "harness"
+        }
+      }
+    ],
+    "version": 1
+  },
+  "selection": {
+    "job_ref": {
+      "incarnation": "2049a7bf-0192-45de-aa59-8535c8848875",
+      "job_id": "job_40179a544e84",
+      "state_id": "state_a99677cccf03a326",
+      "version": 2
+    },
+    "repo": "/repo",
+    "session_id": "session-A",
+    "source": "harness"
+  }
+}

--- a/webapp/src/__tests__/metadataMigration.test.tsx
+++ b/webapp/src/__tests__/metadataMigration.test.tsx
@@ -116,6 +116,9 @@ it('selected native action pages and output are bounded and explicit, PM control
   await act(async () => { fireEvent.click(screen.getByText('Inspect output')); });
   expect(screen.getByText('Native output fixture')).toBeInTheDocument();
   cleanup();
+  // Same-target reopen keeps membership traversal; the PM half needs a fresh store so the
+  // fixture's per-page revision counter does not outrun its fixed detail revision.
+  store.dispose(); store = new JobMetadataStore(new JobMetadataClient(1000));
   await open(); for (let i = 0; i < 8; i++) await store.advance();
   const pm = metadataJobs(store.getSnapshot()).find(j => j.source === 'harness')!;
   render(<JobMetadataContext.Provider value={store}><MetadataInspection job={pm} /></JobMetadataContext.Provider>);

--- a/webapp/src/__tests__/sessionWorkerUsage.integration.test.tsx
+++ b/webapp/src/__tests__/sessionWorkerUsage.integration.test.tsx
@@ -143,8 +143,8 @@ describe('automatic current headers and session worker usage', () => {
     expect(result.kind === 'present' && expertHeaderModel(result.row.header)).toBe('gpt-6-astra');
   });
   it('rejects unproven or malformed model metadata', () => {
-    expect(() => parseExpertHeader(header({ model_provenance: 'unknown' }))).toThrow();
-    expect(() => parseExpertHeader(header({ model: '' }))).toThrow();
+    expect(parseExpertHeader(header({ model_provenance: 'unknown' }))).toMatchObject({ model: null, model_provenance: 'unknown' });
+    expect(parseExpertHeader(header({ model: '' }))).toMatchObject({ model: null, model_provenance: 'unknown' });
     expect(() => parseExpertHeader({ ...header(), model_provenance: 'history' })).toThrow();
     expect(expertHeaderModel(header({ model: null, model_provenance: 'unknown' }))).toBeNull();
     expect(expertHeaderModel(header({ model: 'codex' }))).toBeNull();

--- a/webapp/src/__tests__/useJobMetadata.traversal.test.ts
+++ b/webapp/src/__tests__/useJobMetadata.traversal.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { JobMetadataClient } from '../lib/jobMetadata';
+import { JobMetadataStore } from '../lib/useJobMetadata';
+import { context, handshake, list, response, token, view } from './jobMetadata.fixtures';
+
+let store: JobMetadataStore;
+let request: ReturnType<typeof vi.fn<(path: string, init?: RequestInit) => Promise<Response>>>;
+
+async function open() {
+  store.setTarget(context);
+  expect(await store.readView()).toBe('applied');
+}
+
+function partialPage(cursor: string) {
+  return { outcome: 'partial' as const, revision: 20, checkpoint: 0, scanned: 51, next_cursor: cursor };
+}
+
+function metadataUrl(path: unknown): URL {
+  return new URL(String(path), 'http://local');
+}
+
+beforeEach(() => {
+  Reflect.deleteProperty(window, 'harnessIPC');
+  request = vi.fn(async (path: string) => path === '/api/endpoint' ? response(handshake) : path.endsWith('/view') ? response(view()) : response(list()));
+  vi.stubGlobal('fetch', request);
+  store = new JobMetadataStore(new JobMetadataClient(1000));
+});
+afterEach(() => { store.dispose(); vi.useRealTimers(); vi.unstubAllGlobals(); });
+
+it('invalidate retains metadata streams and observations; same-generation adopt keeps traversal', async () => {
+  await open();
+  const cursor = token(11);
+  request.mockResolvedValue(response({ ...list([]), page: partialPage(cursor) }));
+  await store.advance();
+  const before = store.getSnapshot();
+  expect(before.streams[0]).toMatchObject({ state: 'partial', traversal: { cursor } });
+  expect(before.observations).toEqual([]);
+
+  store.invalidate();
+  const mid = store.getSnapshot();
+  expect(mid.view).toMatchObject({ kind: 'target', reason: 'invalidated' });
+  expect(mid.streams[0]).toMatchObject({ state: 'partial', traversal: { cursor } });
+  expect(mid.headers).toEqual(before.headers);
+  expect(mid.pins).toEqual(before.pins);
+  expect(mid.detailCache).toEqual(before.detailCache);
+
+  request.mockResolvedValue(response(view()));
+  expect(await store.readView()).toBe('applied');
+  expect(store.getSnapshot().streams[0]).toMatchObject({ state: 'partial', traversal: { cursor } });
+  expect(store.getSnapshot().view.kind).toBe('view');
+});
+
+it('same-target setTarget retains metadata stream traversal like invalidate', async () => {
+  await open();
+  const cursor = token(12);
+  request.mockResolvedValue(response({ ...list([]), page: partialPage(cursor) }));
+  await store.advance();
+  expect(store.getSnapshot().streams[0]).toMatchObject({ state: 'partial', traversal: { cursor } });
+
+  store.setTarget(context);
+  expect(store.getSnapshot().view).toMatchObject({ kind: 'target', reason: 'not_opened' });
+  expect(store.getSnapshot().streams[0]).toMatchObject({ state: 'partial', traversal: { cursor } });
+
+  request.mockResolvedValue(response(view()));
+  expect(await store.readView()).toBe('applied');
+  expect(store.getSnapshot().streams[0]).toMatchObject({ state: 'partial', traversal: { cursor } });
+});
+
+it('liveOnly continues a partial metadata stream cursor across invalidate+readView', async () => {
+  await open();
+  const cursor = token(13);
+  request.mockImplementation(async (path: string) => {
+    if (path === '/api/endpoint') return response(handshake);
+    if (String(path).endsWith('/view')) return response(view());
+    const status = metadataUrl(path).searchParams.get('status');
+    if (status === 'running') {
+      return response({
+        ...list([]),
+        store: { source: 'harness', state_id: 'store-A' },
+        mode: 'snapshot',
+        page: partialPage(cursor),
+      });
+    }
+    if (status === null) {
+      return response({
+        ...list([]),
+        store: { source: 'harness', state_id: 'store-A' },
+        mode: metadataUrl(path).searchParams.get('mode') ?? 'snapshot',
+      });
+    }
+    return response({
+      ...list([]),
+      store: { source: 'harness', state_id: 'store-A' },
+      mode: 'snapshot',
+      page: { outcome: 'unavailable', revision: 0, scanned: 0, checkpoint: 0, next_cursor: null },
+    });
+  });
+
+  for (let i = 0; i < 24; i++) {
+    await store.advance();
+    const streams = store.getSnapshot().streams;
+    const running = streams.find(s => s.stream.status === 'running');
+    const otherActiveOpen = streams.some(s => s.stream.status !== null && s.stream.status !== 'running' && s.state !== 'unavailable');
+    if (running?.state === 'partial' && !otherActiveOpen) break;
+  }
+  expect(store.getSnapshot().streams.find(s => s.stream.status === 'running')).toMatchObject({
+    state: 'partial',
+    traversal: { cursor },
+  });
+
+  store.invalidate();
+  request.mockImplementation(async (path: string) => {
+    if (path === '/api/endpoint') return response(handshake);
+    if (String(path).endsWith('/view')) return response(view());
+    const status = metadataUrl(path).searchParams.get('status');
+    if (status === 'running') {
+      return response({
+        ...list([]),
+        store: { source: 'harness', state_id: 'store-A' },
+        mode: 'snapshot',
+        page: partialPage(token(99)),
+      });
+    }
+    return response({
+      ...list([]),
+      store: { source: 'harness', state_id: 'store-A' },
+      mode: metadataUrl(path).searchParams.get('mode') ?? 'snapshot',
+      page: { outcome: 'unavailable', revision: 0, scanned: 0, checkpoint: 0, next_cursor: null },
+    });
+  });
+  expect(await store.readView()).toBe('applied');
+  expect(store.getSnapshot().streams.find(s => s.stream.status === 'running')).toMatchObject({
+    state: 'partial',
+    traversal: { cursor },
+  });
+
+  request.mockClear();
+  expect(await store.advance(false, { liveOnly: true })).toBe('applied');
+  const continued = request.mock.calls
+    .map(([path]) => metadataUrl(path))
+    .find(url => url.pathname === '/api/jobs/metadata' && url.searchParams.get('status') === 'running');
+  expect(continued).toBeTruthy();
+  expect(continued?.searchParams.get('cursor')).toBe(cursor);
+});
+
+it('changed metadata view_generation after view_changed rebuilds traversal from page 1', async () => {
+  await open();
+  const cursor = token(14);
+  request.mockResolvedValue(response({ ...list([]), page: partialPage(cursor) }));
+  await store.advance();
+  expect(store.getSnapshot().streams[0]).toMatchObject({ state: 'partial', traversal: { cursor } });
+
+  request.mockResolvedValue(response({ code: 'view_changed' }, 409));
+  expect(await store.advance()).toBe('failed');
+  expect(store.getSnapshot().view).toMatchObject({ kind: 'target', reason: 'view_changed' });
+
+  request.mockResolvedValue(response(view('generation-2')));
+  expect(await store.readView()).toBe('applied');
+  expect(store.getSnapshot().streams[0]).toMatchObject({
+    state: 'ready',
+    traversal: { mode: 'snapshot', after_revision: 0, cursor: null },
+  });
+});

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -126,6 +126,8 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
     ? native?.summaryFreshness === 'observed'
     : listed?.freshness === 'observed');
   const initialPMRead = useRef(false);
+  const pmHydrateAttempts = useRef(0);
+  const pmHydrateKey = useRef('');
   const inspect = (lane: LocalDetail['lane'] = 'actions') => {
     if (compact) return;
     revealInspection();
@@ -138,8 +140,19 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
     }
   };
   const hydratePM = selectedPM ?? canonicalSelection;
+  const hydrateKey = hydratePM ? metadataSelectionKey(hydratePM) : '';
   useEffect(() => {
-    if (deferAutoRead || initialPMRead.current || !hydratePM || detail?.observation || state.working || state.view.kind !== 'view') return;
+    if (hydrateKey !== pmHydrateKey.current) {
+      pmHydrateKey.current = hydrateKey;
+      initialPMRead.current = false;
+      pmHydrateAttempts.current = 0;
+    }
+  }, [hydrateKey]);
+  useEffect(() => {
+    if (deferAutoRead || !hydratePM || detail?.observation || detail?.error || state.view.kind !== 'view') return;
+    if (state.working) return;
+    if (pmHydrateAttempts.current >= 8) return;
+    pmHydrateAttempts.current += 1;
     initialPMRead.current = true;
     try {
       store.select(hydratePM);
@@ -147,7 +160,28 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
     } catch {
       initialPMRead.current = false;
     }
-  }, [hydratePM, detail?.observation, state.working, state.view, store]);
+  }, [deferAutoRead, hydratePM, detail?.observation, detail?.error, state.working, state.view, store]);
+  useEffect(() => {
+    if (deferAutoRead || !hydratePM || detail?.observation || detail?.error || state.view.kind !== 'view') return;
+    if (pmHydrateAttempts.current >= 8) return;
+    const timer = window.setInterval(() => {
+      if (pmHydrateAttempts.current >= 8) return;
+      const snap = store.getSnapshot();
+      if (snap.working || snap.view.kind !== 'view') return;
+      const key = metadataSelectionKey(hydratePM);
+      const current = snap.detail.kind === 'selected' && metadataSelectionKey(snap.detail.selection) === key ? snap.detail : snap.detailCache[key];
+      if (current?.observation || current?.error) return;
+      pmHydrateAttempts.current += 1;
+      initialPMRead.current = true;
+      try {
+        store.select(hydratePM);
+        void store.readDetail();
+      } catch {
+        initialPMRead.current = false;
+      }
+    }, 2000);
+    return () => window.clearInterval(timer);
+  }, [deferAutoRead, hydratePM, detail?.observation, detail?.error, state.view, store]);
   const initialNativeRead = useRef(false);
   const initialRoutingRead = useRef(false);
   useEffect(() => {
@@ -227,13 +261,24 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
   );
   const expert = currentExpert(state, expertKey);
   const nativeRows = native?.tasks?.rows ?? [];
-  const expertRows = nativeRows.length === 0 && expert && expert.kind !== 'unavailable' ? expert.tasks : [];
+  const preferCanonicalRoster = !!canonical && !!expert && expert.kind !== 'unavailable' && expert.tasks.length > 0;
+  const expertRows = (preferCanonicalRoster || nativeRows.length === 0) && expert && expert.kind !== 'unavailable' ? expert.tasks : [];
   const taskStatusById = new Map((observation?.tasks.rows ?? []).map(task => [task.id, task.status ?? 'unknown']));
-  const adapter = nativeSummary?.display?.adapter || nativeRows[0]?.adapter || expertRows[0]?.adapter || '';
+  for (const task of expertRows) {
+    if (!taskStatusById.has(task.id)) taskStatusById.set(task.id, observation?.lifecycle ?? job.status);
+  }
+  const headerJobId = canonical?.job_ref.job_id ?? job.id;
+  const canonicalGoal = observation?.display?.kind === 'available' ? observation.display.goal_preview : undefined;
+  const instructionFallback = native?.observation?.selected_context?.request?.text?.trim() || undefined;
+  const cardTitle = canonicalGoal || (canonical ? instructionFallback : undefined) || jobDisplayTitle(job);
+  const adapter = (preferCanonicalRoster ? expertRows[0]?.adapter : undefined)
+    || nativeSummary?.display?.adapter || nativeRows[0]?.adapter || expertRows[0]?.adapter || '';
   const activityAt = nativeSummary && nativeActiveStatuses.includes(nativeSummary.lifecycle)
     ? nativeSummary.updated_at ?? nativeSummary.created_at : null;
   const since = relativeSince(activityAt, now);
-  const workerCount = nativeRows.length || expertRows.length || nativeSummary?.task_count || 0;
+  const workerCount = preferCanonicalRoster
+    ? expertRows.length
+    : nativeRows.length || expertRows.length || nativeSummary?.task_count || 0;
   const workerKill = local && view.kind === 'view' && job.session_id === view.context.session_id ? {
     disabled: !nativeSelection || !nativeFresh || (nativeSummary != null && terminal.has(nativeSummary.lifecycle)) || state.working || stopping,
     request: () => void nativeStop(),
@@ -285,9 +330,10 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
     </> : null;
   return <div className="px-2 pb-2 pt-1 flex flex-col gap-2 bg-panel2/10 text-xs text-muted">
     <div className="flex flex-col gap-1.5 border-b border-edge/20 pb-2">
-      <button className="self-start font-mono text-[9px] text-faint hover:text-muted" aria-label={`Job ${job.id}`} onClick={() => {
-        void navigator.clipboard.writeText(job.id).then(() => setNotice('Job ID copied.'), () => setNotice('Unable to copy job ID.'));
-      }}>Job {job.id}</button>
+      {canonical && cardTitle && <p className="text-[11px] font-semibold text-txt break-words">{cardTitle}</p>}
+      <button className="self-start font-mono text-[9px] text-faint hover:text-muted" aria-label={`Job ${headerJobId}`} onClick={() => {
+        void navigator.clipboard.writeText(headerJobId).then(() => setNotice('Job ID copied.'), () => setNotice('Unable to copy job ID.'));
+      }}>Job {headerJobId}</button>
       {compact && !showDump && <ExpertCost header={costHeader} now={now} compact />}
       {adapter && <p className="text-faint lowercase">{adapter}</p>}
       {since && <div className="flex items-center gap-1 text-[9px] text-faint tabular-nums">
@@ -296,17 +342,26 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
       </div>}
     </div>
     {workerCount > 0 && <CompactSwarmDashboard
-      title={jobDisplayTitle(job)} lifecycle={nativeSummary?.lifecycle ?? job.status}
-      workerStatuses={taskStatusById} expert={expert && expert.kind !== 'unavailable' ? expert : undefined}
+      title={cardTitle} lifecycle={observation?.lifecycle ?? nativeSummary?.lifecycle ?? job.status}
+      workerStatuses={taskStatusById}
+      expert={(preferCanonicalRoster || nativeRows.length === 0) && expert && expert.kind !== 'unavailable' ? expert : undefined}
       headerModel={expertHeaderModel(currentHeader(state, expertKey)) ?? nativeSummary?.display?.model ?? undefined}
-      nativeTasks={nativeRows} nativeRoutes={nativeRouteByTask} routeCoverage={nativeRows.length ? nativeRouteCoverage : undefined}
-      artifactCount={nativeSummary?.artifact_count ?? observation?.artifact_count ?? null}
-      workerCount={nativeSummary?.task_count ?? observation?.task_count ?? job.task_count ?? null}
-      workerCoverage={local ? nativeFresh && native?.tasks?.page.outcome === 'complete'
+      nativeTasks={preferCanonicalRoster ? undefined : nativeRows}
+      nativeRoutes={preferCanonicalRoster ? undefined : nativeRouteByTask}
+      routeCoverage={preferCanonicalRoster ? undefined : (nativeRows.length ? nativeRouteCoverage : undefined)}
+      artifactCount={preferCanonicalRoster
+        ? (observation?.artifact_count ?? expert?.artifacts.filter(a => a.type.toUpperCase() !== 'ROUTING').length ?? null)
+        : (nativeSummary?.artifact_count ?? observation?.artifact_count ?? null)}
+      workerCount={preferCanonicalRoster
+        ? (observation?.task_count ?? expert?.header?.selected_workers ?? expertRows.length)
+        : (nativeSummary?.task_count ?? observation?.task_count ?? job.task_count ?? null)}
+      workerCoverage={preferCanonicalRoster
+        ? (expert?.coverage.tasks === 'complete' ? 'complete' : 'partial')
+        : local ? nativeFresh && native?.tasks?.page.outcome === 'complete'
         && native.tasks.page.revision === nativeSummary?.revision ? 'complete' : 'partial'
         : expert?.coverage.tasks === 'complete' ? 'complete' : 'partial'}
       usage={costHeader?.usage?.tokens ?? (nativeSummary?.usage?.kind === 'reported' ? nativeSummary.usage.tokens : null)}
-      cancel={nativeRows.length ? workerKill : undefined}
+      cancel={preferCanonicalRoster ? undefined : (nativeRows.length ? workerKill : undefined)}
     />}
     {compact && onOpenDashboard && <div className="flex flex-wrap gap-1">
       <button type="button" className={button} onClick={onOpenDashboard}>See in Puppetmaster dashboard</button>
@@ -467,10 +522,22 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   const hidden = scoped.filter(j => !isActive(j) && !isNativeActivity(j) && preferences.dismissed.includes(j.metadata_key ?? ''));
   const createdAt = new Map(state.local.observations.map(o => [localKey(o.row.local_ref), o.row.created_at]));
   for (const job of jobs) {
-    const date = currentHeader(state, job.metadata_key ?? '')?.created_at;
+    const listedLocal = job.local_ref
+      ? state.local.observations.find(o => localKey(o.row.local_ref) === localKey(job.local_ref!))?.row : undefined;
+    const key = expertLookupKey(job.metadata_key, listedLocal?.canonical, state.view.kind === 'view' ? state.view.context.repo : undefined);
+    const date = currentHeader(state, key)?.created_at;
     if (date) createdAt.set(job.metadata_key ?? '', Date.parse(date));
   }
-  const quality = (job: Job) => { const expert = currentExpert(state, job.metadata_key ?? ''); return expert ? expertJobQuality(expert) : currentHeader(state, job.metadata_key ?? '')?.quality ?? 'unverified'; };
+  const quality = (job: Job) => {
+    const listedLocal = job.local_ref
+      ? state.local.observations.find(o => localKey(o.row.local_ref) === localKey(job.local_ref!))?.row
+        ?? (state.localDetail?.observation?.summary && localKey(state.localDetail.selection) === localKey(job.local_ref)
+          ? state.localDetail.observation.summary : undefined)
+      : undefined;
+    const key = expertLookupKey(job.metadata_key, listedLocal?.canonical, state.view.kind === 'view' ? state.view.context.repo : undefined);
+    const expert = currentExpert(state, key);
+    return expert ? expertJobQuality(expert) : currentHeader(state, key)?.quality ?? 'unverified';
+  };
   const selectedSummary = state.localDetail?.observation?.summary;
   if (selectedSummary && !createdAt.has(localKey(selectedSummary.local_ref))) createdAt.set(localKey(selectedSummary.local_ref), selectedSummary.created_at);
   const shown = scoped.filter(j => !hidden.includes(j)).filter(j => {
@@ -525,9 +592,15 @@ function ObservedJobs({ enabled, preferenceKey }: { enabled: boolean; preference
   };
   const renderJob = (job: Job) => {
     const key = job.metadata_key ?? '', title = jobDisplayTitle(job), open = preferences.expanded.includes(key);
-    const expert = currentExpert(state, key), model = (expert ? expertJobModel(expert) : null) ?? expertHeaderModel(currentHeader(state, key));
+    const listedLocal = job.local_ref
+      ? state.local.observations.find(o => localKey(o.row.local_ref) === localKey(job.local_ref!))?.row
+        ?? (state.localDetail?.observation?.summary && localKey(state.localDetail.selection) === localKey(job.local_ref)
+          ? state.localDetail.observation.summary : undefined)
+      : undefined;
+    const expertKey = expertLookupKey(key, listedLocal?.canonical, state.view.kind === 'view' ? state.view.context.repo : undefined);
+    const expert = currentExpert(state, expertKey), model = (expert ? expertJobModel(expert) : null) ?? expertHeaderModel(currentHeader(state, expertKey));
     const routing = expert && expert.kind !== 'unavailable' && expert.coverage.tasks === 'complete' && expert.tasks.length === 0 && isLiveObservation(job) && !model;
-    const header = currentHeader(state, key);
+    const header = currentHeader(state, expertKey);
     const workerCount = header?.selected_workers;
     const finishedWorkers = header?.completed_workers;
     const showWorkerProgress = workerCount !== undefined && workerCount > 0 && finishedWorkers !== undefined;

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -126,8 +126,6 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
     ? native?.summaryFreshness === 'observed'
     : listed?.freshness === 'observed');
   const initialPMRead = useRef(false);
-  const pmHydrateAttempts = useRef(0);
-  const pmHydrateKey = useRef('');
   const inspect = (lane: LocalDetail['lane'] = 'actions') => {
     if (compact) return;
     revealInspection();
@@ -139,49 +137,40 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
       void store.readDetail();
     }
   };
-  const hydratePM = selectedPM ?? canonicalSelection;
-  const hydrateKey = hydratePM ? metadataSelectionKey(hydratePM) : '';
   useEffect(() => {
-    if (hydrateKey !== pmHydrateKey.current) {
-      pmHydrateKey.current = hydrateKey;
-      initialPMRead.current = false;
-      pmHydrateAttempts.current = 0;
-    }
-  }, [hydrateKey]);
-  useEffect(() => {
-    if (deferAutoRead || !hydratePM || detail?.observation || detail?.error || state.view.kind !== 'view') return;
-    if (state.working) return;
-    if (pmHydrateAttempts.current >= 8) return;
-    pmHydrateAttempts.current += 1;
+    if (deferAutoRead || initialPMRead.current || !selectedPM || detail?.observation || state.working || state.view.kind !== 'view') return;
     initialPMRead.current = true;
     try {
-      store.select(hydratePM);
+      store.select(selectedPM);
       void store.readDetail();
     } catch {
       initialPMRead.current = false;
     }
-  }, [deferAutoRead, hydratePM, detail?.observation, detail?.error, state.working, state.view, store]);
+  }, [deferAutoRead, selectedPM, detail?.observation, state.working, state.view, store]);
+  // A local alias with a canonical PM ref hydrates that job cache-only: it never takes over
+  // the selection and re-attempts whenever the store settles idle without an observation
+  // or error for the key (at most every 2s), so a reset after invalidate cannot strand it.
+  const canonicalKey = !selectedPM && canonicalSelection ? metadataSelectionKey(canonicalSelection) : '';
+  const canonicalRef = useRef(canonicalSelection);
+  canonicalRef.current = canonicalSelection;
   useEffect(() => {
-    if (deferAutoRead || !hydratePM || detail?.observation || detail?.error || state.view.kind !== 'view') return;
-    if (pmHydrateAttempts.current >= 8) return;
-    const timer = window.setInterval(() => {
-      if (pmHydrateAttempts.current >= 8) return;
+    if (deferAutoRead || !canonicalKey || state.view.kind !== 'view') return;
+    let last: number | null = null;
+    const attempt = () => {
+      const selection = canonicalRef.current;
       const snap = store.getSnapshot();
-      if (snap.working || snap.view.kind !== 'view') return;
-      const key = metadataSelectionKey(hydratePM);
-      const current = snap.detail.kind === 'selected' && metadataSelectionKey(snap.detail.selection) === key ? snap.detail : snap.detailCache[key];
+      if (!selection || snap.working || snap.view.kind !== 'view') return;
+      const current = snap.detail.kind === 'selected' && metadataSelectionKey(snap.detail.selection) === canonicalKey
+        ? snap.detail : snap.detailCache[canonicalKey];
       if (current?.observation || current?.error) return;
-      pmHydrateAttempts.current += 1;
-      initialPMRead.current = true;
-      try {
-        store.select(hydratePM);
-        void store.readDetail();
-      } catch {
-        initialPMRead.current = false;
-      }
-    }, 2000);
-    return () => window.clearInterval(timer);
-  }, [deferAutoRead, hydratePM, detail?.observation, detail?.error, state.view, store]);
+      const at = Date.now();
+      if (last !== null && at - last < 2000) return;
+      last = at;
+      void store.hydrateDetail(selection);
+    };
+    attempt();
+    return store.subscribe(attempt);
+  }, [deferAutoRead, canonicalKey, state.view.kind, store]);
   const initialNativeRead = useRef(false);
   const initialRoutingRead = useRef(false);
   useEffect(() => {
@@ -212,7 +201,7 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
     store.select(selectedPM);
     void store.readDetail();
   }, [compact, deferAutoRead, navigation, selectedPM, state.working, state.view, store]);
-  const observation = hydratePM ? detail?.observation : undefined;
+  const observation = selectedPM ?? canonicalSelection ? detail?.observation : undefined;
   const detailFresh = detail?.freshness === 'observed' && (!observation?.expert || !!currentExpert(state, metadataSelectionKey(observation.selection)));
   const bindings = observation?.tasks.rows.flatMap(t => t.binding ? [t.binding] : []) ?? [];
   const authorizedJob: Job = { ...job, unavailable_fields: ['artifacts'], cancellation_view:

--- a/webapp/src/lib/expertMetadata.ts
+++ b/webapp/src/lib/expertMetadata.ts
@@ -16,91 +16,114 @@ export type ExpertArtifact = { id: string; task_id: string | null; type: string;
 export type ExpertMetadata = { kind: 'available' | 'partial' | 'unavailable'; reason: string | null; header: ExpertHeader | null; live_economics?: ExpertHeader | null; compaction?: { coverage: 'complete' | 'partial' | 'unavailable'; reason: string };
   tasks: ExpertTask[]; artifacts: ExpertArtifact[]; coverage: { tasks: 'complete' | 'partial' | 'unknown'; artifacts: 'complete' | 'partial' | 'unknown' };
   quality: 'ok' | 'degraded' | 'unverified' };
-function invalid(): never { throw new Error('invalid_metadata'); }
-function object(value: unknown, keys?: string[], optional: string[] = []): Record<string, unknown> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return invalid();
+function invalid(detail?: string): never {
+  const error = new Error(detail ? `invalid_metadata:${detail}` : 'invalid_metadata');
+  if (detail) (error as Error & { detail?: string }).detail = detail;
+  throw error;
+}
+function object(value: unknown, keys?: string[], optional: string[] = [], path = 'object'): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return invalid(path);
   const result = Object.fromEntries(Object.entries(value));
-  if (keys && (keys.some(key => !Object.hasOwn(result, key)) || Object.keys(result).some(key => !keys.includes(key) && !optional.includes(key)))) return invalid();
+  if (keys && (keys.some(key => !Object.hasOwn(result, key)) || Object.keys(result).some(key => !keys.includes(key) && !optional.includes(key)))) return invalid(path);
   return result;
 }
-function string(value: unknown): string { if (typeof value !== 'string' || new TextEncoder().encode(value).length > 16384) return invalid(); return value; }
-function nullableString(value: unknown): string | null { return value === null ? null : string(value); }
-function number(value: unknown): number | null { if (value === null) return null; if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return invalid(); return value; }
-function boolean(value: unknown): boolean { if (typeof value !== 'boolean') return invalid(); return value; }
-function choice<T extends string>(value: unknown, choices: readonly T[]): T { for (const item of choices) if (value === item) return item; return invalid(); }
-function rows<T>(value: unknown, parse: (value: unknown) => T, max = 50): T[] { if (!Array.isArray(value) || value.length > max) return invalid(); return value.map(parse); }
-function count(value: unknown): number { const n = number(value); if (n === null || !Number.isSafeInteger(n)) return invalid(); return n; }
-function nullableCount(value: unknown): number | null { return value === null ? null : count(value); }
-function timestamp(value: unknown): string | null { const s = nullableString(value); if (s !== null && (s.length > 64 || !/(Z|[+-]\d{2}:\d{2})$/.test(s) || !Number.isFinite(Date.parse(s)))) return invalid(); return s; }
+function string(value: unknown, path = 'string'): string { if (typeof value !== 'string' || new TextEncoder().encode(value).length > 16384) return invalid(path); return value; }
+function nullableString(value: unknown, path = 'string'): string | null { return value === null ? null : string(value, path); }
+function number(value: unknown, path = 'number'): number | null { if (value === null) return null; if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return invalid(path); return value; }
+function boolean(value: unknown, path = 'boolean'): boolean { if (typeof value !== 'boolean') return invalid(path); return value; }
+function choice<T extends string>(value: unknown, choices: readonly T[], path = 'choice'): T { for (const item of choices) if (value === item) return item; return invalid(path); }
+function rows<T>(value: unknown, parse: (value: unknown) => T, max = 50, path = 'rows'): T[] { if (!Array.isArray(value) || value.length > max) return invalid(path); return value.map(parse); }
+function count(value: unknown, path = 'count'): number { const n = number(value, path); if (n === null || !Number.isSafeInteger(n)) return invalid(path); return n; }
+function nullableCount(value: unknown, path = 'count'): number | null { return value === null ? null : count(value, path); }
+function timestamp(value: unknown, path = 'timestamp'): string | null {
+  const s = nullableString(value, path);
+  if (s !== null && (s.length > 64 || !/(Z|[+-]\d{2}:\d{2})$/.test(s) || !Number.isFinite(Date.parse(s)))) return null;
+  return s;
+}
 export function parseExpertHeader(value: unknown): ExpertHeader | null {
   if (value === null) return null;
-  const v = object(value, ['created_at', 'completed_at', 'cost'], ['updated_at', 'latest_task_updated_at', 'completed_workers', 'selected_workers', 'workers_complete', 'usage', 'savings', 'quality', 'model', 'model_provenance']);
-  const c = object(v.cost, ['selected_usd', 'source', 'basis', 'measured_cost_usd', 'estimated_cost_usd'], ['plan_workers', 'complete']);
-  const header: ExpertHeader = { created_at: timestamp(v.created_at), completed_at: timestamp(v.completed_at), cost: {
-    selected_usd: number(c.selected_usd), source: choice(c.source, ['terminal_cost_receipt', 'selected_current_records', 'unavailable']),
-    basis: choice(c.basis, ['measured', 'estimated', 'mixed', 'plan', 'unknown']), measured_cost_usd: number(c.measured_cost_usd), estimated_cost_usd: number(c.estimated_cost_usd),
+  const v = object(value, ['created_at', 'completed_at', 'cost'], ['updated_at', 'latest_task_updated_at', 'completed_workers', 'selected_workers', 'workers_complete', 'usage', 'savings', 'quality', 'model', 'model_provenance'], 'header');
+  const c = object(v.cost, ['selected_usd', 'source', 'basis', 'measured_cost_usd', 'estimated_cost_usd'], ['plan_workers', 'complete'], 'header.cost');
+  const header: ExpertHeader = { created_at: timestamp(v.created_at, 'header.created_at'), completed_at: timestamp(v.completed_at, 'header.completed_at'), cost: {
+    selected_usd: number(c.selected_usd, 'header.cost.selected_usd'), source: choice(c.source, ['terminal_cost_receipt', 'selected_current_records', 'unavailable'], 'header.cost.source'),
+    basis: choice(c.basis, ['measured', 'estimated', 'mixed', 'plan', 'unknown'], 'header.cost.basis'), measured_cost_usd: number(c.measured_cost_usd, 'header.cost.measured_cost_usd'), estimated_cost_usd: number(c.estimated_cost_usd, 'header.cost.estimated_cost_usd'),
   } };
-  if (header.cost.source === 'unavailable' && (header.cost.selected_usd !== null || header.cost.measured_cost_usd !== null || header.cost.estimated_cost_usd !== null)) return invalid();
+  if (header.cost.source === 'unavailable' && (header.cost.selected_usd !== null || header.cost.measured_cost_usd !== null || header.cost.estimated_cost_usd !== null)) return invalid('header.cost.source');
   if (v.model !== undefined || v.model_provenance !== undefined) {
-    header.model = nullableString(v.model);
-    header.model_provenance = choice(v.model_provenance, ['job_routing', 'task_assignment', 'uniform_task_assignments', 'unknown'] as const);
-    if (header.model !== null && (!header.model.trim() || header.model.length > 256 || /[\u0000-\u001f]/.test(header.model))) return invalid();
-    if ((header.model === null) !== (header.model_provenance === 'unknown')) return invalid();
+    let model = nullableString(v.model, 'header.model');
+    let provenance = choice(v.model_provenance, ['job_routing', 'task_assignment', 'uniform_task_assignments', 'unknown'] as const, 'header.model_provenance');
+    if (model !== null && (!model.trim() || model.length > 256 || /[\u0000-\u001f]/.test(model))) { model = null; provenance = 'unknown'; }
+    if ((model === null) !== (provenance === 'unknown')) { model = null; provenance = 'unknown'; }
+    header.model = model;
+    header.model_provenance = provenance;
   }
-  if (v.quality !== undefined) header.quality = choice(v.quality, ['ok', 'degraded', 'unverified'] as const);
-  if (v.updated_at !== undefined) header.updated_at = timestamp(v.updated_at);
-  if (v.latest_task_updated_at !== undefined) header.latest_task_updated_at = timestamp(v.latest_task_updated_at);
+  if (v.quality !== undefined) header.quality = choice(v.quality, ['ok', 'degraded', 'unverified'] as const, 'header.quality');
+  if (v.updated_at !== undefined) header.updated_at = timestamp(v.updated_at, 'header.updated_at');
+  if (v.latest_task_updated_at !== undefined) header.latest_task_updated_at = timestamp(v.latest_task_updated_at, 'header.latest_task_updated_at');
   if (v.usage !== undefined) {
-    const u = object(v.usage, ['tokens', 'tokens_known_workers', 'cost_known_workers', 'selected_workers', 'complete']);
-    header.completed_workers = count(v.completed_workers); header.selected_workers = count(v.selected_workers); header.workers_complete = boolean(v.workers_complete);
-    header.usage = { tokens: nullableCount(u.tokens), tokens_known_workers: count(u.tokens_known_workers), cost_known_workers: count(u.cost_known_workers), selected_workers: count(u.selected_workers), complete: boolean(u.complete) };
-    header.cost.complete = boolean(c.complete); header.cost.plan_workers = count(c.plan_workers);
-    const a = object(v.savings, ['routing_usd', 'cache_usd', 'compaction_usd', 'compact_tokens', 'selected_usd', 'basis', 'source']);
-    header.savings = { routing_usd: number(a.routing_usd), cache_usd: number(a.cache_usd), compaction_usd: number(a.compaction_usd), compact_tokens: nullableCount(a.compact_tokens), selected_usd: number(a.selected_usd), basis: choice(a.basis, ['estimated']), source: choice(a.source, ['selected_current_records']) };
-    if (header.completed_workers > header.selected_workers || header.usage.selected_workers !== header.selected_workers || header.usage.tokens_known_workers > header.selected_workers || header.usage.cost_known_workers > header.selected_workers || header.cost.plan_workers > header.selected_workers || header.cost.source !== 'selected_current_records') return invalid();
-  } else if (['completed_workers', 'selected_workers', 'workers_complete', 'savings'].some(key => v[key] !== undefined) || c.source === 'selected_current_records' || c.complete !== undefined || c.plan_workers !== undefined) return invalid();
+    const u = object(v.usage, ['tokens', 'tokens_known_workers', 'cost_known_workers', 'selected_workers', 'complete'], [], 'header.usage');
+    header.completed_workers = count(v.completed_workers, 'header.completed_workers'); header.selected_workers = count(v.selected_workers, 'header.selected_workers'); header.workers_complete = boolean(v.workers_complete, 'header.workers_complete');
+    header.usage = { tokens: nullableCount(u.tokens, 'header.usage.tokens'), tokens_known_workers: count(u.tokens_known_workers, 'header.usage.tokens_known_workers'), cost_known_workers: count(u.cost_known_workers, 'header.usage.cost_known_workers'), selected_workers: count(u.selected_workers, 'header.usage.selected_workers'), complete: boolean(u.complete, 'header.usage.complete') };
+    header.cost.complete = boolean(c.complete, 'header.cost.complete'); header.cost.plan_workers = count(c.plan_workers, 'header.cost.plan_workers');
+    const a = object(v.savings, ['routing_usd', 'cache_usd', 'compaction_usd', 'compact_tokens', 'selected_usd', 'basis', 'source'], [], 'header.savings');
+    header.savings = { routing_usd: number(a.routing_usd, 'header.savings.routing_usd'), cache_usd: number(a.cache_usd, 'header.savings.cache_usd'), compaction_usd: number(a.compaction_usd, 'header.savings.compaction_usd'), compact_tokens: nullableCount(a.compact_tokens, 'header.savings.compact_tokens'), selected_usd: number(a.selected_usd, 'header.savings.selected_usd'), basis: choice(a.basis, ['estimated'], 'header.savings.basis'), source: choice(a.source, ['selected_current_records'], 'header.savings.source') };
+    if (header.completed_workers > header.selected_workers || header.usage.selected_workers !== header.selected_workers || header.usage.tokens_known_workers > header.selected_workers || header.usage.cost_known_workers > header.selected_workers || header.cost.plan_workers > header.selected_workers || header.cost.source !== 'selected_current_records') return invalid('header.usage');
+  } else if (['completed_workers', 'selected_workers', 'workers_complete', 'savings'].some(key => v[key] !== undefined) || c.source === 'selected_current_records' || c.complete !== undefined || c.plan_workers !== undefined) return invalid('header.usage');
   return header;
 }
 export function parseExpertMetadata(value: unknown, references?: readonly Pick<ExpertArtifact, 'id' | 'task_id'>[]): ExpertMetadata {
-  const v = object(value, ['kind', 'reason', 'header', 'tasks', 'artifacts', 'coverage', 'quality'], ['live_economics', 'economics', 'compaction']), coverage = object(v.coverage, ['tasks', 'artifacts']);
+  const v = object(value, ['kind', 'reason', 'header', 'tasks', 'artifacts', 'coverage', 'quality'], ['live_economics', 'economics', 'compaction'], 'expert'), coverage = object(v.coverage, ['tasks', 'artifacts'], [], 'expert.coverage');
   const parsed: ExpertMetadata = {
-    kind: choice(v.kind, ['available', 'partial', 'unavailable']), reason: nullableString(v.reason), header: parseExpertHeader(v.header), ...(v.live_economics === undefined ? {} : { live_economics: parseExpertHeader(v.live_economics) }),
-    tasks: rows(v.tasks, value => { const t = object(value, ['id', 'role', 'instruction', 'instruction_truncated', 'adapter', 'model', 'created_at', 'updated_at', 'usage']), u = object(t.usage, ['tokens_in', 'tokens_out', 'est_cost_usd', 'estimated', 'cost_provenance'], ['tokens', 'source_artifact_id', 'route_forecast_usd', 'plan_billed']); return {
-      id: string(t.id), role: string(t.role), instruction: string(t.instruction), instruction_truncated: boolean(t.instruction_truncated),
-      adapter: string(t.adapter), model: nullableString(t.model), created_at: timestamp(t.created_at), updated_at: timestamp(t.updated_at),
-      usage: { tokens_in: nullableCount(u.tokens_in), tokens_out: nullableCount(u.tokens_out), est_cost_usd: number(u.est_cost_usd), estimated: u.estimated === null ? null : boolean(u.estimated), cost_provenance: nullableString(u.cost_provenance), ...(u.route_forecast_usd === undefined ? {} : { route_forecast_usd: number(u.route_forecast_usd) }), ...(u.plan_billed === undefined ? {} : { plan_billed: boolean(u.plan_billed) }), ...(u.tokens === undefined ? {} : { tokens: nullableCount(u.tokens) }), ...(u.source_artifact_id === undefined ? {} : { source_artifact_id: nullableString(u.source_artifact_id) }) },
-    }; }),
-    artifacts: rows(v.artifacts, value => { const a = object(value, ['id', 'task_id', 'type', 'created_by', 'created_at', 'headline', 'detail', 'result', 'failure', 'confidence', 'model', 'adapter', 'policy', 'provider', 'role', 'est_cost_usd', 'rejected', 'check_result']); return {
-      id: string(a.id), task_id: nullableString(a.task_id), type: string(a.type), created_by: string(a.created_by), created_at: timestamp(a.created_at),
-      headline: string(a.headline), detail: nullableString(a.detail), result: nullableString(a.result), failure: nullableString(a.failure), confidence: number(a.confidence),
-      model: nullableString(a.model), adapter: nullableString(a.adapter), policy: nullableString(a.policy), provider: nullableString(a.provider), role: nullableString(a.role), est_cost_usd: number(a.est_cost_usd),
-      rejected: rows(a.rejected, value => { const r = object(value, ['model', 'reason']); return { model: string(r.model), reason: string(r.reason) }; }, 32),
-      check_result: choice(a.check_result, ['passed', 'failed', 'unavailable']),
-    }; }),
-    coverage: { tasks: choice(coverage.tasks, ['complete', 'partial', 'unknown']), artifacts: choice(coverage.artifacts, ['complete', 'partial', 'unknown']) },
-    quality: choice(v.quality, ['ok', 'degraded', 'unverified']),
+    kind: choice(v.kind, ['available', 'partial', 'unavailable'], 'expert.kind'), reason: nullableString(v.reason, 'expert.reason'), header: parseExpertHeader(v.header), ...(v.live_economics === undefined ? {} : { live_economics: parseExpertHeader(v.live_economics) }),
+    tasks: rows(v.tasks, value => { const t = object(value, ['id', 'role', 'instruction', 'instruction_truncated', 'adapter', 'model', 'created_at', 'updated_at', 'usage'], [], 'expert.task'), u = object(t.usage, ['tokens_in', 'tokens_out', 'est_cost_usd', 'estimated', 'cost_provenance'], ['tokens', 'source_artifact_id', 'route_forecast_usd', 'plan_billed'], 'expert.task.usage');
+      let model = nullableString(t.model, 'expert.task.model');
+      if (model !== null && !model.trim()) model = null;
+      return {
+      id: string(t.id, 'expert.task.id'), role: string(t.role, 'expert.task.role'), instruction: string(t.instruction, 'expert.task.instruction'), instruction_truncated: boolean(t.instruction_truncated, 'expert.task.instruction_truncated'),
+      adapter: string(t.adapter, 'expert.task.adapter'), model, created_at: timestamp(t.created_at, 'expert.task.created_at'), updated_at: timestamp(t.updated_at, 'expert.task.updated_at'),
+      usage: { tokens_in: nullableCount(u.tokens_in, 'expert.task.usage.tokens_in'), tokens_out: nullableCount(u.tokens_out, 'expert.task.usage.tokens_out'), est_cost_usd: number(u.est_cost_usd, 'expert.task.usage.est_cost_usd'), estimated: u.estimated === null ? null : boolean(u.estimated, 'expert.task.usage.estimated'), cost_provenance: nullableString(u.cost_provenance, 'expert.task.usage.cost_provenance'), ...(u.route_forecast_usd === undefined ? {} : { route_forecast_usd: number(u.route_forecast_usd, 'expert.task.usage.route_forecast_usd') }), ...(u.plan_billed === undefined ? {} : { plan_billed: boolean(u.plan_billed, 'expert.task.usage.plan_billed') }), ...(u.tokens === undefined ? {} : { tokens: nullableCount(u.tokens, 'expert.task.usage.tokens') }), ...(u.source_artifact_id === undefined ? {} : { source_artifact_id: nullableString(u.source_artifact_id, 'expert.task.usage.source_artifact_id') }) },
+    }; }, 50, 'expert.tasks'),
+    artifacts: rows(v.artifacts, value => { const a = object(value, ['id', 'task_id', 'type', 'created_by', 'created_at', 'headline', 'detail', 'result', 'failure', 'confidence', 'model', 'adapter', 'policy', 'provider', 'role', 'est_cost_usd', 'rejected', 'check_result'], [], 'expert.artifact');
+      const confidence = number(a.confidence, 'expert.artifact.confidence');
+      const check = a.check_result === 'passed' || a.check_result === 'failed' || a.check_result === 'unavailable'
+        ? a.check_result : 'unavailable';
+      return {
+      id: string(a.id, 'expert.artifact.id'), task_id: nullableString(a.task_id, 'expert.artifact.task_id'), type: string(a.type, 'expert.artifact.type'), created_by: string(a.created_by, 'expert.artifact.created_by'), created_at: timestamp(a.created_at, 'expert.artifact.created_at'),
+      headline: string(a.headline, 'expert.artifact.headline'), detail: nullableString(a.detail, 'expert.artifact.detail'), result: nullableString(a.result, 'expert.artifact.result'), failure: nullableString(a.failure, 'expert.artifact.failure'),
+      confidence: confidence !== null && confidence > 1 ? null : confidence,
+      model: nullableString(a.model, 'expert.artifact.model'), adapter: nullableString(a.adapter, 'expert.artifact.adapter'), policy: nullableString(a.policy, 'expert.artifact.policy'), provider: nullableString(a.provider, 'expert.artifact.provider'), role: nullableString(a.role, 'expert.artifact.role'), est_cost_usd: number(a.est_cost_usd, 'expert.artifact.est_cost_usd'),
+      rejected: rows(a.rejected, value => { const r = object(value, ['model', 'reason'], [], 'expert.artifact.rejected'); return { model: string(r.model, 'expert.artifact.rejected.model'), reason: string(r.reason, 'expert.artifact.rejected.reason') }; }, 32, 'expert.artifact.rejected'),
+      check_result: check,
+    }; }, 50, 'expert.artifacts'),
+    coverage: { tasks: choice(coverage.tasks, ['complete', 'partial', 'unknown'], 'expert.coverage.tasks'), artifacts: choice(coverage.artifacts, ['complete', 'partial', 'unknown'], 'expert.coverage.artifacts') },
+    quality: choice(v.quality, ['ok', 'degraded', 'unverified'], 'expert.quality'),
   };
   if (v.economics !== undefined) {
-    if (v.live_economics !== undefined) return invalid();
-    const economics = object(v.economics, ['header', 'tasks'], ['compaction']);
-    if (economics.compaction !== undefined) { const c = object(economics.compaction, ['coverage', 'reason']); parsed.compaction = { coverage: choice(c.coverage, ['complete', 'partial', 'unavailable']), reason: string(c.reason) }; }
+    if (v.live_economics !== undefined) return invalid('expert.economics');
+    const economics = object(v.economics, ['header', 'tasks'], ['compaction'], 'expert.economics');
+    if (economics.compaction !== undefined) { const c = object(economics.compaction, ['coverage', 'reason'], [], 'expert.economics.compaction'); parsed.compaction = { coverage: choice(c.coverage, ['complete', 'partial', 'unavailable'], 'expert.economics.compaction.coverage'), reason: string(c.reason, 'expert.economics.compaction.reason') }; }
     parsed.live_economics = parseExpertHeader(economics.header);
-    if (!parsed.live_economics?.usage) return invalid();
-    const usages = object(economics.tasks);
-    if (Object.keys(usages).length > 50 || Object.keys(usages).some(id => !parsed.tasks.some(t => t.id === id))) return invalid();
+    if (!parsed.live_economics?.usage) return invalid('expert.economics.header.usage');
+    const usages = object(economics.tasks, undefined, undefined, 'expert.economics.tasks');
+    if (Object.keys(usages).length > 50 || Object.keys(usages).some(id => !parsed.tasks.some(t => t.id === id))) return invalid('expert.economics.tasks');
     parsed.tasks = parsed.tasks.map(task => {
       if (!Object.hasOwn(usages, task.id)) return task;
-      const u = object(usages[task.id], ['tokens_in', 'tokens_out', 'tokens', 'est_cost_usd', 'estimated', 'cost_provenance', 'source_artifact_id', 'route_forecast_usd', 'plan_billed']);
-      const source = nullableString(u.source_artifact_id);
-      if (source !== null && !(references ?? parsed.artifacts).some(a => a.id === source && a.task_id === task.id)) return invalid();
-      return { ...task, usage: { tokens_in: nullableCount(u.tokens_in), tokens_out: nullableCount(u.tokens_out), tokens: nullableCount(u.tokens), est_cost_usd: number(u.est_cost_usd), estimated: u.estimated === null ? null : boolean(u.estimated), cost_provenance: nullableString(u.cost_provenance), source_artifact_id: source, route_forecast_usd: number(u.route_forecast_usd), plan_billed: boolean(u.plan_billed) } };
+      const u = object(usages[task.id], ['tokens_in', 'tokens_out', 'tokens', 'est_cost_usd', 'estimated', 'cost_provenance', 'source_artifact_id', 'route_forecast_usd', 'plan_billed'], [], 'expert.economics.task');
+      let source = nullableString(u.source_artifact_id, 'expert.economics.task.source_artifact_id');
+      if (source !== null && !(references ?? parsed.artifacts).some(a => a.id === source && a.task_id === task.id)) source = null;
+      return { ...task, usage: { tokens_in: nullableCount(u.tokens_in, 'expert.economics.task.tokens_in'), tokens_out: nullableCount(u.tokens_out, 'expert.economics.task.tokens_out'), tokens: nullableCount(u.tokens, 'expert.economics.task.tokens'), est_cost_usd: number(u.est_cost_usd, 'expert.economics.task.est_cost_usd'), estimated: u.estimated === null ? null : boolean(u.estimated, 'expert.economics.task.estimated'), cost_provenance: nullableString(u.cost_provenance, 'expert.economics.task.cost_provenance'), source_artifact_id: source, route_forecast_usd: number(u.route_forecast_usd, 'expert.economics.task.route_forecast_usd'), plan_billed: boolean(u.plan_billed, 'expert.economics.task.plan_billed') } };
     });
   }
-  if (v.compaction !== undefined) { if (v.economics !== undefined) return invalid(); const c = object(v.compaction, ['coverage', 'reason']); parsed.compaction = { coverage: choice(c.coverage, ['complete', 'partial', 'unavailable']), reason: string(c.reason) }; }
-  if (parsed.compaction && parsed.compaction.coverage !== 'complete' && parsed.live_economics?.savings?.compact_tokens !== null && parsed.live_economics?.savings?.compact_tokens !== undefined) return invalid();
-  if (new Set(parsed.tasks.map(t => t.id)).size !== parsed.tasks.length || new Set(parsed.artifacts.map(a => a.id)).size !== parsed.artifacts.length
-    || parsed.artifacts.some(a => a.confidence !== null && a.confidence > 1)
-    || parsed.quality === 'ok' && (parsed.coverage.tasks !== 'complete' || parsed.coverage.artifacts !== 'complete')
-    || parsed.kind === 'unavailable' && (parsed.tasks.length || parsed.artifacts.length || parsed.quality !== 'unverified')) return invalid();
+  if (v.compaction !== undefined) { if (v.economics !== undefined) return invalid('expert.compaction'); const c = object(v.compaction, ['coverage', 'reason'], [], 'expert.compaction'); parsed.compaction = { coverage: choice(c.coverage, ['complete', 'partial', 'unavailable'], 'expert.compaction.coverage'), reason: string(c.reason, 'expert.compaction.reason') }; }
+  if (parsed.compaction && parsed.compaction.coverage !== 'complete' && parsed.live_economics?.savings?.compact_tokens !== null && parsed.live_economics?.savings?.compact_tokens !== undefined) {
+    parsed.live_economics = { ...parsed.live_economics, savings: { ...parsed.live_economics.savings!, compact_tokens: null } };
+  }
+  if (new Set(parsed.tasks.map(t => t.id)).size !== parsed.tasks.length || new Set(parsed.artifacts.map(a => a.id)).size !== parsed.artifacts.length) return invalid('expert.duplicate_id');
+  if (parsed.quality === 'ok' && (parsed.coverage.tasks !== 'complete' || parsed.coverage.artifacts !== 'complete')) parsed.quality = 'unverified';
+  if (parsed.kind === 'unavailable' && (parsed.tasks.length || parsed.artifacts.length || parsed.quality !== 'unverified')) {
+    parsed.tasks = [];
+    parsed.artifacts = [];
+    parsed.quality = 'unverified';
+  }
   return parsed;
 }

--- a/webapp/src/lib/expertMetadata.ts
+++ b/webapp/src/lib/expertMetadata.ts
@@ -16,11 +16,11 @@ export type ExpertArtifact = { id: string; task_id: string | null; type: string;
 export type ExpertMetadata = { kind: 'available' | 'partial' | 'unavailable'; reason: string | null; header: ExpertHeader | null; live_economics?: ExpertHeader | null; compaction?: { coverage: 'complete' | 'partial' | 'unavailable'; reason: string };
   tasks: ExpertTask[]; artifacts: ExpertArtifact[]; coverage: { tasks: 'complete' | 'partial' | 'unknown'; artifacts: 'complete' | 'partial' | 'unknown' };
   quality: 'ok' | 'degraded' | 'unverified' };
-function invalid(detail?: string): never {
-  const error = new Error(detail ? `invalid_metadata:${detail}` : 'invalid_metadata');
-  if (detail) (error as Error & { detail?: string }).detail = detail;
-  throw error;
+export class ExpertParseError extends Error {
+  readonly detail: string;
+  constructor(detail = 'expert') { super(`invalid_metadata:${detail}`); this.detail = detail; }
 }
+function invalid(detail?: string): never { throw new ExpertParseError(detail); }
 function object(value: unknown, keys?: string[], optional: string[] = [], path = 'object'): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return invalid(path);
   const result = Object.fromEntries(Object.entries(value));

--- a/webapp/src/lib/jobMetadata.ts
+++ b/webapp/src/lib/jobMetadata.ts
@@ -1,4 +1,4 @@
-import { parseExpertMetadata, parseExpertHeader } from './expertMetadata';
+import { parseExpertMetadata, parseExpertHeader, ExpertParseError } from './expertMetadata';
 import type { ExpertMetadata, ExpertHeader } from './expertMetadata';
 import { parseMetadataDisplay, parseSelectedEconomics, parseSelectedHistory, historyCursors } from './selectedMetadataEvidence';
 import type { MetadataDisplay, SelectedEconomics, SelectedHistory, HistoryCursorName } from './selectedMetadataEvidence';
@@ -246,12 +246,7 @@ export function parseMetadataDetail(v: unknown, c: MetadataContext, selected: Me
   if (o.expert !== undefined) {
     try { expert = parseExpertMetadata(o.expert, artifacts.rows); }
     catch (error) {
-      if (error instanceof Error && (error.message === 'invalid_metadata' || error.message.startsWith('invalid_metadata:'))) {
-        const detail = 'detail' in error && typeof (error as { detail?: unknown }).detail === 'string'
-          ? (error as { detail: string }).detail
-          : error.message.startsWith('invalid_metadata:') ? error.message.slice('invalid_metadata:'.length) : 'expert';
-        throw new MetadataError('invalid_metadata', detail);
-      }
+      if (error instanceof ExpertParseError) throw new MetadataError('invalid_metadata', error.detail);
       throw error;
     }
   }
@@ -293,9 +288,8 @@ export function parseMetadataPins(v: unknown, c: MetadataContext, selections: Me
         if (header !== undefined) {
           try { parsedHeader = parseExpertHeader(header); }
           catch (error) {
-            if (error instanceof Error && (error.message === 'invalid_metadata' || error.message.startsWith('invalid_metadata:'))) {
-              parsedHeader = null;
-            } else throw error;
+            if (!(error instanceof ExpertParseError)) throw error;
+            parsedHeader = null;
           }
         }
         return { selection: s, result: { kind: 'present', row: { ...r, ...(parsedHeader === undefined ? {} : { header: parsedHeader }) } } } satisfies MetadataPinResult;

--- a/webapp/src/lib/jobMetadata.ts
+++ b/webapp/src/lib/jobMetadata.ts
@@ -49,9 +49,14 @@ export type DetailCursors = { task_cursor: string | null; artifact_cursor: strin
 export type MetadataErrorCode = 'invalid_metadata' | 'invalid_request' | 'view_changed' | 'refresh_in_progress' | 'endpoint_changed' | 'unavailable' | 'outcome_unknown' | 'bounds_exceeded' | 'busy';
 export class MetadataError extends Error {
   readonly code: MetadataErrorCode;
-  constructor(code: MetadataErrorCode) { super(code); this.code = code; }
+  readonly detail?: string;
+  constructor(code: MetadataErrorCode, detail?: string) {
+    super(detail ? `${code}:${detail}` : code);
+    this.code = code;
+    if (detail !== undefined) this.detail = detail;
+  }
 }
-function fail(): never { throw new MetadataError('invalid_metadata'); }
+function fail(detail?: string): never { throw new MetadataError('invalid_metadata', detail); }
 function record(v: unknown): v is Record<string, unknown> { return v !== null && typeof v === 'object' && !Array.isArray(v); }
 function object(v: unknown, fields: string[]): Record<string, unknown> {
   if (!record(v) || Object.keys(v).length !== fields.length || !fields.every(k => Object.hasOwn(v, k))) return fail();
@@ -237,20 +242,36 @@ export function parseMetadataDetail(v: unknown, c: MetadataContext, selected: Me
   const cost = record(o.cost) && o.cost.kind === 'unavailable' && Object.keys(o.cost).length === 2
     ? { kind: 'unavailable', reason: text(o.cost.reason) } satisfies MetadataDetail['cost'] : parseSelectedEconomics(o.cost, s.job_ref);
   const tasks = resourcePage(o.tasks, cursors.task_cursor, task), artifacts = resourcePage(o.artifacts, cursors.artifact_cursor, artifact);
+  let expert: ExpertMetadata | undefined;
+  if (o.expert !== undefined) {
+    try { expert = parseExpertMetadata(o.expert, artifacts.rows); }
+    catch (error) {
+      if (error instanceof Error && (error.message === 'invalid_metadata' || error.message.startsWith('invalid_metadata:'))) {
+        const detail = 'detail' in error && typeof (error as { detail?: unknown }).detail === 'string'
+          ? (error as { detail: string }).detail
+          : error.message.startsWith('invalid_metadata:') ? error.message.slice('invalid_metadata:'.length) : 'expert';
+        throw new MetadataError('invalid_metadata', detail);
+      }
+      throw error;
+    }
+  }
   const parsed: MetadataDetail = { version: 1, context: expectedContext(o.context, c), selection: s, lifecycle: nullableText(o.lifecycle),
     tasks, artifacts,
-    ...(o.expert === undefined ? {} : { expert: parseExpertMetadata(o.expert, artifacts.rows) }),
+    ...(expert === undefined ? {} : { expert }),
     ...(o.display === undefined ? {} : { display: parseMetadataDisplay(o.display) }),
     ...(o.task_count === undefined ? {} : { task_count: nullableCount(o.task_count) }),
     ...(o.artifact_count === undefined ? {} : { artifact_count: nullableCount(o.artifact_count) }),
     history: parseSelectedHistory(o.history, s.job_ref, cursors), cost, cancellation_authority: false, missing: missing(o.missing) };
-  const expert = parsed.expert;
-  if (expert && expert.kind !== 'unavailable') {
-    if (parsed.tasks.page.revision !== parsed.artifacts.page.revision
-      || expert.tasks.some(t => !parsed.tasks.rows.some(ref => ref.id === t.id && ref.binding !== null))
-      || expert.artifacts.some(a => !parsed.artifacts.rows.some(ref => ref.id === a.id && ref.task_id === a.task_id && ref.type?.toLowerCase() === a.type.toLowerCase()))
-      || expert.coverage.tasks === 'complete' && (parsed.tasks.page.outcome !== 'complete' || cursors.task_cursor !== null || expert.tasks.length !== parsed.tasks.rows.length)
-      || expert.coverage.artifacts === 'complete' && (parsed.artifacts.page.outcome !== 'complete' || cursors.artifact_cursor !== null || expert.artifacts.length !== parsed.artifacts.rows.length)) return fail();
+  if (parsed.expert && parsed.expert.kind !== 'unavailable') {
+    const skewed = parsed.tasks.page.revision !== parsed.artifacts.page.revision;
+    const unbound = parsed.expert.tasks.some(t => !parsed.tasks.rows.some(ref => ref.id === t.id && ref.binding !== null));
+    const missingArt = parsed.expert.artifacts.some(a => !parsed.artifacts.rows.some(ref => ref.id === a.id && ref.task_id === a.task_id && ref.type?.toLowerCase() === a.type.toLowerCase()));
+    const taskGap = parsed.expert.coverage.tasks === 'complete' && (parsed.tasks.page.outcome !== 'complete' || cursors.task_cursor !== null || parsed.expert.tasks.length !== parsed.tasks.rows.length);
+    const artGap = parsed.expert.coverage.artifacts === 'complete' && (parsed.artifacts.page.outcome !== 'complete' || cursors.artifact_cursor !== null || parsed.expert.artifacts.length !== parsed.artifacts.rows.length);
+    if (skewed || unbound || missingArt || taskGap || artGap) {
+      parsed.expert = { kind: 'unavailable', reason: skewed ? 'lane_revision_skew' : 'expert_ref_mismatch',
+        header: null, tasks: [], artifacts: [], coverage: { tasks: 'unknown', artifacts: 'unknown' }, quality: 'unverified' };
+    }
   }
   return parsed;
 }
@@ -267,8 +288,17 @@ export function parseMetadataPins(v: unknown, c: MetadataContext, selections: Me
         const raw = record(result.row) ? result.row : fail();
         const { header, ...summary } = raw;
         const r = row(summary, c);
-        if (r.deleted || metadataSelectionKey(r.selection) !== metadataSelectionKey(s)) return fail();
-        return { selection: s, result: { kind: 'present', row: { ...r, ...(header === undefined ? {} : { header: parseExpertHeader(header) }) } } } satisfies MetadataPinResult;
+        if (r.deleted || metadataSelectionKey(r.selection) !== metadataSelectionKey(s)) return fail('pins.row');
+        let parsedHeader: ExpertHeader | null | undefined;
+        if (header !== undefined) {
+          try { parsedHeader = parseExpertHeader(header); }
+          catch (error) {
+            if (error instanceof Error && (error.message === 'invalid_metadata' || error.message.startsWith('invalid_metadata:'))) {
+              parsedHeader = null;
+            } else throw error;
+          }
+        }
+        return { selection: s, result: { kind: 'present', row: { ...r, ...(parsedHeader === undefined ? {} : { header: parsedHeader }) } } } satisfies MetadataPinResult;
       }
       case 'unavailable': {
         const result = object(o.result, ['kind', 'reason']);

--- a/webapp/src/lib/jobMetadataContext.tsx
+++ b/webapp/src/lib/jobMetadataContext.tsx
@@ -3,9 +3,32 @@ import type { ReactNode } from 'react';
 import { JobMetadataStore, useJobMetadata } from './useJobMetadata';
 import type { JobMetadataState } from './useJobMetadata';
 import type { Job } from './api';
-import { canonicalPMReplacesLocal, metadataSelectionKey } from './jobMetadata';
+import { canonicalExpertSelection, canonicalPMReplacesLocal, metadataSelectionKey } from './jobMetadata';
+import type { LocalObservation } from './localJobMetadata';
 import { localKey, nativeActiveStatuses } from './localJobMetadata';
 import { isCommandJob } from './jobClassification';
+
+/** Prefer the freshest local observation when the same job_id appears under multiple keys. */
+function preferFresherLocal(a: LocalObservation, b: LocalObservation): LocalObservation {
+  const winner = a.row.revision !== b.row.revision
+    ? (a.row.revision > b.row.revision ? a : b)
+    : a.freshness !== b.freshness
+      ? (a.freshness === 'observed' ? a : b)
+      : (a.observedAt >= b.observedAt ? a : b);
+  const other = winner === a ? b : a;
+  // localDetail summaries are inserted as stale/observedAt 0; keep list freshness when they win on revision.
+  if (winner.freshness === 'stale' && winner.observedAt === 0 && other.freshness === 'observed'
+    && other.row.local_ref.job_id === winner.row.local_ref.job_id) {
+    return { ...winner, freshness: 'observed', observedAt: other.observedAt };
+  }
+  return winner;
+}
+
+function localGoalFallback(row: LocalObservation['row'], selectedContextRequest?: string): string {
+  if (selectedContextRequest?.trim()) return selectedContextRequest.trim();
+  if (row.display) return `${row.display.label}${row.display.model ? ` · ${row.display.model}` : ''}`;
+  return row.kind.replaceAll('_', ' ');
+}
 
 const inactive = new JobMetadataStore();
 export const JobMetadataContext = createContext(inactive);
@@ -42,9 +65,12 @@ export function metadataActivity(state: JobMetadataState): { count: number; labe
 /** Current selected facts are valid only for this exact source and revision. */
 export function currentExpert(state: JobMetadataState, key: string) {
   const selected = state.detail.kind === 'selected' && metadataSelectionKey(state.detail.selection) === key ? state.detail : state.detailCache[key];
-  if (!selected || selected.freshness !== 'observed' || selected.error || !selected.observation) return undefined;
+  if (!selected?.observation || selected.error) return undefined;
   const listed = state.observations.find(o => metadataSelectionKey(o.row.selection) === key);
   if (listed?.freshness === 'stale') return undefined;
+  // An unrelated lane failure stamps every cached detail stale; a hydrated expert
+  // whose own list row is still fresh stays visible.
+  if (selected.freshness !== 'observed' && !selected.observation.expert) return undefined;
   const latest = Math.max(0, ...[...state.observations, ...state.pins.flatMap(p => p.observation ? [p.observation] : [])].filter(o => metadataSelectionKey(o.row.selection) === key).map(o => o.row.revision), state.headers[key]?.observation.row.revision ?? 0);
   return selected.observation.tasks.page.revision >= latest && selected.observation.artifacts.page.revision >= latest ? selected.observation.expert : undefined;
 }
@@ -88,20 +114,53 @@ export function metadataJobs(state: JobMetadataState): Job[] {
     unavailable_fields: ['artifacts', 'tasks'], artifacts_complete: false,
     ...(row.task_count === null ? {} : { task_count: row.task_count }),
   }));
-  const nativeObserved = new Map(state.local.observations.map(o => [localKey(o.row.local_ref), o]));
+  // Dedupe by job_id: local.observations and localDetail.summary can both contribute
+  // the same alias under different localKeys (incarnation churn) and double the Active list.
+  const nativeByJobId = new Map<string, LocalObservation>();
+  for (const observation of state.local.observations) {
+    const id = observation.row.local_ref.job_id;
+    const existing = nativeByJobId.get(id);
+    nativeByJobId.set(id, existing ? preferFresherLocal(existing, observation) : observation);
+  }
   const selectedSummary = state.localDetail?.observation?.summary;
-  if (selectedSummary && !nativeObserved.has(localKey(selectedSummary.local_ref))) nativeObserved.set(localKey(selectedSummary.local_ref), { row: selectedSummary, freshness: 'stale', observedAt: 0 });
-  const local: Job[] = [...nativeObserved.values()]
-    .filter(local => !canonicalPMReplacesLocal(local, [...observed.values()]))
-    .map(({ row, freshness }) => ({
-    id: row.local_ref.job_id, local_ref: row.local_ref, source: 'local', metadata_only: true,
-    metadata_key: localKey(row.local_ref), goal: (row.display ? `${row.display.label}${row.display.model ? ` · ${row.display.model}` : ''}` : row.kind.replaceAll('_', ' ')),
-    status: row.lifecycle, session_id: row.session_id, job_kind: row.kind, role: row.kind,
-    adapter: row.display?.adapter,
-    ...(row.parent_ref ? { parent_ref: row.parent_ref } : {}),
-    ...(freshness === 'stale' ? { read_status: 'unavailable' } : {}),
-    updated_at: row.updated_at, unavailable_fields: ['artifacts', 'tasks'], artifacts_complete: false,
-    ...(row.task_count === null ? {} : { task_count: row.task_count }),
-  }));
+  if (selectedSummary) {
+    const candidate: LocalObservation = { row: selectedSummary, freshness: 'stale', observedAt: 0 };
+    const id = selectedSummary.local_ref.job_id;
+    const existing = nativeByJobId.get(id);
+    nativeByJobId.set(id, existing ? preferFresherLocal(existing, candidate) : candidate);
+  }
+  const selectedRequest = state.localDetail?.observation?.selected_context?.request?.text;
+  const repo = state.view.kind === 'view' ? state.view.context.repo : '';
+  const local: Job[] = [...nativeByJobId.values()]
+    .filter(localObs => !canonicalPMReplacesLocal(localObs, [...observed.values()]))
+    .map(({ row, freshness }) => {
+      const canonical = row.canonical;
+      const canonKey = canonical && repo ? metadataSelectionKey(canonicalExpertSelection(canonical, repo)) : '';
+      const detailObservation = canonKey
+        ? (state.detail.kind === 'selected' && metadataSelectionKey(state.detail.selection) === canonKey
+          ? state.detail.observation : state.detailCache[canonKey]?.observation) ?? undefined
+        : undefined;
+      let goalFromPm: string | undefined;
+      if (detailObservation?.display?.kind === 'available' && detailObservation.display.goal_preview) {
+        goalFromPm = detailObservation.display.goal_preview;
+      } else if (canonKey) {
+        const listed = [...observed.values()].find(o => metadataSelectionKey(o.row.selection) === canonKey);
+        if (listed?.row.display.kind === 'available' && listed.row.display.goal_preview) {
+          goalFromPm = listed.row.display.goal_preview;
+        }
+      }
+      const sameDetail = selectedSummary && localKey(selectedSummary.local_ref) === localKey(row.local_ref);
+      return {
+        id: row.local_ref.job_id, local_ref: row.local_ref, source: 'local' as const, metadata_only: true as const,
+        metadata_key: localKey(row.local_ref),
+        goal: goalFromPm || localGoalFallback(row, sameDetail ? selectedRequest : undefined),
+        status: row.lifecycle, session_id: row.session_id, job_kind: row.kind, role: row.kind,
+        adapter: row.display?.adapter,
+        ...(row.parent_ref ? { parent_ref: row.parent_ref } : {}),
+        ...(freshness === 'stale' ? { read_status: 'unavailable' as const } : {}),
+        updated_at: row.updated_at, unavailable_fields: ['artifacts', 'tasks'], artifacts_complete: false,
+        ...(row.task_count === null ? {} : { task_count: row.task_count }),
+      };
+    });
   return [...pm, ...local];
 }

--- a/webapp/src/lib/selectedMetadataEvidence.ts
+++ b/webapp/src/lib/selectedMetadataEvidence.ts
@@ -24,7 +24,7 @@ export type SelectedHistory = { kind: 'unavailable'; reason: string } | ({ kind:
   captured_attempts: number | null; captured_runs: number | null; captured_process_outcomes: number | null; captured_observations: number | null;
   outcome: 'available' | 'unavailable'; coverage: 'captured' | 'partial' | 'unknown'; complete_invocation_history: false;
 } } & Record<HistoryLaneName, HistoryLane>);
-function fail(): never { throw new MetadataError('invalid_metadata'); }
+function fail(detail?: string): never { throw new MetadataError('invalid_metadata', detail); }
 function object(v: unknown): Record<string, unknown> { if (!v || typeof v !== 'object' || Array.isArray(v)) return fail(); return v as Record<string, unknown>; }
 function string(v: unknown, max = 2048): string { if (typeof v !== 'string' || new TextEncoder().encode(v).length > max) return fail(); return v; }
 function count(v: unknown): number { if (typeof v !== 'number' || !Number.isSafeInteger(v) || v < 0) return fail(); return v; }

--- a/webapp/src/lib/useJobMetadata.ts
+++ b/webapp/src/lib/useJobMetadata.ts
@@ -77,14 +77,24 @@ export class JobMetadataStore {
   private lastAdmittedView: MetadataView | null = null;
   private sessionPages = new Map<string, Pick<JobMetadataState, 'observations' | 'local' | 'headers' | 'pins'>>();
   constructor(client = new JobMetadataClient()) { this.client = client; }
-  /** Flip to target without blanking streams, observations, or detail cache. */
-  private retargetInPlace(target: MetadataTarget, reason: Extract<ViewState, { kind: 'target' }>['reason']): void {
+  /** Flip to target keeping PM membership traversal and list observations. The local
+   *  lane and selected-inspection state are fenced and reset like a fresh context. */
+  private retargetInPlace(target: MetadataTarget, reason: Extract<ViewState, { kind: 'target' }>['reason'], stale: boolean): void {
+    const fresh = blank(this.state.epoch + 1, { kind: 'target', target, reason });
     this.publish({
-      ...this.state,
-      epoch: this.state.epoch + 1,
+      ...fresh,
       contextEpoch: this.state.contextEpoch + 1,
       working: this.inFlight,
-      view: { kind: 'target', target, reason },
+      streams: this.state.streams,
+      nextStream: this.state.nextStream,
+      nextForeground: this.state.nextForeground,
+      nextPrimaryActive: this.state.nextPrimaryActive,
+      activeSnapshotKeys: this.state.activeSnapshotKeys,
+      observations: stale ? this.state.observations.map(o => ({ ...o, freshness: 'stale' })) : this.state.observations,
+      removals: this.state.removals,
+      observedAt: this.state.observedAt,
+      headers: this.state.headers,
+      pins: this.state.pins,
     });
   }
   private sessionPageKey(target: { repo: string; session_id: string }): string {
@@ -94,6 +104,8 @@ export class JobMetadataStore {
     const view = this.state.view;
     if (view.kind === 'idle' || !view.target.session_id) return;
     if (!this.state.observations.length && !this.state.local.observations.length) return;
+    // An invalidated retarget already remembered the last-good page; its stale copy must not replace it.
+    if (view.kind === 'target' && view.reason === 'invalidated') return;
     const key = this.sessionPageKey(view.target);
     this.sessionPages.delete(key);
     this.sessionPages.set(key, {
@@ -150,7 +162,7 @@ export class JobMetadataStore {
       && previous.target.repo === nextTarget.repo
       && previous.target.session_id === nextTarget.session_id;
     if (sameIds) {
-      this.retargetInPlace(nextTarget, 'not_opened');
+      this.retargetInPlace(nextTarget, 'not_opened', false);
       return;
     }
     this.lastAdmittedView = null;
@@ -177,7 +189,7 @@ export class JobMetadataStore {
       return;
     }
     if (old.kind === 'view') this.lastAdmittedView = old.view;
-    this.retargetInPlace(old.target, 'invalidated');
+    this.retargetInPlace(old.target, 'invalidated', true);
   };
   closeConnection(): void { this.client.close(); this.client = new JobMetadataClient(); }
   dispose(): void {
@@ -695,6 +707,31 @@ export class JobMetadataStore {
     this.publish({ ...this.state, epoch: this.state.epoch + 1, localDetail: null, detail: captured === null ? { kind: 'none' }
       : this.state.detailCache[metadataSelectionKey(captured)] ?? { kind: 'selected', selection: captured, observation: null, freshness: 'stale',
         cursors: { task_cursor: null, artifact_cursor: null }, error: null } });
+  }
+  /** Read a PM job's detail into detailCache without taking over the current selection.
+   *  Fenced by context, not by selection epoch, so a local inspection opened mid-read keeps
+   *  its lane while the canonical roster still lands. */
+  hydrateDetail(selection: MetadataSelection): Promise<MetadataActionResult> {
+    const view = this.state.view;
+    if (view.kind !== 'view' || view.refresh !== 'idle') return Promise.resolve('skipped');
+    const captured = this.captureSelection(selection);
+    const key = metadataSelectionKey(captured);
+    const contextEpoch = this.state.contextEpoch;
+    const cursors: DetailCursors = { task_cursor: null, artifact_cursor: null };
+    return this.run(async () => {
+      const response = await this.client.detail(view.context, captured, cursors);
+      if (this.disposed || this.state.contextEpoch !== contextEpoch || this.state.view.kind !== 'view') return;
+      const floor = Math.max(0, ...this.state.observations.filter(o => metadataSelectionKey(o.row.selection) === key).map(o => o.row.revision));
+      const incomplete = response.tasks.page.revision < floor || response.artifacts.page.revision < floor
+        || [response.tasks.page.outcome, response.artifacts.page.outcome].some(o => o === 'unavailable' || o === 'cursor_expired');
+      const entry: DetailState = { kind: 'selected', selection: captured, observation: response, cursors,
+        freshness: incomplete ? 'stale' : 'observed', error: incomplete ? 'unavailable' : null };
+      const current = this.state.detail;
+      const retained = Object.entries(this.state.detailCache).filter(([cached]) => cached !== key).slice(-7);
+      this.publish({ ...this.state, selectedRefreshedAt: Date.now(),
+        detail: current.kind === 'selected' && metadataSelectionKey(current.selection) === key ? entry : current,
+        detailCache: Object.fromEntries([...retained, [key, entry]]) });
+    });
   }
   /** Refresh starts both lanes; advance carries the other lane's independent cursor unchanged. */
   readDetail(advance: 'refresh' | 'tasks' | 'artifacts' | HistoryLaneName = 'refresh', scheduled = false): Promise<MetadataActionResult> {

--- a/webapp/src/lib/useJobMetadata.ts
+++ b/webapp/src/lib/useJobMetadata.ts
@@ -73,8 +73,20 @@ export class JobMetadataStore {
   private timer: ReturnType<typeof setInterval> | null = null;
   private disposed = false;
   private scheduleGeneration = 0;
+  /** Last successfully adopted view; survives target/invalidate so adopt can detect an unchanged generation. */
+  private lastAdmittedView: MetadataView | null = null;
   private sessionPages = new Map<string, Pick<JobMetadataState, 'observations' | 'local' | 'headers' | 'pins'>>();
   constructor(client = new JobMetadataClient()) { this.client = client; }
+  /** Flip to target without blanking streams, observations, or detail cache. */
+  private retargetInPlace(target: MetadataTarget, reason: Extract<ViewState, { kind: 'target' }>['reason']): void {
+    this.publish({
+      ...this.state,
+      epoch: this.state.epoch + 1,
+      contextEpoch: this.state.contextEpoch + 1,
+      working: this.inFlight,
+      view: { kind: 'target', target, reason },
+    });
+  }
   private sessionPageKey(target: { repo: string; session_id: string }): string {
     return `${target.repo}\n${target.session_id}`;
   }
@@ -130,7 +142,6 @@ export class JobMetadataStore {
   };
   setTarget(target: MetadataTarget): void {
     if (this.disposed) return;
-    // Every call is a new incarnation, even when the visible IDs are equal.
     this.rememberSessionPage();
     this.stopTicks();
     const nextTarget = validateMetadataTarget(target);
@@ -138,6 +149,11 @@ export class JobMetadataStore {
     const sameIds = previous.kind !== 'idle'
       && previous.target.repo === nextTarget.repo
       && previous.target.session_id === nextTarget.session_id;
+    if (sameIds) {
+      this.retargetInPlace(nextTarget, 'not_opened');
+      return;
+    }
+    this.lastAdmittedView = null;
     const page = this.restoreSessionPage(nextTarget);
     this.publish({
       ...blank(this.state.epoch + 1, { kind: 'target', target: nextTarget, reason: 'not_opened' }),
@@ -148,7 +164,7 @@ export class JobMetadataStore {
         local: page.local,
         headers: page.headers,
         pins: page.pins,
-        startupStopped: !sameIds,
+        startupStopped: true,
       } : {}),
     });
   }
@@ -156,7 +172,12 @@ export class JobMetadataStore {
     if (this.disposed) return;
     this.rememberSessionPage();
     const old = this.state.view;
-    this.publish({ ...blank(this.state.epoch + 1, old.kind === 'idle' ? old : { kind: 'target', target: old.target, reason: 'invalidated' }), contextEpoch: this.state.contextEpoch + 1, working: this.inFlight });
+    if (old.kind === 'idle') {
+      this.publish({ ...blank(this.state.epoch + 1, old), contextEpoch: this.state.contextEpoch + 1, working: this.inFlight });
+      return;
+    }
+    if (old.kind === 'view') this.lastAdmittedView = old.view;
+    this.retargetInPlace(old.target, 'invalidated');
   };
   closeConnection(): void { this.client.close(); this.client = new JobMetadataClient(); }
   dispose(): void {
@@ -210,13 +231,20 @@ export class JobMetadataStore {
   private adopt(view: MetadataView, target: MetadataTarget): void {
     const context: MetadataContext = { ...view.context, scope: target.scope };
     const previous = this.state.view;
-    const same = previous.kind === 'view' && sameMetadataContext(previous.context, context)
-      && previous.view.local?.incarnation === view.local?.incarnation;
+    const priorView = previous.kind === 'view' ? previous.view : this.lastAdmittedView;
+    const priorContext: MetadataContext | null = previous.kind === 'view'
+      ? previous.context
+      : previous.kind === 'target' && this.lastAdmittedView
+        ? { ...this.lastAdmittedView.context, scope: previous.target.scope }
+        : null;
+    const same = priorContext !== null && priorView !== null
+      && sameMetadataContext(priorContext, context)
+      && priorView.local?.incarnation === view.local?.incarnation;
     const sameSession = previous.kind !== 'idle'
       && previous.target.repo === target.repo
       && previous.target.session_id === target.session_id;
-    const sameIncarnation = previous.kind !== 'view'
-      || previous.view.local?.incarnation === view.local?.incarnation;
+    const sameIncarnation = priorView === null
+      || priorView.local?.incarnation === view.local?.incarnation;
     const keep = !same && sameSession && sameIncarnation && (this.state.observations.length || this.state.local.observations.length)
       ? {
         observations: this.state.observations,
@@ -227,6 +255,7 @@ export class JobMetadataStore {
       }
       : {};
     const base = same ? this.state : { ...blank(this.state.epoch, { kind: 'idle' }), ...keep, contextEpoch: this.state.contextEpoch + (previous.kind === 'view' ? 1 : 0) };
+    this.lastAdmittedView = view;
     this.publish({ ...base, error: this.sourceCapture?.key === this.captureKey(view) ? this.sourceCapture.error : null, working: true, view: { kind: 'view', target, context, view, refresh: 'idle' },
       streams: same ? base.streams : metadataStreams(view, target.scope).map(initialMetadataStream) });
   }


### PR DESCRIPTION
Fixes the tracker showing "Job updates unavailable (invalid metadata)", a synthetic local alias, duplicate ACTIVE rows, and no Puppetmaster job row.

Five root causes, each with a hermetic test:

- Session-scope membership scan (limit 50 / max_scan 51) never reached the job. `read_job_page` now reads known canonical refs exactly and prepends them on page 1 before the scan.
- `JobMetadataStore` restarted PM traversal on every invalidate/setTarget. Traversal and list observations are retained across same-context re-adopt; the local lane and selected inspection still reset.
- Alias cards never hydrated the PM roster and `store.select` stole selection. New cache-only, context-fenced `hydrateDetail`; roster, header id and goal come from the PM expert when canonical.
- Alias appeared under two localKeys. Active list dedupes by local job id.
- Task and artifact lanes were separate reads; a write between them skewed revisions and the strict parser rejected the whole detail. Reader re-reads for a matched pair (bounded) then emits typed `unavailable(lane_revision_skew)`; the parser degrades single fields and `MetadataError.detail` names the failing path.

Proof: hermetic harness with a real `run_swarm` dispatch driven headless against this webapp. Mid-flight: one ACTIVE row, canonical on the wire, no banner. Finished: Job id, Worker orchestration card, named roster, selected worker evidence.

pytest 7538 passed / 68 skipped, vitest 2552 passed, tsc clean.