### PR TITLE
fix: preserve wiki excerpts in automatic grounding

### DIFF
--- a/harness/wiki.py
+++ b/harness/wiki.py
@@ -336,6 +336,7 @@ class WikiClient:
                 title = str(hit.get("title") or slug)
                 snippet = (
                     hit.get("snippet")
+                    or hit.get("excerpt")
                     or hit.get("description")
                     or hit.get("body")
                     or ""

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -96,6 +96,29 @@ def test_ingest_posts_correct_payload(monkeypatch):
     assert captured["auth"] == "Bearer secret"
 
 
+def test_search_pages_maps_portable_wiki_excerpt_to_snippet(monkeypatch):
+    class FakeResp:
+        status = 200
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self):
+            return json.dumps({"results": [{
+                "title": "Session review artifact overwrite",
+                "slug": "incident-session-review-artifact-overwrite",
+                "excerpt": "A review agent silently replaced 4,847 bytes.",
+            }]}).encode()
+
+    monkeypatch.setattr(
+        "harness.wiki._wiki_safe_urlopen", lambda req, timeout=0: FakeResp()
+    )
+
+    hits = WikiClient(base_url="https://wiki.example.com", token="secret").search_pages(
+        "artifact overwrite"
+    )
+
+    assert hits[0]["snippet"] == "A review agent silently replaced 4,847 bytes."
+
+
 def test_strip_cross_host_auth_headers():
     import urllib.request
     from harness.wiki import _strip_cross_host_auth_headers


### PR DESCRIPTION
wiki: preserve Portable LLM Wiki excerpts in automatic grounding

Portable LLM Wiki's documented and live `/wiki/search` response carries page text in `excerpt`. Marionette's `WikiClient.search_pages` only read `snippet`, `description`, or `body`, so automatic grounding found the right titles while silently injecting empty page text.

Map the protocol's `excerpt` field into Marionette's internal `snippet` shape. Keep the older aliases for compatible servers.

Proof:

- Contract RED: a real-shape search result returned `snippet == ""` before the change.
- Contract GREEN: the same result preserves the excerpt.
- Mounted proof: a fresh Marionette session against a private local Portable LLM Wiki answered the session-review overwrite incident from automatically supplied context, with tools forbidden: 4,847 bytes, recovered from Hermes `state.db`.
- `pytest -q tests/test_wiki.py tests/test_wiki_grounding.py` — 24 passed.