### PR TITLE
absorb #434 #435: wiki excerpt map and query-window hydrate

### DIFF
--- a/harness/wiki.py
+++ b/harness/wiki.py
@@ -171,6 +171,84 @@ def _wiki_safe_urlopen(req: urllib.request.Request, timeout: float):
     return opener.open(req, timeout=timeout)
 
 
+def search_hit_snippet(hit):
+    """Map a /wiki/search row to Marionette's internal snippet.
+
+    Portable LLM Wiki's live contract carries page text in ``excerpt``.
+    Older or compatible servers may still send snippet/description/body.
+    """
+    if not isinstance(hit, dict):
+        return ""
+    raw = (
+        hit.get("snippet")
+        or hit.get("excerpt")
+        or hit.get("description")
+        or hit.get("body")
+        or ""
+    )
+    return str(raw).strip()
+
+
+_WINDOW_STOP = frozenset({
+    "the", "and", "for", "with", "what", "about", "this", "that", "from",
+    "your", "have", "been", "were", "they", "them", "than", "then", "into",
+    "just", "like", "some", "more", "did", "does", "how", "why", "who",
+    "when", "where", "can", "could", "should", "would", "will", "not",
+    "but", "are", "was", "you", "our", "any", "all", "its",
+})
+
+
+def query_relevant_passage(body, query, max_chars):
+    """Pick a bounded window around query terms. Prefix is last resort.
+
+    Deterministic and key-free: no second /wiki/query LLM call. Title-only
+    matches (no body term) keep the page head so the 280-char excerpt path
+    still has a fallback.
+    """
+    text = str(body or "")
+    if not text:
+        return ""
+    limit = max(1, int(max_chars))
+    if len(text) <= limit:
+        return text
+    tokens = []
+    seen = set()
+    for raw in re.findall(r"[A-Za-z0-9_]{3,}", str(query or "").lower()):
+        if raw in _WINDOW_STOP or raw in seen:
+            continue
+        seen.add(raw)
+        tokens.append(raw)
+        if len(tokens) >= 12:
+            break
+    if not tokens:
+        return text[:limit]
+    hay = text.lower()
+    best_i = 0
+    best = -1
+    step = max(64, limit // 3)
+    last = max(0, len(text) - limit)
+    i = 0
+    while i <= last:
+        window = hay[i:i + limit]
+        score = 0
+        for tok in tokens:
+            score += window.count(tok)
+        if score > best:
+            best = score
+            best_i = i
+        if i == last:
+            break
+        i = min(last, i + step)
+    if best <= 0:
+        return text[:limit]
+    start = text.rfind("\n", 0, best_i + 1)
+    if start == -1 or (best_i - start) > (limit // 2):
+        start = best_i
+    else:
+        start += 1
+    return text[start:start + limit]
+
+
 @dataclass
 class WikiResult:
     ok: bool
@@ -334,20 +412,35 @@ class WikiClient:
                     continue
                 slug = str(hit.get("slug") or "")
                 title = str(hit.get("title") or slug)
-                snippet = (
-                    hit.get("snippet")
-                    or hit.get("description")
-                    or hit.get("body")
-                    or ""
-                )
                 hits.append({
                     "title": title,
                     "slug": slug,
-                    "snippet": str(snippet).strip(),
+                    "snippet": search_hit_snippet(hit),
                 })
             return hits
         except Exception:
             return []
+
+    def page_body(self, slug: str) -> str:
+        """Fetch one page body through GET /wiki/page/{slug}. Never raises."""
+        if not self.configured or not (slug or "").strip():
+            return ""
+        try:
+            safe_slug = urllib.parse.quote(slug.strip(), safe="")
+            req = urllib.request.Request(
+                "%s/wiki/page/%s" % (self.base_url, safe_slug),
+                method="GET",
+                headers=self._auth_headers(),
+            )
+            with _wiki_safe_urlopen(req, timeout=self.timeout) as r:
+                if r.status != 200:
+                    return ""
+                data = json.loads(r.read().decode("utf-8", "replace"))
+            if not isinstance(data, dict):
+                return ""
+            return str(data.get("body") or data.get("content") or "").strip()
+        except Exception:
+            return ""
 
     def query(self, question: str) -> str:
         """Query the wiki's LLM query/search surface.
@@ -412,7 +505,7 @@ class WikiClient:
                             if isinstance(hit, dict):
                                 title = hit.get("title") or hit.get("slug", "")
                                 slug = hit.get("slug", "")
-                                snip = hit.get("snippet") or hit.get("description") or ""
+                                snip = search_hit_snippet(hit)
                                 lines.append(f"- {title} ({slug}): {snip}")
                         return self._prepend_tier_caveat("\n".join(lines)[:4000])
         except Exception:

--- a/harness/wiki_distill.py
+++ b/harness/wiki_distill.py
@@ -21,7 +21,7 @@ import os
 import re
 
 from .skill_distiller import distill_session, distill_rules
-from .wiki import session_digest
+from .wiki import query_relevant_passage, session_digest
 
 
 def _slugify(s: str) -> str:
@@ -99,6 +99,17 @@ class WikiDistillMixin:
             lines = [authoritative, "### Wiki grounding (auto-injected)"]
             budget = max_chars - len(authoritative) - 40
             per_hit = max(120, budget // max(1, len(hits)))
+            # Hydrate the top-ranked page, then keep a query-matched window —
+            # not the page prefix. Failed fetch keeps the search excerpt.
+            try:
+                top_slug = str(hits[0].get("slug") or "").strip()
+                top_body = self._wiki.page_body(top_slug) if top_slug else ""
+                if top_body:
+                    passage = query_relevant_passage(top_body, user_message, per_hit)
+                    if passage:
+                        hits[0] = dict(hits[0], snippet=passage)
+            except Exception:
+                pass
             for hit in hits:
                 title = str(hit.get("title") or hit.get("slug") or "").strip()
                 slug = str(hit.get("slug") or "").strip()

--- a/tests/test_v09215_live_path.py
+++ b/tests/test_v09215_live_path.py
@@ -144,6 +144,7 @@ def test_send_standard_wiki_uses_tighter_budget(tmp_path, monkeypatch):
         ]
 
     monkeypatch.setattr(s._wiki, "search_pages", fake_search)
+    monkeypatch.setattr(s._wiki, "page_body", lambda slug: "")
     events = list(s.send("add OAuth support"))
     prof = next(e for e in events if e.kind == "task_profile")
     assert prof.data["profile"] == STANDARD

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -134,3 +134,158 @@ def test_wiki_safe_urlopen_blocks_metadata_literal():
     req = urllib.request.Request("https://169.254.169.254/latest/meta-data/")
     with pytest.raises(urllib.error.URLError):
         _wiki_safe_urlopen(req, timeout=1)
+
+
+def test_search_hit_snippet_maps_excerpt_and_aliases():
+    from harness.wiki import search_hit_snippet
+
+    assert search_hit_snippet({"excerpt": "  protocol text  "}) == "protocol text"
+    assert search_hit_snippet({"snippet": "old", "excerpt": "new"}) == "old"
+    assert search_hit_snippet({"description": "compat"}) == "compat"
+    assert search_hit_snippet({"body": "full"}) == "full"
+    assert search_hit_snippet({}) == ""
+    assert search_hit_snippet("nope") == ""
+
+
+def test_query_relevant_passage_picks_match_past_prefix():
+    from harness.wiki import query_relevant_passage
+
+    body = (
+        "Introduction to the incident.\n"
+        + ("A" * 3500)
+        + "\nThe prevention is reserving a unique path for each worker.\n"
+        + ("Z" * 2000)
+    )
+    query = "what prevention did we choose for unique worker paths?"
+    window = query_relevant_passage(body, query, 400)
+    assert "prevention is reserving a unique path" in window
+    assert window[:400] != body[:400]
+
+
+def test_query_relevant_passage_head_fallback_when_no_body_terms():
+    from harness.wiki import query_relevant_passage
+
+    body = ("alpha " * 200) + "omega"
+    window = query_relevant_passage(body, "zzzz notpresent", 80)
+    assert window == body[:80]
+
+
+def test_wiki_client_search_pages_maps_excerpt(monkeypatch):
+    captured = {}
+
+    class FakeResp:
+        status = 200
+
+        def read(self):
+            return json.dumps({
+                "results": [
+                    {
+                        "title": "Incident",
+                        "slug": "incident",
+                        "excerpt": "The prevention is reserving a unique path.",
+                    }
+                ]
+            }).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def fake_urlopen(req, timeout=20):
+        captured["url"] = req.full_url
+        captured["auth"] = req.headers.get("Authorization")
+        return FakeResp()
+
+    monkeypatch.setattr("harness.wiki._wiki_safe_urlopen", fake_urlopen)
+    client = WikiClient(base_url="https://wiki.example.com", token="secret")
+    hits = client.search_pages("prevention", limit=3)
+    assert hits == [{
+        "title": "Incident",
+        "slug": "incident",
+        "snippet": "The prevention is reserving a unique path.",
+    }]
+    assert "/wiki/search?q=" in captured["url"]
+    assert captured["auth"] == "Bearer secret"
+
+
+def test_wiki_client_page_body_reads_body_not_excerpt(monkeypatch):
+    captured = {}
+
+    class FakeResp:
+        status = 200
+
+        def read(self):
+            return json.dumps({
+                "slug": "incident",
+                "excerpt": "intro only",
+                "body": "full page body with the prevention below the fold",
+            }).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def fake_urlopen(req, timeout=20):
+        captured["url"] = req.full_url
+        captured["auth"] = req.headers.get("Authorization")
+        return FakeResp()
+
+    monkeypatch.setattr("harness.wiki._wiki_safe_urlopen", fake_urlopen)
+    client = WikiClient(base_url="https://wiki.example.com", token="secret")
+    assert client.page_body("decisions/incident page") == (
+        "full page body with the prevention below the fold"
+    )
+    assert captured["url"] == (
+        "https://wiki.example.com/wiki/page/decisions%2Fincident%20page"
+    )
+    assert captured["auth"] == "Bearer secret"
+
+
+def test_wiki_client_page_body_ignores_excerpt_only_payload(monkeypatch):
+    class FakeResp:
+        status = 200
+
+        def read(self):
+            return json.dumps({"excerpt": "not a full page"}).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr("harness.wiki._wiki_safe_urlopen", lambda req, timeout=20: FakeResp())
+    client = WikiClient(base_url="https://wiki.example.com", token="secret")
+    assert client.page_body("incident") == ""
+
+
+def test_wiki_client_query_search_fallback_maps_excerpt(monkeypatch):
+    class FakeResp:
+        status = 200
+
+        def read(self):
+            return json.dumps({
+                "results": [
+                    {"title": "T", "slug": "t", "excerpt": "excerpt text"},
+                ]
+            }).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def fake_urlopen(req, timeout=20):
+        if "/wiki/search" in req.full_url:
+            return FakeResp()
+        raise RuntimeError("no rag")
+
+    monkeypatch.setattr("harness.wiki._wiki_safe_urlopen", fake_urlopen)
+    client = WikiClient(base_url="https://wiki.example.com", token="secret")
+    out = client.query("prevention")
+    assert "excerpt text" in out

--- a/tests/test_wiki_grounding.py
+++ b/tests/test_wiki_grounding.py
@@ -55,6 +55,7 @@ def test_wiki_section_non_empty_with_mocked_search(tmp_path, monkeypatch):
         ]
 
     monkeypatch.setattr(s._wiki, "search_pages", fake_search)
+    monkeypatch.setattr(s._wiki, "page_body", lambda slug: "")
     section = s._build_turn_wiki_section("what about the default driver?")
     assert section
     assert "WIKI HAS ALREADY BEEN QUERIED" in section
@@ -103,6 +104,7 @@ def test_ledger_record_written_on_successful_inject(tmp_path, monkeypatch):
             {"title": "B", "slug": "b", "snippet": "beta"},
         ],
     )
+    monkeypatch.setattr(s._wiki, "page_body", lambda slug: "")
 
     section = s._build_turn_wiki_section("prior release decision?")
     assert section
@@ -194,6 +196,7 @@ def test_wiki_section_standard_profile_uses_tighter_budget(tmp_path, monkeypatch
         ]
 
     monkeypatch.setattr(s._wiki, "search_pages", fake_search)
+    monkeypatch.setattr(s._wiki, "page_body", lambda slug: "")
     section = s._build_turn_wiki_section("what about the default driver?")
     assert captured["limit"] == 3
     assert section
@@ -222,6 +225,7 @@ def test_wiki_section_deep_profile_keeps_full_budget(tmp_path, monkeypatch):
         ]
 
     monkeypatch.setattr(s._wiki, "search_pages", fake_search)
+    monkeypatch.setattr(s._wiki, "page_body", lambda slug: "")
     section = s._build_turn_wiki_section("audit authentication architecture")
     assert captured["limit"] == 5
     assert section
@@ -256,3 +260,69 @@ def test_wiki_client_search_pages_parses_results(monkeypatch):
     hits = client.search_pages("auth flow", limit=3)
     assert hits == [{"title": "T", "slug": "t", "snippet": "snippet text"}]
     assert "/wiki/search?q=" in captured["url"]
+
+
+def test_wiki_section_hydrates_query_window_not_page_prefix(tmp_path, monkeypatch):
+    s = _session(
+        tmp_path,
+        wiki_url="https://wiki.example.com",
+        wiki_token="tok",
+        repo=str(tmp_path / "marionette"),
+    )
+    s._task_profile = STANDARD
+    fetched = []
+
+    def fake_search(query, *, limit=5):
+        return [
+            {
+                "title": "Incident",
+                "slug": "incident",
+                "snippet": "Introduction to the incident and why it started.",
+            },
+            {
+                "title": "Secondary",
+                "slug": "secondary",
+                "snippet": "Neighbor page stays an excerpt.",
+            },
+        ]
+
+    def fake_page(slug):
+        fetched.append(slug)
+        return (
+            "Introduction to the incident and why it started.\n"
+            + ("A" * 3500)
+            + "\nThe prevention is reserving a unique path for each worker.\n"
+            + ("Z" * 2000)
+        )
+
+    monkeypatch.setattr(s._wiki, "search_pages", fake_search)
+    monkeypatch.setattr(s._wiki, "page_body", fake_page)
+    section = s._build_turn_wiki_section(
+        "what prevention did we choose for unique worker paths?"
+    )
+    assert fetched == ["incident"]
+    assert "prevention is reserving a unique path" in section
+    assert "Neighbor page stays an excerpt" in section
+    assert len(section) <= s._WIKI_GROUNDING_STANDARD_MAX_CHARS
+
+
+def test_wiki_section_keeps_excerpt_when_page_fetch_fails(tmp_path, monkeypatch):
+    s = _session(
+        tmp_path,
+        wiki_url="https://wiki.example.com",
+        wiki_token="tok",
+        repo=str(tmp_path / "marionette"),
+    )
+
+    monkeypatch.setattr(
+        s._wiki,
+        "search_pages",
+        lambda q, *, limit=5: [{
+            "title": "Incident",
+            "slug": "incident",
+            "snippet": "Search excerpt stayed after a failed hydrate.",
+        }],
+    )
+    monkeypatch.setattr(s._wiki, "page_body", lambda slug: "")
+    section = s._build_turn_wiki_section("what prevention did we choose?")
+    assert "Search excerpt stayed after a failed hydrate" in section


### PR DESCRIPTION
## Summary
- Absorb Benton #434/#435 onto `dev` with credit. Live Portable LLM Wiki `/wiki/search` carries page text in `excerpt`; Marionette only read `snippet`/`description`/`body`, so auto-grounding ranked the right titles and injected empty text.
- Keep the top-page `GET /wiki/page/{slug}` hydrate. Do **not** dump the page prefix into the prompt. After fetch, pick a query-matched window (`query_relevant_passage`) scored on the user message, then keep existing STANDARD 2,500 / DEEP 8,000 caps.
- Answers #436: the protocol should own query-matched search excerpts long-term. Marionette ships a key-free client window now so large pages are not dumbed down to the intro. `/wiki/query` stays the synthesizer path, not auto-inject.

## Test plan
- [x] `pytest -q tests/test_wiki.py tests/test_wiki_grounding.py tests/test_v09215_live_path.py tests/test_task_profile.py` (56 passed)
- [x] Live `GET /wiki/search` on portablellm.wiki returns `excerpt` and no `snippet`
- [ ] CI `tests` on this absorb PR

Closes #434
Closes #435
Fixes #436