### PR TITLE
tracker: follow a live job instead of freezing or blanking the roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Puppetmaster is the bundled kernel — not a second product to set up.
 stdlib-only backend (urllib + sqlite); `puppetmaster-ai==1.27.12` is the one
 real dependency the installer puts in the venv.
 
-> Status: v0.9.468, deliberately pre-1.0. Pin stays `puppetmaster-ai==1.27.12`. Hidden-tab streams keep draining on a 33ms timeout instead of parking a rAF; an empty typewriter buffer stops the pump until the next delta; submit-pin honors a user scroll gesture; stdio MCP `start()` reaps the child if initialize times out; HTTP MCP SSE picks the last JSON-RPC result, not a trailing progress notification. Runtime pin: `puppetmaster-ai==1.27.12`.
+> Status: v0.9.469, deliberately pre-1.0. Pin stays `puppetmaster-ai==1.27.12`. Swarm Tracker follows a live job: the canonical alias re-hydrates on list revision or every 4s instead of freezing on its first read; a transient store lock (`read_snapshot_unavailable`), a mid-read revision advance, or a re-read expert race keeps the last roster visibly stale instead of blanking the card; the card body no longer repeats the whole instruction as a title. v0.9.468: Hidden-tab streams keep draining on a 33ms timeout instead of parking a rAF; an empty typewriter buffer stops the pump until the next delta; submit-pin honors a user scroll gesture; stdio MCP `start()` reaps the child if initialize times out; HTTP MCP SSE picks the last JSON-RPC result, not a trailing progress notification. Runtime pin: `puppetmaster-ai==1.27.12`.
 
 ## Documentation
 

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -7,7 +7,7 @@ DurableState read layer is what the GUI renders.
 
 Driver default: glm-5.2 (MIT, efficient, 100% on the discriminating eval).
 """
-__version__ = "0.9.468"
+__version__ = "0.9.469"
 
 # On Windows, default every subprocess to a hidden console. The backend runs
 # console-less under Electron; without this, each git/node/uv/puppetmaster

--- a/harness/job_readmodel.py
+++ b/harness/job_readmodel.py
@@ -32,6 +32,20 @@ from .job_expert_compaction import read_selected_compaction
 
 PAGE_BUDGET = dict(limit=50, max_scan=51, max_bytes=32768)
 EXACT_BUDGET = dict(limit=1, max_scan=2, max_bytes=8192)
+SNAPSHOT_RETRIES = 3
+
+
+def _read_page(method, *args, **kwargs):
+    """Live workers hold SQLite write locks for short bursts; the store reports that as
+    ``read_snapshot_unavailable`` with a retry hint. Honor it a bounded number of times so a
+    lock burst does not surface as an unavailable roster."""
+    page = method(*args, **kwargs)
+    for _ in range(SNAPSHOT_RETRIES - 1):
+        if page.outcome != 'unavailable' or getattr(page, 'reason', None) != 'read_snapshot_unavailable':
+            break
+        time.sleep(min(max(getattr(page, 'retry_after_ms', None) or 100, 20), 250) / 1000)
+        page = method(*args, **kwargs)
+    return page
 HISTORY_BUDGET = dict(limit=20, max_scan=21, max_bytes=8192)
 HISTORY_LANES = {
     'attempts': 'list_attempt_refs', 'runs': 'list_run_refs',
@@ -434,7 +448,7 @@ class MetadataReader:
         if store is None:
             return None, None, 'store_unavailable'
         try:
-            page = store.list_job_summaries(job_ref=selection.job_ref, **EXACT_BUDGET)
+            page = _read_page(store.list_job_summaries, job_ref=selection.job_ref, **EXACT_BUDGET)
         except StoreIdentityError:
             return None, None, 'selection_changed'
         if page.outcome != 'complete':
@@ -512,7 +526,7 @@ class MetadataReader:
             selected_pages = {}
             for lane, method in (('tasks', store.list_task_refs), ('artifacts', store.list_artifact_refs)):
                 self.check(ctx)
-                selected_pages[lane] = method(selection.job_ref, cursor=cursors[lane], **PAGE_BUDGET)
+                selected_pages[lane] = _read_page(method, selection.job_ref, cursor=cursors[lane], **PAGE_BUDGET)
             if selected_pages['tasks'].revision == selected_pages['artifacts'].revision:
                 break
         for lane, page in selected_pages.items():
@@ -544,9 +558,11 @@ class MetadataReader:
         else:
             result['expert'] = self._expert(store, row, selection, selected_pages, cursors)
         # Separate bounded reads are not a transaction. Never return lanes from a
-        # selection that lost ownership or changed while they were being read.
+        # selection that lost ownership or identity while they were being read. A live
+        # job's summary revision advances under every worker write; that is the same
+        # selection, and the lane pages already carry their own revisions.
         _, current, reason = self._selected(selection)
-        if reason or current.revision != row.revision:
+        if reason or current.job_ref != row.job_ref:
             result.update(lifecycle=None, display=dict(kind='unavailable', reason='selection_changed'),
                           task_count=None, artifact_count=None,
                           tasks=dict(page=_page(), rows=[]), artifacts=dict(page=_page(), rows=[]),
@@ -577,7 +593,7 @@ class MetadataReader:
             return None
         cursors = dict(tasks=None, artifacts=None)
         for _ in range(3):
-            pages = {lane: method(selection.job_ref, cursor=None, **PAGE_BUDGET)
+            pages = {lane: _read_page(method, selection.job_ref, cursor=None, **PAGE_BUDGET)
                      for lane, method in (('tasks', store.list_task_refs), ('artifacts', store.list_artifact_refs))}
             if pages['tasks'].revision == pages['artifacts'].revision:
                 break
@@ -600,7 +616,7 @@ class MetadataReader:
             return job_expert.unavailable('lane_revision_skew')
         deadline = time.monotonic() + 2
         _, current, reason = self._selected(selection, pin=pin)
-        if reason or current.revision != row.revision:
+        if reason or current.job_ref != row.job_ref:
             return job_expert.unavailable('selection_changed')
         job = job or store.get_job(selection.job_ref.job_id)
         if job.id != selection.job_ref.job_id or str(job.status) != row.status:
@@ -648,12 +664,18 @@ class MetadataReader:
         if known is not None and job.session_id and created_at and time.monotonic() < deadline:
             compaction = read_selected_compaction(known.root, session_id=job.session_id, job_id=job.id,
                 created_at=datetime.fromisoformat(created_at.replace('Z', '+00:00')).timestamp())
-        # Re-read the identical finite reference pages. A task binding or artifact
-        # revision changed during hydration must invalidate the entire projection.
+        # Re-read the identical finite reference pages. A row hydrated above that was revised
+        # meanwhile would publish stale content, so that still invalidates the projection.
+        # Rows appended by a live job (a task bound, an artifact landed) leave this projection
+        # one step behind: report partial coverage rather than no roster. The page revision
+        # alone advances under every store write and is not a change to the selection.
         for lane, method in (('tasks', store.list_task_refs), ('artifacts', store.list_artifact_refs)):
-            current = method(selection.job_ref, cursor=cursors[lane], **PAGE_BUDGET)
-            if current != pages[lane]:
+            current = _read_page(method, selection.job_ref, cursor=cursors[lane], **PAGE_BUDGET)
+            hydrated = tuple(pages[lane].items)
+            if current.outcome != pages[lane].outcome or tuple(current.items[:len(hydrated)]) != hydrated:
                 return job_expert.unavailable('selection_changed')
+            if len(current.items) != len(hydrated):
+                coverage[lane] = 'partial'
         if pages['tasks'].revision != pages['artifacts'].revision:
             return job_expert.unavailable('lane_revision_skew')
         if time.monotonic() >= deadline:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pm-harness"
-version = "0.9.468"
+version = "0.9.469"
 description = "Research rig: which LLMs can drive Puppetmaster as a native harness layer"
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_job_metadata_contract.py
+++ b/tests/test_job_metadata_contract.py
@@ -221,6 +221,24 @@ def test_selected_reads_use_exact_public_bodies_without_scans_or_writes(case, mo
     assert any('selected_economics_current' in sql for sql in reads)
 
 
+def test_live_revision_advance_during_selected_read_keeps_lanes(case, monkeypatch):
+    """A worker write landing mid-read moves the job revision; the selection is unchanged."""
+    store, job, reader, _ = case
+    handle = reader.sources.stores[0].handle
+    original = handle.list_run_refs
+    def advanced(*a, **kw):
+        result = original(*a, **kw)
+        store.save_task(Task(job.id, 'worker', 'landed mid-read'))
+        return result
+    monkeypatch.setattr(handle, 'list_run_refs', advanced)
+    code, selected = detail(case)
+    assert code == 200 and 'selection_changed' not in selected['missing']
+    assert selected['lifecycle'] is not None
+    assert selected['tasks']['page']['outcome'] == 'complete'
+    assert selected['expert']['kind'] != 'unavailable'
+    assert selected['expert']['coverage']['tasks'] == 'partial'
+
+
 def test_ownership_change_during_selected_read_discards_all_lanes(case, monkeypatch):
     store, job, reader, _ = case
     handle = reader.sources.stores[0].handle

--- a/tests/test_job_readmodel_expert_midflight.py
+++ b/tests/test_job_readmodel_expert_midflight.py
@@ -137,3 +137,51 @@ def test_lane_revision_skew_degrades_expert_not_lanes(tmp_path):
     }
     expert = reader._expert(attached, row, selection, skewed, dict(tasks=None, artifacts=None))
     assert expert == job_expert.unavailable('lane_revision_skew')
+
+
+def test_read_page_retries_snapshot_unavailable_then_returns_live_page(monkeypatch):
+    from types import SimpleNamespace
+
+    from harness import job_readmodel
+
+    naps = []
+    monkeypatch.setattr(job_readmodel.time, 'sleep', naps.append)
+    pages = iter([
+        SimpleNamespace(outcome='unavailable', reason='read_snapshot_unavailable', retry_after_ms=40),
+        SimpleNamespace(outcome='unavailable', reason='read_snapshot_unavailable', retry_after_ms=None),
+        SimpleNamespace(outcome='complete', reason=None, retry_after_ms=None),
+    ])
+    calls = []
+
+    def method(*args, **kwargs):
+        calls.append((args, kwargs))
+        return next(pages)
+
+    page = job_readmodel._read_page(method, 'ref', cursor=None, limit=1)
+    assert page.outcome == 'complete'
+    assert len(calls) == 3 and calls[0] == (('ref',), dict(cursor=None, limit=1))
+    assert naps == [0.04, 0.1]
+
+
+def test_read_page_gives_up_after_bounded_retries(monkeypatch):
+    from types import SimpleNamespace
+
+    from harness import job_readmodel
+
+    monkeypatch.setattr(job_readmodel.time, 'sleep', lambda _s: None)
+    locked = SimpleNamespace(outcome='unavailable', reason='read_snapshot_unavailable', retry_after_ms=100)
+    calls = []
+    page = job_readmodel._read_page(lambda: calls.append(1) or locked)
+    assert page is locked and len(calls) == job_readmodel.SNAPSHOT_RETRIES
+
+
+def test_read_page_does_not_retry_other_outcomes(monkeypatch):
+    from types import SimpleNamespace
+
+    from harness import job_readmodel
+
+    monkeypatch.setattr(job_readmodel.time, 'sleep', lambda _s: pytest.fail('unexpected sleep'))
+    missing = SimpleNamespace(outcome='unavailable', reason='missing', retry_after_ms=None)
+    calls = []
+    assert job_readmodel._read_page(lambda: calls.append(1) or missing) is missing
+    assert calls == [1]

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-harness",
-  "version": "0.9.468",
+  "version": "0.9.469",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-harness",
-      "version": "0.9.468",
+      "version": "0.9.469",
       "dependencies": {
         "@chenglou/pretext": "^0.0.8",
         "@codemirror/lang-css": "^6.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-harness",
   "private": true,
-  "version": "0.9.468",
+  "version": "0.9.469",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webapp/src/__tests__/MetadataJobs.canonicalAlias.test.tsx
+++ b/webapp/src/__tests__/MetadataJobs.canonicalAlias.test.tsx
@@ -508,6 +508,26 @@ describe('metadataJobs alias dedupe', () => {
     expect(expert?.kind).toBe('available');
     expect(expert?.tasks).toHaveLength(4);
   });
+
+  it('keeps the hydrated roster when a live list row runs ahead of the last detail read', () => {
+    const c = context();
+    const selected = pmSelection(c);
+    const key = metadataSelectionKey(selected);
+    const detail = fourTaskDetail(selected, c);
+    const state = {
+      view: { kind: 'view', target: { repo: c.repo, session_id: c.session_id, scope: 'all' }, context: c, view: view(c.view_generation), refresh: 'idle' },
+      observations: [{ row: { ...pmRow(c), revision: detail.tasks.page.revision + 250 }, freshness: 'observed' }],
+      pins: [],
+      detail: { kind: 'none' },
+      detailCache: {
+        [key]: { kind: 'selected', selection: selected, cursors: { task_cursor: null, artifact_cursor: null }, observation: detail, freshness: 'observed', error: null },
+      },
+      headers: {},
+      error: null,
+      working: false,
+    } as unknown as JobMetadataState;
+    expect(currentExpert(state, key)?.tasks).toHaveLength(4);
+  });
 });
 
 describe('SwarmPane canonical alias presentation', () => {
@@ -534,6 +554,22 @@ describe('SwarmPane canonical alias presentation', () => {
       fixture.unmount();
     }
   });
+
+  it('re-hydrates a live canonical alias so the roster follows the job instead of freezing', async () => {
+    const fixture = await mountCanonicalAlias({ includePmList: false });
+    const detailCalls = () => fixture.requestJSON.mock.calls.filter(([, path]) => String(path).includes('/detail')).length;
+    try {
+      const row = await screen.findByTestId(`inspect-local-${localSummary().local_ref.job_id}`);
+      fireEvent.click(within(row).getByRole('button', { name: /Provider worker|canonical swarm goal|Synthetic alias/ }));
+      await screen.findByRole('group', { name: 'Workers' });
+      const first = detailCalls();
+      expect(first).toBeGreaterThan(0);
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 4600)); });
+      await waitFor(() => expect(detailCalls()).toBeGreaterThan(first));
+    } finally {
+      fixture.unmount();
+    }
+  }, 15000);
 
   it('hides the alias once the canonical PM row is observed', async () => {
     const fixture = await mountCanonicalAlias({ includePmList: false });

--- a/webapp/src/__tests__/useJobMetadata.traversal.test.ts
+++ b/webapp/src/__tests__/useJobMetadata.traversal.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
-import { JobMetadataClient } from '../lib/jobMetadata';
+import { JobMetadataClient, metadataSelectionKey } from '../lib/jobMetadata';
 import { JobMetadataStore } from '../lib/useJobMetadata';
-import { context, handshake, list, response, token, view } from './jobMetadata.fixtures';
+import { context, detail, handshake, list, response, selection, token, view } from './jobMetadata.fixtures';
 
 let store: JobMetadataStore;
 let request: ReturnType<typeof vi.fn<(path: string, init?: RequestInit) => Promise<Response>>>;
@@ -160,4 +160,26 @@ it('changed metadata view_generation after view_changed rebuilds traversal from 
     state: 'ready',
     traversal: { mode: 'snapshot', after_revision: 0, cursor: null },
   });
+});
+
+it('hydrateDetail keeps the last hydrated observation visibly stale across a transient unavailable read', async () => {
+  await open();
+  const good = detail();
+  request.mockImplementation(async (path: string) => path.endsWith('/view') ? response(view()) : path.includes('/detail') ? response(good) : response(list()));
+  expect(await store.hydrateDetail(selection())).toBe('applied');
+  const key = metadataSelectionKey(selection());
+  expect(store.getSnapshot().detailCache[key]).toMatchObject({ freshness: 'observed', error: null });
+
+  const locked = { ...good, lifecycle: null,
+    tasks: { page: { outcome: 'unavailable', revision: 0, scanned: 0, checkpoint: 0, next_cursor: null }, rows: [] },
+    artifacts: { page: { outcome: 'unavailable', revision: 0, scanned: 0, checkpoint: 0, next_cursor: null }, rows: [] },
+    display: { kind: 'unavailable', reason: 'read_snapshot_unavailable' }, task_count: null, artifact_count: null,
+    history: { kind: 'unavailable', reason: 'read_snapshot_unavailable' }, cost: { kind: 'unavailable', reason: 'read_snapshot_unavailable' },
+    missing: ['history', 'cost', 'read_snapshot_unavailable'] };
+  request.mockImplementation(async (path: string) => path.endsWith('/view') ? response(view()) : path.includes('/detail') ? response(locked) : response(list()));
+  expect(await store.hydrateDetail(selection())).toBe('applied');
+  const entry = store.getSnapshot().detailCache[key];
+  expect(entry).toMatchObject({ freshness: 'stale', error: null });
+  expect(entry.observation?.tasks.rows).toHaveLength(1);
+  expect(entry.observation?.lifecycle).toBe('running');
 });

--- a/webapp/src/components/MetadataJobs.tsx
+++ b/webapp/src/components/MetadataJobs.tsx
@@ -148,9 +148,10 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
     }
   }, [deferAutoRead, selectedPM, detail?.observation, state.working, state.view, store]);
   // A local alias with a canonical PM ref hydrates that job cache-only: it never takes over
-  // the selection and re-attempts whenever the store settles idle without an observation
-  // or error for the key (at most every 2s), so a reset after invalidate cannot strand it.
-  const canonicalKey = !selectedPM && canonicalSelection ? metadataSelectionKey(canonicalSelection) : '';
+  // the selection. While the job is live it re-hydrates when the listed row's revision moves
+  // past the cached detail or every 4s, so the roster follows routing and completion instead
+  // of freezing on the first observation. A selected inspection owns its own refresh cadence.
+  const canonicalKey = canonicalSelection ? metadataSelectionKey(canonicalSelection) : '';
   const canonicalRef = useRef(canonicalSelection);
   canonicalRef.current = canonicalSelection;
   useEffect(() => {
@@ -160,16 +161,24 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
       const selection = canonicalRef.current;
       const snap = store.getSnapshot();
       if (!selection || snap.working || snap.view.kind !== 'view') return;
-      const current = snap.detail.kind === 'selected' && metadataSelectionKey(snap.detail.selection) === canonicalKey
-        ? snap.detail : snap.detailCache[canonicalKey];
-      if (current?.observation || current?.error) return;
+      if (snap.detail.kind === 'selected' && metadataSelectionKey(snap.detail.selection) === canonicalKey) return;
+      const current = snap.detailCache[canonicalKey];
       const at = Date.now();
-      if (last !== null && at - last < 2000) return;
+      let due = !current?.observation && !current?.error;
+      if (current?.observation && !current.error) {
+        const hydrated = Math.max(current.observation.tasks.page.revision, current.observation.artifacts.page.revision);
+        const listedRevision = snap.observations.find(o => metadataSelectionKey(o.row.selection) === canonicalKey)?.row.revision ?? 0;
+        const live = current.observation.lifecycle === null || !terminal.has(current.observation.lifecycle);
+        due = listedRevision > hydrated || (live && (last === null || at - last >= 4000));
+      }
+      if (!due || (last !== null && at - last < 2000)) return;
       last = at;
       void store.hydrateDetail(selection);
     };
     attempt();
-    return store.subscribe(attempt);
+    const tick = setInterval(() => { if (!document.hidden) attempt(); }, 2000);
+    const unsubscribe = store.subscribe(attempt);
+    return () => { clearInterval(tick); unsubscribe(); };
   }, [deferAutoRead, canonicalKey, state.view.kind, store]);
   const initialNativeRead = useRef(false);
   const initialRoutingRead = useRef(false);
@@ -319,7 +328,6 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
     </> : null;
   return <div className="px-2 pb-2 pt-1 flex flex-col gap-2 bg-panel2/10 text-xs text-muted">
     <div className="flex flex-col gap-1.5 border-b border-edge/20 pb-2">
-      {canonical && cardTitle && <p className="text-[11px] font-semibold text-txt break-words">{cardTitle}</p>}
       <button className="self-start font-mono text-[9px] text-faint hover:text-muted" aria-label={`Job ${headerJobId}`} onClick={() => {
         void navigator.clipboard.writeText(headerJobId).then(() => setNotice('Job ID copied.'), () => setNotice('Unable to copy job ID.'));
       }}>Job {headerJobId}</button>
@@ -331,7 +339,7 @@ function SelectedInspection({ job, navigation, compact, onReveal, onOpenDashboar
       </div>}
     </div>
     {workerCount > 0 && <CompactSwarmDashboard
-      title={cardTitle} lifecycle={observation?.lifecycle ?? nativeSummary?.lifecycle ?? job.status}
+      title={cardTitle} lifecycle={terminal.has(job.status) ? job.status : observation?.lifecycle ?? nativeSummary?.lifecycle ?? job.status}
       workerStatuses={taskStatusById}
       expert={(preferCanonicalRoster || nativeRows.length === 0) && expert && expert.kind !== 'unavailable' ? expert : undefined}
       headerModel={expertHeaderModel(currentHeader(state, expertKey)) ?? nativeSummary?.display?.model ?? undefined}

--- a/webapp/src/lib/jobMetadataContext.tsx
+++ b/webapp/src/lib/jobMetadataContext.tsx
@@ -71,8 +71,10 @@ export function currentExpert(state: JobMetadataState, key: string) {
   // An unrelated lane failure stamps every cached detail stale; a hydrated expert
   // whose own list row is still fresh stays visible.
   if (selected.freshness !== 'observed' && !selected.observation.expert) return undefined;
-  const latest = Math.max(0, ...[...state.observations, ...state.pins.flatMap(p => p.observation ? [p.observation] : [])].filter(o => metadataSelectionKey(o.row.selection) === key).map(o => o.row.revision), state.headers[key]?.observation.row.revision ?? 0);
-  return selected.observation.tasks.page.revision >= latest && selected.observation.artifacts.page.revision >= latest ? selected.observation.expert : undefined;
+  // A live job's list row runs ahead of the last detail read between refreshes. The roster
+  // stays visible from that read and the refresh cadence catches it up; the card takes its
+  // lifecycle from the fresher list row, so a settled job never renders as running.
+  return selected.observation.expert;
 }
 export function currentHeader(state: JobMetadataState, key: string) {
   const expert = currentExpert(state, key);

--- a/webapp/src/lib/useJobMetadata.ts
+++ b/webapp/src/lib/useJobMetadata.ts
@@ -52,6 +52,16 @@ function blank(epoch: number, view: ViewState): JobMetadataState {
   return { headerError: null, headerReads: {}, headers: {}, nextHeader: 0, selectedRefreshedAt: 0, startupStopped: false, activeSnapshotKeys: {}, localActive: { initialized: false, snapshotRevisions: {}, traversal: { mode: 'snapshot', after_revision: 0, cursor: null }, state: 'ready', keys: [], missing: [], observedAt: null }, nextPrimaryActive: 0, contextEpoch: 0, followedLocal: [], followedCursors: {}, nextFollowed: 0, actionPage: null, local: { observations: [], traversal: { mode: 'snapshot', after_revision: 0, cursor: null }, state: 'ready', missing: [], observedAt: null }, localDetail: null, advanceNumber: 0, observedAt: {}, epoch, view, working: false, error: null, observations: [], removals: [], streams: [], nextStream: 0, nextForeground: 0, pins: [], detail: { kind: 'none' }, detailCache: {}, displayLimited: false };
 }
 function code(error: unknown): MetadataErrorCode { return error instanceof MetadataError ? error.code : 'outcome_unknown'; }
+/** A live job's expert projection is re-read after hydration and can miss a race the lanes
+ *  survived (`selection_changed`, `deadline`, `lane_revision_skew`). Those are transient, so
+ *  the last projected roster carries forward until the next read lands a fresh one. */
+const transientExpert = new Set(['selection_changed', 'deadline', 'lane_revision_skew', 'read_snapshot_unavailable']);
+function carryExpert(response: MetadataDetail, previous: MetadataDetail | null | undefined): MetadataDetail {
+  const current = response.expert, prior = previous?.expert;
+  if (!current || current.kind !== 'unavailable' || !transientExpert.has(current.reason ?? '')) return response;
+  if (!prior || prior.kind === 'unavailable') return response;
+  return { ...response, expert: prior };
+}
 const contextEvents = ['harness-project-switching', 'harness-project-selected', 'harness-session-changed', 'harness-config-changed'];
 
 /** One owner per workspace UI. Subscribers are passive; only the owner starts work. */
@@ -724,8 +734,13 @@ export class JobMetadataStore {
       const floor = Math.max(0, ...this.state.observations.filter(o => metadataSelectionKey(o.row.selection) === key).map(o => o.row.revision));
       const incomplete = response.tasks.page.revision < floor || response.artifacts.page.revision < floor
         || [response.tasks.page.outcome, response.artifacts.page.outcome].some(o => o === 'unavailable' || o === 'cursor_expired');
-      const entry: DetailState = { kind: 'selected', selection: captured, observation: response, cursors,
-        freshness: incomplete ? 'stale' : 'observed', error: incomplete ? 'unavailable' : null };
+      // A transient unavailable read (store lock, lane skew) keeps the last hydrated roster
+      // visibly stale rather than blanking the card; the next tick re-hydrates.
+      const previous = this.state.detailCache[key]?.observation;
+      const entry: DetailState = incomplete && previous
+        ? { kind: 'selected', selection: captured, observation: previous, cursors, freshness: 'stale', error: null }
+        : { kind: 'selected', selection: captured, observation: carryExpert(response, previous), cursors,
+          freshness: incomplete ? 'stale' : 'observed', error: incomplete ? 'unavailable' : null };
       const current = this.state.detail;
       const retained = Object.entries(this.state.detailCache).filter(([cached]) => cached !== key).slice(-7);
       this.publish({ ...this.state, selectedRefreshedAt: Date.now(),
@@ -756,7 +771,7 @@ export class JobMetadataStore {
       const revisionFloor = Math.max(detail.observation?.tasks.page.revision ?? 0, ...this.state.observations.filter(o => metadataSelectionKey(o.row.selection) === metadataSelectionKey(detail.selection)).map(o => o.row.revision));
       const incomplete = response.tasks.page.revision < revisionFloor || response.artifacts.page.revision < revisionFloor || selectedHistoryUnavailable || [response.tasks.page.outcome, response.artifacts.page.outcome].some(o => o === 'unavailable' || o === 'cursor_expired');
       // An unavailable selected lookup retains the last observation visibly stale.
-      const observation = incomplete && detail.observation ? detail.observation : response;
+      const observation = incomplete && detail.observation ? detail.observation : carryExpert(response, detail.observation);
       this.publish({ ...this.state, selectedRefreshedAt: Date.now(), advanceNumber: this.state.advanceNumber + Number(scheduled), detail: { ...detail, observation, cursors: incomplete ? detail.cursors : captured,
         freshness: incomplete ? 'stale' : 'observed', error: incomplete ? 'unavailable' : null } });
     }, () => { if (scheduled) this.publish({ ...this.state, selectedRefreshedAt: Date.now(), advanceNumber: this.state.advanceNumber + 1 }); });


### PR DESCRIPTION
Fixes the live Swarm Tracker card for a running swarm: one-shot canonical hydration froze on the first read; store lock bursts, mid-read revision advances, and expert re-read races each blanked the card.

- harness/job_readmodel.py: bounded retry on read_snapshot_unavailable; selection_changed only on identity/ownership change; expert re-read reports appended rows as partial coverage.
- webapp: alias re-hydrates on listed revision or every 4s while live; transient unavailable read/expert carries the previous roster forward stale; currentExpert no longer hides a roster because the list row ran ahead; settled list lifecycle wins the pill; instruction wall removed from the card body.
- Tests: 3 retry unit tests, live-revision-advance contract test, alias re-hydration RTL test, store carry-forward test, expert-visible-when-list-ahead test.

Live proof on a real running swarm: routed roster at every 5s sample over 60s, no alerts.

v0.9.469.