### PR TITLE
fix: OpenCode Go stream-death and edit ordinal

### DIFF
--- a/harness/api/session_control.py
+++ b/harness/api/session_control.py
@@ -714,7 +714,11 @@ def post_session_rewind(body: dict, svc: SessionControlServices) -> tuple[int, J
             user_ordinal = int(body.get("user_ordinal"))
         except (TypeError, ValueError):
             return 400, {"ok": False, "error": "user_ordinal must be an int"}
-        result = pilot.rewind_to_user_ordinal(user_ordinal)
+        hint = body.get("text") or body.get("text_hint")
+        if isinstance(hint, str) and hint.strip():
+            result = pilot.rewind_to_user_ordinal(user_ordinal, text_hint=hint)
+        else:
+            result = pilot.rewind_to_user_ordinal(user_ordinal)
     elif body.get("display_index") is not None:
         try:
             display_index = int(body.get("display_index"))

--- a/harness/conversation.py
+++ b/harness/conversation.py
@@ -1985,7 +1985,26 @@ class ConversationalSession(
             "workspace_notice": None,
         }
 
-    def rewind_to_user_ordinal(self, user_ordinal: int) -> dict:
+    def _display_user_rows(self):
+        """(index, ordinal, text) for each display user message."""
+        rows = []
+        seen = 0
+        for i, row in enumerate(self._display_transcript or []):
+            if not isinstance(row, dict):
+                continue
+            rtype = row.get("type") or "message"
+            if rtype not in ("message", ""):
+                continue
+            if (row.get("role") or "") != "user":
+                continue
+            text = row.get("text") or row.get("content") or ""
+            if not isinstance(text, str):
+                text = str(text or "")
+            rows.append((i, seen, text))
+            seen += 1
+        return rows
+
+    def rewind_to_user_ordinal(self, user_ordinal: int, text_hint: Optional[str] = None) -> dict:
         """Hermes-style undo for message edit: truncate at the Nth user turn (0-based).
 
         Soft-stashes the discarded tail on ``_rewind_stash`` so the UI can offer
@@ -1996,6 +2015,10 @@ class ConversationalSession(
         later-turn pre-mutation checkpoint), also restores workspace files to
         that snapshot. If none exists, transcript rewind still succeeds with an
         honest notice that disk was not restored.
+
+        After a mid-turn model swap the UI can count one extra optimistic user
+        row. A past-end ordinal clamps to the latest user turn; ``text_hint``
+        matches the last display user with that text.
         """
         if self.is_turn_busy():
             return {
@@ -2007,25 +2030,27 @@ class ConversationalSession(
             return {"ok": False, "error": "user_ordinal out of range"}
 
         display = list(self._display_transcript or [])
+        users = self._display_user_rows()
         display_index = None
-        seen = 0
         prefill = ""
-        for i, row in enumerate(display):
-            if not isinstance(row, dict):
-                continue
-            rtype = row.get("type") or "message"
-            if rtype not in ("message", ""):
-                continue
-            if (row.get("role") or "") != "user":
-                continue
+        resolved_ordinal = user_ordinal
+        ordinal_clamped = False
+        for i, seen, text in users:
             if seen == user_ordinal:
                 display_index = i
-                prefill = row.get("text") or row.get("content") or ""
-                if not isinstance(prefill, str):
-                    prefill = str(prefill or "")
+                prefill = text
                 break
-            seen += 1
-
+        if display_index is None:
+            hint = (text_hint or "").strip()
+            if hint:
+                for i, seen, text in users:
+                    if text.strip() == hint:
+                        display_index = i
+                        prefill = text
+                        resolved_ordinal = seen
+            if display_index is None and users:
+                display_index, resolved_ordinal, prefill = users[-1]
+                ordinal_clamped = True
         if display_index is None:
             return {"ok": False, "error": "user_ordinal out of range"}
 
@@ -2035,19 +2060,19 @@ class ConversationalSession(
             if hi == 0:
                 continue
             if (m.get("role") or "") == "user":
-                if seen_h == user_ordinal:
+                if seen_h == resolved_ordinal:
                     cut_hist = hi
                     break
                 seen_h += 1
 
-        workspace = self._restore_workspace_for_rewind(user_ordinal)
+        workspace = self._restore_workspace_for_rewind(resolved_ordinal)
 
         self._rewind_stash = {
             "history": self.export_history(),
             "display": list(display),
             "job_ids": list(self._session_job_ids or []),
             "display_index": display_index,
-            "user_ordinal": user_ordinal,
+            "user_ordinal": resolved_ordinal,
             "prefill": prefill,
             "workspace_auto_snapshot_id": workspace.get("auto_snapshot_id"),
             "workspace_restored": bool(workspace.get("workspace_restored")),
@@ -2076,6 +2101,12 @@ class ConversationalSession(
                 f"{honesty} "
                 "Resubmit the edited text to start a new turn, or Cancel to restore the transcript."
             )
+        if ordinal_clamped:
+            notice = (
+                "Editing the latest user message "
+                f"(requested turn {user_ordinal} was past the transcript). "
+                + notice
+            )
         return {
             "ok": True,
             "prefill": prefill,
@@ -2083,6 +2114,8 @@ class ConversationalSession(
             "removed_count": removed,
             "kept_display": len(self._display_transcript),
             "display_index": display_index,
+            "user_ordinal": resolved_ordinal,
+            "ordinal_clamped": ordinal_clamped,
             "workspace_restored": bool(workspace.get("workspace_restored")),
             "checkpoint_id": workspace.get("checkpoint_id"),
             "restored_files": list(workspace.get("restored_files") or []),

--- a/pmharness/drivers/codex_responses.py
+++ b/pmharness/drivers/codex_responses.py
@@ -91,11 +91,16 @@ _CODEX_MAX_INCOMPLETE_RETRIES = 3
 # timeout, which left Electron on Still working until Stop sealed the
 # already-buffered summary. Drain a short idle for in-flight summary tokens,
 # then finish. Non-ChatGPT Responses hosts (OpenCode Go Muse, etc.) must
-# wait for an authoritative terminal instead of forging completed.
+# not forge completed. They still arm a short idle so comment keepalives
+# cannot reset urlopen's long timeout forever after reasoning or answer
+# tokens; that path settles incomplete.
 _POST_ANSWER_SLICE_SECONDS = 0.25
 _POST_ANSWER_IDLE_SECONDS = 0.5
 _POST_ANSWER_MAX_SECONDS = 2.0
 _POST_ANSWER_KEEPALIVE_LIMIT = 3
+_NON_CHATGPT_IDLE_SLICE_SECONDS = 2.0
+_NON_CHATGPT_IDLE_MAX_SECONDS = 20.0
+_NON_CHATGPT_IDLE_KEEPALIVE_LIMIT = 8
 _INCOMPLETE_ANSWER_SUFFIXES = (":", ",", ";", "—", "–", "-", "/", "(", "[", "{")
 _CONTENT_FILTER_MSG = (
     "Model declined to respond (content filter). Try rephrasing the request "
@@ -756,6 +761,7 @@ def _consume_codex_sse(
     drain_started = 0.0
     last_meaningful = 0.0
     keepalive_streak = 0
+    go_idle_armed = False
 
     def _finish_tool_free_answer():
         nonlocal saw_terminal, terminal_status
@@ -796,11 +802,33 @@ def _consume_codex_sse(
             return True
         return False
 
+    def _begin_non_chatgpt_idle_watch():
+        """Arm a short read timeout after Go/OpenAI activity. Never forges completed."""
+        nonlocal go_idle_armed, last_meaningful, keepalive_streak
+        if chatgpt_backend:
+            return
+        last_meaningful = time.monotonic()
+        keepalive_streak = 0
+        go_idle_armed = True
+        _arm_post_answer_idle_timeout(resp_fp, _NON_CHATGPT_IDLE_SLICE_SECONDS)
+
+    def _should_finish_go_idle():
+        if chatgpt_backend or not go_idle_armed:
+            return False
+        if keepalive_streak >= _NON_CHATGPT_IDLE_KEEPALIVE_LIMIT:
+            return True
+        if last_meaningful and (
+            time.monotonic() - last_meaningful >= _NON_CHATGPT_IDLE_MAX_SECONDS
+        ):
+            return True
+        return False
+
     def _begin_post_answer_drain():
         """Start the short post-answer drain. False means caller should stop."""
         nonlocal post_answer_drain, drain_started, last_meaningful
         nonlocal keepalive_streak
         if not chatgpt_backend:
+            _begin_non_chatgpt_idle_watch()
             return True
         if not _idle_drain_allowed():
             return True
@@ -830,7 +858,11 @@ def _consume_codex_sse(
             ):
                 _finish_tool_free_answer()
                 break
-            if not collected_items and not text_deltas:
+            if (
+                not collected_items
+                and not text_deltas
+                and not reasoning_deltas
+            ):
                 return {
                     "status": "failed",
                     "output": [],
@@ -849,6 +881,10 @@ def _consume_codex_sse(
                 if keepalive_streak >= _POST_ANSWER_KEEPALIVE_LIMIT or _should_finish_drain():
                     _finish_tool_free_answer()
                     break
+            elif go_idle_armed:
+                keepalive_streak += 1
+                if _should_finish_go_idle():
+                    break
             continue
         data_str = line[5:].strip()
         if not data_str or data_str == "[DONE]":
@@ -858,6 +894,10 @@ def _consume_codex_sse(
                 keepalive_streak += 1
                 if keepalive_streak >= _POST_ANSWER_KEEPALIVE_LIMIT or _should_finish_drain():
                     _finish_tool_free_answer()
+                    break
+            elif go_idle_armed:
+                keepalive_streak += 1
+                if _should_finish_go_idle():
                     break
             continue
         try:
@@ -895,6 +935,7 @@ def _consume_codex_sse(
                 # Codex keeps the SSE open for a trailing summary.
                 if channel == "answer":
                     _seal_open_channels(("progress", "reasoning"), sid)
+            _begin_non_chatgpt_idle_watch()
             if _drain_tick():
                 break
             continue
@@ -957,6 +998,7 @@ def _consume_codex_sse(
             reasoning_text = event.get("delta") or ""
             if isinstance(reasoning_text, str) and reasoning_text:
                 reasoning_deltas.append(reasoning_text)
+                _begin_non_chatgpt_idle_watch()
                 item_id = event.get("item_id") or event.get("id")
                 out_idx = event.get("output_index")
                 sid, channel, oi_int = _resolve_channel(
@@ -1065,7 +1107,7 @@ def _consume_codex_sse(
     else:
         output = []
 
-    if not saw_terminal and not output:
+    if not saw_terminal and not output and not reasoning_deltas:
         return {
             "status": "failed",
             "output": [],

--- a/pmharness/drivers/openai_compat.py
+++ b/pmharness/drivers/openai_compat.py
@@ -1366,10 +1366,31 @@ class OpenAICompatDriver:
 
             req = http_request(self, url, data=data, headers=headers, method="POST")
             try:
+                from pmharness.drivers.codex_responses import (
+                    _arm_post_answer_idle_timeout,
+                )
+
                 with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                    idle_armed = False
+                    keepalives = 0
                     for line in resp:
                         if not acc.feed(line):
                             break
+                        if not acc.stream_started:
+                            continue
+                        raw = (
+                            line.decode("utf-8", "replace").strip()
+                            if isinstance(line, bytes)
+                            else str(line).strip()
+                        )
+                        if not raw or not raw.startswith("data:"):
+                            keepalives += 1
+                            if keepalives >= 8:
+                                break
+                            continue
+                        keepalives = 0
+                        idle_armed = True
+                        _arm_post_answer_idle_timeout(resp, 2.0)
             except urllib.error.HTTPError as e:
                 detail = e.read().decode("utf-8", "replace")[:500]
                 # Endpoint rejected the `reasoning` field: disable it for the

--- a/tests/test_codex_responses_driver.py
+++ b/tests/test_codex_responses_driver.py
@@ -953,6 +953,49 @@ def test_consume_sse_opencode_empty_eof_after_item_added_names_host():
     assert "codex" not in err
 
 
+class _GoKeepaliveFp:
+    """OpenCode Go keepalives reset a long urlopen timeout unless consume arms one."""
+
+    def __init__(self):
+        self.timeout = None
+        self._n = 0
+
+    def settimeout(self, seconds):
+        self.timeout = seconds
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._n == 0:
+            self._n += 1
+            return (
+                b'data: {"type":"response.reasoning.delta","delta":"worth it? nah."}\n'
+            )
+        if self.timeout is not None and float(self.timeout) <= 5.0:
+            raise TimeoutError("go idle")
+        self._n += 1
+        if self._n > 40:
+            raise AssertionError(
+                "consume_codex_sse did not arm a short Go idle timeout"
+            )
+        return b": keepalive\n"
+
+
+def test_consume_sse_go_reasoning_keepalives_settle_incomplete():
+    raw = _consume_codex_sse(
+        _GoKeepaliveFp(),
+        chatgpt_backend=False,
+        stream_label="OpenCode Responses",
+    )
+    assert raw["status"] == "incomplete"
+    assert raw["status"] != "completed"
+    assert "worth it? nah." in str(raw.get("reasoning") or "")
+    err = str(raw.get("error") or "").lower()
+    assert "opencode responses" in err
+    assert "codex" not in err
+
+
 def test_consume_sse_chatgpt_still_seals_after_answer_timeout():
     """ChatGPT anti-hang drain must not regress when chatgpt_backend defaults."""
 

--- a/tests/test_session_rewind_edit.py
+++ b/tests/test_session_rewind_edit.py
@@ -256,6 +256,44 @@ def test_rewind_without_checkpoint_does_not_claim_disk_restore(tmp_path):
     assert target.read_text(encoding="utf-8") == "stale agent edit\n"
 
 
+def test_rewind_clamps_past_end_ordinal_to_last_user(tmp_path):
+    s = _sess(tmp_path)
+    s._display_transcript = [
+        {"type": "message", "role": "user", "text": "one"},
+        {"type": "message", "role": "assistant", "text": "a1"},
+    ]
+    s._history = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "a1"},
+    ]
+    res = s.rewind_to_user_ordinal(1)
+    assert res["ok"] is True
+    assert res["prefill"] == "one"
+    assert res.get("ordinal_clamped") is True
+    assert "latest user message" in (res.get("notice") or "").lower()
+    assert s._display_transcript == []
+
+
+def test_rewind_text_hint_finds_user_when_ordinal_misses(tmp_path):
+    s = _sess(tmp_path)
+    s._display_transcript = [
+        {"type": "message", "role": "user", "text": "alpha"},
+        {"type": "message", "role": "assistant", "text": "a1"},
+        {"type": "message", "role": "user", "text": "beta"},
+    ]
+    s._history = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "alpha"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "beta"},
+    ]
+    res = s.rewind_to_user_ordinal(9, text_hint="beta")
+    assert res["ok"] is True
+    assert res["prefill"] == "beta"
+    assert len(s._display_transcript) == 2
+
+
 def test_find_rewind_checkpoint_prefers_exact_then_later_ordinal(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/webapp/src/__tests__/conversation.helpers.test.ts
+++ b/webapp/src/__tests__/conversation.helpers.test.ts
@@ -2886,7 +2886,7 @@ describe("composerSend module", () => {
 
     expect(stopLocal).not.toHaveBeenCalled();
     expect(interruptSession).not.toHaveBeenCalled();
-    expect(rewindSession).toHaveBeenCalledWith(2);
+    expect(rewindSession).toHaveBeenCalledWith(2, { text: "draft" });
     expect(result.kind).toBe("success");
     if (result.kind === "success") {
       expect(result.workspace_restored).toBe(false);

--- a/webapp/src/components/conversation/composerSend.ts
+++ b/webapp/src/components/conversation/composerSend.ts
@@ -315,7 +315,10 @@ export async function runEditMessageFlow(opts: {
   originalText: string;
   stopLocal: () => void;
   interruptSession: () => Promise<InterruptSessionResponse>;
-  rewindSession: (userOrdinal: number) => Promise<RewindSessionResponse>;
+  rewindSession: (
+    userOrdinal: number,
+    extra?: { text?: string },
+  ) => Promise<RewindSessionResponse>;
 }): Promise<EditMessageFlowResult> {
   if (opts.composerBusy) {
     const stopResult = await runStopFlow({
@@ -328,7 +331,9 @@ export async function runEditMessageFlow(opts: {
   }
 
   try {
-    const res = await opts.rewindSession(opts.userOrdinal);
+    const res = await opts.rewindSession(opts.userOrdinal, {
+      text: opts.originalText,
+    });
     if (!res?.ok) {
       return {
         kind: "rewind_failed",

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1755,7 +1755,7 @@ export const api = {
       "/api/session/interrupt",
       sessionId ? { session_id: sessionId } : {},
     ),
-  rewindSession: (userOrdinal: number) =>
+  rewindSession: (userOrdinal: number, opts?: { text?: string }) =>
     postJSON<{
       ok: boolean;
       prefill?: string;
@@ -1766,7 +1766,10 @@ export const api = {
       workspace_restored?: boolean;
       checkpoint_id?: string | null;
       restored_files?: string[];
-    }>("/api/session/rewind", { user_ordinal: userOrdinal }),
+    }>("/api/session/rewind", {
+      user_ordinal: userOrdinal,
+      ...(opts?.text ? { text: opts.text } : {}),
+    }),
   restoreRewind: () =>
     postJSON<{
       ok: boolean;


### PR DESCRIPTION
## Summary
- OpenCode Go Responses (and chat-completions) keepalives no longer hold a turn open forever after reasoning/answer tokens. The stream settles **incomplete** — it does not forge `completed`.
- Edit-resubmit after a mid-turn model swap no longer dies with `user ordinal out of range`. Rewind matches by text, then clamps to the latest user turn with an honest notice.

## Test plan
- [x] `pytest tests/test_codex_responses_driver.py tests/test_session_rewind_edit.py tests/test_openai_compat_stream_terminals.py` (includes new Go keepalive + rewind tests)
- [x] `vitest run src/__tests__/conversation.helpers.test.ts`
- [ ] Live: OpenCode Go turn that streams thinking then idles should show Continue/Retry instead of hanging
- [ ] Live: hang or incomplete turn, swap model, Edit last prompt — composer prefills, no ordinal error