### PR TITLE
fix: hydrate top wiki result within grounding budget

### DIFF
--- a/harness/wiki.py
+++ b/harness/wiki.py
@@ -349,6 +349,25 @@ class WikiClient:
         except Exception:
             return []
 
+    def page_body(self, slug: str) -> str:
+        """Fetch one page body through the native wiki page endpoint."""
+        if not self.configured or not (slug or "").strip():
+            return ""
+        try:
+            safe_slug = urllib.parse.quote(slug.strip(), safe="")
+            req = urllib.request.Request(
+                f"{self.base_url}/wiki/page/{safe_slug}",
+                method="GET",
+                headers=self._auth_headers(),
+            )
+            with _wiki_safe_urlopen(req, timeout=self.timeout) as r:
+                if r.status != 200:
+                    return ""
+                data = json.loads(r.read().decode("utf-8", "replace"))
+            return str(data.get("body") or "") if isinstance(data, dict) else ""
+        except Exception:
+            return ""
+
     def query(self, question: str) -> str:
         """Query the wiki's LLM query/search surface.
 

--- a/harness/wiki_distill.py
+++ b/harness/wiki_distill.py
@@ -89,6 +89,10 @@ class WikiDistillMixin:
                 self._wiki_cache_pages = 0
                 return wiki_section
 
+            top_body = self._wiki.page_body(str(hits[0].get("slug") or ""))
+            if top_body:
+                hits[0] = {**hits[0], "snippet": top_body}
+
             authoritative = (
                 "WIKI HAS ALREADY BEEN QUERIED FOR THIS TURN. Relevant notes and "
                 "decisions from your durable wiki are provided in the section below. "

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -96,6 +96,36 @@ def test_ingest_posts_correct_payload(monkeypatch):
     assert captured["auth"] == "Bearer secret"
 
 
+def test_page_body_fetches_the_native_page_endpoint(monkeypatch):
+    captured = {}
+
+    class FakeResp:
+        status = 200
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self):
+            return json.dumps({"body": "The durable answer is later in the page."}).encode()
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["auth"] = req.headers.get("Authorization")
+        captured["timeout"] = timeout
+        return FakeResp()
+
+    monkeypatch.setattr("harness.wiki._wiki_safe_urlopen", fake_urlopen)
+
+    body = WikiClient(
+        base_url="https://wiki.example.com", token="secret", timeout=7
+    ).page_body(
+        "incident-session-review-artifact-overwrite"
+    )
+
+    assert body == "The durable answer is later in the page."
+    assert captured["url"].endswith("/wiki/page/incident-session-review-artifact-overwrite")
+    assert captured["auth"] == "Bearer secret"
+    assert captured["timeout"] == 7
+
+
 def test_strip_cross_host_auth_headers():
     import urllib.request
     from harness.wiki import _strip_cross_host_auth_headers

--- a/tests/test_wiki_grounding.py
+++ b/tests/test_wiki_grounding.py
@@ -55,11 +55,50 @@ def test_wiki_section_non_empty_with_mocked_search(tmp_path, monkeypatch):
         ]
 
     monkeypatch.setattr(s._wiki, "search_pages", fake_search)
+    monkeypatch.setattr(s._wiki, "page_body", lambda slug: "")
     section = s._build_turn_wiki_section("what about the default driver?")
     assert section
     assert "WIKI HAS ALREADY BEEN QUERIED" in section
     assert "Driver decision" in section
     assert "stub-oracle-v2" in section
+
+
+def test_wiki_section_hydrates_top_page_inside_existing_budget(tmp_path):
+    s = _session(tmp_path)
+    s._task_profile = STANDARD
+
+    class FakeWiki:
+        configured = True
+
+        def search_pages(self, query, *, limit=5):
+            return [
+                {
+                    "title": "Overwrite incident",
+                    "slug": "overwrite-incident",
+                    "snippet": "A review artifact was overwritten.",
+                },
+                {
+                    "title": "Other note",
+                    "slug": "other-note",
+                    "snippet": "Keep this secondary candidate visible.",
+                },
+            ]
+
+        def page_body(self, slug):
+            assert slug == "overwrite-incident"
+            return (
+                "A" * 350
+                + " The prevention is reserving a unique path before writing."
+                + " Z" * 5000
+            )
+
+    s._wiki = FakeWiki()
+
+    section = s._build_turn_wiki_section("what prevents the overwrite now?")
+
+    assert "The prevention is reserving a unique path before writing." in section
+    assert "Keep this secondary candidate visible." in section
+    assert len(section) <= s._WIKI_GROUNDING_STANDARD_MAX_CHARS + 1
 
 
 def test_trailer_includes_wiki_after_cg(tmp_path, monkeypatch):


### PR DESCRIPTION
wiki: hydrate the top search result inside the existing grounding budget

Automatic grounding currently stops at Portable LLM Wiki's roughly 280-character page excerpt. Marionette can select the correct page yet miss the decision or explanation immediately below its introduction.

After search ranks the candidates, fetch the top page through the protocol's existing `GET /wiki/page/{slug}` endpoint. Feed that body through Marionette's existing per-hit and total grounding caps: 2,500 characters for STANDARD turns and 8,000 for DEEP. Secondary excerpts remain visible. An empty or failed page fetch keeps the search excerpt unchanged.

This complements #434: that PR restores Portable Wiki excerpts for every candidate; this PR hydrates only the highest-ranked page.

Proof:

- RED: the overwrite incident was selected, but a no-tools turn could not name the prevention stored after character 280.
- GREEN: fresh Marionette session `cf4a48bb458e`, against a private local Portable LLM Wiki, named both prevention guards using only automatically supplied context and no tools.
- The semantic test uses a page body larger than the STANDARD budget, places the answer after character 280, preserves a secondary candidate, and asserts the final section stays capped.
- `pytest -q tests/test_wiki.py tests/test_wiki_grounding.py` — 25 passed.

Observed trade: the initial grounding slice grows, while the mounted case avoids a follow-up `query_wiki` call and turn. Total context reduction across representative sessions is expected but not claimed as measured.