### PR TITLE
Release v0.9.468

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.467, deliberately pre-1.0. Pin stays `puppetmaster-ai==1.27.12`. Swarm Tracker surfaces the Puppetmaster job for every local alias: session snapshots read known canonical refs before the membership scan, the metadata store keeps its traversal across retargets, alias cards hydrate the PM roster cache-only, active rows dedupe by job id, and a mid-flight task/artifact revision skew degrades to a typed unavailable instead of an invalid-metadata banner. Runtime pin: `puppetmaster-ai==1.27.12`.
+> Status: v0.9.468, deliberately pre-1.0. Pin stays `puppetmaster-ai==1.27.12`. Hidden-tab streams keep draining on a 33ms timeout instead of parking a rAF; an empty typewriter buffer stops the pump until the next delta; submit-pin honors a user scroll gesture; stdio MCP `start()` reaps the child if initialize times out; HTTP MCP SSE picks the last JSON-RPC result, not a trailing progress notification. Runtime pin: `puppetmaster-ai==1.27.12`.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.467"
+__version__ = "0.9.468"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/mcp_client.py
+++ b/harness/mcp_client.py
@@ -172,15 +172,18 @@ class StdioMcpClient:
         self._reader_error = None
         self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
         self._reader_thread.start()
-        # handshake
-        resp = self._request("initialize", {
-            "protocolVersion": PROTOCOL_VERSION,
-            "capabilities": {"tools": {}},
-            "clientInfo": CLIENT_INFO,
-        }, timeout=self.startup_timeout)
-        self._server_info = resp.get("serverInfo", {})
-        self._capabilities = resp.get("capabilities", {})
-        self._notify("notifications/initialized", {})
+        try:
+            resp = self._request("initialize", {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "clientInfo": CLIENT_INFO,
+            }, timeout=self.startup_timeout)
+            self._server_info = resp.get("serverInfo", {})
+            self._capabilities = resp.get("capabilities", {})
+            self._notify("notifications/initialized", {})
+        except Exception:
+            self.stop()
+            raise
 
     def stop(self) -> None:
         if self._proc and self._proc.poll() is None:

--- a/harness/mcp_http_client.py
+++ b/harness/mcp_http_client.py
@@ -33,6 +33,43 @@ from .mcp_client import (
 from .web_tools import _PinnedIP
 
 
+def _sse_json_objects(raw: str) -> List[dict]:
+    """Parse SSE ``data:`` frames. Consecutive data lines are one event."""
+    objects: List[dict] = []
+    data_parts: List[str] = []
+
+    def flush() -> None:
+        if not data_parts:
+            return
+        blob = "\n".join(data_parts)
+        del data_parts[:]
+        try:
+            parsed = json.loads(blob)
+        except json.JSONDecodeError:
+            return
+        if isinstance(parsed, dict):
+            objects.append(parsed)
+
+    for line in raw.splitlines():
+        if line == "":
+            flush()
+        elif line.startswith("data:"):
+            data_parts.append(line[5:].lstrip())
+    flush()
+    return objects
+
+
+def _sse_rpc_message(raw: str) -> Optional[dict]:
+    """Last JSON-RPC result/error in an SSE body; skip progress notifications."""
+    objects = _sse_json_objects(raw)
+    for obj in reversed(objects):
+        if "result" in obj or "error" in obj:
+            return obj
+        if "id" in obj and "method" not in obj:
+            return obj
+    return None
+
+
 def mcp_allow_private_urls() -> bool:
     """Whether HTTP MCP may target loopback/LAN (Docker, local gateways).
 
@@ -334,16 +371,8 @@ class HttpMcpClient:
             raise McpError(f"MCP server '{self.name}' unreachable: {e}")
         if not raw.strip():
             return None  # notification -> empty 202
-        # SSE-framed response: extract the JSON from the last data: line
         if "text/event-stream" in ctype:
-            obj = None
-            for line in raw.splitlines():
-                if line.startswith("data:"):
-                    try:
-                        obj = json.loads(line[5:].strip())
-                    except json.JSONDecodeError:
-                        continue
-            return obj
+            return _sse_rpc_message(raw)
         try:
             return json.loads(raw)
         except json.JSONDecodeError:

--- a/harness/tool_discovery.py
+++ b/harness/tool_discovery.py
@@ -101,7 +101,10 @@ def core_visible_names(
     """Core always-visible tool names for the current pilot mode / task profile.
 
     MICRO returns the compact micro set (plus hash_edit when enabled) so prompts
-    stay small; STANDARD/DEEP keep CORE_PILOT / CORE_WORKER behavior.
+    stay small, but only for the interactive pilot (``no_delegation=False``).
+    A no-delegation leaf worker keeps CORE_WORKER — it cannot run_swarm and
+    needs the full non-delegation toolkit. STANDARD/DEEP keep CORE_PILOT /
+    CORE_WORKER regardless.
     """
     try:
         from .task_profile import MICRO, micro_visible_tool_names, normalize_profile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.467"
+version = "0.9.468"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_job_expert_economics_lane.py
+++ b/tests/test_job_expert_economics_lane.py
@@ -116,6 +116,14 @@ def test_header_clock_is_attested_and_task_clock_is_separate():
     assert result['latest_task_updated_at'] == second.updated_at
 
 
+def test_latest_task_updated_at_accepts_colonless_offset():
+    """timestamp() normalizes +0000 before the max() key parses the wire form."""
+    job, task = setup_records()
+    second = replace(task, id='second', updated_at='2026-09-07T13:00:00+0000')
+    result = project(job, [task, second], [])['header']
+    assert result['latest_task_updated_at'] is not None
+
+
 def test_source_attested_routing_cache_compaction_values_are_additive():
     job, task = setup_records()
     route = Artifact(job_id=job.id, task_id=task.id, type=ArtifactType.ROUTING,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,10 +1,13 @@
 """MCP client + manager against an in-repo fake stdio server (zero external deps)."""
 import json
+import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
+import harness.mcp_client as mcp_mod
 from harness.mcp_client import StdioMcpClient, McpError
 from harness.mcp_manager import CATALOG, McpManager
 from harness.tool_discovery import mcp_tools_from_list_result
@@ -509,4 +512,48 @@ def test_stdio_cancel_unblocks_without_killing_server():
         assert any(t.name == "slow" for t in tools)
     finally:
         c.stop()
+
+
+def test_start_reaps_child_when_handshake_times_out(tmp_path):
+    """start() must stop() the process group if initialize never answers."""
+    script = tmp_path / "mute_mcp.py"
+    script.write_text(
+        "import time\ntime.sleep(60)\n",
+        encoding="utf-8",
+    )
+    spawned = []
+    real_popen = subprocess.Popen
+
+    def _capture_popen(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        spawned.append(proc)
+        return proc
+
+    orig = mcp_mod.subprocess.Popen
+    mcp_mod.subprocess.Popen = _capture_popen
+    c = StdioMcpClient(
+        name="mute",
+        command=sys.executable,
+        args=[str(script)],
+        startup_timeout=0.4,
+    )
+    try:
+        with pytest.raises(McpError, match="timeout waiting for initialize"):
+            c.start()
+        assert spawned, "start() never spawned a child"
+        child = spawned[0]
+        deadline = time.time() + 3
+        while child.poll() is None and time.time() < deadline:
+            time.sleep(0.05)
+        assert child.poll() is not None, "handshake timeout left the MCP child running"
+        assert c._proc is None
+    finally:
+        mcp_mod.subprocess.Popen = orig
+        try:
+            c.stop()
+        except Exception:
+            pass
+        for proc in spawned:
+            if proc.poll() is None:
+                proc.kill()
 

--- a/tests/test_mcp_http_client.py
+++ b/tests/test_mcp_http_client.py
@@ -10,7 +10,11 @@ from typing import Optional
 
 import pytest
 
-from harness.mcp_http_client import HttpMcpClient, SafeRedirectHandler
+from harness.mcp_http_client import (
+    HttpMcpClient,
+    SafeRedirectHandler,
+    _sse_rpc_message,
+)
 
 
 class _RedirectHandler(http.server.BaseHTTPRequestHandler):
@@ -297,3 +301,27 @@ def test_redirect_unredirected_header_precedence(redirect_handler):
     )
     assert not redirected.has_header("Authorization")
     assert redirected.get_header("Accept") == "application/json"
+
+
+def test_sse_rpc_message_skips_trailing_progress_notification():
+    raw = (
+        'data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"ping"}]}}\n\n'
+        'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"p":1}}\n\n'
+    )
+    msg = _sse_rpc_message(raw)
+    assert msg is not None
+    assert msg.get("result", {}).get("tools")[0]["name"] == "ping"
+
+
+def test_sse_rpc_message_joins_multiline_data_field():
+    raw = (
+        'data: {"jsonrpc":"2.0","id":2,\n'
+        'data: "result":{"ok":true}}\n\n'
+    )
+    msg = _sse_rpc_message(raw)
+    assert msg == {"jsonrpc": "2.0", "id": 2, "result": {"ok": True}}
+
+
+def test_sse_rpc_message_single_result_still_wins():
+    raw = 'data: {"jsonrpc":"2.0","id":3,"result":{"ok":true}}\n\n'
+    assert _sse_rpc_message(raw)["result"]["ok"] is True

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.467",
+  "version": "0.9.468",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.467",
+      "version": "0.9.468",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.467",
+  "version": "0.9.468",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -3763,7 +3763,7 @@ describe("completionNotify / feedScroll / streamTerminal / swarmPoll", () => {
         return 1;
       },
     );
-    expect(scheduled).toBe(1);
+    expect(scheduled).toBe(0);
   });
 });
 
@@ -3809,7 +3809,7 @@ describe("streamTypewriter first reveal", () => {
     expect(refs.typeDoneRef.current).toBe(false);
   });
 
-  it("empty idle start still schedules without appending", () => {
+  it("empty idle start does not schedule a heartbeat pump", () => {
     const refs = makeRefs("");
     const chunks: string[] = [];
     let scheduled = 0;
@@ -3818,8 +3818,8 @@ describe("streamTypewriter first reveal", () => {
       return 1;
     });
     expect(chunks).toEqual([]);
-    expect(scheduled).toBe(1);
-    expect(refs.typeRafRef.current).toBe(1);
+    expect(scheduled).toBe(0);
+    expect(refs.typeRafRef.current).toBeNull();
   });
 
   it("flush and cancel invariants remain after first reveal", () => {
@@ -3864,7 +3864,7 @@ describe("streamTypewriter first reveal", () => {
     expect(chunks.join("").length).toBeLessThanOrEqual(text.length);
   });
 
-  it("empty-buffer pump with typeDone false reschedules without appending", () => {
+  it("empty-buffer pump with typeDone false stops without rescheduling", () => {
     const refs = {
       typeBufRef: { current: "" },
       typeRafRef: { current: 5 as number | null },
@@ -3877,8 +3877,8 @@ describe("streamTypewriter first reveal", () => {
       return 99;
     });
     expect(chunks).toEqual([]);
-    expect(scheduled).toBe(1);
-    expect(refs.typeRafRef.current).toBe(99);
+    expect(scheduled).toBe(0);
+    expect(refs.typeRafRef.current).toBeNull();
     expect(refs.typeBufRef.current).toBe("");
     expect(refs.typeDoneRef.current).toBe(false);
   });

--- a/webapp/src/__tests__/streamTypewriter.scheduler.test.ts
+++ b/webapp/src/__tests__/streamTypewriter.scheduler.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  STREAM_PAINT_MS,
+  cancelStreamPaint,
+  pumpTypewriterFrame,
+  scheduleStreamPaint,
+  streamPaintHandleCount,
+} from "../components/conversation/streamTypewriter";
+
+function refs(buf: string, done = false) {
+  return {
+    typeBufRef: { current: buf },
+    typeRafRef: { current: null as number | null },
+    typeDoneRef: { current: done },
+  };
+}
+
+function setVisibility(state: "hidden" | "visible"): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("streamTypewriter scheduler", () => {
+  afterEach(() => {
+    setVisibility("visible");
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not reschedule when the buffer is empty and the turn is not done", () => {
+    const r = refs("");
+    let scheduled = 0;
+    pumpTypewriterFrame(r, () => undefined, () => {
+      scheduled += 1;
+      return 1;
+    });
+    expect(scheduled).toBe(0);
+    expect(r.typeRafRef.current).toBeNull();
+  });
+
+  it("converts a pending rAF to a timeout when the tab hides", () => {
+    vi.useFakeTimers();
+    const rafIds: number[] = [];
+    let nextRaf = 1;
+    const rafCbs = new Map<number, FrameRequestCallback>();
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      const id = nextRaf++;
+      rafIds.push(id);
+      rafCbs.set(id, cb);
+      return id;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+      rafCbs.delete(id);
+    });
+
+    setVisibility("visible");
+    let fired = 0;
+    const token = scheduleStreamPaint(() => {
+      fired += 1;
+    });
+    expect(rafCbs.size).toBe(1);
+    expect(streamPaintHandleCount()).toBe(1);
+
+    setVisibility("hidden");
+    expect(rafCbs.size).toBe(0);
+    expect(streamPaintHandleCount()).toBe(1);
+
+    vi.advanceTimersByTime(STREAM_PAINT_MS);
+    expect(fired).toBe(1);
+    expect(streamPaintHandleCount()).toBe(0);
+    cancelStreamPaint(token);
+  });
+
+  it("cancelStreamPaint drops the map entry", () => {
+    vi.useFakeTimers();
+    setVisibility("hidden");
+    const token = scheduleStreamPaint(() => undefined);
+    expect(streamPaintHandleCount()).toBe(1);
+    cancelStreamPaint(token);
+    expect(streamPaintHandleCount()).toBe(0);
+    vi.advanceTimersByTime(STREAM_PAINT_MS);
+  });
+});

--- a/webapp/src/__tests__/streamTypewriter.slowBatch.test.ts
+++ b/webapp/src/__tests__/streamTypewriter.slowBatch.test.ts
@@ -22,4 +22,15 @@ describe("streamTypewriter slow-model batching", () => {
     expect(painted[0].length).toBeLessThan(burst.length);
     expect(r.typeBufRef.current).toBe(burst.slice(painted[0].length));
   });
+
+  it("stops the pump on an empty live buffer so tool-call gaps do not idle-spin", () => {
+    const r = refs("");
+    let scheduled = 0;
+    pumpTypewriterFrame(r, () => undefined, () => {
+      scheduled += 1;
+      return 7;
+    });
+    expect(scheduled).toBe(0);
+  });
 });
+

--- a/webapp/src/components/Conversation.tsx
+++ b/webapp/src/components/Conversation.tsx
@@ -2999,6 +2999,7 @@ export default function Conversation({
       scrollReleasedByGestureRef.current = false;
       scrollSettlingRef.current = true;
       const pinSubmittedRow = () => {
+        if (scrollReleasedByGestureRef.current) return;
         const el = feedRef.current;
         const scrollToEnd = scrollFeedToEndRef.current;
         if (scrollToEnd) {

--- a/webapp/src/components/conversation/streamTypewriter.ts
+++ b/webapp/src/components/conversation/streamTypewriter.ts
@@ -14,26 +14,54 @@ import { typewriterCharsPerFrame } from "./streamBubbles";
 /** Hidden-tab fallback only. Visible paints use rAF so ticks land on vsync. */
 export const STREAM_PAINT_MS = 33;
 
-type PaintHandle = { kind: "raf" | "timeout"; id: number };
+type PaintHandle = { kind: "raf" | "timeout"; id: number; cb: () => void };
 const paintHandles = new Map<number, PaintHandle>();
 let nextPaintToken = 1;
+let visibilityBridgeBound = false;
+
+function isDocumentHidden(): boolean {
+  return typeof document !== "undefined" && document.visibilityState === "hidden";
+}
+
+function armTimeout(token: number, cb: () => void): void {
+  const id = window.setTimeout(() => {
+    paintHandles.delete(token);
+    cb();
+  }, STREAM_PAINT_MS);
+  paintHandles.set(token, { kind: "timeout", id, cb });
+}
+
+function onVisibilityChange(): void {
+  if (!isDocumentHidden()) return;
+  for (const [token, handle] of Array.from(paintHandles.entries())) {
+    if (handle.kind !== "raf") continue;
+    cancelAnimationFrame(handle.id);
+    armTimeout(token, handle.cb);
+  }
+}
+
+function ensureVisibilityBridge(): void {
+  if (visibilityBridgeBound || typeof document === "undefined") return;
+  visibilityBridgeBound = true;
+  document.addEventListener("visibilitychange", onVisibilityChange);
+}
 
 export function scheduleStreamPaint(cb: () => void): number {
   const token = nextPaintToken++;
-  const hidden = typeof document !== "undefined" && document.visibilityState === "hidden";
-  if (hidden || typeof requestAnimationFrame !== "function") {
-    const id = window.setTimeout(() => {
-      paintHandles.delete(token);
-      cb();
-    }, STREAM_PAINT_MS);
-    paintHandles.set(token, { kind: "timeout", id });
+  ensureVisibilityBridge();
+  if (isDocumentHidden() || typeof requestAnimationFrame !== "function") {
+    armTimeout(token, cb);
     return token;
   }
   const id = requestAnimationFrame(() => {
     paintHandles.delete(token);
+    if (isDocumentHidden()) {
+      armTimeout(token, cb);
+      return;
+    }
     cb();
   });
-  paintHandles.set(token, { kind: "raf", id });
+  paintHandles.set(token, { kind: "raf", id, cb });
   return token;
 }
 
@@ -43,6 +71,11 @@ export function cancelStreamPaint(id: number): void {
   paintHandles.delete(id);
   if (handle.kind === "raf") cancelAnimationFrame(handle.id);
   else clearTimeout(handle.id);
+}
+
+/** Test seam: pending scheduler tokens (rAF or timeout). */
+export function streamPaintHandleCount(): number {
+  return paintHandles.size;
 }
 
 export type TypewriterRefs = {
@@ -84,13 +117,10 @@ export function pumpTypewriterFrame(
   refs.typeRafRef.current = null;
   const buf = refs.typeBufRef.current;
   if (!buf) {
-    if (!refs.typeDoneRef.current) {
-      scheduleTypewriterPump(refs, appendStreamingText, schedule);
-    }
     return;
   }
   takeTypewriterChunk(refs, appendStreamingText);
-  if (refs.typeBufRef.current || !refs.typeDoneRef.current) {
+  if (refs.typeBufRef.current) {
     scheduleTypewriterPump(refs, appendStreamingText, schedule);
   }
 }
@@ -107,7 +137,9 @@ export function startTypewriterLoop(
   if (refs.typeBufRef.current) {
     takeTypewriterChunk(refs, appendStreamingText);
   }
-  scheduleTypewriterPump(refs, appendStreamingText, schedule);
+  if (refs.typeBufRef.current) {
+    scheduleTypewriterPump(refs, appendStreamingText, schedule);
+  }
 }
 
 export function flushTypewriterBuffer(


### PR DESCRIPTION
## Why

Hidden-tab streams parked a `requestAnimationFrame` and stopped draining. Stdio MCP `initialize` timeouts left the child running. HTTP MCP SSE treated a trailing progress notification as the RPC result. Submit-pin yanked after the user had already scrolled away.

## Scope

- `streamTypewriter.ts`: `visibilitychange` converts a pending rAF to a 33ms timeout. An empty buffer does not reschedule.
- `Conversation.tsx`: submit-pin returns if `scrollReleasedByGestureRef` is set.
- `mcp_client.py`: `start()` calls `stop()` and re-raises on handshake failure.
- `mcp_http_client.py`: join multiline `data:` lines, pick the last JSON-RPC result or error, skip trailing progress.
- MICRO `no_delegation` carve-out is documented only.
- Lock test for colonless `+0000` timestamps already normalized by `timestamp()`.

Mechanical: version stamps to 0.9.468. Pin stays `puppetmaster-ai==1.27.12`.

## Tradeoffs

Visible tabs still use vsync rAF. Hidden tabs use the timeout path.

## Blast radius

`StdioMcpClient.start()` always reaps the child on handshake failure. Manager `start_server` also stops on `McpError`. A second `stop()` is a no-op.

HTTP MCP `_post` no longer treats a trailing notification as the result.

## Verification

- pytest: `test_mcp.py`, `test_mcp_hardening.py`, `test_mcp_http_client.py`, `test_job_expert_economics_lane.py`, `test_task_profile.py`, `test_version_consistency.py`
- vitest: typewriter scheduler, slowBatch, `conversation.helpers` (167)
- full `pytest tests -q`: 7543 passed, 68 skipped
- CI still has to prove 3.9, 3.11, Windows, and frontend-build